### PR TITLE
[FDRS-645] bare pome run defaults to the demo task — that was ours, run yours

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pome-sh",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Digital-twin testing for AI agents — run scenarios against resettable local or hosted twins, record tool calls, and score the result.",
   "keywords": [
     "ai",

--- a/cli/src/cli/default-task.ts
+++ b/cli/src/cli/default-task.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-645 — "run yours": bare `pome run` (no path) defaults to the demo
+// task, closing the demo → run-yours seam (north-star moment 05: their
+// agent, k=5, the same task they just watched the demo agent attempt).
+//
+// The default is a USER-VISIBLE COPY at scenarios/first-run-demo.md, dropped
+// on first use from the packaged demo task (src/demo/first-run-demo.md plus
+// its compiled seed sidecar — the client parser requires the sidecar when a
+// prose ## Seed State section is present). The copy — never the canonical
+// packaged md — gains `runs: 5`, so the design's k=5 default rides the
+// existing scenario-config `runs` mechanism (an explicit -n still wins) and
+// the packaged md stays byte-identical to the server-owned judge definition
+// regenerated from it (pome-cloud#209 lockstep).
+//
+// The packaged md's maintainer comment (the CANONICAL/lockstep warning) is
+// swapped for a user-facing one in the copy: the copy is the user's file —
+// authenticated runs are judged against the criteria declared in it.
+
+import { existsSync } from "node:fs";
+import { copyFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { DEMO_TASK_NAME, demoTaskPath } from "../demo/task.js";
+
+/** Design default k for "run yours" (moment 05: "Their agent · k=5"). */
+export const DEFAULT_TASK_TRIALS = 5;
+
+export const DEFAULT_TASK_DIR = "scenarios";
+
+export const DEFAULT_TASK_FILENAME = `${DEMO_TASK_NAME}.md`;
+
+const USER_COPY_COMMENT = `<!--
+Copied into your project by \`pome run\` — the "run yours" default: the same
+task the demo agent just attempted, now for your agent. This copy is yours.
+Edit the prompt/criteria freely (your runs are judged against the criteria
+declared in this file), or delete it and the next bare \`pome run\` re-copies
+the original. Config pins runs: ${DEFAULT_TASK_TRIALS} — an explicit -n overrides it.
+-->`;
+
+/** The ## Config section's fenced yaml block: (heading + everything up to
+ *  and including the opening fence line)(fence body)(closing fence). The
+ *  gap between heading and fence never crosses into another ## section. */
+const CONFIG_FENCE_RE =
+  /(##[ \t]*config[^\n]*\n(?:(?!\n##[ \t])[\s\S])*?```(?:yaml)?[ \t]*\n)([\s\S]*?)(```)/i;
+
+export interface DefaultTaskResolution {
+  /** Absolute path of the task markdown to run. */
+  path: string;
+  /** Project-relative path, for terminal copy. */
+  relativePath: string;
+  /** True when this call dropped the copy (first use). */
+  copied: boolean;
+  /** False when the packaged md's Config fence couldn't be located, so the
+   *  k=5 default could not be pinned into the copy. */
+  trialsApplied: boolean;
+}
+
+/** Pin `runs: N` inside the ## Config yaml fence. No-op (applied=true) when
+ *  the fence already sets runs; applied=false when no fence exists. */
+export function withDefaultTrials(
+  source: string,
+  runs: number = DEFAULT_TASK_TRIALS,
+): { content: string; applied: boolean } {
+  const match = CONFIG_FENCE_RE.exec(source);
+  if (!match) return { content: source, applied: false };
+  const [whole, head, body, tail] = match;
+  if (/^[ \t]*runs[ \t]*:/m.test(body)) return { content: source, applied: true };
+  const glue = body === "" || body.endsWith("\n") ? "" : "\n";
+  const content =
+    source.slice(0, match.index) +
+    head +
+    body +
+    `${glue}runs: ${runs}\n` +
+    tail +
+    source.slice(match.index + whole.length);
+  return { content, applied: true };
+}
+
+/** Swap the packaged maintainer preamble (the CANONICAL/lockstep warning —
+ *  true of the packaged md, wrong and confusing in the user's copy) for the
+ *  user-facing comment. When no preamble exists, insert after the H1. */
+export function withUserCopyComment(source: string): string {
+  const commentRe = /<!--[\s\S]*?-->/;
+  const comment = commentRe.exec(source);
+  const firstSection = source.search(/^##[ \t]/m);
+  if (comment && (firstSection === -1 || comment.index < firstSection)) {
+    return (
+      source.slice(0, comment.index) +
+      USER_COPY_COMMENT +
+      source.slice(comment.index + comment[0].length)
+    );
+  }
+  const h1 = /^#[ \t].+$/m.exec(source);
+  if (!h1) return `${USER_COPY_COMMENT}\n\n${source}`;
+  const insertAt = h1.index + h1[0].length;
+  return `${source.slice(0, insertAt)}\n\n${USER_COPY_COMMENT}${source.slice(insertAt)}`;
+}
+
+/**
+ * Resolve the bare-`pome run` default task, dropping the user copy on first
+ * use. Never clobbers an existing scenarios/first-run-demo.md — that file is
+ * the user's (possibly edited) task from a prior bare run.
+ */
+export async function ensureDefaultTask(
+  cwd: string = process.cwd(),
+): Promise<DefaultTaskResolution> {
+  const relativePath = join(DEFAULT_TASK_DIR, DEFAULT_TASK_FILENAME);
+  const target = join(cwd, relativePath);
+  if (existsSync(target)) {
+    return { path: target, relativePath, copied: false, trialsApplied: true };
+  }
+
+  const packagedMd = demoTaskPath();
+  const packagedSeed = packagedMd.replace(/\.md$/, ".seed.json");
+  if (!existsSync(packagedSeed)) {
+    throw new Error(
+      `Packaged demo seed not found at ${packagedSeed}. This is a packaging ` +
+        "bug — scripts/copy-prompts.mjs ships src/demo/ (task md + seed " +
+        "sidecar) into dist/.",
+    );
+  }
+
+  const raw = await readFile(packagedMd, "utf8");
+  const pinned = withDefaultTrials(withUserCopyComment(raw));
+
+  await mkdir(join(cwd, DEFAULT_TASK_DIR), { recursive: true });
+  // Seed first, md last: the md's presence is the commit point (the parser
+  // hard-requires the sidecar once the md's prose ## Seed State is seen), so
+  // a crash between the two writes never strands a half-usable default.
+  await copyFile(packagedSeed, target.replace(/\.md$/, ".seed.json"));
+  try {
+    // "wx": never overwrite — if a concurrent run raced the copy in, theirs
+    // wins and this invocation just runs it.
+    await writeFile(target, pinned.content, { encoding: "utf8", flag: "wx" });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "EEXIST") {
+      return { path: target, relativePath, copied: false, trialsApplied: true };
+    }
+    throw err;
+  }
+  return { path: target, relativePath, copied: true, trialsApplied: pinned.applied };
+}
+
+export function copyAnnounceLine(res: DefaultTaskResolution): string {
+  return `copied the demo task into ${res.relativePath} — this copy is yours to edit`;
+}
+
+/** Printed when the Config fence couldn't be found in the packaged md, so
+ *  the copy runs k=1 unless the user passes -n (honest, never silent). */
+export function trialsPinFallbackLine(): string {
+  return `couldn't pin runs: ${DEFAULT_TASK_TRIALS} in the copy — pass -n ${DEFAULT_TASK_TRIALS} for the design default`;
+}
+
+/** Moment-05 frame ("that was ours, run yours"), printed once the doctor
+ *  gate and credential resolution have passed, ahead of the run output. */
+export function runYoursFrameLines(): string[] {
+  return [
+    `run yours · ${DEMO_TASK_NAME}`,
+    "that was ours — now it's your agent on the same task the demo just ran.",
+  ];
+}

--- a/cli/src/cli/default-task.ts
+++ b/cli/src/cli/default-task.ts
@@ -16,10 +16,11 @@
 // swapped for a user-facing one in the copy: the copy is the user's file —
 // authenticated runs are judged against the criteria declared in it.
 
-import { existsSync } from "node:fs";
+import { constants, existsSync, statSync } from "node:fs";
 import { copyFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { DEMO_TASK_NAME, demoTaskPath } from "../demo/task.js";
+import { HostedUsageError } from "../hosted/errors.js";
 
 /** Design default k for "run yours" (moment 05: "Their agent · k=5"). */
 export const DEFAULT_TASK_TRIALS = 5;
@@ -109,6 +110,15 @@ export async function ensureDefaultTask(
     return { path: target, relativePath, copied: false, trialsApplied: true };
   }
 
+  // A `scenarios` path that exists as a FILE would make the mkdir below
+  // throw a raw EEXIST (exit 2). Name the actual problem as a usage error.
+  const dir = join(cwd, DEFAULT_TASK_DIR);
+  if (existsSync(dir) && !statSync(dir).isDirectory()) {
+    throw new HostedUsageError(
+      `\`${DEFAULT_TASK_DIR}\` exists as a file in this project — the bare \`pome run\` default drops its task into a ${DEFAULT_TASK_DIR}/ directory. Move the file aside, or pass a task path explicitly.`,
+    );
+  }
+
   const packagedMd = demoTaskPath();
   const packagedSeed = packagedMd.replace(/\.md$/, ".seed.json");
   if (!existsSync(packagedSeed)) {
@@ -122,11 +132,21 @@ export async function ensureDefaultTask(
   const raw = await readFile(packagedMd, "utf8");
   const pinned = withDefaultTrials(withUserCopyComment(raw));
 
-  await mkdir(join(cwd, DEFAULT_TASK_DIR), { recursive: true });
+  await mkdir(dir, { recursive: true });
   // Seed first, md last: the md's presence is the commit point (the parser
   // hard-requires the sidecar once the md's prose ## Seed State is seen), so
   // a crash between the two writes never strands a half-usable default.
-  await copyFile(packagedSeed, target.replace(/\.md$/, ".seed.json"));
+  // COPYFILE_EXCL: NO file under scenarios/ is ever overwritten — a user who
+  // deleted only the md but kept an edited seed keeps their seed.
+  try {
+    await copyFile(
+      packagedSeed,
+      target.replace(/\.md$/, ".seed.json"),
+      constants.COPYFILE_EXCL,
+    );
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+  }
   try {
     // "wx": never overwrite — if a concurrent run raced the copy in, theirs
     // wins and this invocation just runs it.

--- a/cli/src/cli/docs-topics.ts
+++ b/cli/src/cli/docs-topics.ts
@@ -83,7 +83,7 @@ export const DOCS_TOPICS: DocsTopic[] = [
     id: "cli-run",
     title: "pome run",
     path: "/docs/cli/run",
-    keywords: ["run", "scenario", "agent", "flags", "artifacts"],
+    keywords: ["run", "scenario", "agent", "flags", "artifacts", "default", "demo task", "run yours"],
   },
   {
     id: "cli-session",

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -32,6 +32,13 @@ import { runScenariosCommand } from "./scenarios.js";
 import { runEvalCommand } from "./eval.js";
 import { runSkillsInstall } from "./skills.js";
 import {
+  copyAnnounceLine,
+  ensureDefaultTask,
+  runYoursFrameLines,
+  trialsPinFallbackLine,
+  type DefaultTaskResolution,
+} from "./default-task.js";
+import {
   findTwin,
   runnableScenarios,
 } from "./scenarios-catalog.js";
@@ -527,7 +534,10 @@ export function createProgram() {
 
   program
     .command("run")
-    .argument("<path>", "Scenario markdown file or directory")
+    .argument(
+      "[path]",
+      'Task markdown file or directory. Omit to run the demo task ("that was ours, run yours"): scenarios/first-run-demo.md is dropped into your project on first use with runs: 5 pinned.',
+    )
     .option("--agent <command>", "Agent command to run")
     .option(
       "-n, --trials <count>",
@@ -557,11 +567,11 @@ export function createProgram() {
       "Self-host: run against an in-process twin and CAPTURE a raw trace only (an audit log — no score, no verdict, no judge). A verdict comes from the cloud: run `pome eval <run-dir>` on the captured trace, or `pome login` and run against Pome cloud.",
     )
     .description(
-      "Run one or more Pome scenarios. Refuses to start if the doctor wiring checks fail (see `pome doctor`); there is no --force.",
+      'Run one or more Pome tasks. With no path, runs the demo task (scenarios/first-run-demo.md, copied into your project on first use — "that was ours, run yours"). Refuses to start if the doctor wiring checks fail (see `pome doctor`); there is no --force.',
     )
     .action(
       async (
-        target: string,
+        target: string | undefined,
         options: {
           agent?: string;
           trials?: string;
@@ -593,6 +603,25 @@ export function createProgram() {
             process.exitCode = exitCodeFor(err);
             return;
           }
+        }
+
+        // FDRS-645 — "run yours": bare `pome run` defaults to the demo task
+        // via a user-visible copy (scenarios/first-run-demo.md, dropped on
+        // first use; its Config pins runs: 5 so an explicit -n still wins).
+        // The moment-05 frame prints later, once the doctor + credential
+        // gates have passed.
+        let defaultTask: DefaultTaskResolution | null = null;
+        if (target === undefined) {
+          try {
+            defaultTask = await ensureDefaultTask();
+          } catch (err) {
+            console.error(err instanceof Error ? err.message : String(err));
+            process.exitCode = exitCodeFor(err);
+            return;
+          }
+          if (defaultTask.copied) console.error(copyAnnounceLine(defaultTask));
+          if (!defaultTask.trialsApplied) console.error(trialsPinFallbackLine());
+          target = defaultTask.path;
         }
 
         let files: string[];
@@ -678,6 +707,12 @@ export function createProgram() {
           }
           process.exitCode = code;
           return;
+        }
+
+        // FDRS-645 — the moment-05 frame, only for the bare-run default and
+        // only once every gate that could refuse the run has passed.
+        if (defaultTask) {
+          for (const line of runYoursFrameLines()) console.error(line);
         }
 
         for (const file of files) {

--- a/cli/test/unit/run-default-task.test.ts
+++ b/cli/test/unit/run-default-task.test.ts
@@ -157,6 +157,27 @@ describe("default-task module (FDRS-645)", () => {
     expect(res.copied).toBe(false);
     expect(await readFile(res.path, "utf8")).toBe(custom);
   });
+
+  it("preserves a user-edited seed when only the md was deleted", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pome-default-task-"));
+    await mkdir(join(dir, "scenarios"), { recursive: true });
+    const editedSeed = '{"edited":"by the user"}';
+    await writeFile(
+      join(dir, "scenarios", "first-run-demo.seed.json"),
+      editedSeed,
+    );
+    const res = await ensureDefaultTask(dir);
+    expect(res.copied).toBe(true);
+    expect(
+      await readFile(join(dir, "scenarios", "first-run-demo.seed.json"), "utf8"),
+    ).toBe(editedSeed);
+  });
+
+  it("names a `scenarios`-is-a-file collision as a usage error", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pome-default-task-"));
+    await writeFile(join(dir, "scenarios"), "not a directory");
+    await expect(ensureDefaultTask(dir)).rejects.toThrow(/exists as a file/);
+  });
 });
 
 describe("bare `pome run` glue (FDRS-645)", () => {

--- a/cli/test/unit/run-default-task.test.ts
+++ b/cli/test/unit/run-default-task.test.ts
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-645 — "run yours": bare `pome run` defaults to the demo task.
+//   - default-task module: the user copy pins `runs: 5` inside the Config
+//     fence, swaps the packaged maintainer comment for the user-facing one,
+//     ships the seed sidecar, and never clobbers an existing copy;
+//   - main.ts glue: bare `pome run` drops the copy on first use, announces
+//     it, prints the moment-05 frame after the doctor + credential gates,
+//     and dispatches the trial-group path with the pinned k=5 (an explicit
+//     -n still wins); an explicit path never triggers any of it.
+
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createProgram } from "../../src/cli/main.js";
+import {
+  DEFAULT_TASK_TRIALS,
+  copyAnnounceLine,
+  ensureDefaultTask,
+  runYoursFrameLines,
+  withDefaultTrials,
+  withUserCopyComment,
+} from "../../src/cli/default-task.js";
+import { DEMO_TASK_NAME, demoTaskPath } from "../../src/demo/task.js";
+import { parseScenario, parseScenarioFile } from "../../src/scenario/parseScenario.js";
+import { runTrialGroup } from "../../src/runner/runTrialGroup.js";
+import { runScenarioHosted } from "../../src/runner/runScenarioHosted.js";
+
+vi.mock("../../src/runner/runTrialGroup.js", () => ({
+  GROUP_FINALIZE_TIMEOUT_MS: 60_000,
+  runTrialGroup: vi.fn(async () => ({
+    groupId: "grp_test",
+    rows: [],
+    exitCode: 0,
+    reliabilityUrl: "https://app.pome.sh/runs/task/first-run-demo",
+  })),
+}));
+
+vi.mock("../../src/runner/runScenarioHosted.js", () => ({
+  runScenarioHosted: vi.fn(async () => ({
+    scenario: { title: "Fixture", slug: "scn", config: { passThreshold: 100 } },
+    runId: "ses_1",
+    cloudRunId: "run_1",
+    cloudDashboardUrl: "https://app.pome.sh/runs/run_1",
+    artifacts: { runDir: "/tmp/runs/x" },
+    score: {
+      satisfaction: 100,
+      passed: 1,
+      failed: 0,
+      skipped: 0,
+      errored: 0,
+      total_required: 1,
+      evaluated: true,
+      can_pass: true,
+      results: [],
+      judge_model: "test-judge",
+      judge_tokens_in: null,
+      judge_tokens_out: null,
+    },
+    exitCode: 0,
+    durationMs: 1000,
+  })),
+}));
+
+const EXPLICIT_SCENARIO =
+  "# Trivial\n\n## Prompt\nPretend prompt.\n\n## Success Criteria\n- [D] No unsupported endpoint was called\n";
+
+const WIRED_AGENT_SOURCE = [
+  'import { withPome } from "@pome-sh/adapter-claude-sdk";',
+  "withPome();",
+  "const baseUrl = process.env.POME_GITHUB_REST_URL;",
+  "export { baseUrl };",
+].join("\n");
+
+async function fixtureRepo(opts: { wired?: boolean } = {}): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "pome-run-default-"));
+  await mkdir(join(dir, "src"), { recursive: true });
+  await writeFile(
+    join(dir, "pome.config.json"),
+    JSON.stringify({ agent: { command: 'node -e "process.exit(0)"' } }, null, 2),
+  );
+  if (opts.wired !== false) {
+    await writeFile(join(dir, "src/agent.ts"), WIRED_AGENT_SOURCE);
+  } else {
+    // A hardcoded production host fails the doctor routing probe.
+    await writeFile(
+      join(dir, "src/agent.ts"),
+      'const base = "https://api.github.com";\nexport { base };',
+    );
+  }
+  return dir;
+}
+
+describe("default-task module (FDRS-645)", () => {
+  it("pins runs: 5 into the real packaged md's Config fence and the real parser reads it back", async () => {
+    const raw = await readFile(demoTaskPath(), "utf8");
+    const sidecar = JSON.parse(
+      await readFile(demoTaskPath().replace(/\.md$/, ".seed.json"), "utf8"),
+    ) as unknown;
+    const pinned = withDefaultTrials(raw);
+    expect(pinned.applied).toBe(true);
+    const parsed = parseScenario(pinned.content, DEMO_TASK_NAME, sidecar);
+    expect(parsed.config.runs).toBe(DEFAULT_TASK_TRIALS);
+    // Everything the judge definition is regenerated from is untouched.
+    expect(parsed.title).toBe(DEMO_TASK_NAME);
+    expect(parsed.criteria.length).toBeGreaterThan(0);
+    expect(parsed.prompt).toContain("POST /orders");
+  });
+
+  it("leaves a fence that already sets runs alone", () => {
+    const src = "# t\n\n## Config\n```yaml\nruns: 2\ntimeout: 60\n```\n";
+    const out = withDefaultTrials(src);
+    expect(out.applied).toBe(true);
+    expect(out.content).toBe(src);
+  });
+
+  it("reports applied=false when no Config fence exists", () => {
+    const out = withDefaultTrials("# t\n\n## Prompt\nhi\n");
+    expect(out.applied).toBe(false);
+    expect(out.content).toBe("# t\n\n## Prompt\nhi\n");
+  });
+
+  it("swaps the packaged maintainer comment for the user-facing one", async () => {
+    const raw = await readFile(demoTaskPath(), "utf8");
+    const out = withUserCopyComment(raw);
+    expect(out).not.toContain("CANONICAL");
+    expect(out).toContain("This copy is yours.");
+    // Still exactly one preamble comment, before the first section.
+    expect(out.indexOf("<!--")).toBeLessThan(out.search(/^##[ \t]/m));
+  });
+
+  it("ensureDefaultTask drops md + seed sidecar once, then reuses the copy", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pome-default-task-"));
+    const first = await ensureDefaultTask(dir);
+    expect(first.copied).toBe(true);
+    expect(first.trialsApplied).toBe(true);
+    expect(existsSync(join(dir, "scenarios", "first-run-demo.md"))).toBe(true);
+    expect(existsSync(join(dir, "scenarios", "first-run-demo.seed.json"))).toBe(true);
+
+    // The dropped copy parses with the real parser: sidecar honored, k pinned.
+    const parsed = await parseScenarioFile(first.path);
+    expect(parsed.config.runs).toBe(DEFAULT_TASK_TRIALS);
+    expect(parsed.slug).toBe(DEMO_TASK_NAME);
+
+    const second = await ensureDefaultTask(dir);
+    expect(second.copied).toBe(false);
+    expect(second.path).toBe(first.path);
+  });
+
+  it("never clobbers a user-edited copy", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pome-default-task-"));
+    await mkdir(join(dir, "scenarios"), { recursive: true });
+    const custom = "# first-run-demo\n\n## Prompt\nmine now\n\n## Success Criteria\n- [D] x\n\n## Config\n```yaml\nruns: 2\n```\n";
+    await writeFile(join(dir, "scenarios", "first-run-demo.md"), custom);
+    const res = await ensureDefaultTask(dir);
+    expect(res.copied).toBe(false);
+    expect(await readFile(res.path, "utf8")).toBe(custom);
+  });
+});
+
+describe("bare `pome run` glue (FDRS-645)", () => {
+  const originalCwd = process.cwd();
+  const originalExitCode = process.exitCode;
+  let stderr: string[];
+
+  beforeEach(() => {
+    stderr = [];
+    vi.spyOn(console, "error").mockImplementation((msg?: unknown) => {
+      stderr.push(String(msg));
+    });
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.exitCode = undefined;
+    process.env.POME_API_KEY = "pme_test_env_key";
+    vi.mocked(runTrialGroup).mockClear();
+    vi.mocked(runScenarioHosted).mockClear();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    delete process.env.POME_API_KEY;
+    vi.restoreAllMocks();
+    process.exitCode = originalExitCode;
+  });
+
+  async function run(...args: string[]): Promise<void> {
+    await createProgram().parseAsync(["node", "pome", "run", ...args]);
+  }
+
+  it("bare run drops the copy, announces it, frames, and dispatches k=5", async () => {
+    const dir = await fixtureRepo();
+    process.chdir(dir);
+    await run();
+
+    expect(process.exitCode ?? 0).toBe(0);
+    expect(existsSync(join(dir, "scenarios", "first-run-demo.md"))).toBe(true);
+    expect(existsSync(join(dir, "scenarios", "first-run-demo.seed.json"))).toBe(true);
+
+    const err = stderr.join("\n");
+    expect(err).toContain("copied the demo task into");
+    for (const line of runYoursFrameLines()) expect(err).toContain(line);
+
+    expect(runScenarioHosted).not.toHaveBeenCalled();
+    expect(runTrialGroup).toHaveBeenCalledTimes(1);
+    const options = vi.mocked(runTrialGroup).mock.calls[0]![0];
+    expect(options.trials).toBe(DEFAULT_TASK_TRIALS);
+    expect(options.scenarioPath.endsWith(join("scenarios", "first-run-demo.md"))).toBe(true);
+  }, 30_000);
+
+  it("second bare run reuses the copy without re-announcing", async () => {
+    const dir = await fixtureRepo();
+    process.chdir(dir);
+    await run();
+    stderr.length = 0;
+    vi.mocked(runTrialGroup).mockClear();
+
+    await run();
+    expect(runTrialGroup).toHaveBeenCalledTimes(1);
+    const err = stderr.join("\n");
+    expect(err).not.toContain("copied the demo task into");
+    expect(err).toContain(runYoursFrameLines()[0]);
+  }, 30_000);
+
+  it("an explicit -n beats the copy's pinned runs", async () => {
+    const dir = await fixtureRepo();
+    process.chdir(dir);
+    await run("-n", "3");
+    expect(runTrialGroup).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(runTrialGroup).mock.calls[0]![0].trials).toBe(3);
+  }, 30_000);
+
+  it("a user-edited copy's runs field drives the default (runs: 1 → single-run path)", async () => {
+    const dir = await fixtureRepo();
+    process.chdir(dir);
+    await mkdir(join(dir, "scenarios"), { recursive: true });
+    await writeFile(
+      join(dir, "scenarios", "first-run-demo.md"),
+      "# first-run-demo\n\n## Prompt\nmine\n\n## Success Criteria\n- [D] x\n\n## Config\n```yaml\nruns: 1\n```\n",
+    );
+    await run();
+    expect(runTrialGroup).not.toHaveBeenCalled();
+    expect(runScenarioHosted).toHaveBeenCalledTimes(1);
+  }, 30_000);
+
+  it("an explicit path never announces, frames, or drops the copy", async () => {
+    const dir = await fixtureRepo();
+    process.chdir(dir);
+    await mkdir(join(dir, "scenarios"), { recursive: true });
+    await writeFile(join(dir, "scenarios", "scn.md"), EXPLICIT_SCENARIO);
+    await run("scenarios/scn.md");
+
+    expect(existsSync(join(dir, "scenarios", "first-run-demo.md"))).toBe(false);
+    const err = stderr.join("\n");
+    expect(err).not.toContain("copied the demo task into");
+    expect(err).not.toContain(runYoursFrameLines()[0]);
+    expect(runScenarioHosted).toHaveBeenCalledTimes(1);
+  }, 30_000);
+
+  it("a failing doctor gate refuses before the frame ever prints", async () => {
+    const dir = await fixtureRepo({ wired: false });
+    process.chdir(dir);
+    await run();
+
+    expect(process.exitCode).toBe(1);
+    const err = stderr.join("\n");
+    expect(err).toContain("wiring check failed");
+    expect(err).not.toContain(runYoursFrameLines()[0]);
+    expect(runTrialGroup).not.toHaveBeenCalled();
+    expect(runScenarioHosted).not.toHaveBeenCalled();
+  }, 30_000);
+});


### PR DESCRIPTION
<!-- Closes FDRS-645 -->

## What
`pome run` with no path now runs the demo task: a user-visible copy (`scenarios/first-run-demo.md` + seed sidecar) is dropped into the project on first use with `runs: 5` pinned into its Config fence, the moment-05 frame ("that was ours — now it's your agent on the same task the demo just ran.") prints once the doctor + credential gates pass, and the existing moment-04 group summary carries the framed handoff link to the reliability page.

## Why
FDRS-645 — journey stage 05 ("run yours"), the north-star activation: their agent, k=5, the same task they just watched the demo agent attempt. The [DECISION] trail (copy-on-demand vs packaged-path vs copy-at-install; `runs: 5` in the copy so the packaged md stays byte-identical to the server judge definition) is on the ticket, 2026-07-06.

## Notes for reviewer
- The packaged `cli/src/demo/first-run-demo.md` is untouched (pome-cloud#209 lockstep intact); only the COPY gains `runs: 5` + a user-facing comment replacing the CANONICAL/lockstep warning. A unit test parses the transformed copy with the real parser and pins prompt/criteria/seed unchanged.
- Nothing under `scenarios/` is ever overwritten: md via `wx`, seed via `COPYFILE_EXCL` (adversarial-review fix — a user who deleted only the md keeps an edited seed). `scenarios`-exists-as-a-file is a named usage error (exit 5).
- Explicit-path runs, k=1, `--local`, exit codes: unchanged (regression tests assert no frame/copy on explicit paths; the frame never prints when doctor or auth refuses).
- 493 tests + typecheck + `gate:no-eval` green; adversarially reviewed (2 majors found → fixed with regression tests).

## Review required
Yes — public OSS API (the `pome run` argument contract changes from required to optional).

### Founder briefing (3 min)
- **What changed** — bare `pome run` now defaults to running the packaged demo task via an editable project-local copy, k=5, with the run-yours frame; explicit paths behave exactly as before.
- **What it means for your repo / workflow** — the CLI's `run` surface gains a zero-argument mode; docs/snippets that say "pome run needs a path" are stale, and the demo → run-yours seam is now a single command.
- **The one thing you must know** — the copy (not the packaged md) carries `runs: 5`; the packaged md stays byte-identical to the server-owned judge definition, so no pome-cloud regeneration is needed.

*Merged under Ao's explicit 2026-07-06 session authorization ("全部 merge"); Gagan post-merge read requested.*