### PR TITLE
fix(ci): bump CI Node 20 to 22 to restore better-sqlite3 install (FDRS-652)

### DIFF
--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   test:
-    name: ubuntu-latest · Node 20
+    name: ubuntu-latest · Node 22
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -33,7 +33,7 @@ jobs:
           bun-version: 1.3.10
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version: 22
       - run: node scripts/verify-vendor.mjs
       - run: bun install --frozen-lockfile
       - run: bun run typecheck

--- a/.github/workflows/golden-gate.yml
+++ b/.github/workflows/golden-gate.yml
@@ -47,7 +47,7 @@ jobs:
           bun-version: 1.3.10
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version: 22
       - run: node scripts/verify-vendor.mjs
       - run: bun install --frozen-lockfile
       - run: bun run test test/golden/golden-scenario.test.ts

--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -30,7 +30,7 @@ jobs:
           bun-version: 1.3.10
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org
       - run: bun install --frozen-lockfile
 
@@ -88,7 +88,7 @@ jobs:
           bun-version: 1.3.10
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org
       - run: bun install --frozen-lockfile
       - run: bun run --filter '@pome-sh/sdk' typecheck


### PR DESCRIPTION
<!-- Closes FDRS-652 -->

## What

Bumps `actions/setup-node` from Node 20 to Node 22 in the three workflows that pair it with a `bun install` touching better-sqlite3: `cli-ci.yml` (job renamed `ubuntu-latest · Node 22`), `golden-gate.yml`, and both `sdk-publish.yml` jobs.

## Why

better-sqlite3 12.10.0 publishes no Node-20 (ABI 115) prebuilds — only Node 22+ — so the Node-20 jobs have always compiled it from source (invisibly: bun suppresses install-script output on success). On 2026-07-02 between 21:49Z (last green, same runner image, same Node 20.20.2) and 23:15Z (first red), bun's `bunx node-gyp@latest` shim started resolving node-gyp 13.0.1, whose bundled undici requires `webidl.util.markAsUncloneable` and crashes on Node 20, killing `bun install --frozen-lockfile` before any project code runs. On Node 22 the prebuild (`node-v127-linux-x64`) downloads and node-gyp is never invoked — proven on main today by agent-trace-overhead-gate's identical `cd cli && bun install --frozen-lockfile` on Node 22 (run 28654567992, install + build steps green).

## Notes for reviewer

- `engines: node >=20` in `cli/package.json` (and AGENTS.md's "targets node ≥20") now claims a floor CI no longer exercises. Node 20 is EOL, GitHub is deprecating Node-20 runners, and the ecosystem has dropped its prebuilds — bumping engines to `>=22` is a separate product decision, not made here.
- Rejected alternative: pinning node-gyp as a cli devDep would keep Node-20 CI alive but tests a configuration no user ships and keeps every run compiling sqlite from source.
- Scope of FDRS-652 is the install step. cli-ci may still be red downstream at typecheck/test on the known shared-types-seam issue (`cli/src/runner/correlateRun.ts`), which is tracked separately.