### PR TITLE
fix(cli): stamp exec bit on published main.js so npm -g install resolves pome (FDRS-666)

### DIFF
--- a/cli/.changeset/mighty-crabs-shave.md
+++ b/cli/.changeset/mighty-crabs-shave.md
@@ -1,0 +1,5 @@
+---
+"pome-sh": patch
+---
+
+`npm install -g pome-sh` now yields a runnable `pome` with no manual `chmod`: the build stamps the executable bit on `dist/src/cli/main.js`, so the published tarball carries it (`npm pack` preserves disk modes; tsc emits 644). FDRS-666.

--- a/cli/package.json
+++ b/cli/package.json
@@ -45,7 +45,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && node scripts/copy-prompts.mjs",
+    "build": "tsc -p tsconfig.build.json && node scripts/copy-prompts.mjs && node -e \"fs.chmodSync('dist/src/cli/main.js', 0o755)\"",
     "dev": "tsx src/cli/main.ts",
     "pome": "node dist/src/cli/main.js",
     "prepare": "npm run build",

--- a/cli/test/unit/bin-exec-bit.test.ts
+++ b/cli/test/unit/bin-exec-bit.test.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-666 — `npm pack` preserves file modes straight from disk, and a
+// global install's `pome` bin symlink points at dist/src/cli/main.js. tsc
+// emits 644, so without the build script's chmod the published CLI is
+// unresolvable on PATH (`npm i -g pome-sh` → `pome` not found until a
+// manual `chmod +x`). The npx path and project-local .bin shims exec via
+// node and never caught this. Guard the built artifact's mode here —
+// cli-ci runs `bun run build` before `bun run test`, so dist/ exists in CI.
+
+import { existsSync, statSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const BIN = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../dist/src/cli/main.js",
+);
+
+describe("published bin exec bit (FDRS-666)", () => {
+  // File modes are a POSIX concept and the publish packs on POSIX CI; skip
+  // on Windows and on local checkouts that haven't built dist/ yet.
+  it.skipIf(process.platform === "win32" || !existsSync(BIN))(
+    "dist/src/cli/main.js carries the executable bit after build",
+    () => {
+      const mode = statSync(BIN).mode;
+      expect(
+        mode & 0o111,
+        `dist/src/cli/main.js mode is 0${(mode & 0o777).toString(8)} — the build script's chmod is gone`,
+      ).not.toBe(0);
+    },
+  );
+});


### PR DESCRIPTION
<!-- Closes FDRS-666 -->

## What
The CLI build now stamps the executable bit on `dist/src/cli/main.js` (`node -e "fs.chmodSync(...)"`, Windows-safe), so the published tarball carries it and `npm install -g pome-sh` yields a working `pome` on PATH with no manual `chmod`. A unit test guards the built artifact's mode (cli-ci builds before testing), and a patch changeset ships it with 0.6.7.

## Why
Surfaced in the 2026-07-06 first-publish e2e: `npm i -g pome-sh@0.6.6` landed `main.js` mode 644 — tsc emits 644, `npm pack` preserves disk modes, and the global-install bin symlink needs its target executable. The npx path and project-local `.bin` shims exec via node, which is why the demo run and pack smoke never caught it (FDRS-666).

## Notes for reviewer
Verified end-to-end locally: `npm pack` → tarball entry is `-rwxr-xr-x` → `npm i -g --prefix <tmp>` → `pome version` prints 0.6.6 with no chmod. The regression test skips on Windows and on checkouts without a built `dist/` (CI always builds first).