### PR TITLE
feat(cli): gate pome run on the doctor preflight (FDRS-641)

### DIFF
--- a/cli/.changeset/fdrs-634-pome-doctor.md
+++ b/cli/.changeset/fdrs-634-pome-doctor.md
@@ -1,0 +1,16 @@
+---
+"pome-sh": minor
+---
+
+**New `pome doctor` command: named-cause wiring verification (FDRS-634).**
+
+Four checks, in order: (1) pome.config.json present + valid; (2) twin
+reachable — boots the github twin in-process and walks the agent's real
+path, root health plus the bearer-authed session route; (3) requests routed
+to the twin — a static scan that names hardcoded production hosts
+(file:line, e.g. "src/agent/triage.ts reads a hardcoded https://api.github.com
+on line 12, ignoring POME_GITHUB_REST_URL") and looks for POME_*_REST_URL /
+withPome() wiring evidence; (4) egress floor active (fails on a `*`
+wildcard in POME_EGRESS_ALLOW). On failure it prints exactly one named
+cause + one concrete fix and exits non-zero. All four pass on a wired copy
+of `examples/triage-agent`.

--- a/cli/.changeset/fdrs-635-egress-deny-by-default.md
+++ b/cli/.changeset/fdrs-635-egress-deny-by-default.md
@@ -1,0 +1,16 @@
+---
+"pome-sh": minor
+---
+
+**`pome run` now enforces a deny-by-default egress floor at the capture-server (FDRS-635).**
+
+A CONNECT to any non-allowlisted host is refused with 403 before the upstream
+dial — an agent that strays to e.g. `api.github.com` gets
+connection-refused, not a silent passthrough to production. The allowlist is
+twin hosts + LLM provider hosts + loopback; the default provider set mirrors
+the API keys `pome run` already forwards to agents (Anthropic, OpenAI,
+Google Generative AI, OpenRouter, Vercel AI Gateway) plus
+`ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` / `OPENAI_API_BASE` hosts.
+`POME_EGRESS_ALLOW=<host,…>` extends it per-host. Refusals are recorded in a
+new `egress.jsonl` sidecar next to `events.jsonl` and named in the run
+output. Twin and LLM traffic is unaffected; loopback can never be refused.

--- a/cli/.changeset/fdrs-641-run-doctor-gate.md
+++ b/cli/.changeset/fdrs-641-run-doctor-gate.md
@@ -1,0 +1,18 @@
+---
+"pome-sh": minor
+---
+
+**`pome run` now gates on the doctor preflight (FDRS-641).**
+
+A repo failing any applicable doctor check refuses to spawn the agent —
+before credentials are resolved and before any twin/session is provisioned —
+printing the doctor output (one named cause + one concrete fix) and exiting
+non-zero. There is deliberately no `--force` / `--skip-checks` escape: pome
+will not run trials against a live API. Local runs get the full engine
+(including the in-process twin boot); hosted runs skip the local twin boot
+(the cloud provisions the session twin) but still gate on config, routing,
+and the egress floor.
+
+Breaking for config-less flows: `pome run` now requires a `pome.config.json`
+(run `pome init`, or `pome install` once it lands) even when `--agent` is
+passed explicitly.

--- a/cli/src/capture-server/egress.ts
+++ b/cli/src/capture-server/egress.ts
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-635 — deny-by-default egress floor for the capture-server.
+//
+// "Prod-safety is a network control, not a rule" (north-star board block 06):
+// under `pome run` the CONNECT proxy refuses tunnels to any host outside the
+// allowlist — twin hosts + LLM provider hosts + loopback — so an agent that
+// strays to e.g. api.github.com gets connection-refused, not a silent
+// passthrough to production.
+//
+// The default provider set mirrors `DEFAULT_AGENT_ENV_ALLOWLIST` in
+// agentRunner.ts: a provider whose API key the runner forwards by default is
+// a provider the floor lets the agent dial by default. Everything else goes
+// through the paired valves — POME_AGENT_ENV_ALLOWLIST for the key,
+// POME_EGRESS_ALLOW for the host.
+//
+// Known boundary (by design, see FDRS-635): the floor only binds processes
+// that honor proxy env vars. Agents that bypass HTTPS_PROXY are caught by
+// `pome doctor`'s routing probe — the two layers are complementary.
+
+import { readFile } from "node:fs/promises";
+
+// Providers whose keys the runner forwards by default (agentRunner.ts).
+// `*.anthropic.com` (not just api.) keeps the Claude Agent SDK's own
+// telemetry (statsig.anthropic.com) from showing up as refused-egress noise
+// on every default-stack run. Deliberately NOT `*.googleapis.com` — that
+// would open storage.googleapis.com and friends.
+export const DEFAULT_LLM_PROVIDER_HOSTS: readonly string[] = [
+  "*.anthropic.com", // ANTHROPIC_API_KEY
+  "anthropic.com",
+  "api.openai.com", // OPENAI_API_KEY
+  "generativelanguage.googleapis.com", // GOOGLE_API_KEY / GOOGLE_GENERATIVE_AI_API_KEY
+  "openrouter.ai", // OPENROUTER_API_KEY
+  "ai-gateway.vercel.sh", // AI_GATEWAY_API_KEY
+];
+
+// Custom LLM endpoints: when the runner's environment points a provider SDK
+// at a non-default base URL, that host joins the allowlist.
+const BASE_URL_ENV_VARS = ["ANTHROPIC_BASE_URL", "OPENAI_BASE_URL", "OPENAI_API_BASE"] as const;
+
+export interface BlockedEgress {
+  host: string;
+  port: number;
+  count: number;
+}
+
+// Sidecar row written by the capture-server for every refused CONNECT. Lives
+// in egress.jsonl, deliberately NOT events.jsonl — the events row shape is
+// locked by shared-types and consumed by the correlator, and the refusal is
+// runner-facing diagnostics, not trace data.
+export interface EgressRefusedRow {
+  ts: string;
+  kind: "EgressRefusedEvent";
+  host: string;
+  port: number;
+}
+
+function normalizeHost(host: string): string {
+  let value = host.trim().toLowerCase();
+  if (value.endsWith(".")) value = value.slice(0, -1);
+  if (value.startsWith("[") && value.endsWith("]")) value = value.slice(1, -1);
+  return value;
+}
+
+function isLoopback(host: string): boolean {
+  if (host === "localhost" || host.endsWith(".localhost")) return true;
+  if (host === "::1" || host === "0:0:0:0:0:0:0:1") return true;
+  // 127.0.0.0/8 — the whole loopback block, not just 127.0.0.1.
+  return /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host);
+}
+
+// `patterns` entries: exact hostname, `*.suffix` (any-depth subdomain, not
+// the apex), or bare `*` (allow everything — floor off). Ports never take
+// part in matching: the floor is a host-level control.
+export function isHostAllowed(host: string, patterns: readonly string[]): boolean {
+  const candidate = normalizeHost(host);
+  if (candidate.length === 0) return false;
+  if (isLoopback(candidate)) return true;
+
+  for (const raw of patterns) {
+    const pattern = normalizeHost(raw);
+    if (pattern.length === 0) continue;
+    if (pattern === "*") return true;
+    if (pattern.startsWith("*.")) {
+      if (candidate.endsWith(pattern.slice(1))) return true;
+      continue;
+    }
+    if (candidate === pattern) return true;
+  }
+  return false;
+}
+
+export function parseAllowCsv(csv: string | undefined): string[] {
+  return (csv ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+// Compute the allowlist for one run: default LLM providers + custom LLM
+// base-URL hosts + the POME_EGRESS_ALLOW valve + the twin URLs the runner is
+// about to inject (loopback in self-host; hosted twin domains future-proof).
+export function buildEgressAllowlist(
+  env: Record<string, string | undefined>,
+  opts: { twinUrls?: readonly string[] } = {},
+): string[] {
+  const patterns = [...DEFAULT_LLM_PROVIDER_HOSTS];
+
+  for (const key of BASE_URL_ENV_VARS) {
+    const value = env[key]?.trim();
+    if (!value) continue;
+    try {
+      patterns.push(new URL(value).hostname);
+    } catch {
+      // Malformed base URL — the provider SDK will fail on it anyway; the
+      // floor doesn't need to.
+    }
+  }
+
+  patterns.push(...parseAllowCsv(env.POME_EGRESS_ALLOW));
+
+  for (const url of opts.twinUrls ?? []) {
+    try {
+      patterns.push(new URL(url).hostname);
+    } catch {
+      // ignore malformed twin URLs
+    }
+  }
+
+  return [...new Set(patterns.map(normalizeHost).filter((p) => p.length > 0))];
+}
+
+// Read the egress sidecar and aggregate refusals per host:port, most-hit
+// first. Tolerates a missing file (no refusals — the common case) and junk
+// lines (partial writes on a crashed run).
+export async function readBlockedEgress(path: string): Promise<BlockedEgress[]> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch {
+    return [];
+  }
+
+  const counts = new Map<string, BlockedEgress>();
+  for (const line of raw.split("\n")) {
+    if (line.trim().length === 0) continue;
+    let row: unknown;
+    try {
+      row = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (typeof row !== "object" || row === null) continue;
+    const { kind, host, port } = row as Partial<EgressRefusedRow>;
+    if (kind !== "EgressRefusedEvent" || typeof host !== "string" || typeof port !== "number") {
+      continue;
+    }
+    const key = `${host}:${port}`;
+    const existing = counts.get(key);
+    if (existing) existing.count += 1;
+    else counts.set(key, { host, port, count: 1 });
+  }
+
+  return [...counts.values()].sort((a, b) => b.count - a.count);
+}

--- a/cli/src/capture-server/index.ts
+++ b/cli/src/capture-server/index.ts
@@ -17,10 +17,22 @@ import { createServer as createHttpServer, type Server, type IncomingMessage } f
 import { connect as netConnect, type Socket } from "node:net";
 import { dirname } from "node:path";
 import { redactEvent } from "../recorder/redaction.js";
+import { isHostAllowed, type EgressRefusedRow } from "./egress.js";
 
 export interface CaptureServerOptions {
   port: number; // 0 = ephemeral
   eventsOut: string;
+  // FDRS-635 — deny-by-default egress floor. CONNECTs to hosts outside this
+  // allowlist (patterns: exact host, `*.suffix`, or bare `*`) are refused
+  // with 403 before any upstream dial. Loopback is always allowed so twin
+  // traffic can never be broken by a bad allowlist. Omitting the option means
+  // "no extra hosts": loopback-only — the floor is the default, not opt-in.
+  allowHosts?: readonly string[];
+  // Where refused CONNECTs are recorded (JSONL, one EgressRefusedRow per
+  // refusal). A sidecar next to events.jsonl — deliberately NOT events.jsonl,
+  // whose row shape is locked by shared-types / the correlator. Optional: the
+  // floor enforces regardless; without it refusals just aren't persisted.
+  egressOut?: string;
 }
 
 export interface CaptureServerHandle {
@@ -66,6 +78,12 @@ export async function runCaptureServer(
 ): Promise<CaptureServerHandle> {
   await mkdir(dirname(options.eventsOut), { recursive: true });
   const writer = createWriteStream(options.eventsOut, { flags: "a" });
+  const allowHosts = options.allowHosts ?? [];
+  let egressWriter: WriteStream | null = null;
+  if (options.egressOut) {
+    await mkdir(dirname(options.egressOut), { recursive: true });
+    egressWriter = createWriteStream(options.egressOut, { flags: "a" });
+  }
 
   const pendingWrites = new Set<Promise<void>>();
   const liveSockets = new Set<Socket>();
@@ -80,7 +98,7 @@ export async function runCaptureServer(
   });
 
   server.on("connect", (req: IncomingMessage, clientSocket: Socket, head: Buffer) => {
-    handleConnect({ req, clientSocket, head, writer, liveSockets, pendingWrites });
+    handleConnect({ req, clientSocket, head, writer, egressWriter, allowHosts, liveSockets, pendingWrites });
   });
 
   await new Promise<void>((resolve, reject) => {
@@ -113,6 +131,10 @@ export async function runCaptureServer(
     await serverClosed;
     await flush();
     await new Promise<void>((resolve) => writer.end(() => resolve()));
+    if (egressWriter) {
+      const ew = egressWriter;
+      await new Promise<void>((resolve) => ew.end(() => resolve()));
+    }
   };
 
   return { port, flush, close };
@@ -123,6 +145,8 @@ interface ConnectArgs {
   clientSocket: Socket;
   head: Buffer;
   writer: WriteStream;
+  egressWriter: WriteStream | null;
+  allowHosts: readonly string[];
   liveSockets: Set<Socket>;
   pendingWrites: Set<Promise<void>>;
 }
@@ -132,6 +156,8 @@ function handleConnect({
   clientSocket,
   head,
   writer,
+  egressWriter,
+  allowHosts,
   liveSockets,
   pendingWrites,
 }: ConnectArgs): void {
@@ -141,6 +167,31 @@ function handleConnect({
     return;
   }
   const { host, port } = target;
+
+  // FDRS-635 — the egress floor: refuse the tunnel BEFORE dialing upstream.
+  // The refusal is recorded in the egress sidecar so `pome run` can name the
+  // blocked host in its output.
+  if (!isHostAllowed(host, allowHosts)) {
+    if (egressWriter) {
+      const row: EgressRefusedRow = {
+        ts: new Date().toISOString(),
+        kind: "EgressRefusedEvent",
+        host,
+        port,
+      };
+      const ew = egressWriter;
+      const write = new Promise<void>((resolve) => {
+        ew.write(JSON.stringify(row) + "\n", () => resolve());
+      });
+      pendingWrites.add(write);
+      void write.finally(() => pendingWrites.delete(write));
+    }
+    clientSocket.end(
+      "HTTP/1.1 403 Forbidden\r\ncontent-type: text/plain\r\nconnection: close\r\n\r\n" +
+        `pome egress floor: CONNECT to ${host}:${port} refused — not on the allowlist (twin hosts + LLM providers + localhost). Extend with POME_EGRESS_ALLOW=<host,...> if this host is intentional.\r\n`,
+    );
+    return;
+  }
 
   // Pause until upstream is ready. Without pausing, the client might send
   // payload bytes between now and the upstream connect, and they'd be dropped

--- a/cli/src/capture-server/run.ts
+++ b/cli/src/capture-server/run.ts
@@ -9,16 +9,25 @@ import { runCaptureServer } from "./index.js";
 export interface RunCaptureServerCommandOptions {
   port: number;
   eventsOut: string;
+  // FDRS-635 — egress-floor allowlist patterns (already parsed from CSV) and
+  // the sidecar path for refused-CONNECT rows.
+  allowHosts?: readonly string[];
+  egressOut?: string;
 }
 
 export async function runCaptureServerCommand(
   options: RunCaptureServerCommandOptions,
 ): Promise<void> {
   const eventsOut = resolve(options.eventsOut);
-  const handle = await runCaptureServer({ port: options.port, eventsOut });
+  const egressOut = options.egressOut ? resolve(options.egressOut) : undefined;
+  const allowHosts = options.allowHosts ?? [];
+  const handle = await runCaptureServer({ port: options.port, eventsOut, allowHosts, egressOut });
 
   console.error(
     `pome capture-server listening on 127.0.0.1:${handle.port} (events → ${eventsOut})`,
+  );
+  console.error(
+    `pome capture-server egress floor: deny-by-default (${allowHosts.length} allowlisted pattern(s) + loopback)`,
   );
 
   let shuttingDown = false;

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -574,7 +574,9 @@ export function createProgram() {
       "--local",
       "Self-host: run against an in-process twin and capture a trace WITHOUT scoring. Evaluation (pass/fail) is a hosted feature — `pome login` and re-run to score on Pome cloud. See ADR-004.",
     )
-    .description("Run one or more Pome scenarios")
+    .description(
+      "Run one or more Pome scenarios. Refuses to start if the doctor wiring checks fail (see `pome doctor`); there is no --force.",
+    )
     .action(
       async (
         target: string,
@@ -631,6 +633,31 @@ export function createProgram() {
         } else if (options.hosted) {
           console.error("Note: --hosted is now the default; the flag is a deprecated no-op and will be removed in a future release.");
         }
+
+        // FDRS-641 — doctor preflight gate. A repo failing any applicable
+        // doctor check refuses to spawn the agent — BEFORE credentials are
+        // resolved and before any twin/session is provisioned. Local runs get
+        // the full engine (incl. local twin boot); hosted runs skip the local
+        // twin (the cloud provisions the session twin) but still gate on
+        // config, routing, and the egress floor. Deliberately no --force /
+        // --skip-checks escape: "never a false success" — pome will not run
+        // trials against a live API. (Design: CLI moments 03; engine:
+        // FDRS-634.)
+        {
+          const { runDoctorChecks } = await import("../doctor/checks.js");
+          const { renderDoctorReport } = await import("../doctor/render.js");
+          const doctorReport = await runDoctorChecks({ mode: useLocal ? "full" : "hosted" });
+          if (!doctorReport.ok) {
+            for (const line of renderDoctorReport(doctorReport)) console.error(line);
+            console.error("");
+            console.error(
+              "pome run: wiring check failed — refusing to spawn the agent. Fix the cause above and re-run (there is no --force).",
+            );
+            process.exitCode = 1;
+            return;
+          }
+        }
+
         try {
           hostedCreds = useLocal
             ? null

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -734,6 +734,19 @@ export function createProgram() {
     );
 
   program
+    .command("doctor")
+    .description(
+      "Check the agent↔twin wiring: pome.config.json present + valid, twin reachable, requests routed to the twin (not a hardcoded production host), egress floor active. On failure prints one named cause (file:line where knowable) + one concrete fix and exits non-zero.",
+    )
+    .action(async () => {
+      const { runDoctorChecks } = await import("../doctor/checks.js");
+      const { renderDoctorReport } = await import("../doctor/render.js");
+      const report = await runDoctorChecks();
+      for (const line of renderDoctorReport(report)) console.error(line);
+      if (!report.ok) process.exitCode = 1;
+    });
+
+  program
     .command("matrix")
     .description(
       "Run a fleet of agents across many scenarios (agents × scenarios × runs) and aggregate into outcome-level reports (matrix.json + report.md)",

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -711,6 +711,20 @@ export function createProgram() {
               console.error(`  ${runScoreLine(result.score, result.scenario.config.passThreshold, "numeric score")}`);
               console.error(`  run: ${result.artifacts.runDir}`);
             }
+            // FDRS-635 — name every host the egress floor refused, so a stray
+            // production call is a visible event, never a silent passthrough.
+            if (result.blockedEgress.length > 0) {
+              const refusals = result.blockedEgress.reduce((n, b) => n + b.count, 0);
+              const named = result.blockedEgress
+                .map((b) => `${b.host}:${b.port}${b.count > 1 ? ` ×${b.count}` : ""}`)
+                .join(", ");
+              console.error(
+                `  egress: refused ${refusals} tunnel(s) to non-allowlisted host(s) — ${named}`,
+              );
+              console.error(
+                "          twin + LLM traffic is unaffected; extend with POME_EGRESS_ALLOW=<host,…> if intentional.",
+              );
+            }
             if (result.exitCode !== 0) worstExit = result.exitCode;
           }
         }
@@ -979,7 +993,15 @@ export function createProgram() {
       "--events-out <path>",
       "Path to events.jsonl. Created if missing; appended to otherwise.",
     )
-    .action(async (opts: { port: string; eventsOut?: string }) => {
+    .option(
+      "--allow <hosts>",
+      "FDRS-635: comma-separated egress allowlist patterns (exact host or *.suffix). The floor is deny-by-default: only these hosts + loopback are tunnelled; everything else gets 403.",
+    )
+    .option(
+      "--egress-out <path>",
+      "Path to egress.jsonl, the sidecar recording refused CONNECTs. Optional; the floor enforces regardless.",
+    )
+    .action(async (opts: { port: string; eventsOut?: string; allow?: string; egressOut?: string }) => {
       if (!opts.eventsOut) {
         console.error("pome capture-server: --events-out <path> is required");
         process.exitCode = 2;
@@ -992,7 +1014,13 @@ export function createProgram() {
         return;
       }
       const { runCaptureServerCommand } = await import("../capture-server/run.js");
-      await runCaptureServerCommand({ port, eventsOut: opts.eventsOut });
+      const { parseAllowCsv } = await import("../capture-server/egress.js");
+      await runCaptureServerCommand({
+        port,
+        eventsOut: opts.eventsOut,
+        allowHosts: parseAllowCsv(opts.allow),
+        egressOut: opts.egressOut,
+      });
     });
 
   program

--- a/cli/src/doctor/checks.ts
+++ b/cli/src/doctor/checks.ts
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-634 — the doctor check engine: config → twin → routing → egress, in
+// order, stopping at the first failure so the report carries exactly ONE
+// named cause and one concrete fix. "Never a false success": a wall of
+// maybes hides the next step; one cause names it.
+//
+// The engine is deliberately separate from the `pome doctor` command so
+// `pome run` can reuse it as a preflight gate (FDRS-641). Checks are written
+// against the generic twin surface (bootTwin / the sdk's `/_pome/health`
+// route contract) — twin internals are the architecture refactor's
+// construction zone and stay untouched.
+
+import { serve } from "@hono/node-server";
+import { randomBytes, randomUUID } from "node:crypto";
+import { dirname, relative } from "node:path";
+import { sign } from "hono/jwt";
+import { buildEgressAllowlist } from "../capture-server/egress.js";
+import { findProjectConfigPath, readProjectConfig } from "../cli/project-config.js";
+import { getAvailablePort } from "../runner/ports.js";
+import { bootTwin } from "../twin/twinHarness.js";
+import { scanAgentSources } from "./scan.js";
+
+export type DoctorCheckId = "config" | "twin" | "routing" | "egress";
+
+export interface DoctorCheck {
+  id: DoctorCheckId;
+  status: "pass" | "fail";
+  label: string;
+  detail?: string; // short suffix on a pass line, e.g. "github · local"
+  cause?: string; // fail only — the ONE named cause
+  fix?: string; // fail only — the ONE concrete fix (may be multi-line)
+}
+
+export interface DoctorReport {
+  ok: boolean;
+  checks: DoctorCheck[];
+}
+
+export interface RunDoctorChecksOptions {
+  cwd?: string;
+  // Injectable for tests; defaults to process.env. Read by the egress check
+  // (floor wildcard) — NOT forwarded to any agent.
+  env?: Record<string, string | undefined>;
+}
+
+export async function runDoctorChecks(
+  options: RunDoctorChecksOptions = {},
+): Promise<DoctorReport> {
+  const cwd = options.cwd ?? process.cwd();
+  const env = options.env ?? process.env;
+
+  const checks: DoctorCheck[] = [];
+  const steps: Array<(configDir: string) => Promise<DoctorCheck>> = [
+    (dir) => checkTwinReachable(dir),
+    (dir) => checkRouting(dir),
+    async (dir) => checkEgressFloor(env, dir),
+  ];
+
+  const config = await checkConfig(cwd);
+  checks.push(config);
+  if (config.status === "fail") return { ok: false, checks };
+  const configDir = config.configDir!;
+
+  for (const step of steps) {
+    const result = await step(configDir);
+    checks.push(result);
+    if (result.status === "fail") return { ok: false, checks };
+  }
+
+  return { ok: true, checks };
+}
+
+type ConfigCheck = DoctorCheck & { configDir?: string };
+
+async function checkConfig(cwd: string): Promise<ConfigCheck> {
+  const path = await findProjectConfigPath(cwd);
+  if (!path) {
+    return {
+      id: "config",
+      status: "fail",
+      label: "pome.config.json not found",
+      cause: `no pome.config.json found in ${cwd} or any parent directory.`,
+      fix: "run pome init to scaffold one, then re-run pome doctor",
+    };
+  }
+
+  let read;
+  try {
+    read = await readProjectConfig(cwd);
+  } catch {
+    read = null;
+  }
+  if (!read) {
+    return {
+      id: "config",
+      status: "fail",
+      label: "pome.config.json is not valid",
+      cause: `${path} exists but is not parseable JSON.`,
+      fix: "fix the JSON (or delete the file and run pome init), then re-run pome doctor",
+    };
+  }
+
+  const command = read.config.agent?.command;
+  if (command !== undefined && (typeof command !== "string" || command.trim().length === 0)) {
+    return {
+      id: "config",
+      status: "fail",
+      label: "pome.config.json is not valid",
+      cause: `${path} has an agent.command that is not a non-empty string.`,
+      fix: 'set agent.command to the command that starts your agent, e.g. "bun run src/index.ts"',
+    };
+  }
+
+  return {
+    id: "config",
+    status: "pass",
+    label: "pome.config.json found",
+    configDir: dirname(read.path),
+  };
+}
+
+// Boot the github twin in-process, serve it on an ephemeral loopback port,
+// and walk the same path an agent would: the root health route, then the
+// bearer-authed session health route with a freshly minted JWT.
+async function checkTwinReachable(_configDir: string): Promise<DoctorCheck> {
+  const fail = (cause: string): DoctorCheck => ({
+    id: "twin",
+    status: "fail",
+    label: "twin not reachable",
+    cause,
+    fix: "bun install (twin dependencies), then re-run pome doctor — if it persists, file an issue with the error above",
+  });
+
+  let harness;
+  try {
+    harness = await bootTwin({
+      twin: "github",
+      seedState: undefined,
+      runId: `doctor_${randomUUID()}`,
+    });
+  } catch (err) {
+    return fail(`the github twin failed to boot locally: ${firstLine(err)}`);
+  }
+
+  let server: { close: () => void } | null = null;
+  try {
+    const port = await getAvailablePort();
+    server = serve({ fetch: harness.app.fetch, port, hostname: "127.0.0.1" });
+    const base = `http://127.0.0.1:${port}`;
+
+    const health = await fetch(`${base}/healthz`);
+    if (!health.ok) {
+      return fail(`the twin's health route answered ${health.status} at ${base}/healthz.`);
+    }
+
+    const sid = `doctor_${randomUUID()}`;
+    const authSecret = process.env.TWIN_AUTH_SECRET ?? randomBytes(32).toString("hex");
+    process.env.TWIN_AUTH_SECRET = authSecret;
+    const token = await sign(
+      { sid, team_id: "tm_local", login: "pome-agent", exp: Math.floor(Date.now() / 1000) + 120 },
+      authSecret,
+    );
+    const sessionHealth = await fetch(`${base}/s/${sid}/_pome/health`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!sessionHealth.ok) {
+      return fail(
+        `the twin is up but rejected the session route (${sessionHealth.status} at /s/<sid>/_pome/health) — the auth contract the agent relies on is broken.`,
+      );
+    }
+
+    return { id: "twin", status: "pass", label: "twin reachable", detail: "github · local" };
+  } catch (err) {
+    return fail(`could not reach the locally served twin: ${firstLine(err)}`);
+  } finally {
+    server?.close();
+    harness.close();
+  }
+}
+
+async function checkRouting(configDir: string): Promise<DoctorCheck> {
+  const scan = await scanAgentSources(configDir);
+
+  if (scan.hardcoded) {
+    const { file, line, host, envVar } = scan.hardcoded;
+    return {
+      id: "routing",
+      status: "fail",
+      label: "requests are not routed to the twin",
+      cause: `${file} reads from a hardcoded https://${host} on line ${line}, ignoring ${envVar} — so its requests would bypass the twin.`,
+      fix: [
+        "read the base URL from the env the runner injects —",
+        `const { ${envVar}: baseUrl } = process.env`,
+        "then re-run pome doctor",
+      ].join("\n"),
+    };
+  }
+
+  if (scan.wiring.envVar === null && !scan.wiring.adapterImport) {
+    return {
+      id: "routing",
+      status: "fail",
+      label: "requests are not routed to the twin",
+      cause: `no POME_*_REST_URL / POME_*_MCP_URL read and no @pome-sh adapter found in the ${scan.filesScanned} source file(s) under ${relative(process.cwd(), configDir) || "."} — the agent has no path to the twin.`,
+      fix: [
+        'wire the adapter: import { withPome } from "@pome-sh/adapter-claude-sdk"; call withPome() at startup;',
+        "read the twin base URL from POME_GITHUB_REST_URL (injected by the runner) — or run pome install to have your coding agent wire it.",
+      ].join("\n"),
+    };
+  }
+
+  return {
+    id: "routing",
+    status: "pass",
+    label: "requests route to the twin",
+    detail: scan.wiring.envVar ? `reads ${scan.wiring.envVar}` : "withPome() installed",
+  };
+}
+
+function checkEgressFloor(
+  env: Record<string, string | undefined>,
+  _configDir: string,
+): DoctorCheck {
+  const patterns = buildEgressAllowlist(env);
+  if (patterns.includes("*")) {
+    return {
+      id: "egress",
+      status: "fail",
+      label: "egress floor disabled",
+      cause:
+        "the egress floor is disabled — a `*` wildcard in POME_EGRESS_ALLOW allows every host, so a stray production call would pass through silently.",
+      fix: "remove `*` from POME_EGRESS_ALLOW (list specific hosts instead), then re-run pome doctor",
+    };
+  }
+  return {
+    id: "egress",
+    status: "pass",
+    label: "egress floor active",
+    detail: `deny-by-default · ${patterns.length} pattern(s) + loopback`,
+  };
+}
+
+function firstLine(err: unknown): string {
+  const message = err instanceof Error ? err.message : String(err);
+  return message.split("\n")[0] ?? message;
+}

--- a/cli/src/doctor/checks.ts
+++ b/cli/src/doctor/checks.ts
@@ -17,7 +17,6 @@ import { sign } from "hono/jwt";
 import { buildEgressAllowlist } from "../capture-server/egress.js";
 import { findProjectConfigPath, readProjectConfig } from "../cli/project-config.js";
 import { getAvailablePort } from "../runner/ports.js";
-import { bootTwin } from "../twin/twinHarness.js";
 import { scanAgentSources } from "./scan.js";
 
 export type DoctorCheckId = "config" | "twin" | "routing" | "egress";
@@ -41,6 +40,12 @@ export interface RunDoctorChecksOptions {
   // Injectable for tests; defaults to process.env. Read by the egress check
   // (floor wildcard) — NOT forwarded to any agent.
   env?: Record<string, string | undefined>;
+  // "full" (default, `pome doctor` + local-run gate) boots the local twin.
+  // "hosted" (the hosted-run gate, FDRS-641) skips the local twin boot: a
+  // hosted run never touches it — the cloud provisions the session twin —
+  // and the local boot needs better-sqlite3, unavailable under the Bun
+  // runtime hosted runs commonly use. Config/routing/egress still gate.
+  mode?: "full" | "hosted";
 }
 
 export async function runDoctorChecks(
@@ -48,10 +53,11 @@ export async function runDoctorChecks(
 ): Promise<DoctorReport> {
   const cwd = options.cwd ?? process.cwd();
   const env = options.env ?? process.env;
+  const mode = options.mode ?? "full";
 
   const checks: DoctorCheck[] = [];
   const steps: Array<(configDir: string) => Promise<DoctorCheck>> = [
-    (dir) => checkTwinReachable(dir),
+    ...(mode === "full" ? [(dir: string) => checkTwinReachable(dir)] : []),
     (dir) => checkRouting(dir),
     async (dir) => checkEgressFloor(env, dir),
   ];
@@ -133,6 +139,9 @@ async function checkTwinReachable(_configDir: string): Promise<DoctorCheck> {
 
   let harness;
   try {
+    // Dynamic import: the twin harness pulls in better-sqlite3, which the
+    // hosted-mode gate must never load (unavailable under the Bun runtime).
+    const { bootTwin } = await import("../twin/twinHarness.js");
     harness = await bootTwin({
       twin: "github",
       seedState: undefined,

--- a/cli/src/doctor/render.ts
+++ b/cli/src/doctor/render.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-634 — terminal rendering for the doctor report, per
+// `CLI moments.dc.html` moment 03: one line per executed check, then (on
+// failure) exactly one cause/fix card and the two closing warning lines.
+// Plain text, no color deps — matches the rest of the CLI's output.
+
+import type { DoctorReport } from "./checks.js";
+
+const CAUSE_COLUMN = "cause  ";
+const FIX_COLUMN = "fix    ";
+const CONTINUATION = " ".repeat(FIX_COLUMN.length);
+
+export function renderDoctorReport(report: DoctorReport): string[] {
+  const lines: string[] = ["checking your wiring …"];
+
+  for (const check of report.checks) {
+    const glyph = check.status === "pass" ? "✓" : "✗";
+    const detail = check.detail ? `  ${check.detail}` : "";
+    lines.push(`${glyph} ${check.label}${detail}`);
+  }
+
+  const failed = report.checks.find((c) => c.status === "fail");
+  if (failed) {
+    lines.push("");
+    if (failed.cause) lines.push(`${CAUSE_COLUMN}${failed.cause}`);
+    if (failed.fix) {
+      const [first, ...rest] = failed.fix.split("\n");
+      lines.push(`${FIX_COLUMN}${first ?? ""}`);
+      for (const line of rest) lines.push(`${CONTINUATION}${line}`);
+    }
+    lines.push("");
+    lines.push("until this passes, your agent would hit production.");
+    lines.push("pome will not run trials against a live API.");
+  }
+
+  return lines;
+}

--- a/cli/src/doctor/scan.ts
+++ b/cli/src/doctor/scan.ts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-634 — static routing scan: the named-cause half of doctor's routing
+// check.
+//
+// Finds hardcoded production API hosts (file:line) that would bypass the
+// POME_*_REST_URL env contract, and collects positive wiring evidence — a
+// POME_*_{REST,MCP}_URL / POME_*_API_BASE read or an adapter import. The
+// dynamic proof that requests reach the twin is `pome run`'s recorded trace;
+// doctor stays fast, deterministic, and LLM-free, so its routing verdict is
+// "would this source bypass the twin", answered statically with a nameable
+// file and line.
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join, relative } from "node:path";
+
+export interface HardcodedHostFinding {
+  file: string; // relative to the scanned root
+  line: number; // 1-based
+  host: string;
+  envVar: string; // the env the code ignores by hardcoding
+}
+
+export interface WiringEvidence {
+  envVar: string | null; // first POME_*_{REST,MCP}_URL / POME_*_API_BASE seen
+  adapterImport: boolean; // @pome-sh/adapter-* import or withPome() call
+}
+
+export interface ScanResult {
+  hardcoded: HardcodedHostFinding | null;
+  wiring: WiringEvidence;
+  filesScanned: number;
+}
+
+// Production hosts of the twinned services. A hardcoded one of these in
+// agent source means requests would bypass the twin — exactly the failure
+// the design's moment-03 card names.
+const PRODUCTION_HOSTS: ReadonlyArray<{ host: string; envVar: string }> = [
+  { host: "api.github.com", envVar: "POME_GITHUB_REST_URL" },
+  { host: "api.stripe.com", envVar: "POME_STRIPE_REST_URL" },
+  { host: "hooks.slack.com", envVar: "POME_SLACK_REST_URL" },
+  { host: "slack.com/api", envVar: "POME_SLACK_REST_URL" },
+];
+
+const WIRING_ENV_REGEX = /POME_[A-Z0-9]+_(?:REST_URL|MCP_URL|API_BASE)/;
+const ADAPTER_REGEX = /@pome-sh\/adapter-|withPome\s*\(/;
+
+const CODE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
+const SKIP_DIRS = new Set([
+  "node_modules",
+  ".git",
+  "dist",
+  "build",
+  "out",
+  "coverage",
+  "runs",
+  ".pome-data",
+]);
+const MAX_FILES = 400;
+const MAX_FILE_BYTES = 1_000_000;
+
+function isCommentLine(line: string): boolean {
+  const trimmed = line.trimStart();
+  return (
+    trimmed.startsWith("//") ||
+    trimmed.startsWith("*") ||
+    trimmed.startsWith("/*") ||
+    trimmed.startsWith("#")
+  );
+}
+
+async function collectFiles(root: string): Promise<string[]> {
+  const files: string[] = [];
+  const queue: string[] = [root];
+  while (queue.length > 0 && files.length < MAX_FILES) {
+    const dir = queue.shift()!;
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (!SKIP_DIRS.has(entry.name)) queue.push(join(dir, entry.name));
+        continue;
+      }
+      const dot = entry.name.lastIndexOf(".");
+      if (dot === -1 || !CODE_EXTENSIONS.has(entry.name.slice(dot))) continue;
+      files.push(join(dir, entry.name));
+      if (files.length >= MAX_FILES) break;
+    }
+  }
+  return files;
+}
+
+export async function scanAgentSources(rootDir: string): Promise<ScanResult> {
+  const files = await collectFiles(rootDir);
+  let hardcoded: HardcodedHostFinding | null = null;
+  const wiring: WiringEvidence = { envVar: null, adapterImport: false };
+  let filesScanned = 0;
+
+  for (const file of files) {
+    try {
+      const info = await stat(file);
+      if (info.size > MAX_FILE_BYTES) continue;
+    } catch {
+      continue;
+    }
+    let content: string;
+    try {
+      content = await readFile(file, "utf8");
+    } catch {
+      continue;
+    }
+    filesScanned += 1;
+
+    const lines = content.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+      if (isCommentLine(line)) continue;
+
+      if (!hardcoded) {
+        for (const { host, envVar } of PRODUCTION_HOSTS) {
+          if (line.includes(host)) {
+            hardcoded = {
+              file: relative(rootDir, file),
+              line: i + 1,
+              host,
+              envVar,
+            };
+            break;
+          }
+        }
+      }
+
+      if (wiring.envVar === null) {
+        const match = WIRING_ENV_REGEX.exec(line);
+        if (match) wiring.envVar = match[0];
+      }
+      if (!wiring.adapterImport && ADAPTER_REGEX.test(line)) {
+        wiring.adapterImport = true;
+      }
+    }
+  }
+
+  return { hardcoded, wiring, filesScanned };
+}

--- a/cli/src/runner/captureServerChild.ts
+++ b/cli/src/runner/captureServerChild.ts
@@ -19,10 +19,16 @@ import { spawn, type ChildProcess } from "node:child_process";
 export interface SpawnCaptureServerChildOptions {
   // Absolute path to events.jsonl. Passed verbatim to `--events-out`.
   eventsOut: string;
+  // FDRS-635 — egress-floor allowlist patterns, passed as `--allow` (CSV).
+  // Omitted/empty means loopback-only: the floor is deny-by-default.
+  allowHosts?: readonly string[];
+  // FDRS-635 — sidecar path for refused-CONNECT rows, passed as `--egress-out`.
+  egressOut?: string;
   // Override for tests. Defaults to process.execPath.
   execPath?: string;
   // Override for tests. When omitted we re-invoke this binary
-  // (process.argv[1]) with `capture-server --port 0 --events-out <path>`.
+  // (process.argv[1]) with `capture-server --port 0 --events-out <path>`
+  // plus the egress flags above.
   binArgs?: string[];
   // Max time to wait for the listening line before rejecting. Default 5s.
   readyTimeoutMs?: number;
@@ -45,7 +51,7 @@ export async function spawnCaptureServerChild(
   const execPath = options.execPath ?? process.execPath;
   const binArgs =
     options.binArgs ??
-    defaultBinArgs(options.eventsOut);
+    defaultBinArgs(options.eventsOut, options.allowHosts, options.egressOut);
   const readyTimeoutMs = options.readyTimeoutMs ?? 5_000;
   const shutdownGraceMs = options.shutdownGraceMs ?? 5_000;
 
@@ -125,7 +131,11 @@ export async function spawnCaptureServerChild(
   };
 }
 
-function defaultBinArgs(eventsOut: string): string[] {
+function defaultBinArgs(
+  eventsOut: string,
+  allowHosts?: readonly string[],
+  egressOut?: string,
+): string[] {
   // process.argv[1] is the script path we were invoked with. Re-invoking it
   // gives us the same binary (and the same code) without depending on PATH
   // having a `pome` shim — important when running from the dev tree
@@ -136,7 +146,19 @@ function defaultBinArgs(eventsOut: string): string[] {
       "Cannot determine pome binary path (process.argv[1] is empty). Pass `binArgs` explicitly.",
     );
   }
-  return [script, "capture-server", "--port", "0", "--events-out", eventsOut];
+  return [script, "capture-server", "--port", "0", "--events-out", eventsOut, ...egressArgs(allowHosts, egressOut)];
+}
+
+// Shared by defaultBinArgs and runScenario's test-override path so the two
+// spawn shapes can't drift.
+export function egressArgs(
+  allowHosts?: readonly string[],
+  egressOut?: string,
+): string[] {
+  const args: string[] = [];
+  if (allowHosts && allowHosts.length > 0) args.push("--allow", allowHosts.join(","));
+  if (egressOut) args.push("--egress-out", egressOut);
+  return args;
 }
 
 function makeShutdown(

--- a/cli/src/runner/runScenario.ts
+++ b/cli/src/runner/runScenario.ts
@@ -8,7 +8,8 @@ import { parseScenarioFile } from "../scenario/parseScenario.js";
 import { bootTwin } from "../twin/twinHarness.js";
 import { getAvailablePort } from "./ports.js";
 import { runAgentCommand } from "./agentRunner.js";
-import { spawnCaptureServerChild } from "./captureServerChild.js";
+import { egressArgs, spawnCaptureServerChild } from "./captureServerChild.js";
+import { buildEgressAllowlist, readBlockedEgress, type BlockedEgress } from "../capture-server/egress.js";
 import { mergeAdapterSignalsIntoEvents } from "./mergeAdapterSignals.js";
 import { scoreAndWriteRun, writeRunNoScore } from "./runScenarioCore.js";
 
@@ -75,10 +76,20 @@ export async function runScenario(options: RunScenarioOptions) {
   // The agent inherits HTTP_PROXY/HTTPS_PROXY pointing at this child;
   // NO_PROXY keeps twin traffic out of the proxy so it isn't double-counted
   // as LlmCallEvent. FDRS-405: `noCapture` skips spawn + env injection.
+  //
+  // FDRS-635: the child enforces the deny-by-default egress floor. The
+  // allowlist is LLM providers + custom base-URL hosts + POME_EGRESS_ALLOW;
+  // the self-host twin lives on loopback, which the floor always allows.
+  // Refused CONNECTs land in the egress sidecar, read back after the run so
+  // the CLI can name the blocked hosts.
+  const egressAllowHosts = buildEgressAllowlist(process.env);
+  const egressJsonlPath = join(runDir, "egress.jsonl");
   const captureServer = options.noCapture
     ? null
     : await spawnCaptureServerChild({
         eventsOut: resolvePath(eventsJsonlPath),
+        allowHosts: egressAllowHosts,
+        egressOut: resolvePath(egressJsonlPath),
         execPath: options.captureServerCommand?.execPath,
         binArgs: options.captureServerCommand
           ? [
@@ -88,10 +99,20 @@ export async function runScenario(options: RunScenarioOptions) {
               "0",
               "--events-out",
               resolvePath(eventsJsonlPath),
+              ...egressArgs(egressAllowHosts, resolvePath(egressJsonlPath)),
             ]
           : undefined,
       });
   if (captureServer) options.onCaptureServerSpawned?.(captureServer.pid);
+
+  // Drain the capture-server (flushing any in-flight egress rows), then read
+  // back the refusals. Idempotent shutdown — the finally block's call is a
+  // no-op afterwards.
+  const collectBlockedEgress = async (): Promise<BlockedEgress[]> => {
+    if (!captureServer) return [];
+    await captureServer.shutdown();
+    return readBlockedEgress(egressJsonlPath);
+  };
 
   const twinName = scenario.config.twins[0] ?? "github";
   const port = await getAvailablePort();
@@ -185,7 +206,8 @@ export async function runScenario(options: RunScenarioOptions) {
       // exitCode would already be 3 here because preflight.exitCode !== 0, but be
       // explicit for clarity.
       void exitCode;
-      return { scenario, runId, artifacts, score, agent: preflight, exitCode: 3 };
+      const blockedEgress = await collectBlockedEgress();
+      return { scenario, runId, artifacts, score, agent: preflight, exitCode: 3, blockedEgress };
     }
 
     const agent = await runAgentCommand({
@@ -209,7 +231,8 @@ export async function runScenario(options: RunScenarioOptions) {
       stateFinal
     });
     await mergeAdapterSignalsIntoEvents(signalsPath, eventsJsonlPath);
-    return { scenario, runId, artifacts, score, agent, exitCode };
+    const blockedEgress = await collectBlockedEgress();
+    return { scenario, runId, artifacts, score, agent, exitCode, blockedEgress };
   } finally {
     // Drain capture-server first so any in-flight LlmCallEvent rows land
     // in events.jsonl before we move on; THEN close the twin (which would

--- a/cli/test/e2e/doctor.test.ts
+++ b/cli/test/e2e/doctor.test.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-634 — acceptance: all four doctor checks pass on a correctly wired
+// copy of examples/triage-agent (the ticket's verification target). The
+// example's real source is copied as-is; only pome.config.json is added —
+// exactly what a user lands on after `pome install`.
+
+import { cp, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { runDoctorChecks } from "../../src/doctor/checks.js";
+
+describe("pome doctor — wired triage-agent acceptance (FDRS-634)", () => {
+  it("passes all four checks on a wired copy of examples/triage-agent", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pome-doctor-triage-"));
+    const exampleSrc = new URL("../../../examples/triage-agent/src/", import.meta.url).pathname;
+    await cp(exampleSrc, join(dir, "src"), { recursive: true });
+    await writeFile(
+      join(dir, "pome.config.json"),
+      JSON.stringify({ agent: { command: "bun run src/index.ts", sdk: "claude" } }, null, 2) + "\n",
+    );
+
+    const report = await runDoctorChecks({ cwd: dir, env: {} });
+    expect(report.checks.map((c) => `${c.id}:${c.status}`)).toEqual([
+      "config:pass",
+      "twin:pass",
+      "routing:pass",
+      "egress:pass",
+    ]);
+    expect(report.ok).toBe(true);
+  }, 30_000);
+});

--- a/cli/test/e2e/runScenarioEgress.test.ts
+++ b/cli/test/e2e/runScenarioEgress.test.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-635 — E2E test that `pome run` (via `runScenario`) enforces the
+// deny-by-default egress floor end-to-end: the agent's CONNECT to a
+// non-allowlisted host is refused with 403 (asserted inside the fixture),
+// loopback tunnels still work, twin traffic is unaffected, and the refused
+// host is surfaced on the run result so the CLI can name it in the output.
+
+import { mkdtemp } from "node:fs/promises";
+import { createServer as createNetServer, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { runScenario } from "../../src/runner/runScenario.js";
+
+function listenEphemeral(server: ReturnType<typeof createNetServer>): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (typeof addr === "object" && addr) resolve(addr.port);
+      else reject(new Error("ephemeral listen returned no address"));
+    });
+  });
+}
+
+function appendAllowlist(existing: string | undefined, names: string[]): string {
+  const values = new Set((existing ?? "").split(",").map((entry) => entry.trim()).filter(Boolean));
+  for (const name of names) values.add(name);
+  return [...values].join(",");
+}
+
+describe("runScenario — egress floor wiring (FDRS-635)", () => {
+  let echoPort = 0;
+  let echoCloser: (() => Promise<void>) | null = null;
+
+  beforeAll(async () => {
+    const sockets = new Set<Socket>();
+    const server = createNetServer((socket) => {
+      sockets.add(socket);
+      socket.on("data", (chunk) => socket.write(chunk));
+      socket.once("close", () => sockets.delete(socket));
+    });
+    echoPort = await listenEphemeral(server);
+    echoCloser = () =>
+      new Promise<void>((resolve) => {
+        for (const s of sockets) s.destroy();
+        server.close(() => resolve());
+      });
+  });
+
+  afterAll(async () => {
+    if (echoCloser) await echoCloser();
+  });
+
+  it("refuses the stray host, keeps loopback traffic, and names the refusal on the result", async () => {
+    const artifactsDir = await mkdtemp(join(tmpdir(), "pome-runs-"));
+    const probePath = new URL("../fixtures/agents/egress-probe-agent.ts", import.meta.url).pathname;
+
+    const previousAllowlist = process.env.POME_AGENT_ENV_ALLOWLIST;
+    process.env.POME_EGRESS_TEST_BLOCKED = "api.github.com:443";
+    process.env.POME_CAPTURE_TEST_TARGET = `127.0.0.1:${echoPort}`;
+    process.env.POME_AGENT_ENV_ALLOWLIST = appendAllowlist(previousAllowlist, [
+      "POME_EGRESS_TEST_BLOCKED",
+      "POME_CAPTURE_TEST_TARGET",
+    ]);
+
+    try {
+      const result = await runScenario({
+        scenarioPath: "scenarios/01-bug-happy-path.md",
+        agentCommand: `bun ${probePath}`,
+        artifactsDir,
+        captureServerCommand: {
+          execPath: "bun",
+          prefixArgs: ["src/cli/main.ts"],
+        },
+      });
+
+      // The fixture exits non-zero if the blocked CONNECT was NOT refused
+      // with 403 — so a passing run already proves the refusal happened.
+      expect(result.exitCode).toBe(0);
+
+      expect(result.blockedEgress).toEqual([
+        { host: "api.github.com", port: 443, count: 1 },
+      ]);
+    } finally {
+      delete process.env.POME_EGRESS_TEST_BLOCKED;
+      delete process.env.POME_CAPTURE_TEST_TARGET;
+      if (previousAllowlist === undefined) delete process.env.POME_AGENT_ENV_ALLOWLIST;
+      else process.env.POME_AGENT_ENV_ALLOWLIST = previousAllowlist;
+    }
+  }, 60_000);
+});

--- a/cli/test/e2e/runScenarioHosted.test.ts
+++ b/cli/test/e2e/runScenarioHosted.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { spawn } from "node:child_process";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -80,6 +80,21 @@ describe("pome run --hosted (e2e via spawn)", () => {
     receivedResult = null;
     finalizeResponseOverrides = {};
     tmp = await mkdtemp(join(tmpdir(), "pome-e2e-"));
+    // FDRS-641 — `pome run` gates on the doctor preflight (config present,
+    // routing wired, egress floor; local twin boot is skipped on hosted
+    // runs). Make tmp a wired repo and spawn the CLI from it, matching what
+    // a real post-`pome install` project looks like.
+    await writeFile(
+      join(tmp, "pome.config.json"),
+      JSON.stringify({ agent: { command: "true" } }, null, 2),
+      "utf8"
+    );
+    await mkdir(join(tmp, "src"), { recursive: true });
+    await writeFile(
+      join(tmp, "src", "agent.ts"),
+      "const baseUrl = process.env.POME_GITHUB_REST_URL;\nexport { baseUrl };\n",
+      "utf8"
+    );
     port = await startFakeCloud();
   });
 
@@ -131,6 +146,7 @@ describe("pome run --hosted (e2e via spawn)", () => {
         join(tmp, "runs"),
       ],
       {
+        cwd: tmp,
         env: { ...process.env, POME_API_KEY: "pme_e2e_test" },
       }
     );
@@ -201,6 +217,7 @@ describe("pome run --hosted (e2e via spawn)", () => {
         join(tmp, "runs"),
       ],
       {
+        cwd: tmp,
         env: { ...process.env, POME_API_KEY: "pme_e2e_test" },
       },
     );

--- a/cli/test/fixtures/agents/egress-probe-agent.ts
+++ b/cli/test/fixtures/agents/egress-probe-agent.ts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-635 test fixture: same scripted triage work as capture-probe-agent.ts,
+// then two raw CONNECTs through the runner-injected HTTPS_PROXY:
+//   1. POME_EGRESS_TEST_BLOCKED ("host:port") — MUST be refused with 403 by
+//      the egress floor. A 200 here means the proxy silently passed a
+//      non-allowlisted host through to "production", which is exactly the
+//      failure FDRS-635 exists to prevent — so the fixture exits non-zero.
+//   2. POME_CAPTURE_TEST_TARGET ("host:port", a loopback echo) — MUST still
+//      tunnel (200): loopback/twin-adjacent traffic is unaffected.
+
+import { createConnection } from "node:net";
+import { URL } from "node:url";
+
+type GitHubIssue = {
+  number: number;
+  title: string;
+  body: string;
+  labels: Array<{ name: string }>;
+  assignee: { login: string } | null;
+};
+
+if (process.env.POME_PREFLIGHT === "1") {
+  console.log("preflight ok");
+  process.exit(0);
+}
+
+const task = requiredEnv("POME_TASK");
+const baseUrl = requiredEnv("POME_GITHUB_REST_URL");
+const authToken = process.env.POME_AUTH_TOKEN;
+const issueNumber = Number(task.match(/#(\d+)/)?.[1] ?? "1");
+const repo = (task.match(/in\s+([a-z0-9_.-]+\/[a-z0-9_.-]+)/i)?.[1] ?? "acme/api").replace(/[.,]+$/, "");
+const [owner, name] = repo.split("/") as [string, string];
+
+async function main() {
+  const issue = await github<GitHubIssue>(`/repos/${owner}/${name}/issues/${issueNumber}`);
+  const existing = issue.labels.find((l) => ["bug", "feature", "question"].includes(l.name));
+  if (!existing) {
+    const label = classify(issue);
+    await github(`/repos/${owner}/${name}/issues/${issueNumber}/labels`, {
+      method: "POST",
+      body: { labels: [label] },
+    });
+    await github(`/repos/${owner}/${name}/issues/${issueNumber}/assignees`, {
+      method: "POST",
+      body: { assignees: ["alice"] },
+    });
+  }
+
+  const blockedStatus = await connectStatus(requiredEnv("POME_EGRESS_TEST_BLOCKED"));
+  if (blockedStatus !== "403") {
+    throw new Error(
+      `expected the egress floor to refuse the blocked target with 403, got ${blockedStatus}`,
+    );
+  }
+
+  const allowedStatus = await connectStatus(requiredEnv("POME_CAPTURE_TEST_TARGET"));
+  if (allowedStatus !== "200") {
+    throw new Error(`expected the loopback tunnel to stay open (200), got ${allowedStatus}`);
+  }
+
+  console.log(JSON.stringify({ task, summary: "egress fixture done" }));
+}
+
+// Open one CONNECT through the proxy and return the response status code.
+// For a 200, write one probe payload then close.
+function connectStatus(target: string): Promise<string> {
+  const proxyUrl = requiredEnv("HTTPS_PROXY");
+  const url = new URL(proxyUrl);
+
+  return new Promise((resolve, reject) => {
+    const sock = createConnection({ host: url.hostname, port: Number(url.port) });
+    let buf = "";
+    let done = false;
+    sock.on("error", reject);
+    sock.on("data", (chunk: Buffer) => {
+      if (done) return;
+      buf += chunk.toString("utf8");
+      const match = /^HTTP\/1\.[01] (\d{3})/.exec(buf);
+      if (!match) return;
+      done = true;
+      const status = match[1]!;
+      if (status === "200") {
+        sock.write("probe");
+        setTimeout(() => sock.end(), 50);
+      } else {
+        sock.end();
+      }
+      resolve(status);
+    });
+    sock.write(`CONNECT ${target} HTTP/1.1\r\nHost: ${target}\r\n\r\n`);
+  });
+}
+
+function classify(issue: GitHubIssue): string {
+  const text = `${issue.title}\n${issue.body}`.toLowerCase();
+  if (text.includes("500") || text.includes("error") || text.includes("null") || text.includes("failing")) return "bug";
+  if (text.includes("add") || text.includes("export") || text.includes("feature")) return "feature";
+  return "question";
+}
+
+async function github<T = unknown>(path: string, options: { method?: string; body?: unknown } = {}): Promise<T> {
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: options.method ?? "GET",
+    headers: authToken
+      ? { Authorization: `Bearer ${authToken}`, ...(options.body ? { "content-type": "application/json" } : {}) }
+      : options.body
+        ? { "content-type": "application/json" }
+        : {},
+    body: options.body ? JSON.stringify(options.body) : undefined,
+  });
+  if (!res.ok) {
+    throw new Error(`${options.method ?? "GET"} ${path} failed: ${res.status} ${await res.text()}`);
+  }
+  return (await res.json()) as T;
+}
+
+function requiredEnv(n: string): string {
+  const v = process.env[n]?.trim();
+  if (!v) throw new Error(`${n} is required`);
+  return v;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/cli/test/integration/capture-server-egress.test.ts
+++ b/cli/test/integration/capture-server-egress.test.ts
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-635 — integration tests for the capture-server's deny-by-default
+// egress floor.
+//
+// The proxy refuses CONNECT tunnels to hosts outside the allowlist with a
+// 403 BEFORE dialing upstream, and records each refusal in the egress
+// sidecar (egress.jsonl — deliberately NOT events.jsonl, whose row shape is
+// locked by shared-types / the correlator). Loopback targets are always
+// allowed so twin traffic can never be broken by a bad allowlist.
+//
+// The "allowed but unresolvable" case asserts the ordering: an allowlisted
+// host fails with 502 (upstream dial attempted, `.invalid` never resolves —
+// RFC 6761), a denied host fails with 403 (never dialed). Distinct status
+// codes prove the gate fires before the dial.
+
+import { mkdtemp, readFile } from "node:fs/promises";
+import { createServer as createNetServer, createConnection, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  runCaptureServer,
+  type CaptureServerHandle,
+} from "../../src/capture-server/index.js";
+
+function listenEphemeral(server: ReturnType<typeof createNetServer>): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (typeof addr === "object" && addr) resolve(addr.port);
+      else reject(new Error("ephemeral listen returned no address"));
+    });
+  });
+}
+
+async function startUpstream(): Promise<{
+  port: number;
+  connections: () => number;
+  close: () => Promise<void>;
+}> {
+  const sockets = new Set<Socket>();
+  let connections = 0;
+  const server = createNetServer((socket) => {
+    connections += 1;
+    sockets.add(socket);
+    socket.on("data", (chunk) => {
+      socket.write(chunk);
+    });
+    socket.once("close", () => sockets.delete(socket));
+  });
+  const port = await listenEphemeral(server);
+  return {
+    port,
+    connections: () => connections,
+    close: () =>
+      new Promise<void>((resolve) => {
+        for (const s of sockets) s.destroy();
+        server.close(() => resolve());
+      }),
+  };
+}
+
+// Retry `fn` until it returns non-null or ~2s elapse.
+async function pollFor<T>(fn: () => Promise<T | null>): Promise<T> {
+  for (let i = 0; i < 40; i++) {
+    const value = await fn();
+    if (value !== null) return value;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error("condition not reached within 2s");
+}
+
+// Send one CONNECT and resolve with the response status line (e.g. "200",
+// "403", "502"). For a 200, immediately close the tunnel.
+function connectStatus(
+  proxyPort: number,
+  targetHost: string,
+  targetPort: number,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const sock = createConnection({ host: "127.0.0.1", port: proxyPort });
+    let header = "";
+    let done = false;
+    sock.on("error", reject);
+    sock.on("data", (chunk: Buffer) => {
+      if (done) return;
+      header += chunk.toString("utf8");
+      const match = /^HTTP\/1\.[01] (\d{3})/.exec(header);
+      if (!match) return;
+      done = true;
+      const status = match[1]!;
+      sock.end();
+      resolve(status);
+    });
+    sock.on("close", () => {
+      if (!done) reject(new Error(`socket closed before a status line: ${header.slice(0, 120)}`));
+    });
+    sock.write(
+      `CONNECT ${targetHost}:${targetPort} HTTP/1.1\r\nHost: ${targetHost}:${targetPort}\r\n\r\n`,
+    );
+  });
+}
+
+describe("pome capture-server — egress floor (FDRS-635)", () => {
+  let capture: CaptureServerHandle | null = null;
+  let upstream: Awaited<ReturnType<typeof startUpstream>> | null = null;
+
+  beforeEach(async () => {
+    upstream = await startUpstream();
+  });
+
+  afterEach(async () => {
+    if (capture) await capture.close();
+    capture = null;
+    if (upstream) await upstream.close();
+    upstream = null;
+  });
+
+  it("refuses a CONNECT to a non-allowlisted host with 403 and records it in egress.jsonl", async () => {
+    const runDir = await mkdtemp(join(tmpdir(), "pome-egress-int-"));
+    const eventsOut = join(runDir, "events.jsonl");
+    const egressOut = join(runDir, "egress.jsonl");
+    capture = await runCaptureServer({ port: 0, eventsOut, allowHosts: [], egressOut });
+
+    const status = await connectStatus(capture.port, "blocked.example", 443);
+    expect(status).toBe("403");
+
+    await capture.flush();
+
+    // The refusal is a sidecar row, not an LlmCallEvent.
+    const egressRows = (await readFile(egressOut, "utf8"))
+      .split("\n")
+      .filter((l) => l.length > 0)
+      .map((l) => JSON.parse(l) as { kind: string; host: string; port: number });
+    expect(egressRows).toHaveLength(1);
+    expect(egressRows[0]).toMatchObject({
+      kind: "EgressRefusedEvent",
+      host: "blocked.example",
+      port: 443,
+    });
+
+    const events = (await readFile(eventsOut, "utf8")).trim();
+    expect(events).toBe("");
+  });
+
+  it("still tunnels loopback targets with an empty allowlist (twin traffic can never break)", async () => {
+    const runDir = await mkdtemp(join(tmpdir(), "pome-egress-int-"));
+    const eventsOut = join(runDir, "events.jsonl");
+    const egressOut = join(runDir, "egress.jsonl");
+    capture = await runCaptureServer({ port: 0, eventsOut, allowHosts: [], egressOut });
+
+    const status = await connectStatus(capture.port, "127.0.0.1", upstream!.port);
+    expect(status).toBe("200");
+
+    // The LlmCallEvent lands when the server-side sockets close — that
+    // trails the client's close by an event-loop turn or two, so poll.
+    const lines = await pollFor(async () => {
+      await capture!.flush();
+      const content = (await readFile(eventsOut, "utf8")).trim().split("\n").filter(Boolean);
+      return content.length >= 1 ? content : null;
+    });
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]!).kind).toBe("LlmCallEvent");
+  });
+
+  it("lets an allowlisted host through the gate (dial attempted → 502 on NXDOMAIN, never 403)", async () => {
+    const runDir = await mkdtemp(join(tmpdir(), "pome-egress-int-"));
+    capture = await runCaptureServer({
+      port: 0,
+      eventsOut: join(runDir, "events.jsonl"),
+      allowHosts: ["api.allowed.invalid"],
+      egressOut: join(runDir, "egress.jsonl"),
+    });
+
+    const status = await connectStatus(capture.port, "api.allowed.invalid", 443);
+    expect(status).toBe("502");
+  });
+
+  it("never dials upstream for a refused host", async () => {
+    const runDir = await mkdtemp(join(tmpdir(), "pome-egress-int-"));
+    capture = await runCaptureServer({
+      port: 0,
+      eventsOut: join(runDir, "events.jsonl"),
+      allowHosts: [],
+      egressOut: join(runDir, "egress.jsonl"),
+    });
+
+    // Target the live upstream's port but under a denied hostname: if the
+    // gate leaked, the dial would succeed and the upstream would see a
+    // connection.
+    const before = upstream!.connections();
+    const status = await connectStatus(capture.port, "denied.example", upstream!.port);
+    expect(status).toBe("403");
+    expect(upstream!.connections()).toBe(before);
+  });
+
+  it("enforces the floor even without an egress sidecar configured", async () => {
+    const runDir = await mkdtemp(join(tmpdir(), "pome-egress-int-"));
+    capture = await runCaptureServer({
+      port: 0,
+      eventsOut: join(runDir, "events.jsonl"),
+      allowHosts: [],
+    });
+
+    const status = await connectStatus(capture.port, "blocked.example", 443);
+    expect(status).toBe("403");
+  });
+});

--- a/cli/test/unit/capture-server-egress.test.ts
+++ b/cli/test/unit/capture-server-egress.test.ts
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-635 — unit tests for the egress floor's allowlist semantics.
+//
+// The floor is deny-by-default: only twin hosts + LLM provider hosts +
+// loopback may be CONNECTed to. The default provider set deliberately
+// mirrors `DEFAULT_AGENT_ENV_ALLOWLIST` in agentRunner.ts — a provider the
+// runner hands an API key for by default is a provider the floor lets the
+// agent dial by default. Everything else goes through the paired valves:
+// POME_AGENT_ENV_ALLOWLIST (key) + POME_EGRESS_ALLOW (host).
+
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  buildEgressAllowlist,
+  isHostAllowed,
+  parseAllowCsv,
+  readBlockedEgress,
+} from "../../src/capture-server/egress.js";
+
+describe("isHostAllowed", () => {
+  it("always allows the loopback family, even with an empty allowlist", () => {
+    expect(isHostAllowed("127.0.0.1", [])).toBe(true);
+    expect(isHostAllowed("127.1.2.3", [])).toBe(true);
+    expect(isHostAllowed("localhost", [])).toBe(true);
+    expect(isHostAllowed("LOCALHOST", [])).toBe(true);
+    expect(isHostAllowed("::1", [])).toBe(true);
+    expect(isHostAllowed("api.localhost", [])).toBe(true);
+  });
+
+  it("denies non-loopback hosts when the allowlist is empty", () => {
+    expect(isHostAllowed("api.github.com", [])).toBe(false);
+    expect(isHostAllowed("128.0.0.1", [])).toBe(false);
+    expect(isHostAllowed("127.evil.com", [])).toBe(false);
+  });
+
+  it("matches exact entries case-insensitively and ignores trailing dots", () => {
+    const patterns = ["api.github.com"];
+    expect(isHostAllowed("api.github.com", patterns)).toBe(true);
+    expect(isHostAllowed("API.GitHub.COM", patterns)).toBe(true);
+    expect(isHostAllowed("api.github.com.", patterns)).toBe(true);
+    expect(isHostAllowed("api.github.com.evil.io", patterns)).toBe(false);
+    expect(isHostAllowed("xapi.github.com", patterns)).toBe(false);
+  });
+
+  it("matches `*.suffix` entries against subdomains but not the apex", () => {
+    const patterns = ["*.anthropic.com"];
+    expect(isHostAllowed("api.anthropic.com", patterns)).toBe(true);
+    expect(isHostAllowed("statsig.anthropic.com", patterns)).toBe(true);
+    expect(isHostAllowed("a.b.anthropic.com", patterns)).toBe(true);
+    expect(isHostAllowed("anthropic.com", patterns)).toBe(false);
+    expect(isHostAllowed("evil-anthropic.com", patterns)).toBe(false);
+    expect(isHostAllowed("anthropic.com.evil.io", patterns)).toBe(false);
+  });
+
+  it("treats a bare `*` entry as allow-everything", () => {
+    expect(isHostAllowed("api.github.com", ["*"])).toBe(true);
+  });
+});
+
+describe("buildEgressAllowlist", () => {
+  it("allows the default LLM providers whose keys the runner forwards by default", () => {
+    const patterns = buildEgressAllowlist({});
+    expect(isHostAllowed("api.anthropic.com", patterns)).toBe(true);
+    expect(isHostAllowed("statsig.anthropic.com", patterns)).toBe(true);
+    expect(isHostAllowed("api.openai.com", patterns)).toBe(true);
+    expect(isHostAllowed("generativelanguage.googleapis.com", patterns)).toBe(true);
+    expect(isHostAllowed("openrouter.ai", patterns)).toBe(true);
+    expect(isHostAllowed("ai-gateway.vercel.sh", patterns)).toBe(true);
+  });
+
+  it("does not allow production API hosts or unrelated Google surfaces by default", () => {
+    const patterns = buildEgressAllowlist({});
+    expect(isHostAllowed("api.github.com", patterns)).toBe(false);
+    expect(isHostAllowed("api.stripe.com", patterns)).toBe(false);
+    expect(isHostAllowed("slack.com", patterns)).toBe(false);
+    // *.googleapis.com would be far too broad (storage, GCS, …).
+    expect(isHostAllowed("storage.googleapis.com", patterns)).toBe(false);
+  });
+
+  it("derives extra hosts from well-known BASE_URL env vars", () => {
+    const patterns = buildEgressAllowlist({
+      ANTHROPIC_BASE_URL: "https://llm-proxy.corp.example:8443/v1",
+      OPENAI_BASE_URL: "http://my-ollama.lan:11434/v1",
+    });
+    expect(isHostAllowed("llm-proxy.corp.example", patterns)).toBe(true);
+    expect(isHostAllowed("my-ollama.lan", patterns)).toBe(true);
+  });
+
+  it("ignores malformed BASE_URL env values instead of throwing", () => {
+    const patterns = buildEgressAllowlist({ ANTHROPIC_BASE_URL: "not a url" });
+    expect(isHostAllowed("api.anthropic.com", patterns)).toBe(true);
+  });
+
+  it("honors the POME_EGRESS_ALLOW valve (CSV of extra patterns)", () => {
+    const patterns = buildEgressAllowlist({
+      POME_EGRESS_ALLOW: "bedrock-runtime.us-east-1.amazonaws.com, *.mistral.ai",
+    });
+    expect(isHostAllowed("bedrock-runtime.us-east-1.amazonaws.com", patterns)).toBe(true);
+    expect(isHostAllowed("api.mistral.ai", patterns)).toBe(true);
+    expect(isHostAllowed("s3.us-east-1.amazonaws.com", patterns)).toBe(false);
+  });
+
+  it("includes twin URL hosts when provided", () => {
+    const patterns = buildEgressAllowlist({}, { twinUrls: ["https://twins.pome.sh/s/abc"] });
+    expect(isHostAllowed("twins.pome.sh", patterns)).toBe(true);
+  });
+});
+
+describe("parseAllowCsv", () => {
+  it("splits, trims, and drops empty entries", () => {
+    expect(parseAllowCsv(" a.example ,,*.b.example , ")).toEqual(["a.example", "*.b.example"]);
+    expect(parseAllowCsv(undefined)).toEqual([]);
+    expect(parseAllowCsv("")).toEqual([]);
+  });
+});
+
+describe("readBlockedEgress", () => {
+  it("aggregates refused rows per host:port, most-hit first, skipping junk lines", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pome-egress-"));
+    const path = join(dir, "egress.jsonl");
+    const rows = [
+      { ts: "2026-07-02T00:00:00Z", kind: "EgressRefusedEvent", host: "api.github.com", port: 443 },
+      { ts: "2026-07-02T00:00:01Z", kind: "EgressRefusedEvent", host: "api.github.com", port: 443 },
+      { ts: "2026-07-02T00:00:02Z", kind: "EgressRefusedEvent", host: "example.com", port: 443 },
+    ];
+    await writeFile(path, rows.map((r) => JSON.stringify(r)).join("\n") + "\nnot-json\n");
+
+    const blocked = await readBlockedEgress(path);
+    expect(blocked).toEqual([
+      { host: "api.github.com", port: 443, count: 2 },
+      { host: "example.com", port: 443, count: 1 },
+    ]);
+  });
+
+  it("returns [] when the file is missing or empty", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pome-egress-"));
+    expect(await readBlockedEgress(join(dir, "missing.jsonl"))).toEqual([]);
+    const empty = join(dir, "empty.jsonl");
+    await writeFile(empty, "");
+    expect(await readBlockedEgress(empty)).toEqual([]);
+  });
+});

--- a/cli/test/unit/doctor/checks.test.ts
+++ b/cli/test/unit/doctor/checks.test.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-634 — unit tests for the doctor check engine.
+//
+// Four checks, in order: config present+valid → twin reachable → routing →
+// egress floor. The engine stops at the first failure so the report carries
+// exactly ONE named cause + one concrete fix ("never a false success" wants
+// one clear next step, not a wall of maybes).
+
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { runDoctorChecks } from "../../../src/doctor/checks.js";
+
+const WIRED_AGENT = [
+  'import { withPome } from "@pome-sh/adapter-claude-sdk";',
+  "withPome();",
+  'const baseUrl = process.env.POME_GITHUB_REST_URL ?? "http://127.0.0.1:3333";',
+  "export { baseUrl };",
+].join("\n");
+
+async function repo(files: Record<string, string>): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "pome-doctor-"));
+  for (const [rel, content] of Object.entries(files)) {
+    const path = join(dir, rel);
+    await mkdir(join(path, ".."), { recursive: true });
+    await writeFile(path, content);
+  }
+  return dir;
+}
+
+const VALID_CONFIG = JSON.stringify({ agent: { command: "bun src/agent.ts", sdk: "claude" } });
+
+describe("runDoctorChecks", () => {
+  it("fails the config check when no pome.config.json exists, pointing at pome init", async () => {
+    const dir = await repo({ "src/agent.ts": WIRED_AGENT });
+
+    const report = await runDoctorChecks({ cwd: dir });
+    expect(report.ok).toBe(false);
+    expect(report.checks).toHaveLength(1);
+    expect(report.checks[0]).toMatchObject({ id: "config", status: "fail" });
+    expect(report.checks[0]!.cause).toContain("pome.config.json");
+    expect(report.checks[0]!.fix).toContain("pome init");
+  });
+
+  it("fails the config check on unparseable JSON, naming the file", async () => {
+    const dir = await repo({
+      "pome.config.json": "{ not json",
+      "src/agent.ts": WIRED_AGENT,
+    });
+
+    const report = await runDoctorChecks({ cwd: dir });
+    expect(report.ok).toBe(false);
+    expect(report.checks[0]).toMatchObject({ id: "config", status: "fail" });
+    expect(report.checks[0]!.cause).toContain("pome.config.json");
+  });
+
+  it("passes all four checks on a correctly wired repo", async () => {
+    const dir = await repo({
+      "pome.config.json": VALID_CONFIG,
+      "src/agent.ts": WIRED_AGENT,
+    });
+
+    const report = await runDoctorChecks({ cwd: dir, env: {} });
+    expect(report.checks.map((c) => `${c.id}:${c.status}`)).toEqual([
+      "config:pass",
+      "twin:pass",
+      "routing:pass",
+      "egress:pass",
+    ]);
+    expect(report.ok).toBe(true);
+  }, 30_000);
+
+  it("fails routing on a hardcoded production host with file:line cause and env-read fix", async () => {
+    const dir = await repo({
+      "pome.config.json": VALID_CONFIG,
+      "src/agent.ts": [
+        'import fetch from "node-fetch";',
+        'const gh = "https://api.github.com";',
+        "export { gh };",
+      ].join("\n"),
+    });
+
+    const report = await runDoctorChecks({ cwd: dir, env: {} });
+    expect(report.ok).toBe(false);
+    const routing = report.checks.at(-1)!;
+    expect(routing).toMatchObject({ id: "routing", status: "fail" });
+    expect(routing.cause).toContain("src/agent.ts");
+    expect(routing.cause).toContain("line 2");
+    expect(routing.cause).toContain("api.github.com");
+    expect(routing.cause).toContain("POME_GITHUB_REST_URL");
+    expect(routing.fix).toContain("POME_GITHUB_REST_URL");
+    // Engine stopped at the failure — egress never ran.
+    expect(report.checks.map((c) => c.id)).toEqual(["config", "twin", "routing"]);
+  }, 30_000);
+
+  it("fails routing when no wiring evidence exists at all", async () => {
+    const dir = await repo({
+      "pome.config.json": VALID_CONFIG,
+      "src/agent.ts": "export const nothing = 1;",
+    });
+
+    const report = await runDoctorChecks({ cwd: dir, env: {} });
+    expect(report.ok).toBe(false);
+    const routing = report.checks.at(-1)!;
+    expect(routing).toMatchObject({ id: "routing", status: "fail" });
+    expect(routing.fix).toContain("withPome");
+  }, 30_000);
+
+  it("fails the egress check when a wildcard disables the floor", async () => {
+    const dir = await repo({
+      "pome.config.json": VALID_CONFIG,
+      "src/agent.ts": WIRED_AGENT,
+    });
+
+    const report = await runDoctorChecks({ cwd: dir, env: { POME_EGRESS_ALLOW: "*" } });
+    expect(report.ok).toBe(false);
+    const egress = report.checks.at(-1)!;
+    expect(egress).toMatchObject({ id: "egress", status: "fail" });
+    expect(egress.cause).toContain("POME_EGRESS_ALLOW");
+    expect(egress.fix).toContain("*");
+  }, 30_000);
+});

--- a/cli/test/unit/doctor/checks.test.ts
+++ b/cli/test/unit/doctor/checks.test.ts
@@ -107,6 +107,21 @@ describe("runDoctorChecks", () => {
     expect(routing.fix).toContain("withPome");
   }, 30_000);
 
+  it("skips the local twin boot in hosted mode but still gates config/routing/egress", async () => {
+    const dir = await repo({
+      "pome.config.json": VALID_CONFIG,
+      "src/agent.ts": WIRED_AGENT,
+    });
+
+    const report = await runDoctorChecks({ cwd: dir, env: {}, mode: "hosted" });
+    expect(report.checks.map((c) => `${c.id}:${c.status}`)).toEqual([
+      "config:pass",
+      "routing:pass",
+      "egress:pass",
+    ]);
+    expect(report.ok).toBe(true);
+  });
+
   it("fails the egress check when a wildcard disables the floor", async () => {
     const dir = await repo({
       "pome.config.json": VALID_CONFIG,

--- a/cli/test/unit/doctor/render.test.ts
+++ b/cli/test/unit/doctor/render.test.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-634 — the doctor's terminal rendering, per `CLI moments.dc.html`
+// moment 03: check lines, then (on failure) exactly one cause/fix card and
+// the two closing warning lines.
+
+import { describe, expect, it } from "vitest";
+import { renderDoctorReport } from "../../../src/doctor/render.js";
+import type { DoctorReport } from "../../../src/doctor/checks.js";
+
+describe("renderDoctorReport", () => {
+  it("renders all-pass reports without a cause card", () => {
+    const report: DoctorReport = {
+      ok: true,
+      checks: [
+        { id: "config", status: "pass", label: "pome.config.json found" },
+        { id: "twin", status: "pass", label: "twin reachable", detail: "github · local" },
+        { id: "routing", status: "pass", label: "requests route to the twin", detail: "reads POME_GITHUB_REST_URL" },
+        { id: "egress", status: "pass", label: "egress floor active", detail: "deny-by-default · 6 pattern(s) + loopback" },
+      ],
+    };
+
+    const text = renderDoctorReport(report).join("\n");
+    expect(text).toContain("checking your wiring …");
+    expect(text).toContain("✓ pome.config.json found");
+    expect(text).toContain("✓ twin reachable  github · local");
+    expect(text).not.toContain("cause");
+    expect(text).not.toContain("your agent would hit production");
+  });
+
+  it("renders one cause/fix card and the production warning on failure", () => {
+    const report: DoctorReport = {
+      ok: false,
+      checks: [
+        { id: "config", status: "pass", label: "pome.config.json found" },
+        { id: "twin", status: "pass", label: "twin reachable", detail: "github · local" },
+        {
+          id: "routing",
+          status: "fail",
+          label: "requests are not routed to the twin",
+          cause:
+            "src/agent/triage.ts reads from a hardcoded https://api.github.com on line 12, ignoring POME_GITHUB_REST_URL — so its requests would bypass the twin.",
+          fix: "read the base URL from the env the runner injects —\nconst { POME_GITHUB_REST_URL: baseUrl } = process.env\nthen re-run pome doctor",
+        },
+      ],
+    };
+
+    const lines = renderDoctorReport(report);
+    const text = lines.join("\n");
+    expect(text).toContain("✗ requests are not routed to the twin");
+    expect(text).toContain(
+      "cause  src/agent/triage.ts reads from a hardcoded https://api.github.com on line 12, ignoring POME_GITHUB_REST_URL — so its requests would bypass the twin.",
+    );
+    expect(text).toContain("fix    read the base URL from the env the runner injects —");
+    // Continuation lines of the fix stay aligned under the fix column.
+    expect(text).toContain("       const { POME_GITHUB_REST_URL: baseUrl } = process.env");
+    expect(text).toContain("until this passes, your agent would hit production.");
+    expect(text).toContain("pome will not run trials against a live API.");
+  });
+});

--- a/cli/test/unit/doctor/scan.test.ts
+++ b/cli/test/unit/doctor/scan.test.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-634 — unit tests for the doctor's static routing scan.
+//
+// The scan is the named-cause half of the routing check: it finds hardcoded
+// production API hosts (file:line) that would bypass the POME_*_REST_URL env
+// contract, and collects positive wiring evidence (env-var reads / adapter
+// import). The dynamic half — requests observably reaching the twin — is
+// what `pome run`'s trace records; doctor stays fast and LLM-free.
+
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { scanAgentSources } from "../../../src/doctor/scan.js";
+
+async function fixture(files: Record<string, string>): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "pome-doctor-scan-"));
+  for (const [rel, content] of Object.entries(files)) {
+    const path = join(dir, rel);
+    await mkdir(join(path, ".."), { recursive: true });
+    await writeFile(path, content);
+  }
+  return dir;
+}
+
+describe("scanAgentSources", () => {
+  it("finds a hardcoded production host with file and line", async () => {
+    const dir = await fixture({
+      "src/agent/triage.ts": [
+        'import fetch from "node-fetch";',
+        "",
+        'const gh = "https://api.github.com";',
+        "export const x = 1;",
+      ].join("\n"),
+    });
+
+    const result = await scanAgentSources(dir);
+    expect(result.hardcoded).toEqual({
+      file: "src/agent/triage.ts",
+      line: 3,
+      host: "api.github.com",
+      envVar: "POME_GITHUB_REST_URL",
+    });
+  });
+
+  it("maps stripe and slack production hosts to their env vars", async () => {
+    const stripe = await fixture({ "a.ts": 'fetch("https://api.stripe.com/v1/charges");' });
+    expect((await scanAgentSources(stripe)).hardcoded?.envVar).toBe("POME_STRIPE_REST_URL");
+
+    const slack = await fixture({ "b.ts": 'fetch("https://hooks.slack.com/services/T0/B0/x");' });
+    expect((await scanAgentSources(slack)).hardcoded?.envVar).toBe("POME_SLACK_REST_URL");
+  });
+
+  it("ignores hosts that only appear in comments", async () => {
+    const dir = await fixture({
+      "src/index.ts": [
+        "// in production this would call https://api.github.com",
+        " * docs: https://api.github.com/repos",
+        'const base = process.env.POME_GITHUB_REST_URL ?? "http://127.0.0.1:3333";',
+      ].join("\n"),
+    });
+
+    const result = await scanAgentSources(dir);
+    expect(result.hardcoded).toBeNull();
+    expect(result.wiring.envVar).toBe("POME_GITHUB_REST_URL");
+  });
+
+  it("does not flag loopback fallback URLs", async () => {
+    const dir = await fixture({
+      "src/index.ts": 'const url = process.env.POME_GITHUB_MCP_URL ?? "http://127.0.0.1:3333/s/demo/mcp";',
+    });
+
+    const result = await scanAgentSources(dir);
+    expect(result.hardcoded).toBeNull();
+    expect(result.wiring.envVar).toBe("POME_GITHUB_MCP_URL");
+  });
+
+  it("collects adapter-import evidence", async () => {
+    const dir = await fixture({
+      "src/index.ts": [
+        'import { withPome, tool, query } from "@pome-sh/adapter-claude-sdk";',
+        "withPome();",
+      ].join("\n"),
+    });
+
+    const result = await scanAgentSources(dir);
+    expect(result.wiring.adapterImport).toBe(true);
+  });
+
+  it("skips node_modules and non-code files", async () => {
+    const dir = await fixture({
+      "node_modules/evil/index.js": 'fetch("https://api.github.com");',
+      "README.md": "call https://api.github.com",
+      "src/ok.ts": "export const ok = process.env.POME_GITHUB_REST_URL;",
+    });
+
+    const result = await scanAgentSources(dir);
+    expect(result.hardcoded).toBeNull();
+    expect(result.filesScanned).toBe(1);
+  });
+});

--- a/cli/test/unit/run-doctor-gate.test.ts
+++ b/cli/test/unit/run-doctor-gate.test.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-641 — `pome run` gates on the doctor preflight: a repo failing any
+// doctor check refuses to spawn the agent (before any twin/session is
+// provisioned), prints the doctor output, and exits non-zero. There is no
+// --force / --skip-checks escape — "pome will not run trials against a
+// live API."
+
+import { cp, mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createProgram } from "../../src/cli/main.js";
+
+const SCENARIO_SRC = new URL("../../scenarios/01-bug-happy-path.md", import.meta.url).pathname;
+const SCENARIO_SEED_SRC = new URL("../../scenarios/01-bug-happy-path.seed.json", import.meta.url).pathname;
+
+async function fixtureRepo(agentSource: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "pome-run-gate-"));
+  await mkdir(join(dir, "src"), { recursive: true });
+  await mkdir(join(dir, "scenarios"), { recursive: true });
+  await writeFile(
+    join(dir, "pome.config.json"),
+    JSON.stringify({ agent: { command: 'node -e "process.exit(0)"' } }, null, 2),
+  );
+  await writeFile(join(dir, "src/agent.ts"), agentSource);
+  await cp(SCENARIO_SRC, join(dir, "scenarios/01-bug-happy-path.md"));
+  await cp(SCENARIO_SEED_SRC, join(dir, "scenarios/01-bug-happy-path.seed.json"));
+  return dir;
+}
+
+describe("pome run — doctor preflight gate (FDRS-641)", () => {
+  const originalCwd = process.cwd();
+  const originalExitCode = process.exitCode;
+  let stderr: string[];
+
+  beforeEach(() => {
+    stderr = [];
+    vi.spyOn(console, "error").mockImplementation((msg?: unknown) => {
+      stderr.push(String(msg));
+    });
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    vi.restoreAllMocks();
+    process.exitCode = originalExitCode;
+  });
+
+  it("refuses to run in a repo failing doctor, printing the named cause", async () => {
+    const dir = await fixtureRepo(
+      ['import fetch from "node-fetch";', 'const gh = "https://api.github.com";', "export { gh };"].join("\n"),
+    );
+    process.chdir(dir);
+
+    await createProgram().parseAsync([
+      "node",
+      "pome",
+      "run",
+      "scenarios/01-bug-happy-path.md",
+      "--local",
+      // Keep the test hermetic under vitest: the capture-server child
+      // re-invokes process.argv[1], which is vitest's fork bootstrap here.
+      // The gate under test fires long before capture is a factor.
+      "--no-capture",
+    ]);
+
+    expect(process.exitCode).toBe(1);
+    const text = stderr.join("\n");
+    expect(text).toContain("cause");
+    expect(text).toContain("api.github.com");
+    expect(text).toContain("refusing to spawn the agent");
+    // The gate fired before any run happened: no per-scenario result lines.
+    expect(text).not.toMatch(/\b(TRACE|PASS|FAIL)\b/);
+  }, 30_000);
+
+  it("runs exactly as before on a correctly wired repo", async () => {
+    const dir = await fixtureRepo(
+      [
+        'import { withPome } from "@pome-sh/adapter-claude-sdk";',
+        "withPome();",
+        "const baseUrl = process.env.POME_GITHUB_REST_URL;",
+        "export { baseUrl };",
+      ].join("\n"),
+    );
+    process.chdir(dir);
+
+    await createProgram().parseAsync([
+      "node",
+      "pome",
+      "run",
+      "scenarios/01-bug-happy-path.md",
+      "--local",
+      "--no-capture",
+    ]);
+
+    const text = stderr.join("\n");
+    expect(text).toContain("TRACE");
+    expect(process.exitCode ?? 0).toBe(0);
+  }, 60_000);
+
+  it("offers no --force / --skip-checks escape", () => {
+    const run = createProgram().commands.find((c) => c.name() === "run");
+    expect(run).toBeDefined();
+    const flags = run!.options.map((o) => o.long);
+    expect(flags).not.toContain("--force");
+    expect(flags).not.toContain("--skip-checks");
+  });
+});


### PR DESCRIPTION
<!-- Closes FDRS-641 -->

## What

`pome run` in a repo failing any applicable doctor check refuses to spawn the agent — before credentials are resolved and before any twin/session is provisioned — printing the doctor report (one named cause + fix) and exiting non-zero (stacked on #32). There is deliberately no `--force` / `--skip-checks` escape. Local runs use the full engine (incl. the in-process twin boot); hosted runs skip the local twin boot (the cloud provisions the session twin) but still gate on config, routing, and the egress floor.

## Why

M2 of [First-run journey v1](https://linear.app/pome-sh/project/first-run-journey-v1-81772a84fa54), locked decision: "never a false success" — the design's exact line renders in the refusal: "pome will not run trials against a live API."

## Notes for reviewer

- **Behavior change**: `pome run` now requires a wired repo (config present) even with an explicit `--agent` flag — flagged in the changeset. The hosted e2e fixtures became wired repos (config + `POME_GITHUB_REST_URL`-reading src), which is what any post-`pome install` project looks like.
- Hosted mode skips the local twin boot for two reasons: it's not what a hosted run touches, and the boot needs better-sqlite3 (unavailable under the Bun runtime the hosted e2e — and users — commonly run the CLI with).
- Preflight latency on a wired repo: the doctor engine (incl. twin boot) measures well under 100ms in the test suite — imperceptible next to agent runtime; the gate runs once per invocation, not per scenario file.
- A no-escape assertion is part of the test: the `run` command's option list is asserted to contain no `--force` / `--skip-checks`.

## Review required

Yes — changes public `pome run` behavior (refuses config-less/unwired repos; no escape hatch).