### PR TITLE
fix(cli): hosted env injects POME_TWIN_BASE_URL; errored trials name their cause (FDRS-667)

### DIFF
--- a/cli/.changeset/hosted-preflight-forensics.md
+++ b/cli/.changeset/hosted-preflight-forensics.md
@@ -1,0 +1,5 @@
+---
+"pome-sh": patch
+---
+
+Hosted runs now truly mirror self-host for agent env: `POME_TWIN_BASE_URL` is injected (derived from the session's twin URL), so agents with the standalone loopback fallback pass preflight instead of probing 127.0.0.1:3333. Errored trials name their cause — the agent's last stderr line lands in the trial row and the full stdout/stderr is written under the artifacts dir before the session is abandoned. `CLAUDE_CODE_OAUTH_TOKEN` is forwarded to agent subprocesses for Claude subscription auth. FDRS-667.

--- a/cli/scripts/make-unwired-fixture.mjs
+++ b/cli/scripts/make-unwired-fixture.mjs
@@ -127,6 +127,35 @@ replaceOnce(
   "the MCP_URL env read",
 );
 
+// 5. The preflight's runner-mode gate (FDRS-667) → the unconditional probe
+// a pre-pome repo would have. The gate keys off POME_GITHUB_MCP_URL, which
+// must not survive unwiring.
+replaceOnce(
+  [
+    "  // Standalone mode only: probe the docker twin's root /healthz so \"docker",
+    "  // compose isn't up\" gets a direct message. When a pome runner injected",
+    "  // POME_GITHUB_MCP_URL there is no loopback twin — TWIN_BASE_URL falls back",
+    "  // to 127.0.0.1:3333 and hosted `pome run` died here probing it (FDRS-667).",
+    "  // The authenticated ${MCP_URL}/tools probe below already covers",
+    "  // reachability + auth in every mode.",
+    "  if (!process.env.POME_GITHUB_MCP_URL) {",
+    "    const healthUrl = `${TWIN_BASE_URL.replace(/\\/$/, \"\")}/healthz`;",
+    "    const res = await fetch(healthUrl).catch((err) => {",
+    "      throw new Error(`twin not reachable at ${healthUrl}: ${err instanceof Error ? err.message : String(err)}`);",
+    "    });",
+    "    if (!res.ok) throw new Error(`twin healthz returned ${res.status}`);",
+    "  }",
+  ].join("\n"),
+  [
+    "  const healthUrl = `${TWIN_BASE_URL.replace(/\\/$/, \"\")}/healthz`;",
+    "  const res = await fetch(healthUrl).catch((err) => {",
+    "    throw new Error(`twin not reachable at ${healthUrl}: ${err instanceof Error ? err.message : String(err)}`);",
+    "  });",
+    "  if (!res.ok) throw new Error(`twin healthz returned ${res.status}`);",
+  ].join("\n"),
+  "the preflight runner-mode healthz gate",
+);
+
 for (const leftover of ["withPome", "@pome-sh/adapter", "POME_TWIN_BASE_URL", "POME_GITHUB_MCP_URL"]) {
   if (index.includes(leftover)) {
     console.error(`make-unwired-fixture: "${leftover}" still present after unwiring — update this script.`);

--- a/cli/src/runner/agentRunner.ts
+++ b/cli/src/runner/agentRunner.ts
@@ -100,6 +100,11 @@ const SAFE_PARENT_ENV = new Set([
 const DEFAULT_AGENT_ENV_ALLOWLIST = new Set([
   "AI_GATEWAY_API_KEY",
   "ANTHROPIC_API_KEY",
+  // FDRS-667 — Claude subscription auth (`claude setup-token`). Without
+  // this the Claude Agent SDK inside the agent subprocess only sees an API
+  // key, and subscription-only users fail auth under `pome run` while the
+  // same agent works when launched by hand.
+  "CLAUDE_CODE_OAUTH_TOKEN",
   "GOOGLE_API_KEY",
   "GOOGLE_GENERATIVE_AI_API_KEY",
   "OPENAI_API_KEY",

--- a/cli/src/runner/runScenarioHosted.ts
+++ b/cli/src/runner/runScenarioHosted.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { createHash, randomUUID } from "node:crypto";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { runAgentCommand } from "./agentRunner.js";
@@ -174,6 +174,12 @@ export async function runScenarioHosted(
       OTEL_RESOURCE_ATTRIBUTES: `pome.session_id=${session.session_id},pome.run_id=${runId}${
         agentId ? `,pome.agent_id=${agentId}` : ""
       }`,
+      // FDRS-667 — the twin base URL, same value the self-host docs teach
+      // agents to fall back on. Agent code written against the standalone
+      // docker twin reads POME_TWIN_BASE_URL with a 127.0.0.1:3333 fallback;
+      // without this injection that fallback fires on hosted runs and the
+      // agent probes a loopback port nothing listens on.
+      POME_TWIN_BASE_URL: session.twin_url,
       POME_GITHUB_REST_URL: session.twin_url,
       POME_GITHUB_MCP_URL: `${session.twin_url}/mcp`,
       POME_GITHUB_TOKEN: session.provider_credentials.github?.token ?? session.agent_token,
@@ -229,13 +235,21 @@ export async function runScenarioHosted(
       // preflight quotes the cap that actually killed it, never the full
       // scenario timeout. Only a real-run failure classifies as
       // agent_timeout / agent_exit_nonzero.
+      //
+      // FDRS-667 — name the cause. The errored trial row renders the reason
+      // verbatim, so a bare "agent preflight failed" leaves the user with
+      // zero forensics (the k=5 first-publish e2e died five times on the
+      // same swallowed stderr). Append the agent's last stderr line to the
+      // exit-shaped failures; timeouts already name what killed them.
+      const failed = preflight.exitCode !== 0 ? preflight : agentResult;
+      const cause = stderrTail(failed.stderr);
       const failure =
         preflight.exitCode !== 0
           ? {
               errorCode: "preflight_failed",
               reason: preflight.timedOut
                 ? `agent preflight timed out after ${preflightTimeoutSeconds}s`
-                : "agent preflight failed",
+                : `agent preflight failed${cause ? ` — ${cause}` : ""}`,
             }
           : agentResult.timedOut
             ? {
@@ -244,8 +258,21 @@ export async function runScenarioHosted(
               }
             : {
                 errorCode: "agent_exit_nonzero",
-                reason: `agent exited non-zero (exit ${agentResult.exitCode})`,
+                reason: `agent exited non-zero (exit ${agentResult.exitCode})${cause ? ` — ${cause}` : ""}`,
               };
+      // FDRS-667 — an abandoned trial never reaches the artifact write in
+      // step 5, so land the agent's output where a completed trial's would
+      // go (runs/<slug>/<session>/): stdout.txt + stderr.log, redacted like
+      // writeRunArtifactsCore's copies. Best effort — forensics must never
+      // mask the trial's own error.
+      try {
+        const runDir = join(artifactsDir, scenario.slug, runId);
+        await mkdir(runDir, { recursive: true });
+        await writeFile(join(runDir, "stdout.txt"), redactSecrets(failed.stdout) as string);
+        await writeFile(join(runDir, "stderr.log"), redactSecrets(failed.stderr) as string);
+      } catch {
+        // ignore — the thrown HostedTrialError below is the signal that matters
+      }
       await abandonBestEffort(client, session.session_id, failure.errorCode);
       throw new HostedTrialError(failure.reason, failure.errorCode);
     }
@@ -468,6 +495,20 @@ export async function runScenarioHosted(
     await client.deleteSession(session.session_id).catch(() => undefined);
     await rm(signalsDir, { recursive: true, force: true }).catch(() => undefined);
   }
+}
+
+/** FDRS-667 — the last non-empty stderr line, flattened and bounded, as the
+ *  one named cause an errored trial row can render inline. Redacted with the
+ *  same rules as the on-disk stderr.log copy. */
+function stderrTail(stderr: string): string | null {
+  const last = stderr
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .at(-1);
+  if (!last) return null;
+  const flat = (redactSecrets(last.replace(/\s+/g, " ")) as string).trim();
+  return flat.length > 160 ? `${flat.slice(0, 157)}…` : flat;
 }
 
 /** Abandon is a bookkeeping signal — a failure to deliver it must never

--- a/cli/test/integration/runScenarioHosted.trial.test.ts
+++ b/cli/test/integration/runScenarioHosted.trial.test.ts
@@ -14,7 +14,7 @@
 //     finalizes (covered by runScenarioHosted.test.ts, re-asserted here).
 
 import { describe, it, expect, afterEach } from "vitest";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { serve, type ServerType } from "@hono/node-server";
@@ -215,10 +215,15 @@ describe("runScenarioHosted trial seams (FDRS-636)", () => {
     expect(cloud.lifecycle()).toEqual(["abandon", "delete"]);
   });
 
-  it("abandonOnFailure + preflight failure → abandon(preflight_failed), no finalize", async () => {
+  it("abandonOnFailure + preflight failure → abandon(preflight_failed), no finalize; reason names the stderr tail and forensics land in artifactsDir (FDRS-667)", async () => {
     cloud = await startFakeCloud();
     const path = await scenarioPath(SCENARIO);
-    const agent = `node -e ${JSON.stringify("process.exit(1)")}`;
+    // Mimics the first-publish e2e: the example's preflight throws its named
+    // cause to stderr and exits 1. That cause must surface in the errored
+    // trial row instead of a bare "agent preflight failed".
+    const agent = `node -e ${JSON.stringify(
+      "console.error('twin not reachable at http://127.0.0.1:3333/healthz: fetch failed'); process.exit(1)",
+    )}`;
 
     await expect(
       runScenarioHosted({
@@ -229,10 +234,46 @@ describe("runScenarioHosted trial seams (FDRS-636)", () => {
         premintedSession: await premintedFor(cloud.port),
         abandonOnFailure: true,
       }),
-    ).rejects.toMatchObject({ errorCode: "preflight_failed" });
+    ).rejects.toMatchObject({
+      errorCode: "preflight_failed",
+      message:
+        "agent preflight failed — twin not reachable at http://127.0.0.1:3333/healthz: fetch failed",
+    });
 
     expect(cloud.finalizeCalls()).toBe(0);
     expect(cloud.abandonBodies()).toEqual([{ error_code: "preflight_failed" }]);
+
+    // FDRS-667 — an abandoned trial still writes stdout.txt/stderr.log where
+    // a completed trial's artifacts would go, so `runs/` is never empty.
+    const files = await readdir(join(tmp!, "runs"), { recursive: true });
+    const stderrLog = files.find((f) => String(f).endsWith("stderr.log"));
+    expect(stderrLog, `runs/ contained: ${files.join(", ")}`).toBeDefined();
+    expect(
+      await readFile(join(tmp!, "runs", String(stderrLog)), "utf8"),
+    ).toContain("twin not reachable at http://127.0.0.1:3333/healthz");
+  });
+
+  it("injects POME_TWIN_BASE_URL = session twin_url so loopback-fallback agents pass hosted preflight (FDRS-667)", async () => {
+    cloud = await startFakeCloud();
+    const path = await scenarioPath(SCENARIO);
+    const expected = `http://127.0.0.1:${cloud.port}/s/${SESSION_ID}`;
+    // Exits 0 (both preflight and run) only when the env mirrors self-host.
+    const agent = `node -e ${JSON.stringify(
+      `process.exit(process.env.POME_TWIN_BASE_URL === '${expected}' ? 0 : 1)`,
+    )}`;
+
+    const result = await runScenarioHosted({
+      scenarioPath: path,
+      agentCommand: agent,
+      artifactsDir: join(tmp!, "runs"),
+      hosted: { baseUrl: `http://127.0.0.1:${cloud.port}`, apiKey: "pme_test" },
+      premintedSession: await premintedFor(cloud.port),
+      abandonOnFailure: true,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(cloud.finalizeCalls()).toBe(1);
+    expect(cloud.abandonBodies()).toEqual([]);
   });
 
   it("abandonOnFailure + preflight HANG past its cap → abandon(preflight_failed) quoting the 10s cap, not the scenario timeout", async () => {

--- a/cli/test/unit/runner/agentRunner.test.ts
+++ b/cli/test/unit/runner/agentRunner.test.ts
@@ -3,6 +3,7 @@ import { runAgentCommand } from "../../../src/runner/agentRunner.js";
 
 const SAVED_ENV: Record<string, string | undefined> = {};
 const ENV_KEYS = [
+  "CLAUDE_CODE_OAUTH_TOKEN",
   "OPENAI_API_KEY",
   "POME_INHERIT_AGENT_ENV",
   "POME_TRUST_AGENT_COMMAND",
@@ -46,10 +47,12 @@ describe("runAgentCommand", () => {
   it("forwards documented provider keys without inheriting unrelated secrets", async () => {
     saveEnv();
     process.env.OPENAI_API_KEY = "sk-test-provider";
+    // FDRS-667 — Claude subscription auth must reach the agent subprocess.
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = "sk-ant-oat-test";
     process.env.SECRET_SHOULD_NOT_LEAK = "raw-secret";
 
     const result = await runAgentCommand({
-      command: `${process.execPath} -e "process.stdout.write(JSON.stringify({ openai: process.env.OPENAI_API_KEY || null, secret: process.env.SECRET_SHOULD_NOT_LEAK || null }))"`,
+      command: `${process.execPath} -e "process.stdout.write(JSON.stringify({ openai: process.env.OPENAI_API_KEY || null, oauth: process.env.CLAUDE_CODE_OAUTH_TOKEN || null, secret: process.env.SECRET_SHOULD_NOT_LEAK || null }))"`,
       env: {},
       timeoutSeconds: 5,
     });
@@ -57,6 +60,7 @@ describe("runAgentCommand", () => {
     expect(result.exitCode).toBe(0);
     expect(JSON.parse(result.stdout)).toEqual({
       openai: "sk-test-provider",
+      oauth: "sk-ant-oat-test",
       secret: null,
     });
   });

--- a/examples/triage-agent/README.md
+++ b/examples/triage-agent/README.md
@@ -14,7 +14,9 @@ This is the example referenced in the README quickstart and the demo video
   `docker compose up` from the repo root. The twin auto-generates a
   bearer secret at `<repo-root>/.pome-data/github/secret` on first run.
 - `bun >= 1.3.0` and `node >= 20`.
-- An Anthropic API key for the agent loop. BYOK via `ANTHROPIC_API_KEY`.
+- Claude auth for the agent loop: BYOK via `ANTHROPIC_API_KEY`, or a Claude
+  subscription (`CLAUDE_CODE_OAUTH_TOKEN` from `claude setup-token`, or a
+  stored `claude` login).
 
 ## Install
 
@@ -82,7 +84,7 @@ All optional. Defaults match the repo-root `docker compose up`.
 
 | Env var | Default | Purpose |
 | --- | --- | --- |
-| `ANTHROPIC_API_KEY` | — (required) | Used by the Claude Agent SDK. |
+| `ANTHROPIC_API_KEY` | — | Claude API key for the Agent SDK. Alternatives: `CLAUDE_CODE_OAUTH_TOKEN`, or a stored `claude` subscription login. |
 | `POME_GITHUB_MCP_URL` | `http://127.0.0.1:3333/s/demo/mcp` | Twin MCP endpoint. Pome CLI sets this automatically. |
 | `POME_AUTH_TOKEN` | — | Pre-minted bearer JWT. Pome CLI sets this; otherwise the agent mints its own. |
 | `POME_TASK` | bundled triage prompt | Override the agent's task. Pome CLI sets this from the scenario file. |

--- a/examples/triage-agent/src/index.ts
+++ b/examples/triage-agent/src/index.ts
@@ -308,19 +308,37 @@ function readSecretFromDisk(): string {
 }
 
 async function preflight(token: string): Promise<void> {
-  const healthUrl = `${TWIN_BASE_URL.replace(/\/$/, "")}/healthz`;
-  const res = await fetch(healthUrl).catch((err) => {
-    throw new Error(`twin not reachable at ${healthUrl}: ${err instanceof Error ? err.message : String(err)}`);
-  });
-  if (!res.ok) throw new Error(`twin healthz returned ${res.status}`);
+  // Standalone mode only: probe the docker twin's root /healthz so "docker
+  // compose isn't up" gets a direct message. When a pome runner injected
+  // POME_GITHUB_MCP_URL there is no loopback twin — TWIN_BASE_URL falls back
+  // to 127.0.0.1:3333 and hosted `pome run` died here probing it (FDRS-667).
+  // The authenticated ${MCP_URL}/tools probe below already covers
+  // reachability + auth in every mode.
+  if (!process.env.POME_GITHUB_MCP_URL) {
+    const healthUrl = `${TWIN_BASE_URL.replace(/\/$/, "")}/healthz`;
+    const res = await fetch(healthUrl).catch((err) => {
+      throw new Error(`twin not reachable at ${healthUrl}: ${err instanceof Error ? err.message : String(err)}`);
+    });
+    if (!res.ok) throw new Error(`twin healthz returned ${res.status}`);
+  }
 
-  if (!process.env.ANTHROPIC_API_KEY) {
-    throw new Error("ANTHROPIC_API_KEY is not set — the agent needs it to call Claude.");
+  // Claude auth: the Agent SDK takes an API key (ANTHROPIC_API_KEY), a
+  // subscription token (CLAUDE_CODE_OAUTH_TOKEN, from `claude setup-token`),
+  // or a `claude` login stored on this machine — that last one is invisible
+  // to env, so hard-failing here would block subscription users whose runs
+  // would succeed. Warn with both options instead of throwing (FDRS-667).
+  if (!process.env.ANTHROPIC_API_KEY && !process.env.CLAUDE_CODE_OAUTH_TOKEN) {
+    console.warn(
+      "warning: neither ANTHROPIC_API_KEY nor CLAUDE_CODE_OAUTH_TOKEN is set — continuing, assuming a stored `claude` subscription login. " +
+        "If the run fails on auth: export ANTHROPIC_API_KEY=sk-ant-… (API key) or CLAUDE_CODE_OAUTH_TOKEN (run `claude setup-token`)."
+    );
   }
 
   // Sanity-check the bearer token by hitting a session-scoped endpoint.
   const probe = await fetch(`${trimSlash(MCP_URL)}/tools`, {
     headers: { authorization: `Bearer ${token}` }
+  }).catch((err) => {
+    throw new Error(`twin MCP not reachable at ${MCP_URL}/tools: ${err instanceof Error ? err.message : String(err)}`);
   });
   if (!probe.ok) throw new Error(`twin MCP probe failed: ${probe.status}`);
 


### PR DESCRIPTION
<!-- Closes FDRS-667 -->

## What
Hosted `pome run` now injects `POME_TWIN_BASE_URL` (= the session's twin URL) so the agent env truly mirrors self-host; errored trials print the agent's last stderr line as a named cause (instead of the bare `agent preflight failed — excluded`) and land redacted `stdout.txt`/`stderr.log` under the artifacts dir before abandoning. The bundled `examples/triage-agent` preflight probes the loopback `/healthz` only in standalone mode and no longer hard-fails without `ANTHROPIC_API_KEY` — it warns, naming both the API-key and Claude-subscription options — and `agentRunner` forwards `CLAUDE_CODE_OAUTH_TOKEN` to agent subprocesses.

## Why
The 2026-07-06 first-publish e2e died at the "run yours" stop: all five hosted trials errored on the example's `${TWIN_BASE_URL}/healthz` probe falling back to `http://127.0.0.1:3333`, with the stderr swallowed and `runs/` empty — zero forensics (FDRS-667).

## Notes for reviewer
- The stub-cloud hosted-preflight coverage the ticket suggested lives in `cli/test/integration/runScenarioHosted.trial.test.ts`: one test asserts the errored reason carries the stderr tail + forensics land on disk, another asserts `POME_TWIN_BASE_URL` reaches the agent.
- `cli/scripts/make-unwired-fixture.mjs` gained a replacement for the new runner-mode gate (its leftover check forbids `POME_GITHUB_MCP_URL` surviving unwiring) — verified by running the script.
- The auth check is now a warning, not an error: a stored `claude` subscription login is invisible to env, so a hard fail would block users whose runs would succeed.

## Review required
Yes — touches the public agent env contract (`POME_TWIN_BASE_URL` injection) and the agent-subprocess env allowlist (`CLAUDE_CODE_OAUTH_TOKEN`).

### Founder briefing (3 min)
- **What changed** — hosted runs inject the twin base URL, errored trials name their cause with on-disk forensics, and the flagship example + runner accept Claude subscription auth.
- **What it means for your workflow** — customer agents written against the standalone docker twin (loopback fallback) now pass hosted preflight unmodified, and a failed `-n k` run leaves `runs/<slug>/<session>/stderr.log` to debug instead of an empty dir.
- **The one thing you must know** — `CLAUDE_CODE_OAUTH_TOKEN` is now on the default agent env allowlist: subscription users' agent subprocesses receive it under `pome run`, same trust boundary as `ANTHROPIC_API_KEY`.