### PR TITLE
feat(cli): gate pome run on the doctor preflight (FDRS-641)

### DIFF
--- a/cli/.changeset/fdrs-641-run-doctor-gate.md
+++ b/cli/.changeset/fdrs-641-run-doctor-gate.md
@@ -1,0 +1,18 @@
+---
+"pome-sh": minor
+---
+
+**`pome run` now gates on the doctor preflight (FDRS-641).**
+
+A repo failing any applicable doctor check refuses to spawn the agent —
+before credentials are resolved and before any twin/session is provisioned —
+printing the doctor output (one named cause + one concrete fix) and exiting
+non-zero. There is deliberately no `--force` / `--skip-checks` escape: pome
+will not run trials against a live API. Local runs get the full engine
+(including the in-process twin boot); hosted runs skip the local twin boot
+(the cloud provisions the session twin) but still gate on config, routing,
+and the egress floor.
+
+Breaking for config-less flows: `pome run` now requires a `pome.config.json`
+(run `pome init`, or `pome install` once it lands) even when `--agent` is
+passed explicitly.

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -574,7 +574,9 @@ export function createProgram() {
       "--local",
       "Self-host: run against an in-process twin and capture a trace WITHOUT scoring. Evaluation (pass/fail) is a hosted feature — `pome login` and re-run to score on Pome cloud. See ADR-004.",
     )
-    .description("Run one or more Pome scenarios")
+    .description(
+      "Run one or more Pome scenarios. Refuses to start if the doctor wiring checks fail (see `pome doctor`); there is no --force.",
+    )
     .action(
       async (
         target: string,
@@ -631,6 +633,31 @@ export function createProgram() {
         } else if (options.hosted) {
           console.error("Note: --hosted is now the default; the flag is a deprecated no-op and will be removed in a future release.");
         }
+
+        // FDRS-641 — doctor preflight gate. A repo failing any applicable
+        // doctor check refuses to spawn the agent — BEFORE credentials are
+        // resolved and before any twin/session is provisioned. Local runs get
+        // the full engine (incl. local twin boot); hosted runs skip the local
+        // twin (the cloud provisions the session twin) but still gate on
+        // config, routing, and the egress floor. Deliberately no --force /
+        // --skip-checks escape: "never a false success" — pome will not run
+        // trials against a live API. (Design: CLI moments 03; engine:
+        // FDRS-634.)
+        {
+          const { runDoctorChecks } = await import("../doctor/checks.js");
+          const { renderDoctorReport } = await import("../doctor/render.js");
+          const doctorReport = await runDoctorChecks({ mode: useLocal ? "full" : "hosted" });
+          if (!doctorReport.ok) {
+            for (const line of renderDoctorReport(doctorReport)) console.error(line);
+            console.error("");
+            console.error(
+              "pome run: wiring check failed — refusing to spawn the agent. Fix the cause above and re-run (there is no --force).",
+            );
+            process.exitCode = 1;
+            return;
+          }
+        }
+
         try {
           hostedCreds = useLocal
             ? null

--- a/cli/src/doctor/checks.ts
+++ b/cli/src/doctor/checks.ts
@@ -17,7 +17,6 @@ import { sign } from "hono/jwt";
 import { buildEgressAllowlist } from "../capture-server/egress.js";
 import { findProjectConfigPath, readProjectConfig } from "../cli/project-config.js";
 import { getAvailablePort } from "../runner/ports.js";
-import { bootTwin } from "../twin/twinHarness.js";
 import { scanAgentSources } from "./scan.js";
 
 export type DoctorCheckId = "config" | "twin" | "routing" | "egress";
@@ -41,6 +40,12 @@ export interface RunDoctorChecksOptions {
   // Injectable for tests; defaults to process.env. Read by the egress check
   // (floor wildcard) — NOT forwarded to any agent.
   env?: Record<string, string | undefined>;
+  // "full" (default, `pome doctor` + local-run gate) boots the local twin.
+  // "hosted" (the hosted-run gate, FDRS-641) skips the local twin boot: a
+  // hosted run never touches it — the cloud provisions the session twin —
+  // and the local boot needs better-sqlite3, unavailable under the Bun
+  // runtime hosted runs commonly use. Config/routing/egress still gate.
+  mode?: "full" | "hosted";
 }
 
 export async function runDoctorChecks(
@@ -48,10 +53,11 @@ export async function runDoctorChecks(
 ): Promise<DoctorReport> {
   const cwd = options.cwd ?? process.cwd();
   const env = options.env ?? process.env;
+  const mode = options.mode ?? "full";
 
   const checks: DoctorCheck[] = [];
   const steps: Array<(configDir: string) => Promise<DoctorCheck>> = [
-    (dir) => checkTwinReachable(dir),
+    ...(mode === "full" ? [(dir: string) => checkTwinReachable(dir)] : []),
     (dir) => checkRouting(dir),
     async (dir) => checkEgressFloor(env, dir),
   ];
@@ -133,6 +139,9 @@ async function checkTwinReachable(_configDir: string): Promise<DoctorCheck> {
 
   let harness;
   try {
+    // Dynamic import: the twin harness pulls in better-sqlite3, which the
+    // hosted-mode gate must never load (unavailable under the Bun runtime).
+    const { bootTwin } = await import("../twin/twinHarness.js");
     harness = await bootTwin({
       twin: "github",
       seedState: undefined,

--- a/cli/test/e2e/runScenarioHosted.test.ts
+++ b/cli/test/e2e/runScenarioHosted.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { spawn } from "node:child_process";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -80,6 +80,21 @@ describe("pome run --hosted (e2e via spawn)", () => {
     receivedResult = null;
     finalizeResponseOverrides = {};
     tmp = await mkdtemp(join(tmpdir(), "pome-e2e-"));
+    // FDRS-641 — `pome run` gates on the doctor preflight (config present,
+    // routing wired, egress floor; local twin boot is skipped on hosted
+    // runs). Make tmp a wired repo and spawn the CLI from it, matching what
+    // a real post-`pome install` project looks like.
+    await writeFile(
+      join(tmp, "pome.config.json"),
+      JSON.stringify({ agent: { command: "true" } }, null, 2),
+      "utf8"
+    );
+    await mkdir(join(tmp, "src"), { recursive: true });
+    await writeFile(
+      join(tmp, "src", "agent.ts"),
+      "const baseUrl = process.env.POME_GITHUB_REST_URL;\nexport { baseUrl };\n",
+      "utf8"
+    );
     port = await startFakeCloud();
   });
 
@@ -131,6 +146,7 @@ describe("pome run --hosted (e2e via spawn)", () => {
         join(tmp, "runs"),
       ],
       {
+        cwd: tmp,
         env: { ...process.env, POME_API_KEY: "pme_e2e_test" },
       }
     );
@@ -201,6 +217,7 @@ describe("pome run --hosted (e2e via spawn)", () => {
         join(tmp, "runs"),
       ],
       {
+        cwd: tmp,
         env: { ...process.env, POME_API_KEY: "pme_e2e_test" },
       },
     );

--- a/cli/test/unit/doctor/checks.test.ts
+++ b/cli/test/unit/doctor/checks.test.ts
@@ -107,6 +107,21 @@ describe("runDoctorChecks", () => {
     expect(routing.fix).toContain("withPome");
   }, 30_000);
 
+  it("skips the local twin boot in hosted mode but still gates config/routing/egress", async () => {
+    const dir = await repo({
+      "pome.config.json": VALID_CONFIG,
+      "src/agent.ts": WIRED_AGENT,
+    });
+
+    const report = await runDoctorChecks({ cwd: dir, env: {}, mode: "hosted" });
+    expect(report.checks.map((c) => `${c.id}:${c.status}`)).toEqual([
+      "config:pass",
+      "routing:pass",
+      "egress:pass",
+    ]);
+    expect(report.ok).toBe(true);
+  });
+
   it("fails the egress check when a wildcard disables the floor", async () => {
     const dir = await repo({
       "pome.config.json": VALID_CONFIG,

--- a/cli/test/unit/run-doctor-gate.test.ts
+++ b/cli/test/unit/run-doctor-gate.test.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-641 — `pome run` gates on the doctor preflight: a repo failing any
+// doctor check refuses to spawn the agent (before any twin/session is
+// provisioned), prints the doctor output, and exits non-zero. There is no
+// --force / --skip-checks escape — "pome will not run trials against a
+// live API."
+
+import { cp, mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createProgram } from "../../src/cli/main.js";
+
+const SCENARIO_SRC = new URL("../../scenarios/01-bug-happy-path.md", import.meta.url).pathname;
+const SCENARIO_SEED_SRC = new URL("../../scenarios/01-bug-happy-path.seed.json", import.meta.url).pathname;
+
+async function fixtureRepo(agentSource: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "pome-run-gate-"));
+  await mkdir(join(dir, "src"), { recursive: true });
+  await mkdir(join(dir, "scenarios"), { recursive: true });
+  await writeFile(
+    join(dir, "pome.config.json"),
+    JSON.stringify({ agent: { command: 'node -e "process.exit(0)"' } }, null, 2),
+  );
+  await writeFile(join(dir, "src/agent.ts"), agentSource);
+  await cp(SCENARIO_SRC, join(dir, "scenarios/01-bug-happy-path.md"));
+  await cp(SCENARIO_SEED_SRC, join(dir, "scenarios/01-bug-happy-path.seed.json"));
+  return dir;
+}
+
+describe("pome run — doctor preflight gate (FDRS-641)", () => {
+  const originalCwd = process.cwd();
+  const originalExitCode = process.exitCode;
+  let stderr: string[];
+
+  beforeEach(() => {
+    stderr = [];
+    vi.spyOn(console, "error").mockImplementation((msg?: unknown) => {
+      stderr.push(String(msg));
+    });
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    vi.restoreAllMocks();
+    process.exitCode = originalExitCode;
+  });
+
+  it("refuses to run in a repo failing doctor, printing the named cause", async () => {
+    const dir = await fixtureRepo(
+      ['import fetch from "node-fetch";', 'const gh = "https://api.github.com";', "export { gh };"].join("\n"),
+    );
+    process.chdir(dir);
+
+    await createProgram().parseAsync([
+      "node",
+      "pome",
+      "run",
+      "scenarios/01-bug-happy-path.md",
+      "--local",
+      // Keep the test hermetic under vitest: the capture-server child
+      // re-invokes process.argv[1], which is vitest's fork bootstrap here.
+      // The gate under test fires long before capture is a factor.
+      "--no-capture",
+    ]);
+
+    expect(process.exitCode).toBe(1);
+    const text = stderr.join("\n");
+    expect(text).toContain("cause");
+    expect(text).toContain("api.github.com");
+    expect(text).toContain("refusing to spawn the agent");
+    // The gate fired before any run happened: no per-scenario result lines.
+    expect(text).not.toMatch(/\b(TRACE|PASS|FAIL)\b/);
+  }, 30_000);
+
+  it("runs exactly as before on a correctly wired repo", async () => {
+    const dir = await fixtureRepo(
+      [
+        'import { withPome } from "@pome-sh/adapter-claude-sdk";',
+        "withPome();",
+        "const baseUrl = process.env.POME_GITHUB_REST_URL;",
+        "export { baseUrl };",
+      ].join("\n"),
+    );
+    process.chdir(dir);
+
+    await createProgram().parseAsync([
+      "node",
+      "pome",
+      "run",
+      "scenarios/01-bug-happy-path.md",
+      "--local",
+      "--no-capture",
+    ]);
+
+    const text = stderr.join("\n");
+    expect(text).toContain("TRACE");
+    expect(process.exitCode ?? 0).toBe(0);
+  }, 60_000);
+
+  it("offers no --force / --skip-checks escape", () => {
+    const run = createProgram().commands.find((c) => c.name() === "run");
+    expect(run).toBeDefined();
+    const flags = run!.options.map((o) => o.long);
+    expect(flags).not.toContain("--force");
+    expect(flags).not.toContain("--skip-checks");
+  });
+});


### PR DESCRIPTION
<!-- Closes FDRS-641 -->

## What

`pome run` in a repo failing any applicable doctor check refuses to spawn the agent — before credentials are resolved and before any twin/session is provisioned — printing the doctor report (one named cause + fix) and exiting non-zero (stacked on #32). There is deliberately no `--force` / `--skip-checks` escape. Local runs use the full engine (incl. the in-process twin boot); hosted runs skip the local twin boot (the cloud provisions the session twin) but still gate on config, routing, and the egress floor.

## Why

M2 of [First-run journey v1](https://linear.app/pome-sh/project/first-run-journey-v1-81772a84fa54), locked decision: "never a false success" — the design's exact line renders in the refusal: "pome will not run trials against a live API."

## Notes for reviewer

- **Behavior change**: `pome run` now requires a wired repo (config present) even with an explicit `--agent` flag — flagged in the changeset. The hosted e2e fixtures became wired repos (config + `POME_GITHUB_REST_URL`-reading src), which is what any post-`pome install` project looks like.
- Hosted mode skips the local twin boot for two reasons: it's not what a hosted run touches, and the boot needs better-sqlite3 (unavailable under the Bun runtime the hosted e2e — and users — commonly run the CLI with).
- Preflight latency on a wired repo: the doctor engine (incl. twin boot) measures well under 100ms in the test suite — imperceptible next to agent runtime; the gate runs once per invocation, not per scenario file.
- A no-escape assertion is part of the test: the `run` command's option list is asserted to contain no `--force` / `--skip-checks`.

## Review required

Yes — changes public `pome run` behavior (refuses config-less/unwired repos; no escape hatch).

> Supersedes #33 — its head branch was deleted mid-choreography after a conflicting merge attempt; this is the same single commit rebased onto main (now including #35), full suite re-verified.
