### PR TITLE
[FDRS-643] live-run fixes: tolerate code/model verdict vocab; bearer-aware deleteSession

### DIFF
--- a/cli/.changeset/fdrs-643-live-run-fixes.md
+++ b/cli/.changeset/fdrs-643-live-run-fixes.md
@@ -1,0 +1,9 @@
+---
+"pome-sh": patch
+---
+
+Live-run fixes from the first real `pome demo` round-trip (FDRS-643): the
+finalize-response reader now tolerates the unified `code`/`model` criterion
+vocabulary the post-W3 cloud judge emits (legacy `D`/`P` still accepted), and
+`deleteSession` sends the configured auth scheme instead of a hardcoded
+`x-api-key` header (demo teardown carries a bearer `demo_token`).

--- a/cli/src/hosted/client.ts
+++ b/cli/src/hosted/client.ts
@@ -597,7 +597,11 @@ export function createHostedClient(config: HostedClientConfig): HostedClient {
           `${config.baseUrl}/v1/sessions/${encodeURIComponent(sessionId)}`,
           {
             method: "DELETE",
-            headers: { "x-api-key": config.apiKey },
+            // authHeaders, not a hardcoded x-api-key: demo teardown carries a
+            // bearer demo_token (FDRS-643 live-run finding — the hardcoded
+            // header made every demo DELETE an opaque 404, silently swallowed
+            // by best-effort).
+            headers: authHeaders,
             signal: ctrl.signal,
           }
         );

--- a/cli/src/score/view.ts
+++ b/cli/src/score/view.ts
@@ -14,7 +14,14 @@
 // under FDRS-657; only the pure display model survives, moved out of the
 // `evaluator/` tree so the `no-eval-in-oss` gate can assert that tree is gone.
 
-import type { Criterion } from "../scenario/scenarioSchema.js";
+// Wire-side criterion, NOT the scenario-markdown one: cloud responses carry
+// the unified "code"/"model" vocabulary (legacy "D"/"P" tolerated) while
+// scenario files still parse [D]/[P] markers. This module renders CLOUD
+// verdicts, so it takes the wide wire shape (FDRS-643 live-run finding).
+import type { z } from "zod";
+import type { criterionSchema } from "../types/shared.js";
+
+type WireCriterion = z.infer<typeof criterionSchema>;
 
 // FDRS-591 + FDRS-611 — unified per-criterion outcome model as reported by the
 // cloud judge.
@@ -30,7 +37,7 @@ import type { Criterion } from "../scenario/scenarioSchema.js";
 export type CriterionOutcome = "passed" | "failed" | "skipped" | "errored";
 
 export type CriterionResult = {
-  criterion: Criterion;
+  criterion: WireCriterion;
   // FDRS-591/611: explicit four-state outcome. ADDITIVE + OPTIONAL — when
   // absent (older cloud producers) it is derived from `passed`/`skipped` via
   // `outcomeOf`.

--- a/cli/src/types/shared.ts
+++ b/cli/src/types/shared.ts
@@ -122,7 +122,13 @@ export function isLegacyEventRow(row: unknown): boolean {
 }
 
 export const criterionSchema = z.object({
-  type: z.enum(["D", "P"]),
+  // Tolerant reader across the naming unification (2026-07-02 [DECISION] /
+  // W3): legacy "D"/"P" and the unified "code"/"model" are the same two
+  // grader kinds. The post-W3 cloud judge emits "code"/"model" in finalize
+  // responses (pome-cloud services/judge.ts) — found live on the first
+  // `pome demo` round-trip (FDRS-643). Print-through is correct: the W3
+  // markers are `[code]`/`[model]`.
+  type: z.enum(["D", "P", "code", "model"]),
   text: z.string().min(1),
 });
 

--- a/cli/test/unit/hosted/client.test.ts
+++ b/cli/test/unit/hosted/client.test.ts
@@ -819,3 +819,79 @@ describe("HostedClient.deleteSession", () => {
     await expect(client.deleteSession("ses_missing", false)).rejects.toBeInstanceOf(HostedOrchError);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FDRS-643 live-run regressions (first real cloud round-trip, 2026-07-05)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("FDRS-643 live-run regressions", () => {
+  it("parses a finalize response whose criteria_results use the code/model vocabulary (post-W3 cloud)", async () => {
+    // The cloud judge emits the unified vocabulary (criterion.type
+    // "code"/"model") since shared-types 0.5.0; the response reader must
+    // tolerate BOTH vocabularies (found live: every demo trial errored
+    // "unexpected response shape: invalid_union").
+    mockFetch(async () =>
+      new Response(
+        JSON.stringify({
+          run_id: "run_w3",
+          score: 100,
+          judge_model: "google/gemini-2.5-flash",
+          dashboard_url: "https://app.pome.sh/runs/run_w3",
+          criteria_results: [
+            {
+              criterion: { type: "model", text: "labels applied correctly" },
+              passed: true,
+              skipped: false,
+              reason: "ok",
+              confidence: 0.9,
+              judge_model: "google/gemini-2.5-flash",
+            },
+            {
+              criterion: { type: "code", text: "no new labels created" },
+              passed: true,
+              skipped: false,
+              reason: "ok",
+            },
+          ],
+        }),
+        { status: 201, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const client = createHostedClient({ baseUrl: BASE, apiKey: KEY });
+    const out = await client.finalize("ses_abc", {
+      stopReason: "agent_exit_0",
+      exitCode: 0,
+      durationMs: 4321,
+      agentModel: "unknown",
+      agentSdk: null,
+      criteria: [],
+      scenarioName: "first-run-demo",
+      scenarioHash: "a".repeat(64),
+      scenarioPrompt: "p",
+      expectedBehavior: "e",
+      traceStorageKey: "team-tm_x/session-ses_abc/events.jsonl",
+    });
+    expect(out.criteria_results).toHaveLength(2);
+    expect(out.criteria_results?.[0]?.criterion.type).toBe("model");
+    expect(out.criteria_results?.[1]?.criterion.type).toBe("code");
+  });
+
+  it("sends Authorization: Bearer on DELETE when authScheme is bearer (demo teardown)", async () => {
+    let sawAuth: string | null = null;
+    let sawApiKey: string | null = null;
+    mockFetch(async (_url, init) => {
+      const headers = new Headers(init?.headers);
+      sawAuth = headers.get("authorization");
+      sawApiKey = headers.get("x-api-key");
+      return new Response(null, { status: 204 });
+    });
+    const client = createHostedClient({
+      baseUrl: BASE,
+      apiKey: "eyJhbGciOiJIUzI1NiJ9.eyJzaWQiOiJ4In0.c2ln",
+      authScheme: "bearer",
+    });
+    await client.deleteSession("ses_abc", false);
+    expect(sawAuth).toBe("Bearer eyJhbGciOiJIUzI1NiJ9.eyJzaWQiOiJ4In0.c2ln");
+    expect(sawApiKey).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- Part of FDRS-643 — second live-run fix wave (paired with pome-cloud#211, deployed v0.2.8). -->

## What
Two fixes found by the first real `pome demo` round-trips: (1) the finalize-response reader's `criterion.type` now tolerates the unified `code`/`model` vocabulary the post-W3 cloud judge emits (legacy `D`/`P` still accepted; `score/view` takes the wide wire shape — scenario-markdown parsing stays `[D]`/`[P]`); (2) `deleteSession` uses the client's `authHeaders` instead of a hardcoded `x-api-key`, so demo teardown's bearer `demo_token` works.

## Why
Live run #2 (post-v0.2.8): every trial errored `unexpected response shape: invalid_union` — the request side sends `D`/`P` (cloud tolerates), but the response comes back `code`/`model` and the CLI rejected it. The tolerant-reader principle from the naming unification was broken in exactly one spot: the CLI's own response schema. Bonus: printing the type through gives the W3 `[code]`/`[model]` markers for free.

## Notes for reviewer
- TDD: 2 regression tests red-first (a post-W3-shaped finalize response; DELETE header assertion under `authScheme: "bearer"`). 457/457 green, typecheck + `gate:no-eval` + build green, changeset (patch) included.
- Correction of an earlier claim: the suspected "all-errored demo exits 0" bug was a measurement artifact (`$?` after a `| tee` pipeline reads tee's exit) — `runDemo`'s exit logic was already correct, no change made.