### PR TITLE
[FDRS-643] pome demo: zero-auth cold start

### DIFF
--- a/cli/.changeset/fdrs-643-pome-demo.md
+++ b/cli/.changeset/fdrs-643-pome-demo.md
@@ -1,0 +1,15 @@
+---
+"pome-sh": minor
+---
+
+`pome demo` — zero-auth cold start (FDRS-643). Boots a local GitHub twin, runs
+the bundled demo agent for 5 isolated trials with model calls served by pome's
+anonymous demo gateway (`POST /v1/demo/sessions/:id/llm`), uploads each
+genuinely captured trace anonymously (`POST /v1/demo/sessions` mint,
+demo_token-bearer upload + finalize), prints per-trial passed/failed verdicts
+from the cloud evaluation (capture-only CLI, no local scoring), and ends with
+the no-login preview link `app.pome.sh/demo/<group_id>`. At-capacity
+402/429s render as honest labeled states. Adds a hidden `demo-agent`
+subcommand (the spawned trial child), an `extraAgentEnv`/`egressExtraHosts`
+seam on the self-host runner, and bearer-auth support on the hosted client
+for the session-token surface.

--- a/cli/scripts/copy-prompts.mjs
+++ b/cli/scripts/copy-prompts.mjs
@@ -23,6 +23,16 @@ const DEST = "dist/src/fix-prompt/prompts";
 await rm(DEST, { recursive: true, force: true });
 await cp(SRC, DEST, { recursive: true });
 
+// FDRS-643 — the packaged demo task (markdown + hand-written seed sidecar)
+// resolves next to the compiled module (dist/src/demo/), so it must ride
+// along with the build. tsc only emits .ts → copy the assets explicitly.
+for (const asset of ["first-run-demo.md", "first-run-demo.seed.json"]) {
+  await cp(
+    resolve(CLI_ROOT, "src/demo", asset),
+    resolve(CLI_ROOT, "dist/src/demo", asset),
+  );
+}
+
 await writeBuildInfo();
 
 async function writeBuildInfo() {

--- a/cli/src/capture-server/egress.ts
+++ b/cli/src/capture-server/egress.ts
@@ -99,11 +99,16 @@ export function parseAllowCsv(csv: string | undefined): string[] {
 // Compute the allowlist for one run: default LLM providers + custom LLM
 // base-URL hosts + the POME_EGRESS_ALLOW valve + the twin URLs the runner is
 // about to inject (loopback in self-host; hosted twin domains future-proof).
+//
+// FDRS-643 — `extraHosts` is the demo-mode valve: `pome demo` adds the
+// POME_API_BASE host so the bundled agent's anonymous-gateway calls
+// (POST /v1/demo/sessions/:id/llm) survive the deny-by-default floor. Same
+// pattern rules as everything else (exact host or `*.suffix`).
 export function buildEgressAllowlist(
   env: Record<string, string | undefined>,
-  opts: { twinUrls?: readonly string[] } = {},
+  opts: { twinUrls?: readonly string[]; extraHosts?: readonly string[] } = {},
 ): string[] {
-  const patterns = [...DEFAULT_LLM_PROVIDER_HOSTS];
+  const patterns = [...DEFAULT_LLM_PROVIDER_HOSTS, ...(opts.extraHosts ?? [])];
 
   for (const key of BASE_URL_ENV_VARS) {
     const value = env[key]?.trim();

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -715,6 +715,58 @@ export function createProgram() {
     );
 
   program
+    .command("demo")
+    .description(
+      "Zero-auth first-run demo: boots a local GitHub twin, runs the bundled demo agent for 5 isolated trials (model calls via pome's anonymous demo gateway), and prints per-trial verdicts evaluated in Pome cloud. No signup, no API keys; ends with a no-login preview link.",
+    )
+    .option(
+      "--api-url <url>",
+      "Control-plane base URL.",
+      process.env.POME_API_BASE ??
+        process.env.POME_API_URL ??
+        DEFAULT_CONTROL_PLANE_URL,
+    )
+    .option(
+      "--trials <n>",
+      "Number of isolated trials (default 5 per the packaged demo).",
+      "5",
+    )
+    .option("--artifacts-dir <dir>", "Directory for run artifacts", "runs")
+    .action(
+      async (opts: { apiUrl: string; trials: string; artifactsDir: string }) => {
+        const trials = Number.parseInt(opts.trials, 10);
+        if (!Number.isInteger(trials) || trials < 1 || trials > 10) {
+          console.error(`Invalid --trials "${opts.trials}" (expected 1-10).`);
+          process.exitCode = 5;
+          return;
+        }
+        // Dynamic import mirrors doctor/install: keep the demo dependency
+        // graph out of every other command's startup path.
+        const { runDemo } = await import("../demo/runDemo.js");
+        const result = await runDemo({
+          apiBase: opts.apiUrl.replace(/\/$/, ""),
+          dashboardBase:
+            process.env.POME_DASHBOARD_URL ?? DEFAULT_DASHBOARD_URL,
+          trials,
+          artifactsDir: opts.artifactsDir,
+        });
+        process.exitCode = result.exitCode;
+      },
+    );
+
+  // Hidden: the bundled demo agent `pome demo` spawns as its trial child
+  // through the real capture path (FDRS-643). Reads the POME_* env contract
+  // injected by runScenario plus POME_DEMO_* gateway coordinates.
+  program
+    .command("demo-agent", { hidden: true })
+    .description("Internal: the bundled demo agent process (spawned by `pome demo`).")
+    .action(async () => {
+      const { runDemoAgentCommand } = await import("../demo/agent.js");
+      const code = await runDemoAgentCommand();
+      if (code !== 0) process.exitCode = code;
+    });
+
+  program
     .command("doctor")
     .description(
       "Check the agent↔twin wiring: pome.config.json present + valid, twin reachable, requests routed to the twin (not a hardcoded production host), egress floor active. On failure prints one named cause (file:line where knowable) + one concrete fix and exits non-zero.",

--- a/cli/src/demo/agent.ts
+++ b/cli/src/demo/agent.ts
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-643 — the bundled demo agent: a small tool-loop agent that drives the
+// packaged first-run demo task against the LOCAL GitHub twin, with its model
+// calls served by pome's anonymous demo gateway (FDRS-637).
+//
+// It is spawned by `pome demo` as `pome demo-agent`, a child of the REAL
+// capture path (runScenario): the runner injects the standard POME_* twin
+// contract plus the demo-specific vars below, and HTTP(S)_PROXY pointing at
+// the capture-server so the gateway calls land in events.jsonl as genuine
+// LlmCallEvent rows.
+//
+// Env contract (beyond runScenario's standard POME_* set):
+//   POME_DEMO_LLM_URL    — {POME_API_BASE}/v1/demo/sessions/{sid}/llm
+//   POME_DEMO_TOKEN      — the trial session's demo_token (Bearer)
+//   POME_DEMO_TASK_NAME  — server-allowlisted task name ("first-run-demo")
+//   POME_DEMO_REPO       — "owner/name" the packaged seed created
+//
+// The agent exposes exactly three tools — list_open_issues, add_label,
+// comment_on_issue — matching the packaged task. It never scores anything
+// (capture-only CLI): it acts, the trace is judged in the cloud.
+//
+// Honest failure contract: when the GATEWAY says the demo is at capacity
+// (402/429 machine-readable errors), the agent prints a
+// `POME_DEMO_CAPACITY:<kind>` marker to stderr and exits non-zero so the
+// parent renders the labeled state — never a fabricated completion.
+
+import {
+  callDemoGateway,
+  type DemoMessage,
+  type DemoTextPart,
+  type DemoToolCallPart,
+  type DemoToolDef,
+  type DemoToolResultPart,
+} from "./gateway.js";
+import { DemoCapacityError, capacityMarkerLine } from "./capacity.js";
+
+/** Ceiling on gateway round-trips per trial. Deliberately below the server's
+ *  per-session call cap (default 20) so a wandering loop fails as OUR
+ *  "agent gave up", not as a server 429. */
+const MAX_TURNS = 12;
+
+export const DEMO_AGENT_TOOLS: DemoToolDef[] = [
+  {
+    name: "list_open_issues",
+    description:
+      "List the open issues in the repository you are triaging. Returns number, title, body, and current labels for each.",
+    input_schema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "add_label",
+    description:
+      "Apply an EXISTING label to an issue by number. Fails if the label does not exist in the repository.",
+    input_schema: {
+      type: "object",
+      properties: {
+        issue_number: { type: "number", description: "Issue number, e.g. 1" },
+        label: { type: "string", description: "Name of an existing label" },
+      },
+      required: ["issue_number", "label"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "comment_on_issue",
+    description: "Leave one comment on an issue by number.",
+    input_schema: {
+      type: "object",
+      properties: {
+        issue_number: { type: "number", description: "Issue number, e.g. 1" },
+        body: { type: "string", description: "Comment body (markdown)" },
+      },
+      required: ["issue_number", "body"],
+      additionalProperties: false,
+    },
+  },
+];
+
+export interface DemoAgentEnv {
+  task: string;
+  twinRestUrl: string;
+  twinAuthToken: string;
+  gatewayUrl: string;
+  demoToken: string;
+  taskName: string;
+  repo: string; // "owner/name"
+  proxyUrl?: string;
+  noProxy?: string;
+}
+
+export function readDemoAgentEnv(env: NodeJS.ProcessEnv): DemoAgentEnv {
+  const required = (name: string): string => {
+    const value = env[name]?.trim();
+    if (!value) throw new Error(`${name} is required for pome demo-agent`);
+    return value;
+  };
+  return {
+    task: required("POME_TASK"),
+    twinRestUrl: required("POME_GITHUB_REST_URL"),
+    twinAuthToken: required("POME_AUTH_TOKEN"),
+    gatewayUrl: required("POME_DEMO_LLM_URL"),
+    demoToken: required("POME_DEMO_TOKEN"),
+    taskName: required("POME_DEMO_TASK_NAME"),
+    repo: required("POME_DEMO_REPO"),
+    proxyUrl: env.HTTPS_PROXY ?? env.HTTP_PROXY,
+    noProxy: env.NO_PROXY,
+  };
+}
+
+interface TwinIssue {
+  number: number;
+  title: string;
+  body: string;
+  labels: Array<{ name: string } | string>;
+}
+
+async function twinFetch<T>(
+  agentEnv: DemoAgentEnv,
+  path: string,
+  init?: { method?: string; body?: unknown },
+): Promise<T> {
+  const res = await fetch(`${agentEnv.twinRestUrl}${path}`, {
+    method: init?.method ?? "GET",
+    headers: {
+      authorization: `Bearer ${agentEnv.twinAuthToken}`,
+      ...(init?.body !== undefined ? { "content-type": "application/json" } : {}),
+    },
+    body: init?.body !== undefined ? JSON.stringify(init.body) : undefined,
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(
+      `${init?.method ?? "GET"} ${path} → ${res.status}: ${text.slice(0, 300)}`,
+    );
+  }
+  return (text.length ? JSON.parse(text) : {}) as T;
+}
+
+/** Execute one tool call against the twin. Tool failures are returned as
+ *  error strings (the model gets to react), not thrown. */
+export async function executeDemoTool(
+  agentEnv: DemoAgentEnv,
+  name: string,
+  input: unknown,
+): Promise<{ output: unknown; isError: boolean }> {
+  const [owner, repo] = agentEnv.repo.split("/") as [string, string];
+  const args = (input ?? {}) as Record<string, unknown>;
+  try {
+    switch (name) {
+      case "list_open_issues": {
+        const issues = await twinFetch<TwinIssue[]>(
+          agentEnv,
+          `/repos/${owner}/${repo}/issues?state=open`,
+        );
+        return {
+          output: issues.map((issue) => ({
+            number: issue.number,
+            title: issue.title,
+            body: issue.body,
+            labels: (issue.labels ?? []).map((label) =>
+              typeof label === "string" ? label : label.name,
+            ),
+          })),
+          isError: false,
+        };
+      }
+      case "add_label": {
+        const issueNumber = Number(args.issue_number);
+        const label = String(args.label ?? "");
+        if (!Number.isInteger(issueNumber) || label.length === 0) {
+          return { output: "add_label requires issue_number and label", isError: true };
+        }
+        await twinFetch(agentEnv, `/repos/${owner}/${repo}/issues/${issueNumber}/labels`, {
+          method: "POST",
+          body: { labels: [label] },
+        });
+        return { output: `applied label "${label}" to issue #${issueNumber}`, isError: false };
+      }
+      case "comment_on_issue": {
+        const issueNumber = Number(args.issue_number);
+        const body = String(args.body ?? "");
+        if (!Number.isInteger(issueNumber) || body.length === 0) {
+          return { output: "comment_on_issue requires issue_number and body", isError: true };
+        }
+        await twinFetch(agentEnv, `/repos/${owner}/${repo}/issues/${issueNumber}/comments`, {
+          method: "POST",
+          body: { body },
+        });
+        return { output: `commented on issue #${issueNumber}`, isError: false };
+      }
+      default:
+        return { output: `unknown tool: ${name}`, isError: true };
+    }
+  } catch (err) {
+    return {
+      output: err instanceof Error ? err.message : String(err),
+      isError: true,
+    };
+  }
+}
+
+/**
+ * The tool loop. Exit codes: 0 done; 1 loop error/exhaustion; 42 gateway
+ * capacity (marker on stderr).
+ */
+export async function runDemoAgent(
+  agentEnv: DemoAgentEnv,
+  io: { log: (line: string) => void; error: (line: string) => void },
+): Promise<number> {
+  const messages: DemoMessage[] = [{ role: "user", content: agentEnv.task }];
+
+  try {
+    for (let turn = 0; turn < MAX_TURNS; turn += 1) {
+      const response = await callDemoGateway({
+        gatewayUrl: agentEnv.gatewayUrl,
+        demoToken: agentEnv.demoToken,
+        taskName: agentEnv.taskName,
+        messages,
+        tools: DEMO_AGENT_TOOLS,
+        proxyUrl: agentEnv.proxyUrl,
+        noProxy: agentEnv.noProxy,
+      });
+
+      if (response.tool_calls.length === 0) {
+        io.log(response.text.trim().length > 0 ? response.text.trim() : "(done)");
+        return 0;
+      }
+
+      const assistantParts: Array<DemoTextPart | DemoToolCallPart> = [];
+      if (response.text.trim().length > 0) {
+        assistantParts.push({ type: "text", text: response.text });
+      }
+      for (const call of response.tool_calls) {
+        assistantParts.push({
+          type: "tool-call",
+          toolCallId: call.id,
+          toolName: call.name,
+          input: call.input,
+        });
+      }
+      messages.push({ role: "assistant", content: assistantParts });
+
+      const resultParts: DemoToolResultPart[] = [];
+      for (const call of response.tool_calls) {
+        const result = await executeDemoTool(agentEnv, call.name, call.input);
+        // AI SDK canonical tool-result output shape ({type, value}) — the
+        // gateway forwards `output` verbatim into ModelMessage content.
+        resultParts.push({
+          type: "tool-result",
+          toolCallId: call.id,
+          toolName: call.name,
+          output: result.isError
+            ? { type: "error-text", value: String(result.output) }
+            : { type: "json", value: result.output },
+        });
+      }
+      messages.push({ role: "tool", content: resultParts });
+    }
+
+    io.error(`demo agent gave up after ${MAX_TURNS} model calls without finishing`);
+    return 1;
+  } catch (err) {
+    if (err instanceof DemoCapacityError) {
+      io.error(capacityMarkerLine(err.kind));
+      io.error(err.message);
+      return 42;
+    }
+    io.error(err instanceof Error ? err.message : String(err));
+    return 1;
+  }
+}
+
+/** `pome demo-agent` entrypoint (hidden command in main.ts). */
+export async function runDemoAgentCommand(): Promise<number> {
+  if (process.env.POME_PREFLIGHT === "1") {
+    console.log("preflight ok");
+    return 0;
+  }
+  const agentEnv = readDemoAgentEnv(process.env);
+  return runDemoAgent(agentEnv, {
+    log: (line) => console.log(line),
+    error: (line) => console.error(line),
+  });
+}

--- a/cli/src/demo/capacity.ts
+++ b/cli/src/demo/capacity.ts
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-643 / FDRS-662 — honest at-capacity states for the anonymous demo.
+//
+// The demo's cloud surface returns machine-readable 402/429 errors at three
+// choke points (mint, model-call gateway, finalize/judge). Each maps to an
+// honest labeled terminal state — never a stack trace, never a fabricated
+// completion. Kinds of record (pome-cloud routes/demo-sessions.ts,
+// routes/demo-llm.ts, routes/finalize.ts):
+//   - mint 429 (per-IP daily session cap; no `kind` in details)
+//   - mint 402 (house team session quota; no `kind`)
+//   - gateway 429 kind=session_llm_call_cap
+//   - gateway 429 kind=demo_ip_llm_cap
+//   - gateway 402 kind=daily_model_cap
+//   - finalize 402 kind=daily_judge_cap
+//   - gateway 503 kind=ai_gateway_disabled / demo_model_unpriced
+
+export type DemoCapacityKind =
+  | "demo_ip_mint_cap"
+  | "demo_mint_quota"
+  | "session_llm_call_cap"
+  | "demo_ip_llm_cap"
+  | "daily_model_cap"
+  | "daily_judge_cap"
+  | "gateway_unavailable"
+  | "unknown_capacity";
+
+export class DemoCapacityError extends Error {
+  constructor(
+    public readonly kind: DemoCapacityKind,
+    message: string,
+  ) {
+    super(message);
+    this.name = "DemoCapacityError";
+  }
+}
+
+/** Map a machine-readable error `kind` string (from the cloud envelope's
+ *  details) + HTTP status to a DemoCapacityKind. */
+export function capacityKindFrom(
+  status: number,
+  detailsKind: unknown,
+): DemoCapacityKind | null {
+  if (typeof detailsKind === "string") {
+    switch (detailsKind) {
+      case "session_llm_call_cap":
+        return "session_llm_call_cap";
+      case "demo_ip_llm_cap":
+        return "demo_ip_llm_cap";
+      case "daily_model_cap":
+        return "daily_model_cap";
+      case "daily_judge_cap":
+        return "daily_judge_cap";
+      case "ai_gateway_disabled":
+      case "demo_model_unpriced":
+        return "gateway_unavailable";
+      default:
+        break;
+    }
+  }
+  if (status === 402 || status === 429) return "unknown_capacity";
+  if (status === 503) return "gateway_unavailable";
+  return null;
+}
+
+/** One honest human line per at-capacity kind (design: "the demo is at
+ *  capacity today — try again tomorrow" register; no stack traces). */
+export function capacityLabel(kind: DemoCapacityKind): string {
+  switch (kind) {
+    case "demo_ip_mint_cap":
+    case "demo_ip_llm_cap":
+      return "the demo hit today's limit for this network — try again tomorrow, or sign up for a free account";
+    case "daily_model_cap":
+      return "the demo's daily model budget is exhausted — try again tomorrow, or sign up for a free account";
+    case "daily_judge_cap":
+      return "the demo's daily evaluation budget is exhausted — try again tomorrow, or sign up for a free account";
+    case "session_llm_call_cap":
+      return "this trial hit its model-call ceiling";
+    case "gateway_unavailable":
+      return "the demo model gateway is unavailable right now — try again shortly";
+    case "demo_mint_quota":
+    case "unknown_capacity":
+      return "the demo is at capacity today — try again tomorrow";
+  }
+}
+
+/** Marker line the bundled agent prints to stderr when the GATEWAY reports
+ *  capacity, so the parent `pome demo` process (which only sees the child's
+ *  exit code + stderr) can render the honest label instead of a generic
+ *  "trial errored". */
+export const CAPACITY_STDERR_PREFIX = "POME_DEMO_CAPACITY:";
+
+export function capacityMarkerLine(kind: DemoCapacityKind): string {
+  return `${CAPACITY_STDERR_PREFIX}${kind}`;
+}
+
+export function parseCapacityMarker(stderr: string): DemoCapacityKind | null {
+  const match = stderr.match(
+    new RegExp(`${CAPACITY_STDERR_PREFIX}([a-z_]+)`, "m"),
+  );
+  if (!match) return null;
+  const kind = match[1] as DemoCapacityKind;
+  const known: DemoCapacityKind[] = [
+    "demo_ip_mint_cap",
+    "demo_mint_quota",
+    "session_llm_call_cap",
+    "demo_ip_llm_cap",
+    "daily_model_cap",
+    "daily_judge_cap",
+    "gateway_unavailable",
+    "unknown_capacity",
+  ];
+  return known.includes(kind) ? kind : "unknown_capacity";
+}

--- a/cli/src/demo/first-run-demo.md
+++ b/cli/src/demo/first-run-demo.md
@@ -1,0 +1,67 @@
+# first-run-demo
+
+<!--
+FDRS-643 — the packaged `npx pome-sh demo` task. This markdown is the
+CANONICAL source of the demo task content: the cloud's server-owned judge
+definition (pome-cloud apps/control-plane/src/lib/demo.ts,
+DEMO_TASK_DEFINITIONS["first-run-demo"]) is regenerated FROM this file — the
+judge scores the server copy, never a client-supplied body, so the two must
+stay in lockstep. Changing the prompt / expected behavior / criteria here
+without regenerating the server definition means the cloud judges a
+different task than the one the bundled agent ran.
+
+The three tools the bundled demo agent exposes (src/demo/agent.ts) are the
+contract this task is written against: list_open_issues, add_label,
+comment_on_issue.
+-->
+
+## Prompt
+
+You are triaging the acme/api repository. Find the open issue that reports a
+500 error on POST /orders, apply the existing `bug` label to it, and leave
+exactly one comment on that issue naming the failing endpoint and summarizing
+the reported evidence for the maintainer. Use only the tools you are given.
+
+## Expected Behavior
+
+The agent lists the open issues, identifies the 500-error report among the
+decoys, applies the existing `bug` label to exactly that issue, and leaves one
+comment naming the failing endpoint (POST /orders) with the reported evidence
+— without creating labels, inventing endpoints or ids, or touching any other
+issue.
+
+## Success Criteria
+
+- [P] The existing `bug` label was applied to the issue reporting the 500 error on POST /orders, and to no other issue.
+- [P] Exactly one comment was left on that issue, and it names the failing endpoint (POST /orders).
+- [P] No other issue was modified and no new label was created.
+
+## Seed State
+
+A GitHub-shaped twin seeded for issue triage (compiled sidecar:
+`first-run-demo.seed.json` — hand-written, kept in lockstep with this prose).
+
+### Repository: `acme/api`
+
+A normal public repo, default branch `main`. `alice` and `bob` are
+collaborators. Exactly three labels exist — `bug`, `feature`, `question` —
+so the agent must pick one rather than invent one.
+
+### Issues
+
+Three open issues, none labeled, none assigned:
+
+- **#1** `500 error on POST /orders after deploy` — "Started failing right
+  after the 14:00 deploy. Stack trace points to OrderController#create."
+  (the target)
+- **#2** `Add CSV export for the orders dashboard` — a feature request
+  (decoy)
+- **#3** `How do we rotate the staging API keys?` — a question (decoy)
+
+## Config
+
+```yaml
+twins: [github]
+timeout: 60
+passThreshold: 100
+```

--- a/cli/src/demo/first-run-demo.seed.json
+++ b/cli/src/demo/first-run-demo.seed.json
@@ -1,0 +1,60 @@
+{
+  "_meta": {
+    "version": 1,
+    "source_hash": "handwritten",
+    "model": "handwritten",
+    "compiled_at": "2026-07-05T00:00:00.000Z"
+  },
+  "repositories": [
+    {
+      "owner": "acme",
+      "name": "api",
+      "description": "ACME API service",
+      "default_branch": "main",
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a",
+          "description": "Something isn't working"
+        },
+        {
+          "name": "feature",
+          "color": "a2eeef",
+          "description": "New feature request"
+        },
+        {
+          "name": "question",
+          "color": "d876e3",
+          "description": "Further information is requested"
+        }
+      ],
+      "collaborators": ["alice", "bob"],
+      "issues": [
+        {
+          "number": 1,
+          "title": "500 error on POST /orders after deploy",
+          "body": "Started failing right after the 14:00 deploy. Stack trace points to OrderController#create.",
+          "state": "open",
+          "labels": [],
+          "assignee": null
+        },
+        {
+          "number": 2,
+          "title": "Add CSV export for the orders dashboard",
+          "body": "Finance wants to pull monthly order data into a spreadsheet without asking engineering.",
+          "state": "open",
+          "labels": [],
+          "assignee": null
+        },
+        {
+          "number": 3,
+          "title": "How do we rotate the staging API keys?",
+          "body": "The runbook mentions a rotation script but I can't find it in the repo.",
+          "state": "open",
+          "labels": [],
+          "assignee": null
+        }
+      ]
+    }
+  ]
+}

--- a/cli/src/demo/gateway.ts
+++ b/cli/src/demo/gateway.ts
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-643 — client for the anonymous demo model-call gateway (FDRS-637):
+// POST {POME_API_BASE}/v1/demo/sessions/:id/llm, Authorization: Bearer
+// <demo_token>.
+//
+// The wire shape is a STRICT ModelMessage subset (pome-cloud
+// routes/demo-llm.ts): user text, assistant text/tool-call parts, tool
+// results — NO `system` role (server-owned prompt), NO `model` field
+// (server-pinned). Unknown fields are a 422 BY DESIGN; that strictness IS the
+// scenario lock, so this client never spreads extra keys into messages.
+// Requests travel through the runner-injected capture proxy
+// (proxyRequest.ts) so each gateway call lands in events.jsonl as a genuine
+// LlmCallEvent and stays inside the egress floor.
+
+import { z } from "zod";
+import { DemoCapacityError, capacityKindFrom, capacityLabel } from "./capacity.js";
+import { postJsonMaybeViaProxy } from "./proxyRequest.js";
+
+// ─── Wire types (strict subset — mirror of demo-llm.ts's Zod schema) ────────
+
+export type DemoTextPart = { type: "text"; text: string };
+export type DemoToolCallPart = {
+  type: "tool-call";
+  toolCallId: string;
+  toolName: string;
+  input: unknown;
+};
+export type DemoToolResultPart = {
+  type: "tool-result";
+  toolCallId: string;
+  toolName: string;
+  output: unknown;
+};
+
+export type DemoMessage =
+  | { role: "user"; content: string }
+  | { role: "assistant"; content: string | Array<DemoTextPart | DemoToolCallPart> }
+  | { role: "tool"; content: DemoToolResultPart[] };
+
+export interface DemoToolDef {
+  name: string;
+  description?: string;
+  input_schema: Record<string, unknown>;
+}
+
+const gatewayResponseSchema = z.object({
+  text: z.string(),
+  tool_calls: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+      input: z.unknown(),
+    }),
+  ),
+  finish_reason: z.string(),
+  usage: z
+    .object({
+      input_tokens: z.number(),
+      output_tokens: z.number(),
+    })
+    .optional(),
+});
+export type GatewayResponse = z.infer<typeof gatewayResponseSchema>;
+
+export interface CallDemoGatewayOptions {
+  /** Full gateway URL: {apiBase}/v1/demo/sessions/{sid}/llm. */
+  gatewayUrl: string;
+  demoToken: string;
+  taskName: string;
+  messages: DemoMessage[];
+  tools?: DemoToolDef[];
+  /** Proxy coordinates (HTTPS_PROXY / NO_PROXY from the runner). */
+  proxyUrl?: string;
+  noProxy?: string;
+  timeoutMs?: number;
+  /** Test seam — force the CONNECT path for loopback targets. */
+  forceProxyForTest?: boolean;
+}
+
+export class DemoGatewayError extends Error {
+  constructor(
+    message: string,
+    public readonly status?: number,
+  ) {
+    super(message);
+    this.name = "DemoGatewayError";
+  }
+}
+
+export async function callDemoGateway(
+  options: CallDemoGatewayOptions,
+): Promise<GatewayResponse> {
+  const { status, bodyText } = await postJsonMaybeViaProxy({
+    url: options.gatewayUrl,
+    headers: { authorization: `Bearer ${options.demoToken}` },
+    body: {
+      task_name: options.taskName,
+      messages: options.messages,
+      ...(options.tools && options.tools.length > 0
+        ? { tools: options.tools }
+        : {}),
+    },
+    proxyUrl: options.proxyUrl,
+    noProxy: options.noProxy,
+    timeoutMs: options.timeoutMs ?? 120_000,
+    forceProxy: options.forceProxyForTest,
+  });
+
+  let json: unknown = {};
+  try {
+    json = bodyText.length ? JSON.parse(bodyText) : {};
+  } catch {
+    throw new DemoGatewayError(
+      `demo gateway returned non-JSON (status ${status})`,
+      status,
+    );
+  }
+
+  if (status < 200 || status >= 300) {
+    const envelope = (
+      json as {
+        error?: { message?: string; details?: Record<string, unknown> };
+      }
+    ).error;
+    const kind = capacityKindFrom(status, envelope?.details?.kind);
+    if (kind) {
+      throw new DemoCapacityError(kind, envelope?.message ?? capacityLabel(kind));
+    }
+    throw new DemoGatewayError(
+      envelope?.message ?? `demo gateway → HTTP ${status}`,
+      status,
+    );
+  }
+
+  const parsed = gatewayResponseSchema.safeParse(json);
+  if (!parsed.success) {
+    throw new DemoGatewayError(
+      `demo gateway returned an unexpected shape: ${parsed.error.message}`,
+      status,
+    );
+  }
+  return parsed.data;
+}

--- a/cli/src/demo/ids.ts
+++ b/cli/src/demo/ids.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-643 — trial-group identity for `pome demo`.
+//
+// One `grp_` + nanoid21 id per demo invocation, shared by all k=5 demo
+// sessions (mint body `group_id`), copied by the cloud onto
+// `sessions.group_id` at mint and `runs.group_id` at finalize, and forming
+// the no-login preview URL `app.pome.sh/demo/<group_id>`.
+//
+// Format contract: the cloud validates `^[A-Za-z0-9_-]{6,64}$`
+// (isValidGroupId in pome-cloud lib/demo.ts). "grp_" + 21 url-safe chars =
+// 25 chars, comfortably inside.
+
+import { randomBytes } from "node:crypto";
+
+const NANOID_ALPHABET =
+  "useandom-26T198340PX75pxJACKVERYMINDBUSHWOLF_GQZbfghjklqvwyzrict";
+
+/** nanoid-shaped random string over the url-safe 64-char alphabet. */
+export function nanoid(size = 21): string {
+  const bytes = randomBytes(size);
+  let id = "";
+  for (let i = 0; i < size; i += 1) {
+    // 64-char alphabet ⇒ 6 bits per char; masking keeps the distribution
+    // uniform (no modulo bias).
+    id += NANOID_ALPHABET[bytes[i]! & 63];
+  }
+  return id;
+}
+
+/** Mint one trial-group id: `grp_` + nanoid21. */
+export function newGroupId(): string {
+  return `grp_${nanoid(21)}`;
+}

--- a/cli/src/demo/mint.ts
+++ b/cli/src/demo/mint.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-643 — anonymous demo session minting.
+//
+// POST {POME_API_BASE}/v1/demo/sessions with
+//   { task_name: "first-run-demo", task_hash: "", group_id: "grp_…" }
+// → { session_id, demo_token, expires_at }. No auth: the response's
+// demo_token (a sid-scoped JWT) is the credential for everything that
+// follows (gateway calls, blob uploads, finalize).
+//
+// All k sessions are minted UPFRONT (one shared group_id per invocation);
+// each session's 15-minute TTL comfortably covers the whole k=5 run, so mint
+// order is irrelevant. 402/429/503 map to DemoCapacityError so the CLI
+// renders an honest labeled state.
+
+import { z } from "zod";
+import { HostedOrchError } from "../hosted/errors.js";
+import { DemoCapacityError, capacityKindFrom, capacityLabel } from "./capacity.js";
+
+export const demoSessionSchema = z.object({
+  session_id: z.string().min(1),
+  demo_token: z.string().min(1),
+  expires_at: z.string(),
+});
+export type DemoSession = z.infer<typeof demoSessionSchema>;
+
+export interface MintDemoSessionsOptions {
+  apiBase: string;
+  taskName: string;
+  groupId: string;
+  count: number;
+  /** Injectable for tests. Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+export async function mintDemoSessions(
+  options: MintDemoSessionsOptions,
+): Promise<DemoSession[]> {
+  const sessions: DemoSession[] = [];
+  for (let i = 0; i < options.count; i += 1) {
+    sessions.push(await mintOne(options));
+  }
+  return sessions;
+}
+
+async function mintOne(options: MintDemoSessionsOptions): Promise<DemoSession> {
+  const doFetch = options.fetchImpl ?? fetch;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), options.timeoutMs ?? 30_000);
+  let res: Response;
+  try {
+    res = await doFetch(`${options.apiBase}/v1/demo/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        task_name: options.taskName,
+        task_hash: "",
+        group_id: options.groupId,
+      }),
+      signal: ctrl.signal,
+    });
+  } catch (err) {
+    throw new HostedOrchError(
+      err instanceof Error ? err.message : "network error",
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const text = await res.text();
+  let json: unknown = {};
+  try {
+    json = text.length ? JSON.parse(text) : {};
+  } catch {
+    throw new HostedOrchError(
+      `POST /v1/demo/sessions returned non-JSON (status ${res.status})`,
+    );
+  }
+
+  if (!res.ok) {
+    const envelope = (
+      json as {
+        error?: { message?: string; details?: Record<string, unknown> };
+      }
+    ).error;
+    // Mint 429 = per-IP daily session cap, 402 = house-team session quota
+    // (neither carries a `kind` in details today — map by status).
+    let kind = capacityKindFrom(res.status, envelope?.details?.kind);
+    if (kind === "unknown_capacity") {
+      kind = res.status === 429 ? "demo_ip_mint_cap" : "demo_mint_quota";
+    }
+    if (kind) {
+      throw new DemoCapacityError(kind, envelope?.message ?? capacityLabel(kind));
+    }
+    throw new HostedOrchError(
+      envelope?.message ?? `POST /v1/demo/sessions → HTTP ${res.status}`,
+      undefined,
+      res.status,
+    );
+  }
+
+  const parsed = demoSessionSchema.safeParse(json);
+  if (!parsed.success) {
+    throw new HostedOrchError(
+      `POST /v1/demo/sessions returned an unexpected shape: ${parsed.error.message}`,
+    );
+  }
+  return parsed.data;
+}

--- a/cli/src/demo/proxyRequest.ts
+++ b/cli/src/demo/proxyRequest.ts
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-643 — proxy-aware JSON POST for the bundled demo agent.
+//
+// The demo agent is spawned through the real capture path (FDRS-399): the
+// runner injects HTTP(S)_PROXY pointing at the capture-server, whose CONNECT
+// tunnels become the LlmCallEvent rows in events.jsonl and whose
+// deny-by-default egress floor (FDRS-635) is the prod-safety control. Node's
+// global fetch does NOT honor proxy env vars, so an agent that used bare
+// fetch for its gateway calls would silently bypass both — no trace row, no
+// floor. This helper restores the contract without adding a dependency:
+//   - target in NO_PROXY / loopback, or no proxy configured → plain fetch;
+//   - otherwise: CONNECT through the proxy, TLS-wrap for https targets, then
+//     a plain node:http request over the established socket.
+
+import { request as httpRequest } from "node:http";
+import { connect as netConnect, type Socket } from "node:net";
+import { connect as tlsConnect } from "node:tls";
+
+export interface ProxyJsonResponse {
+  status: number;
+  bodyText: string;
+}
+
+export interface PostJsonOptions {
+  url: string;
+  headers: Record<string, string>;
+  body: unknown;
+  /** e.g. process.env.HTTPS_PROXY. Absent → direct fetch. */
+  proxyUrl?: string;
+  /** e.g. process.env.NO_PROXY ("127.0.0.1,localhost"). */
+  noProxy?: string;
+  timeoutMs?: number;
+  /** Test seam: force the CONNECT-proxy path even for loopback targets
+   *  (unit tests run every server on 127.0.0.1, which the production
+   *  bypass would otherwise route around). */
+  forceProxy?: boolean;
+}
+
+export function isLoopbackHost(host: string): boolean {
+  const value = host.trim().toLowerCase();
+  if (value === "localhost" || value.endsWith(".localhost")) return true;
+  if (value === "::1" || value === "[::1]") return true;
+  return /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(value);
+}
+
+export function matchesNoProxy(host: string, noProxy: string | undefined): boolean {
+  if (!noProxy) return false;
+  const candidate = host.trim().toLowerCase();
+  return noProxy
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry) => entry.length > 0)
+    .some((entry) =>
+      entry === "*" ||
+      candidate === entry ||
+      candidate.endsWith(entry.startsWith(".") ? entry : `.${entry}`),
+    );
+}
+
+export async function postJsonMaybeViaProxy(
+  options: PostJsonOptions,
+): Promise<ProxyJsonResponse> {
+  const target = new URL(options.url);
+  const useProxy =
+    Boolean(options.proxyUrl) &&
+    (options.forceProxy === true ||
+      (!isLoopbackHost(target.hostname) &&
+        !matchesNoProxy(target.hostname, options.noProxy)));
+
+  if (!useProxy) {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), options.timeoutMs ?? 60_000);
+    try {
+      const res = await fetch(options.url, {
+        method: "POST",
+        headers: { ...options.headers, "content-type": "application/json" },
+        body: JSON.stringify(options.body),
+        signal: ctrl.signal,
+      });
+      return { status: res.status, bodyText: await res.text() };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  return postJsonThroughConnectProxy(target, options);
+}
+
+async function postJsonThroughConnectProxy(
+  target: URL,
+  options: PostJsonOptions,
+): Promise<ProxyJsonResponse> {
+  const proxy = new URL(options.proxyUrl!);
+  const targetPort = Number(target.port || (target.protocol === "https:" ? 443 : 80));
+  const timeoutMs = options.timeoutMs ?? 60_000;
+
+  const rawSocket = await connectTunnel(
+    proxy.hostname,
+    Number(proxy.port || 80),
+    target.hostname,
+    targetPort,
+    timeoutMs,
+  );
+
+  const socket: Socket =
+    target.protocol === "https:"
+      ? await new Promise<Socket>((resolve, reject) => {
+          const tlsSocket = tlsConnect(
+            { socket: rawSocket, servername: target.hostname },
+            () => resolve(tlsSocket),
+          );
+          tlsSocket.once("error", reject);
+        })
+      : rawSocket;
+
+  return new Promise<ProxyJsonResponse>((resolve, reject) => {
+    const payload = JSON.stringify(options.body);
+    const req = httpRequest(
+      {
+        createConnection: () => socket,
+        method: "POST",
+        host: target.hostname,
+        port: targetPort,
+        path: `${target.pathname}${target.search}`,
+        headers: {
+          ...options.headers,
+          host: target.host,
+          "content-type": "application/json",
+          "content-length": Buffer.byteLength(payload),
+          connection: "close",
+        },
+        timeout: timeoutMs,
+      },
+      (res) => {
+        let bodyText = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk: string) => {
+          bodyText += chunk;
+        });
+        res.on("end", () => {
+          resolve({ status: res.statusCode ?? 0, bodyText });
+        });
+        res.on("error", reject);
+      },
+    );
+    req.on("timeout", () => {
+      req.destroy(new Error(`request to ${target.host} timed out after ${timeoutMs}ms`));
+    });
+    req.on("error", (err) => {
+      socket.destroy();
+      reject(err);
+    });
+    req.end(payload);
+  });
+}
+
+function connectTunnel(
+  proxyHost: string,
+  proxyPort: number,
+  targetHost: string,
+  targetPort: number,
+  timeoutMs: number,
+): Promise<Socket> {
+  return new Promise<Socket>((resolve, reject) => {
+    const sock = netConnect({ host: proxyHost, port: proxyPort });
+    let buf = "";
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      sock.destroy();
+      reject(new Error(`CONNECT to ${targetHost}:${targetPort} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    const fail = (err: Error): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      sock.destroy();
+      reject(err);
+    };
+    sock.once("error", fail);
+    const onData = (chunk: Buffer): void => {
+      buf += chunk.toString("utf8");
+      const headerEnd = buf.indexOf("\r\n\r\n");
+      if (headerEnd === -1) return;
+      sock.off("data", onData);
+      if (!/^HTTP\/1\.[01] 200/.test(buf)) {
+        // FDRS-635 — a refused CONNECT (egress floor) surfaces as its 403
+        // status line, so the caller can say WHY the call failed.
+        fail(new Error(`CONNECT ${targetHost}:${targetPort} refused: ${buf.split("\r\n")[0]}`));
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      sock.pause();
+      // Bytes past the header (rare for CONNECT) belong to the tunneled
+      // stream; push them back so the TLS/http layer sees them.
+      const rest = Buffer.from(buf.slice(headerEnd + 4), "utf8");
+      if (rest.length > 0) sock.unshift(rest);
+      sock.resume();
+      resolve(sock);
+    };
+    sock.on("data", onData);
+    sock.write(
+      `CONNECT ${targetHost}:${targetPort} HTTP/1.1\r\nHost: ${targetHost}:${targetPort}\r\n\r\n`,
+    );
+  });
+}

--- a/cli/src/demo/render.ts
+++ b/cli/src/demo/render.ts
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-643 — pure terminal rendering for `pome demo`, matching the
+// design-of-record (CLI moments.dc.html moment 01, task/code-model
+// vocabulary):
+//
+//   [bordered reassurance box]
+//   spinning up github twin … ready (1.2s)
+//   running 5 isolated trials of first-run-demo …
+//   trial 1  ✓  passed   14.3s
+//   trial 3  ✗  failed   15.9s  <criterion failure note>
+//   trial 5  ⚠  errored         <reason> — excluded
+//   ─────
+//   2 of 4 passed · 1 trial errored on <reason>, excluded from the fraction
+//   <failing-criterion phrase> in 2 of 4 — start there
+//   see the full breakdown — read-only, still no account:
+//   → https://app.pome.sh/demo/<group_id>
+//
+// Demo verdicts are WORDS (passed/failed), never scores; errored rows show
+// no duration and are EXCLUDED from the fraction's denominator.
+
+export type TrialVerdict =
+  | { kind: "passed"; seconds: number }
+  | { kind: "failed"; seconds: number; note: string }
+  | { kind: "errored"; reason: string };
+
+/** Reassurance frame. "No signup. No API keys." is verbatim copy of record
+ *  ([DECISION] #5); the third line names the three places honestly — local
+ *  twin locally, model calls via the anonymous demo gateway, trace evaluated
+ *  in pome cloud. */
+export function reassuranceBox(): string[] {
+  const lines = [
+    "pome demo · running locally",
+    "No signup. No API keys.",
+    "The GitHub twin runs on your machine; model calls go through pome's",
+    "anonymous demo gateway; the trace is evaluated in pome cloud.",
+    "Your repo and your data are never touched.",
+  ];
+  const width = Math.max(...lines.map((line) => line.length));
+  const top = `┌${"─".repeat(width + 2)}┐`;
+  const bottom = `└${"─".repeat(width + 2)}┘`;
+  return [top, ...lines.map((line) => `│ ${line.padEnd(width)} │`), bottom];
+}
+
+export function twinReadyLine(seconds: number): string {
+  return `spinning up github twin … ready (${seconds.toFixed(1)}s)`;
+}
+
+export function trialsHeaderLine(count: number, taskName: string): string {
+  return `running ${count} isolated trials of ${taskName} …`;
+}
+
+export function evaluatingLine(index: number): string {
+  return `trial ${index}  …  evaluating in the cloud …`;
+}
+
+export function trialLine(index: number, verdict: TrialVerdict): string {
+  switch (verdict.kind) {
+    case "passed":
+      return `trial ${index}  ✓  passed   ${formatSeconds(verdict.seconds)}`;
+    case "failed":
+      return `trial ${index}  ✗  failed   ${formatSeconds(verdict.seconds)}  ${verdict.note}`;
+    case "errored":
+      return `trial ${index}  ⚠  errored         ${verdict.reason} — excluded`;
+  }
+}
+
+function formatSeconds(seconds: number): string {
+  return `${seconds.toFixed(1)}s`;
+}
+
+export interface SummaryInput {
+  verdicts: TrialVerdict[];
+  /** Most-common failed-criterion phrase across evaluated trials, if any. */
+  failingCriterionPhrase?: string;
+  /** How many evaluated trials failed that criterion. */
+  failingCriterionCount?: number;
+  previewUrl: string;
+}
+
+export function summaryLines(input: SummaryInput): string[] {
+  const passed = input.verdicts.filter((v) => v.kind === "passed").length;
+  const failed = input.verdicts.filter((v) => v.kind === "failed").length;
+  const errored = input.verdicts.filter(
+    (v): v is Extract<TrialVerdict, { kind: "errored" }> => v.kind === "errored",
+  );
+  const denominator = passed + failed;
+
+  const lines: string[] = ["─────"];
+
+  let fraction: string;
+  if (denominator === 0) {
+    fraction = "no trials were evaluated";
+  } else {
+    fraction = `${passed} of ${denominator} passed`;
+  }
+  if (errored.length > 0) {
+    const reason = errored[0]!.reason;
+    const noun = errored.length === 1 ? "trial" : "trials";
+    fraction += ` · ${errored.length} ${noun} errored on ${reason}, excluded from the fraction`;
+  }
+  lines.push(fraction);
+
+  if (
+    input.failingCriterionPhrase &&
+    typeof input.failingCriterionCount === "number" &&
+    input.failingCriterionCount > 0 &&
+    denominator > 0
+  ) {
+    lines.push(
+      `${input.failingCriterionPhrase} in ${input.failingCriterionCount} of ${denominator} — start there`,
+    );
+  }
+
+  if (denominator > 0) {
+    lines.push("see the full breakdown — read-only, still no account:");
+    lines.push(`→ ${input.previewUrl}`);
+  }
+
+  return lines;
+}
+
+/** Compress a criterion's text into the short "start there" phrase: first
+ *  clause, lower-cased lead, ~60 chars. */
+export function criterionPhrase(text: string): string {
+  const clause = text.split(/[.;]/)[0]?.trim() ?? text.trim();
+  const lowered = clause.length > 0 ? clause[0]!.toLowerCase() + clause.slice(1) : clause;
+  return lowered.length > 64 ? `${lowered.slice(0, 61).trimEnd()}…` : lowered;
+}

--- a/cli/src/demo/runDemo.ts
+++ b/cli/src/demo/runDemo.ts
@@ -1,0 +1,360 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-643 — `pome demo` orchestration: zero-auth cold start.
+//
+// Flow per the 2026-07-05 [DECISION] set:
+//   1. Reassurance frame first.
+//   2. Mint ALL k demo sessions upfront (POST /v1/demo/sessions, one shared
+//      grp_ id) — each 15-min TTL comfortably covers the run.
+//   3. Per trial: run the bundled agent through the REAL capture path
+//      (runScenario: in-process twin + capture-server child + POME_* env),
+//      upload the captured blobs with the trial's demo_token as Bearer, then
+//      POST /finalize (explicit 60s timeout) — the terminal verdict comes
+//      from that cloud evaluation. The CLI never scores locally.
+//   4. Errored trials are excluded from the verdict fraction; at-capacity
+//      402/429s render as honest labeled states (FDRS-662), never stack
+//      traces, never fabricated completions.
+//   5. Output ends with the no-login preview link
+//      {dashboard}/demo/<group_id>.
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { getAvailablePort } from "../runner/ports.js";
+import { runScenario, type RunScenarioOptions } from "../runner/runScenario.js";
+import { bootTwin } from "../twin/twinHarness.js";
+import { parseScenarioFile } from "../scenario/parseScenario.js";
+import { createHostedClient, type HostedClient } from "../hosted/client.js";
+import {
+  scoreFromFinalizeResponse,
+  uploadRunBlobs,
+} from "../hosted/uploadAndFinalize.js";
+import { outcomeOf, scoreStatus } from "../score/view.js";
+import { HostedQuotaError } from "../hosted/errors.js";
+import {
+  DemoCapacityError,
+  capacityKindFrom,
+  capacityLabel,
+  parseCapacityMarker,
+} from "./capacity.js";
+import { newGroupId } from "./ids.js";
+import { mintDemoSessions, type DemoSession } from "./mint.js";
+import {
+  criterionPhrase,
+  evaluatingLine,
+  reassuranceBox,
+  summaryLines,
+  trialLine,
+  trialsHeaderLine,
+  twinReadyLine,
+  type TrialVerdict,
+} from "./render.js";
+import { DEMO_REPO, DEMO_TASK_NAME, demoTaskPath } from "./task.js";
+
+/** Explicit finalize timeout — the hosted client defaults to 30s; the demo
+ *  judge measured 5-8s, 60s is belt-and-braces ([DECISION]). */
+const DEMO_FINALIZE_TIMEOUT_MS = 60_000;
+
+export type DemoTrialClient = Pick<
+  HostedClient,
+  | "requestEventsUploadUrl"
+  | "requestStateUploadUrl"
+  | "requestSignalsUploadUrl"
+  | "finalize"
+>;
+
+export interface RunDemoOptions {
+  /** Control-plane base URL (POME_API_BASE, default https://api.pome.sh). */
+  apiBase: string;
+  /** Dashboard base for the preview link (default https://app.pome.sh). */
+  dashboardBase: string;
+  trials?: number;
+  artifactsDir?: string;
+  out?: (line: string) => void;
+  // ── test seams ─────────────────────────────────────────────────────────
+  /** Agent command override. Default re-invokes this binary: `<node> <main.js> demo-agent`. */
+  agentCommand?: string;
+  captureServerCommand?: RunScenarioOptions["captureServerCommand"];
+  runScenarioFn?: typeof runScenario;
+  mintFn?: typeof mintDemoSessions;
+  /** Per-session upload/finalize client factory (bearer demo_token). */
+  trialClientFactory?: (session: DemoSession) => DemoTrialClient;
+  /** Skip the warm-up twin boot (tests). */
+  skipTwinWarmup?: boolean;
+}
+
+export interface RunDemoResult {
+  exitCode: number;
+  groupId: string;
+  verdicts: TrialVerdict[];
+}
+
+export async function runDemo(options: RunDemoOptions): Promise<RunDemoResult> {
+  const out = options.out ?? ((line: string) => console.error(line));
+  const trials = options.trials ?? 5;
+  const artifactsDir = options.artifactsDir ?? "runs";
+  const runScenarioFn = options.runScenarioFn ?? runScenario;
+  const mintFn = options.mintFn ?? mintDemoSessions;
+  const trialClientFactory =
+    options.trialClientFactory ??
+    ((session: DemoSession): DemoTrialClient =>
+      createHostedClient({
+        baseUrl: options.apiBase,
+        apiKey: session.demo_token,
+        authScheme: "bearer",
+        timeoutMs: DEMO_FINALIZE_TIMEOUT_MS,
+      }));
+
+  const groupId = newGroupId();
+  const scenarioPath = demoTaskPath();
+
+  for (const line of reassuranceBox()) out(line);
+  out("");
+
+  // Mint all k sessions upfront — the group exists before the first trial
+  // runs, and an at-capacity day fails HERE with one honest line instead of
+  // half-way through a run.
+  let sessions: DemoSession[];
+  try {
+    sessions = await mintFn({
+      apiBase: options.apiBase,
+      taskName: DEMO_TASK_NAME,
+      groupId,
+      count: trials,
+    });
+  } catch (err) {
+    if (err instanceof DemoCapacityError) {
+      out(capacityLabel(err.kind));
+      return { exitCode: 4, groupId, verdicts: [] };
+    }
+    out(
+      `could not reach the pome demo service (${err instanceof Error ? err.message : String(err)})`,
+    );
+    return { exitCode: 2, groupId, verdicts: [] };
+  }
+
+  // Warm-up boot: validates the packaged seed and gives the design's
+  // "spinning up github twin … ready" line an honest measurement. Each trial
+  // then boots its own isolated twin inside runScenario.
+  if (options.skipTwinWarmup !== true) {
+    const scenario = await parseScenarioFile(scenarioPath);
+    const warmupStart = Date.now();
+    const port = await getAvailablePort();
+    const harness = await bootTwin({
+      twin: "github",
+      seedState: scenario.seedState,
+      runId: "demo-warmup",
+      twinBaseUrl: `http://127.0.0.1:${port}`,
+    });
+    harness.close();
+    out(twinReadyLine((Date.now() - warmupStart) / 1000));
+  }
+
+  out(trialsHeaderLine(trials, DEMO_TASK_NAME));
+
+  const agentCommand =
+    options.agentCommand ?? defaultDemoAgentCommand(process.execPath, process.argv[1]);
+
+  const verdicts: TrialVerdict[] = [];
+  // Failed-criterion texts across evaluated trials, for the "start there" line.
+  const collectedFailures: string[] = [];
+  let capacityAbort: string | null = null;
+
+  for (let i = 0; i < trials; i += 1) {
+    const session = sessions[i]!;
+    const trialNumber = i + 1;
+
+    let verdict: TrialVerdict;
+    try {
+      verdict = await runOneTrial({
+        trialNumber,
+        session,
+        scenarioPath,
+        agentCommand,
+        artifactsDir,
+        apiBase: options.apiBase,
+        runScenarioFn,
+        client: trialClientFactory(session),
+        captureServerCommand: options.captureServerCommand,
+        out,
+        collectedFailures,
+      });
+    } catch (err) {
+      if (err instanceof DemoCapacityError) {
+        capacityAbort = capacityLabel(err.kind);
+        verdict = { kind: "errored", reason: "demo at capacity" };
+      } else if (isJudgeCapQuota(err)) {
+        capacityAbort = capacityLabel("daily_judge_cap");
+        verdict = { kind: "errored", reason: "demo at capacity" };
+      } else {
+        verdict = {
+          kind: "errored",
+          reason: shortReason(err instanceof Error ? err.message : String(err)),
+        };
+      }
+    }
+
+    verdicts.push(verdict);
+    out(trialLine(trialNumber, verdict));
+
+    if (capacityAbort) break;
+  }
+
+  if (capacityAbort) out(capacityAbort);
+
+  const failing = mostCommonFailedCriterion(collectedFailures);
+  out("");
+  for (const line of summaryLines({
+    verdicts,
+    failingCriterionPhrase: failing?.phrase,
+    failingCriterionCount: failing?.count,
+    previewUrl: `${options.dashboardBase.replace(/\/$/, "")}/demo/${groupId}`,
+  })) {
+    out(line);
+  }
+
+  const evaluated = verdicts.filter((v) => v.kind !== "errored").length;
+  const exitCode = evaluated > 0 ? 0 : capacityAbort ? 4 : 1;
+  return { exitCode, groupId, verdicts };
+}
+
+interface RunOneTrialInput {
+  trialNumber: number;
+  session: DemoSession;
+  scenarioPath: string;
+  agentCommand: string;
+  artifactsDir: string;
+  apiBase: string;
+  runScenarioFn: typeof runScenario;
+  client: DemoTrialClient;
+  captureServerCommand?: RunScenarioOptions["captureServerCommand"];
+  out: (line: string) => void;
+  collectedFailures: string[];
+}
+
+async function runOneTrial(input: RunOneTrialInput): Promise<TrialVerdict> {
+  const startedAt = Date.now();
+  const result = await input.runScenarioFn({
+    scenarioPath: input.scenarioPath,
+    agentCommand: input.agentCommand,
+    artifactsDir: input.artifactsDir,
+    captureServerCommand: input.captureServerCommand,
+    extraAgentEnv: {
+      POME_DEMO_LLM_URL: `${input.apiBase}/v1/demo/sessions/${input.session.session_id}/llm`,
+      POME_DEMO_TOKEN: input.session.demo_token,
+      POME_DEMO_TASK_NAME: DEMO_TASK_NAME,
+      POME_DEMO_REPO: DEMO_REPO,
+    },
+    egressExtraHosts: [new URL(input.apiBase).hostname],
+  });
+  const agentSeconds = (Date.now() - startedAt) / 1000;
+
+  if (result.exitCode !== 0) {
+    const capacityKind = parseCapacityMarker(result.agent.stderr);
+    if (capacityKind) {
+      throw new DemoCapacityError(capacityKind, capacityLabel(capacityKind));
+    }
+    if (result.agent.timedOut) {
+      return { kind: "errored", reason: "trial timed out" };
+    }
+    return {
+      kind: "errored",
+      reason: shortReason(lastLine(result.agent.stderr) ?? "agent failed"),
+    };
+  }
+
+  // Upload the genuinely captured blobs, then ask the cloud for the verdict.
+  input.out(evaluatingLine(input.trialNumber));
+  const runDir = result.artifacts.runDir;
+  const [eventsJsonl, stateInitialJson, stateFinalJson] = await Promise.all([
+    readFile(join(runDir, "events.jsonl"), "utf8"),
+    readFile(join(runDir, "state_initial.json"), "utf8"),
+    readFile(join(runDir, "state_final.json"), "utf8"),
+  ]);
+  const uploaded = await uploadRunBlobs(input.client, input.session.session_id, {
+    eventsJsonl,
+    stateInitialJson,
+    stateFinalJson,
+    signalsJsonl: "",
+  });
+
+  // criteria: [] — demo finalize replaces the client body with the
+  // server-owned task definition entirely (scenario_name selects it).
+  const finalized = await input.client.finalize(input.session.session_id, {
+    stopReason: "completed",
+    exitCode: 0,
+    durationMs: Math.max(0, Math.round(agentSeconds * 1000)),
+    agentModel: "demo-gateway",
+    agentSdk: null,
+    criteria: [],
+    scenarioName: DEMO_TASK_NAME,
+    scenarioHash: "",
+    scenarioPrompt: "",
+    expectedBehavior: "",
+    traceStorageKey: uploaded.eventsKey ?? undefined,
+    stateInitialStorageKey: uploaded.stateInitialKey ?? undefined,
+    stateFinalStorageKey: uploaded.stateFinalKey ?? undefined,
+  });
+
+  const score = scoreFromFinalizeResponse(finalized);
+  const status = scoreStatus(score, 100);
+  if (status === "pass") {
+    return { kind: "passed", seconds: agentSeconds };
+  }
+  if (status === "fail") {
+    const failedResults = score.results.filter((r) => outcomeOf(r) === "failed");
+    for (const r of failedResults) input.collectedFailures.push(r.criterion.text);
+    const note = failedResults[0]
+      ? criterionPhrase(failedResults[0].criterion.text)
+      : "criterion not met";
+    return { kind: "failed", seconds: agentSeconds, note };
+  }
+  // Un-evaluated: the judge could not produce a verdict for this trace —
+  // honest exclusion, not a fabricated word.
+  return { kind: "errored", reason: "cloud could not evaluate the trace" };
+}
+
+function isJudgeCapQuota(err: unknown): boolean {
+  return (
+    err instanceof HostedQuotaError &&
+    capacityKindFrom(402, err.details?.kind) === "daily_judge_cap"
+  );
+}
+
+function mostCommonFailedCriterion(
+  failures: string[],
+): { phrase: string; count: number } | null {
+  if (failures.length === 0) return null;
+  const counts = new Map<string, number>();
+  for (const text of failures) {
+    counts.set(text, (counts.get(text) ?? 0) + 1);
+  }
+  const [text, count] = [...counts.entries()].sort((a, b) => b[1] - a[1])[0]!;
+  return { phrase: criterionPhrase(text), count };
+}
+
+function lastLine(text: string): string | null {
+  const lines = text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  return lines.length > 0 ? lines[lines.length - 1]! : null;
+}
+
+function shortReason(reason: string): string {
+  const flat = reason.replace(/\s+/g, " ").trim();
+  return flat.length > 72 ? `${flat.slice(0, 69)}…` : flat;
+}
+
+/** Production default: re-invoke this same binary as `pome demo-agent`.
+ *  Quotes both parts so paths with spaces survive runAgentCommand's
+ *  shell-less split. */
+export function defaultDemoAgentCommand(
+  execPath: string,
+  scriptPath: string | undefined,
+): string {
+  if (!scriptPath || scriptPath.length === 0) {
+    throw new Error(
+      "Cannot determine the pome binary path for the demo agent (process.argv[1] is empty).",
+    );
+  }
+  return `"${execPath}" "${scriptPath}" demo-agent`;
+}

--- a/cli/src/demo/task.ts
+++ b/cli/src/demo/task.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-643 — the packaged first-run demo task.
+//
+// `first-run-demo.md` (+ its hand-written seed sidecar) in this directory is
+// the CANONICAL demo task content. The cloud's server-owned judge definition
+// (pome-cloud apps/control-plane/src/lib/demo.ts,
+// DEMO_TASK_DEFINITIONS["first-run-demo"]) is regenerated from that markdown;
+// at finalize the cloud IGNORES the client body entirely and judges the
+// server copy, so the CLI-side pin here is informational (mint sends
+// task_hash: "").
+
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** Server-allowlisted demo task name (mint + gateway + finalize key). */
+export const DEMO_TASK_NAME = "first-run-demo";
+
+/** The repo the packaged seed creates; handed to the bundled agent. */
+export const DEMO_REPO = "acme/api";
+
+/**
+ * Absolute path of the packaged demo task markdown. Resolves next to this
+ * module: `src/demo/` in the dev tree, `dist/src/demo/` in the published
+ * package (copied by scripts/copy-prompts.mjs).
+ */
+export function demoTaskPath(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidate = join(here, "first-run-demo.md");
+  if (!existsSync(candidate)) {
+    throw new Error(
+      `Packaged demo task not found at ${candidate}. ` +
+        "This is a packaging bug — the demo task markdown ships with pome-sh " +
+        "(scripts/copy-prompts.mjs copies src/demo/ into dist/).",
+    );
+  }
+  return candidate;
+}

--- a/cli/src/hosted/client.ts
+++ b/cli/src/hosted/client.ts
@@ -23,10 +23,18 @@ import {
 
 export interface HostedClientConfig {
   baseUrl: string;
+  /** Team API key (`pme_…`) — or, with `authScheme: "bearer"`, a
+   *  session-scoped JWT (demo_token / agent_token). */
   apiKey: string;
   /** Per-request timeout. Defaults to 30s; the cloud's own twin spawn is
    *  ~2s cold but we leave headroom for GHCR pulls.  */
   timeoutMs?: number;
+  /** FDRS-643 — how the credential travels. "x-api-key" (default) is the
+   *  team-key contract. "bearer" sends `Authorization: Bearer <apiKey>` for
+   *  the session-token surface (upload-url/finalize accept a sid-scoped JWT
+   *  via requireApiKeyOrSessionToken; `pome demo` authenticates each trial's
+   *  uploads with its demo_token this way). */
+  authScheme?: "x-api-key" | "bearer";
 }
 
 export interface CreateSessionInput {
@@ -185,6 +193,10 @@ export interface HostedClient {
 
 export function createHostedClient(config: HostedClientConfig): HostedClient {
   const timeoutMs = config.timeoutMs ?? 30_000;
+  const authHeaders: Record<string, string> =
+    config.authScheme === "bearer"
+      ? { authorization: `Bearer ${config.apiKey}` }
+      : { "x-api-key": config.apiKey };
 
   async function readResponse<T>(
     res: Response,
@@ -203,13 +215,19 @@ export function createHostedClient(config: HostedClientConfig): HostedClient {
       // `{ message: "Forbidden", documentation_url: "" }`. Handle both.
       const cloudErr = (json as { error?: { type?: string; message?: string; request_id?: string } }).error;
       const twinErr = cloudErr ? null : (json as { message?: string });
+      const cloudDetails = (
+        cloudErr as { details?: Record<string, unknown> } | undefined
+      )?.details;
       const msg = cloudErr?.message ?? twinErr?.message ?? `HTTP ${res.status}`;
       const reqId = cloudErr?.request_id;
       if (res.status === 401 || res.status === 403) {
         throw new HostedAuthError(msg, reqId);
       }
       if (res.status === 402 || res.status === 429) {
-        throw new HostedQuotaError(msg, reqId);
+        // FDRS-643 — carry the machine-readable envelope details (e.g.
+        // `kind: "daily_judge_cap"`) so `pome demo` can render an honest
+        // labeled at-capacity state instead of a generic quota message.
+        throw new HostedQuotaError(msg, reqId, cloudDetails);
       }
       throw new HostedOrchError(msg, reqId, res.status);
     }
@@ -234,7 +252,7 @@ export function createHostedClient(config: HostedClientConfig): HostedClient {
       res = await fetch(`${config.baseUrl}${path}`, {
         method: "POST",
         headers: {
-          "x-api-key": config.apiKey,
+          ...authHeaders,
           "content-type": "application/json",
         },
         body: JSON.stringify(body),
@@ -284,7 +302,7 @@ export function createHostedClient(config: HostedClientConfig): HostedClient {
     try {
       res = await fetch(`${config.baseUrl}${path}`, {
         method: "GET",
-        headers: { "x-api-key": config.apiKey },
+        headers: authHeaders,
         signal: ctrl.signal,
       });
     } catch (err) {

--- a/cli/src/hosted/errors.ts
+++ b/cli/src/hosted/errors.ts
@@ -24,7 +24,15 @@ export class HostedAuthError extends Error {
 }
 
 export class HostedQuotaError extends Error {
-  constructor(message: string, public readonly requestId?: string) {
+  /** `details` mirrors the cloud error envelope's machine-readable details
+   *  (e.g. `{ kind: "daily_judge_cap" }`) so `pome demo` (FDRS-643/662) can
+   *  render honest labeled at-capacity states. Optional: older responses and
+   *  the twin-pod 401 shape carry none. */
+  constructor(
+    message: string,
+    public readonly requestId?: string,
+    public readonly details?: Record<string, unknown>,
+  ) {
     super(message);
     this.name = "HostedQuotaError";
   }

--- a/cli/src/runner/runScenario.ts
+++ b/cli/src/runner/runScenario.ts
@@ -36,6 +36,15 @@ export type RunScenarioOptions = {
   // Fired once the capture-server child is up and listening, with its pid.
   // Tests use this to assert no orphan after the run.
   onCaptureServerSpawned?: (pid: number) => void;
+  // FDRS-643 — extra env injected into the agent child on top of the POME_*
+  // contract vars. `pome demo` uses this to hand the bundled agent its
+  // anonymous-gateway coordinates (POME_DEMO_LLM_URL, POME_DEMO_TOKEN, …).
+  // Spread after the built-ins (a caller may deliberately override them) but
+  // BEFORE the proxy vars — the capture path is not overridable.
+  extraAgentEnv?: Record<string, string>;
+  // FDRS-643 — extra egress-floor allowlist patterns for this run (demo mode
+  // adds the POME_API_BASE host so gateway CONNECTs aren't refused).
+  egressExtraHosts?: readonly string[];
 };
 
 export async function runScenario(options: RunScenarioOptions) {
@@ -76,7 +85,9 @@ export async function runScenario(options: RunScenarioOptions) {
   // the self-host twin lives on loopback, which the floor always allows.
   // Refused CONNECTs land in the egress sidecar, read back after the run so
   // the CLI can name the blocked hosts.
-  const egressAllowHosts = buildEgressAllowlist(process.env);
+  const egressAllowHosts = buildEgressAllowlist(process.env, {
+    extraHosts: options.egressExtraHosts,
+  });
   const egressJsonlPath = join(runDir, "egress.jsonl");
   const captureServer = options.noCapture
     ? null
@@ -167,6 +178,7 @@ export async function runScenario(options: RunScenarioOptions) {
     POME_RUN_ID: runId,
     POME_ARTIFACTS_DIR: runDir,
     POME_ADAPTER_SIGNALS_PATH: signalsPathForEnv,
+    ...(options.extraAgentEnv ?? {}),
     ...proxyEnv,
   };
 

--- a/cli/test/fixtures/demo/demoLlmSchema.ts
+++ b/cli/test/fixtures/demo/demoLlmSchema.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-643 test fixture — structural MIRROR of the cloud's demo model-call
+// gateway request schema (pome-cloud apps/control-plane/src/routes/demo-llm.ts,
+// FDRS-637). The strictness IS the contract: a `system` role, a `model`
+// field, or any unknown key is a 422 on the real gateway, so the stub
+// servers in these tests validate with the same shape to prove the CLI's
+// wire bodies would survive the real thing. Any change to the server schema
+// must be reflected here (and vice versa).
+
+import { z } from "zod";
+
+const MAX_TEXT_CHARS = 32_000;
+
+const toolCallPartSchema = z
+  .object({
+    type: z.literal("tool-call"),
+    toolCallId: z.string().min(1).max(200),
+    toolName: z.string().min(1).max(64),
+    input: z.unknown(),
+  })
+  .strict();
+
+const toolResultPartSchema = z
+  .object({
+    type: z.literal("tool-result"),
+    toolCallId: z.string().min(1).max(200),
+    toolName: z.string().min(1).max(64),
+    output: z.unknown(),
+  })
+  .strict();
+
+const messageSchema = z.union([
+  z
+    .object({
+      role: z.literal("user"),
+      content: z.string().min(1).max(MAX_TEXT_CHARS),
+    })
+    .strict(),
+  z
+    .object({
+      role: z.literal("assistant"),
+      content: z.union([
+        z.string().max(MAX_TEXT_CHARS),
+        z
+          .array(
+            z.union([
+              z
+                .object({
+                  type: z.literal("text"),
+                  text: z.string().max(MAX_TEXT_CHARS),
+                })
+                .strict(),
+              toolCallPartSchema,
+            ]),
+          )
+          .min(1)
+          .max(32),
+      ]),
+    })
+    .strict(),
+  z
+    .object({
+      role: z.literal("tool"),
+      content: z.array(toolResultPartSchema).min(1).max(32),
+    })
+    .strict(),
+]);
+
+const toolDefSchema = z
+  .object({
+    name: z.string().regex(/^[A-Za-z0-9_-]{1,64}$/),
+    description: z.string().max(2000).optional(),
+    input_schema: z.record(z.string(), z.unknown()),
+  })
+  .strict();
+
+export const demoLlmRequestSchema = z
+  .object({
+    task_name: z.string().min(1).max(200),
+    messages: z.array(messageSchema).min(1).max(200),
+    tools: z.array(toolDefSchema).max(32).optional(),
+  })
+  .strict();

--- a/cli/test/integration/demo-e2e.test.ts
+++ b/cli/test/integration/demo-e2e.test.ts
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-643 — `pome demo` end-to-end against a STUB cloud: real runScenario
+// (in-process github twin + real capture-server child), the REAL bundled
+// demo agent spawned as `bun src/cli/main.ts demo-agent`, and a scripted
+// control plane serving mint / gateway (strict-schema-validated) /
+// presigned uploads / finalize. Everything short of the real cloud + a real
+// model — the founder's Phase G live run covers those.
+import { createServer, type Server } from "node:http";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { runDemo } from "../../src/demo/runDemo.js";
+import { demoLlmRequestSchema } from "../fixtures/demo/demoLlmSchema.js";
+
+interface StubCloud {
+  server: Server;
+  port: number;
+  minted: Array<{ task_name: string; task_hash: string; group_id?: string }>;
+  gatewayBodies: Array<{ sessionId: string; body: unknown; auth: string | undefined }>;
+  putBodies: Map<string, string>;
+  finalized: Array<{ sessionId: string; body: Record<string, unknown>; auth: string | undefined }>;
+}
+
+function scriptedGatewayTurn(turn: number): unknown {
+  if (turn === 1) {
+    return {
+      text: "Listing the open issues.",
+      tool_calls: [{ id: "c1", name: "list_open_issues", input: {} }],
+      finish_reason: "tool-calls",
+      usage: { input_tokens: 400, output_tokens: 30 },
+    };
+  }
+  if (turn === 2) {
+    return {
+      text: "",
+      tool_calls: [
+        { id: "c2", name: "add_label", input: { issue_number: 1, label: "bug" } },
+        {
+          id: "c3",
+          name: "comment_on_issue",
+          input: {
+            issue_number: 1,
+            body: "POST /orders 500s since the 14:00 deploy — OrderController#create.",
+          },
+        },
+      ],
+      finish_reason: "tool-calls",
+      usage: { input_tokens: 600, output_tokens: 60 },
+    };
+  }
+  return {
+    text: "Labeled #1 as bug and left one comment naming POST /orders.",
+    tool_calls: [],
+    finish_reason: "stop",
+    usage: { input_tokens: 700, output_tokens: 25 },
+  };
+}
+
+async function startStubCloud(): Promise<StubCloud> {
+  const minted: StubCloud["minted"] = [];
+  const gatewayBodies: StubCloud["gatewayBodies"] = [];
+  const putBodies = new Map<string, string>();
+  const finalized: StubCloud["finalized"] = [];
+  const gatewayTurns = new Map<string, number>();
+  let mintCount = 0;
+
+  const server = createServer((req, res) => {
+    let raw = "";
+    req.on("data", (chunk) => {
+      raw += String(chunk);
+    });
+    req.on("end", () => {
+      const url = req.url ?? "";
+      const json = (status: number, body: unknown): void => {
+        res.writeHead(status, { "content-type": "application/json" });
+        res.end(JSON.stringify(body));
+      };
+
+      if (req.method === "PUT" && url.startsWith("/put/")) {
+        putBodies.set(url, raw);
+        res.writeHead(200);
+        res.end();
+        return;
+      }
+
+      if (req.method === "POST" && url === "/v1/demo/sessions") {
+        minted.push(JSON.parse(raw));
+        mintCount += 1;
+        json(201, {
+          session_id: `ses_${mintCount}`,
+          demo_token: `header.payload${mintCount}.sig`,
+          expires_at: new Date(Date.now() + 15 * 60_000).toISOString(),
+        });
+        return;
+      }
+
+      const llmMatch = url.match(/^\/v1\/demo\/sessions\/([^/]+)\/llm$/);
+      if (req.method === "POST" && llmMatch) {
+        const sessionId = llmMatch[1]!;
+        const body = JSON.parse(raw);
+        gatewayBodies.push({ sessionId, body, auth: req.headers.authorization });
+        const parsed = demoLlmRequestSchema.safeParse(body);
+        if (!parsed.success) {
+          json(422, {
+            error: {
+              type: "validation_failed",
+              message: `strict schema: ${JSON.stringify(parsed.error.issues)}`,
+            },
+          });
+          return;
+        }
+        const turn = (gatewayTurns.get(sessionId) ?? 0) + 1;
+        gatewayTurns.set(sessionId, turn);
+        json(200, scriptedGatewayTurn(turn));
+        return;
+      }
+
+      const uploadMatch = url.match(
+        /^\/v1\/sessions\/([^/]+)\/(result-upload-url|state-upload-url|signals-upload-url)$/,
+      );
+      if (req.method === "POST" && uploadMatch) {
+        const sessionId = uploadMatch[1]!;
+        const route = uploadMatch[2]!;
+        const base = `http://127.0.0.1:${port}`;
+        if (route === "result-upload-url") {
+          json(200, {
+            url: `${base}/put/${sessionId}/events.jsonl`,
+            key: `team-tm_demo_anonymous/session-${sessionId}/events.jsonl`,
+          });
+        } else if (route === "signals-upload-url") {
+          json(200, {
+            url: `${base}/put/${sessionId}/signals.jsonl`,
+            key: `team-tm_demo_anonymous/session-${sessionId}/signals.jsonl`,
+          });
+        } else {
+          json(200, {
+            state_initial: {
+              url: `${base}/put/${sessionId}/state_initial.json`,
+              key: `team-tm_demo_anonymous/session-${sessionId}/state_initial.json`,
+            },
+            state_final: {
+              url: `${base}/put/${sessionId}/state_final.json`,
+              key: `team-tm_demo_anonymous/session-${sessionId}/state_final.json`,
+            },
+          });
+        }
+        return;
+      }
+
+      const finalizeMatch = url.match(/^\/v1\/sessions\/([^/]+)\/finalize$/);
+      if (req.method === "POST" && finalizeMatch) {
+        const sessionId = finalizeMatch[1]!;
+        finalized.push({
+          sessionId,
+          body: JSON.parse(raw) as Record<string, unknown>,
+          auth: req.headers.authorization,
+        });
+        json(201, {
+          run_id: `run_${sessionId}`,
+          score: 100,
+          judge_model: "google/gemini-3.1-flash-lite",
+          dashboard_url: `http://127.0.0.1:${port}/runs/run_${sessionId}`,
+          criteria_results: [
+            {
+              criterion: { type: "P", text: "The bug label was applied." },
+              outcome: "passed",
+              passed: true,
+              skipped: false,
+              reason: "ok",
+            },
+          ],
+        });
+        return;
+      }
+
+      json(404, { error: { type: "not_found", message: `no stub for ${req.method} ${url}` } });
+    });
+  });
+
+  const port = await new Promise<number>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (typeof addr === "object" && addr) resolve(addr.port);
+      else reject(new Error("no address"));
+    });
+  });
+
+  return { server, port, minted, gatewayBodies, putBodies, finalized };
+}
+
+let cloud: StubCloud | null = null;
+afterAll(async () => {
+  if (cloud) {
+    await new Promise<void>((resolve) => cloud!.server.close(() => resolve()));
+  }
+});
+
+describe("pome demo end-to-end against a stub cloud (FDRS-643)", () => {
+  it("mint → real capture path + real demo agent → upload → finalize → verdict lines + preview link", async () => {
+    cloud = await startStubCloud();
+    const artifactsDir = await mkdtemp(join(tmpdir(), "pome-demo-e2e-"));
+    const out: string[] = [];
+
+    const result = await runDemo({
+      apiBase: `http://127.0.0.1:${cloud.port}`,
+      dashboardBase: "https://app.pome.sh",
+      trials: 2,
+      artifactsDir,
+      out: (line) => out.push(line),
+      // Run from source under bun, mirroring runScenarioCapture's overrides.
+      agentCommand: "bun src/cli/main.ts demo-agent",
+      captureServerCommand: { execPath: "bun", prefixArgs: ["src/cli/main.ts"] },
+    });
+
+    const text = out.join("\n");
+
+    // Terminal shape (moment 01): reassurance frame → twin line → trials →
+    // verdict words → summary fraction → no-login preview link.
+    expect(text).toContain("No signup. No API keys.");
+    expect(text).toMatch(/spinning up github twin … ready \(\d+\.\ds\)/);
+    expect(text).toContain("running 2 isolated trials of first-run-demo …");
+    expect(text).toMatch(/trial 1 {2}✓ {2}passed {3}\d+\.\ds/);
+    expect(text).toMatch(/trial 2 {2}✓ {2}passed {3}\d+\.\ds/);
+    expect(text).toContain("2 of 2 passed");
+    expect(text).toContain(`→ https://app.pome.sh/demo/${result.groupId}`);
+    expect(result.exitCode).toBe(0);
+
+    // Mint: 2 sessions, one shared grp_ id, scenario-locked task name,
+    // informational-empty hash.
+    expect(cloud.minted).toHaveLength(2);
+    for (const mint of cloud.minted) {
+      expect(mint).toEqual({
+        task_name: "first-run-demo",
+        task_hash: "",
+        group_id: result.groupId,
+      });
+    }
+
+    // Gateway: every call carried the right session's demo_token and a
+    // strict-schema-valid body (the stub 422s otherwise, which would have
+    // errored the trials). 3 turns per trial.
+    expect(cloud.gatewayBodies).toHaveLength(6);
+    for (const call of cloud.gatewayBodies) {
+      expect(call.auth).toBe(
+        `Bearer header.payload${call.sessionId.replace("ses_", "")}.sig`,
+      );
+    }
+
+    // The uploaded events.jsonl is the genuinely captured trace: the twin's
+    // recorded REST calls (label + comment on issue #1) are in the blob.
+    const eventsUploads = [...cloud.putBodies.entries()].filter(([key]) =>
+      key.endsWith("/events.jsonl"),
+    );
+    expect(eventsUploads).toHaveLength(2);
+    for (const [, body] of eventsUploads) {
+      expect(body).toContain("TwinHttpEvent");
+      expect(body).toContain("/repos/acme/api/issues/1/labels");
+      expect(body).toContain("/repos/acme/api/issues/1/comments");
+    }
+
+    // Finalize: bearer demo_token, criteria [] (server-owned judge content),
+    // scenario_name selecting the packaged task, storage-key overrides
+    // pointing at the uploaded blobs.
+    expect(cloud.finalized.map((f) => f.sessionId).sort()).toEqual(["ses_1", "ses_2"]);
+    for (const call of cloud.finalized) {
+      expect(call.auth).toMatch(/^Bearer header\.payload\d\.sig$/);
+      expect(call.body.criteria).toEqual([]);
+      expect(call.body.scenario_name).toBe("first-run-demo");
+      expect(call.body.stop_reason).toBe("completed");
+      expect(call.body.trace_storage_key).toBe(
+        `team-tm_demo_anonymous/session-${call.sessionId}/events.jsonl`,
+      );
+      expect(call.body.state_initial_storage_key).toBe(
+        `team-tm_demo_anonymous/session-${call.sessionId}/state_initial.json`,
+      );
+    }
+  }, 120_000);
+});

--- a/cli/test/unit/demo/agent.test.ts
+++ b/cli/test/unit/demo/agent.test.ts
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-643 — the bundled demo agent's tool loop, driven by a scripted stub
+// gateway (validating the strict demo-llm schema on every call) against a
+// stub twin capturing the REST calls the three tools make.
+import { createServer, type Server } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { runDemoAgent, type DemoAgentEnv } from "../../../src/demo/agent.js";
+import { demoLlmRequestSchema } from "../../fixtures/demo/demoLlmSchema.js";
+
+function listen(server: Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (typeof addr === "object" && addr) resolve(addr.port);
+      else reject(new Error("no address"));
+    });
+  });
+}
+
+const openServers: Server[] = [];
+afterEach(async () => {
+  await Promise.all(
+    openServers.splice(0).map(
+      (server) => new Promise<void>((resolve) => server.close(() => resolve())),
+    ),
+  );
+});
+
+type GatewayTurn = { status: number; body: unknown };
+
+function stubGateway(turns: GatewayTurn[]): {
+  server: Server;
+  bodies: unknown[];
+} {
+  const bodies: unknown[] = [];
+  const server = createServer((req, res) => {
+    let raw = "";
+    req.on("data", (chunk) => {
+      raw += String(chunk);
+    });
+    req.on("end", () => {
+      const body = JSON.parse(raw);
+      bodies.push(body);
+      // Contract check on EVERY call — a drifting wire shape fails loudly.
+      const parsed = demoLlmRequestSchema.safeParse(body);
+      if (!parsed.success) {
+        res.writeHead(422, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify({
+            error: {
+              type: "validation_failed",
+              message: `strict schema: ${JSON.stringify(parsed.error.issues)}`,
+            },
+          }),
+        );
+        return;
+      }
+      const turn = turns[Math.min(bodies.length - 1, turns.length - 1)]!;
+      res.writeHead(turn.status, { "content-type": "application/json" });
+      res.end(JSON.stringify(turn.body));
+    });
+  });
+  return { server, bodies };
+}
+
+function stubTwin(): {
+  server: Server;
+  calls: Array<{ method: string; url: string; body: unknown; auth: string | undefined }>;
+} {
+  const calls: Array<{ method: string; url: string; body: unknown; auth: string | undefined }> = [];
+  const server = createServer((req, res) => {
+    let raw = "";
+    req.on("data", (chunk) => {
+      raw += String(chunk);
+    });
+    req.on("end", () => {
+      calls.push({
+        method: req.method ?? "",
+        url: req.url ?? "",
+        body: raw.length > 0 ? JSON.parse(raw) : undefined,
+        auth: req.headers.authorization,
+      });
+      res.writeHead(200, { "content-type": "application/json" });
+      if (req.method === "GET" && req.url?.startsWith("/repos/acme/api/issues")) {
+        res.end(
+          JSON.stringify([
+            {
+              number: 1,
+              title: "500 error on POST /orders after deploy",
+              body: "Stack trace points to OrderController#create.",
+              state: "open",
+              labels: [],
+            },
+            {
+              number: 2,
+              title: "Add CSV export",
+              body: "Finance wants it.",
+              state: "open",
+              labels: [{ name: "feature" }],
+            },
+          ]),
+        );
+        return;
+      }
+      res.end(JSON.stringify({ ok: true }));
+    });
+  });
+  return { server, calls };
+}
+
+function agentEnvFor(gatewayPort: number, twinPort: number): DemoAgentEnv {
+  return {
+    task: "Triage the 500 error in acme/api.",
+    twinRestUrl: `http://127.0.0.1:${twinPort}`,
+    twinAuthToken: "twin.jwt.token",
+    gatewayUrl: `http://127.0.0.1:${gatewayPort}/v1/demo/sessions/ses_1/llm`,
+    demoToken: "demo.jwt.token",
+    taskName: "first-run-demo",
+    repo: "acme/api",
+  };
+}
+
+function collectIo(): { io: { log: (l: string) => void; error: (l: string) => void }; logs: string[]; errors: string[] } {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  return {
+    io: { log: (l) => logs.push(l), error: (l) => errors.push(l) },
+    logs,
+    errors,
+  };
+}
+
+describe("runDemoAgent (FDRS-643 tool loop)", () => {
+  it("runs list → act → finish, executing tools against the twin, and exits 0", async () => {
+    const gateway = stubGateway([
+      {
+        status: 200,
+        body: {
+          text: "Let me look at the issues.",
+          tool_calls: [{ id: "c1", name: "list_open_issues", input: {} }],
+          finish_reason: "tool-calls",
+        },
+      },
+      {
+        status: 200,
+        body: {
+          text: "",
+          tool_calls: [
+            { id: "c2", name: "add_label", input: { issue_number: 1, label: "bug" } },
+            {
+              id: "c3",
+              name: "comment_on_issue",
+              input: { issue_number: 1, body: "POST /orders 500s — see OrderController#create." },
+            },
+          ],
+          finish_reason: "tool-calls",
+        },
+      },
+      {
+        status: 200,
+        body: { text: "Labeled #1 as bug and left a comment.", tool_calls: [], finish_reason: "stop" },
+      },
+    ]);
+    const twin = stubTwin();
+    openServers.push(gateway.server, twin.server);
+    const [gatewayPort, twinPort] = await Promise.all([
+      listen(gateway.server),
+      listen(twin.server),
+    ]);
+
+    const { io, logs } = collectIo();
+    const code = await runDemoAgent(agentEnvFor(gatewayPort, twinPort), io);
+    expect(code).toBe(0);
+    expect(logs.join("\n")).toContain("Labeled #1 as bug");
+
+    // Twin saw exactly the three tool-backed REST calls, bearer-authed.
+    expect(twin.calls.map((c) => `${c.method} ${c.url}`)).toEqual([
+      "GET /repos/acme/api/issues?state=open",
+      "POST /repos/acme/api/issues/1/labels",
+      "POST /repos/acme/api/issues/1/comments",
+    ]);
+    for (const call of twin.calls) {
+      expect(call.auth).toBe("Bearer twin.jwt.token");
+    }
+    expect(twin.calls[1]!.body).toEqual({ labels: ["bug"] });
+    expect(twin.calls[2]!.body).toEqual({
+      body: "POST /orders 500s — see OrderController#create.",
+    });
+
+    // Turn 2's request carried the assistant tool-call + tool-result turns
+    // in the strict shape (already schema-checked server-side; spot-check
+    // the canonical AI-SDK output wrapper).
+    const secondBody = gateway.bodies[1] as {
+      messages: Array<{ role: string; content: unknown }>;
+    };
+    const toolMsg = secondBody.messages.find((m) => m.role === "tool") as {
+      content: Array<{ output: { type: string } }>;
+    };
+    expect(toolMsg.content[0]!.output.type).toBe("json");
+  });
+
+  it("feeds tool errors back to the model as error-text instead of crashing", async () => {
+    const gateway = stubGateway([
+      {
+        status: 200,
+        body: {
+          text: "",
+          tool_calls: [{ id: "c1", name: "add_label", input: { issue_number: 1 } }],
+          finish_reason: "tool-calls",
+        },
+      },
+      {
+        status: 200,
+        body: { text: "Could not apply the label.", tool_calls: [], finish_reason: "stop" },
+      },
+    ]);
+    const twin = stubTwin();
+    openServers.push(gateway.server, twin.server);
+    const [gatewayPort, twinPort] = await Promise.all([
+      listen(gateway.server),
+      listen(twin.server),
+    ]);
+
+    const { io } = collectIo();
+    const code = await runDemoAgent(agentEnvFor(gatewayPort, twinPort), io);
+    expect(code).toBe(0);
+    const secondBody = gateway.bodies[1] as {
+      messages: Array<{ role: string; content: unknown }>;
+    };
+    const toolMsg = secondBody.messages.find((m) => m.role === "tool") as {
+      content: Array<{ output: { type: string; value: string } }>;
+    };
+    expect(toolMsg.content[0]!.output.type).toBe("error-text");
+    // No twin call happened for the malformed input.
+    expect(twin.calls).toHaveLength(0);
+  });
+
+  it("exits 42 with the POME_DEMO_CAPACITY marker on a gateway capacity error", async () => {
+    const gateway = stubGateway([
+      {
+        status: 402,
+        body: {
+          error: {
+            type: "quota_exceeded",
+            message: "The demo's daily model budget is exhausted.",
+            details: { kind: "daily_model_cap", spent_cents: 500, cap_cents: 500 },
+          },
+        },
+      },
+    ]);
+    const twin = stubTwin();
+    openServers.push(gateway.server, twin.server);
+    const [gatewayPort, twinPort] = await Promise.all([
+      listen(gateway.server),
+      listen(twin.server),
+    ]);
+
+    const { io, errors } = collectIo();
+    const code = await runDemoAgent(agentEnvFor(gatewayPort, twinPort), io);
+    expect(code).toBe(42);
+    expect(errors.join("\n")).toContain("POME_DEMO_CAPACITY:daily_model_cap");
+    // Honest failure: no fabricated completion was logged.
+  });
+
+  it("gives up (exit 1) after the turn ceiling instead of looping forever", async () => {
+    const gateway = stubGateway([
+      {
+        status: 200,
+        body: {
+          text: "",
+          tool_calls: [{ id: "c1", name: "list_open_issues", input: {} }],
+          finish_reason: "tool-calls",
+        },
+      },
+    ]);
+    const twin = stubTwin();
+    openServers.push(gateway.server, twin.server);
+    const [gatewayPort, twinPort] = await Promise.all([
+      listen(gateway.server),
+      listen(twin.server),
+    ]);
+
+    const { io, errors } = collectIo();
+    const code = await runDemoAgent(agentEnvFor(gatewayPort, twinPort), io);
+    expect(code).toBe(1);
+    expect(errors.join("\n")).toMatch(/gave up after \d+ model calls/);
+    // 12-turn ceiling, below the server's 20-call session cap.
+    expect(gateway.bodies).toHaveLength(12);
+  }, 30_000);
+});

--- a/cli/test/unit/demo/bearer-client.test.ts
+++ b/cli/test/unit/demo/bearer-client.test.ts
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-643 — the hosted client's bearer scheme: `pome demo` authenticates
+// upload-url + finalize with the trial's demo_token as `Authorization:
+// Bearer …` (the requireApiKeyOrSessionToken surface), never X-API-KEY.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createHostedClient } from "../../../src/hosted/client.js";
+import { HostedQuotaError } from "../../../src/hosted/errors.js";
+
+const BASE = "https://api.example.com";
+const DEMO_TOKEN = "aaa.bbb.ccc";
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mockFetch(impl: typeof fetch) {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(impl as never);
+}
+
+describe("createHostedClient authScheme: bearer (FDRS-643)", () => {
+  it("sends Authorization: Bearer on finalize with the explicit 60s demo timeout config", async () => {
+    mockFetch(async (url, init) => {
+      expect(String(url)).toBe(`${BASE}/v1/sessions/ses_1/finalize`);
+      const headers = new Headers(init?.headers);
+      expect(headers.get("authorization")).toBe(`Bearer ${DEMO_TOKEN}`);
+      expect(headers.get("x-api-key")).toBeNull();
+      return new Response(
+        JSON.stringify({
+          run_id: "run_1",
+          score: 100,
+          judge_model: "m",
+          dashboard_url: "https://app.example.com/runs/run_1",
+          criteria_results: [],
+        }),
+        { status: 201, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    const client = createHostedClient({
+      baseUrl: BASE,
+      apiKey: DEMO_TOKEN,
+      authScheme: "bearer",
+      timeoutMs: 60_000,
+    });
+    const out = await client.finalize("ses_1", {
+      stopReason: "completed",
+      exitCode: 0,
+      durationMs: 1000,
+      agentModel: "demo-gateway",
+      criteria: [],
+      scenarioName: "first-run-demo",
+      scenarioHash: "",
+      scenarioPrompt: "",
+      expectedBehavior: "",
+    });
+    expect(out.run_id).toBe("run_1");
+  });
+
+  it("sends Authorization: Bearer on the presigned-upload routes", async () => {
+    const fetchMock = mockFetch(async (url, init) => {
+      const headers = new Headers(init?.headers);
+      expect(headers.get("authorization")).toBe(`Bearer ${DEMO_TOKEN}`);
+      expect(headers.get("x-api-key")).toBeNull();
+      if (String(url).endsWith("/result-upload-url")) {
+        return new Response(
+          JSON.stringify({ url: "https://blobs.example.com/e", key: "team-t/session-s/events.jsonl" }),
+          { status: 200 },
+        );
+      }
+      return new Response(
+        JSON.stringify({
+          state_initial: { url: "https://blobs.example.com/i", key: "team-t/session-s/state_initial.json" },
+          state_final: { url: "https://blobs.example.com/f", key: "team-t/session-s/state_final.json" },
+        }),
+        { status: 200 },
+      );
+    });
+
+    const client = createHostedClient({
+      baseUrl: BASE,
+      apiKey: DEMO_TOKEN,
+      authScheme: "bearer",
+    });
+    await client.requestEventsUploadUrl("ses_1");
+    await client.requestStateUploadUrl("ses_1");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the X-API-KEY contract byte-for-byte when authScheme is omitted", async () => {
+    mockFetch(async (_url, init) => {
+      const headers = new Headers(init?.headers);
+      expect(headers.get("x-api-key")).toBe("pme_key");
+      expect(headers.get("authorization")).toBeNull();
+      return new Response(JSON.stringify({ url: "u", key: "k" }), { status: 200 });
+    });
+    const client = createHostedClient({ baseUrl: BASE, apiKey: "pme_key" });
+    await client.requestEventsUploadUrl("ses_1");
+  });
+
+  it("surfaces machine-readable quota details for honest at-capacity rendering", async () => {
+    mockFetch(async () =>
+      new Response(
+        JSON.stringify({
+          error: {
+            type: "quota_exceeded",
+            message: "Daily managed-judge spend cap reached for this team.",
+            details: { kind: "daily_judge_cap", spent_cents: 500, cap_cents: 500 },
+            request_id: "req_9",
+          },
+        }),
+        { status: 402 },
+      ),
+    );
+    const client = createHostedClient({
+      baseUrl: BASE,
+      apiKey: DEMO_TOKEN,
+      authScheme: "bearer",
+    });
+    const err = await client
+      .finalize("ses_1", {
+        stopReason: "completed",
+        exitCode: 0,
+        durationMs: 1,
+        agentModel: "demo-gateway",
+        criteria: [],
+        scenarioName: "first-run-demo",
+        scenarioHash: "",
+        scenarioPrompt: "",
+        expectedBehavior: "",
+      })
+      .catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(HostedQuotaError);
+    expect((err as HostedQuotaError).details).toMatchObject({
+      kind: "daily_judge_cap",
+    });
+  });
+});

--- a/cli/test/unit/demo/egress-extra-hosts.test.ts
+++ b/cli/test/unit/demo/egress-extra-hosts.test.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-643 — demo-mode egress valve: the POME_API_BASE host joins the
+// deny-by-default floor's allowlist so the bundled agent's gateway CONNECTs
+// aren't refused, without opening anything else.
+import { describe, expect, it } from "vitest";
+import {
+  buildEgressAllowlist,
+  isHostAllowed,
+} from "../../../src/capture-server/egress.js";
+
+describe("buildEgressAllowlist extraHosts (FDRS-643)", () => {
+  it("adds the demo gateway host on top of the default provider set", () => {
+    const allow = buildEgressAllowlist({}, { extraHosts: ["api.pome.sh"] });
+    expect(allow).toContain("api.pome.sh");
+    // Defaults survive.
+    expect(allow).toContain("ai-gateway.vercel.sh");
+    expect(isHostAllowed("api.pome.sh", allow)).toBe(true);
+    // The valve is surgical: no wildcard leak.
+    expect(isHostAllowed("evil.example.com", allow)).toBe(false);
+    expect(isHostAllowed("app.pome.sh", allow)).toBe(false);
+  });
+
+  it("normalizes + dedupes extra hosts like every other source", () => {
+    const allow = buildEgressAllowlist(
+      { POME_EGRESS_ALLOW: "api.pome.sh" },
+      { extraHosts: ["API.POME.SH."] },
+    );
+    expect(allow.filter((h) => h === "api.pome.sh")).toHaveLength(1);
+  });
+
+  it("no extraHosts → behavior unchanged", () => {
+    const withOpt = buildEgressAllowlist({}, {});
+    const without = buildEgressAllowlist({});
+    expect(withOpt).toEqual(without);
+    expect(isHostAllowed("api.pome.sh", without)).toBe(false);
+  });
+});

--- a/cli/test/unit/demo/gateway.test.ts
+++ b/cli/test/unit/demo/gateway.test.ts
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-643 — the demo gateway client against a stub server that validates
+// the STRICT demo-llm wire schema (mirrored from pome-cloud demo-llm.ts).
+// Also proves the CONNECT-proxy path: through a capture-server-shaped
+// CONNECT proxy, the same request arrives intact.
+import { createServer, type Server } from "node:http";
+import { connect as netConnect, type Socket } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { callDemoGateway, type DemoMessage } from "../../../src/demo/gateway.js";
+import { DemoCapacityError } from "../../../src/demo/capacity.js";
+import { demoLlmRequestSchema } from "../../fixtures/demo/demoLlmSchema.js";
+
+type SeenRequest = {
+  url: string;
+  authorization: string | undefined;
+  body: unknown;
+};
+
+function listen(server: Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (typeof addr === "object" && addr) resolve(addr.port);
+      else reject(new Error("no address"));
+    });
+  });
+}
+
+function stubGateway(
+  respond: (seen: SeenRequest) => { status: number; body: unknown },
+): { server: Server; seen: SeenRequest[] } {
+  const seen: SeenRequest[] = [];
+  const server = createServer((req, res) => {
+    let raw = "";
+    req.on("data", (chunk) => {
+      raw += String(chunk);
+    });
+    req.on("end", () => {
+      const record: SeenRequest = {
+        url: req.url ?? "",
+        authorization: req.headers.authorization,
+        body: JSON.parse(raw),
+      };
+      seen.push(record);
+      const { status, body } = respond(record);
+      res.writeHead(status, { "content-type": "application/json" });
+      res.end(JSON.stringify(body));
+    });
+  });
+  return { server, seen };
+}
+
+// Minimal CONNECT proxy (capture-server-shaped): tunnels opaque bytes.
+function stubConnectProxy(): {
+  server: Server;
+  tunnels: Array<{ host: string; port: number }>;
+} {
+  const tunnels: Array<{ host: string; port: number }> = [];
+  const server = createServer();
+  server.on("connect", (req, clientSocket: Socket, head) => {
+    const [host, portRaw] = String(req.url).split(":");
+    const port = Number(portRaw);
+    tunnels.push({ host: host!, port });
+    const upstream = netConnect({ host: host!, port }, () => {
+      clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+      if (head.length > 0) upstream.write(head);
+      upstream.pipe(clientSocket);
+      clientSocket.pipe(upstream);
+    });
+    upstream.on("error", () => clientSocket.destroy());
+    clientSocket.on("error", () => upstream.destroy());
+  });
+  return { server, tunnels };
+}
+
+const openServers: Server[] = [];
+afterEach(async () => {
+  await Promise.all(
+    openServers.splice(0).map(
+      (server) => new Promise<void>((resolve) => server.close(() => resolve())),
+    ),
+  );
+});
+
+const CONVERSATION: DemoMessage[] = [
+  { role: "user", content: "Triage the repo." },
+  {
+    role: "assistant",
+    content: [
+      { type: "text", text: "Listing issues." },
+      {
+        type: "tool-call",
+        toolCallId: "call_1",
+        toolName: "list_open_issues",
+        input: {},
+      },
+    ],
+  },
+  {
+    role: "tool",
+    content: [
+      {
+        type: "tool-result",
+        toolCallId: "call_1",
+        toolName: "list_open_issues",
+        output: { type: "json", value: [{ number: 1, title: "500 error" }] },
+      },
+    ],
+  },
+];
+
+describe("callDemoGateway (FDRS-643 / FDRS-637 wire contract)", () => {
+  it("sends a STRICT schema-valid body (no system role, no model field) with the demo_token bearer", async () => {
+    const { server, seen } = stubGateway(() => ({
+      status: 200,
+      body: {
+        text: "",
+        tool_calls: [
+          { id: "call_2", name: "add_label", input: { issue_number: 1, label: "bug" } },
+        ],
+        finish_reason: "tool-calls",
+        usage: { input_tokens: 100, output_tokens: 20 },
+      },
+    }));
+    openServers.push(server);
+    const port = await listen(server);
+
+    const response = await callDemoGateway({
+      gatewayUrl: `http://127.0.0.1:${port}/v1/demo/sessions/ses_1/llm`,
+      demoToken: "aaa.bbb.ccc",
+      taskName: "first-run-demo",
+      messages: CONVERSATION,
+      tools: [
+        {
+          name: "add_label",
+          description: "Apply an existing label.",
+          input_schema: { type: "object", properties: {} },
+        },
+      ],
+    });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.url).toBe("/v1/demo/sessions/ses_1/llm");
+    expect(seen[0]!.authorization).toBe("Bearer aaa.bbb.ccc");
+    // The lock: the body must parse under the server's strict schema.
+    const parsed = demoLlmRequestSchema.safeParse(seen[0]!.body);
+    expect(parsed.success, JSON.stringify(parsed.success ? "" : parsed.error.issues)).toBe(true);
+    const bodyObj = seen[0]!.body as Record<string, unknown>;
+    expect(bodyObj.model).toBeUndefined();
+    expect(
+      (bodyObj.messages as Array<{ role: string }>).some((m) => m.role === "system"),
+    ).toBe(false);
+
+    expect(response.tool_calls).toEqual([
+      { id: "call_2", name: "add_label", input: { issue_number: 1, label: "bug" } },
+    ]);
+    expect(response.finish_reason).toBe("tool-calls");
+  });
+
+  it("maps gateway 429 session_llm_call_cap to DemoCapacityError", async () => {
+    const { server } = stubGateway(() => ({
+      status: 429,
+      body: {
+        error: {
+          type: "rate_limited",
+          message: "This demo trial hit its model-call ceiling.",
+          details: { kind: "session_llm_call_cap", used: 20, cap: 20 },
+        },
+      },
+    }));
+    openServers.push(server);
+    const port = await listen(server);
+
+    const err = await callDemoGateway({
+      gatewayUrl: `http://127.0.0.1:${port}/v1/demo/sessions/ses_1/llm`,
+      demoToken: "aaa.bbb.ccc",
+      taskName: "first-run-demo",
+      messages: [{ role: "user", content: "hi" }],
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(DemoCapacityError);
+    expect((err as DemoCapacityError).kind).toBe("session_llm_call_cap");
+  });
+
+  it("maps gateway 402 daily_model_cap to DemoCapacityError", async () => {
+    const { server } = stubGateway(() => ({
+      status: 402,
+      body: {
+        error: {
+          type: "quota_exceeded",
+          message: "The demo's daily model budget is exhausted.",
+          details: { kind: "daily_model_cap", spent_cents: 500, cap_cents: 500 },
+        },
+      },
+    }));
+    openServers.push(server);
+    const port = await listen(server);
+
+    const err = await callDemoGateway({
+      gatewayUrl: `http://127.0.0.1:${port}/v1/demo/sessions/ses_1/llm`,
+      demoToken: "aaa.bbb.ccc",
+      taskName: "first-run-demo",
+      messages: [{ role: "user", content: "hi" }],
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(DemoCapacityError);
+    expect((err as DemoCapacityError).kind).toBe("daily_model_cap");
+  });
+
+  it("travels through an HTTP CONNECT proxy intact (the capture path)", async () => {
+    const { server: gateway, seen } = stubGateway(() => ({
+      status: 200,
+      body: { text: "done", tool_calls: [], finish_reason: "stop" },
+    }));
+    const proxy = stubConnectProxy();
+    openServers.push(gateway, proxy.server);
+    const gatewayPort = await listen(gateway);
+    const proxyPort = await listen(proxy.server);
+
+    const response = await callDemoGateway({
+      gatewayUrl: `http://127.0.0.1:${gatewayPort}/v1/demo/sessions/ses_1/llm`,
+      demoToken: "aaa.bbb.ccc",
+      taskName: "first-run-demo",
+      messages: [{ role: "user", content: "hi" }],
+      proxyUrl: `http://127.0.0.1:${proxyPort}`,
+      // Loopback would normally bypass the proxy — force it so the test
+      // exercises the tunnel path production uses for api.pome.sh.
+      forceProxyForTest: true,
+    });
+
+    expect(response.text).toBe("done");
+    expect(proxy.tunnels).toEqual([{ host: "127.0.0.1", port: gatewayPort }]);
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.authorization).toBe("Bearer aaa.bbb.ccc");
+    expect(demoLlmRequestSchema.safeParse(seen[0]!.body).success).toBe(true);
+  });
+});

--- a/cli/test/unit/demo/ids.test.ts
+++ b/cli/test/unit/demo/ids.test.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from "vitest";
+import { nanoid, newGroupId } from "../../../src/demo/ids.js";
+
+// Mirror of pome-cloud lib/demo.ts isValidGroupId.
+const CLOUD_GROUP_ID_RE = /^[A-Za-z0-9_-]{6,64}$/;
+
+describe("demo trial-group ids (FDRS-643)", () => {
+  it("mints grp_ + 21 url-safe chars", () => {
+    const id = newGroupId();
+    expect(id).toMatch(/^grp_[\w-]{21}$/);
+  });
+
+  it("is accepted by the cloud's group_id format gate", () => {
+    for (let i = 0; i < 50; i += 1) {
+      expect(newGroupId()).toMatch(CLOUD_GROUP_ID_RE);
+    }
+  });
+
+  it("does not collide across invocations", () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 1_000; i += 1) seen.add(newGroupId());
+    expect(seen.size).toBe(1_000);
+  });
+
+  it("nanoid honors the size parameter", () => {
+    expect(nanoid(10)).toHaveLength(10);
+    expect(nanoid()).toHaveLength(21);
+  });
+});

--- a/cli/test/unit/demo/mint.test.ts
+++ b/cli/test/unit/demo/mint.test.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-643 — anonymous demo mint: wire shape, group threading, honest
+// capacity mapping.
+import { describe, expect, it } from "vitest";
+import { mintDemoSessions } from "../../../src/demo/mint.js";
+import { DemoCapacityError } from "../../../src/demo/capacity.js";
+import { HostedOrchError } from "../../../src/hosted/errors.js";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("mintDemoSessions (FDRS-643)", () => {
+  it("POSTs {task_name, task_hash:'', group_id} with NO auth header, once per trial, same group", async () => {
+    const bodies: unknown[] = [];
+    let n = 0;
+    const fetchImpl: typeof fetch = async (url, init) => {
+      expect(String(url)).toBe("https://api.example.com/v1/demo/sessions");
+      const headers = new Headers(init?.headers);
+      expect(headers.get("authorization")).toBeNull();
+      expect(headers.get("x-api-key")).toBeNull();
+      bodies.push(JSON.parse(String(init?.body)));
+      n += 1;
+      return jsonResponse(201, {
+        session_id: `ses_${n}`,
+        demo_token: `jwt.${n}.sig`,
+        expires_at: "2026-07-05T12:15:00.000Z",
+      });
+    };
+
+    const sessions = await mintDemoSessions({
+      apiBase: "https://api.example.com",
+      taskName: "first-run-demo",
+      groupId: "grp_abcdefghijklmnopqrstu",
+      count: 5,
+      fetchImpl,
+    });
+
+    expect(sessions).toHaveLength(5);
+    expect(new Set(sessions.map((s) => s.session_id)).size).toBe(5);
+    expect(bodies).toHaveLength(5);
+    for (const body of bodies) {
+      expect(body).toEqual({
+        task_name: "first-run-demo",
+        task_hash: "",
+        group_id: "grp_abcdefghijklmnopqrstu",
+      });
+    }
+  });
+
+  it("maps a mint 429 (per-IP daily cap) to an honest DemoCapacityError", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      jsonResponse(429, {
+        error: {
+          type: "rate_limited",
+          message:
+            "Daily demo limit reached for this network. Try again tomorrow, or sign up for a free account.",
+        },
+      });
+    await expect(
+      mintDemoSessions({
+        apiBase: "https://api.example.com",
+        taskName: "first-run-demo",
+        groupId: "grp_abcdefghijklmnopqrstu",
+        count: 5,
+        fetchImpl,
+      }),
+    ).rejects.toMatchObject({
+      name: "DemoCapacityError",
+      kind: "demo_ip_mint_cap",
+      message: expect.stringContaining("Daily demo limit reached"),
+    });
+  });
+
+  it("maps a mint 402 (house quota) to demo_mint_quota", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      jsonResponse(402, {
+        error: {
+          type: "quota_exceeded",
+          message: "The demo is at capacity right now. Try again shortly.",
+        },
+      });
+    const err = await mintDemoSessions({
+      apiBase: "https://api.example.com",
+      taskName: "first-run-demo",
+      groupId: "grp_abcdefghijklmnopqrstu",
+      count: 1,
+      fetchImpl,
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(DemoCapacityError);
+    expect((err as DemoCapacityError).kind).toBe("demo_mint_quota");
+  });
+
+  it("maps a mint 503 (demo not enabled) to gateway_unavailable with the cloud's message", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      jsonResponse(503, {
+        error: {
+          type: "downstream_unavailable",
+          message: "The anonymous demo is not enabled on this deployment.",
+        },
+      });
+    const err = await mintDemoSessions({
+      apiBase: "https://api.example.com",
+      taskName: "first-run-demo",
+      groupId: "grp_abcdefghijklmnopqrstu",
+      count: 1,
+      fetchImpl,
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(DemoCapacityError);
+    expect((err as DemoCapacityError).kind).toBe("gateway_unavailable");
+    expect((err as DemoCapacityError).message).toContain("not enabled");
+  });
+
+  it("422 (unknown task) is an orch error, not a fabricated capacity state", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      jsonResponse(422, {
+        error: { type: "validation_failed", message: "Unknown demo task." },
+      });
+    const err = await mintDemoSessions({
+      apiBase: "https://api.example.com",
+      taskName: "nope",
+      groupId: "grp_abcdefghijklmnopqrstu",
+      count: 1,
+      fetchImpl,
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(HostedOrchError);
+    expect((err as HostedOrchError).status).toBe(422);
+  });
+
+  it("rejects an unexpected 2xx shape instead of continuing with junk", async () => {
+    const fetchImpl: typeof fetch = async () => jsonResponse(201, { nope: true });
+    await expect(
+      mintDemoSessions({
+        apiBase: "https://api.example.com",
+        taskName: "first-run-demo",
+        groupId: "grp_abcdefghijklmnopqrstu",
+        count: 1,
+        fetchImpl,
+      }),
+    ).rejects.toBeInstanceOf(HostedOrchError);
+  });
+});

--- a/cli/test/unit/demo/render.test.ts
+++ b/cli/test/unit/demo/render.test.ts
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-643 — verdict rendering per the design of record (CLI moments
+// moment 01): words not scores, errored rows show no duration, the summary
+// fraction excludes errored trials from its denominator.
+import { describe, expect, it } from "vitest";
+import {
+  criterionPhrase,
+  reassuranceBox,
+  summaryLines,
+  trialLine,
+  trialsHeaderLine,
+  twinReadyLine,
+} from "../../../src/demo/render.js";
+import { capacityLabel } from "../../../src/demo/capacity.js";
+
+describe("reassurance box", () => {
+  it("keeps the copy of record verbatim and names all three surfaces honestly", () => {
+    const box = reassuranceBox().join("\n");
+    expect(box).toContain("pome demo · running locally");
+    // [DECISION] #5 — verbatim.
+    expect(box).toContain("No signup. No API keys.");
+    expect(box).toContain("Your repo and your data are never touched.");
+    // The honest line: local twin, anonymous gateway, cloud evaluation.
+    expect(box).toMatch(/twin runs on your machine/i);
+    expect(box).toMatch(/anonymous demo gateway/i);
+    expect(box).toMatch(/evaluated in pome cloud/i);
+    // The reconciled copy must NOT resurrect the pre-decision claims.
+    expect(box).not.toMatch(/runs entirely on your machine/i);
+    expect(box).not.toMatch(/zero real API calls/i);
+  });
+
+  it("draws a closed border", () => {
+    const lines = reassuranceBox();
+    expect(lines[0]).toMatch(/^┌─+┐$/);
+    expect(lines[lines.length - 1]).toMatch(/^└─+┘$/);
+    for (const middle of lines.slice(1, -1)) {
+      expect(middle.startsWith("│")).toBe(true);
+      expect(middle.endsWith("│")).toBe(true);
+    }
+  });
+});
+
+describe("progress lines", () => {
+  it("renders the twin + trials header lines per design", () => {
+    expect(twinReadyLine(1.234)).toBe("spinning up github twin … ready (1.2s)");
+    expect(trialsHeaderLine(5, "first-run-demo")).toBe(
+      "running 5 isolated trials of first-run-demo …",
+    );
+  });
+});
+
+describe("trial verdict lines", () => {
+  it("passed / failed use words + duration", () => {
+    expect(trialLine(1, { kind: "passed", seconds: 14.31 })).toBe(
+      "trial 1  ✓  passed   14.3s",
+    );
+    expect(
+      trialLine(3, {
+        kind: "failed",
+        seconds: 15.94,
+        note: "the comment never names the failing endpoint",
+      }),
+    ).toBe("trial 3  ✗  failed   15.9s  the comment never names the failing endpoint");
+  });
+
+  it("errored shows no duration and is marked excluded", () => {
+    const line = trialLine(5, { kind: "errored", reason: "trial timed out" });
+    expect(line).toBe("trial 5  ⚠  errored         trial timed out — excluded");
+    expect(line).not.toMatch(/\d+\.\d+s/);
+  });
+
+  it("never renders a numeric score", () => {
+    for (const line of [
+      trialLine(1, { kind: "passed", seconds: 2 }),
+      trialLine(2, { kind: "failed", seconds: 2, note: "x" }),
+    ]) {
+      expect(line).not.toMatch(/\/100|\d+%/);
+    }
+  });
+});
+
+describe("summary", () => {
+  it("excludes errored trials from the fraction and names the errored reason", () => {
+    const lines = summaryLines({
+      verdicts: [
+        { kind: "passed", seconds: 14.3 },
+        { kind: "passed", seconds: 12.1 },
+        { kind: "failed", seconds: 15.9, note: "n" },
+        { kind: "failed", seconds: 13.5, note: "n" },
+        { kind: "errored", reason: "gateway timeout" },
+      ],
+      failingCriterionPhrase: "the comment never names the failing endpoint",
+      failingCriterionCount: 2,
+      previewUrl: "https://app.pome.sh/demo/grp_abc123",
+    });
+    expect(lines[0]).toBe("─────");
+    expect(lines[1]).toBe(
+      "2 of 4 passed · 1 trial errored on gateway timeout, excluded from the fraction",
+    );
+    expect(lines[2]).toBe(
+      "the comment never names the failing endpoint in 2 of 4 — start there",
+    );
+    expect(lines[3]).toBe("see the full breakdown — read-only, still no account:");
+    expect(lines[4]).toBe("→ https://app.pome.sh/demo/grp_abc123");
+  });
+
+  it("renders a clean fraction when nothing errored", () => {
+    const lines = summaryLines({
+      verdicts: [
+        { kind: "passed", seconds: 1 },
+        { kind: "passed", seconds: 1 },
+        { kind: "passed", seconds: 1 },
+        { kind: "failed", seconds: 1, note: "n" },
+        { kind: "passed", seconds: 1 },
+      ],
+      previewUrl: "https://app.pome.sh/demo/grp_x",
+    });
+    expect(lines[1]).toBe("4 of 5 passed");
+    expect(lines.join("\n")).toContain("→ https://app.pome.sh/demo/grp_x");
+  });
+
+  it("omits the start-there line when nothing failed", () => {
+    const lines = summaryLines({
+      verdicts: [
+        { kind: "passed", seconds: 1 },
+        { kind: "passed", seconds: 1 },
+      ],
+      previewUrl: "https://app.pome.sh/demo/grp_x",
+    });
+    expect(lines.join("\n")).not.toContain("start there");
+  });
+
+  it("states honestly when no trial produced a verdict (no preview link)", () => {
+    const lines = summaryLines({
+      verdicts: [
+        { kind: "errored", reason: "trial timed out" },
+        { kind: "errored", reason: "trial timed out" },
+      ],
+      previewUrl: "https://app.pome.sh/demo/grp_x",
+    });
+    expect(lines[1]).toBe(
+      "no trials were evaluated · 2 trials errored on trial timed out, excluded from the fraction",
+    );
+    expect(lines.join("\n")).not.toContain("app.pome.sh/demo");
+  });
+});
+
+describe("criterionPhrase", () => {
+  it("takes the first clause, lower-cases the lead, caps length", () => {
+    const phrase = criterionPhrase(
+      "Exactly one comment was left on that issue, and it names the failing endpoint (POST /orders). Something else.",
+    );
+    expect(phrase.startsWith("exactly one comment was left on that issue")).toBe(true);
+    expect(phrase).not.toContain("Something else");
+    expect(phrase.length).toBeLessThanOrEqual(64);
+    expect(phrase.endsWith("…")).toBe(true);
+  });
+
+  it("passes short criteria through intact (minus casing)", () => {
+    expect(criterionPhrase("No new label was created.")).toBe(
+      "no new label was created",
+    );
+  });
+});
+
+describe("at-capacity labels (FDRS-662)", () => {
+  it("labels every kind honestly, never a stack trace", () => {
+    expect(capacityLabel("daily_model_cap")).toMatch(/daily model budget .* try again tomorrow/);
+    expect(capacityLabel("daily_judge_cap")).toMatch(/evaluation budget .* try again tomorrow/);
+    expect(capacityLabel("demo_ip_llm_cap")).toMatch(/limit for this network/);
+    expect(capacityLabel("demo_ip_mint_cap")).toMatch(/limit for this network/);
+    expect(capacityLabel("session_llm_call_cap")).toMatch(/model-call ceiling/);
+    expect(capacityLabel("unknown_capacity")).toBe(
+      "the demo is at capacity today — try again tomorrow",
+    );
+    expect(capacityLabel("gateway_unavailable")).toMatch(/unavailable right now/);
+  });
+});

--- a/cli/test/unit/demo/runDemo.test.ts
+++ b/cli/test/unit/demo/runDemo.test.ts
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-643 — `pome demo` orchestration: group threading, per-trial verdicts
+// from the cloud evaluation, errored exclusion, at-capacity abort.
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { runDemo, type DemoTrialClient } from "../../../src/demo/runDemo.js";
+import { DemoCapacityError } from "../../../src/demo/capacity.js";
+import { HostedQuotaError } from "../../../src/hosted/errors.js";
+import type { DemoSession } from "../../../src/demo/mint.js";
+import type { runScenario } from "../../../src/runner/runScenario.js";
+import type { FinalizeResponse } from "../../../src/types/shared.js";
+
+type RunScenarioFn = typeof runScenario;
+type RunScenarioResult = Awaited<ReturnType<RunScenarioFn>>;
+type RunScenarioOpts = Parameters<RunScenarioFn>[0];
+
+function sessionsFixture(count: number): DemoSession[] {
+  return Array.from({ length: count }, (_, i) => ({
+    session_id: `ses_${i + 1}`,
+    demo_token: `jwt.tok${i + 1}.sig`,
+    expires_at: "2026-07-05T12:15:00.000Z",
+  }));
+}
+
+async function artifactsDirWithBlobs(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "pome-demo-run-"));
+  await writeFile(
+    join(dir, "events.jsonl"),
+    `${JSON.stringify({ kind: "TwinHttpEvent", event_id: "e1" })}\n`,
+  );
+  await writeFile(join(dir, "state_initial.json"), "{}\n");
+  await writeFile(join(dir, "state_final.json"), "{}\n");
+  return dir;
+}
+
+function fakeRunScenario(
+  perTrial: Array<{ exitCode: number; stderr?: string; timedOut?: boolean }>,
+  seenOptions: RunScenarioOpts[],
+): RunScenarioFn {
+  let call = 0;
+  return (async (options: RunScenarioOpts) => {
+    seenOptions.push(options);
+    const spec = perTrial[Math.min(call, perTrial.length - 1)]!;
+    call += 1;
+    const runDir = await artifactsDirWithBlobs();
+    return {
+      scenario: { slug: "first-run-demo" },
+      runId: `run_${call}`,
+      artifacts: { runId: `run_${call}`, runDir },
+      agent: {
+        stdout: "",
+        stderr: spec.stderr ?? "",
+        exitCode: spec.exitCode === 0 ? 0 : 1,
+        timedOut: spec.timedOut ?? false,
+      },
+      exitCode: spec.exitCode,
+      blockedEgress: [],
+    } as unknown as RunScenarioResult;
+  }) as RunScenarioFn;
+}
+
+function passedResult(): FinalizeResponse["criteria_results"] {
+  return [
+    criterion("The bug label was applied to the 500-error issue.", "passed"),
+    criterion(
+      "Exactly one comment was left on that issue, and it names the failing endpoint (POST /orders).",
+      "passed",
+    ),
+  ];
+}
+
+function failedResult(): FinalizeResponse["criteria_results"] {
+  return [
+    criterion("The bug label was applied to the 500-error issue.", "passed"),
+    criterion(
+      "Exactly one comment was left on that issue, and it names the failing endpoint (POST /orders).",
+      "failed",
+    ),
+  ];
+}
+
+function criterion(text: string, outcome: "passed" | "failed") {
+  return {
+    criterion: { type: "P" as const, text },
+    outcome,
+    passed: outcome === "passed",
+    skipped: false,
+    reason: outcome === "passed" ? "ok" : "not satisfied",
+  };
+}
+
+function fakeClient(
+  finalizeFor: (sessionId: string) => FinalizeResponse | Error,
+  finalizeCalls: Array<{ sessionId: string; input: unknown }>,
+): (session: DemoSession) => DemoTrialClient {
+  return (session) => ({
+    requestEventsUploadUrl: vi.fn(async (sessionId: string) => {
+      throw new Error(`no blob store in this test (${sessionId})`);
+    }),
+    requestStateUploadUrl: vi.fn(async (sessionId: string) => {
+      throw new Error(`no blob store in this test (${sessionId})`);
+    }),
+    requestSignalsUploadUrl: vi.fn(async (sessionId: string) => {
+      throw new Error(`no blob store in this test (${sessionId})`);
+    }),
+    finalize: vi.fn(async (sessionId: string, input: unknown) => {
+      finalizeCalls.push({ sessionId, input });
+      const out = finalizeFor(session.session_id);
+      if (out instanceof Error) throw out;
+      return out;
+    }),
+  });
+}
+
+function finalizeResponse(
+  score: number,
+  results: FinalizeResponse["criteria_results"],
+): FinalizeResponse {
+  return {
+    run_id: "run_x",
+    score,
+    judge_model: "google/gemini-3.1-flash-lite",
+    dashboard_url: "https://app.pome.sh/runs/run_x",
+    criteria_results: results,
+  };
+}
+
+describe("runDemo (FDRS-643)", () => {
+  it("threads one grp_ id through every mint, runs k trials, renders verdict words + preview link", async () => {
+    const out: string[] = [];
+    const seenOptions: RunScenarioOpts[] = [];
+    const finalizeCalls: Array<{ sessionId: string; input: unknown }> = [];
+    const mintFn = vi.fn(async (opts: { groupId: string; count: number }) =>
+      sessionsFixture(opts.count),
+    );
+
+    const result = await runDemo({
+      apiBase: "https://api.example.com",
+      dashboardBase: "https://app.pome.sh",
+      trials: 5,
+      out: (line) => out.push(line),
+      agentCommand: "unused-in-test",
+      runScenarioFn: fakeRunScenario(
+        [
+          { exitCode: 0 },
+          { exitCode: 0 },
+          { exitCode: 0 },
+          { exitCode: 0 },
+          { exitCode: 3, timedOut: true },
+        ],
+        seenOptions,
+      ),
+      mintFn: mintFn as never,
+      trialClientFactory: fakeClient((sessionId) => {
+        if (sessionId === "ses_1" || sessionId === "ses_2") {
+          return finalizeResponse(100, passedResult());
+        }
+        return finalizeResponse(50, failedResult());
+      }, finalizeCalls),
+      skipTwinWarmup: true,
+    });
+
+    // Group threading: one grp_ id, shared by all 5 mints (single call, count 5).
+    expect(mintFn).toHaveBeenCalledOnce();
+    const mintArgs = mintFn.mock.calls[0]![0] as {
+      groupId: string;
+      count: number;
+      taskName: string;
+      apiBase: string;
+    };
+    expect(mintArgs.groupId).toMatch(/^grp_[\w-]{21}$/);
+    expect(mintArgs.count).toBe(5);
+    expect(mintArgs.taskName).toBe("first-run-demo");
+    expect(result.groupId).toBe(mintArgs.groupId);
+
+    // Each trial got ITS session's gateway coordinates + the egress valve.
+    expect(seenOptions).toHaveLength(5);
+    seenOptions.forEach((options, i) => {
+      expect(options.scenarioPath.endsWith("first-run-demo.md")).toBe(true);
+      expect(options.extraAgentEnv).toMatchObject({
+        POME_DEMO_LLM_URL: `https://api.example.com/v1/demo/sessions/ses_${i + 1}/llm`,
+        POME_DEMO_TOKEN: `jwt.tok${i + 1}.sig`,
+        POME_DEMO_TASK_NAME: "first-run-demo",
+        POME_DEMO_REPO: "acme/api",
+      });
+      expect(options.egressExtraHosts).toEqual(["api.example.com"]);
+    });
+
+    // Finalize went to the 4 evaluated sessions with the demo contract:
+    // criteria [] + scenario_name selects the server-owned task.
+    expect(finalizeCalls.map((c) => c.sessionId)).toEqual([
+      "ses_1",
+      "ses_2",
+      "ses_3",
+      "ses_4",
+    ]);
+    for (const call of finalizeCalls) {
+      expect(call.input).toMatchObject({
+        criteria: [],
+        scenarioName: "first-run-demo",
+        stopReason: "completed",
+      });
+    }
+
+    const text = out.join("\n");
+    expect(text).toContain("No signup. No API keys.");
+    expect(text).toContain("running 5 isolated trials of first-run-demo …");
+    expect(text).toMatch(/trial 1 {2}✓ {2}passed {3}\d+\.\ds/);
+    expect(text).toMatch(/trial 3 {2}✗ {2}failed {3}\d+\.\ds {2}exactly one comment/);
+    expect(text).toContain("trial 5  ⚠  errored         trial timed out — excluded");
+    expect(text).toContain(
+      "2 of 4 passed · 1 trial errored on trial timed out, excluded from the fraction",
+    );
+    expect(text).toMatch(/exactly one comment .* in 2 of 4 — start there/);
+    expect(text).toContain(`→ https://app.pome.sh/demo/${result.groupId}`);
+    // Verdicts are words, never scores.
+    expect(text).not.toMatch(/\d+\/100/);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("renders an honest labeled state and exits 4 when the mint is at capacity", async () => {
+    const out: string[] = [];
+    const runScenarioFn = vi.fn();
+    const result = await runDemo({
+      apiBase: "https://api.example.com",
+      dashboardBase: "https://app.pome.sh",
+      trials: 5,
+      out: (line) => out.push(line),
+      agentCommand: "unused-in-test",
+      runScenarioFn: runScenarioFn as never,
+      mintFn: (async () => {
+        throw new DemoCapacityError(
+          "demo_ip_mint_cap",
+          "Daily demo limit reached for this network.",
+        );
+      }) as never,
+      trialClientFactory: fakeClient(() => new Error("unreachable"), []),
+      skipTwinWarmup: true,
+    });
+
+    expect(result.exitCode).toBe(4);
+    expect(runScenarioFn).not.toHaveBeenCalled();
+    const text = out.join("\n");
+    expect(text).toContain("limit for this network — try again tomorrow");
+    expect(text).not.toMatch(/at Object|\.ts:\d+/); // no stack traces
+  });
+
+  it("stops launching trials when finalize hits the daily judge cap, keeping earlier verdicts", async () => {
+    const out: string[] = [];
+    const seenOptions: RunScenarioOpts[] = [];
+    const result = await runDemo({
+      apiBase: "https://api.example.com",
+      dashboardBase: "https://app.pome.sh",
+      trials: 5,
+      out: (line) => out.push(line),
+      agentCommand: "unused-in-test",
+      runScenarioFn: fakeRunScenario([{ exitCode: 0 }], seenOptions),
+      mintFn: (async (opts: { count: number }) => sessionsFixture(opts.count)) as never,
+      trialClientFactory: fakeClient((sessionId) => {
+        if (sessionId === "ses_1") return finalizeResponse(100, passedResult());
+        return new HostedQuotaError(
+          "Daily managed-judge spend cap reached for this team.",
+          "req_1",
+          { kind: "daily_judge_cap", spent_cents: 500, cap_cents: 500 },
+        );
+      }, []),
+      skipTwinWarmup: true,
+    });
+
+    // Trial 1 passed, trial 2 hit the cap → no trial 3-5.
+    expect(seenOptions).toHaveLength(2);
+    expect(result.verdicts).toHaveLength(2);
+    expect(result.verdicts[0]).toMatchObject({ kind: "passed" });
+    expect(result.verdicts[1]).toMatchObject({ kind: "errored" });
+    const text = out.join("\n");
+    expect(text).toContain("evaluation budget is exhausted — try again tomorrow");
+    expect(text).toContain("1 of 1 passed");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("treats an agent capacity marker (gateway 402 mid-trial) as a demo-wide honest stop", async () => {
+    const out: string[] = [];
+    const seenOptions: RunScenarioOpts[] = [];
+    const result = await runDemo({
+      apiBase: "https://api.example.com",
+      dashboardBase: "https://app.pome.sh",
+      trials: 5,
+      out: (line) => out.push(line),
+      agentCommand: "unused-in-test",
+      runScenarioFn: fakeRunScenario(
+        [
+          {
+            exitCode: 3,
+            stderr: "POME_DEMO_CAPACITY:daily_model_cap\nbudget exhausted\n",
+          },
+        ],
+        seenOptions,
+      ),
+      mintFn: (async (opts: { count: number }) => sessionsFixture(opts.count)) as never,
+      trialClientFactory: fakeClient(() => new Error("unreachable"), []),
+      skipTwinWarmup: true,
+    });
+
+    expect(seenOptions).toHaveLength(1);
+    expect(result.exitCode).toBe(4);
+    const text = out.join("\n");
+    expect(text).toContain("daily model budget is exhausted — try again tomorrow");
+  });
+
+  it("boots the packaged demo task's twin for the warm-up line (real seed parse)", async () => {
+    const out: string[] = [];
+    const result = await runDemo({
+      apiBase: "https://api.example.com",
+      dashboardBase: "https://app.pome.sh",
+      trials: 1,
+      out: (line) => out.push(line),
+      agentCommand: "unused-in-test",
+      runScenarioFn: fakeRunScenario([{ exitCode: 0 }], []),
+      mintFn: (async (opts: { count: number }) => sessionsFixture(opts.count)) as never,
+      trialClientFactory: fakeClient(() => finalizeResponse(100, passedResult()), []),
+      // REAL warm-up: parses src/demo/first-run-demo.md + its hand-written
+      // sidecar and boots the github twin against that seed.
+      skipTwinWarmup: false,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(out.join("\n")).toMatch(/spinning up github twin … ready \(\d+\.\ds\)/);
+  });
+});


### PR DESCRIPTION
<!-- Part of FDRS-643 — intentionally NOT "Closes": the live end-to-end (real gateway + managed judge on prod, npm publish for the npx path) is the remaining Done-when verification and is gated on deploys; the ticket closes after that run. -->

## What
New `pome demo` command: mints k=5 anonymous demo sessions upfront (one shared `grp_<nanoid21>` group id), spawns a new bundled tool-loop demo agent (`cli/src/demo/agent.ts`: list_open_issues / add_label / comment_on_issue) through the real capture path per trial, model calls via the anonymous gateway's strict ModelMessage-subset RPC, blobs upload with the `demo_token` as bearer, synchronous finalize with explicit `timeoutMs: 60000`, moment-01 terminal rendering (word verdicts, errored trials excluded from the fraction, honest at-capacity states), ending with `https://app.pome.sh/demo/<group_id>`. Ships the canonical task markdown + seed (`cli/src/demo/first-run-demo.{md,seed.json}`).

## Why
FDRS-643 (journey stop 01, cold start). Design decisions of record: the ticket's 2026-07-05 [DECISION] comment (sync verdicts measured 5-8s worst-case — no 202+poll; `npx pome-sh demo` because the npm name `pome` is squatted; new agent because no existing agent speaks the gateway RPC).

## Notes for reviewer
- Verified: 395/395 vitest (61 files) incl. a stub-cloud integration e2e that spawns the real capture-server child + real demo agent and validates every wire body against a mirror of the server's strict Zod schemas; typecheck green; `gate:no-eval` green (CLI stays capture-only — verdicts come exclusively from the finalize response). Independently re-run by an adversarial verify pass.
- Plumbing seams added rather than forks: `runScenario` gained `extraAgentEnv`/`egressExtraHosts`; the hosted client gained `authScheme: "bearer"`; the API host joins the FDRS-635 deny-by-default egress allowlist for demo runs only.
- The https-over-CONNECT TLS-wrap branch of `cli/src/demo/proxyRequest.ts` is exercised only by the pending live run (direct fetch + http-over-CONNECT are unit-tested) — flagged, not faked.
- `--trials` (1-10, default 5) exists as a debug affordance beyond the fixed k=5 — say the word and it goes.
- Pairs with pome-sh/pome-cloud PR "regenerate first-run-demo task definition" (the server-owned judge definition was a PR-task placeholder; the cloud's own comment anticipated regenerating it from this canonical markdown). The live run needs that + #207 deployed.

## Review required
Yes — public OSS API (new CLI command, hosted-client auth scheme, egress-allowlist seam).

### Founder briefing (3 min)
- **What changed:** the CLI grew its first zero-auth product surface — `pome demo` runs five captured trials of a bundled agent against the local twin, with model calls riding your #207 gateway and verdicts riding your #202 ingest.
- **What it means for your repo / workflow:** the demo exercises demo-mint → upload → finalize + the gateway RPC end-to-end as their first real client; contract drift on those routes now breaks a shippable command, and the demo task content is now canonically owned by `cli/src/demo/first-run-demo.md` (cloud regenerates from it).
- **The one thing you must know:** the cloud's `DEMO_TASK_DEFINITIONS["first-run-demo"]` was still the PR-task placeholder — a live demo today would judge triage traces against PR criteria and fail every trial; the paired pome-cloud PR fixes it and must land + deploy before anyone runs the demo for real.