### PR TITLE
feat(capture-server): deny-by-default egress floor (FDRS-635)

### DIFF
--- a/cli/.changeset/fdrs-635-egress-deny-by-default.md
+++ b/cli/.changeset/fdrs-635-egress-deny-by-default.md
@@ -1,0 +1,16 @@
+---
+"pome-sh": minor
+---
+
+**`pome run` now enforces a deny-by-default egress floor at the capture-server (FDRS-635).**
+
+A CONNECT to any non-allowlisted host is refused with 403 before the upstream
+dial — an agent that strays to e.g. `api.github.com` gets
+connection-refused, not a silent passthrough to production. The allowlist is
+twin hosts + LLM provider hosts + loopback; the default provider set mirrors
+the API keys `pome run` already forwards to agents (Anthropic, OpenAI,
+Google Generative AI, OpenRouter, Vercel AI Gateway) plus
+`ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` / `OPENAI_API_BASE` hosts.
+`POME_EGRESS_ALLOW=<host,…>` extends it per-host. Refusals are recorded in a
+new `egress.jsonl` sidecar next to `events.jsonl` and named in the run
+output. Twin and LLM traffic is unaffected; loopback can never be refused.

--- a/cli/src/capture-server/egress.ts
+++ b/cli/src/capture-server/egress.ts
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-635 — deny-by-default egress floor for the capture-server.
+//
+// "Prod-safety is a network control, not a rule" (north-star board block 06):
+// under `pome run` the CONNECT proxy refuses tunnels to any host outside the
+// allowlist — twin hosts + LLM provider hosts + loopback — so an agent that
+// strays to e.g. api.github.com gets connection-refused, not a silent
+// passthrough to production.
+//
+// The default provider set mirrors `DEFAULT_AGENT_ENV_ALLOWLIST` in
+// agentRunner.ts: a provider whose API key the runner forwards by default is
+// a provider the floor lets the agent dial by default. Everything else goes
+// through the paired valves — POME_AGENT_ENV_ALLOWLIST for the key,
+// POME_EGRESS_ALLOW for the host.
+//
+// Known boundary (by design, see FDRS-635): the floor only binds processes
+// that honor proxy env vars. Agents that bypass HTTPS_PROXY are caught by
+// `pome doctor`'s routing probe — the two layers are complementary.
+
+import { readFile } from "node:fs/promises";
+
+// Providers whose keys the runner forwards by default (agentRunner.ts).
+// `*.anthropic.com` (not just api.) keeps the Claude Agent SDK's own
+// telemetry (statsig.anthropic.com) from showing up as refused-egress noise
+// on every default-stack run. Deliberately NOT `*.googleapis.com` — that
+// would open storage.googleapis.com and friends.
+export const DEFAULT_LLM_PROVIDER_HOSTS: readonly string[] = [
+  "*.anthropic.com", // ANTHROPIC_API_KEY
+  "anthropic.com",
+  "api.openai.com", // OPENAI_API_KEY
+  "generativelanguage.googleapis.com", // GOOGLE_API_KEY / GOOGLE_GENERATIVE_AI_API_KEY
+  "openrouter.ai", // OPENROUTER_API_KEY
+  "ai-gateway.vercel.sh", // AI_GATEWAY_API_KEY
+];
+
+// Custom LLM endpoints: when the runner's environment points a provider SDK
+// at a non-default base URL, that host joins the allowlist.
+const BASE_URL_ENV_VARS = ["ANTHROPIC_BASE_URL", "OPENAI_BASE_URL", "OPENAI_API_BASE"] as const;
+
+export interface BlockedEgress {
+  host: string;
+  port: number;
+  count: number;
+}
+
+// Sidecar row written by the capture-server for every refused CONNECT. Lives
+// in egress.jsonl, deliberately NOT events.jsonl — the events row shape is
+// locked by shared-types and consumed by the correlator, and the refusal is
+// runner-facing diagnostics, not trace data.
+export interface EgressRefusedRow {
+  ts: string;
+  kind: "EgressRefusedEvent";
+  host: string;
+  port: number;
+}
+
+function normalizeHost(host: string): string {
+  let value = host.trim().toLowerCase();
+  if (value.endsWith(".")) value = value.slice(0, -1);
+  if (value.startsWith("[") && value.endsWith("]")) value = value.slice(1, -1);
+  return value;
+}
+
+function isLoopback(host: string): boolean {
+  if (host === "localhost" || host.endsWith(".localhost")) return true;
+  if (host === "::1" || host === "0:0:0:0:0:0:0:1") return true;
+  // 127.0.0.0/8 — the whole loopback block, not just 127.0.0.1.
+  return /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host);
+}
+
+// `patterns` entries: exact hostname, `*.suffix` (any-depth subdomain, not
+// the apex), or bare `*` (allow everything — floor off). Ports never take
+// part in matching: the floor is a host-level control.
+export function isHostAllowed(host: string, patterns: readonly string[]): boolean {
+  const candidate = normalizeHost(host);
+  if (candidate.length === 0) return false;
+  if (isLoopback(candidate)) return true;
+
+  for (const raw of patterns) {
+    const pattern = normalizeHost(raw);
+    if (pattern.length === 0) continue;
+    if (pattern === "*") return true;
+    if (pattern.startsWith("*.")) {
+      if (candidate.endsWith(pattern.slice(1))) return true;
+      continue;
+    }
+    if (candidate === pattern) return true;
+  }
+  return false;
+}
+
+export function parseAllowCsv(csv: string | undefined): string[] {
+  return (csv ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+// Compute the allowlist for one run: default LLM providers + custom LLM
+// base-URL hosts + the POME_EGRESS_ALLOW valve + the twin URLs the runner is
+// about to inject (loopback in self-host; hosted twin domains future-proof).
+export function buildEgressAllowlist(
+  env: Record<string, string | undefined>,
+  opts: { twinUrls?: readonly string[] } = {},
+): string[] {
+  const patterns = [...DEFAULT_LLM_PROVIDER_HOSTS];
+
+  for (const key of BASE_URL_ENV_VARS) {
+    const value = env[key]?.trim();
+    if (!value) continue;
+    try {
+      patterns.push(new URL(value).hostname);
+    } catch {
+      // Malformed base URL — the provider SDK will fail on it anyway; the
+      // floor doesn't need to.
+    }
+  }
+
+  patterns.push(...parseAllowCsv(env.POME_EGRESS_ALLOW));
+
+  for (const url of opts.twinUrls ?? []) {
+    try {
+      patterns.push(new URL(url).hostname);
+    } catch {
+      // ignore malformed twin URLs
+    }
+  }
+
+  return [...new Set(patterns.map(normalizeHost).filter((p) => p.length > 0))];
+}
+
+// Read the egress sidecar and aggregate refusals per host:port, most-hit
+// first. Tolerates a missing file (no refusals — the common case) and junk
+// lines (partial writes on a crashed run).
+export async function readBlockedEgress(path: string): Promise<BlockedEgress[]> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch {
+    return [];
+  }
+
+  const counts = new Map<string, BlockedEgress>();
+  for (const line of raw.split("\n")) {
+    if (line.trim().length === 0) continue;
+    let row: unknown;
+    try {
+      row = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (typeof row !== "object" || row === null) continue;
+    const { kind, host, port } = row as Partial<EgressRefusedRow>;
+    if (kind !== "EgressRefusedEvent" || typeof host !== "string" || typeof port !== "number") {
+      continue;
+    }
+    const key = `${host}:${port}`;
+    const existing = counts.get(key);
+    if (existing) existing.count += 1;
+    else counts.set(key, { host, port, count: 1 });
+  }
+
+  return [...counts.values()].sort((a, b) => b.count - a.count);
+}

--- a/cli/src/capture-server/index.ts
+++ b/cli/src/capture-server/index.ts
@@ -17,10 +17,22 @@ import { createServer as createHttpServer, type Server, type IncomingMessage } f
 import { connect as netConnect, type Socket } from "node:net";
 import { dirname } from "node:path";
 import { redactEvent } from "../recorder/redaction.js";
+import { isHostAllowed, type EgressRefusedRow } from "./egress.js";
 
 export interface CaptureServerOptions {
   port: number; // 0 = ephemeral
   eventsOut: string;
+  // FDRS-635 — deny-by-default egress floor. CONNECTs to hosts outside this
+  // allowlist (patterns: exact host, `*.suffix`, or bare `*`) are refused
+  // with 403 before any upstream dial. Loopback is always allowed so twin
+  // traffic can never be broken by a bad allowlist. Omitting the option means
+  // "no extra hosts": loopback-only — the floor is the default, not opt-in.
+  allowHosts?: readonly string[];
+  // Where refused CONNECTs are recorded (JSONL, one EgressRefusedRow per
+  // refusal). A sidecar next to events.jsonl — deliberately NOT events.jsonl,
+  // whose row shape is locked by shared-types / the correlator. Optional: the
+  // floor enforces regardless; without it refusals just aren't persisted.
+  egressOut?: string;
 }
 
 export interface CaptureServerHandle {
@@ -66,6 +78,12 @@ export async function runCaptureServer(
 ): Promise<CaptureServerHandle> {
   await mkdir(dirname(options.eventsOut), { recursive: true });
   const writer = createWriteStream(options.eventsOut, { flags: "a" });
+  const allowHosts = options.allowHosts ?? [];
+  let egressWriter: WriteStream | null = null;
+  if (options.egressOut) {
+    await mkdir(dirname(options.egressOut), { recursive: true });
+    egressWriter = createWriteStream(options.egressOut, { flags: "a" });
+  }
 
   const pendingWrites = new Set<Promise<void>>();
   const liveSockets = new Set<Socket>();
@@ -80,7 +98,7 @@ export async function runCaptureServer(
   });
 
   server.on("connect", (req: IncomingMessage, clientSocket: Socket, head: Buffer) => {
-    handleConnect({ req, clientSocket, head, writer, liveSockets, pendingWrites });
+    handleConnect({ req, clientSocket, head, writer, egressWriter, allowHosts, liveSockets, pendingWrites });
   });
 
   await new Promise<void>((resolve, reject) => {
@@ -113,6 +131,10 @@ export async function runCaptureServer(
     await serverClosed;
     await flush();
     await new Promise<void>((resolve) => writer.end(() => resolve()));
+    if (egressWriter) {
+      const ew = egressWriter;
+      await new Promise<void>((resolve) => ew.end(() => resolve()));
+    }
   };
 
   return { port, flush, close };
@@ -123,6 +145,8 @@ interface ConnectArgs {
   clientSocket: Socket;
   head: Buffer;
   writer: WriteStream;
+  egressWriter: WriteStream | null;
+  allowHosts: readonly string[];
   liveSockets: Set<Socket>;
   pendingWrites: Set<Promise<void>>;
 }
@@ -132,6 +156,8 @@ function handleConnect({
   clientSocket,
   head,
   writer,
+  egressWriter,
+  allowHosts,
   liveSockets,
   pendingWrites,
 }: ConnectArgs): void {
@@ -141,6 +167,31 @@ function handleConnect({
     return;
   }
   const { host, port } = target;
+
+  // FDRS-635 — the egress floor: refuse the tunnel BEFORE dialing upstream.
+  // The refusal is recorded in the egress sidecar so `pome run` can name the
+  // blocked host in its output.
+  if (!isHostAllowed(host, allowHosts)) {
+    if (egressWriter) {
+      const row: EgressRefusedRow = {
+        ts: new Date().toISOString(),
+        kind: "EgressRefusedEvent",
+        host,
+        port,
+      };
+      const ew = egressWriter;
+      const write = new Promise<void>((resolve) => {
+        ew.write(JSON.stringify(row) + "\n", () => resolve());
+      });
+      pendingWrites.add(write);
+      void write.finally(() => pendingWrites.delete(write));
+    }
+    clientSocket.end(
+      "HTTP/1.1 403 Forbidden\r\ncontent-type: text/plain\r\nconnection: close\r\n\r\n" +
+        `pome egress floor: CONNECT to ${host}:${port} refused — not on the allowlist (twin hosts + LLM providers + localhost). Extend with POME_EGRESS_ALLOW=<host,...> if this host is intentional.\r\n`,
+    );
+    return;
+  }
 
   // Pause until upstream is ready. Without pausing, the client might send
   // payload bytes between now and the upstream connect, and they'd be dropped

--- a/cli/src/capture-server/run.ts
+++ b/cli/src/capture-server/run.ts
@@ -9,16 +9,25 @@ import { runCaptureServer } from "./index.js";
 export interface RunCaptureServerCommandOptions {
   port: number;
   eventsOut: string;
+  // FDRS-635 — egress-floor allowlist patterns (already parsed from CSV) and
+  // the sidecar path for refused-CONNECT rows.
+  allowHosts?: readonly string[];
+  egressOut?: string;
 }
 
 export async function runCaptureServerCommand(
   options: RunCaptureServerCommandOptions,
 ): Promise<void> {
   const eventsOut = resolve(options.eventsOut);
-  const handle = await runCaptureServer({ port: options.port, eventsOut });
+  const egressOut = options.egressOut ? resolve(options.egressOut) : undefined;
+  const allowHosts = options.allowHosts ?? [];
+  const handle = await runCaptureServer({ port: options.port, eventsOut, allowHosts, egressOut });
 
   console.error(
     `pome capture-server listening on 127.0.0.1:${handle.port} (events → ${eventsOut})`,
+  );
+  console.error(
+    `pome capture-server egress floor: deny-by-default (${allowHosts.length} allowlisted pattern(s) + loopback)`,
   );
 
   let shuttingDown = false;

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -711,6 +711,20 @@ export function createProgram() {
               console.error(`  ${runScoreLine(result.score, result.scenario.config.passThreshold, "numeric score")}`);
               console.error(`  run: ${result.artifacts.runDir}`);
             }
+            // FDRS-635 — name every host the egress floor refused, so a stray
+            // production call is a visible event, never a silent passthrough.
+            if (result.blockedEgress.length > 0) {
+              const refusals = result.blockedEgress.reduce((n, b) => n + b.count, 0);
+              const named = result.blockedEgress
+                .map((b) => `${b.host}:${b.port}${b.count > 1 ? ` ×${b.count}` : ""}`)
+                .join(", ");
+              console.error(
+                `  egress: refused ${refusals} tunnel(s) to non-allowlisted host(s) — ${named}`,
+              );
+              console.error(
+                "          twin + LLM traffic is unaffected; extend with POME_EGRESS_ALLOW=<host,…> if intentional.",
+              );
+            }
             if (result.exitCode !== 0) worstExit = result.exitCode;
           }
         }
@@ -979,7 +993,15 @@ export function createProgram() {
       "--events-out <path>",
       "Path to events.jsonl. Created if missing; appended to otherwise.",
     )
-    .action(async (opts: { port: string; eventsOut?: string }) => {
+    .option(
+      "--allow <hosts>",
+      "FDRS-635: comma-separated egress allowlist patterns (exact host or *.suffix). The floor is deny-by-default: only these hosts + loopback are tunnelled; everything else gets 403.",
+    )
+    .option(
+      "--egress-out <path>",
+      "Path to egress.jsonl, the sidecar recording refused CONNECTs. Optional; the floor enforces regardless.",
+    )
+    .action(async (opts: { port: string; eventsOut?: string; allow?: string; egressOut?: string }) => {
       if (!opts.eventsOut) {
         console.error("pome capture-server: --events-out <path> is required");
         process.exitCode = 2;
@@ -992,7 +1014,13 @@ export function createProgram() {
         return;
       }
       const { runCaptureServerCommand } = await import("../capture-server/run.js");
-      await runCaptureServerCommand({ port, eventsOut: opts.eventsOut });
+      const { parseAllowCsv } = await import("../capture-server/egress.js");
+      await runCaptureServerCommand({
+        port,
+        eventsOut: opts.eventsOut,
+        allowHosts: parseAllowCsv(opts.allow),
+        egressOut: opts.egressOut,
+      });
     });
 
   program

--- a/cli/src/runner/captureServerChild.ts
+++ b/cli/src/runner/captureServerChild.ts
@@ -19,10 +19,16 @@ import { spawn, type ChildProcess } from "node:child_process";
 export interface SpawnCaptureServerChildOptions {
   // Absolute path to events.jsonl. Passed verbatim to `--events-out`.
   eventsOut: string;
+  // FDRS-635 — egress-floor allowlist patterns, passed as `--allow` (CSV).
+  // Omitted/empty means loopback-only: the floor is deny-by-default.
+  allowHosts?: readonly string[];
+  // FDRS-635 — sidecar path for refused-CONNECT rows, passed as `--egress-out`.
+  egressOut?: string;
   // Override for tests. Defaults to process.execPath.
   execPath?: string;
   // Override for tests. When omitted we re-invoke this binary
-  // (process.argv[1]) with `capture-server --port 0 --events-out <path>`.
+  // (process.argv[1]) with `capture-server --port 0 --events-out <path>`
+  // plus the egress flags above.
   binArgs?: string[];
   // Max time to wait for the listening line before rejecting. Default 5s.
   readyTimeoutMs?: number;
@@ -45,7 +51,7 @@ export async function spawnCaptureServerChild(
   const execPath = options.execPath ?? process.execPath;
   const binArgs =
     options.binArgs ??
-    defaultBinArgs(options.eventsOut);
+    defaultBinArgs(options.eventsOut, options.allowHosts, options.egressOut);
   const readyTimeoutMs = options.readyTimeoutMs ?? 5_000;
   const shutdownGraceMs = options.shutdownGraceMs ?? 5_000;
 
@@ -125,7 +131,11 @@ export async function spawnCaptureServerChild(
   };
 }
 
-function defaultBinArgs(eventsOut: string): string[] {
+function defaultBinArgs(
+  eventsOut: string,
+  allowHosts?: readonly string[],
+  egressOut?: string,
+): string[] {
   // process.argv[1] is the script path we were invoked with. Re-invoking it
   // gives us the same binary (and the same code) without depending on PATH
   // having a `pome` shim — important when running from the dev tree
@@ -136,7 +146,19 @@ function defaultBinArgs(eventsOut: string): string[] {
       "Cannot determine pome binary path (process.argv[1] is empty). Pass `binArgs` explicitly.",
     );
   }
-  return [script, "capture-server", "--port", "0", "--events-out", eventsOut];
+  return [script, "capture-server", "--port", "0", "--events-out", eventsOut, ...egressArgs(allowHosts, egressOut)];
+}
+
+// Shared by defaultBinArgs and runScenario's test-override path so the two
+// spawn shapes can't drift.
+export function egressArgs(
+  allowHosts?: readonly string[],
+  egressOut?: string,
+): string[] {
+  const args: string[] = [];
+  if (allowHosts && allowHosts.length > 0) args.push("--allow", allowHosts.join(","));
+  if (egressOut) args.push("--egress-out", egressOut);
+  return args;
 }
 
 function makeShutdown(

--- a/cli/src/runner/runScenario.ts
+++ b/cli/src/runner/runScenario.ts
@@ -8,7 +8,8 @@ import { parseScenarioFile } from "../scenario/parseScenario.js";
 import { bootTwin } from "../twin/twinHarness.js";
 import { getAvailablePort } from "./ports.js";
 import { runAgentCommand } from "./agentRunner.js";
-import { spawnCaptureServerChild } from "./captureServerChild.js";
+import { egressArgs, spawnCaptureServerChild } from "./captureServerChild.js";
+import { buildEgressAllowlist, readBlockedEgress, type BlockedEgress } from "../capture-server/egress.js";
 import { mergeAdapterSignalsIntoEvents } from "./mergeAdapterSignals.js";
 import { scoreAndWriteRun, writeRunNoScore } from "./runScenarioCore.js";
 
@@ -75,10 +76,20 @@ export async function runScenario(options: RunScenarioOptions) {
   // The agent inherits HTTP_PROXY/HTTPS_PROXY pointing at this child;
   // NO_PROXY keeps twin traffic out of the proxy so it isn't double-counted
   // as LlmCallEvent. FDRS-405: `noCapture` skips spawn + env injection.
+  //
+  // FDRS-635: the child enforces the deny-by-default egress floor. The
+  // allowlist is LLM providers + custom base-URL hosts + POME_EGRESS_ALLOW;
+  // the self-host twin lives on loopback, which the floor always allows.
+  // Refused CONNECTs land in the egress sidecar, read back after the run so
+  // the CLI can name the blocked hosts.
+  const egressAllowHosts = buildEgressAllowlist(process.env);
+  const egressJsonlPath = join(runDir, "egress.jsonl");
   const captureServer = options.noCapture
     ? null
     : await spawnCaptureServerChild({
         eventsOut: resolvePath(eventsJsonlPath),
+        allowHosts: egressAllowHosts,
+        egressOut: resolvePath(egressJsonlPath),
         execPath: options.captureServerCommand?.execPath,
         binArgs: options.captureServerCommand
           ? [
@@ -88,10 +99,20 @@ export async function runScenario(options: RunScenarioOptions) {
               "0",
               "--events-out",
               resolvePath(eventsJsonlPath),
+              ...egressArgs(egressAllowHosts, resolvePath(egressJsonlPath)),
             ]
           : undefined,
       });
   if (captureServer) options.onCaptureServerSpawned?.(captureServer.pid);
+
+  // Drain the capture-server (flushing any in-flight egress rows), then read
+  // back the refusals. Idempotent shutdown — the finally block's call is a
+  // no-op afterwards.
+  const collectBlockedEgress = async (): Promise<BlockedEgress[]> => {
+    if (!captureServer) return [];
+    await captureServer.shutdown();
+    return readBlockedEgress(egressJsonlPath);
+  };
 
   const twinName = scenario.config.twins[0] ?? "github";
   const port = await getAvailablePort();
@@ -185,7 +206,8 @@ export async function runScenario(options: RunScenarioOptions) {
       // exitCode would already be 3 here because preflight.exitCode !== 0, but be
       // explicit for clarity.
       void exitCode;
-      return { scenario, runId, artifacts, score, agent: preflight, exitCode: 3 };
+      const blockedEgress = await collectBlockedEgress();
+      return { scenario, runId, artifacts, score, agent: preflight, exitCode: 3, blockedEgress };
     }
 
     const agent = await runAgentCommand({
@@ -209,7 +231,8 @@ export async function runScenario(options: RunScenarioOptions) {
       stateFinal
     });
     await mergeAdapterSignalsIntoEvents(signalsPath, eventsJsonlPath);
-    return { scenario, runId, artifacts, score, agent, exitCode };
+    const blockedEgress = await collectBlockedEgress();
+    return { scenario, runId, artifacts, score, agent, exitCode, blockedEgress };
   } finally {
     // Drain capture-server first so any in-flight LlmCallEvent rows land
     // in events.jsonl before we move on; THEN close the twin (which would

--- a/cli/test/e2e/runScenarioEgress.test.ts
+++ b/cli/test/e2e/runScenarioEgress.test.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-635 — E2E test that `pome run` (via `runScenario`) enforces the
+// deny-by-default egress floor end-to-end: the agent's CONNECT to a
+// non-allowlisted host is refused with 403 (asserted inside the fixture),
+// loopback tunnels still work, twin traffic is unaffected, and the refused
+// host is surfaced on the run result so the CLI can name it in the output.
+
+import { mkdtemp } from "node:fs/promises";
+import { createServer as createNetServer, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { runScenario } from "../../src/runner/runScenario.js";
+
+function listenEphemeral(server: ReturnType<typeof createNetServer>): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (typeof addr === "object" && addr) resolve(addr.port);
+      else reject(new Error("ephemeral listen returned no address"));
+    });
+  });
+}
+
+function appendAllowlist(existing: string | undefined, names: string[]): string {
+  const values = new Set((existing ?? "").split(",").map((entry) => entry.trim()).filter(Boolean));
+  for (const name of names) values.add(name);
+  return [...values].join(",");
+}
+
+describe("runScenario — egress floor wiring (FDRS-635)", () => {
+  let echoPort = 0;
+  let echoCloser: (() => Promise<void>) | null = null;
+
+  beforeAll(async () => {
+    const sockets = new Set<Socket>();
+    const server = createNetServer((socket) => {
+      sockets.add(socket);
+      socket.on("data", (chunk) => socket.write(chunk));
+      socket.once("close", () => sockets.delete(socket));
+    });
+    echoPort = await listenEphemeral(server);
+    echoCloser = () =>
+      new Promise<void>((resolve) => {
+        for (const s of sockets) s.destroy();
+        server.close(() => resolve());
+      });
+  });
+
+  afterAll(async () => {
+    if (echoCloser) await echoCloser();
+  });
+
+  it("refuses the stray host, keeps loopback traffic, and names the refusal on the result", async () => {
+    const artifactsDir = await mkdtemp(join(tmpdir(), "pome-runs-"));
+    const probePath = new URL("../fixtures/agents/egress-probe-agent.ts", import.meta.url).pathname;
+
+    const previousAllowlist = process.env.POME_AGENT_ENV_ALLOWLIST;
+    process.env.POME_EGRESS_TEST_BLOCKED = "api.github.com:443";
+    process.env.POME_CAPTURE_TEST_TARGET = `127.0.0.1:${echoPort}`;
+    process.env.POME_AGENT_ENV_ALLOWLIST = appendAllowlist(previousAllowlist, [
+      "POME_EGRESS_TEST_BLOCKED",
+      "POME_CAPTURE_TEST_TARGET",
+    ]);
+
+    try {
+      const result = await runScenario({
+        scenarioPath: "scenarios/01-bug-happy-path.md",
+        agentCommand: `bun ${probePath}`,
+        artifactsDir,
+        captureServerCommand: {
+          execPath: "bun",
+          prefixArgs: ["src/cli/main.ts"],
+        },
+      });
+
+      // The fixture exits non-zero if the blocked CONNECT was NOT refused
+      // with 403 — so a passing run already proves the refusal happened.
+      expect(result.exitCode).toBe(0);
+
+      expect(result.blockedEgress).toEqual([
+        { host: "api.github.com", port: 443, count: 1 },
+      ]);
+    } finally {
+      delete process.env.POME_EGRESS_TEST_BLOCKED;
+      delete process.env.POME_CAPTURE_TEST_TARGET;
+      if (previousAllowlist === undefined) delete process.env.POME_AGENT_ENV_ALLOWLIST;
+      else process.env.POME_AGENT_ENV_ALLOWLIST = previousAllowlist;
+    }
+  }, 60_000);
+});

--- a/cli/test/fixtures/agents/egress-probe-agent.ts
+++ b/cli/test/fixtures/agents/egress-probe-agent.ts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-635 test fixture: same scripted triage work as capture-probe-agent.ts,
+// then two raw CONNECTs through the runner-injected HTTPS_PROXY:
+//   1. POME_EGRESS_TEST_BLOCKED ("host:port") — MUST be refused with 403 by
+//      the egress floor. A 200 here means the proxy silently passed a
+//      non-allowlisted host through to "production", which is exactly the
+//      failure FDRS-635 exists to prevent — so the fixture exits non-zero.
+//   2. POME_CAPTURE_TEST_TARGET ("host:port", a loopback echo) — MUST still
+//      tunnel (200): loopback/twin-adjacent traffic is unaffected.
+
+import { createConnection } from "node:net";
+import { URL } from "node:url";
+
+type GitHubIssue = {
+  number: number;
+  title: string;
+  body: string;
+  labels: Array<{ name: string }>;
+  assignee: { login: string } | null;
+};
+
+if (process.env.POME_PREFLIGHT === "1") {
+  console.log("preflight ok");
+  process.exit(0);
+}
+
+const task = requiredEnv("POME_TASK");
+const baseUrl = requiredEnv("POME_GITHUB_REST_URL");
+const authToken = process.env.POME_AUTH_TOKEN;
+const issueNumber = Number(task.match(/#(\d+)/)?.[1] ?? "1");
+const repo = (task.match(/in\s+([a-z0-9_.-]+\/[a-z0-9_.-]+)/i)?.[1] ?? "acme/api").replace(/[.,]+$/, "");
+const [owner, name] = repo.split("/") as [string, string];
+
+async function main() {
+  const issue = await github<GitHubIssue>(`/repos/${owner}/${name}/issues/${issueNumber}`);
+  const existing = issue.labels.find((l) => ["bug", "feature", "question"].includes(l.name));
+  if (!existing) {
+    const label = classify(issue);
+    await github(`/repos/${owner}/${name}/issues/${issueNumber}/labels`, {
+      method: "POST",
+      body: { labels: [label] },
+    });
+    await github(`/repos/${owner}/${name}/issues/${issueNumber}/assignees`, {
+      method: "POST",
+      body: { assignees: ["alice"] },
+    });
+  }
+
+  const blockedStatus = await connectStatus(requiredEnv("POME_EGRESS_TEST_BLOCKED"));
+  if (blockedStatus !== "403") {
+    throw new Error(
+      `expected the egress floor to refuse the blocked target with 403, got ${blockedStatus}`,
+    );
+  }
+
+  const allowedStatus = await connectStatus(requiredEnv("POME_CAPTURE_TEST_TARGET"));
+  if (allowedStatus !== "200") {
+    throw new Error(`expected the loopback tunnel to stay open (200), got ${allowedStatus}`);
+  }
+
+  console.log(JSON.stringify({ task, summary: "egress fixture done" }));
+}
+
+// Open one CONNECT through the proxy and return the response status code.
+// For a 200, write one probe payload then close.
+function connectStatus(target: string): Promise<string> {
+  const proxyUrl = requiredEnv("HTTPS_PROXY");
+  const url = new URL(proxyUrl);
+
+  return new Promise((resolve, reject) => {
+    const sock = createConnection({ host: url.hostname, port: Number(url.port) });
+    let buf = "";
+    let done = false;
+    sock.on("error", reject);
+    sock.on("data", (chunk: Buffer) => {
+      if (done) return;
+      buf += chunk.toString("utf8");
+      const match = /^HTTP\/1\.[01] (\d{3})/.exec(buf);
+      if (!match) return;
+      done = true;
+      const status = match[1]!;
+      if (status === "200") {
+        sock.write("probe");
+        setTimeout(() => sock.end(), 50);
+      } else {
+        sock.end();
+      }
+      resolve(status);
+    });
+    sock.write(`CONNECT ${target} HTTP/1.1\r\nHost: ${target}\r\n\r\n`);
+  });
+}
+
+function classify(issue: GitHubIssue): string {
+  const text = `${issue.title}\n${issue.body}`.toLowerCase();
+  if (text.includes("500") || text.includes("error") || text.includes("null") || text.includes("failing")) return "bug";
+  if (text.includes("add") || text.includes("export") || text.includes("feature")) return "feature";
+  return "question";
+}
+
+async function github<T = unknown>(path: string, options: { method?: string; body?: unknown } = {}): Promise<T> {
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: options.method ?? "GET",
+    headers: authToken
+      ? { Authorization: `Bearer ${authToken}`, ...(options.body ? { "content-type": "application/json" } : {}) }
+      : options.body
+        ? { "content-type": "application/json" }
+        : {},
+    body: options.body ? JSON.stringify(options.body) : undefined,
+  });
+  if (!res.ok) {
+    throw new Error(`${options.method ?? "GET"} ${path} failed: ${res.status} ${await res.text()}`);
+  }
+  return (await res.json()) as T;
+}
+
+function requiredEnv(n: string): string {
+  const v = process.env[n]?.trim();
+  if (!v) throw new Error(`${n} is required`);
+  return v;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/cli/test/integration/capture-server-egress.test.ts
+++ b/cli/test/integration/capture-server-egress.test.ts
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-635 — integration tests for the capture-server's deny-by-default
+// egress floor.
+//
+// The proxy refuses CONNECT tunnels to hosts outside the allowlist with a
+// 403 BEFORE dialing upstream, and records each refusal in the egress
+// sidecar (egress.jsonl — deliberately NOT events.jsonl, whose row shape is
+// locked by shared-types / the correlator). Loopback targets are always
+// allowed so twin traffic can never be broken by a bad allowlist.
+//
+// The "allowed but unresolvable" case asserts the ordering: an allowlisted
+// host fails with 502 (upstream dial attempted, `.invalid` never resolves —
+// RFC 6761), a denied host fails with 403 (never dialed). Distinct status
+// codes prove the gate fires before the dial.
+
+import { mkdtemp, readFile } from "node:fs/promises";
+import { createServer as createNetServer, createConnection, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  runCaptureServer,
+  type CaptureServerHandle,
+} from "../../src/capture-server/index.js";
+
+function listenEphemeral(server: ReturnType<typeof createNetServer>): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (typeof addr === "object" && addr) resolve(addr.port);
+      else reject(new Error("ephemeral listen returned no address"));
+    });
+  });
+}
+
+async function startUpstream(): Promise<{
+  port: number;
+  connections: () => number;
+  close: () => Promise<void>;
+}> {
+  const sockets = new Set<Socket>();
+  let connections = 0;
+  const server = createNetServer((socket) => {
+    connections += 1;
+    sockets.add(socket);
+    socket.on("data", (chunk) => {
+      socket.write(chunk);
+    });
+    socket.once("close", () => sockets.delete(socket));
+  });
+  const port = await listenEphemeral(server);
+  return {
+    port,
+    connections: () => connections,
+    close: () =>
+      new Promise<void>((resolve) => {
+        for (const s of sockets) s.destroy();
+        server.close(() => resolve());
+      }),
+  };
+}
+
+// Retry `fn` until it returns non-null or ~2s elapse.
+async function pollFor<T>(fn: () => Promise<T | null>): Promise<T> {
+  for (let i = 0; i < 40; i++) {
+    const value = await fn();
+    if (value !== null) return value;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error("condition not reached within 2s");
+}
+
+// Send one CONNECT and resolve with the response status line (e.g. "200",
+// "403", "502"). For a 200, immediately close the tunnel.
+function connectStatus(
+  proxyPort: number,
+  targetHost: string,
+  targetPort: number,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const sock = createConnection({ host: "127.0.0.1", port: proxyPort });
+    let header = "";
+    let done = false;
+    sock.on("error", reject);
+    sock.on("data", (chunk: Buffer) => {
+      if (done) return;
+      header += chunk.toString("utf8");
+      const match = /^HTTP\/1\.[01] (\d{3})/.exec(header);
+      if (!match) return;
+      done = true;
+      const status = match[1]!;
+      sock.end();
+      resolve(status);
+    });
+    sock.on("close", () => {
+      if (!done) reject(new Error(`socket closed before a status line: ${header.slice(0, 120)}`));
+    });
+    sock.write(
+      `CONNECT ${targetHost}:${targetPort} HTTP/1.1\r\nHost: ${targetHost}:${targetPort}\r\n\r\n`,
+    );
+  });
+}
+
+describe("pome capture-server — egress floor (FDRS-635)", () => {
+  let capture: CaptureServerHandle | null = null;
+  let upstream: Awaited<ReturnType<typeof startUpstream>> | null = null;
+
+  beforeEach(async () => {
+    upstream = await startUpstream();
+  });
+
+  afterEach(async () => {
+    if (capture) await capture.close();
+    capture = null;
+    if (upstream) await upstream.close();
+    upstream = null;
+  });
+
+  it("refuses a CONNECT to a non-allowlisted host with 403 and records it in egress.jsonl", async () => {
+    const runDir = await mkdtemp(join(tmpdir(), "pome-egress-int-"));
+    const eventsOut = join(runDir, "events.jsonl");
+    const egressOut = join(runDir, "egress.jsonl");
+    capture = await runCaptureServer({ port: 0, eventsOut, allowHosts: [], egressOut });
+
+    const status = await connectStatus(capture.port, "blocked.example", 443);
+    expect(status).toBe("403");
+
+    await capture.flush();
+
+    // The refusal is a sidecar row, not an LlmCallEvent.
+    const egressRows = (await readFile(egressOut, "utf8"))
+      .split("\n")
+      .filter((l) => l.length > 0)
+      .map((l) => JSON.parse(l) as { kind: string; host: string; port: number });
+    expect(egressRows).toHaveLength(1);
+    expect(egressRows[0]).toMatchObject({
+      kind: "EgressRefusedEvent",
+      host: "blocked.example",
+      port: 443,
+    });
+
+    const events = (await readFile(eventsOut, "utf8")).trim();
+    expect(events).toBe("");
+  });
+
+  it("still tunnels loopback targets with an empty allowlist (twin traffic can never break)", async () => {
+    const runDir = await mkdtemp(join(tmpdir(), "pome-egress-int-"));
+    const eventsOut = join(runDir, "events.jsonl");
+    const egressOut = join(runDir, "egress.jsonl");
+    capture = await runCaptureServer({ port: 0, eventsOut, allowHosts: [], egressOut });
+
+    const status = await connectStatus(capture.port, "127.0.0.1", upstream!.port);
+    expect(status).toBe("200");
+
+    // The LlmCallEvent lands when the server-side sockets close — that
+    // trails the client's close by an event-loop turn or two, so poll.
+    const lines = await pollFor(async () => {
+      await capture!.flush();
+      const content = (await readFile(eventsOut, "utf8")).trim().split("\n").filter(Boolean);
+      return content.length >= 1 ? content : null;
+    });
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]!).kind).toBe("LlmCallEvent");
+  });
+
+  it("lets an allowlisted host through the gate (dial attempted → 502 on NXDOMAIN, never 403)", async () => {
+    const runDir = await mkdtemp(join(tmpdir(), "pome-egress-int-"));
+    capture = await runCaptureServer({
+      port: 0,
+      eventsOut: join(runDir, "events.jsonl"),
+      allowHosts: ["api.allowed.invalid"],
+      egressOut: join(runDir, "egress.jsonl"),
+    });
+
+    const status = await connectStatus(capture.port, "api.allowed.invalid", 443);
+    expect(status).toBe("502");
+  });
+
+  it("never dials upstream for a refused host", async () => {
+    const runDir = await mkdtemp(join(tmpdir(), "pome-egress-int-"));
+    capture = await runCaptureServer({
+      port: 0,
+      eventsOut: join(runDir, "events.jsonl"),
+      allowHosts: [],
+      egressOut: join(runDir, "egress.jsonl"),
+    });
+
+    // Target the live upstream's port but under a denied hostname: if the
+    // gate leaked, the dial would succeed and the upstream would see a
+    // connection.
+    const before = upstream!.connections();
+    const status = await connectStatus(capture.port, "denied.example", upstream!.port);
+    expect(status).toBe("403");
+    expect(upstream!.connections()).toBe(before);
+  });
+
+  it("enforces the floor even without an egress sidecar configured", async () => {
+    const runDir = await mkdtemp(join(tmpdir(), "pome-egress-int-"));
+    capture = await runCaptureServer({
+      port: 0,
+      eventsOut: join(runDir, "events.jsonl"),
+      allowHosts: [],
+    });
+
+    const status = await connectStatus(capture.port, "blocked.example", 443);
+    expect(status).toBe("403");
+  });
+});

--- a/cli/test/unit/capture-server-egress.test.ts
+++ b/cli/test/unit/capture-server-egress.test.ts
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-635 — unit tests for the egress floor's allowlist semantics.
+//
+// The floor is deny-by-default: only twin hosts + LLM provider hosts +
+// loopback may be CONNECTed to. The default provider set deliberately
+// mirrors `DEFAULT_AGENT_ENV_ALLOWLIST` in agentRunner.ts — a provider the
+// runner hands an API key for by default is a provider the floor lets the
+// agent dial by default. Everything else goes through the paired valves:
+// POME_AGENT_ENV_ALLOWLIST (key) + POME_EGRESS_ALLOW (host).
+
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  buildEgressAllowlist,
+  isHostAllowed,
+  parseAllowCsv,
+  readBlockedEgress,
+} from "../../src/capture-server/egress.js";
+
+describe("isHostAllowed", () => {
+  it("always allows the loopback family, even with an empty allowlist", () => {
+    expect(isHostAllowed("127.0.0.1", [])).toBe(true);
+    expect(isHostAllowed("127.1.2.3", [])).toBe(true);
+    expect(isHostAllowed("localhost", [])).toBe(true);
+    expect(isHostAllowed("LOCALHOST", [])).toBe(true);
+    expect(isHostAllowed("::1", [])).toBe(true);
+    expect(isHostAllowed("api.localhost", [])).toBe(true);
+  });
+
+  it("denies non-loopback hosts when the allowlist is empty", () => {
+    expect(isHostAllowed("api.github.com", [])).toBe(false);
+    expect(isHostAllowed("128.0.0.1", [])).toBe(false);
+    expect(isHostAllowed("127.evil.com", [])).toBe(false);
+  });
+
+  it("matches exact entries case-insensitively and ignores trailing dots", () => {
+    const patterns = ["api.github.com"];
+    expect(isHostAllowed("api.github.com", patterns)).toBe(true);
+    expect(isHostAllowed("API.GitHub.COM", patterns)).toBe(true);
+    expect(isHostAllowed("api.github.com.", patterns)).toBe(true);
+    expect(isHostAllowed("api.github.com.evil.io", patterns)).toBe(false);
+    expect(isHostAllowed("xapi.github.com", patterns)).toBe(false);
+  });
+
+  it("matches `*.suffix` entries against subdomains but not the apex", () => {
+    const patterns = ["*.anthropic.com"];
+    expect(isHostAllowed("api.anthropic.com", patterns)).toBe(true);
+    expect(isHostAllowed("statsig.anthropic.com", patterns)).toBe(true);
+    expect(isHostAllowed("a.b.anthropic.com", patterns)).toBe(true);
+    expect(isHostAllowed("anthropic.com", patterns)).toBe(false);
+    expect(isHostAllowed("evil-anthropic.com", patterns)).toBe(false);
+    expect(isHostAllowed("anthropic.com.evil.io", patterns)).toBe(false);
+  });
+
+  it("treats a bare `*` entry as allow-everything", () => {
+    expect(isHostAllowed("api.github.com", ["*"])).toBe(true);
+  });
+});
+
+describe("buildEgressAllowlist", () => {
+  it("allows the default LLM providers whose keys the runner forwards by default", () => {
+    const patterns = buildEgressAllowlist({});
+    expect(isHostAllowed("api.anthropic.com", patterns)).toBe(true);
+    expect(isHostAllowed("statsig.anthropic.com", patterns)).toBe(true);
+    expect(isHostAllowed("api.openai.com", patterns)).toBe(true);
+    expect(isHostAllowed("generativelanguage.googleapis.com", patterns)).toBe(true);
+    expect(isHostAllowed("openrouter.ai", patterns)).toBe(true);
+    expect(isHostAllowed("ai-gateway.vercel.sh", patterns)).toBe(true);
+  });
+
+  it("does not allow production API hosts or unrelated Google surfaces by default", () => {
+    const patterns = buildEgressAllowlist({});
+    expect(isHostAllowed("api.github.com", patterns)).toBe(false);
+    expect(isHostAllowed("api.stripe.com", patterns)).toBe(false);
+    expect(isHostAllowed("slack.com", patterns)).toBe(false);
+    // *.googleapis.com would be far too broad (storage, GCS, …).
+    expect(isHostAllowed("storage.googleapis.com", patterns)).toBe(false);
+  });
+
+  it("derives extra hosts from well-known BASE_URL env vars", () => {
+    const patterns = buildEgressAllowlist({
+      ANTHROPIC_BASE_URL: "https://llm-proxy.corp.example:8443/v1",
+      OPENAI_BASE_URL: "http://my-ollama.lan:11434/v1",
+    });
+    expect(isHostAllowed("llm-proxy.corp.example", patterns)).toBe(true);
+    expect(isHostAllowed("my-ollama.lan", patterns)).toBe(true);
+  });
+
+  it("ignores malformed BASE_URL env values instead of throwing", () => {
+    const patterns = buildEgressAllowlist({ ANTHROPIC_BASE_URL: "not a url" });
+    expect(isHostAllowed("api.anthropic.com", patterns)).toBe(true);
+  });
+
+  it("honors the POME_EGRESS_ALLOW valve (CSV of extra patterns)", () => {
+    const patterns = buildEgressAllowlist({
+      POME_EGRESS_ALLOW: "bedrock-runtime.us-east-1.amazonaws.com, *.mistral.ai",
+    });
+    expect(isHostAllowed("bedrock-runtime.us-east-1.amazonaws.com", patterns)).toBe(true);
+    expect(isHostAllowed("api.mistral.ai", patterns)).toBe(true);
+    expect(isHostAllowed("s3.us-east-1.amazonaws.com", patterns)).toBe(false);
+  });
+
+  it("includes twin URL hosts when provided", () => {
+    const patterns = buildEgressAllowlist({}, { twinUrls: ["https://twins.pome.sh/s/abc"] });
+    expect(isHostAllowed("twins.pome.sh", patterns)).toBe(true);
+  });
+});
+
+describe("parseAllowCsv", () => {
+  it("splits, trims, and drops empty entries", () => {
+    expect(parseAllowCsv(" a.example ,,*.b.example , ")).toEqual(["a.example", "*.b.example"]);
+    expect(parseAllowCsv(undefined)).toEqual([]);
+    expect(parseAllowCsv("")).toEqual([]);
+  });
+});
+
+describe("readBlockedEgress", () => {
+  it("aggregates refused rows per host:port, most-hit first, skipping junk lines", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pome-egress-"));
+    const path = join(dir, "egress.jsonl");
+    const rows = [
+      { ts: "2026-07-02T00:00:00Z", kind: "EgressRefusedEvent", host: "api.github.com", port: 443 },
+      { ts: "2026-07-02T00:00:01Z", kind: "EgressRefusedEvent", host: "api.github.com", port: 443 },
+      { ts: "2026-07-02T00:00:02Z", kind: "EgressRefusedEvent", host: "example.com", port: 443 },
+    ];
+    await writeFile(path, rows.map((r) => JSON.stringify(r)).join("\n") + "\nnot-json\n");
+
+    const blocked = await readBlockedEgress(path);
+    expect(blocked).toEqual([
+      { host: "api.github.com", port: 443, count: 2 },
+      { host: "example.com", port: 443, count: 1 },
+    ]);
+  });
+
+  it("returns [] when the file is missing or empty", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pome-egress-"));
+    expect(await readBlockedEgress(join(dir, "missing.jsonl"))).toEqual([]);
+    const empty = join(dir, "empty.jsonl");
+    await writeFile(empty, "");
+    expect(await readBlockedEgress(empty)).toEqual([]);
+  });
+});


### PR DESCRIPTION
<!-- Closes FDRS-635 -->

## What

Under `pome run`, a CONNECT to any non-allowlisted host is now refused at the capture-server with a 403 **before the upstream dial**, recorded in a new `egress.jsonl` sidecar next to `events.jsonl`, and named in the run output (`egress: refused N tunnel(s) … — api.github.com:443`). Allowlist = twin hosts + LLM provider hosts + loopback; loopback (twin traffic) can never be refused. `pome capture-server` gains `--allow <csv>` / `--egress-out <path>`; the runner computes and passes both.

## Why

M2 of [First-run journey v1](https://linear.app/pome-sh/project/first-run-journey-v1-81772a84fa54): the trust surface. North-star board block 06 — "Prod-safety is a network control, not a rule." An agent that strays to `api.github.com` under `pome run` gets connection-refused, not a silent passthrough to production.

## Notes for reviewer

- **Default provider set mirrors `DEFAULT_AGENT_ENV_ALLOWLIST`** (agentRunner.ts): a provider whose API key the runner forwards by default (Anthropic incl. `*.anthropic.com` telemetry, OpenAI, Google Generative AI, OpenRouter, Vercel AI Gateway) is a provider the floor dials by default. Everything else goes through the paired valves: `POME_AGENT_ENV_ALLOWLIST` (key) + `POME_EGRESS_ALLOW` (host). `ANTHROPIC_BASE_URL`/`OPENAI_BASE_URL`/`OPENAI_API_BASE` hosts join automatically.
- **Refusals are a sidecar, NOT events.jsonl** — the LlmCallEvent row shape is locked by shared-types/the correlator (untouched, per the M2 construction-zone rule).
- Known boundary (by design, in the ticket): the floor only binds processes that honor proxy env. Env-bypassing agents are caught by `pome doctor`'s routing probe (FDRS-634, stacked on this) — the layers are complementary.
- Hosted runs don't spawn the capture-server (unchanged) — the floor binds the self-host path.
- TDD: 20 new tests (unit allowlist semantics; integration 403-before-dial proven via 403-vs-502 ordering + never-dialed upstream assertion; e2e fixture agent asserts its stray CONNECT gets 403 while loopback stays open). Full suite: 599 passing; the one failing test (`correlateRun`) and one typecheck error pre-exist on main (shared-types seam — `fix/shared-types-seam` is in flight).

## Review required

Yes — changes the public CLI's runtime network behavior (deny-by-default egress under `pome run`).