### PR TITLE
feat(cli): pome install — agent-driven wiring with diff gate (FDRS-642)

### DIFF
--- a/cli/.changeset/pome-install-agent-driven-wiring.md
+++ b/cli/.changeset/pome-install-agent-driven-wiring.md
@@ -1,0 +1,5 @@
+---
+"pome-sh": minor
+---
+
+`pome install` — agent-driven wiring with the diff gate in your coding agent's own edit-approval UI. Checks auth (routes through `pome login` when needed), detects your coding agent, ensures the evolved `pome-setup` skill, hands off to an interactive session, then verifies the wiring with `pome doctor` to green. No coding agent on PATH → prints manual wiring steps plus a paste-into-any-agent prompt. The `pome-setup` skill is rewritten adapter-first (`withPome()` + env-injected base URLs) with hard rules: no secrets in source, read-before-write, minimal targeted edits, diff approval before applying, and doctor-green as the only done.

--- a/cli/scripts/make-unwired-fixture.mjs
+++ b/cli/scripts/make-unwired-fixture.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-642 — build an UNWIRED copy of examples/triage-agent for the
+// `pome install` manual acceptance run.
+//
+// The copy looks like a pre-pome repo: no adapter import, no withPome(),
+// and the twin base URL replaced by a hardcoded production host
+// (https://api.github.com) — exactly the finding doctor's routing scan
+// names with file:line. `pome install` + the pome-setup skill should take
+// this copy back to doctor-green. There is no pome.config.json either, so
+// the first doctor red is "config missing" (the skill runs `pome init`),
+// then the hardcoded-host red.
+//
+// The package.json keeps the adapter dependency, rewritten to an absolute
+// file: path — pre-npm-publish the adapter only exists inside a pome-twins
+// checkout, and the wiring agent should be able to `import` it without
+// also having to invent the dependency line.
+//
+// Usage: node cli/scripts/make-unwired-fixture.mjs [dest-dir]
+//   dest-dir defaults to a fresh directory under the OS tmpdir.
+//   Prints the fixture path on stdout; everything else goes to stderr.
+
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { cp, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const src = join(repoRoot, "examples", "triage-agent");
+const dest = process.argv[2]
+  ? resolve(process.argv[2])
+  : await mkdtemp(join(tmpdir(), "pome-unwired-"));
+
+const SKIP_SEGMENTS = new Set(["node_modules", "runs", "test", ".pome"]);
+await cp(src, dest, {
+  recursive: true,
+  filter: (p) => !p.split(sep).some((segment) => SKIP_SEGMENTS.has(segment)),
+});
+
+// The README documents the wired example; stale claims would just confuse
+// the wiring agent. The scenario file (01-triage-acme-issues.md) stays —
+// it's what `pome run` needs after the wiring lands.
+await rm(join(dest, "README.md"), { force: true });
+// bun.lock pins the adapter at a relative file: path that breaks outside
+// the monorepo — drop it and let `bun install` regenerate.
+await rm(join(dest, "bun.lock"), { force: true });
+
+// ---- src/index.ts: strip the wiring -----------------------------------
+
+const indexPath = join(dest, "src", "index.ts");
+let index = await readFile(indexPath, "utf8");
+
+function replaceOnce(from, to, what) {
+  if (!index.includes(from)) {
+    console.error(`make-unwired-fixture: could not find ${what} in src/index.ts.`);
+    console.error("examples/triage-agent drifted — update this script's replacements.");
+    process.exit(2);
+  }
+  index = index.replace(from, to);
+}
+
+// 1. Neutral file header — the original names Pome throughout.
+replaceOnce(
+  /^\/\*\*[\s\S]*?\*\//.exec(index)?.[0] ?? "<header comment>",
+  [
+    "/**",
+    " * triage-agent: a small Claude Agent SDK agent that triages open GitHub",
+    " * issues — for each open issue it picks one of `bug` / `feature` /",
+    " * `question`, applies the label, and posts a one-sentence comment",
+    " * explaining the choice.",
+    " */",
+  ].join("\n"),
+  "the file header comment",
+);
+
+// 2. Adapter import (+ its doc comment) → plain SDK import.
+replaceOnce(
+  [
+    "// F0-4 / L7 — overlay pome adapter signals on the Claude Agent SDK trace.",
+    "// `withPome()` installs a `globalThis.fetch` hook that emits",
+    "// `ToolUseEvent` / `HookEvent` / `SubagentSpawnEvent` rows to",
+    "// `POME_ADAPTER_SIGNALS_PATH` (Pome CLI injects this env var) and a",
+    "// `x-pome-correlation-id` header on outgoing fetches so the twin recorder",
+    "// links each twin-HTTP row back to the originating tool call. `tool` and",
+    "// `query` are drop-in replacements for the upstream SDK exports — the",
+    "// adapter just adds the signals layer. `createSdkMcpServer` is not part of",
+    "// the adapter's surface; keep importing it from the SDK directly.",
+    'import { createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";',
+    'import { query, tool, withPome } from "@pome-sh/adapter-claude-sdk";',
+  ].join("\n"),
+  'import { createSdkMcpServer, query, tool } from "@anthropic-ai/claude-agent-sdk";',
+  "the adapter import block",
+);
+
+// 3. The startup hook (and the import.meta.main comments that name pome).
+replaceOnce(
+  [
+    "// Only run the agent when executed directly (`bun run src/index.ts`). Guarding",
+    "// on `import.meta.main` keeps the module importable — e.g. by the secret-path",
+    "// unit test — without kicking off a full agent run on import.",
+    "if (import.meta.main) {",
+    "  // Install the pome fetch-hook only for a real run — keeps the module free of",
+    "  // import-time side effects (the secret-path unit test imports it).",
+    "  withPome();",
+    "  await main();",
+    "}",
+  ].join("\n"),
+  ["if (import.meta.main) {", "  await main();", "}"].join("\n"),
+  "the withPome() startup block",
+);
+
+// 4. Env-injected base URL → hardcoded production host. This is the exact
+// line doctor's routing scan (PRODUCTION_HOSTS) names as the cause.
+replaceOnce(
+  'const TWIN_BASE_URL = process.env.POME_TWIN_BASE_URL ?? "http://127.0.0.1:3333";',
+  'const TWIN_BASE_URL = "https://api.github.com";',
+  "the TWIN_BASE_URL env read",
+);
+replaceOnce(
+  "const MCP_URL = process.env.POME_GITHUB_MCP_URL ?? `${TWIN_BASE_URL}/s/${SID}/mcp`;",
+  "const MCP_URL = `${TWIN_BASE_URL}/s/${SID}/mcp`;",
+  "the MCP_URL env read",
+);
+
+for (const leftover of ["withPome", "@pome-sh/adapter", "POME_TWIN_BASE_URL", "POME_GITHUB_MCP_URL"]) {
+  if (index.includes(leftover)) {
+    console.error(`make-unwired-fixture: "${leftover}" still present after unwiring — update this script.`);
+    process.exit(2);
+  }
+}
+await writeFile(indexPath, index);
+
+// ---- package.json: keep the adapter resolvable from the copy ----------
+
+const pkgPath = join(dest, "package.json");
+const pkg = JSON.parse(await readFile(pkgPath, "utf8"));
+pkg.name = "triage-agent-unwired";
+pkg.description =
+  "Manual-acceptance fixture (FDRS-642): examples/triage-agent with the pome wiring stripped.";
+pkg.dependencies["@pome-sh/adapter-claude-sdk"] = `file:${join(repoRoot, "packages", "adapter-claude-sdk")}`;
+await writeFile(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+
+// bun copies file: deps at install time, so the adapter's dist must exist
+// BEFORE the fixture's `bun install` — otherwise the wired agent dies at
+// import with "Cannot find module ./dist/index.js" (the FDRS-658 class of
+// failure). Build it here if this checkout hasn't yet.
+const adapterDir = join(repoRoot, "packages", "adapter-claude-sdk");
+if (!existsSync(join(adapterDir, "dist", "index.js"))) {
+  console.error("adapter dist missing — building @pome-sh/adapter-claude-sdk …");
+  try {
+    await execFileAsync("bun", ["run", "build"], { cwd: adapterDir });
+  } catch (err) {
+    console.error(`adapter build failed: ${err instanceof Error ? err.message : err}`);
+    console.error(`run \`bun run build\` in ${adapterDir} before \`bun install\` in the fixture.`);
+  }
+}
+
+console.log(dest);
+console.error("");
+console.error("unwired fixture ready. acceptance run:");
+console.error(`  cd ${dest}`);
+console.error("  bun install");
+console.error("  pome doctor     # red: no pome.config.json; after the skill runs pome init,");
+console.error("                  # red: hardcoded https://api.github.com in src/index.ts");
+console.error("  pome install    # hands off to your coding agent; approve its edits; ends green");

--- a/cli/skills/pome-setup/SKILL.md
+++ b/cli/skills/pome-setup/SKILL.md
@@ -1,203 +1,150 @@
 ---
 name: pome-setup
-description: Use when the user wants to wire a coding agent up to pome for the first time (so pome can test it against deterministic SaaS twins), or after they've changed which third-party services their agent integrates with. Triggers on phrases like "set up pome", "register my agent with pome", "test my agent with pome", or "use /pome-setup". Identifies the agent and its services, registers it on the pome dashboard, and writes a starter TESTS.md.
+description: Use when wiring a repository's coding agent to pome so pome can run it against deterministic SaaS twins (GitHub, Stripe, Slack) — first-time setup, after the agent's third-party services change, when `pome doctor` reports the repo unwired, or when a `pome install` session hands off to you. Triggers on "wire my agent to pome", "set up pome", "make this repo pome-ready", or "/pome-setup".
 ---
 
 # pome-setup
 
-One-shot wire-up for an existing coding agent so the user can test it with pome (`https://pome.sh`). The pome CLI runs agents against deterministic SaaS twins (GitHub, Stripe, …), records every tool call, and scores the result.
+Wire an existing coding agent's repository to pome (`https://pome.sh`), adapter-first, and prove the wiring with `pome doctor`. The job is not done until doctor exits green.
 
-This skill makes the project pome-ready. It does **not** modify how the agent runs in production — pome only captures tool calls during a `pome run` invocation.
+Pome runs agents against deterministic SaaS twins — local, resettable copies of the GitHub/Stripe/Slack APIs — and records every tool call as a trace. The OSS CLI is capture-only: a local run (`pome run --local`) records a raw trace and never scores; verdicts come from Pome cloud (`pome eval <run-dir>` on a captured trace, or a hosted `pome run`).
 
-The skill pauses for explicit user confirmation between every state-changing step. Do not skip the pauses — first-time users need to see what's about to happen before it happens.
+Wiring changes nothing about production behavior: the adapter only emits trace signals during a pome run, and twin base URLs come from env vars the pome runner injects at run time.
 
-## Prerequisites — check first
+## Hard rules
+
+Follow these on every step. They are not optional.
+
+1. **Never write secrets into source, config, or chat.** No API keys, tokens, or credential values in any file you edit or any message you print. The pome runner injects `POME_*` env vars at run time; read them, never inline their values.
+2. **Read every file immediately before you write it**, even if you already read it earlier in the session. Stale edits break repos.
+3. **Minimal, targeted edits.** Change what the wiring requires and nothing else — no refactors, no reformatting, no drive-by fixes.
+4. **Show the diff and get explicit user approval before applying any edit.** If your harness has an edit-approval UI, that gate counts. If it doesn't, print the proposed change in chat and wait for a yes.
+5. **Never weaken the capture layer.** Don't remove `withPome()`, don't add `*` to `POME_EGRESS_ALLOW`, don't route around the twin.
+6. **No production-host literals in agent source.** `pome doctor` treats a hardcoded `https://api.github.com` — even as a `??` fallback — as a twin bypass and fails. Production fallbacks belong in deployment env, not in source literals. (Loopback fallbacks like `http://127.0.0.1:3333` are fine.)
+7. **Don't guess service coverage.** If the agent talks to a service pome has no twin for, say so explicitly and skip that service — never fake wiring.
+8. **Finish with `pome doctor` and iterate until green.** Never report success while any check is red.
+
+## Steps
+
+### 0. Preflight
 
 ```bash
 pome version
 ```
 
-If the command is missing, install:
+If the command is missing, install it (`npm install -g pome-sh`), then continue.
+
+Auth — any one of these passing is enough (the macOS Keychain item is service `sh.pome.cli`, account `hosted`):
 
 ```bash
-npm install -g pome-sh
-```
-
-If `pome version` works, continue.
-
-## Steps
-
-### 1. Identify the agent and its services
-
-Establish two things by reading the repo (look at `package.json`, `Cargo.toml`, `pyproject.toml`, agent source files, env files, README):
-
-- **Agent type**: Claude Code, Codex, Cursor, an SDK-built agent (Anthropic SDK / OpenAI SDK), or a custom Node/Python/Bash script that drives an LLM.
-- **Services the agent talks to**: which third-party APIs does it call? GitHub? Stripe? Others?
-
-Pome currently ships twins for these services (run `pome scenarios` to see the live list):
-
-| Service | Twin id |
-| --- | --- |
-| GitHub | `github` |
-
-**Pause and confirm with the user in one short message** — name the agent, name the services, and ask if anything's missing. Wait for the user to confirm before continuing. Misidentified services lead to irrelevant scenarios.
-
-### 2. Verify auth — log in if needed
-
-Any of these passing is sufficient — macOS Keychain is preferred over the file fallback, and a `POME_API_KEY` env var beats both for CI / direnv setups:
-
-```bash
-security find-generic-password -s "pome-sh" -w >/dev/null 2>&1 \
+security find-generic-password -s "sh.pome.cli" -a hosted -w >/dev/null 2>&1 \
   || test -f ~/.pome/credentials.json \
   || [ -n "$POME_API_KEY" ] \
   && echo ok
 ```
 
-If this does not print `ok`, run:
+If this does not print `ok`, run `pome login` (opens a browser; stores credentials in the macOS Keychain, or `~/.pome/credentials.json` on other platforms). When a `pome install` session handed off to you, auth was already checked — the probe just confirms instantly.
+
+### 1. Identify the agent and its services
+
+Read the repo (`package.json` / `pyproject.toml` / agent source / README) and establish three things:
+
+- **Entrypoint + start command** — the exact command that starts the agent (e.g. `bun run src/index.ts`).
+- **Framework** — Claude Agent SDK (`@anthropic-ai/claude-agent-sdk`), another SDK, or a custom script driving an LLM.
+- **Services** — which third-party APIs the agent calls (GitHub? Stripe? Slack?). Run `pome scenarios` to see which twins exist.
+
+**Pause: confirm the agent and its services with the user in one short message** before touching anything. Misidentified services produce irrelevant wiring.
+
+### 2. Ensure pome.config.json
 
 ```bash
-pome login
+test -f pome.config.json && echo ready || echo "needs pome init"
 ```
 
-This opens the browser and stores a `pme_…` API key in the **macOS Keychain** (preferred on macOS) or `~/.pome/credentials.json` (other OSes / Keychain unavailable).
+If absent, tell the user `pome init` will scaffold `pome.config.json`, `scenarios/`, and example agents — after they confirm, run it.
 
-### 3. Scaffold the project if it's not already pome-ready
+Then set `agent.command` in `pome.config.json` to the real start command from step 1. The scaffold default runs a bundled example, not the user's agent. Show the line you set; confirm before moving on.
 
-Check first:
+### 3. Wire the adapter (Claude Agent SDK repos)
+
+For repos built on `@anthropic-ai/claude-agent-sdk`:
+
+1. Add the dependency, matching the repo's package manager (lockfile tells you): `npm install @pome-sh/adapter-claude-sdk`.
+2. Swap imports — `query` and `tool` come from the adapter as drop-in replacements; `createSdkMcpServer` and everything else stay on the SDK:
+
+   ```ts
+   import { query, tool, withPome } from "@pome-sh/adapter-claude-sdk";
+   import { createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
+   ```
+
+3. Call `withPome()` once at agent startup, before any requests are made. It hooks `fetch` to emit trace signals and correlation headers — only during a pome run.
+
+For other stacks there is no adapter yet: wiring is step 4 alone, and the trace comes from the twin side. Say so explicitly in the confirmation message.
+
+### 4. Route requests through the env pome injects
+
+Find every place the agent reaches a twinned service and read the base URL from env instead of a literal:
+
+```ts
+// twin URL + token injected by the pome runner — never production
+const { POME_GITHUB_REST_URL: baseUrl, POME_AUTH_TOKEN: token } = process.env;
+```
+
+| Env var | What the runner injects |
+| --- | --- |
+| `POME_<SERVICE>_REST_URL` | REST base URL of that service's twin (e.g. `POME_GITHUB_REST_URL`) |
+| `POME_<SERVICE>_MCP_URL` | MCP endpoint of that twin |
+| `POME_AUTH_TOKEN` | Bearer token for the twin session |
+| `POME_TASK` | The scenario's task prompt |
+
+Remove hardcoded production hosts entirely (hard rule 6).
+
+### 5. Verify: pome doctor to green
 
 ```bash
-test -f pome.config.json && echo ready || echo "needs scaffolding"
+pome doctor
 ```
 
-If the file is absent, **tell the user what's about to happen and wait for confirmation**:
-
-> `pome.config.json` is missing — I'll run `pome init` to scaffold `scenarios/`, `examples/agents/`, and the config file. Continue?
-
-After the user confirms, run:
-
-```bash
-pome init
-```
-
-This creates `scenarios/`, `examples/agents/`, and a `pome.config.json` with `agent.command` and `passThreshold`.
-
-If `pome init` just ran, **open `pome.config.json` and set `agent.command`** to how the user's actual agent is invoked (the default is a placeholder). Examples:
-
-- Claude Code: `"claude -p \"$POME_TASK\""`
-- Anthropic SDK agent: `"node dist/agent.js"` (or `"npx tsx src/agent.ts"`)
-- Python agent: `"python -m my_agent"`
-
-The agent reads its task from the `POME_TASK` env var and tool-call URLs from `POME_GITHUB_REST_URL`, `POME_GITHUB_TOKEN`, etc. (see `pome docs cli-reference` for the full env-var list). The agent should **not** require any other source change — pome injects these env vars at run time.
-
-Show the user the line you set and ask them to confirm it's right before moving on.
-
-### 4. Register the agent on the dashboard
-
-Pick a short, lowercase, hyphenated name based on the repo. Default to the repo directory name; ask the user if you're unsure.
-
-**Wait for the user to confirm the name before registering**:
-
-> I'll register this agent on app.pome.sh as `<name>`. Continue?
-
-After confirmation, run:
-
-```bash
-pome register agent <name>
-```
-
-This creates the agent on `app.pome.sh` under the user's team and writes `agentId` and `agentSlug` into `pome.config.json`. Both keys are load-bearing — do not hand-edit them out.
-
-Compose the dashboard URL from the slug for step 6:
+Doctor runs four checks in order — config → twin reachable → routing → egress floor — and stops at the first failure with ONE named cause (file:line where knowable) and ONE concrete fix. Apply the minimal fix (hard rules 2–4 still apply) and re-run. Loop until it ends green:
 
 ```
-https://app.pome.sh/agents/<slug>
+✓ pome.config.json found
+✓ twin reachable  github · local
+✓ requests route to the twin  reads POME_GITHUB_REST_URL
+✓ egress floor active  deny-by-default · N pattern(s) + loopback
 ```
 
-The slug is whatever the command printed (typically a slugified version of the name). If you missed it, read it back with:
+### 6. Print next steps — don't run them
 
-```bash
-node -e 'console.log(JSON.parse(require("fs").readFileSync("pome.config.json","utf8")).agentSlug)'
-```
-
-### 5. Write a starter `TESTS.md`
-
-For an agent that talks to GitHub, suggest **all five bundled runnable scenarios** — they cover the canonical triage / labeling / context / identity-safety cases and give a meaningful first signal. Start narrower only if the user explicitly asks.
-
-**Pause and confirm with the user** before writing the file:
-
-> I'll create `TESTS.md` with these 5 scenarios so the first `/pome-test` run gives a useful breadth:
->
-> - `scenarios/01-bug-happy-path.md` — clear bug triage (apply label, assign owner)
-> - `scenarios/02-missing-label.md` — create-and-retry recovery
-> - `scenarios/03-already-triaged.md` — don't pile on a finished issue
-> - `scenarios/04-judge-context.md` — exercises the LLM-judge evaluator
-> - `scenarios/05-github-identity-spoof.md` — refuse unauthorized PR merge
->
-> Or pick a subset — five is the breadth suggestion, not a hard requirement. What do you want?
-
-After the user picks a list, write `TESTS.md` in the repo root:
-
-```markdown
-# Pome tests
-
-Run with `/pome-test`.
-
-## Scenarios
-
-- scenarios/01-bug-happy-path.md
-- scenarios/02-missing-label.md
-- scenarios/03-already-triaged.md
-- scenarios/04-judge-context.md
-- scenarios/05-github-identity-spoof.md
-```
-
-For services other than GitHub, list whichever bundled scenarios for that twin make sense — run `pome scenarios <twin>` to see the catalog.
-
-Copy the scenario files into the local repo so the user can read and edit them:
-
-```bash
-pome scenarios github --copy
-```
-
-Substitute the right twin id if not GitHub. Re-prompt the user if they need a different twin.
-
-### 6. Print the dashboard URL and offer to run /pome-test
-
-Print, in this exact shape (substitute values):
+End the session by printing exactly this shape (substitute the twin and scenario):
 
 ```
-Agent registered: <agent-name>
-Dashboard:        https://app.pome.sh/agents/<slug>
-Tests:            TESTS.md (N scenarios)
+wiring verified — pome doctor is green.
 
-Ready to run? Invoke /pome-test, or say "yes" and I'll run it now.
+next steps:
+  pome scenarios github --copy               # pull runnable scenarios into ./scenarios/
+  pome run scenarios/01-bug-happy-path.md    # 5 isolated trials against the twin
+  pome register agent <name>                 # optional: group dashboard runs under one agent
 ```
-
-If the user says yes, invoke the `pome-test` skill.
-
-## Output contract
-
-When this skill finishes successfully:
-
-- `pome.config.json` exists with `agentId`, `agentSlug`, and a real `agent.command`.
-- `TESTS.md` exists in the repo root with at least one scenario path (default: all 5 GitHub scenarios).
-- The bundled scenario files live under `scenarios/` in the repo.
-- The agent appears on `app.pome.sh` under the user's account at `app.pome.sh/agents/<slug>`.
-- The chat ends with the dashboard URL and an offer to invoke `/pome-test`.
 
 ## Common pitfalls
 
 | Symptom | Fix |
 | --- | --- |
-| `pome register agent` fails with 401/403 | Re-run `pome login` (or set `POME_API_KEY`). |
-| `pome.config.json` exists but `agent.command` is the default `npx tsx examples/agents/scripted-triage-agent.ts` | Replace with how the user's real agent is invoked. The default is for the bundled example only. |
-| User's agent talks to a service pome doesn't have a twin for yet | Note it explicitly in the confirmation message. Skip that service's scenarios for now; the user can request it from pome. |
-| Repo isn't a Node/git project | `pome init` still works — it only writes files. Skip steps that depend on `package.json`. |
-| User edited `pome.config.json` and the dashboard stopped grouping runs by agent | Re-add the `agentId` and `agentSlug` keys; both are written by `pome register agent` and the dashboard needs both. |
+| `npm install @pome-sh/adapter-claude-sdk` 404s | The adapter's npm publish is staged (OSS Launch Stage 1). Inside a pome-twins checkout, depend on it via `"@pome-sh/adapter-claude-sdk": "file:<checkout>/packages/adapter-claude-sdk"`; external repos should watch the pome release notes. |
+| doctor: "reads from a hardcoded https://api.github.com" | A production-host literal survives in agent source — even a `?? "https://api.github.com"` fallback triggers it. Move the fallback out of source; read `POME_GITHUB_REST_URL`. |
+| doctor: "twin not reachable" | Twin dependencies missing — run the repo's install (`bun install` / `npm install`) and re-run `pome doctor`. |
+| doctor: "egress floor disabled" | Remove `*` from `POME_EGRESS_ALLOW`. Never widen egress to pass a check. |
+| Hosted commands fail 401/403 | Re-run `pome login` (or set `POME_API_KEY` in CI). |
+| `agent.command` is still the scaffold default | Point it at the user's real agent (step 1's start command); the default runs a bundled example. |
+| The agent talks to a service with no twin | Name it in the confirmation message and skip it (hard rule 7). The user can request the twin from pome. |
 
-## Reference
+## Output contract
 
-- Skill contract: `pome docs skills`
-- Dashboard layout: `pome docs dashboard`
-- CLI flags and env vars: `pome docs cli-reference`
-- Scenario catalog: `pome scenarios`
+When this skill finishes successfully:
+
+- `pome.config.json` exists with a real `agent.command`.
+- Claude Agent SDK repos: `@pome-sh/adapter-claude-sdk` resolves and `withPome()` runs at startup.
+- No hardcoded production hosts remain in agent source; twinned-service base URLs are read from `POME_*` env.
+- `pome doctor` exits green — all four checks.
+- The session ends with the next-steps block printed, not executed.

--- a/cli/src/cli/install.ts
+++ b/cli/src/cli/install.ts
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-642 — `pome install`: agent-driven wiring with the diff gate in the
+// coding agent's own edit-approval UI.
+//
+// v1 is skills-first thin orchestration (see the ticket's [DECISION]): the
+// wiring brain is the user's own coding agent, invoked interactively — not
+// an embedded SDK, not a pome-hosted LLM gateway. The CLI's job is the
+// bracket around that session:
+//
+//   auth check → detect agent → git-as-undo guard → ensure the pome-setup
+//   skill → interactive session (the user approves edits in the agent's own
+//   UI) → doctor verify to green (CLI moments 02, "verifying the wiring").
+//
+// No coding agent on PATH → print manual wiring steps + a paste-into-any-
+// agent prompt and exit 0 (the designed fallback, not a failure). Doctor
+// red after the session → named cause + fix, exit 1. The terminal-rendered
+// file-list + diff + [y/N] gate from moment 02 is deferred to FDRS-661; the
+// pome-setup skill written for this cut is the knowledge layer both reuse.
+
+import { execFile, spawn } from "node:child_process";
+import { accessSync, constants, statSync } from "node:fs";
+import { delimiter, join } from "node:path";
+import { createInterface } from "node:readline";
+import { promisify } from "node:util";
+
+import { HostedAuthError } from "../hosted/errors.js";
+import { resolveCredentials } from "./credentials.js";
+import { loginWithClerk, type LoginOptions } from "./login.js";
+import { runSkillsInstall } from "./skills.js";
+
+const execFileAsync = promisify(execFile);
+
+/** Coding agents `pome install` can hand off to, in detection order. */
+const KNOWN_AGENTS = [{ bin: "claude", label: "Claude Code" }] as const;
+
+/** First message of the interactive session. The skill carries the wiring
+ *  knowledge; this only names it, sets adapter-first, and fixes the exit
+ *  contract (pome verifies with doctor after the session ends). */
+export const KICKOFF_PROMPT =
+  "Use the pome-setup skill to wire this repository to pome (adapter-first: " +
+  "withPome() + env-injected base URL). Follow the skill's steps and show me " +
+  "each edit for approval before applying. When the wiring is done, exit " +
+  "this session — pome will verify it with `pome doctor`.";
+
+/** Self-contained fallback prompt for users without a detected coding agent
+ *  (their agent won't have the pome-setup skill installed). */
+export const PASTE_PROMPT = [
+  "Wire this repository to pome (https://pome.sh) so its agent runs against a twin in test:",
+  "1. If pome.config.json is missing, run `pome init`; set agent.command to how this agent starts.",
+  "2. Claude Agent SDK repos: add @pome-sh/adapter-claude-sdk, import query/tool from it (drop-in replacements), and call withPome() once at startup.",
+  "3. Replace every hardcoded production API host (e.g. https://api.github.com) with the env the pome runner injects: read POME_GITHUB_REST_URL / POME_GITHUB_MCP_URL and POME_AUTH_TOKEN from process.env. Never write secrets or URLs into source.",
+  "4. Make minimal, targeted edits and show each diff for approval before applying.",
+  "5. Finish by running `pome doctor` and fixing its named cause until it exits green.",
+].join("\n");
+
+export interface InstallOptions {
+  apiUrl: string;
+  dashboardUrl: string;
+  /** Repo root the session wires. Defaults to process.cwd(). */
+  cwd?: string;
+  /** Test seam — forwarded to resolveCredentials. */
+  credentialsPath?: string;
+  /** Test seam — defaults to process.stdin.isTTY. */
+  stdinIsTTY?: boolean;
+  /** Test seam — defaults to a readline [y/N] prompt on stderr. */
+  confirm?: (question: string) => Promise<boolean>;
+  /** Test seam — defaults to loginWithClerk (opens a browser). */
+  login?: (options: LoginOptions) => Promise<void>;
+}
+
+export async function runInstall(options: InstallOptions): Promise<void> {
+  const cwd = options.cwd ?? process.cwd();
+  const stdinIsTTY = options.stdinIsTTY ?? Boolean(process.stdin.isTTY);
+  const confirm = options.confirm ?? promptYesNo;
+  const login = options.login ?? loginWithClerk;
+
+  // Interactive by design: the whole point is handing THIS terminal to an
+  // agent session the user supervises. A pipe can't approve edits.
+  if (!stdinIsTTY) {
+    console.error(
+      "pome install is interactive — it hands your terminal to a coding agent session.",
+    );
+    console.error(
+      "Run it from a terminal. For unattended setups, wire manually: see `pome docs`.",
+    );
+    process.exitCode = 2;
+    return;
+  }
+
+  console.error("pome will wire your agent to a twin in test.");
+  console.error("");
+
+  // 1. Auth first — auth happens at this journey stage (Done-when bullet 1).
+  // Logging in here means neither the agent session nor anything after it
+  // trips over missing credentials.
+  try {
+    await resolveCredentials({
+      apiBaseUrl: options.apiUrl,
+      credentialsPath: options.credentialsPath,
+    });
+    console.error("✓ signed in");
+  } catch (err) {
+    if (!(err instanceof HostedAuthError)) throw err;
+    console.error("no pome credentials found — routing through pome login first.");
+    await login({
+      apiUrl: options.apiUrl,
+      dashboardUrl: options.dashboardUrl,
+      keyName: "pome install",
+    });
+  }
+
+  // 2. Detect the coding agent before the git guard: the fallback path edits
+  // nothing, so an unclean tree shouldn't block it.
+  const agent = detectAgent(process.env);
+  if (!agent) {
+    printManualFallback();
+    return; // exit 0 — the designed no-agent outcome, not a failure.
+  }
+
+  // 3. Git-as-undo guard. The session edits files and git is the only
+  // rollback — make that precondition explicit instead of assuming it.
+  const tree = await inspectWorkingTree(cwd);
+  if (tree === "dirty") {
+    console.error("");
+    console.error(
+      "this repo has uncommitted changes. the agent session edits files, and its",
+    );
+    console.error(
+      "edits will mix with yours — git is the only undo for an agent mis-edit.",
+    );
+    if (!(await confirm("continue anyway? (commit or stash first is safer) [y/N] "))) {
+      console.error("aborted — nothing changed. commit or stash, then re-run pome install.");
+      return;
+    }
+  } else if (tree === "not-a-repo") {
+    console.error("");
+    console.error(
+      "this directory is not a git repository — if the agent session mis-edits a",
+    );
+    console.error("file, there is NO undo.");
+    if (!(await confirm("continue without version control? [y/N] "))) {
+      console.error(
+        "aborted — nothing changed. git init && git add -A && git commit, then re-run.",
+      );
+      return;
+    }
+  }
+
+  // 4. Ensure the pome-setup skill is where the agent looks for it
+  // (~/.claude/skills/, symlinked to this install; skips if present).
+  console.error("");
+  await runSkillsInstall({});
+  if (process.exitCode === 2) {
+    // runSkillsInstall signals failure (no ~/.claude, packaging problem) via
+    // exitCode — the session would run without the skill, so hand the user
+    // the manual path instead. Keep exit 2: unlike the no-agent fallback,
+    // this is a real environment problem.
+    console.error("");
+    console.error("couldn't install the pome-setup skill — falling back to manual steps.");
+    printManualFallback();
+    return;
+  }
+
+  // 5. Hand off. stdio inherit = the user drives the agent in this terminal;
+  // the diff gate is the agent's own edit-approval UI (deliberately no
+  // --permission-mode override).
+  console.error("");
+  console.error(
+    `handing off to ${agent.label} — review and approve its edits in the session.`,
+  );
+  console.error("exit the session when the wiring is done; pome verifies it after.");
+  console.error("");
+  const sessionExit = await runAgentSession(agent.path, [KICKOFF_PROMPT], cwd);
+  if (sessionExit !== 0) {
+    console.error(
+      `(${agent.label} exited ${sessionExit} — verifying anyway; doctor is the source of truth.)`,
+    );
+  }
+
+  // 6. The ending pome's terminal owns: doctor verify to green (moment 02).
+  // Dynamic import keeps the twin harness out of the way until needed —
+  // same pattern as the `doctor` and `run` commands.
+  console.error("");
+  const { runDoctorChecks } = await import("../doctor/checks.js");
+  const { renderDoctorReport } = await import("../doctor/render.js");
+  const report = await runDoctorChecks({ mode: "full", cwd });
+  for (const line of renderDoctorReport(report, { header: "verifying the wiring …" })) {
+    console.error(line);
+  }
+  console.error("");
+  if (report.ok) {
+    console.error("wiring verified — your agent is ready.");
+    console.error("");
+    console.error(
+      "next: pome scenarios github --copy      # pull runnable scenarios into ./scenarios/",
+    );
+    console.error("      pome run scenarios/01-bug-happy-path.md");
+    return;
+  }
+  console.error(
+    "the agent session ended but the wiring isn't green — fix the cause above,",
+  );
+  console.error("or re-run pome install to hand the fix back to your agent.");
+  process.exitCode = 1;
+}
+
+export interface DetectedAgent {
+  bin: string;
+  label: string;
+  path: string;
+}
+
+/** First known coding agent found on PATH, or null. Exported for tests. */
+export function detectAgent(
+  env: Record<string, string | undefined> = process.env,
+): DetectedAgent | null {
+  for (const agent of KNOWN_AGENTS) {
+    const found = findExecutableOnPath(agent.bin, env);
+    if (found) return { ...agent, path: found };
+  }
+  return null;
+}
+
+function findExecutableOnPath(
+  bin: string,
+  env: Record<string, string | undefined>,
+): string | null {
+  const names =
+    process.platform === "win32" ? [`${bin}.cmd`, `${bin}.exe`, bin] : [bin];
+  for (const dir of (env.PATH ?? "").split(delimiter)) {
+    if (!dir) continue;
+    for (const name of names) {
+      const candidate = join(dir, name);
+      try {
+        accessSync(candidate, constants.X_OK);
+        if (statSync(candidate).isFile()) return candidate;
+      } catch {
+        /* keep looking */
+      }
+    }
+  }
+  return null;
+}
+
+type WorkingTree = "clean" | "dirty" | "not-a-repo";
+
+async function inspectWorkingTree(cwd: string): Promise<WorkingTree> {
+  try {
+    const { stdout } = await execFileAsync("git", ["status", "--porcelain"], {
+      cwd,
+    });
+    return stdout.trim().length === 0 ? "clean" : "dirty";
+  } catch {
+    // Not a git repo, or no git binary — either way there is no undo.
+    return "not-a-repo";
+  }
+}
+
+async function promptYesNo(question: string): Promise<boolean> {
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    const answer = await new Promise<string>((resolve) =>
+      rl.question(question, resolve),
+    );
+    return /^y(es)?$/i.test(answer.trim());
+  } finally {
+    rl.close();
+  }
+}
+
+function runAgentSession(
+  command: string,
+  args: string[],
+  cwd: string,
+): Promise<number> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(command, args, { cwd, stdio: "inherit" });
+    child.once("error", rejectPromise);
+    child.once("exit", (code, signal) => {
+      resolvePromise(code ?? (signal ? 1 : 0));
+    });
+  });
+}
+
+function printManualFallback(): void {
+  console.error(
+    `no coding agent found on PATH (looked for: ${KNOWN_AGENTS.map((a) => a.bin).join(", ")}).`,
+  );
+  console.error("");
+  console.error("wire it manually:");
+  console.error("  1. config       pome init                  # if pome.config.json is missing;");
+  console.error("                                              # then set agent.command to your agent's start command");
+  console.error("  2. adapter      npm install @pome-sh/adapter-claude-sdk");
+  console.error('  3. hook + env   import { withPome } from "@pome-sh/adapter-claude-sdk"; withPome();');
+  console.error("                  read the twin URL from env, never hardcode:");
+  console.error("                  const { POME_GITHUB_REST_URL: baseUrl, POME_AUTH_TOKEN: token } = process.env;");
+  console.error("  4. verify       pome doctor                # must end green");
+  console.error("");
+  console.error("or paste this into any coding agent:");
+  console.error("─".repeat(72));
+  console.error(PASTE_PROMPT);
+  console.error("─".repeat(72));
+}

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -199,6 +199,28 @@ export function createProgram() {
     });
 
   program
+    .command("install")
+    .description(
+      "Wire this repo to pome with your own coding agent: checks auth (routes through pome login when needed), hands off to an interactive agent session — you approve its edits in the agent's own UI — then verifies with pome doctor. No coding agent on PATH → prints manual wiring steps + a paste-into-any-agent prompt.",
+    )
+    .option(
+      "--api-url <url>",
+      "Control-plane base URL.",
+      process.env.POME_API_URL ?? DEFAULT_CONTROL_PLANE_URL,
+    )
+    .option(
+      "--dashboard-url <url>",
+      "App URL for Clerk sign-in (must serve /cli/login).",
+      process.env.POME_DASHBOARD_URL ?? DEFAULT_DASHBOARD_URL,
+    )
+    .action(async (opts: { apiUrl: string; dashboardUrl: string }) => {
+      // Dynamic import mirrors the doctor/run commands: keep install's
+      // dependency graph out of every other command's startup path.
+      const { runInstall } = await import("./install.js");
+      await runInstall({ apiUrl: opts.apiUrl, dashboardUrl: opts.dashboardUrl });
+    });
+
+  program
     .command("login")
     .description("Sign in with Clerk and store a hosted team API key (macOS Keychain or ~/.pome/credentials.json)")
     .option(

--- a/cli/src/doctor/render.ts
+++ b/cli/src/doctor/render.ts
@@ -10,8 +10,18 @@ const CAUSE_COLUMN = "cause  ";
 const FIX_COLUMN = "fix    ";
 const CONTINUATION = " ".repeat(FIX_COLUMN.length);
 
-export function renderDoctorReport(report: DoctorReport): string[] {
-  const lines: string[] = ["checking your wiring …"];
+export interface RenderDoctorReportOptions {
+  /** First line of the report. `pome doctor` and the run gate keep the
+   *  moment-03 default; `pome install` passes moment 02's
+   *  "verifying the wiring …" (FDRS-642). */
+  header?: string;
+}
+
+export function renderDoctorReport(
+  report: DoctorReport,
+  options: RenderDoctorReportOptions = {},
+): string[] {
+  const lines: string[] = [options.header ?? "checking your wiring …"];
 
   for (const check of report.checks) {
     const glyph = check.status === "pass" ? "✓" : "✗";

--- a/cli/test/unit/install-command.test.ts
+++ b/cli/test/unit/install-command.test.ts
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-642 — `pome install` orchestration: the auth branch, agent detection
+// with the no-agent fallback, the git-as-undo guard, skill ensure, the
+// interactive handoff, and the doctor verify that owns the ending.
+//
+// The agent session is a fake `claude` shell script placed on a stubbed
+// PATH: detection, spawn, and the kickoff prompt are exercised for real;
+// only the LLM is fake. Doctor runs the real engine against tmp fixture
+// repos (run-doctor-gate.test.ts pattern).
+
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  detectAgent,
+  KICKOFF_PROMPT,
+  PASTE_PROMPT,
+  runInstall,
+} from "../../src/cli/install.js";
+import { createProgram } from "../../src/cli/main.js";
+
+const execFileAsync = promisify(execFile);
+
+const API_URL = "https://api.pome.test";
+const DASHBOARD_URL = "https://app.pome.test";
+
+const WIRED_SOURCE = [
+  'import { withPome } from "@pome-sh/adapter-claude-sdk";',
+  "withPome();",
+  "const baseUrl = process.env.POME_GITHUB_REST_URL;",
+  "export { baseUrl };",
+].join("\n");
+
+const UNWIRED_SOURCE = ['const gh = "https://api.github.com";', "export { gh };"].join("\n");
+
+const tempDirs: string[] = [];
+
+async function tempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+/** A repo the doctor engine can walk: config + one agent source file. */
+async function fixtureRepo(agentSource: string): Promise<string> {
+  const dir = await tempDir("pome-install-repo-");
+  await mkdir(join(dir, "src"), { recursive: true });
+  await writeFile(
+    join(dir, "pome.config.json"),
+    JSON.stringify({ agent: { command: 'node -e "process.exit(0)"' } }, null, 2),
+  );
+  await writeFile(join(dir, "src/agent.ts"), agentSource);
+  return dir;
+}
+
+/** A stubbed HOME with ~/.claude present so runSkillsInstall has a dest. */
+async function fakeHome(): Promise<string> {
+  const home = await tempDir("pome-install-home-");
+  await mkdir(join(home, ".claude"), { recursive: true });
+  return home;
+}
+
+/** A PATH dir holding a fake `claude` that records its first argument. */
+async function fakeClaudeBin(): Promise<{ binDir: string; argsFile: string }> {
+  const binDir = await tempDir("pome-install-bin-");
+  const argsFile = join(binDir, "claude-args.txt");
+  await writeFile(
+    join(binDir, "claude"),
+    `#!/bin/sh\nprintf '%s' "$1" > "${argsFile}"\nexit 0\n`,
+    { mode: 0o755 },
+  );
+  return { binDir, argsFile };
+}
+
+describe("pome install (FDRS-642)", () => {
+  let stderrLines: string[];
+
+  const stderrText = () => stderrLines.join("\n");
+
+  beforeEach(() => {
+    stderrLines = [];
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      stderrLines.push(args.map(String).join(" "));
+    });
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    process.exitCode = undefined;
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    process.exitCode = undefined;
+    await Promise.all(
+      tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it("registers a top-level install command with --api-url/--dashboard-url", () => {
+    const install = createProgram().commands.find((c) => c.name() === "install");
+    expect(install).toBeDefined();
+    const flags = install!.options.map((o) => o.long);
+    expect(flags).toContain("--api-url");
+    expect(flags).toContain("--dashboard-url");
+  });
+
+  it("refuses when stdin is not a TTY", async () => {
+    await runInstall({ apiUrl: API_URL, dashboardUrl: DASHBOARD_URL, stdinIsTTY: false });
+    expect(process.exitCode).toBe(2);
+    expect(stderrText()).toContain("pome install is interactive");
+  });
+
+  it("passes auth silently with POME_API_KEY and prints the manual fallback when no agent is on PATH", async () => {
+    const emptyBin = await tempDir("pome-install-emptybin-");
+    vi.stubEnv("PATH", emptyBin);
+    vi.stubEnv("POME_API_KEY", "pme_test");
+    vi.stubEnv("POME_CLI_DISABLE_KEYCHAIN", "1");
+    const login = vi.fn(async () => {});
+
+    await runInstall({
+      apiUrl: API_URL,
+      dashboardUrl: DASHBOARD_URL,
+      stdinIsTTY: true,
+      login,
+    });
+
+    expect(login).not.toHaveBeenCalled();
+    const text = stderrText();
+    expect(text).toContain("✓ signed in");
+    expect(text).toContain("no coding agent found on PATH");
+    // Both halves of the fallback: manual steps + the paste-anywhere prompt.
+    expect(text).toContain("pome doctor");
+    expect(text).toContain(PASTE_PROMPT);
+    expect(text).not.toContain("verifying the wiring");
+    // The designed no-agent outcome, not a failure.
+    expect(process.exitCode).toBeFalsy();
+  });
+
+  it("routes through pome login when no credentials exist anywhere", async () => {
+    const emptyBin = await tempDir("pome-install-emptybin-");
+    const missingCreds = join(await tempDir("pome-install-creds-"), "credentials.json");
+    vi.stubEnv("PATH", emptyBin);
+    vi.stubEnv("POME_API_KEY", "");
+    vi.stubEnv("POME_CLI_DISABLE_KEYCHAIN", "1");
+    const login = vi.fn(async () => {});
+
+    await runInstall({
+      apiUrl: API_URL,
+      dashboardUrl: DASHBOARD_URL,
+      stdinIsTTY: true,
+      credentialsPath: missingCreds,
+      login,
+    });
+
+    expect(login).toHaveBeenCalledExactlyOnceWith({
+      apiUrl: API_URL,
+      dashboardUrl: DASHBOARD_URL,
+      keyName: "pome install",
+    });
+    expect(stderrText()).toContain("routing through pome login");
+  });
+
+  it("detects an executable claude on PATH", async () => {
+    const { binDir } = await fakeClaudeBin();
+    expect(detectAgent({ PATH: binDir })).toMatchObject({
+      bin: "claude",
+      label: "Claude Code",
+      path: join(binDir, "claude"),
+    });
+    const emptyBin = await tempDir("pome-install-emptybin-");
+    expect(detectAgent({ PATH: emptyBin })).toBeNull();
+  });
+
+  it("warns on a dirty tree and aborts before spawning when the user declines", async () => {
+    const { binDir, argsFile } = await fakeClaudeBin();
+    const home = await fakeHome();
+    const repo = await fixtureRepo(WIRED_SOURCE);
+    // git init + untracked files = a dirty tree, no commit config needed.
+    await execFileAsync("git", ["init"], { cwd: repo });
+    // Fake bin first so it wins detection; the rest of PATH keeps git around.
+    vi.stubEnv("PATH", `${binDir}${delimiter}${process.env.PATH ?? ""}`);
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("POME_API_KEY", "pme_test");
+    vi.stubEnv("POME_CLI_DISABLE_KEYCHAIN", "1");
+    const confirm = vi.fn(async () => false);
+
+    await runInstall({
+      apiUrl: API_URL,
+      dashboardUrl: DASHBOARD_URL,
+      stdinIsTTY: true,
+      cwd: repo,
+      confirm,
+    });
+
+    expect(confirm).toHaveBeenCalledOnce();
+    const text = stderrText();
+    expect(text).toContain("uncommitted changes");
+    expect(text).toContain("aborted — nothing changed");
+    // The session was never spawned and doctor never ran.
+    expect(existsSync(argsFile)).toBe(false);
+    expect(text).not.toContain("verifying the wiring");
+    expect(process.exitCode).toBeFalsy();
+  });
+
+  it("hands off to the detected agent and verifies to green on a wired repo", async () => {
+    const { binDir, argsFile } = await fakeClaudeBin();
+    const home = await fakeHome();
+    const repo = await fixtureRepo(WIRED_SOURCE);
+    // PATH holds only the fake agent: no git → the not-a-repo warning path.
+    vi.stubEnv("PATH", binDir);
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("POME_API_KEY", "pme_test");
+    vi.stubEnv("POME_CLI_DISABLE_KEYCHAIN", "1");
+    const confirm = vi.fn(async () => true);
+
+    await runInstall({
+      apiUrl: API_URL,
+      dashboardUrl: DASHBOARD_URL,
+      stdinIsTTY: true,
+      cwd: repo,
+      confirm,
+    });
+
+    // The no-undo warning fired and was accepted.
+    expect(confirm).toHaveBeenCalledOnce();
+    expect(stderrText()).toContain("not a git repository");
+    // The kickoff prompt reached the agent verbatim.
+    expect(await readFile(argsFile, "utf8")).toBe(KICKOFF_PROMPT);
+    // The skill was ensured into the (stubbed) home.
+    expect(
+      existsSync(join(home, ".claude", "skills", "pome-setup", "SKILL.md")),
+    ).toBe(true);
+    const text = stderrText();
+    expect(text).toContain("handing off to Claude Code");
+    expect(text).toContain("verifying the wiring …");
+    expect(text).toContain("wiring verified — your agent is ready.");
+    expect(text).toContain("pome run scenarios/01-bug-happy-path.md");
+    expect(process.exitCode).toBeFalsy();
+  }, 60_000);
+
+  it("ends red with doctor's named cause when the session leaves the repo unwired", async () => {
+    const { binDir } = await fakeClaudeBin();
+    const home = await fakeHome();
+    const repo = await fixtureRepo(UNWIRED_SOURCE);
+    vi.stubEnv("PATH", binDir);
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("POME_API_KEY", "pme_test");
+    vi.stubEnv("POME_CLI_DISABLE_KEYCHAIN", "1");
+
+    await runInstall({
+      apiUrl: API_URL,
+      dashboardUrl: DASHBOARD_URL,
+      stdinIsTTY: true,
+      cwd: repo,
+      confirm: async () => true,
+    });
+
+    const text = stderrText();
+    expect(text).toContain("verifying the wiring …");
+    expect(text).toContain("cause");
+    expect(text).toContain("api.github.com");
+    expect(text).toContain("re-run pome install");
+    expect(process.exitCode).toBe(1);
+  }, 60_000);
+});


### PR DESCRIPTION
<!-- Closes FDRS-642 -->

## What

Top-level `pome install`: auth check (routes through `pome login` when absent) → detects the user's coding agent (`claude` on PATH) → ensures the rewritten adapter-first `pome-setup` skill (symlink via the `pome skills install` mechanism) → hands off to an interactive agent session whose edits the user approves in the agent's own edit-approval UI → auto-runs `pome doctor` and renders it with moment-02's "verifying the wiring …" header — green with next steps, or the named cause + fix and exit 1. No coding agent on PATH → manual wiring steps + a paste-into-any-agent prompt (exit 0). Ships an unwired-fixture script (`cli/scripts/make-unwired-fixture.mjs`) for acceptance runs.

## Why

FDRS-642 (M2: Wiring, First-run journey v1). v1 is skills-first thin orchestration per the ticket's [DECISION]: the wiring brain is the user's own coding agent — no embedded SDK, no pome-hosted LLM gateway. The rewritten `SKILL.md` is the long-lived knowledge layer FDRS-661 (terminal diff gate) reuses unchanged.

## Notes for reviewer

- `pome-setup/SKILL.md` is a rewrite, not a patch: adapter-first wiring, PostHog-commandments-style hard rules (no secrets in source/chat, read-before-write, minimal diffs, approval before applying, doctor-green as the only done), wiring-only scope — register/TESTS.md/scenarios-copy dropped (hosted `pome run` doesn't require `agentId`; TESTS.md was local-scoring-era). Old keychain probe `-s "pome-sh"` never matched the real service — corrected to `sh.pome.cli`/`hosted`.
- `renderDoctorReport` gains an optional `header` param; `doctor`/`run` callers unchanged.
- Dirty-git guard: warn + [y/N] (default N); heavier warning when not a git repo; non-TTY stdin refused (exit 2).
- Acceptance evidence (headless, founder-delegated): real `claude -p` session on the unwired triage-agent copy produced exactly the moment-02 diff (adapter import swap, `withPome()` before first request, env-injected base URLs, real `agent.command`) and `pome install` ended 4-green, exit 0; independent `pome doctor` re-run confirmed. No-claude run printed the fallback and exited 0. Headless caveat: edit approval was auto-accepted (`--dangerously-skip-permissions`); the interactive approval UX itself is Claude Code native behavior, not this repo's code.
- Known pre-publish wart the wiring agent surfaced: the `file:` adapter dep drags `@anthropic-ai/claude-agent-sdk@0.3.201` next to the example's pinned `0.2.139` → type-identity mismatch at `createSdkMcpServer({ tools })` in the *fixture* (type-only, runtime + doctor unaffected; resolves when the adapter's npm publish lands). Nothing in this PR's code is affected.

## Review required

Yes — new public OSS CLI surface (`pome install`) + a `SKILL.md` rewrite that changes agent behavior.

### Founder briefing (3 min)

- **What changed** — `pome install` now exists: it orchestrates the user's own coding agent to wire a repo, then proves the result with `pome doctor`; the `pome-setup` skill was rewritten as the shared knowledge layer.
- **What it means for your repo / workflow** — the first-run journey's wiring step no longer depends on env-var hand-editing or `agent.command` guesswork; anything you build that assumes "repo is wired" can point users at one command, and FDRS-661's embedded-agent cut reuses this exact skill unchanged.
- **The one thing you must know** — the old skill's keychain auth probe (`security find-generic-password -s "pome-sh"`) was checking a service name that has never existed; if any doc or script of yours copied it, it silently reports "not logged in" forever — the real item is `sh.pome.cli` / account `hosted`.