### PR TITLE
[FDRS-636] pome run -n k: real trial groups

### DIFF
--- a/cli/.changeset/fdrs-636-run-trial-groups.md
+++ b/cli/.changeset/fdrs-636-run-trial-groups.md
@@ -1,0 +1,22 @@
+---
+"pome-sh": minor
+---
+
+`pome run <task> -n k` — real trial groups end-to-end (FDRS-636). `-n` (integer
+1-20, hosted only) runs k isolated trials of one task as a single group;
+the default k comes from the scenario config's `runs` field (capped at 20).
+k>1 mints all k sessions upfront on `POST /v1/sessions` with one shared
+`grp_`+nanoid21 `group_id` and a fresh idempotency key per mint, then runs
+the trials sequentially through the existing hosted runner (explicit 60s
+finalize timeout). The terminal prints the moment-04 verdict table — numeric
+cloud-judge scores per trial (capture-only CLI, no local scoring), errored
+trials excluded from the summary fraction — and hands off to the task's
+reliability page (`{dashboard}/runs/task/<taskName>`). A trial that fails
+preflight, times out, or crashes is abandoned via
+`POST /v1/sessions/:id/abandon` with a machine `error_code`
+(`preflight_failed` / `agent_timeout` / `agent_exit_nonzero` /
+`trial_crashed`) and the remaining trials continue. Group exit code
+(documented in `src/hosted/errors.ts`): 0 iff at least one trial completed
+AND every completed trial passed; 1 when a completed trial failed; 2 when
+nothing completed. k=1 keeps today's single-run behavior exactly — no group
+is ever stamped.

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -21,6 +21,7 @@ import {
 } from "../recorder/inspect.js";
 import { runScenario } from "../runner/runScenario.js";
 import { runScenarioHosted } from "../runner/runScenarioHosted.js";
+import { effectiveTrialCount, parseTrialsFlag } from "../runner/trialCount.js";
 import { runScoreLine, scoreStatus } from "../score/view.js";
 import { HostedUsageError, exitCodeFor } from "../hosted/errors.js";
 import { resolveCredentials, clearLocalCredentials } from "./credentials.js";
@@ -528,6 +529,14 @@ export function createProgram() {
     .command("run")
     .argument("<path>", "Scenario markdown file or directory")
     .option("--agent <command>", "Agent command to run")
+    .option(
+      "-n, --trials <count>",
+      "FDRS-636: run <count> isolated trials of the task as ONE trial group (integer 1-20; hosted only). " +
+        "Default is the scenario config's `runs` field (capped at 20). k>1 mints all sessions upfront with a shared group id, " +
+        "runs trials sequentially, prints the per-trial verdict table (numeric cloud-judge scores), and exits 0 iff at least one " +
+        "trial completed and every completed trial passed (1: a completed trial failed; 2: nothing completed). " +
+        "k=1 keeps today's single-run behavior exactly.",
+    )
     .option("--artifacts-dir <dir>", "Directory for run artifacts", "runs")
     // --hosted is now the default. The flag stays as a one-release no-op so
     // existing scripts and copy-pasted `pome docs` snippets don't break;
@@ -555,6 +564,7 @@ export function createProgram() {
         target: string,
         options: {
           agent?: string;
+          trials?: string;
           artifactsDir: string;
           hosted: boolean;
           local?: boolean;
@@ -571,6 +581,20 @@ export function createProgram() {
         // typed errors (HostedAuthError, HostedQuotaError,
         // HostedUsageError, HostedOrchError) here and map via
         // `exitCodeFor` so the documented contract holds.
+
+        // FDRS-636 — validate -n before anything runs (documented exit 5 on
+        // a bad value, same as any other usage error).
+        let trialsFlag: number | undefined;
+        if (options.trials !== undefined) {
+          try {
+            trialsFlag = parseTrialsFlag(options.trials);
+          } catch (err) {
+            console.error(err instanceof Error ? err.message : String(err));
+            process.exitCode = exitCodeFor(err);
+            return;
+          }
+        }
+
         let files: string[];
         let hostedCreds: { apiBaseUrl: string; apiKey: string } | null;
         try {
@@ -603,6 +627,17 @@ export function createProgram() {
           );
         } else if (options.hosted) {
           console.error("Note: --hosted is now the default; the flag is a deprecated no-op and will be removed in a future release.");
+        }
+
+        // FDRS-636 — trial groups are a hosted feature: the verdicts come
+        // from cloud evaluation, and self-host runs are capture-only. Reject
+        // the combination loudly instead of silently ignoring the flag.
+        if (trialsFlag !== undefined && useLocal) {
+          console.error(
+            "-n/--trials needs the hosted path (verdicts come from the cloud judge); --local runs capture a single trace. Drop --local or -n.",
+          );
+          process.exitCode = 5;
+          return;
         }
 
         // FDRS-641 — doctor preflight gate. A repo failing any applicable
@@ -651,6 +686,43 @@ export function createProgram() {
             // documented exit codes. Anything else falls through to Commander
             // (treated like self-host).
             try {
+              // FDRS-636 — effective trial count: -n wins, else the scenario
+              // config's `runs` field (both capped at 20). k>1 takes the
+              // trial-group path; k=1 stays EXACTLY the single-run path
+              // below (no group is ever stamped for it).
+              const scenarioForRuns = await parseScenarioFile(file);
+              const k = effectiveTrialCount(
+                trialsFlag,
+                scenarioForRuns.config.runs,
+              );
+              if (k > 1) {
+                const { runTrialGroup } = await import(
+                  "../runner/runTrialGroup.js"
+                );
+                const groupResult = await runTrialGroup({
+                  scenarioPath: file,
+                  agentCommand,
+                  agentCommandSource: options.agent
+                    ? "--agent"
+                    : configCommand
+                      ? "pome.config.json"
+                      : "built-in default",
+                  trials: k,
+                  artifactsDir: options.artifactsDir,
+                  hosted: {
+                    baseUrl: hostedCreds.apiBaseUrl,
+                    apiKey: hostedCreds.apiKey,
+                  },
+                  dashboardBaseUrl:
+                    process.env.POME_DASHBOARD_URL ?? DEFAULT_DASHBOARD_URL,
+                  agentModel: options.agentModel,
+                });
+                if (groupResult.exitCode > worstExit) {
+                  worstExit = groupResult.exitCode;
+                }
+                continue;
+              }
+
               const result = await runScenarioHosted({
                 scenarioPath: file,
                 agentCommand,

--- a/cli/src/hosted/client.ts
+++ b/cli/src/hosted/client.ts
@@ -51,6 +51,25 @@ export interface CreateSessionInput {
    *  extracting JSON from the scenario markdown — required for the post-2026-05-22
    *  prose `## Seed State` shape, where the markdown has no fenced JSON block. */
   seed?: unknown;
+  /** FDRS-636 — trial-group identity (`grp_` + nanoid21). `pome run -n k`
+   *  (k>1) stamps ONE shared id on every mint of the invocation; the cloud
+   *  copies it onto `sessions.group_id` at mint and `runs.group_id` at
+   *  finalize, and the reliability page reads the group by it.
+   *  shared-types 0.6.0 adds the field server-side; an older cloud silently
+   *  strips it, so sending it is always safe. NEVER set for k=1 — a group
+   *  of 1 would flip the reliability page off its implicit latest-k
+   *  fallback. */
+  groupId?: string;
+}
+
+/** FDRS-636 — POST /v1/sessions/:id/abandon response. `abandoned: false`
+ *  means the session was already terminal and nothing was rewritten (the
+ *  idempotent no-op branch); `state` echoes the row's current state. */
+export interface AbandonSessionResponse {
+  session_id: string;
+  state: string;
+  error_code: string | null;
+  abandoned: boolean;
 }
 
 // FDRS-655/656 — `pome eval <run-dir>` capture/eval split. The cloud mints
@@ -181,6 +200,16 @@ export interface HostedClient {
     sessionId: string,
     input: SubmitResultInput,
   ): Promise<SubmitResultResponse>;
+  /** FDRS-636 — mark an errored trial's session failed NOW with a short
+   *  machine `error_code` (e.g. "agent_timeout"), instead of letting it sit
+   *  open until the expiry sweeper reaps it. Contract: pome-cloud
+   *  routes/abandon.ts — auth is the same surface as /finalize; an
+   *  already-terminal session is an idempotent no-op (`abandoned: false`);
+   *  a finalized run's session is never clobbered. */
+  abandonSession(
+    sessionId: string,
+    input?: { errorCode?: string },
+  ): Promise<AbandonSessionResponse>;
   requestEventsUploadUrl(sessionId: string): Promise<EventsUploadUrlResponse>;
   requestStateUploadUrl(sessionId: string): Promise<StateUploadUrlResponse>;
   /** F0-4 / L7 — mint a signed PUT for `signals.jsonl` (adapter-emitted
@@ -332,8 +361,48 @@ export function createHostedClient(config: HostedClientConfig): HostedClient {
       if (input.seed !== undefined) {
         body.seed = input.seed;
       }
+      if (input.groupId) {
+        body.group_id = input.groupId;
+      }
       return postJson("/v1/sessions", body, (raw) =>
         createSessionResponseSchema.parse(raw),
+      );
+    },
+
+    async abandonSession(sessionId, input) {
+      const body: Record<string, unknown> = {};
+      if (input?.errorCode) {
+        body.error_code = input.errorCode;
+      }
+      return postJson(
+        `/v1/sessions/${encodeURIComponent(sessionId)}/abandon`,
+        body,
+        (raw) => {
+          if (
+            typeof raw === "object" &&
+            raw !== null &&
+            typeof (raw as { session_id?: unknown }).session_id === "string" &&
+            typeof (raw as { state?: unknown }).state === "string" &&
+            typeof (raw as { abandoned?: unknown }).abandoned === "boolean"
+          ) {
+            const shaped = raw as {
+              session_id: string;
+              state: string;
+              error_code?: unknown;
+              abandoned: boolean;
+            };
+            return {
+              session_id: shaped.session_id,
+              state: shaped.state,
+              error_code:
+                typeof shaped.error_code === "string" ? shaped.error_code : null,
+              abandoned: shaped.abandoned,
+            } satisfies AbandonSessionResponse;
+          }
+          throw new HostedOrchError(
+            "POST /v1/sessions/:id/abandon returned unexpected shape",
+          );
+        },
       );
     },
 

--- a/cli/src/hosted/errors.ts
+++ b/cli/src/hosted/errors.ts
@@ -15,6 +15,15 @@
 //   - F18: hosted sub-threshold runs sometimes returned exit 3 because
 //     `runScenarioHosted.ts` mapped any non-zero agent exit to exit 3,
 //     stealing the auth slot.
+//
+// FDRS-636 — trial groups (`pome run -n k`, k>1) map the WHOLE GROUP to one
+// exit code ([DECISION 2026-07-05]):
+//   0 — at least one trial completed AND every completed trial passed;
+//   1 — at least one completed trial failed its pass threshold;
+//   2 — no trial completed (every trial errored/was abandoned).
+// Errored trials are excluded from the verdict fraction and never lower a
+// passing group below 0 on their own. Single-run (k=1) semantics above are
+// untouched.
 
 export class HostedAuthError extends Error {
   constructor(message: string, public readonly requestId?: string) {
@@ -58,6 +67,18 @@ export class HostedUsageError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "HostedUsageError";
+  }
+}
+
+/** FDRS-636 — a group trial errored before a cloud verdict existed
+ *  (preflight failure, agent timeout, agent crash). The session was
+ *  abandoned (POST /v1/sessions/:id/abandon) with `errorCode`; the group
+ *  runner renders the trial as an errored row EXCLUDED from the verdict
+ *  fraction. `message` is the short human reason shown on that row. */
+export class HostedTrialError extends Error {
+  constructor(message: string, public readonly errorCode: string) {
+    super(message);
+    this.name = "HostedTrialError";
   }
 }
 

--- a/cli/src/runner/groupRender.ts
+++ b/cli/src/runner/groupRender.ts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-636 — pure terminal rendering for `pome run -n k` trial groups,
+// matching the design-of-record (CLI moments.dc.html moment 04,
+// task/code-model vocabulary):
+//
+//   -n sets how many isolated trials to run · the agent command comes from pome.config.json
+//   provisioning 5 isolated github twins … ready
+//   spawning agent <cmd> · from pome.config.json …
+//   trial 1  ✓  100      14.3s
+//   trial 2  ✓  96       12.1s
+//   trial 3  ✗  58       15.9s  <failing criteria summary>
+//   trial 5  ⚠  errored         <reason> — excluded
+//   ─────
+//   2 of 4 passed · 1 errored, excluded from the fraction
+//   <failing-criterion phrase> failed in 2 of 4 — start there
+//   full trace, per-criterion diffs, and the trial spread:
+//   → <reliability page url>
+//
+// Trial verdicts are NUMERIC SCORES from the cloud judge — never words (that
+// vocabulary belongs to `pome demo`, moment 01). Errored rows show no
+// duration and are EXCLUDED from the fraction's denominator.
+
+import { criterionPhrase } from "../demo/render.js";
+
+export type TrialRow =
+  | {
+      kind: "completed";
+      /** Cloud-authoritative satisfaction score, 0-100. */
+      score: number;
+      /** Cleared the scenario's pass threshold. */
+      passed: boolean;
+      seconds: number;
+      /** Failing-criteria summary ("a · b"), absent when none were reported. */
+      note?: string;
+    }
+  | { kind: "errored"; reason: string };
+
+/** The muted hint under the command echo, naming where the agent command
+ *  came from (pome.config.json / --agent / the built-in default). */
+export function flagHintLine(agentCommandSource: string): string {
+  return `-n sets how many isolated trials to run · the agent command comes from ${agentCommandSource}`;
+}
+
+/** Printed once every session of the group is minted (the cloud provisions
+ *  one isolated twin sandbox per session — ADR-012). */
+export function provisioningLine(k: number, twins: string[]): string {
+  return `provisioning ${k} isolated ${twins.join("+")} twins … ready`;
+}
+
+export function spawningAgentLine(command: string, source: string): string {
+  return `spawning agent ${command} · from ${source} …`;
+}
+
+// Column layout (moment 04): score field padded to 9 so durations align;
+// "errored" padded to the duration column (16) so reasons align with the
+// failing-criteria notes.
+export function trialRowLine(n: number, row: TrialRow): string {
+  if (row.kind === "errored") {
+    return `trial ${n}  ⚠  ${"errored".padEnd(16)}${row.reason} — excluded`;
+  }
+  const mark = row.passed ? "✓" : "✗";
+  const base = `trial ${n}  ${mark}  ${String(row.score).padEnd(9)}${row.seconds.toFixed(1)}s`;
+  return row.note ? `${base}  ${row.note}` : base;
+}
+
+export interface GroupSummaryInput {
+  rows: TrialRow[];
+  /** Most-common failed-criterion phrase across completed trials, if any. */
+  failingCriterionPhrase?: string;
+  /** How many completed trials failed that criterion. */
+  failingCriterionCount?: number;
+  /** The task's reliability page (dashboard /runs/task/<taskName>). */
+  reliabilityUrl: string;
+}
+
+export function groupSummaryLines(input: GroupSummaryInput): string[] {
+  const completed = input.rows.filter(
+    (r): r is Extract<TrialRow, { kind: "completed" }> => r.kind === "completed",
+  );
+  const passed = completed.filter((r) => r.passed).length;
+  const errored = input.rows.length - completed.length;
+
+  const lines: string[] = ["─────"];
+
+  // The fraction counts COMPLETED trials only; errored trials are named and
+  // excluded, never silently folded into the denominator.
+  let fraction =
+    completed.length === 0
+      ? "no trials completed"
+      : `${passed} of ${completed.length} passed`;
+  if (errored > 0) {
+    fraction += ` · ${errored} errored, excluded from the fraction`;
+  }
+  lines.push(fraction);
+
+  if (
+    input.failingCriterionPhrase &&
+    typeof input.failingCriterionCount === "number" &&
+    input.failingCriterionCount > 0 &&
+    completed.length > 0
+  ) {
+    lines.push(
+      `${input.failingCriterionPhrase} failed in ${input.failingCriterionCount} of ${completed.length} — start there`,
+    );
+  }
+
+  // The dashboard handoff only makes sense when at least one run row exists.
+  if (completed.length > 0) {
+    lines.push("");
+    lines.push("full trace, per-criterion diffs, and the trial spread:");
+    lines.push(`→ ${input.reliabilityUrl}`);
+  }
+
+  return lines;
+}
+
+/** [DECISION 2026-07-05] group exit code: 0 iff at least one trial completed
+ *  AND every completed trial passed; 1 when a completed trial failed; 2 when
+ *  nothing completed. Documented next to the k=1 mapping in
+ *  src/hosted/errors.ts. */
+export function groupExitCode(rows: TrialRow[]): number {
+  const completed = rows.filter(
+    (r): r is Extract<TrialRow, { kind: "completed" }> => r.kind === "completed",
+  );
+  if (completed.length === 0) return 2;
+  return completed.every((r) => r.passed) ? 0 : 1;
+}
+
+/** Modal failed-criterion text across the group's completed trials, as the
+ *  short phrase the "start there" line renders. */
+export function mostCommonFailedCriterion(
+  failures: string[],
+): { phrase: string; count: number } | null {
+  if (failures.length === 0) return null;
+  const counts = new Map<string, number>();
+  for (const text of failures) {
+    counts.set(text, (counts.get(text) ?? 0) + 1);
+  }
+  const [text, count] = [...counts.entries()].sort((a, b) => b[1] - a[1])[0]!;
+  return { phrase: criterionPhrase(text), count };
+}
+
+/** Flatten an errored trial's reason to one short row-friendly line. */
+export function shortReason(reason: string): string {
+  const flat = reason.replace(/\s+/g, " ").trim();
+  return flat.length > 72 ? `${flat.slice(0, 69)}…` : flat;
+}

--- a/cli/src/runner/runScenarioHosted.ts
+++ b/cli/src/runner/runScenarioHosted.ts
@@ -18,7 +18,12 @@ import {
   normalizeConfigAgentSdk,
   readProjectConfig,
 } from "../cli/project-config.js";
-import type { CriterionDef, RecorderEvent } from "../types/shared.js";
+import { HostedTrialError } from "../hosted/errors.js";
+import type {
+  CreateSessionResponse,
+  CriterionDef,
+  RecorderEvent,
+} from "../types/shared.js";
 import type { RecorderEvent as LegacyGithubRecorderEvent } from "../twin/github/types.js";
 import type { Scenario } from "../scenario/scenarioSchema.js";
 import type { Score } from "../score/view.js";
@@ -33,6 +38,20 @@ export interface RunScenarioHostedOptions {
   client?: HostedClient;
   /** Informational; passed through to `runs.agent_model`. Defaults to "unknown". */
   agentModel?: string;
+  /** FDRS-636 — a session minted by the caller (trial groups mint all k
+   *  upfront with one shared `group_id`). When set, the runner skips its own
+   *  POST /v1/sessions and runs against this session; the `finally` teardown
+   *  still DELETEs it (the trial owns its session either way). */
+  premintedSession?: CreateSessionResponse;
+  /** FDRS-636 — group-trial failure semantics. When true, an agent failure
+   *  (preflight failure / timeout / non-zero exit) or a machinery crash
+   *  ABANDONS the session (POST /:id/abandon with a machine error_code,
+   *  landing BEFORE the teardown DELETE so the code is recorded while the
+   *  row is still open) and throws HostedTrialError INSTEAD of finalizing —
+   *  an errored trial must never produce a judged run row. Default false:
+   *  today's single-run behavior (finalize even on agent timeout) is
+   *  unchanged. */
+  abandonOnFailure?: boolean;
 }
 
 export interface RunScenarioHostedResult {
@@ -43,6 +62,10 @@ export interface RunScenarioHostedResult {
   artifacts: RunArtifacts;
   score: Score;
   exitCode: number;
+  /** Wall time from run start to post-agent state capture — the same value
+   *  reported to /finalize as duration_ms. FDRS-636 renders it as the trial
+   *  row's duration. */
+  durationMs: number;
 }
 
 export async function runScenarioHosted(
@@ -80,17 +103,21 @@ export async function runScenarioHosted(
   // don't race the read in the empty case.
   await writeFile(signalsPath, "");
 
-  // 1. Spawn cloud session — fails fast on auth/quota/orch.
+  // 1. Spawn cloud session — fails fast on auth/quota/orch. FDRS-636 trial
+  // groups mint all k sessions upfront (one shared group_id) and pass each
+  // one in as `premintedSession`; the single-run path mints its own here.
   // Forward the resolved seed (sidecar -> inline JSON -> twin defaults, in that
   // precedence; see parseScenario.resolveSeedState) so the cloud doesn't need
   // to re-extract it from the markdown. Prose `## Seed State` sections have no
   // fenced JSON to extract — cloud would 422 with "no fenced code block".
-  const session = await client.createSession({
-    scenarioSource,
-    twins: scenario.config.twins,
-    agentId,
-    seed: scenario.seedState,
-  });
+  const session =
+    options.premintedSession ??
+    (await client.createSession({
+      scenarioSource,
+      twins: scenario.config.twins,
+      agentId,
+      seed: scenario.seedState,
+    }));
 
   // Use session_id as the local artifact-dir id. The cloud's run_id (assigned
   // at /result time) is reported separately to the caller.
@@ -176,6 +203,32 @@ export async function runScenarioHosted(
       });
     }
 
+    // FDRS-636 — group-trial failure semantics. An agent failure on a group
+    // trial ABANDONS the session with a machine error_code and throws,
+    // instead of finalizing: verdicts come from cloud evaluation only, and a
+    // crashed/timed-out trial must render as an errored row EXCLUDED from
+    // the fraction — never as a judged score over a garbage trace. Default
+    // (single-run) behavior below is untouched: it still finalizes so the
+    // run is visible on the dashboard.
+    if (
+      options.abandonOnFailure &&
+      (agentResult.timedOut || agentResult.exitCode !== 0)
+    ) {
+      const failure = agentResult.timedOut
+        ? {
+            errorCode: "agent_timeout",
+            reason: `agent timed out after ${scenario.config.timeout}s`,
+          }
+        : preflight.exitCode !== 0
+          ? { errorCode: "preflight_failed", reason: "agent preflight failed" }
+          : {
+              errorCode: "agent_exit_nonzero",
+              reason: `agent exited non-zero (exit ${agentResult.exitCode})`,
+            };
+      await abandonBestEffort(client, session.session_id, failure.errorCode);
+      throw new HostedTrialError(failure.reason, failure.errorCode);
+    }
+
     // 4. Capture final state + recorder events. Run in parallel for
     //    latency. If either rejects (e.g., twin pod restarted between
     //    preflight and now), the run fails before finalize fires —
@@ -198,6 +251,7 @@ export async function runScenarioHosted(
     //    judge; the verdict from /finalize is printed to the terminal and
     //    recorded to the dashboard, never persisted next to the trace.
     const completedAt = new Date().toISOString();
+    const durationMs = Date.parse(completedAt) - Date.parse(startedAt);
     const artifacts = await writeRunArtifactsCore({
       artifactsDir,
       runId,
@@ -285,7 +339,7 @@ export async function runScenarioHosted(
     const finalized = await client.finalize(session.session_id, {
       stopReason,
       exitCode: agentResult.exitCode ?? 0,
-      durationMs: Date.parse(completedAt) - Date.parse(startedAt),
+      durationMs,
       agentModel: options.agentModel ?? "unknown",
       agentSdk,
       criteria: criteriaDefs,
@@ -339,11 +393,42 @@ export async function runScenarioHosted(
       artifacts,
       score,
       exitCode,
+      durationMs,
     };
+  } catch (err) {
+    // FDRS-636 — a machinery crash on a group trial (twin state fetch,
+    // upload orchestration, finalize itself) also abandons the session so
+    // the reliability page shows an errored slot with a cause instead of a
+    // session stuck open until the sweeper. Must run BEFORE the `finally`
+    // DELETE below: abandon only transitions OPEN sessions, and error_code
+    // is lost once the row is terminal. Agent failures threw
+    // HostedTrialError above and already abandoned with a sharper code.
+    if (options.abandonOnFailure && !(err instanceof HostedTrialError)) {
+      await abandonBestEffort(client, session.session_id, "trial_crashed");
+    }
+    throw err;
   } finally {
     // Best-effort teardown. TTL would reap anyway; explicit delete keeps
     // the dashboard sessions list tidy.
     await client.deleteSession(session.session_id).catch(() => undefined);
     await rm(signalsDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
+/** Abandon is a bookkeeping signal — a failure to deliver it must never
+ *  mask the trial's own error. */
+async function abandonBestEffort(
+  client: HostedClient,
+  sessionId: string,
+  errorCode: string,
+): Promise<void> {
+  try {
+    await client.abandonSession(sessionId, { errorCode });
+  } catch (err) {
+    console.warn(
+      `[pome] session abandon skipped (${
+        err instanceof Error ? err.message : String(err)
+      }); the expiry sweeper will close ${sessionId}`,
+    );
   }
 }

--- a/cli/src/runner/runScenarioHosted.ts
+++ b/cli/src/runner/runScenarioHosted.ts
@@ -187,10 +187,11 @@ export async function runScenarioHosted(
       POME_ADAPTER_SIGNALS_PATH: signalsPath,
     };
 
+    const preflightTimeoutSeconds = Math.min(10, scenario.config.timeout);
     const preflight = await runAgentCommand({
       command: options.agentCommand,
       env,
-      timeoutSeconds: Math.min(10, scenario.config.timeout),
+      timeoutSeconds: preflightTimeoutSeconds,
       preflight: true,
     });
 
@@ -214,17 +215,29 @@ export async function runScenarioHosted(
       options.abandonOnFailure &&
       (agentResult.timedOut || agentResult.exitCode !== 0)
     ) {
-      const failure = agentResult.timedOut
-        ? {
-            errorCode: "agent_timeout",
-            reason: `agent timed out after ${scenario.config.timeout}s`,
-          }
-        : preflight.exitCode !== 0
-          ? { errorCode: "preflight_failed", reason: "agent preflight failed" }
-          : {
-              errorCode: "agent_exit_nonzero",
-              reason: `agent exited non-zero (exit ${agentResult.exitCode})`,
-            };
+      // Classify PREFLIGHT failures first: when the preflight never passed
+      // (non-zero exit OR killed at its own min(10, timeout)s cap), the real
+      // run never happened, so the code is preflight_failed — and a hung
+      // preflight quotes the cap that actually killed it, never the full
+      // scenario timeout. Only a real-run failure classifies as
+      // agent_timeout / agent_exit_nonzero.
+      const failure =
+        preflight.exitCode !== 0
+          ? {
+              errorCode: "preflight_failed",
+              reason: preflight.timedOut
+                ? `agent preflight timed out after ${preflightTimeoutSeconds}s`
+                : "agent preflight failed",
+            }
+          : agentResult.timedOut
+            ? {
+                errorCode: "agent_timeout",
+                reason: `agent timed out after ${scenario.config.timeout}s`,
+              }
+            : {
+                errorCode: "agent_exit_nonzero",
+                reason: `agent exited non-zero (exit ${agentResult.exitCode})`,
+              };
       await abandonBestEffort(client, session.session_id, failure.errorCode);
       throw new HostedTrialError(failure.reason, failure.errorCode);
     }

--- a/cli/src/runner/runTrialGroup.ts
+++ b/cli/src/runner/runTrialGroup.ts
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-636 — `pome run <task> -n k`: real trial groups end-to-end.
+//
+// Flow per the 2026-07-05 [DECISION] set:
+//   1. Mint ALL k sessions upfront (POST /v1/sessions), one shared
+//      `grp_` + nanoid21 group_id on EVERY mint body and a FRESH
+//      idempotency key per mint — the design's "provisioning k isolated
+//      github twins … ready" moment. A failed mint rolls the half-group
+//      back (best-effort DELETEs) and aborts before any agent spawns.
+//   2. Run the k trials SEQUENTIALLY (bounded parallelism deferred —
+//      plan-quota semantics unresolved). runScenarioHosted stays the
+//      isolation unit: each trial gets its pre-minted session via the
+//      `premintedSession` seam, `abandonOnFailure` on, and still DELETEs
+//      its own session in its `finally`.
+//   3. Errored trials (preflight failure / agent timeout / crash) were
+//      abandoned inside the trial (POST /:id/abandon with a machine
+//      error_code); here they render as errored rows EXCLUDED from the
+//      verdict fraction — remaining trials continue.
+//   4. Verdicts are NUMERIC cloud-judge scores (capture-only CLI, ADR-013);
+//      the summary hands off to the task's reliability page
+//      ({dashboard}/runs/task/<taskName>).
+//
+// k=1 never reaches this module: the single-run path in cli/main.ts stays
+// exactly as it was (no group stamped — a group of 1 would flip the
+// reliability page off its implicit latest-k fallback).
+
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { createHostedClient, type HostedClient } from "../hosted/client.js";
+import { HostedTrialError } from "../hosted/errors.js";
+import { newGroupId } from "../demo/ids.js";
+import { criterionPhrase } from "../demo/render.js";
+import { parseScenarioFile } from "../scenario/parseScenario.js";
+import { outcomeOf } from "../score/view.js";
+import {
+  normalizeConfigAgentId,
+  readProjectConfig,
+} from "../cli/project-config.js";
+import { runScenarioHosted } from "./runScenarioHosted.js";
+import {
+  flagHintLine,
+  groupExitCode,
+  groupSummaryLines,
+  mostCommonFailedCriterion,
+  provisioningLine,
+  shortReason,
+  spawningAgentLine,
+  trialRowLine,
+  type TrialRow,
+} from "./groupRender.js";
+import type { CreateSessionResponse } from "../types/shared.js";
+
+/** Explicit finalize timeout for -n runs ([DECISION]) — the hosted client
+ *  defaults to 30s; the judge measured 5-8s, 60s is belt-and-braces (same
+ *  constant `pome demo` locked for its trial finalizes). */
+export const GROUP_FINALIZE_TIMEOUT_MS = 60_000;
+
+export interface RunTrialGroupOptions {
+  scenarioPath: string;
+  agentCommand: string;
+  /** Where the agent command came from, for the header copy
+   *  ("pome.config.json" | "--agent" | "built-in default"). */
+  agentCommandSource?: string;
+  /** Effective k (2..20). k=1 must take the single-run path instead. */
+  trials: number;
+  artifactsDir?: string;
+  hosted: { baseUrl: string; apiKey: string };
+  /** Dashboard origin for the reliability link — same source as every other
+   *  CLI dashboard link (POME_DASHBOARD_URL / DEFAULT_DASHBOARD_URL). */
+  dashboardBaseUrl: string;
+  /** Informational; forwarded to every trial's `runs.agent_model`. */
+  agentModel?: string;
+  out?: (line: string) => void;
+  // ── test seams ─────────────────────────────────────────────────────────
+  client?: HostedClient;
+  runScenarioHostedFn?: typeof runScenarioHosted;
+  groupId?: string;
+}
+
+export interface RunTrialGroupResult {
+  groupId: string;
+  rows: TrialRow[];
+  exitCode: number;
+  reliabilityUrl: string;
+}
+
+export async function runTrialGroup(
+  options: RunTrialGroupOptions,
+): Promise<RunTrialGroupResult> {
+  if (!Number.isInteger(options.trials) || options.trials < 2) {
+    throw new Error(
+      `runTrialGroup requires k>1 (got ${options.trials}); k=1 takes the single-run path so no group is stamped.`,
+    );
+  }
+  const out = options.out ?? ((line: string) => console.error(line));
+  const runFn = options.runScenarioHostedFn ?? runScenarioHosted;
+  const client =
+    options.client ??
+    createHostedClient({
+      baseUrl: options.hosted.baseUrl,
+      apiKey: options.hosted.apiKey,
+      timeoutMs: GROUP_FINALIZE_TIMEOUT_MS,
+    });
+  const groupId = options.groupId ?? newGroupId();
+  const agentCommandSource = options.agentCommandSource ?? "pome.config.json";
+
+  const scenario = await parseScenarioFile(options.scenarioPath);
+  const scenarioSource = await readFile(options.scenarioPath, "utf8");
+  // Same agent resolution as the single-run path (ADR-013): the group's
+  // trials are recorded under the agent pinned in pome.config.json.
+  const configRead = await readProjectConfig(dirname(options.scenarioPath));
+  const agentId = configRead
+    ? normalizeConfigAgentId(configRead.config)
+    : undefined;
+
+  out(flagHintLine(agentCommandSource));
+  out("");
+
+  // 1. Mint all k sessions upfront. The group exists before the first agent
+  // spawns, and quota/auth failures surface HERE as one clean error instead
+  // of half-way through a run. Fresh idempotency key per mint — the k mint
+  // bodies are otherwise identical, and the cloud would collapse them onto
+  // one session.
+  const sessions: CreateSessionResponse[] = [];
+  try {
+    for (let i = 0; i < options.trials; i += 1) {
+      sessions.push(
+        await client.createSession({
+          scenarioSource,
+          twins: scenario.config.twins,
+          agentId,
+          seed: scenario.seedState,
+          groupId,
+          idempotencyKey: randomUUID(),
+        }),
+      );
+    }
+  } catch (err) {
+    // Roll the half-group back so abandoned mints never linger as open
+    // sessions polluting the reliability view; then let the caller map the
+    // error to the documented exit code.
+    await Promise.all(
+      sessions.map((s) => client.deleteSession(s.session_id).catch(() => undefined)),
+    );
+    throw err;
+  }
+  out(provisioningLine(options.trials, scenario.config.twins));
+  out(spawningAgentLine(options.agentCommand, agentCommandSource));
+  out("");
+
+  // 2. Sequential trials over the pre-minted sessions ([DECISION]: bounded
+  // parallelism deferred until plan-quota semantics are resolved).
+  const rows: TrialRow[] = [];
+  const failedCriteria: string[] = [];
+  for (let i = 0; i < options.trials; i += 1) {
+    const session = sessions[i]!;
+    let row: TrialRow;
+    try {
+      const result = await runFn({
+        scenarioPath: options.scenarioPath,
+        agentCommand: options.agentCommand,
+        artifactsDir: options.artifactsDir,
+        hosted: options.hosted,
+        client,
+        agentModel: options.agentModel,
+        premintedSession: session,
+        abandonOnFailure: true,
+      });
+      const failing = result.score.results.filter(
+        (r) => outcomeOf(r) === "failed",
+      );
+      for (const r of failing) failedCriteria.push(r.criterion.text);
+      row = {
+        kind: "completed",
+        score: result.score.satisfaction,
+        passed: result.exitCode === 0,
+        seconds: result.durationMs / 1000,
+        note:
+          failing.length > 0
+            ? failing.map((r) => criterionPhrase(r.criterion.text)).join(" · ")
+            : undefined,
+      };
+    } catch (err) {
+      // The trial abandoned its session before throwing (or crashed past
+      // the point where a verdict was possible). Errored rows are excluded
+      // from the fraction; the remaining trials continue.
+      row = {
+        kind: "errored",
+        reason:
+          err instanceof HostedTrialError
+            ? err.message
+            : shortReason(err instanceof Error ? err.message : String(err)),
+      };
+    }
+    rows.push(row);
+    out(trialRowLine(i + 1, row));
+  }
+
+  // 3. Summary + the framed handoff to the task's reliability page. Route
+  // shape from the dashboard app (/runs/task/[taskName], ?agent read
+  // client-side); task name = the slug /finalize recorded as
+  // runs.task_name.
+  const failing = mostCommonFailedCriterion(failedCriteria);
+  const base = options.dashboardBaseUrl.replace(/\/$/, "");
+  const reliabilityUrl = `${base}/runs/task/${encodeURIComponent(scenario.slug)}${
+    agentId ? `?agent=${encodeURIComponent(agentId)}` : ""
+  }`;
+  for (const line of groupSummaryLines({
+    rows,
+    failingCriterionPhrase: failing?.phrase,
+    failingCriterionCount: failing?.count,
+    reliabilityUrl,
+  })) {
+    out(line);
+  }
+
+  return { groupId, rows, exitCode: groupExitCode(rows), reliabilityUrl };
+}

--- a/cli/src/runner/trialCount.ts
+++ b/cli/src/runner/trialCount.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-636 — trial-count resolution for `pome run -n k`.
+//
+// [DECISION 2026-07-05]: -n is an integer 1..20 on the hosted run path. The
+// DEFAULT is the scenario config's `runs` field (scenarioConfigSchema parses
+// it, defaulting 1; nothing consumed it before this ticket) — -n overrides;
+// both are capped at 20. k=1 keeps EXACTLY today's single-run behavior (no
+// group is ever stamped — a group of 1 would flip the reliability page off
+// its implicit latest-k fallback and regress the view).
+
+import { HostedUsageError } from "../hosted/errors.js";
+
+/** Hard cap on trials per group — matches the reliability read's bound. */
+export const MAX_TRIALS = 20;
+
+/** Parse the raw `-n` flag value. Throws HostedUsageError (documented
+ *  exit 5) on anything but an integer 1..MAX_TRIALS. */
+export function parseTrialsFlag(raw: string): number {
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    throw new HostedUsageError(
+      `Invalid -n "${raw}" (expected an integer 1-${MAX_TRIALS}).`,
+    );
+  }
+  const n = Number.parseInt(trimmed, 10);
+  if (n < 1 || n > MAX_TRIALS) {
+    throw new HostedUsageError(
+      `Invalid -n "${raw}" (expected an integer 1-${MAX_TRIALS}).`,
+    );
+  }
+  return n;
+}
+
+/** Effective k for one scenario: the validated -n flag when present,
+ *  otherwise the scenario config's `runs` field capped at MAX_TRIALS. */
+export function effectiveTrialCount(
+  flagValue: number | undefined,
+  configRuns: number,
+): number {
+  if (flagValue !== undefined) return flagValue;
+  return Math.min(Math.max(1, Math.trunc(configRuns)), MAX_TRIALS);
+}

--- a/cli/test/integration/run-group-e2e.test.ts
+++ b/cli/test/integration/run-group-e2e.test.ts
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-636 — `pome run -n k` end-to-end against a STUB cloud, in the pattern
+// of demo-e2e.test.ts: the REAL runTrialGroup + runScenarioHosted machinery
+// (per-trial preflight, agent subprocess, state/events capture, presigned
+// uploads, finalize/abandon, teardown DELETE) with a scripted control plane.
+// Everything short of the real cloud + a real judge — the founder's Phase G
+// live run covers those.
+
+import { createServer, type Server } from "node:http";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { runTrialGroup } from "../../src/runner/runTrialGroup.js";
+
+const SCENARIO =
+  "# Trivial\n\n## Prompt\nPretend prompt.\n\n## Success Criteria\n- [D] No unsupported endpoint was called\n";
+
+interface StubCloud {
+  server: Server;
+  port: number;
+  minted: Array<Record<string, unknown>>;
+  finalized: Array<{ sessionId: string; body: Record<string, unknown> }>;
+  abandoned: Array<{ sessionId: string; body: Record<string, unknown> }>;
+  deleted: string[];
+  putKeys: string[];
+}
+
+// Trials keyed by mint order: ses_1 passes (100), ses_2's agent crashes
+// (never finalizes — abandoned), ses_3 completes but fails the judge (58).
+function finalizeResponse(sessionId: string, port: number): unknown {
+  const failing = sessionId === "ses_3";
+  return {
+    run_id: `run_${sessionId}`,
+    score: failing ? 58 : 100,
+    judge_model: "test-judge",
+    dashboard_url: `http://127.0.0.1:${port}/runs/run_${sessionId}`,
+    criteria_results: [
+      {
+        criterion: { type: "P", text: "Severity is set correctly" },
+        outcome: failing ? "failed" : "passed",
+        passed: !failing,
+        skipped: false,
+        reason: failing ? "under-rated" : "ok",
+      },
+    ],
+  };
+}
+
+async function startStubCloud(): Promise<StubCloud> {
+  const minted: StubCloud["minted"] = [];
+  const finalized: StubCloud["finalized"] = [];
+  const abandoned: StubCloud["abandoned"] = [];
+  const deleted: string[] = [];
+  const putKeys: string[] = [];
+  let port = 0;
+
+  const server = createServer((req, res) => {
+    let raw = "";
+    req.on("data", (chunk) => {
+      raw += String(chunk);
+    });
+    req.on("end", () => {
+      const url = req.url ?? "";
+      const json = (status: number, body: unknown): void => {
+        res.writeHead(status, { "content-type": "application/json" });
+        res.end(JSON.stringify(body));
+      };
+
+      if (req.method === "PUT" && url.startsWith("/put/")) {
+        putKeys.push(url);
+        res.writeHead(200);
+        res.end();
+        return;
+      }
+
+      if (req.method === "POST" && url === "/v1/sessions") {
+        minted.push(JSON.parse(raw) as Record<string, unknown>);
+        const n = minted.length;
+        json(201, {
+          session_id: `ses_${n}`,
+          twin_url: `http://127.0.0.1:${port}/s/ses_${n}`,
+          expires_at: new Date(Date.now() + 600_000).toISOString(),
+          agent_token: `tok_${n}`,
+          openapi_url: `http://127.0.0.1:${port}/openapi.json`,
+        });
+        return;
+      }
+
+      const stateMatch = url.match(/^\/s\/([^/]+)\/_pome\/state$/);
+      if (req.method === "GET" && stateMatch) {
+        json(200, {
+          repositories: [
+            { owner: "acme", name: "api", full_name: "acme/api", labels: [], issues: [] },
+          ],
+        });
+        return;
+      }
+      const eventsMatch = url.match(/^\/s\/([^/]+)\/_pome\/events$/);
+      if (req.method === "GET" && eventsMatch) {
+        json(200, []);
+        return;
+      }
+
+      const uploadMatch = url.match(
+        /^\/v1\/sessions\/([^/]+)\/(result-upload-url|state-upload-url|signals-upload-url)$/,
+      );
+      if (req.method === "POST" && uploadMatch) {
+        const sid = uploadMatch[1]!;
+        const route = uploadMatch[2]!;
+        const base = `http://127.0.0.1:${port}`;
+        if (route === "result-upload-url") {
+          json(200, { url: `${base}/put/${sid}/events.jsonl`, key: `team-t/session-${sid}/events.jsonl` });
+        } else if (route === "signals-upload-url") {
+          json(200, { url: `${base}/put/${sid}/signals.jsonl`, key: `team-t/session-${sid}/signals.jsonl` });
+        } else {
+          json(200, {
+            state_initial: {
+              url: `${base}/put/${sid}/state_initial.json`,
+              key: `team-t/session-${sid}/state_initial.json`,
+            },
+            state_final: {
+              url: `${base}/put/${sid}/state_final.json`,
+              key: `team-t/session-${sid}/state_final.json`,
+            },
+          });
+        }
+        return;
+      }
+
+      const finalizeMatch = url.match(/^\/v1\/sessions\/([^/]+)\/finalize$/);
+      if (req.method === "POST" && finalizeMatch) {
+        const sessionId = finalizeMatch[1]!;
+        finalized.push({ sessionId, body: JSON.parse(raw) as Record<string, unknown> });
+        json(201, finalizeResponse(sessionId, port));
+        return;
+      }
+
+      const abandonMatch = url.match(/^\/v1\/sessions\/([^/]+)\/abandon$/);
+      if (req.method === "POST" && abandonMatch) {
+        const sessionId = abandonMatch[1]!;
+        const body = raw.trim().length > 0 ? (JSON.parse(raw) as Record<string, unknown>) : {};
+        abandoned.push({ sessionId, body });
+        json(200, {
+          session_id: sessionId,
+          state: "failed",
+          error_code: body.error_code ?? null,
+          abandoned: true,
+        });
+        return;
+      }
+
+      const deleteMatch = url.match(/^\/v1\/sessions\/([^/]+)$/);
+      if (req.method === "DELETE" && deleteMatch) {
+        deleted.push(deleteMatch[1]!);
+        json(200, { id: deleteMatch[1], state: "expired" });
+        return;
+      }
+
+      json(404, { error: { type: "not_found", message: `no stub for ${req.method} ${url}` } });
+    });
+  });
+
+  port = await new Promise<number>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (typeof addr === "object" && addr) resolve(addr.port);
+      else reject(new Error("no address"));
+    });
+  });
+
+  return { server, port, minted, finalized, abandoned, deleted, putKeys };
+}
+
+let cloud: StubCloud | null = null;
+afterAll(async () => {
+  if (cloud) {
+    await new Promise<void>((resolve) => cloud!.server.close(() => resolve()));
+  }
+});
+
+describe("pome run -n k end-to-end against a stub cloud (FDRS-636)", () => {
+  it("mints k upfront (shared group_id, fresh idempotency keys) → sequential trials → verdict table + summary + reliability link", async () => {
+    cloud = await startStubCloud();
+    const tmp = await mkdtemp(join(tmpdir(), "pome-group-e2e-"));
+    const scenarioPath = join(tmp, "scn.md");
+    await writeFile(scenarioPath, SCENARIO, "utf8");
+    const out: string[] = [];
+
+    // The trial agent keys its behavior off POME_RUN_ID (= the trial's
+    // session id): ses_2 crashes after preflight; everything else exits 0.
+    const agent = `node -e ${JSON.stringify(
+      "if (!process.env.POME_PREFLIGHT && process.env.POME_RUN_ID === 'ses_2') process.exit(1)",
+    )}`;
+
+    const result = await runTrialGroup({
+      scenarioPath,
+      agentCommand: agent,
+      agentCommandSource: "pome.config.json",
+      trials: 3,
+      artifactsDir: join(tmp, "runs"),
+      hosted: { baseUrl: `http://127.0.0.1:${cloud.port}`, apiKey: "pme_test" },
+      dashboardBaseUrl: "https://app.pome.sh",
+      out: (line) => out.push(line),
+    });
+
+    const text = out.join("\n");
+
+    // Terminal shape (moment 04): hint → provisioning → spawning → numeric
+    // verdict rows → divider → fraction over completed trials → start-there
+    // → reliability handoff.
+    expect(text).toContain(
+      "-n sets how many isolated trials to run · the agent command comes from pome.config.json",
+    );
+    expect(text).toContain("provisioning 3 isolated github twins … ready");
+    expect(text).toContain(`spawning agent ${agent} · from pome.config.json …`);
+    expect(text).toMatch(/trial 1 {2}✓ {2}100 {6}\d+\.\ds/);
+    expect(text).toMatch(/trial 2 {2}⚠ {2}errored {9}.+ — excluded/);
+    expect(text).toMatch(/trial 3 {2}✗ {2}58 {7}\d+\.\ds {2}severity is set correctly/);
+    expect(text).toContain("─────");
+    expect(text).toContain("1 of 2 passed · 1 errored, excluded from the fraction");
+    expect(text).toContain("severity is set correctly failed in 1 of 2 — start there");
+    expect(text).toContain("full trace, per-criterion diffs, and the trial spread:");
+    expect(text).toContain("→ https://app.pome.sh/runs/task/scn");
+
+    // Exit contract: a completed trial failed → 1.
+    expect(result.exitCode).toBe(1);
+
+    // Mint: 3 sessions upfront, one shared grp_ id on every body, fresh
+    // idempotency keys, base64 scenario source + resolved seed forwarded.
+    expect(cloud.minted).toHaveLength(3);
+    expect(result.groupId).toMatch(/^grp_[A-Za-z0-9_-]{21}$/);
+    for (const mint of cloud.minted) {
+      expect(mint.group_id).toBe(result.groupId);
+      expect(mint.twins).toEqual(["github"]);
+      expect(typeof mint.scenario_source).toBe("string");
+    }
+    const idemKeys = cloud.minted.map((m) => m.idempotency_key);
+    expect(idemKeys.every((k) => typeof k === "string" && (k as string).length > 0)).toBe(true);
+    expect(new Set(idemKeys).size).toBe(3);
+
+    // Verdicts come from cloud evaluation only: completed trials finalized,
+    // the crashed trial abandoned with a machine error_code and NO finalize.
+    expect(cloud.finalized.map((f) => f.sessionId).sort()).toEqual(["ses_1", "ses_3"]);
+    expect(cloud.abandoned).toEqual([
+      { sessionId: "ses_2", body: { error_code: "agent_exit_nonzero" } },
+    ]);
+
+    // Each trial's teardown DELETEs its own session.
+    expect(cloud.deleted.sort()).toEqual(["ses_1", "ses_2", "ses_3"]);
+
+    // The completed trials' blobs were uploaded before finalize.
+    expect(cloud.putKeys.filter((k) => k.includes("ses_1"))).toContain("/put/ses_1/events.jsonl");
+    expect(cloud.putKeys.filter((k) => k.includes("ses_3"))).toContain("/put/ses_3/events.jsonl");
+  }, 120_000);
+});

--- a/cli/test/integration/runScenarioHosted.trial.test.ts
+++ b/cli/test/integration/runScenarioHosted.trial.test.ts
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-636 — runScenarioHosted's trial seams against a fake cloud:
+//
+//   - `premintedSession` skips the runner's own POST /v1/sessions (trial
+//     groups mint all k upfront) while the `finally` teardown still DELETEs
+//     the trial's own session;
+//   - `abandonOnFailure` turns agent failures (preflight fail / timeout /
+//     non-zero exit) and machinery crashes into POST /:id/abandon with a
+//     machine error_code + a thrown HostedTrialError — an errored trial
+//     must NEVER produce a judged run row (no /finalize);
+//   - the abandon lands BEFORE the teardown DELETE, so error_code is
+//     recorded while the session row is still open;
+//   - default mode (no flag) keeps today's behavior: agent timeout still
+//     finalizes (covered by runScenarioHosted.test.ts, re-asserted here).
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { serve, type ServerType } from "@hono/node-server";
+import { Hono } from "hono";
+import { sign as signJwt } from "hono/jwt";
+import { runScenarioHosted } from "../../src/runner/runScenarioHosted.js";
+import { HostedTrialError } from "../../src/hosted/errors.js";
+import type { CreateSessionResponse } from "../../src/types/shared.js";
+
+const TWIN_AUTH_SECRET = "test-secret-32-chars-minimum-length";
+const SESSION_ID = "ses_preminted";
+
+const SCENARIO =
+  "# Trivial\n\n## Prompt\nPretend prompt.\n\n## Success Criteria\n- [D] No unsupported endpoint was called\n";
+const FAST_TIMEOUT_SCENARIO =
+  "# Slow\n\n## Prompt\nPretend prompt.\n\n## Success Criteria\n- [D] No unsupported endpoint was called\n\n## Config\n```yaml\ntimeout: 1\n```\n";
+
+interface FakeCloud {
+  port: number;
+  close: () => void;
+  mintCalls: () => number;
+  finalizeCalls: () => number;
+  abandonBodies: () => Array<Record<string, unknown>>;
+  deletes: () => string[];
+  /** interleaved log of session-lifecycle calls, e.g. ["abandon","delete"] */
+  lifecycle: () => string[];
+}
+
+async function startFakeCloud(opts?: { stateStatus?: number }): Promise<FakeCloud> {
+  let mintCalls = 0;
+  let finalizeCalls = 0;
+  const abandonBodies: Array<Record<string, unknown>> = [];
+  const deletes: string[] = [];
+  const lifecycle: string[] = [];
+  let port = 0;
+
+  const app = new Hono();
+  app.post("/v1/sessions", async (c) => {
+    mintCalls += 1;
+    const token = await signJwt(
+      { sid: SESSION_ID, team_id: "tm_test", exp: Math.floor(Date.now() / 1000) + 600 },
+      TWIN_AUTH_SECRET,
+    );
+    return c.json({
+      session_id: SESSION_ID,
+      twin_url: `http://127.0.0.1:${port}/s/${SESSION_ID}`,
+      expires_at: new Date(Date.now() + 600_000).toISOString(),
+      agent_token: token,
+      openapi_url: `http://127.0.0.1:${port}/openapi.json`,
+    });
+  });
+  app.get("/s/:sid/_pome/state", (c) => {
+    if (opts?.stateStatus && opts.stateStatus !== 200) {
+      return c.json({ message: "twin pod restarted" }, opts.stateStatus as 500);
+    }
+    return c.json({
+      repositories: [
+        { owner: "acme", name: "api", full_name: "acme/api", labels: [], issues: [] },
+      ],
+    });
+  });
+  app.get("/s/:sid/_pome/events", (c) => c.json([]));
+  app.post("/v1/sessions/:id/finalize", (c) => {
+    finalizeCalls += 1;
+    return c.json(
+      {
+        run_id: "run_x",
+        score: 100,
+        judge_model: "test-judge",
+        dashboard_url: "http://127.0.0.1/runs/run_x",
+      },
+      201,
+    );
+  });
+  app.post("/v1/sessions/:id/abandon", async (c) => {
+    const raw = await c.req.text();
+    const body = raw.trim().length > 0 ? (JSON.parse(raw) as Record<string, unknown>) : {};
+    abandonBodies.push(body);
+    lifecycle.push("abandon");
+    return c.json({
+      session_id: c.req.param("id"),
+      state: "failed",
+      error_code: (body.error_code as string | undefined) ?? null,
+      abandoned: true,
+    });
+  });
+  app.delete("/v1/sessions/:id", (c) => {
+    deletes.push(c.req.param("id"));
+    lifecycle.push("delete");
+    return c.json({ id: c.req.param("id"), state: "expired" });
+  });
+
+  let server: ServerType;
+  port = await new Promise<number>((res) => {
+    server = serve({ fetch: app.fetch, port: 0, hostname: "127.0.0.1" }, (info) =>
+      res(info.port),
+    );
+  });
+
+  return {
+    port,
+    close: () => server!.close(),
+    mintCalls: () => mintCalls,
+    finalizeCalls: () => finalizeCalls,
+    abandonBodies: () => abandonBodies,
+    deletes: () => deletes,
+    lifecycle: () => lifecycle,
+  };
+}
+
+async function premintedFor(port: number): Promise<CreateSessionResponse> {
+  const token = await signJwt(
+    { sid: SESSION_ID, team_id: "tm_test", exp: Math.floor(Date.now() / 1000) + 600 },
+    TWIN_AUTH_SECRET,
+  );
+  return {
+    session_id: SESSION_ID,
+    twin_url: `http://127.0.0.1:${port}/s/${SESSION_ID}`,
+    expires_at: new Date(Date.now() + 600_000).toISOString(),
+    agent_token: token,
+    provider_credentials: {},
+    openapi_url: `http://127.0.0.1:${port}/openapi.json`,
+  };
+}
+
+describe("runScenarioHosted trial seams (FDRS-636)", () => {
+  let cloud: FakeCloud | undefined;
+  let tmp: string | undefined;
+
+  afterEach(async () => {
+    cloud?.close();
+    cloud = undefined;
+    if (tmp) {
+      await rm(tmp, { recursive: true, force: true });
+      tmp = undefined;
+    }
+  });
+
+  async function scenarioPath(source: string): Promise<string> {
+    tmp = await mkdtemp(join(tmpdir(), "pome-trial-seam-"));
+    const p = join(tmp, "scn.md");
+    await writeFile(p, source, "utf8");
+    return p;
+  }
+
+  it("premintedSession skips the runner's own mint and still DELETEs on teardown", async () => {
+    cloud = await startFakeCloud();
+    const path = await scenarioPath(SCENARIO);
+
+    const result = await runScenarioHosted({
+      scenarioPath: path,
+      agentCommand: `node -e ${JSON.stringify("console.log('done')")}`,
+      artifactsDir: join(tmp!, "runs"),
+      hosted: { baseUrl: `http://127.0.0.1:${cloud.port}`, apiKey: "pme_test" },
+      premintedSession: await premintedFor(cloud.port),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.runId).toBe(SESSION_ID);
+    expect(cloud.mintCalls()).toBe(0); // the group minted upfront
+    expect(cloud.finalizeCalls()).toBe(1);
+    expect(cloud.deletes()).toEqual([SESSION_ID]);
+    // FDRS-636 — the runner reports the trial duration for the verdict table.
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("abandonOnFailure + non-zero agent exit → abandon(agent_exit_nonzero), no finalize, HostedTrialError", async () => {
+    cloud = await startFakeCloud();
+    const path = await scenarioPath(SCENARIO);
+
+    // Preflight (POME_PREFLIGHT=1) succeeds; the real run exits 1.
+    const agent = `node -e ${JSON.stringify("process.exit(process.env.POME_PREFLIGHT ? 0 : 1)")}`;
+
+    let thrown: unknown;
+    try {
+      await runScenarioHosted({
+        scenarioPath: path,
+        agentCommand: agent,
+        artifactsDir: join(tmp!, "runs"),
+        hosted: { baseUrl: `http://127.0.0.1:${cloud.port}`, apiKey: "pme_test" },
+        premintedSession: await premintedFor(cloud.port),
+        abandonOnFailure: true,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(HostedTrialError);
+    expect((thrown as HostedTrialError).errorCode).toBe("agent_exit_nonzero");
+    expect(cloud.finalizeCalls()).toBe(0);
+    expect(cloud.abandonBodies()).toEqual([{ error_code: "agent_exit_nonzero" }]);
+    // Abandon lands while the session row is still open — before the DELETE.
+    expect(cloud.lifecycle()).toEqual(["abandon", "delete"]);
+  });
+
+  it("abandonOnFailure + preflight failure → abandon(preflight_failed), no finalize", async () => {
+    cloud = await startFakeCloud();
+    const path = await scenarioPath(SCENARIO);
+    const agent = `node -e ${JSON.stringify("process.exit(1)")}`;
+
+    await expect(
+      runScenarioHosted({
+        scenarioPath: path,
+        agentCommand: agent,
+        artifactsDir: join(tmp!, "runs"),
+        hosted: { baseUrl: `http://127.0.0.1:${cloud.port}`, apiKey: "pme_test" },
+        premintedSession: await premintedFor(cloud.port),
+        abandonOnFailure: true,
+      }),
+    ).rejects.toMatchObject({ errorCode: "preflight_failed" });
+
+    expect(cloud.finalizeCalls()).toBe(0);
+    expect(cloud.abandonBodies()).toEqual([{ error_code: "preflight_failed" }]);
+  });
+
+  it("abandonOnFailure + agent timeout → abandon(agent_timeout), no finalize", async () => {
+    cloud = await startFakeCloud();
+    const path = await scenarioPath(FAST_TIMEOUT_SCENARIO);
+    // Preflight exits 0 instantly; the real run outlives the 1s timeout.
+    const agent = `node -e ${JSON.stringify(
+      "if (process.env.POME_PREFLIGHT) process.exit(0); setTimeout(() => {}, 5000)",
+    )}`;
+
+    await expect(
+      runScenarioHosted({
+        scenarioPath: path,
+        agentCommand: agent,
+        artifactsDir: join(tmp!, "runs"),
+        hosted: { baseUrl: `http://127.0.0.1:${cloud.port}`, apiKey: "pme_test" },
+        premintedSession: await premintedFor(cloud.port),
+        abandonOnFailure: true,
+      }),
+    ).rejects.toMatchObject({ errorCode: "agent_timeout" });
+
+    expect(cloud.finalizeCalls()).toBe(0);
+    expect(cloud.abandonBodies()).toEqual([{ error_code: "agent_timeout" }]);
+  }, 30_000);
+
+  it("abandonOnFailure + machinery crash (twin state 500) → abandon(trial_crashed), original error rethrown", async () => {
+    cloud = await startFakeCloud({ stateStatus: 500 });
+    const path = await scenarioPath(SCENARIO);
+
+    await expect(
+      runScenarioHosted({
+        scenarioPath: path,
+        agentCommand: `node -e ${JSON.stringify("console.log('done')")}`,
+        artifactsDir: join(tmp!, "runs"),
+        hosted: { baseUrl: `http://127.0.0.1:${cloud.port}`, apiKey: "pme_test" },
+        premintedSession: await premintedFor(cloud.port),
+        abandonOnFailure: true,
+      }),
+    ).rejects.toThrow(/twin pod restarted/);
+
+    expect(cloud.finalizeCalls()).toBe(0);
+    expect(cloud.abandonBodies()).toEqual([{ error_code: "trial_crashed" }]);
+    expect(cloud.lifecycle()).toEqual(["abandon", "delete"]);
+  });
+
+  it("default mode (k=1 path) is untouched: agent failure still finalizes, no abandon", async () => {
+    cloud = await startFakeCloud();
+    const path = await scenarioPath(SCENARIO);
+    const agent = `node -e ${JSON.stringify("process.exit(process.env.POME_PREFLIGHT ? 0 : 1)")}`;
+
+    const result = await runScenarioHosted({
+      scenarioPath: path,
+      agentCommand: agent,
+      artifactsDir: join(tmp!, "runs"),
+      hosted: { baseUrl: `http://127.0.0.1:${cloud.port}`, apiKey: "pme_test" },
+      premintedSession: await premintedFor(cloud.port),
+    });
+
+    // Cloud judged 100 → pass; abandon never fired.
+    expect(result.exitCode).toBe(0);
+    expect(cloud.finalizeCalls()).toBe(1);
+    expect(cloud.abandonBodies()).toEqual([]);
+  });
+});

--- a/cli/test/integration/runScenarioHosted.trial.test.ts
+++ b/cli/test/integration/runScenarioHosted.trial.test.ts
@@ -31,6 +31,11 @@ const SCENARIO =
   "# Trivial\n\n## Prompt\nPretend prompt.\n\n## Success Criteria\n- [D] No unsupported endpoint was called\n";
 const FAST_TIMEOUT_SCENARIO =
   "# Slow\n\n## Prompt\nPretend prompt.\n\n## Success Criteria\n- [D] No unsupported endpoint was called\n\n## Config\n```yaml\ntimeout: 1\n```\n";
+// timeout (11) deliberately EXCEEDS the 10s preflight cap so the hung-preflight
+// test below can distinguish the quoted durations: the abandon reason must say
+// 10s (the cap that actually killed it), never 11s (the scenario timeout).
+const PREFLIGHT_HANG_SCENARIO =
+  "# Hang\n\n## Prompt\nPretend prompt.\n\n## Success Criteria\n- [D] No unsupported endpoint was called\n\n## Config\n```yaml\ntimeout: 11\n```\n";
 
 interface FakeCloud {
   port: number;
@@ -229,6 +234,37 @@ describe("runScenarioHosted trial seams (FDRS-636)", () => {
     expect(cloud.finalizeCalls()).toBe(0);
     expect(cloud.abandonBodies()).toEqual([{ error_code: "preflight_failed" }]);
   });
+
+  it("abandonOnFailure + preflight HANG past its cap → abandon(preflight_failed) quoting the 10s cap, not the scenario timeout", async () => {
+    cloud = await startFakeCloud();
+    const path = await scenarioPath(PREFLIGHT_HANG_SCENARIO);
+    // Preflight hangs forever (killed at the min(10, timeout)=10s cap); the
+    // real run would exit 0, but it must never be reached.
+    const agent = `node -e ${JSON.stringify(
+      "if (process.env.POME_PREFLIGHT) { setTimeout(() => {}, 60000); } else { process.exit(0); }",
+    )}`;
+
+    await expect(
+      runScenarioHosted({
+        scenarioPath: path,
+        agentCommand: agent,
+        artifactsDir: join(tmp!, "runs"),
+        hosted: { baseUrl: `http://127.0.0.1:${cloud.port}`, apiKey: "pme_test" },
+        premintedSession: await premintedFor(cloud.port),
+        abandonOnFailure: true,
+      }),
+    ).rejects.toMatchObject({
+      errorCode: "preflight_failed",
+      // The reason quotes the limit that actually killed the preflight (10s),
+      // NOT scenario.config.timeout (11s) — the errored trial card renders
+      // this cause verbatim.
+      message: "agent preflight timed out after 10s",
+    });
+
+    expect(cloud.finalizeCalls()).toBe(0);
+    expect(cloud.abandonBodies()).toEqual([{ error_code: "preflight_failed" }]);
+    expect(cloud.lifecycle()).toEqual(["abandon", "delete"]);
+  }, 30_000);
 
   it("abandonOnFailure + agent timeout → abandon(agent_timeout), no finalize", async () => {
     cloud = await startFakeCloud();

--- a/cli/test/unit/hosted/client.group.test.ts
+++ b/cli/test/unit/hosted/client.group.test.ts
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-636 — hosted-client wire contract for trial groups:
+//   - POST /v1/sessions carries `group_id` + `idempotency_key` when the
+//     caller supplies them (shared-types 0.6.0 adds the field server-side;
+//     an older cloud silently strips it, so sending is always safe);
+//   - POST /v1/sessions/:id/abandon marks an errored trial failed NOW with a
+//     short machine error_code (contract: pome-cloud routes/abandon.ts).
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createHostedClient } from "../../../src/hosted/client.js";
+import { HostedAuthError, HostedOrchError } from "../../../src/hosted/errors.js";
+
+const BASE = "https://api.example.com";
+const KEY = "pme_test_key";
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mockFetch(impl: typeof fetch) {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(impl as never);
+}
+
+const SESSION_RESPONSE = JSON.stringify({
+  session_id: "ses_abc",
+  twin_url: "https://twins.example.com/s/ses_abc",
+  expires_at: "2026-07-05T20:00:00Z",
+  agent_token: "edt_jwt",
+  openapi_url: "https://twins.example.com/s/ses_abc/openapi.json",
+});
+
+describe("HostedClient.createSession — group fields (FDRS-636)", () => {
+  it("forwards group_id and idempotency_key on the mint body", async () => {
+    mockFetch(async (_url, init) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      expect(body.group_id).toBe("grp_useandom26T198340PX75");
+      expect(body.idempotency_key).toBe("idem-1");
+      return new Response(SESSION_RESPONSE, { status: 201 });
+    });
+    const client = createHostedClient({ baseUrl: BASE, apiKey: KEY });
+    const out = await client.createSession({
+      scenarioSource: "x",
+      twins: ["github"],
+      groupId: "grp_useandom26T198340PX75",
+      idempotencyKey: "idem-1",
+    });
+    expect(out.session_id).toBe("ses_abc");
+  });
+
+  it("omits group_id entirely when not provided (k=1 stays exactly today's mint body)", async () => {
+    mockFetch(async (_url, init) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      expect(body).not.toHaveProperty("group_id");
+      expect(body).not.toHaveProperty("idempotency_key");
+      return new Response(SESSION_RESPONSE, { status: 201 });
+    });
+    const client = createHostedClient({ baseUrl: BASE, apiKey: KEY });
+    await client.createSession({ scenarioSource: "x", twins: ["github"] });
+  });
+});
+
+describe("HostedClient.abandonSession (FDRS-636)", () => {
+  it("POSTs {error_code} to /v1/sessions/:id/abandon with the same auth surface as finalize", async () => {
+    mockFetch(async (url, init) => {
+      expect(String(url)).toBe(`${BASE}/v1/sessions/ses_abc/abandon`);
+      expect(init?.method).toBe("POST");
+      const headers = new Headers(init?.headers);
+      expect(headers.get("x-api-key")).toBe(KEY);
+      expect(JSON.parse(String(init?.body))).toEqual({ error_code: "agent_timeout" });
+      return new Response(
+        JSON.stringify({
+          session_id: "ses_abc",
+          state: "failed",
+          error_code: "agent_timeout",
+          abandoned: true,
+        }),
+        { status: 200 },
+      );
+    });
+    const client = createHostedClient({ baseUrl: BASE, apiKey: KEY });
+    const out = await client.abandonSession("ses_abc", { errorCode: "agent_timeout" });
+    expect(out.abandoned).toBe(true);
+    expect(out.state).toBe("failed");
+    expect(out.error_code).toBe("agent_timeout");
+  });
+
+  it("sends an empty body when no error code is known (contract allows it)", async () => {
+    mockFetch(async (_url, init) => {
+      expect(JSON.parse(String(init?.body))).toEqual({});
+      return new Response(
+        JSON.stringify({
+          session_id: "ses_abc",
+          state: "failed",
+          error_code: null,
+          abandoned: true,
+        }),
+        { status: 200 },
+      );
+    });
+    const client = createHostedClient({ baseUrl: BASE, apiKey: KEY });
+    const out = await client.abandonSession("ses_abc");
+    expect(out.error_code).toBeNull();
+  });
+
+  it("an already-terminal session echoes its state with abandoned: false (idempotent no-op)", async () => {
+    mockFetch(async () =>
+      new Response(
+        JSON.stringify({
+          session_id: "ses_abc",
+          state: "done",
+          error_code: null,
+          abandoned: false,
+        }),
+        { status: 200 },
+      ),
+    );
+    const client = createHostedClient({ baseUrl: BASE, apiKey: KEY });
+    const out = await client.abandonSession("ses_abc", { errorCode: "agent_timeout" });
+    expect(out.abandoned).toBe(false);
+    expect(out.state).toBe("done");
+  });
+
+  it("throws HostedAuthError on 401 and HostedOrchError on the opaque 404", async () => {
+    mockFetch(async () =>
+      new Response(JSON.stringify({ error: { type: "invalid_auth", message: "bad key" } }), {
+        status: 401,
+      }),
+    );
+    const client = createHostedClient({ baseUrl: BASE, apiKey: KEY });
+    await expect(client.abandonSession("ses_abc")).rejects.toBeInstanceOf(HostedAuthError);
+
+    mockFetch(async () =>
+      new Response(JSON.stringify({ error: { type: "not_found", message: "Session not found." } }), {
+        status: 404,
+      }),
+    );
+    await expect(client.abandonSession("ses_gone")).rejects.toBeInstanceOf(HostedOrchError);
+  });
+});

--- a/cli/test/unit/run-n-flag.test.ts
+++ b/cli/test/unit/run-n-flag.test.ts
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-636 — `pome run -n k` flag wiring on the hosted path:
+//   - -n is an integer 1..20; invalid values are usage errors (exit 5)
+//     surfaced before the doctor gate ever runs;
+//   - -n is hosted-only: combining it with --local is a usage error;
+//   - the DEFAULT k comes from the scenario config's `runs` field (capped at
+//     20), which nothing consumed before this ticket;
+//   - k=1 (explicit -n 1, or the runs default) stays EXACTLY today's
+//     single-run path — no trial group, no group_id;
+//   - k>1 dispatches to runTrialGroup with the effective k.
+
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createProgram } from "../../src/cli/main.js";
+import { runTrialGroup } from "../../src/runner/runTrialGroup.js";
+import { runScenarioHosted } from "../../src/runner/runScenarioHosted.js";
+
+vi.mock("../../src/runner/runTrialGroup.js", () => ({
+  GROUP_FINALIZE_TIMEOUT_MS: 60_000,
+  runTrialGroup: vi.fn(async () => ({
+    groupId: "grp_test",
+    rows: [],
+    exitCode: 0,
+    reliabilityUrl: "https://app.pome.sh/runs/task/x",
+  })),
+}));
+
+vi.mock("../../src/runner/runScenarioHosted.js", () => ({
+  runScenarioHosted: vi.fn(async () => ({
+    scenario: { title: "Fixture", slug: "scn", config: { passThreshold: 100 } },
+    runId: "ses_1",
+    cloudRunId: "run_1",
+    cloudDashboardUrl: "https://app.pome.sh/runs/run_1",
+    artifacts: { runDir: "/tmp/runs/x" },
+    score: {
+      satisfaction: 100,
+      passed: 1,
+      failed: 0,
+      skipped: 0,
+      errored: 0,
+      total_required: 1,
+      evaluated: true,
+      can_pass: true,
+      results: [],
+      judge_model: "test-judge",
+      judge_tokens_in: null,
+      judge_tokens_out: null,
+    },
+    exitCode: 0,
+    durationMs: 1000,
+  })),
+}));
+
+const SCENARIO =
+  "# Trivial\n\n## Prompt\nPretend prompt.\n\n## Success Criteria\n- [D] No unsupported endpoint was called\n";
+
+function scenarioWithRuns(runs: number): string {
+  return `${SCENARIO}\n## Config\n\`\`\`yaml\nruns: ${runs}\n\`\`\`\n`;
+}
+
+const WIRED_AGENT_SOURCE = [
+  'import { withPome } from "@pome-sh/adapter-claude-sdk";',
+  "withPome();",
+  "const baseUrl = process.env.POME_GITHUB_REST_URL;",
+  "export { baseUrl };",
+].join("\n");
+
+async function fixtureRepo(scenarioSource: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "pome-run-n-"));
+  await mkdir(join(dir, "src"), { recursive: true });
+  await mkdir(join(dir, "scenarios"), { recursive: true });
+  await writeFile(
+    join(dir, "pome.config.json"),
+    JSON.stringify({ agent: { command: 'node -e "process.exit(0)"' } }, null, 2),
+  );
+  await writeFile(join(dir, "src/agent.ts"), WIRED_AGENT_SOURCE);
+  await writeFile(join(dir, "scenarios/scn.md"), scenarioSource, "utf8");
+  return dir;
+}
+
+describe("pome run -n (FDRS-636)", () => {
+  const originalCwd = process.cwd();
+  const originalExitCode = process.exitCode;
+  let stderr: string[];
+
+  beforeEach(() => {
+    stderr = [];
+    vi.spyOn(console, "error").mockImplementation((msg?: unknown) => {
+      stderr.push(String(msg));
+    });
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.exitCode = undefined;
+    process.env.POME_API_KEY = "pme_test_env_key";
+    vi.mocked(runTrialGroup).mockClear();
+    vi.mocked(runScenarioHosted).mockClear();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    delete process.env.POME_API_KEY;
+    vi.restoreAllMocks();
+    process.exitCode = originalExitCode;
+  });
+
+  async function run(...args: string[]): Promise<void> {
+    await createProgram().parseAsync(["node", "pome", "run", ...args]);
+  }
+
+  it.each(["0", "21", "abc", "2.5"])(
+    "-n %s is a usage error (exit 5) and nothing runs",
+    async (bad) => {
+      const dir = await fixtureRepo(SCENARIO);
+      process.chdir(dir);
+      await run("scenarios/scn.md", "-n", bad);
+      expect(process.exitCode).toBe(5);
+      expect(stderr.join("\n")).toMatch(/1-20/);
+      expect(runTrialGroup).not.toHaveBeenCalled();
+      expect(runScenarioHosted).not.toHaveBeenCalled();
+    },
+  );
+
+  it("-n with --local is a usage error — trial groups are hosted-only", async () => {
+    const dir = await fixtureRepo(SCENARIO);
+    process.chdir(dir);
+    await run("scenarios/scn.md", "-n", "3", "--local");
+    expect(process.exitCode).toBe(5);
+    expect(stderr.join("\n")).toMatch(/hosted/i);
+    expect(runTrialGroup).not.toHaveBeenCalled();
+  });
+
+  it("-n 5 dispatches the hosted path to runTrialGroup with trials=5", async () => {
+    const dir = await fixtureRepo(SCENARIO);
+    process.chdir(dir);
+    await run("scenarios/scn.md", "-n", "5");
+
+    expect(process.exitCode ?? 0).toBe(0);
+    expect(runScenarioHosted).not.toHaveBeenCalled();
+    expect(runTrialGroup).toHaveBeenCalledTimes(1);
+    const options = vi.mocked(runTrialGroup).mock.calls[0]![0];
+    expect(options.trials).toBe(5);
+    expect(options.agentCommand).toBe('node -e "process.exit(0)"');
+    expect(options.agentCommandSource).toBe("pome.config.json");
+    expect(options.hosted.apiKey).toBe("pme_test_env_key");
+    expect(options.dashboardBaseUrl).toBe("https://app.pome.sh");
+  }, 30_000);
+
+  it("the scenario config's runs field is the default k (runs: 3 → 3 trials)", async () => {
+    const dir = await fixtureRepo(scenarioWithRuns(3));
+    process.chdir(dir);
+    await run("scenarios/scn.md");
+
+    expect(runTrialGroup).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(runTrialGroup).mock.calls[0]![0].trials).toBe(3);
+    expect(runScenarioHosted).not.toHaveBeenCalled();
+  }, 30_000);
+
+  it("the runs-field default is capped at 20", async () => {
+    const dir = await fixtureRepo(scenarioWithRuns(50));
+    process.chdir(dir);
+    await run("scenarios/scn.md");
+
+    expect(runTrialGroup).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(runTrialGroup).mock.calls[0]![0].trials).toBe(20);
+  }, 30_000);
+
+  it("-n overrides the config runs field", async () => {
+    const dir = await fixtureRepo(scenarioWithRuns(2));
+    process.chdir(dir);
+    await run("scenarios/scn.md", "-n", "4");
+
+    expect(vi.mocked(runTrialGroup).mock.calls[0]![0].trials).toBe(4);
+  }, 30_000);
+
+  it("no -n and runs default (1) keeps EXACTLY today's single-run path", async () => {
+    const dir = await fixtureRepo(SCENARIO);
+    process.chdir(dir);
+    await run("scenarios/scn.md");
+
+    expect(runTrialGroup).not.toHaveBeenCalled();
+    expect(runScenarioHosted).toHaveBeenCalledTimes(1);
+    expect(process.exitCode ?? 0).toBe(0);
+  }, 30_000);
+
+  it("-n 1 also keeps the single-run path (a group of 1 would flip the reliability page off its latest-k fallback)", async () => {
+    const dir = await fixtureRepo(scenarioWithRuns(5));
+    process.chdir(dir);
+    await run("scenarios/scn.md", "-n", "1");
+
+    expect(runTrialGroup).not.toHaveBeenCalled();
+    expect(runScenarioHosted).toHaveBeenCalledTimes(1);
+  }, 30_000);
+
+  it("the group exit code propagates as the command's exit code", async () => {
+    vi.mocked(runTrialGroup).mockResolvedValueOnce({
+      groupId: "grp_test",
+      rows: [],
+      exitCode: 1,
+      reliabilityUrl: "https://app.pome.sh/runs/task/x",
+    });
+    const dir = await fixtureRepo(SCENARIO);
+    process.chdir(dir);
+    await run("scenarios/scn.md", "-n", "2");
+    expect(process.exitCode).toBe(1);
+  }, 30_000);
+});

--- a/cli/test/unit/runner/groupRender.test.ts
+++ b/cli/test/unit/runner/groupRender.test.ts
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-636 — pure terminal rendering for `pome run -n k` trial groups,
+// matching the design-of-record (CLI moments.dc.html moment 04):
+//
+//   -n sets how many isolated trials to run · the agent command comes from pome.config.json
+//   provisioning 5 isolated github twins … ready
+//   spawning agent <cmd> · from pome.config.json …
+//   trial 1  ✓  100      14.3s
+//   trial 3  ✗  58       15.9s  <failing criteria summary>
+//   trial 5  ⚠  errored         <reason> — excluded
+//   ─────
+//   2 of 4 passed · 1 errored, excluded from the fraction
+//   <failing-criterion phrase> failed in 2 of 4 — start there
+//   full trace, per-criterion diffs, and the trial spread:
+//   → <reliability page url>
+//
+// Trial verdicts are NUMERIC SCORES (not words — that vocabulary belongs to
+// `pome demo`); errored rows show no duration and are excluded from the
+// fraction's denominator.
+
+import { describe, expect, it } from "vitest";
+import {
+  flagHintLine,
+  groupExitCode,
+  groupSummaryLines,
+  mostCommonFailedCriterion,
+  provisioningLine,
+  shortReason,
+  spawningAgentLine,
+  trialRowLine,
+  type TrialRow,
+} from "../../../src/runner/groupRender.js";
+
+const completed = (
+  score: number,
+  passed: boolean,
+  seconds: number,
+  note?: string,
+): TrialRow => ({ kind: "completed", score, passed, seconds, note });
+const errored = (reason: string): TrialRow => ({ kind: "errored", reason });
+
+describe("group header lines (moment 04)", () => {
+  it("renders the -n hint naming where the agent command came from", () => {
+    expect(flagHintLine("pome.config.json")).toBe(
+      "-n sets how many isolated trials to run · the agent command comes from pome.config.json",
+    );
+    expect(flagHintLine("--agent")).toBe(
+      "-n sets how many isolated trials to run · the agent command comes from --agent",
+    );
+  });
+
+  it("renders the provisioning line for k twins", () => {
+    expect(provisioningLine(5, ["github"])).toBe(
+      "provisioning 5 isolated github twins … ready",
+    );
+  });
+
+  it("renders the spawning-agent line with the command and its source", () => {
+    expect(
+      spawningAgentLine("npx tsx examples/agents/triage-agent.ts", "pome.config.json"),
+    ).toBe(
+      "spawning agent npx tsx examples/agents/triage-agent.ts · from pome.config.json …",
+    );
+  });
+});
+
+describe("trialRowLine (numeric scores, moment 04 column shape)", () => {
+  it("renders a passing trial with score and duration", () => {
+    expect(trialRowLine(1, completed(100, true, 14.3))).toBe(
+      "trial 1  ✓  100      14.3s",
+    );
+    expect(trialRowLine(2, completed(96, true, 12.1))).toBe(
+      "trial 2  ✓  96       12.1s",
+    );
+  });
+
+  it("renders a failing trial with the failing criteria summary", () => {
+    expect(
+      trialRowLine(3, completed(58, false, 15.9, "assignee never set · severity under-rated")),
+    ).toBe("trial 3  ✗  58       15.9s  assignee never set · severity under-rated");
+  });
+
+  it("renders a failing trial without a note when the cloud sent no criteria results", () => {
+    expect(trialRowLine(4, completed(74, false, 13.5))).toBe(
+      "trial 4  ✗  74       13.5s",
+    );
+  });
+
+  it("renders an errored trial with no duration, reason, and the excluded marker", () => {
+    expect(trialRowLine(5, errored("twin provision timeout"))).toBe(
+      "trial 5  ⚠  errored         twin provision timeout — excluded",
+    );
+  });
+});
+
+describe("groupSummaryLines (errored trials excluded from the fraction)", () => {
+  const url = "https://app.pome.sh/runs/task/01-bug-happy-path";
+
+  it("renders the moment-04 summary: fraction over completed trials only", () => {
+    const rows = [
+      completed(100, true, 14.3),
+      completed(96, true, 12.1),
+      completed(58, false, 15.9, "n"),
+      completed(74, false, 13.5, "n"),
+      errored("twin provision timeout"),
+    ];
+    expect(
+      groupSummaryLines({
+        rows,
+        failingCriterionPhrase: "severity check",
+        failingCriterionCount: 2,
+        reliabilityUrl: url,
+      }),
+    ).toEqual([
+      "─────",
+      "2 of 4 passed · 1 errored, excluded from the fraction",
+      "severity check failed in 2 of 4 — start there",
+      "",
+      "full trace, per-criterion diffs, and the trial spread:",
+      `→ ${url}`,
+    ]);
+  });
+
+  it("omits the errored clause and start-there line when not applicable", () => {
+    const rows = [completed(100, true, 3), completed(100, true, 4)];
+    expect(groupSummaryLines({ rows, reliabilityUrl: url })).toEqual([
+      "─────",
+      "2 of 2 passed",
+      "",
+      "full trace, per-criterion diffs, and the trial spread:",
+      `→ ${url}`,
+    ]);
+  });
+
+  it("says so honestly when no trial completed, and prints no dashboard link", () => {
+    const rows = [errored("agent timed out"), errored("agent timed out")];
+    expect(groupSummaryLines({ rows, reliabilityUrl: url })).toEqual([
+      "─────",
+      "no trials completed · 2 errored, excluded from the fraction",
+    ]);
+  });
+});
+
+describe("groupExitCode ([DECISION]: 0 iff ≥1 completed AND all completed passed)", () => {
+  it("0 when every completed trial passed (errored rows don't block)", () => {
+    expect(groupExitCode([completed(100, true, 1), errored("x")])).toBe(0);
+    expect(groupExitCode([completed(100, true, 1), completed(96, true, 2)])).toBe(0);
+  });
+
+  it("1 when any completed trial failed", () => {
+    expect(groupExitCode([completed(100, true, 1), completed(58, false, 2)])).toBe(1);
+  });
+
+  it("2 when no trial completed at all", () => {
+    expect(groupExitCode([errored("a"), errored("b")])).toBe(2);
+    expect(groupExitCode([])).toBe(2);
+  });
+});
+
+describe("failure aggregation helpers", () => {
+  it("mostCommonFailedCriterion picks the modal criterion text", () => {
+    const got = mostCommonFailedCriterion([
+      "Severity is set correctly",
+      "Assignee is set",
+      "Severity is set correctly",
+    ]);
+    expect(got?.count).toBe(2);
+    expect(got?.phrase).toContain("severity is set correctly");
+  });
+
+  it("mostCommonFailedCriterion returns null with no failures", () => {
+    expect(mostCommonFailedCriterion([])).toBeNull();
+  });
+
+  it("shortReason flattens whitespace and truncates long reasons", () => {
+    expect(shortReason("boom\n  twice")).toBe("boom twice");
+    expect(shortReason("x".repeat(100))).toBe(`${"x".repeat(69)}…`);
+  });
+});

--- a/cli/test/unit/runner/runScenarioHosted.signals-containment.test.ts
+++ b/cli/test/unit/runner/runScenarioHosted.signals-containment.test.ts
@@ -99,6 +99,9 @@ describe("runScenarioHosted signals redaction containment", () => {
       async requestSignalsUploadUrl() {
         throw new HostedOrchError("no route");
       },
+      async abandonSession() {
+        throw new HostedOrchError("no abandon stubbed (single-run path never calls it)");
+      },
       async deleteSession() {
         // no-op
       },

--- a/cli/test/unit/runner/runScenarioHosted.upload.test.ts
+++ b/cli/test/unit/runner/runScenarioHosted.upload.test.ts
@@ -141,6 +141,9 @@ function makeStubClient({
       (async () => {
         throw new HostedOrchError("no signals-upload-url stubbed");
       }),
+    async abandonSession() {
+      throw new HostedOrchError("no abandon stubbed (single-run path never calls it)");
+    },
     async deleteSession() {
       // no-op
     },

--- a/cli/test/unit/runner/runTrialGroup.test.ts
+++ b/cli/test/unit/runner/runTrialGroup.test.ts
@@ -1,0 +1,494 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-636 — `pome run -n k` group orchestration, unit level.
+//
+// Locked decisions under test:
+//   - all k sessions minted UPFRONT with ONE shared `grp_` + nanoid21 id
+//     stamped on every mint body, and a FRESH idempotency key per mint;
+//   - trials run SEQUENTIALLY against the pre-minted sessions
+//     (runScenarioHosted stays the isolation unit, abandonOnFailure on);
+//   - an errored trial renders as an errored row and the remaining trials
+//     continue; errored rows are excluded from the verdict fraction;
+//   - group exit code: 0 iff ≥1 trial completed AND every completed trial
+//     passed; 1 when a completed trial failed; 2 when nothing completed;
+//   - the default hosted client carries the explicit 60s finalize timeout.
+
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createHostedClient, type HostedClient } from "../../../src/hosted/client.js";
+import { HostedOrchError, HostedTrialError } from "../../../src/hosted/errors.js";
+import {
+  GROUP_FINALIZE_TIMEOUT_MS,
+  runTrialGroup,
+} from "../../../src/runner/runTrialGroup.js";
+import type {
+  RunScenarioHostedOptions,
+  RunScenarioHostedResult,
+} from "../../../src/runner/runScenarioHosted.js";
+import type { Score } from "../../../src/score/view.js";
+
+vi.mock("../../../src/hosted/client.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../../src/hosted/client.js")>();
+  return { ...original, createHostedClient: vi.fn(original.createHostedClient) };
+});
+
+const SCENARIO =
+  "# Trivial\n\n## Prompt\nPretend prompt.\n\n## Success Criteria\n- [D] No unsupported endpoint was called\n";
+
+async function scenarioFixture(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "pome-group-"));
+  const path = join(dir, "scn.md");
+  await writeFile(path, SCENARIO, "utf8");
+  return path;
+}
+
+interface FakeCloud {
+  client: HostedClient;
+  events: string[];
+  mints: Array<{ groupId?: string; idempotencyKey?: string; twins: string[] }>;
+  deleted: string[];
+  abandoned: Array<{ sessionId: string; errorCode?: string }>;
+  failMintAt?: number;
+}
+
+function makeFakeClient(overrides: Partial<FakeCloud> = {}): FakeCloud {
+  const events: string[] = [];
+  const mints: FakeCloud["mints"] = [];
+  const deleted: string[] = [];
+  const abandoned: FakeCloud["abandoned"] = [];
+  const cloud: FakeCloud = {
+    events,
+    mints,
+    deleted,
+    abandoned,
+    ...overrides,
+    client: null as unknown as HostedClient,
+  };
+  cloud.client = {
+    async createSession(input) {
+      if (cloud.failMintAt !== undefined && mints.length + 1 === cloud.failMintAt) {
+        throw new HostedOrchError("twin provision timeout");
+      }
+      mints.push({
+        groupId: input.groupId,
+        idempotencyKey: input.idempotencyKey,
+        twins: input.twins,
+      });
+      events.push("mint");
+      const n = mints.length;
+      return {
+        session_id: `ses_${n}`,
+        twin_url: `https://twins.example/s/ses_${n}`,
+        expires_at: new Date(Date.now() + 600_000).toISOString(),
+        agent_token: `tok_${n}`,
+        provider_credentials: {},
+        openapi_url: "https://twins.example/openapi.json",
+      };
+    },
+    async createEvalSession() {
+      throw new Error("not used");
+    },
+    async listSessions() {
+      return [];
+    },
+    async getSession() {
+      throw new Error("not used");
+    },
+    async fetchState() {
+      return {};
+    },
+    async fetchEvents() {
+      return [];
+    },
+    async finalize() {
+      throw new Error("not used — trials are injected");
+    },
+    async submitResult() {
+      throw new Error("not used");
+    },
+    async requestEventsUploadUrl() {
+      throw new Error("not used");
+    },
+    async requestStateUploadUrl() {
+      throw new Error("not used");
+    },
+    async requestSignalsUploadUrl() {
+      throw new Error("not used");
+    },
+    async abandonSession(sessionId, input) {
+      abandoned.push({ sessionId, errorCode: input?.errorCode });
+      return {
+        session_id: sessionId,
+        state: "failed",
+        error_code: input?.errorCode ?? null,
+        abandoned: true,
+      };
+    },
+    async deleteSession(sessionId) {
+      deleted.push(sessionId);
+    },
+  };
+  return cloud;
+}
+
+function scoreOf(satisfaction: number, failedTexts: string[] = []): Score {
+  return {
+    satisfaction,
+    passed: failedTexts.length > 0 ? 1 : 2,
+    failed: failedTexts.length,
+    skipped: 0,
+    errored: 0,
+    total_required: 2,
+    evaluated: true,
+    can_pass: true,
+    results: failedTexts.map((text) => ({
+      criterion: { type: "P" as const, text },
+      outcome: "failed" as const,
+      passed: false,
+      skipped: false,
+      reason: "not met",
+    })),
+    judge_model: "test-judge",
+    judge_tokens_in: null,
+    judge_tokens_out: null,
+  };
+}
+
+function trialResult(input: {
+  sessionId: string;
+  satisfaction: number;
+  exitCode: number;
+  durationMs: number;
+  failedTexts?: string[];
+}): RunScenarioHostedResult {
+  return {
+    runId: input.sessionId,
+    cloudRunId: `run_${input.sessionId}`,
+    cloudDashboardUrl: `https://app.example/runs/run_${input.sessionId}`,
+    score: scoreOf(input.satisfaction, input.failedTexts ?? []),
+    exitCode: input.exitCode,
+    durationMs: input.durationMs,
+    scenario: undefined as never,
+    artifacts: undefined as never,
+  };
+}
+
+beforeEach(() => {
+  vi.mocked(createHostedClient).mockClear();
+});
+
+describe("runTrialGroup — upfront minting (FDRS-636)", () => {
+  it("mints all k sessions upfront with one shared grp_ id and fresh idempotency keys, then runs trials sequentially", async () => {
+    const scenarioPath = await scenarioFixture();
+    const cloud = makeFakeClient();
+    const trialCalls: RunScenarioHostedOptions[] = [];
+
+    const result = await runTrialGroup({
+      scenarioPath,
+      agentCommand: "node agent.js",
+      trials: 3,
+      hosted: { baseUrl: "https://api.example", apiKey: "pme_k" },
+      dashboardBaseUrl: "https://app.pome.sh",
+      agentModel: "claude-x",
+      out: () => {},
+      client: cloud.client,
+      runScenarioHostedFn: async (options) => {
+        trialCalls.push(options);
+        cloud.events.push("trial");
+        return trialResult({
+          sessionId: options.premintedSession!.session_id,
+          satisfaction: 100,
+          exitCode: 0,
+          durationMs: 1200,
+        });
+      },
+    });
+
+    // All mints happen before the first trial (design: "provisioning 5
+    // isolated github twins … ready" precedes any agent spawn).
+    expect(cloud.events).toEqual(["mint", "mint", "mint", "trial", "trial", "trial"]);
+
+    // One shared grp_ + nanoid21 id on EVERY mint body.
+    expect(result.groupId).toMatch(/^grp_[A-Za-z0-9_-]{21}$/);
+    expect(cloud.mints.map((m) => m.groupId)).toEqual([
+      result.groupId,
+      result.groupId,
+      result.groupId,
+    ]);
+
+    // Fresh idempotency key per trial mint.
+    const keys = cloud.mints.map((m) => m.idempotencyKey);
+    expect(keys.every((k) => typeof k === "string" && k.length > 0)).toBe(true);
+    expect(new Set(keys).size).toBe(3);
+
+    // Each trial got its own pre-minted session, in mint order, with the
+    // group client + abandon-on-failure semantics and the forwarded model.
+    expect(trialCalls.map((c) => c.premintedSession?.session_id)).toEqual([
+      "ses_1",
+      "ses_2",
+      "ses_3",
+    ]);
+    for (const call of trialCalls) {
+      expect(call.abandonOnFailure).toBe(true);
+      expect(call.client).toBe(cloud.client);
+      expect(call.agentModel).toBe("claude-x");
+    }
+
+    expect(result.exitCode).toBe(0);
+    expect(result.rows).toHaveLength(3);
+  });
+
+  it("k=1 is never routed here — the group runner refuses it", async () => {
+    const scenarioPath = await scenarioFixture();
+    const cloud = makeFakeClient();
+    await expect(
+      runTrialGroup({
+        scenarioPath,
+        agentCommand: "node agent.js",
+        trials: 1,
+        hosted: { baseUrl: "https://api.example", apiKey: "pme_k" },
+        dashboardBaseUrl: "https://app.pome.sh",
+        out: () => {},
+        client: cloud.client,
+      }),
+    ).rejects.toThrow(/k=1|single/i);
+    expect(cloud.mints).toHaveLength(0);
+  });
+
+  it("a failed mint rolls back the already-minted sessions and rethrows before any trial runs", async () => {
+    const scenarioPath = await scenarioFixture();
+    const cloud = makeFakeClient({ failMintAt: 2 });
+    let trialsRun = 0;
+
+    await expect(
+      runTrialGroup({
+        scenarioPath,
+        agentCommand: "node agent.js",
+        trials: 3,
+        hosted: { baseUrl: "https://api.example", apiKey: "pme_k" },
+        dashboardBaseUrl: "https://app.pome.sh",
+        out: () => {},
+        client: cloud.client,
+        runScenarioHostedFn: async () => {
+          trialsRun += 1;
+          throw new Error("unreachable");
+        },
+      }),
+    ).rejects.toThrow(/twin provision timeout/);
+
+    expect(trialsRun).toBe(0);
+    expect(cloud.deleted).toEqual(["ses_1"]);
+  });
+});
+
+describe("runTrialGroup — errored trials (FDRS-636)", () => {
+  it("an errored trial renders as an errored row, the rest continue, and the fraction excludes it", async () => {
+    const scenarioPath = await scenarioFixture();
+    const cloud = makeFakeClient();
+    const out: string[] = [];
+
+    const result = await runTrialGroup({
+      scenarioPath,
+      agentCommand: "node agent.js",
+      trials: 3,
+      hosted: { baseUrl: "https://api.example", apiKey: "pme_k" },
+      dashboardBaseUrl: "https://app.pome.sh",
+      out: (line) => out.push(line),
+      client: cloud.client,
+      runScenarioHostedFn: async (options) => {
+        const sid = options.premintedSession!.session_id;
+        if (sid === "ses_2") {
+          throw new HostedTrialError("agent timed out", "agent_timeout");
+        }
+        return trialResult({
+          sessionId: sid,
+          satisfaction: 100,
+          exitCode: 0,
+          durationMs: 14_300,
+        });
+      },
+    });
+
+    const text = out.join("\n");
+    expect(text).toContain("trial 1  ✓  100      14.3s");
+    expect(text).toContain("trial 2  ⚠  errored         agent timed out — excluded");
+    expect(text).toContain("trial 3  ✓  100      14.3s");
+    expect(text).toContain("2 of 2 passed · 1 errored, excluded from the fraction");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a non-trial error (auth/orch mid-group) still renders as errored and later trials continue", async () => {
+    const scenarioPath = await scenarioFixture();
+    const cloud = makeFakeClient();
+    const out: string[] = [];
+
+    const result = await runTrialGroup({
+      scenarioPath,
+      agentCommand: "node agent.js",
+      trials: 2,
+      hosted: { baseUrl: "https://api.example", apiKey: "pme_k" },
+      dashboardBaseUrl: "https://app.pome.sh",
+      out: (line) => out.push(line),
+      client: cloud.client,
+      runScenarioHostedFn: async (options) => {
+        const sid = options.premintedSession!.session_id;
+        if (sid === "ses_1") throw new HostedOrchError("twin pod restarted\nmid-run");
+        return trialResult({ sessionId: sid, satisfaction: 96, exitCode: 0, durationMs: 12_100 });
+      },
+    });
+
+    const text = out.join("\n");
+    // Reason is flattened to one short line.
+    expect(text).toContain("trial 1  ⚠  errored         twin pod restarted mid-run — excluded");
+    expect(text).toContain("trial 2  ✓  96       12.1s");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("exit 1 when a completed trial failed; failing criteria feed the start-there line", async () => {
+    const scenarioPath = await scenarioFixture();
+    const cloud = makeFakeClient();
+    const out: string[] = [];
+
+    const result = await runTrialGroup({
+      scenarioPath,
+      agentCommand: "node agent.js",
+      trials: 3,
+      hosted: { baseUrl: "https://api.example", apiKey: "pme_k" },
+      dashboardBaseUrl: "https://app.pome.sh",
+      out: (line) => out.push(line),
+      client: cloud.client,
+      runScenarioHostedFn: async (options) => {
+        const sid = options.premintedSession!.session_id;
+        if (sid === "ses_1") {
+          return trialResult({ sessionId: sid, satisfaction: 100, exitCode: 0, durationMs: 1000 });
+        }
+        return trialResult({
+          sessionId: sid,
+          satisfaction: 58,
+          exitCode: 1,
+          durationMs: 15_900,
+          failedTexts: ["Severity is set correctly"],
+        });
+      },
+    });
+
+    const text = out.join("\n");
+    expect(text).toContain("trial 2  ✗  58       15.9s  severity is set correctly");
+    expect(text).toContain("1 of 3 passed");
+    expect(text).toContain("severity is set correctly failed in 2 of 3 — start there");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("exit 2 when no trial completed", async () => {
+    const scenarioPath = await scenarioFixture();
+    const cloud = makeFakeClient();
+
+    const result = await runTrialGroup({
+      scenarioPath,
+      agentCommand: "node agent.js",
+      trials: 2,
+      hosted: { baseUrl: "https://api.example", apiKey: "pme_k" },
+      dashboardBaseUrl: "https://app.pome.sh",
+      out: () => {},
+      client: cloud.client,
+      runScenarioHostedFn: async () => {
+        throw new HostedTrialError("agent preflight failed", "preflight_failed");
+      },
+    });
+
+    expect(result.rows.every((r) => r.kind === "errored")).toBe(true);
+    expect(result.exitCode).toBe(2);
+  });
+});
+
+describe("runTrialGroup — dashboard link + client construction", () => {
+  it("derives the reliability link from the dashboard base + /runs/task/<taskName>", async () => {
+    const scenarioPath = await scenarioFixture();
+    const cloud = makeFakeClient();
+    const out: string[] = [];
+
+    const result = await runTrialGroup({
+      scenarioPath,
+      agentCommand: "node agent.js",
+      trials: 2,
+      hosted: { baseUrl: "https://api.example", apiKey: "pme_k" },
+      dashboardBaseUrl: "https://app.pome.sh/",
+      out: (line) => out.push(line),
+      client: cloud.client,
+      runScenarioHostedFn: async (options) =>
+        trialResult({
+          sessionId: options.premintedSession!.session_id,
+          satisfaction: 100,
+          exitCode: 0,
+          durationMs: 1000,
+        }),
+    });
+
+    // Route shape from the dashboard app: /runs/task/[taskName]; slug of the
+    // fixture file is "scn". No double slash from the trailing base slash.
+    expect(result.reliabilityUrl).toBe("https://app.pome.sh/runs/task/scn");
+    expect(out.join("\n")).toContain("→ https://app.pome.sh/runs/task/scn");
+  });
+
+  it("appends ?agent=<agentId> when pome.config.json pins one (page groups per agent)", async () => {
+    const scenarioPath = await scenarioFixture();
+    const dir = join(scenarioPath, "..");
+    await writeFile(
+      join(dir, "pome.config.json"),
+      JSON.stringify({ agentId: "agt_123", agent: { command: "node agent.js" } }),
+      "utf8",
+    );
+    const cloud = makeFakeClient();
+
+    const result = await runTrialGroup({
+      scenarioPath,
+      agentCommand: "node agent.js",
+      trials: 2,
+      hosted: { baseUrl: "https://api.example", apiKey: "pme_k" },
+      dashboardBaseUrl: "https://app.pome.sh",
+      out: () => {},
+      client: cloud.client,
+      runScenarioHostedFn: async (options) =>
+        trialResult({
+          sessionId: options.premintedSession!.session_id,
+          satisfaction: 100,
+          exitCode: 0,
+          durationMs: 1000,
+        }),
+    });
+
+    expect(result.reliabilityUrl).toBe(
+      "https://app.pome.sh/runs/task/scn?agent=agt_123",
+    );
+  });
+
+  it("constructs the default client with the explicit 60s finalize timeout ([DECISION])", async () => {
+    const scenarioPath = await scenarioFixture();
+    const fake = makeFakeClient();
+    vi.mocked(createHostedClient).mockReturnValueOnce(fake.client);
+
+    await runTrialGroup({
+      scenarioPath,
+      agentCommand: "node agent.js",
+      trials: 2,
+      hosted: { baseUrl: "https://api.example", apiKey: "pme_k" },
+      dashboardBaseUrl: "https://app.pome.sh",
+      out: () => {},
+      runScenarioHostedFn: async (options) =>
+        trialResult({
+          sessionId: options.premintedSession!.session_id,
+          satisfaction: 100,
+          exitCode: 0,
+          durationMs: 1000,
+        }),
+    });
+
+    expect(GROUP_FINALIZE_TIMEOUT_MS).toBe(60_000);
+    expect(createHostedClient).toHaveBeenCalledWith({
+      baseUrl: "https://api.example",
+      apiKey: "pme_k",
+      timeoutMs: 60_000,
+    });
+  });
+});

--- a/cli/test/unit/runner/trialCount.test.ts
+++ b/cli/test/unit/runner/trialCount.test.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-636 — `pome run -n k` trial-count resolution.
+//
+// [DECISION 2026-07-05]: -n is an integer 1..20 on the hosted run path;
+// the default comes from the scenario config's `runs` field (which
+// scenarioConfigSchema already parses, defaulting 1, but nothing consumed
+// until now); both are capped at 20.
+
+import { describe, expect, it } from "vitest";
+import { HostedUsageError } from "../../../src/hosted/errors.js";
+import {
+  MAX_TRIALS,
+  effectiveTrialCount,
+  parseTrialsFlag,
+} from "../../../src/runner/trialCount.js";
+
+describe("parseTrialsFlag (FDRS-636)", () => {
+  it("accepts integers 1..20", () => {
+    expect(parseTrialsFlag("1")).toBe(1);
+    expect(parseTrialsFlag("5")).toBe(5);
+    expect(parseTrialsFlag("20")).toBe(20);
+  });
+
+  it("rejects 0, negatives, and >20 as usage errors (documented exit 5)", () => {
+    expect(() => parseTrialsFlag("0")).toThrow(HostedUsageError);
+    expect(() => parseTrialsFlag("-3")).toThrow(HostedUsageError);
+    expect(() => parseTrialsFlag("21")).toThrow(HostedUsageError);
+  });
+
+  it("rejects non-integers and trailing garbage", () => {
+    expect(() => parseTrialsFlag("abc")).toThrow(HostedUsageError);
+    expect(() => parseTrialsFlag("2.5")).toThrow(HostedUsageError);
+    expect(() => parseTrialsFlag("5x")).toThrow(HostedUsageError);
+    expect(() => parseTrialsFlag("")).toThrow(HostedUsageError);
+  });
+
+  it("names the expected range in the error message", () => {
+    expect(() => parseTrialsFlag("999")).toThrow(/1-20/);
+  });
+});
+
+describe("effectiveTrialCount (FDRS-636)", () => {
+  it("-n overrides the scenario config's runs field", () => {
+    expect(effectiveTrialCount(5, 2)).toBe(5);
+    expect(effectiveTrialCount(1, 7)).toBe(1);
+  });
+
+  it("defaults to config runs when no flag is given", () => {
+    expect(effectiveTrialCount(undefined, 1)).toBe(1);
+    expect(effectiveTrialCount(undefined, 3)).toBe(3);
+  });
+
+  it("caps the config default at 20", () => {
+    expect(effectiveTrialCount(undefined, 50)).toBe(MAX_TRIALS);
+    expect(effectiveTrialCount(undefined, 20)).toBe(20);
+  });
+
+  it("MAX_TRIALS is the locked cap of 20", () => {
+    expect(MAX_TRIALS).toBe(20);
+  });
+});


### PR DESCRIPTION
<!-- Part of FDRS-636 — pairs with pome-cloud#208 (merged: sessions-side reliability read + abandon route) and pome-cloud#210 (in review: live-mint group_id persistence). The ticket closes after the paired cloud PR lands and a live -n run verifies end-to-end. -->

## What
`pome run <task> -n k` (1..20; config `runs` field wired as the default, capped 20): mints all k sessions upfront with one shared `grp_<nanoid21>` + a fresh `idempotency_key` per mint, runs trials sequentially through the existing per-trial isolation unit (new additive `premintedSession` seam on `runScenarioHosted`; each trial's `finally` still DELETEs its own session), renders the moment-04 verdict table (numeric scores, errored rows excluded from the fraction, "start there" line, reliability-page handoff link), and exits 0 iff ≥1 trial completed and every completed trial passed (1 completed-fail / 2 none-completed; documented in `src/hosted/errors.ts` + help text). Crashed/hung/preflight-failed trials POST `/v1/sessions/:id/abandon` with a machine `error_code` BEFORE teardown DELETE (ordering matters: DELETE flips the row terminal) and never finalize — no fabricated verdicts.

## Why
FDRS-636 CLI half per its 2026-07-05 [DECISION]. k=1 behavior is byte-identical to today (no group stamped — a group of 1 would kick the reliability page off its implicit latest-k fallback).

## Notes for reviewer
- TDD red-first: 59 new tests (455/455 total incl. a stub-cloud e2e proving shared group id, distinct idempotency keys, mints-before-first-spawn, abandon-without-finalize for the crashed trial, abandon-before-DELETE ordering); typecheck, `gate:no-eval`, build, changeset all green. Adversarially verified; the one confirmed issue (hung preflight misclassified as `agent_timeout` with an overstated duration) was fixed in `f372ff5` with a regression test.
- Sending `group_id` on the mint body is safe against a pre-#210 cloud (non-strict schema strips it silently) — no deploy-order coupling.
- Interpretation of record: one group per SCENARIO FILE per invocation (`pome run <dir> -n k` gets a group per file) — a group is k trials of ONE task; a cross-task group would corrupt the reliability view.
- Deferred, flagged in-code: bounded trial parallelism (plan-quota semantics unresolved); mint-upfront vs session-TTL tension for large k with slow agents; abandon `error_code` vocabulary chosen here (`preflight_failed` / `agent_timeout` / `agent_exit_nonzero` / `trial_crashed`) — cloud renders codes verbatim; one-line group exit-code addendum for pome-cloud `docs/05-api-spec.md` rides pome-cloud#210.

## Review required
Yes — public OSS API (new `-n` flag + group semantics on the primary `pome run` surface).

### Founder briefing (3 min)
- **What changed:** `pome run -n 5` now produces a real trial group — five upfront session mints sharing one client-minted `grp_` id, sequential isolated trials, and a verdict table whose fraction counts only completed trials.
- **What it means for your repo / workflow:** your reliability page's real-group branch (#208) starts getting live groups the moment this + #210 land; crashed trials arrive as `failed` sessions with machine `error_code`s (vocabulary above) instead of silently expiring 20 minutes later.
- **The one thing you must know:** errored trials are abandoned and never finalized — the judge never sees them and no run row exists; if you ever see a scored run for a crashed trial, something is fabricating verdicts and that's a bug.