### PR TITLE
ci: version gate for vendored tarballs + twin image publish gates (FDRS-593, FDRS-586)

### DIFF
--- a/.github/workflows/cli-version-gate.yml
+++ b/.github/workflows/cli-version-gate.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - 'cli/src/**'
+      - 'cli/vendor/**'
       - 'cli/package.json'
       - 'cli/.changeset/**'
       - 'scripts/check-cli-version-bump.sh'
@@ -14,7 +15,7 @@ concurrency:
 
 jobs:
   check:
-    name: cli/src/** must bump version or add a changeset
+    name: cli/src/** or cli/vendor/** must bump version or add a changeset
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/cli-version-gate.yml
+++ b/.github/workflows/cli-version-gate.yml
@@ -15,7 +15,11 @@ concurrency:
 
 jobs:
   check:
-    name: cli/src/** or cli/vendor/** must bump version or add a changeset
+    # NB: keep this job name stable — GitHub matches required status checks by
+    # check-run name, so renaming it silently unbinds the gate from any branch
+    # protection that lists the old name. The vendor coverage lives in the
+    # trigger paths + check-cli-version-bump.sh, not this display string.
+    name: cli/src/** must bump version or add a changeset
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/twin-github-image.yml
+++ b/.github/workflows/twin-github-image.yml
@@ -11,17 +11,35 @@ on:
       - 'package.json'
       - 'bun.lock'
       - '.dockerignore'
+      - '.trivyignore'
       - '.github/workflows/twin-github-image.yml'
   workflow_dispatch:
 
 jobs:
+  # Gate the image publish on the twin's own tests. Without this a red test
+  # could still ship a rolling `github` tag to GHCR on a main push, since the
+  # separate `ci` workflow does not block this one. FDRS-586.
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.10
+      - run: bun install --frozen-lockfile
+      - run: bun run --filter @pome-sh/twin-github typecheck
+      - run: bun run --filter @pome-sh/twin-github test
+
   publish:
+    needs: test
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     outputs:
-      digest: ${{ steps.build.outputs.digest }}
+      digest: ${{ steps.push.outputs.digest }}
       tags: ${{ steps.meta.outputs.tags }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -46,17 +64,44 @@ jobs:
             type=semver,pattern=github-{{version}}
             type=semver,pattern=github-v{{version}}
             type=sha,prefix=github-,format=short
+      # Build once and load into the local daemon so Trivy can scan the exact
+      # image before it is pushed. Also tag it locally for the scan ref.
       - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         id: build
         with:
           context: .
           file: packages/twin-github/Dockerfile
-          # PR builds verify the Dockerfile compiles but never push to
-          # GHCR — only main / tag pushes publish. Without this gate
-          # the GITHUB_TOKEN from a fork or unauthorized actor could
-          # poison the image. `github.event_name` is the PR vs push
-          # signal that survives merge-queue retargeting.
-          push: ${{ github.event_name != 'pull_request' }}
+          load: true
+          push: false
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            twin-github:scan
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+      # Fail the publish on fixable HIGH/CRITICAL CVEs. `ignore-unfixed` drops
+      # vulns with no upstream fix (nothing actionable); documented, reviewed
+      # exceptions go in `.trivyignore` at the repo root.
+      - name: Scan image for vulnerabilities (Trivy)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: twin-github:scan
+          format: table
+          severity: HIGH,CRITICAL
+          exit-code: '1'
+          ignore-unfixed: true
+          trivyignores: .trivyignore
+      # PR builds verify the Dockerfile compiles and pass the scan but never
+      # push to GHCR — only main / tag pushes publish. Without this gate the
+      # GITHUB_TOKEN from a fork or unauthorized actor could poison the image.
+      # `github.event_name` is the PR vs push signal that survives merge-queue
+      # retargeting. Layers are reused from the build step's buildx cache.
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        id: push
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          context: .
+          file: packages/twin-github/Dockerfile
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64

--- a/.github/workflows/twin-github-image.yml
+++ b/.github/workflows/twin-github-image.yml
@@ -39,7 +39,6 @@ jobs:
       contents: read
       packages: write
     outputs:
-      digest: ${{ steps.push.outputs.digest }}
       tags: ${{ steps.meta.outputs.tags }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -90,18 +89,18 @@ jobs:
           exit-code: '1'
           ignore-unfixed: true
           trivyignores: .trivyignore
-      # PR builds verify the Dockerfile compiles and pass the scan but never
-      # push to GHCR — only main / tag pushes publish. Without this gate the
-      # GITHUB_TOKEN from a fork or unauthorized actor could poison the image.
-      # `github.event_name` is the PR vs push signal that survives merge-queue
-      # retargeting. Layers are reused from the build step's buildx cache.
-      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        id: push
+      # Push the EXACT image built + scanned above (already loaded into the local
+      # daemon under every steps.meta.outputs.tags) — no second build, so the
+      # published artifact is byte-identical to the one Trivy scanned. PR builds
+      # verify + scan but never push; only main / tag pushes publish. Without
+      # this gate the GITHUB_TOKEN from a fork or unauthorized actor could poison
+      # the image. `github.event_name` is the PR-vs-push signal that survives
+      # merge-queue retargeting.
+      - name: Push scanned image
         if: ${{ github.event_name != 'pull_request' }}
-        with:
-          context: .
-          file: packages/twin-github/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
+        run: |
+          printf '%s\n' "${{ steps.meta.outputs.tags }}" | while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            echo "pushing $tag"
+            docker push "$tag"
+          done

--- a/.github/workflows/twin-slack-image.yml
+++ b/.github/workflows/twin-slack-image.yml
@@ -11,17 +11,35 @@ on:
       - 'package.json'
       - 'bun.lock'
       - '.dockerignore'
+      - '.trivyignore'
       - '.github/workflows/twin-slack-image.yml'
   workflow_dispatch:
 
 jobs:
+  # Gate the image publish on the twin's own tests. Without this a red test
+  # could still ship a rolling `slack` tag to GHCR on a main push, since the
+  # separate `ci` workflow does not block this one. FDRS-586.
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.10
+      - run: bun install --frozen-lockfile
+      - run: bun run --filter @pome-sh/twin-slack typecheck
+      - run: bun run --filter @pome-sh/twin-slack test
+
   publish:
+    needs: test
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     outputs:
-      digest: ${{ steps.build.outputs.digest }}
+      digest: ${{ steps.push.outputs.digest }}
       tags: ${{ steps.meta.outputs.tags }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -46,12 +64,44 @@ jobs:
             type=semver,pattern=slack-{{version}}
             type=semver,pattern=slack-v{{version}}
             type=sha,prefix=slack-,format=short
+      # Build once and load into the local daemon so Trivy can scan the exact
+      # image before it is pushed. Also tag it locally for the scan ref.
       - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         id: build
         with:
           context: .
           file: packages/twin-slack/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          load: true
+          push: false
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            twin-slack:scan
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+      # Fail the publish on fixable HIGH/CRITICAL CVEs. `ignore-unfixed` drops
+      # vulns with no upstream fix (nothing actionable); documented, reviewed
+      # exceptions go in `.trivyignore` at the repo root.
+      - name: Scan image for vulnerabilities (Trivy)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: twin-slack:scan
+          format: table
+          severity: HIGH,CRITICAL
+          exit-code: '1'
+          ignore-unfixed: true
+          trivyignores: .trivyignore
+      # PR builds verify the Dockerfile compiles and pass the scan but never
+      # push to GHCR — only main / tag pushes publish. Without this gate the
+      # GITHUB_TOKEN from a fork or unauthorized actor could poison the image.
+      # `github.event_name` is the PR vs push signal that survives merge-queue
+      # retargeting. Layers are reused from the build step's buildx cache.
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        id: push
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          context: .
+          file: packages/twin-slack/Dockerfile
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64

--- a/.github/workflows/twin-slack-image.yml
+++ b/.github/workflows/twin-slack-image.yml
@@ -39,7 +39,6 @@ jobs:
       contents: read
       packages: write
     outputs:
-      digest: ${{ steps.push.outputs.digest }}
       tags: ${{ steps.meta.outputs.tags }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -90,18 +89,18 @@ jobs:
           exit-code: '1'
           ignore-unfixed: true
           trivyignores: .trivyignore
-      # PR builds verify the Dockerfile compiles and pass the scan but never
-      # push to GHCR — only main / tag pushes publish. Without this gate the
-      # GITHUB_TOKEN from a fork or unauthorized actor could poison the image.
-      # `github.event_name` is the PR vs push signal that survives merge-queue
-      # retargeting. Layers are reused from the build step's buildx cache.
-      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        id: push
+      # Push the EXACT image built + scanned above (already loaded into the local
+      # daemon under every steps.meta.outputs.tags) — no second build, so the
+      # published artifact is byte-identical to the one Trivy scanned. PR builds
+      # verify + scan but never push; only main / tag pushes publish. Without
+      # this gate the GITHUB_TOKEN from a fork or unauthorized actor could poison
+      # the image. `github.event_name` is the PR-vs-push signal that survives
+      # merge-queue retargeting.
+      - name: Push scanned image
         if: ${{ github.event_name != 'pull_request' }}
-        with:
-          context: .
-          file: packages/twin-slack/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
+        run: |
+          printf '%s\n' "${{ steps.meta.outputs.tags }}" | while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            echo "pushing $tag"
+            docker push "$tag"
+          done

--- a/.github/workflows/twin-stripe-image.yml
+++ b/.github/workflows/twin-stripe-image.yml
@@ -11,17 +11,35 @@ on:
       - 'package.json'
       - 'bun.lock'
       - '.dockerignore'
+      - '.trivyignore'
       - '.github/workflows/twin-stripe-image.yml'
   workflow_dispatch:
 
 jobs:
+  # Gate the image publish on the twin's own tests. Without this a red test
+  # could still ship a rolling `stripe` tag to GHCR on a main push, since the
+  # separate `ci` workflow does not block this one. FDRS-586.
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.10
+      - run: bun install --frozen-lockfile
+      - run: bun run --filter @pome-sh/twin-stripe typecheck
+      - run: bun run --filter @pome-sh/twin-stripe test
+
   publish:
+    needs: test
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     outputs:
-      digest: ${{ steps.build.outputs.digest }}
+      digest: ${{ steps.push.outputs.digest }}
       tags: ${{ steps.meta.outputs.tags }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -46,12 +64,44 @@ jobs:
             type=semver,pattern=stripe-{{version}}
             type=semver,pattern=stripe-v{{version}}
             type=sha,prefix=stripe-,format=short
+      # Build once and load into the local daemon so Trivy can scan the exact
+      # image before it is pushed. Also tag it locally for the scan ref.
       - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         id: build
         with:
           context: .
           file: packages/twin-stripe/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          load: true
+          push: false
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            twin-stripe:scan
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+      # Fail the publish on fixable HIGH/CRITICAL CVEs. `ignore-unfixed` drops
+      # vulns with no upstream fix (nothing actionable); documented, reviewed
+      # exceptions go in `.trivyignore` at the repo root.
+      - name: Scan image for vulnerabilities (Trivy)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: twin-stripe:scan
+          format: table
+          severity: HIGH,CRITICAL
+          exit-code: '1'
+          ignore-unfixed: true
+          trivyignores: .trivyignore
+      # PR builds verify the Dockerfile compiles and pass the scan but never
+      # push to GHCR — only main / tag pushes publish. Without this gate the
+      # GITHUB_TOKEN from a fork or unauthorized actor could poison the image.
+      # `github.event_name` is the PR vs push signal that survives merge-queue
+      # retargeting. Layers are reused from the build step's buildx cache.
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        id: push
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          context: .
+          file: packages/twin-stripe/Dockerfile
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64

--- a/.github/workflows/twin-stripe-image.yml
+++ b/.github/workflows/twin-stripe-image.yml
@@ -39,7 +39,6 @@ jobs:
       contents: read
       packages: write
     outputs:
-      digest: ${{ steps.push.outputs.digest }}
       tags: ${{ steps.meta.outputs.tags }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -90,18 +89,18 @@ jobs:
           exit-code: '1'
           ignore-unfixed: true
           trivyignores: .trivyignore
-      # PR builds verify the Dockerfile compiles and pass the scan but never
-      # push to GHCR — only main / tag pushes publish. Without this gate the
-      # GITHUB_TOKEN from a fork or unauthorized actor could poison the image.
-      # `github.event_name` is the PR vs push signal that survives merge-queue
-      # retargeting. Layers are reused from the build step's buildx cache.
-      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        id: push
+      # Push the EXACT image built + scanned above (already loaded into the local
+      # daemon under every steps.meta.outputs.tags) — no second build, so the
+      # published artifact is byte-identical to the one Trivy scanned. PR builds
+      # verify + scan but never push; only main / tag pushes publish. Without
+      # this gate the GITHUB_TOKEN from a fork or unauthorized actor could poison
+      # the image. `github.event_name` is the PR-vs-push signal that survives
+      # merge-queue retargeting.
+      - name: Push scanned image
         if: ${{ github.event_name != 'pull_request' }}
-        with:
-          context: .
-          file: packages/twin-stripe/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
+        run: |
+          printf '%s\n' "${{ steps.meta.outputs.tags }}" | while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            echo "pushing $tag"
+            docker push "$tag"
+          done

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,20 @@
+# Trivy ignore policy — twin image publish gate (FDRS-586)
+#
+# The twin-*-image workflows fail the publish on FIXABLE HIGH/CRITICAL CVEs
+# (severity HIGH,CRITICAL + ignore-unfixed: true). To ship past a specific CVE
+# you must add it here with a justification and a review date — this file IS
+# the audit trail. Rules:
+#
+#   1. Only add a CVE after a human has assessed it is not exploitable in our
+#      usage (e.g. the vulnerable code path is never reached by the twin).
+#   2. One CVE per line, prefixed with a comment: reason + who + review-by date.
+#   3. Re-review each entry by its date; delete it once the base image ships a
+#      fix (ignore-unfixed already suppresses vulns with no fix available, so
+#      entries here are deliberate exceptions to *fixable* findings).
+#
+# Format:
+#   # <reason> — <handle>, review by <YYYY-MM-DD>
+#   CVE-XXXX-YYYYY
+#
+# (No exceptions currently. Keep this list empty unless a fixable HIGH/CRITICAL
+# genuinely cannot be remediated in time and has been reviewed.)

--- a/bun.lock
+++ b/bun.lock
@@ -48,7 +48,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@pome-sh/shared-types": "workspace:*",
-        "hono": "^4.10.7",
+        "hono": "^4.12.27",
         "zod": "^4.1.13",
       },
       "devDependencies": {
@@ -88,7 +88,7 @@
         "@hono/node-server": "^1.19.6",
         "@pome-sh/shared-types": "workspace:*",
         "better-sqlite3": "^12.5.0",
-        "hono": "^4.10.7",
+        "hono": "^4.12.27",
         "zod": "^4.1.13",
       },
       "devDependencies": {
@@ -112,7 +112,7 @@
         "@hono/node-server": "^1.19.6",
         "@pome-sh/shared-types": "workspace:*",
         "better-sqlite3": "^12.5.0",
-        "hono": "^4.10.7",
+        "hono": "^4.12.27",
         "zod": "^4.1.13",
       },
       "devDependencies": {
@@ -136,7 +136,7 @@
         "@hono/node-server": "^1.19.6",
         "@pome-sh/shared-types": "workspace:*",
         "better-sqlite3": "^12.5.0",
-        "hono": "^4.10.7",
+        "hono": "^4.12.27",
         "zod": "^4.1.13",
       },
       "devDependencies": {
@@ -148,6 +148,9 @@
         "vitest": "^4.0.15",
       },
     },
+  },
+  "overrides": {
+    "hono": "^4.12.27",
   },
   "packages": {
     "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.197", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.197", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.197", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.197", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.197", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.197", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.197", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.197", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.197" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-XNIi8W1tb+QfMkcK+5kepOC6BsxG8wtupd72H+pIPzIJypVQhHy7FoX+KBMtTRYwtl+5dsjKyABhjWXebeUilw=="],
@@ -512,7 +515,7 @@
 
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
-    "hono": ["hono@4.12.18", "", {}, "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ=="],
+    "hono": ["hono@4.12.27", "", {}, "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
   },
   "devDependencies": {
     "bun-types": "^1.3.14"
+  },
+  "overrides": {
+    "hono": "^4.12.27"
   }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@pome-sh/shared-types": "workspace:*",
-    "hono": "^4.10.7",
+    "hono": "^4.12.27",
     "zod": "^4.1.13"
   },
   "peerDependencies": {

--- a/packages/twin-github/Dockerfile
+++ b/packages/twin-github/Dockerfile
@@ -12,11 +12,11 @@ COPY package.json bun.lock ./
 COPY packages packages
 RUN bun install --frozen-lockfile
 RUN bun run --cwd packages/twin-github build
-# The runtime image should not include dev/test tooling from the workspace
-# install (for example Vitest/Vite). Reinstall production deps after the build
-# so the scanned/pushed image contains only runtime packages.
-RUN rm -rf node_modules \
-  && bun install --frozen-lockfile --production
+# The runtime image should not include dev/test tooling or unrelated workspace
+# deps. Reinstall only this twin's production graph after the build, hoisted to
+# the root node_modules layout used by the runtime stage.
+RUN rm -rf node_modules packages/*/node_modules \
+  && bun install --frozen-lockfile --production --omit=peer --filter @pome-sh/twin-github --linker=hoisted
 
 # Runtime is node, not bun: better-sqlite3's native binding is not yet
 # supported under bun (https://github.com/oven-sh/bun/issues/4290), so the

--- a/packages/twin-github/Dockerfile
+++ b/packages/twin-github/Dockerfile
@@ -26,6 +26,9 @@ FROM node:24-trixie-slim@sha256:9022946fb57e6fb6a2503931470deba4b49db02bfc8f587f
 WORKDIR /repo
 ENV NODE_ENV=production
 ENV GITHUB_CLONE_HOST=0.0.0.0
+# Runtime only executes `node`; npm/npx from the base image add unused packages
+# (and their CVE surface) to the scanned image.
+RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 COPY --from=build /repo/node_modules ./node_modules
 COPY --from=build /repo/packages/shared-types ./packages/shared-types
 COPY --from=build /repo/packages/twin-github/package.json ./packages/twin-github/package.json

--- a/packages/twin-github/Dockerfile
+++ b/packages/twin-github/Dockerfile
@@ -12,6 +12,11 @@ COPY package.json bun.lock ./
 COPY packages packages
 RUN bun install --frozen-lockfile
 RUN bun run --cwd packages/twin-github build
+# The runtime image should not include dev/test tooling from the workspace
+# install (for example Vitest/Vite). Reinstall production deps after the build
+# so the scanned/pushed image contains only runtime packages.
+RUN rm -rf node_modules \
+  && bun install --frozen-lockfile --production
 
 # Runtime is node, not bun: better-sqlite3's native binding is not yet
 # supported under bun (https://github.com/oven-sh/bun/issues/4290), so the

--- a/packages/twin-github/package.json
+++ b/packages/twin-github/package.json
@@ -32,7 +32,7 @@
     "@hono/node-server": "^1.19.6",
     "@pome-sh/shared-types": "workspace:*",
     "better-sqlite3": "^12.5.0",
-    "hono": "^4.10.7",
+    "hono": "^4.12.27",
     "zod": "^4.1.13"
   },
   "devDependencies": {

--- a/packages/twin-slack/Dockerfile
+++ b/packages/twin-slack/Dockerfile
@@ -22,6 +22,9 @@ FROM node:24-trixie-slim@sha256:9022946fb57e6fb6a2503931470deba4b49db02bfc8f587f
 WORKDIR /repo
 ENV NODE_ENV=production
 ENV SLACK_CLONE_HOST=0.0.0.0
+# Runtime only executes `node`; npm/npx from the base image add unused packages
+# (and their CVE surface) to the scanned image.
+RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 COPY --from=build /repo/node_modules ./node_modules
 COPY --from=build /repo/packages/shared-types ./packages/shared-types
 COPY --from=build /repo/packages/twin-slack/package.json ./packages/twin-slack/package.json

--- a/packages/twin-slack/Dockerfile
+++ b/packages/twin-slack/Dockerfile
@@ -12,11 +12,11 @@ COPY package.json bun.lock ./
 COPY packages packages
 RUN bun install --frozen-lockfile
 RUN bun run --cwd packages/twin-slack build
-# The runtime image should not include dev/test tooling from the workspace
-# install (for example Vitest/Vite). Reinstall production deps after the build
-# so the scanned/pushed image contains only runtime packages.
-RUN rm -rf node_modules \
-  && bun install --frozen-lockfile --production
+# The runtime image should not include dev/test tooling or unrelated workspace
+# deps. Reinstall only this twin's production graph after the build, hoisted to
+# the root node_modules layout used by the runtime stage.
+RUN rm -rf node_modules packages/*/node_modules \
+  && bun install --frozen-lockfile --production --omit=peer --filter @pome-sh/twin-slack --linker=hoisted
 
 FROM node:24-trixie-slim@sha256:9022946fb57e6fb6a2503931470deba4b49db02bfc8f587f93007fd33ef54415 AS runtime
 WORKDIR /repo

--- a/packages/twin-slack/Dockerfile
+++ b/packages/twin-slack/Dockerfile
@@ -12,6 +12,11 @@ COPY package.json bun.lock ./
 COPY packages packages
 RUN bun install --frozen-lockfile
 RUN bun run --cwd packages/twin-slack build
+# The runtime image should not include dev/test tooling from the workspace
+# install (for example Vitest/Vite). Reinstall production deps after the build
+# so the scanned/pushed image contains only runtime packages.
+RUN rm -rf node_modules \
+  && bun install --frozen-lockfile --production
 
 FROM node:24-trixie-slim@sha256:9022946fb57e6fb6a2503931470deba4b49db02bfc8f587f93007fd33ef54415 AS runtime
 WORKDIR /repo

--- a/packages/twin-slack/package.json
+++ b/packages/twin-slack/package.json
@@ -30,7 +30,7 @@
     "@hono/node-server": "^1.19.6",
     "@pome-sh/shared-types": "workspace:*",
     "better-sqlite3": "^12.5.0",
-    "hono": "^4.10.7",
+    "hono": "^4.12.27",
     "zod": "^4.1.13"
   },
   "devDependencies": {

--- a/packages/twin-stripe/Dockerfile
+++ b/packages/twin-stripe/Dockerfile
@@ -26,6 +26,9 @@ FROM node:24-trixie-slim@sha256:9022946fb57e6fb6a2503931470deba4b49db02bfc8f587f
 WORKDIR /repo
 ENV NODE_ENV=production
 ENV STRIPE_CLONE_HOST=0.0.0.0
+# Runtime only executes `node`; npm/npx from the base image add unused packages
+# (and their CVE surface) to the scanned image.
+RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 COPY --from=build /repo/node_modules ./node_modules
 COPY --from=build /repo/packages/shared-types ./packages/shared-types
 COPY --from=build /repo/packages/twin-stripe/package.json ./packages/twin-stripe/package.json

--- a/packages/twin-stripe/Dockerfile
+++ b/packages/twin-stripe/Dockerfile
@@ -12,11 +12,11 @@ COPY package.json bun.lock ./
 COPY packages packages
 RUN bun install --frozen-lockfile
 RUN bun run --cwd packages/twin-stripe build
-# The runtime image should not include dev/test tooling from the workspace
-# install (for example Vitest/Vite). Reinstall production deps after the build
-# so the scanned/pushed image contains only runtime packages.
-RUN rm -rf node_modules \
-  && bun install --frozen-lockfile --production
+# The runtime image should not include dev/test tooling or unrelated workspace
+# deps. Reinstall only this twin's production graph after the build, hoisted to
+# the root node_modules layout used by the runtime stage.
+RUN rm -rf node_modules packages/*/node_modules \
+  && bun install --frozen-lockfile --production --omit=peer --filter @pome-sh/twin-stripe --linker=hoisted
 
 # Runtime is node, not bun: better-sqlite3's native binding is not yet
 # supported under bun (https://github.com/oven-sh/bun/issues/4290), so the

--- a/packages/twin-stripe/Dockerfile
+++ b/packages/twin-stripe/Dockerfile
@@ -12,6 +12,11 @@ COPY package.json bun.lock ./
 COPY packages packages
 RUN bun install --frozen-lockfile
 RUN bun run --cwd packages/twin-stripe build
+# The runtime image should not include dev/test tooling from the workspace
+# install (for example Vitest/Vite). Reinstall production deps after the build
+# so the scanned/pushed image contains only runtime packages.
+RUN rm -rf node_modules \
+  && bun install --frozen-lockfile --production
 
 # Runtime is node, not bun: better-sqlite3's native binding is not yet
 # supported under bun (https://github.com/oven-sh/bun/issues/4290), so the

--- a/packages/twin-stripe/package.json
+++ b/packages/twin-stripe/package.json
@@ -46,7 +46,7 @@
     "@hono/node-server": "^1.19.6",
     "@pome-sh/shared-types": "workspace:*",
     "better-sqlite3": "^12.5.0",
-    "hono": "^4.10.7",
+    "hono": "^4.12.27",
     "zod": "^4.1.13"
   },
   "devDependencies": {

--- a/scripts/check-cli-version-bump.sh
+++ b/scripts/check-cli-version-bump.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
-# Fails (exit 1) if a PR touches `cli/src/**` without either:
+# Fails (exit 1) if a PR touches `cli/src/**` or `cli/vendor/**` without either:
 #   (a) a new changeset file under `cli/.changeset/*.md` (excluding README), OR
 #   (b) a bump to `cli/package.json` version vs the base branch.
 #
 # Purpose: prevent the failure mode behind PR #93, where behavior changes
 # shipped without a version bump so downstream users couldn't tell via
 # `pome --version` whether their install picked up the new code. See FDRS-396.
+#
+# `cli/vendor/**` is covered because the CLI bundles vendored tarballs
+# (@pome-sh/correlator, @pome-sh/shared-types, and — post-consolidation —
+# the twin packages) via `bundleDependencies`. Re-vendoring a tarball is a
+# behavior change that ships to users, yet touches no file under cli/src/**;
+# without this the gate is silent on twin swaps. See FDRS-593.
 #
 # Usage:
 #   BASE_REF=origin/main scripts/check-cli-version-bump.sh
@@ -22,10 +28,10 @@ if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
   exit 2
 fi
 
-# Was anything in cli/src/ touched?
+# Was anything in cli/src/ or cli/vendor/ touched?
 if ! git diff --name-only --diff-filter=ACMRT "$BASE_REF"...HEAD \
-   | grep -qE '^cli/src/'; then
-  echo "✅ No changes under cli/src/; CLI version-bump gate skipped."
+   | grep -qE '^cli/(src|vendor)/'; then
+  echo "✅ No changes under cli/src/ or cli/vendor/; CLI version-bump gate skipped."
   exit 0
 fi
 
@@ -61,7 +67,7 @@ fi
 cat >&2 <<EOF
 ❌ CLI version-bump gate failed.
 
-This PR touches cli/src/** but neither:
+This PR touches cli/src/** or cli/vendor/** but neither:
   (a) added a changeset file under cli/.changeset/, NOR
   (b) bumped cli/package.json version (still $head_version on both sides).
 

--- a/scripts/check-cli-version-bump.sh
+++ b/scripts/check-cli-version-bump.sh
@@ -28,9 +28,12 @@ if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
   exit 2
 fi
 
-# Was anything in cli/src/ or cli/vendor/ touched?
-if ! git diff --name-only --diff-filter=ACMRT "$BASE_REF"...HEAD \
-   | grep -qE '^cli/(src|vendor)/'; then
+# Was anything in cli/src/ or cli/vendor/ touched? Include deletions (D): dropping
+# a vendored tarball (a bundleDependencies entry) is a shipping behavior change too.
+# Capture to a variable first so that under `set -o pipefail` a grep-closed-pipe
+# SIGPIPE on `git diff` can't be misread as "no changes" and silently skip the gate.
+changed_files="$(git diff --name-only --diff-filter=ACMRTD "$BASE_REF"...HEAD)"
+if ! grep -qE '^cli/(src|vendor)/' <<<"$changed_files"; then
   echo "✅ No changes under cli/src/ or cli/vendor/; CLI version-bump gate skipped."
   exit 0
 fi


### PR DESCRIPTION
Two CI-hardening changes for launch readiness. No application code touched.

## 1. Close the CLI version-bump vendor hole (FDRS-593)
The version-bump gate fired only on `cli/src/**` and ignored `cli/vendor/**`. The CLI bundles vendored tarballs (`@pome-sh/correlator`, `@pome-sh/shared-types`, and — after the twin consolidation — the twin packages) via `bundleDependencies`; swapping one ships a behavior change to users while touching no `cli/src/**` file, so it bypassed the gate.

- Add `cli/vendor/**` to the workflow trigger paths and to the touched-file check.
- Include deletions (`--diff-filter` gains `D`): dropping a vendored `bundleDependencies` entry is a shipping change too.
- Capture the diff to a variable instead of piping into `grep -q`, so a `pipefail` SIGPIPE can't be misread as "no changes."
- Job `name:` kept stable (GitHub matches required checks by name — renaming would silently unbind branch protection).

Verified locally: no-cli-change → skip(0); vendor modify/delete without bump → fail(1); with bump → pass(0).

## 2. Gate twin image publish behind tests + Trivy (FDRS-586)
`twin-{github,slack,stripe}-image.yml` built and pushed rolling GHCR tags on every main push with no test gate and no vulnerability scan.

- Add a `test` job (typecheck + test for the twin package); `publish` now `needs:` it.
- Build+load → **Trivy scan (HIGH,CRITICAL; ignore-unfixed)** before push; push only on non-PR events (fork-safety unchanged). PRs now also run the scan.
- Add a documented `.trivyignore` exception policy.

## Tickets
FDRS-593, FDRS-586. Part of the pome-twins launch-readiness wave-2 execution (PR 1 of 5).