### PR TITLE
feat(cli): register at install, quota-bounded trial groups, slug handoff link (FDRS-669/663/665)

### DIFF
--- a/cli/.changeset/fdrs-669-663-665-m0-agent-home-cli.md
+++ b/cli/.changeset/fdrs-669-663-665-m0-agent-home-cli.md
@@ -1,0 +1,36 @@
+---
+"pome-sh": minor
+---
+
+Reliability IA v1 M0, the CLI half (FDRS-669 / FDRS-663 / FDRS-665).
+
+`pome install` registers the agent, idempotently (FDRS-669): after the
+wiring session (and on the no-agent fallback when a config already exists),
+install calls the existing `POST /v1/agents` machinery with the repo
+directory's name and writes `agentId` + `agentSlug` into `pome.config.json`.
+An already-registered repo is a no-op — no duplicate agents, no error, same
+slug. Registration failing never fails the install; it prints the cause and
+the `pome register agent <name>` recovery path. "Default agent" becomes a
+migration-era state only.
+
+Free-tier concurrent quota no longer breaks the k=5 default (FDRS-663,
+[DECISION] option A — bounded/lazy minting): a quota push-back mid-mint
+discovers the plan's concurrent-twin bound instead of aborting the group
+with exit 4. The group runs its trials at that concurrency (resolving
+FDRS-636's deferred "bounded trial parallelism" thread — the bound IS the
+plan quota), and trials past the bound mint lazily as finished trials'
+session DELETEs free slots (quota retries with a 2s pause, 5 attempts, then
+that trial renders as an errored row and the rest continue). The
+provisioning line names the bound honestly ("plan concurrency 3 — 5 trials
+reuse slots as they finish"); trial rows still render in trial order. A
+quota error before the first mint still aborts with exit 4, and non-quota
+mint failures still roll the half-group back.
+
+The `pome run` handoff link lands on the run set, never the agent-less
+empty state (FDRS-665): with a registered slug in `pome.config.json` the
+group summary prints `/agents/<slug>/tasks/<taskName>?group=grp_…`
+(Reliability IA v1 decision 1 — the URL carries the agent by construction;
+`?group` is honored by the page from M1). Legacy fallbacks ride FDRS-668's
+cloud-side redirects: `agentId` without a slug keeps
+`/runs/task/<name>?agent=<id>`, and an unregistered repo prints the bare
+task URL, which auto-selects when exactly one agent has runs for the task.

--- a/cli/src/cli/install.ts
+++ b/cli/src/cli/install.ts
@@ -113,6 +113,14 @@ export async function runInstall(options: InstallOptions): Promise<void> {
   // nothing, so an unclean tree shouldn't block it.
   const agent = detectAgent(process.env);
   if (!agent) {
+    // FDRS-669 — a previously-inited repo still gets its agent registered on
+    // the fallback path; a truly fresh repo has no config yet (the manual
+    // steps below start with `pome init`), so this is a silent no-op there.
+    await registerAgentStep({
+      apiBaseUrl: options.apiUrl,
+      cwd,
+      credentialsPath: options.credentialsPath,
+    });
     printManualFallback();
     return; // exit 0 — the designed no-agent outcome, not a failure.
   }
@@ -177,7 +185,19 @@ export async function runInstall(options: InstallOptions): Promise<void> {
     );
   }
 
-  // 6. The ending pome's terminal owns: doctor verify to green (moment 02).
+  // 6. FDRS-669 — register the agent (idempotent) now that the session has
+  // had its chance to create pome.config.json. Runs before the doctor verify
+  // so even a red-doctor install leaves the repo registered: the first bare
+  // `pome run` submits under this agent, and "Default agent" stays a
+  // migration-era state only (Reliability IA v1, decision 2).
+  console.error("");
+  await registerAgentStep({
+    apiBaseUrl: options.apiUrl,
+    cwd,
+    credentialsPath: options.credentialsPath,
+  });
+
+  // 7. The ending pome's terminal owns: doctor verify to green (moment 02).
   // Dynamic import keeps the twin harness out of the way until needed —
   // same pattern as the `doctor` and `run` commands.
   console.error("");
@@ -240,6 +260,39 @@ function findExecutableOnPath(
     }
   }
   return null;
+}
+
+/** FDRS-669 — the install-time registration bracket. Registration failing
+ *  must not fail the install (runs would just land under "Default agent"
+ *  until the user re-runs install or `pome register agent`), so every
+ *  outcome renders as a line, never an exit code. */
+async function registerAgentStep(input: {
+  apiBaseUrl: string;
+  cwd: string;
+  credentialsPath?: string;
+}): Promise<void> {
+  const { ensureAgentRegistered } = await import("./register.js");
+  try {
+    const result = await ensureAgentRegistered(input);
+    if (result.status === "registered") {
+      console.error(
+        `✓ registered agent (slug=${result.agentSlug}) — runs submit under it.`,
+      );
+    } else if (result.status === "already-registered") {
+      console.error(
+        `✓ agent already registered (${result.agentSlug ?? result.agentId}).`,
+      );
+    }
+    // no-config: silent — the session/manual steps own creating the config;
+    // registration happens on the next `pome install` once it exists.
+  } catch (err) {
+    console.error(
+      `couldn't register the agent: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    console.error(
+      "runs will record under \"Default agent\" until `pome register agent <name>` or a re-run of pome install succeeds.",
+    );
+  }
 }
 
 type WorkingTree = "clean" | "dirty" | "not-a-repo";

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -551,8 +551,9 @@ export function createProgram() {
     .option(
       "-n, --trials <count>",
       "FDRS-636: run <count> isolated trials of the task as ONE trial group (integer 1-20; hosted only). " +
-        "Default is the scenario config's `runs` field (capped at 20). k>1 mints all sessions upfront with a shared group id, " +
-        "runs trials sequentially, prints the per-trial verdict table (numeric cloud-judge scores), and exits 0 iff at least one " +
+        "Default is the scenario config's `runs` field (capped at 20). k>1 mints sessions with a shared group id up to your " +
+        "plan's concurrent-twin quota (FDRS-663: remaining trials reuse slots as earlier trials finish), runs trials at that " +
+        "concurrency, prints the per-trial verdict table (numeric cloud-judge scores), and exits 0 iff at least one " +
         "trial completed and every completed trial passed (1: a completed trial failed; 2: nothing completed). " +
         "k=1 keeps today's single-run behavior exactly.",
     )

--- a/cli/src/cli/project-config.ts
+++ b/cli/src/cli/project-config.ts
@@ -86,6 +86,18 @@ export function normalizeConfigAgentId(config: ProjectConfig): string | undefine
   return trimmed;
 }
 
+/** FDRS-665 — the registered slug (written next to agentId by
+ *  `pome register agent` / `pome install`). Server-canonical; treated as
+ *  opaque here. Absent or malformed → undefined (the URL print falls back
+ *  to the legacy /runs/task shape). */
+export function normalizeConfigAgentSlug(
+  config: ProjectConfig,
+): string | undefined {
+  if (typeof config.agentSlug !== "string") return undefined;
+  const trimmed = config.agentSlug.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
 export function normalizeConfigAgentSdk(config: ProjectConfig): string | null {
   const sdk = config.agent?.sdk;
   if (typeof sdk !== "string") return null;

--- a/cli/src/cli/register.ts
+++ b/cli/src/cli/register.ts
@@ -12,6 +12,8 @@
 // The CLI does not invent a slug — server is canonical. We persist whatever
 // slug the server returns next to the id.
 
+import { basename, dirname } from "node:path";
+
 import {
   HostedAuthError,
   HostedOrchError,
@@ -21,8 +23,10 @@ import { friendlyHostedError } from "./session.js";
 import {
   CONFIG_FILE,
   normalizeConfigAgentId,
+  readProjectConfig,
   readRequiredProjectConfig,
   writeProjectConfig,
+  type ProjectConfigRead,
 } from "./project-config.js";
 
 interface RegisterAgentOptions {
@@ -52,26 +56,25 @@ function parseAgentResponse(raw: unknown): AgentResponse {
   throw new HostedOrchError("POST /v1/agents returned unexpected shape");
 }
 
-export async function runRegisterAgent(
-  opts: RegisterAgentOptions,
-): Promise<void> {
-  const { path, config } = await readRequiredProjectConfig();
-  const existing = normalizeConfigAgentId(config) ?? null;
-  if (existing && !opts.force) {
-    console.error(
-      `Already registered agent ${existing}. Re-run with --force to overwrite.`,
-    );
-    return;
-  }
-
-  const creds = await resolveCredentials({ apiBaseUrl: opts.apiBaseUrl });
+/** POST /v1/agents and persist the returned identity into the config read.
+ *  Shared by `pome register agent` and `pome install` (FDRS-669). */
+async function createAndPersistAgent(input: {
+  apiBaseUrl: string;
+  name: string;
+  configRead: ProjectConfigRead;
+  credentialsPath?: string;
+}): Promise<AgentResponse> {
+  const creds = await resolveCredentials({
+    apiBaseUrl: input.apiBaseUrl,
+    credentialsPath: input.credentialsPath,
+  });
   const res = await fetch(`${creds.apiBaseUrl}/v1/agents`, {
     method: "POST",
     headers: {
       "x-api-key": creds.apiKey,
       "content-type": "application/json",
     },
-    body: JSON.stringify({ name: opts.name }),
+    body: JSON.stringify({ name: input.name }),
   }).catch((err: unknown) => {
     throw new HostedOrchError(
       err instanceof Error ? err.message : "network error",
@@ -103,9 +106,29 @@ export async function runRegisterAgent(
   }
 
   const agent = parseAgentResponse(json);
-  config.agentId = agent.id;
-  config.agentSlug = agent.slug;
-  await writeProjectConfig(path, config);
+  input.configRead.config.agentId = agent.id;
+  input.configRead.config.agentSlug = agent.slug;
+  await writeProjectConfig(input.configRead.path, input.configRead.config);
+  return agent;
+}
+
+export async function runRegisterAgent(
+  opts: RegisterAgentOptions,
+): Promise<void> {
+  const configRead = await readRequiredProjectConfig();
+  const existing = normalizeConfigAgentId(configRead.config) ?? null;
+  if (existing && !opts.force) {
+    console.error(
+      `Already registered agent ${existing}. Re-run with --force to overwrite.`,
+    );
+    return;
+  }
+
+  const agent = await createAndPersistAgent({
+    apiBaseUrl: opts.apiBaseUrl,
+    name: opts.name,
+    configRead,
+  });
 
   const displayName = stripControlCharacters(agent.display_name);
   console.error(
@@ -113,6 +136,50 @@ export async function runRegisterAgent(
   );
   console.error(`Wrote agentId to ${CONFIG_FILE}.`);
   console.error(`Judge model: ${agent.judge_model}.`);
+}
+
+// ── FDRS-669 — `pome install` registration ─────────────────────────────────
+
+export interface EnsureAgentRegisteredOptions {
+  apiBaseUrl: string;
+  /** Where to look for pome.config.json. Defaults to process.cwd(). */
+  cwd?: string;
+  /** Test seam — forwarded to resolveCredentials. */
+  credentialsPath?: string;
+}
+
+export type EnsureAgentRegisteredResult =
+  | { status: "registered"; agentId: string; agentSlug: string }
+  | { status: "already-registered"; agentId: string; agentSlug?: string }
+  | { status: "no-config" };
+
+/** Idempotent registration for `pome install`: a repo with an agentId keeps
+ *  it (no duplicate agents, no error, same slug); a fresh repo registers
+ *  under the config directory's basename (vercel-link shape — the server
+ *  canonicalizes the slug; we persist whatever it returns). */
+export async function ensureAgentRegistered(
+  opts: EnsureAgentRegisteredOptions,
+): Promise<EnsureAgentRegisteredResult> {
+  const configRead = await readProjectConfig(opts.cwd ?? process.cwd());
+  if (!configRead) return { status: "no-config" };
+
+  const existing = normalizeConfigAgentId(configRead.config);
+  if (existing) {
+    const slug = configRead.config.agentSlug;
+    return {
+      status: "already-registered",
+      agentId: existing,
+      agentSlug: typeof slug === "string" && slug.trim() ? slug.trim() : undefined,
+    };
+  }
+
+  const agent = await createAndPersistAgent({
+    apiBaseUrl: opts.apiBaseUrl,
+    name: basename(dirname(configRead.path)),
+    configRead,
+    credentialsPath: opts.credentialsPath,
+  });
+  return { status: "registered", agentId: agent.id, agentSlug: agent.slug };
 }
 
 function stripControlCharacters(value: string): string {

--- a/cli/src/runner/groupRender.ts
+++ b/cli/src/runner/groupRender.ts
@@ -41,9 +41,18 @@ export function flagHintLine(agentCommandSource: string): string {
   return `-n sets how many isolated trials to run · the agent command comes from ${agentCommandSource}`;
 }
 
-/** Printed once every session of the group is minted (the cloud provisions
- *  one isolated twin sandbox per session — ADR-012). */
-export function provisioningLine(k: number, twins: string[]): string {
+/** Printed once the upfront mints are done (the cloud provisions one
+ *  isolated twin sandbox per session — ADR-012). FDRS-663: when the plan's
+ *  concurrent-twin quota bounded the upfront mint below k, the bound is
+ *  named honestly — k stays the design default, the wall-clock stretches. */
+export function provisioningLine(
+  k: number,
+  twins: string[],
+  bound?: number,
+): string {
+  if (bound !== undefined && bound < k) {
+    return `provisioning ${bound} isolated ${twins.join("+")} twins … ready (plan concurrency ${bound} — ${k} trials reuse slots as they finish)`;
+  }
   return `provisioning ${k} isolated ${twins.join("+")} twins … ready`;
 }
 

--- a/cli/src/runner/runTrialGroup.ts
+++ b/cli/src/runner/runTrialGroup.ts
@@ -1,24 +1,34 @@
 // SPDX-License-Identifier: Apache-2.0
 // FDRS-636 — `pome run <task> -n k`: real trial groups end-to-end.
+// FDRS-663 — bounded/lazy minting + bounded trial parallelism.
 //
-// Flow per the 2026-07-05 [DECISION] set:
-//   1. Mint ALL k sessions upfront (POST /v1/sessions), one shared
+// Flow per the 2026-07-05 [DECISION] set, revised by FDRS-663's 2026-07-06
+// [DECISION] (option A — the free-tier `concurrentTwins: 3` mint gate was
+// killing the k=5 default at the 4th upfront mint):
+//   1. Mint sessions upfront (POST /v1/sessions), one shared
 //      `grp_` + nanoid21 group_id on EVERY mint body and a FRESH
 //      idempotency key per mint — the design's "provisioning k isolated
-//      github twins … ready" moment. A failed mint rolls the half-group
-//      back (best-effort DELETEs) and aborts before any agent spawns.
-//   2. Run the k trials SEQUENTIALLY (bounded parallelism deferred —
-//      plan-quota semantics unresolved). runScenarioHosted stays the
-//      isolation unit: each trial gets its pre-minted session via the
+//      github twins … ready" moment. A QUOTA error mid-mint no longer
+//      aborts: it discovers the plan's concurrent-twin bound, and the
+//      group proceeds with the sessions it holds (k stays the design
+//      default; the wall-clock stretches). Any other failed mint — or a
+//      quota error before the FIRST mint succeeds — still rolls the
+//      half-group back (best-effort DELETEs) and aborts before any agent
+//      spawns.
+//   2. Run the k trials with concurrency = the number of upfront mints
+//      (= k when quota never pushed back). runScenarioHosted stays the
+//      isolation unit: each trial gets its session via the
 //      `premintedSession` seam, `abandonOnFailure` on, and still DELETEs
-//      its own session in its `finally`.
-//   3. Errored trials (preflight failure / agent timeout / crash) were
-//      abandoned inside the trial (POST /:id/abandon with a machine
-//      error_code); here they render as errored rows EXCLUDED from the
-//      verdict fraction — remaining trials continue.
+//      its own session in its `finally` — that delete frees the quota slot
+//      the next lazy mint reuses. Trials beyond the bound mint lazily as
+//      slots free (quota retries with a pause: deletes propagate async);
+//      rows render in trial order regardless of completion order.
+//   3. Errored trials (preflight failure / agent timeout / crash / a lazy
+//      mint that never cleared quota) were abandoned inside the trial where
+//      possible; here they render as errored rows EXCLUDED from the verdict
+//      fraction — remaining trials continue.
 //   4. Verdicts are NUMERIC cloud-judge scores (capture-only CLI, ADR-013);
-//      the summary hands off to the task's reliability page
-//      ({dashboard}/runs/task/<taskName>).
+//      the summary hands off to the task's reliability page.
 //
 // k=1 never reaches this module: the single-run path in cli/main.ts stays
 // exactly as it was (no group stamped — a group of 1 would flip the
@@ -28,13 +38,14 @@ import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { createHostedClient, type HostedClient } from "../hosted/client.js";
-import { HostedTrialError } from "../hosted/errors.js";
+import { HostedQuotaError, HostedTrialError } from "../hosted/errors.js";
 import { newGroupId } from "../demo/ids.js";
 import { criterionPhrase } from "../demo/render.js";
 import { parseScenarioFile } from "../scenario/parseScenario.js";
 import { outcomeOf } from "../score/view.js";
 import {
   normalizeConfigAgentId,
+  normalizeConfigAgentSlug,
   readProjectConfig,
 } from "../cli/project-config.js";
 import { runScenarioHosted } from "./runScenarioHosted.js";
@@ -56,6 +67,12 @@ import type { CreateSessionResponse } from "../types/shared.js";
  *  defaults to 30s; the judge measured 5-8s, 60s is belt-and-braces (same
  *  constant `pome demo` locked for its trial finalizes). */
 export const GROUP_FINALIZE_TIMEOUT_MS = 60_000;
+
+/** FDRS-663 — a lazy mint can quota-fail even though a trial just finished:
+ *  the finished trial's DELETE propagates asynchronously. Pause and retry a
+ *  bounded number of times before declaring that trial errored. */
+export const LAZY_MINT_RETRY_MS = 2_000;
+export const LAZY_MINT_MAX_ATTEMPTS = 5;
 
 export interface RunTrialGroupOptions {
   scenarioPath: string;
@@ -82,6 +99,8 @@ export interface RunTrialGroupOptions {
   client?: HostedClient;
   runScenarioHostedFn?: typeof runScenarioHosted;
   groupId?: string;
+  /** FDRS-663 — lazy-mint retry pause; defaults to a real setTimeout. */
+  sleepFn?: (ms: number) => Promise<void>;
 }
 
 export interface RunTrialGroupResult {
@@ -119,28 +138,42 @@ export async function runTrialGroup(
   const agentId = configRead
     ? normalizeConfigAgentId(configRead.config)
     : undefined;
+  const agentSlug = configRead
+    ? normalizeConfigAgentSlug(configRead.config)
+    : undefined;
 
   out(flagHintLine(agentCommandSource));
   out("");
 
-  // 1. Mint all k sessions upfront. The group exists before the first agent
-  // spawns, and quota/auth failures surface HERE as one clean error instead
-  // of half-way through a run. Fresh idempotency key per mint — the k mint
-  // bodies are otherwise identical, and the cloud would collapse them onto
-  // one session.
+  const sleep =
+    options.sleepFn ??
+    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const mintOne = () =>
+    client.createSession({
+      scenarioSource,
+      twins: scenario.config.twins,
+      agentId,
+      seed: scenario.seedState,
+      groupId,
+      // Fresh idempotency key per mint — the mint bodies are otherwise
+      // identical, and the cloud would collapse them onto one session.
+      idempotencyKey: randomUUID(),
+    });
+
+  // 1. Mint upfront, quota-bounded (FDRS-663). The group exists before the
+  // first agent spawns, and auth/orch failures surface HERE as one clean
+  // error instead of half-way through a run. A quota push-back mid-mint is
+  // NOT an error: it discovers the plan's concurrent-twin bound and the
+  // group proceeds at that concurrency, reusing slots as trials finish.
   const sessions: CreateSessionResponse[] = [];
   try {
     for (let i = 0; i < options.trials; i += 1) {
-      sessions.push(
-        await client.createSession({
-          scenarioSource,
-          twins: scenario.config.twins,
-          agentId,
-          seed: scenario.seedState,
-          groupId,
-          idempotencyKey: randomUUID(),
-        }),
-      );
+      try {
+        sessions.push(await mintOne());
+      } catch (err) {
+        if (err instanceof HostedQuotaError && sessions.length > 0) break;
+        throw err;
+      }
     }
   } catch (err) {
     // Roll the half-group back so abandoned mints never linger as open
@@ -151,18 +184,48 @@ export async function runTrialGroup(
     );
     throw err;
   }
-  out(provisioningLine(options.trials, scenario.config.twins));
+  const concurrency = sessions.length;
+  out(
+    provisioningLine(options.trials, scenario.config.twins, concurrency),
+  );
   out(spawningAgentLine(options.agentCommand, agentCommandSource));
   out("");
 
-  // 2. Sequential trials over the pre-minted sessions ([DECISION]: bounded
-  // parallelism deferred until plan-quota semantics are resolved).
-  const rows: TrialRow[] = [];
+  // A trial past the upfront bound mints its session lazily, once its worker
+  // slot frees. The slot's previous trial deleted its session on the way out,
+  // but that DELETE propagates asynchronously — quota errors here retry with
+  // a pause before the trial is declared errored.
+  const mintLazily = async (): Promise<CreateSessionResponse> => {
+    for (let attempt = 1; ; attempt += 1) {
+      try {
+        return await mintOne();
+      } catch (err) {
+        if (err instanceof HostedQuotaError && attempt < LAZY_MINT_MAX_ATTEMPTS) {
+          await sleep(LAZY_MINT_RETRY_MS);
+          continue;
+        }
+        throw err;
+      }
+    }
+  };
+
+  // 2. Trials at bounded concurrency (FDRS-663 resolves FDRS-636's deferred
+  // "bounded trial parallelism" thread: the bound IS the plan's quota).
+  // Rows render in trial order — a finished trial's line waits for every
+  // earlier trial's line.
+  const rows: TrialRow[] = new Array<TrialRow>(options.trials);
   const failedCriteria: string[] = [];
-  for (let i = 0; i < options.trials; i += 1) {
-    const session = sessions[i]!;
+  let printedRows = 0;
+  const flushRows = () => {
+    while (printedRows < options.trials && rows[printedRows] !== undefined) {
+      out(trialRowLine(printedRows + 1, rows[printedRows]!));
+      printedRows += 1;
+    }
+  };
+  const runOneTrial = async (index: number): Promise<void> => {
     let row: TrialRow;
     try {
+      const session = index < sessions.length ? sessions[index]! : await mintLazily();
       const result = await runFn({
         scenarioPath: options.scenarioPath,
         agentCommand: options.agentCommand,
@@ -192,8 +255,9 @@ export async function runTrialGroup(
       };
     } catch (err) {
       // The trial abandoned its session before throwing (or crashed past
-      // the point where a verdict was possible). Errored rows are excluded
-      // from the fraction; the remaining trials continue.
+      // the point where a verdict was possible — or its lazy mint never
+      // cleared quota). Errored rows are excluded from the fraction; the
+      // remaining trials continue.
       row = {
         kind: "errored",
         reason:
@@ -202,19 +266,37 @@ export async function runTrialGroup(
             : shortReason(err instanceof Error ? err.message : String(err)),
       };
     }
-    rows.push(row);
-    out(trialRowLine(i + 1, row));
-  }
+    rows[index] = row;
+    flushRows();
+  };
+  let nextTrial = 0;
+  await Promise.all(
+    Array.from({ length: Math.max(1, concurrency) }, async () => {
+      while (nextTrial < options.trials) {
+        const index = nextTrial;
+        nextTrial += 1;
+        await runOneTrial(index);
+      }
+    }),
+  );
 
-  // 3. Summary + the framed handoff to the task's reliability page. Route
-  // shape from the dashboard app (/runs/task/[taskName], ?agent read
-  // client-side); task name = the slug /finalize recorded as
-  // runs.task_name.
+  // 3. Summary + the framed handoff to the task's reliability page.
+  // FDRS-665 — the URL carries the agent by construction (Reliability IA v1
+  // decision 1): a registered repo prints /agents/<slug>/tasks/<taskName>
+  // with ?group for the run set (forward-compat — the page honors it in M1).
+  // Legacy fallbacks, both served by FDRS-668's cloud-side redirects:
+  // agentId without a slug → /runs/task/<name>?agent=<id> (server-side
+  // id→slug redirect); unregistered repo → the bare task URL, which
+  // auto-selects when exactly one agent has runs for that task. Task name =
+  // the slug /finalize recorded as runs.task_name.
   const failing = mostCommonFailedCriterion(failedCriteria);
   const base = options.dashboardBaseUrl.replace(/\/$/, "");
-  const reliabilityUrl = `${base}/runs/task/${encodeURIComponent(scenario.slug)}${
-    agentId ? `?agent=${encodeURIComponent(agentId)}` : ""
-  }`;
+  const taskPart = encodeURIComponent(scenario.slug);
+  const reliabilityUrl = agentSlug
+    ? `${base}/agents/${encodeURIComponent(agentSlug)}/tasks/${taskPart}?group=${encodeURIComponent(groupId)}`
+    : `${base}/runs/task/${taskPart}${
+        agentId ? `?agent=${encodeURIComponent(agentId)}` : ""
+      }`;
   for (const line of groupSummaryLines({
     rows,
     failingCriterionPhrase: failing?.phrase,

--- a/cli/test/integration/run-group-e2e.test.ts
+++ b/cli/test/integration/run-group-e2e.test.ts
@@ -281,8 +281,12 @@ describe("pome run -n k end-to-end against a stub cloud (FDRS-636)", () => {
     expect(text).toContain(`after the fix lands, re-run the task:  pome run ${scenarioPath} -n 3`);
 
     // And fix-prompt's discovery reassembles this exact run set from disk.
+    // Membership, not order: FDRS-663 runs trials in parallel, so within-set
+    // order is finalized_at (completion) order and either trial can win.
     const discovery = await discoverRunSet(join(tmp, "runs"));
     expect(discovery.set?.groupId).toBe(result.groupId);
-    expect(discovery.set?.trials.map((t) => t.verdict.session_id)).toEqual(["ses_1", "ses_3"]);
+    expect(
+      discovery.set?.trials.map((t) => t.verdict.session_id).sort(),
+    ).toEqual(["ses_1", "ses_3"]);
   }, 120_000);
 });

--- a/cli/test/unit/install-command.test.ts
+++ b/cli/test/unit/install-command.test.ts
@@ -242,6 +242,103 @@ describe("pome install (FDRS-642)", () => {
     expect(process.exitCode).toBeFalsy();
   }, 60_000);
 
+  // FDRS-669 — install registers the agent after the session, idempotently.
+  it("registers the agent after the session so the first run submits under it", async () => {
+    const { binDir } = await fakeClaudeBin();
+    const home = await fakeHome();
+    const repo = await fixtureRepo(WIRED_SOURCE);
+    vi.stubEnv("PATH", binDir);
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("POME_API_KEY", "pme_test");
+    vi.stubEnv("POME_CLI_DISABLE_KEYCHAIN", "1");
+    const realFetch = globalThis.fetch;
+    const agentPosts: unknown[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith("/v1/agents")) {
+        agentPosts.push(JSON.parse(String(init?.body)));
+        return new Response(
+          JSON.stringify({
+            id: "agt_fresh",
+            slug: "fixture-repo",
+            display_name: "fixture-repo",
+            judge_model: "google/gemini-2.5-flash",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return realFetch(input, init);
+    });
+
+    await runInstall({
+      apiUrl: API_URL,
+      dashboardUrl: DASHBOARD_URL,
+      stdinIsTTY: true,
+      cwd: repo,
+      confirm: async () => true,
+    });
+
+    expect(agentPosts).toHaveLength(1);
+    const config = JSON.parse(
+      await readFile(join(repo, "pome.config.json"), "utf8"),
+    ) as Record<string, unknown>;
+    expect(config.agentId).toBe("agt_fresh");
+    expect(config.agentSlug).toBe("fixture-repo");
+    const text = stderrText();
+    expect(text).toContain("registered agent");
+    expect(text).toContain("fixture-repo");
+    expect(process.exitCode).toBeFalsy();
+  }, 60_000);
+
+  it("re-running install on a registered repo is idempotent: no duplicate agent, same slug", async () => {
+    const { binDir } = await fakeClaudeBin();
+    const home = await fakeHome();
+    const repo = await fixtureRepo(WIRED_SOURCE);
+    await writeFile(
+      join(repo, "pome.config.json"),
+      JSON.stringify(
+        {
+          agent: { command: 'node -e "process.exit(0)"' },
+          agentId: "agt_existing",
+          agentSlug: "already-there",
+        },
+        null,
+        2,
+      ),
+    );
+    vi.stubEnv("PATH", binDir);
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("POME_API_KEY", "pme_test");
+    vi.stubEnv("POME_CLI_DISABLE_KEYCHAIN", "1");
+    const realFetch = globalThis.fetch;
+    let agentPosts = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith("/v1/agents")) {
+        agentPosts += 1;
+        throw new Error("must not re-register");
+      }
+      return realFetch(input, init);
+    });
+
+    await runInstall({
+      apiUrl: API_URL,
+      dashboardUrl: DASHBOARD_URL,
+      stdinIsTTY: true,
+      cwd: repo,
+      confirm: async () => true,
+    });
+
+    expect(agentPosts).toBe(0);
+    const config = JSON.parse(
+      await readFile(join(repo, "pome.config.json"), "utf8"),
+    ) as Record<string, unknown>;
+    expect(config.agentId).toBe("agt_existing");
+    expect(config.agentSlug).toBe("already-there");
+    expect(stderrText()).toContain("already-there");
+    expect(process.exitCode).toBeFalsy();
+  }, 60_000);
+
   it("ends red with doctor's named cause when the session leaves the repo unwired", async () => {
     const { binDir } = await fakeClaudeBin();
     const home = await fakeHome();

--- a/cli/test/unit/register.test.ts
+++ b/cli/test/unit/register.test.ts
@@ -2,9 +2,10 @@ import { existsSync, readFileSync } from "node:fs";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { basename } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HostedOrchError } from "../../src/hosted/errors.js";
-import { runRegisterAgent } from "../../src/cli/register.js";
+import { ensureAgentRegistered, runRegisterAgent } from "../../src/cli/register.js";
 
 const originalCwd = process.cwd();
 const tempDirs: string[] = [];
@@ -174,5 +175,83 @@ describe("runRegisterAgent", () => {
       }),
     ).rejects.toThrow(/malformed agentId/);
     expect(existsSync("pome.config.json")).toBe(true);
+  });
+});
+
+// FDRS-669 — the `pome install` registration seam: same machinery as
+// `pome register agent`, but derives the name from the repo directory and
+// never errors on an already-registered repo (idempotent by design).
+describe("ensureAgentRegistered (FDRS-669)", () => {
+  it("registers a fresh repo under the config directory's name and writes agentId + agentSlug", async () => {
+    await writeConfig({ agent: { command: "node a.js" } });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      response({
+        id: "agt_123",
+        slug: "my-repo",
+        display_name: "my-repo",
+        judge_model: "google/gemini-2.5-flash",
+      }),
+    );
+
+    const result = await ensureAgentRegistered({
+      apiBaseUrl: "https://api.example.com",
+    });
+
+    expect(result).toEqual({
+      status: "registered",
+      agentId: "agt_123",
+      agentSlug: "my-repo",
+    });
+    // The server-side name is the repo directory's basename (vercel-link
+    // shape: identity defaults to where you ran it).
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("https://api.example.com/v1/agents");
+    expect(JSON.parse(String((init as RequestInit).body))).toEqual({
+      name: basename(process.cwd()),
+    });
+    expect(readConfig()).toMatchObject({
+      agentId: "agt_123",
+      agentSlug: "my-repo",
+      agent: { command: "node a.js" },
+    });
+  });
+
+  it("is idempotent: an already-registered repo makes no request and keeps the same slug", async () => {
+    await writeConfig({
+      agentId: "agt_existing",
+      agentSlug: "existing-agent",
+      agent: { command: "node a.js" },
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+
+    const first = await ensureAgentRegistered({
+      apiBaseUrl: "https://api.example.com",
+    });
+    const second = await ensureAgentRegistered({
+      apiBaseUrl: "https://api.example.com",
+    });
+
+    expect(first).toEqual({
+      status: "already-registered",
+      agentId: "agt_existing",
+      agentSlug: "existing-agent",
+    });
+    expect(second).toEqual(first);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(readConfig()).toMatchObject({
+      agentId: "agt_existing",
+      agentSlug: "existing-agent",
+    });
+  });
+
+  it("returns no-config without fetching when pome.config.json is absent", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+
+    const result = await ensureAgentRegistered({
+      apiBaseUrl: "https://api.example.com",
+    });
+
+    expect(result).toEqual({ status: "no-config" });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/cli/test/unit/runner/groupRender.test.ts
+++ b/cli/test/unit/runner/groupRender.test.ts
@@ -55,6 +55,17 @@ describe("group header lines (moment 04)", () => {
     );
   });
 
+  // FDRS-663 — the quota bound is named honestly, never silently absorbed.
+  it("names the plan-concurrency bound when the quota bounded the upfront mint", () => {
+    expect(provisioningLine(5, ["github"], 3)).toBe(
+      "provisioning 3 isolated github twins … ready (plan concurrency 3 — 5 trials reuse slots as they finish)",
+    );
+    // Bound == k means quota never pushed back: the classic line.
+    expect(provisioningLine(5, ["github"], 5)).toBe(
+      "provisioning 5 isolated github twins … ready",
+    );
+  });
+
   it("renders the spawning-agent line with the command and its source", () => {
     expect(
       spawningAgentLine("npx tsx examples/agents/triage-agent.ts", "pome.config.json"),

--- a/cli/test/unit/runner/runTrialGroup.test.ts
+++ b/cli/test/unit/runner/runTrialGroup.test.ts
@@ -17,9 +17,15 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createHostedClient, type HostedClient } from "../../../src/hosted/client.js";
-import { HostedOrchError, HostedTrialError } from "../../../src/hosted/errors.js";
+import {
+  HostedOrchError,
+  HostedQuotaError,
+  HostedTrialError,
+} from "../../../src/hosted/errors.js";
 import {
   GROUP_FINALIZE_TIMEOUT_MS,
+  LAZY_MINT_MAX_ATTEMPTS,
+  LAZY_MINT_RETRY_MS,
   runTrialGroup,
 } from "../../../src/runner/runTrialGroup.js";
 import type {
@@ -402,6 +408,282 @@ describe("runTrialGroup — errored trials (FDRS-636)", () => {
   });
 });
 
+// FDRS-663 — free-tier `concurrentTwins: 3` vs the k=5 default. Decided cut
+// (option A): bounded/lazy minting inside the group runner — mint ≤ the
+// team's concurrent quota (discovered adaptively from the mint-gate quota
+// error), run trials with that concurrency, and mint the remaining trials'
+// sessions lazily as slots free up. Resolves FDRS-636's deferred "bounded
+// trial parallelism (plan-quota semantics)" thread.
+interface QuotaCloud {
+  client: HostedClient;
+  /** Every createSession attempt, successful or quota-refused. */
+  attempts: number;
+  mints: Array<{ groupId?: string; idempotencyKey?: string }>;
+  active: number;
+  peakActive: number;
+  /** Simulates the slot freeing when a trial's session is deleted. */
+  release: (sessionId: string) => void;
+}
+
+function makeQuotaCloud(input: {
+  limit: number;
+  /** 1-based createSession attempt numbers that quota-fail regardless of
+   *  the limit — simulates delete-propagation lag on lazy mints. */
+  forcedQuotaAttempts?: number[];
+}): QuotaCloud {
+  const forced = new Set(input.forcedQuotaAttempts ?? []);
+  const released = new Set<string>();
+  const cloud: QuotaCloud = {
+    client: null as unknown as HostedClient,
+    attempts: 0,
+    mints: [],
+    active: 0,
+    peakActive: 0,
+    release: (sessionId) => {
+      if (released.has(sessionId)) return;
+      released.add(sessionId);
+      cloud.active -= 1;
+    },
+  };
+  const unused = () => {
+    throw new Error("not used");
+  };
+  cloud.client = {
+    async createSession(sessionInput) {
+      cloud.attempts += 1;
+      if (forced.has(cloud.attempts) || cloud.active >= input.limit) {
+        throw new HostedQuotaError("Concurrent twin quota exceeded for this team.");
+      }
+      cloud.active += 1;
+      cloud.peakActive = Math.max(cloud.peakActive, cloud.active);
+      cloud.mints.push({
+        groupId: sessionInput.groupId,
+        idempotencyKey: sessionInput.idempotencyKey,
+      });
+      const n = cloud.mints.length;
+      return {
+        session_id: `ses_${n}`,
+        twin_url: `https://twins.example/s/ses_${n}`,
+        expires_at: new Date(Date.now() + 600_000).toISOString(),
+        agent_token: `tok_${n}`,
+        provider_credentials: {},
+        openapi_url: "https://twins.example/openapi.json",
+      };
+    },
+    async deleteSession(sessionId) {
+      cloud.release(sessionId);
+    },
+    createEvalSession: unused,
+    listSessions: async () => [],
+    getSession: unused,
+    fetchState: async () => ({}),
+    fetchEvents: async () => [],
+    finalize: unused,
+    submitResult: unused,
+    requestEventsUploadUrl: unused,
+    requestStateUploadUrl: unused,
+    requestSignalsUploadUrl: unused,
+    abandonSession: async (sessionId) => ({
+      session_id: sessionId,
+      state: "failed",
+      error_code: null,
+      abandoned: true,
+    }),
+  };
+  return cloud;
+}
+
+describe("runTrialGroup — quota-bounded mint + bounded parallelism (FDRS-663)", () => {
+  it("a quota error mid-mint bounds the group instead of aborting: k=5 completes at concurrency 3", async () => {
+    const scenarioPath = await scenarioFixture();
+    const cloud = makeQuotaCloud({ limit: 3 });
+    const out: string[] = [];
+    let activeTrials = 0;
+    let peakTrials = 0;
+
+    const result = await runTrialGroup({
+      scenarioPath,
+      agentCommand: "node agent.js",
+      trials: 5,
+      hosted: { baseUrl: "https://api.example", apiKey: "pme_k" },
+      dashboardBaseUrl: "https://app.pome.sh",
+      out: (line) => out.push(line),
+      client: cloud.client,
+      sleepFn: async () => {},
+      runScenarioHostedFn: async (options) => {
+        activeTrials += 1;
+        peakTrials = Math.max(peakTrials, activeTrials);
+        await new Promise((r) => setTimeout(r, 10));
+        activeTrials -= 1;
+        // runScenarioHosted deletes its own session in its finally — that is
+        // what frees the quota slot for the next lazy mint.
+        cloud.release(options.premintedSession!.session_id);
+        return trialResult({
+          sessionId: options.premintedSession!.session_id,
+          satisfaction: 100,
+          exitCode: 0,
+          durationMs: 1000,
+        });
+      },
+    });
+
+    // All five trials completed without the group aborting on exit 4.
+    expect(result.rows).toHaveLength(5);
+    expect(result.rows.every((r) => r.kind === "completed")).toBe(true);
+    expect(result.exitCode).toBe(0);
+
+    // The cloud never saw more than the plan's concurrent quota, and the
+    // trials actually ran in parallel up to that bound.
+    expect(cloud.peakActive).toBe(3);
+    expect(peakTrials).toBe(3);
+
+    // 5 successful mints (3 upfront + 2 lazy), one shared group id, fresh
+    // idempotency keys throughout.
+    expect(cloud.mints).toHaveLength(5);
+    expect(new Set(cloud.mints.map((m) => m.groupId)).size).toBe(1);
+    expect(new Set(cloud.mints.map((m) => m.idempotencyKey)).size).toBe(5);
+
+    // Honest provisioning copy: the bound is named, not silently absorbed.
+    expect(out.join("\n")).toContain(
+      "provisioning 3 isolated github twins … ready (plan concurrency 3 — 5 trials reuse slots as they finish)",
+    );
+  });
+
+  it("a lazy mint that quota-fails on delete-propagation lag retries after a pause and completes", async () => {
+    const scenarioPath = await scenarioFixture();
+    // Attempts 1-2 mint, attempt 3 hits the limit (bound=2), attempt 4 is the
+    // first lazy mint — forced to fail once as if the freed slot hasn't
+    // propagated — and attempt 5 succeeds.
+    const cloud = makeQuotaCloud({ limit: 2, forcedQuotaAttempts: [4] });
+    const sleeps: number[] = [];
+
+    const result = await runTrialGroup({
+      scenarioPath,
+      agentCommand: "node agent.js",
+      trials: 3,
+      hosted: { baseUrl: "https://api.example", apiKey: "pme_k" },
+      dashboardBaseUrl: "https://app.pome.sh",
+      out: () => {},
+      client: cloud.client,
+      sleepFn: async (ms) => {
+        sleeps.push(ms);
+      },
+      runScenarioHostedFn: async (options) => {
+        await new Promise((r) => setTimeout(r, 5));
+        cloud.release(options.premintedSession!.session_id);
+        return trialResult({
+          sessionId: options.premintedSession!.session_id,
+          satisfaction: 100,
+          exitCode: 0,
+          durationMs: 1000,
+        });
+      },
+    });
+
+    expect(sleeps).toEqual([LAZY_MINT_RETRY_MS]);
+    expect(result.rows.every((r) => r.kind === "completed")).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(cloud.mints).toHaveLength(3);
+  });
+
+  it("a lazy mint that never clears quota errors that trial (excluded) and the rest still count", async () => {
+    const scenarioPath = await scenarioFixture();
+    // Bound discovery at attempt 3; the lazy mint for trial 3 quota-fails on
+    // every one of its attempts.
+    const lazyAttempts = Array.from(
+      { length: LAZY_MINT_MAX_ATTEMPTS },
+      (_, i) => 4 + i,
+    );
+    const cloud = makeQuotaCloud({ limit: 2, forcedQuotaAttempts: lazyAttempts });
+    const out: string[] = [];
+
+    const result = await runTrialGroup({
+      scenarioPath,
+      agentCommand: "node agent.js",
+      trials: 3,
+      hosted: { baseUrl: "https://api.example", apiKey: "pme_k" },
+      dashboardBaseUrl: "https://app.pome.sh",
+      out: (line) => out.push(line),
+      client: cloud.client,
+      sleepFn: async () => {},
+      runScenarioHostedFn: async (options) => {
+        cloud.release(options.premintedSession!.session_id);
+        return trialResult({
+          sessionId: options.premintedSession!.session_id,
+          satisfaction: 100,
+          exitCode: 0,
+          durationMs: 1000,
+        });
+      },
+    });
+
+    const kinds = result.rows.map((r) => r.kind);
+    expect(kinds.filter((k) => k === "completed")).toHaveLength(2);
+    expect(kinds.filter((k) => k === "errored")).toHaveLength(1);
+    expect(out.join("\n")).toContain("2 of 2 passed · 1 errored, excluded from the fraction");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a quota error on the very first mint still aborts the group (nothing to bound)", async () => {
+    const scenarioPath = await scenarioFixture();
+    const cloud = makeQuotaCloud({ limit: 0 });
+    let trialsRun = 0;
+
+    await expect(
+      runTrialGroup({
+        scenarioPath,
+        agentCommand: "node agent.js",
+        trials: 3,
+        hosted: { baseUrl: "https://api.example", apiKey: "pme_k" },
+        dashboardBaseUrl: "https://app.pome.sh",
+        out: () => {},
+        client: cloud.client,
+        sleepFn: async () => {},
+        runScenarioHostedFn: async () => {
+          trialsRun += 1;
+          throw new Error("unreachable");
+        },
+      }),
+    ).rejects.toBeInstanceOf(HostedQuotaError);
+    expect(trialsRun).toBe(0);
+  });
+
+  it("trial rows render in trial order even when later trials finish first", async () => {
+    const scenarioPath = await scenarioFixture();
+    const cloud = makeQuotaCloud({ limit: 2 });
+    const out: string[] = [];
+
+    await runTrialGroup({
+      scenarioPath,
+      agentCommand: "node agent.js",
+      trials: 2,
+      hosted: { baseUrl: "https://api.example", apiKey: "pme_k" },
+      dashboardBaseUrl: "https://app.pome.sh",
+      out: (line) => out.push(line),
+      client: cloud.client,
+      sleepFn: async () => {},
+      runScenarioHostedFn: async (options) => {
+        const sid = options.premintedSession!.session_id;
+        // Trial 1 is slow; trial 2 finishes well before it.
+        await new Promise((r) => setTimeout(r, sid === "ses_1" ? 40 : 1));
+        cloud.release(sid);
+        return trialResult({
+          sessionId: sid,
+          satisfaction: sid === "ses_1" ? 100 : 96,
+          exitCode: 0,
+          durationMs: 1000,
+        });
+      },
+    });
+
+    const rowLines = out.filter((l) => l.startsWith("trial "));
+    expect(rowLines[0]).toContain("trial 1");
+    expect(rowLines[0]).toContain("100");
+    expect(rowLines[1]).toContain("trial 2");
+    expect(rowLines[1]).toContain("96");
+  });
+});
+
 describe("runTrialGroup — dashboard link + client construction", () => {
   it("derives the reliability link from the dashboard base + /runs/task/<taskName>", async () => {
     const scenarioPath = await scenarioFixture();
@@ -429,6 +711,52 @@ describe("runTrialGroup — dashboard link + client construction", () => {
     // fixture file is "scn". No double slash from the trailing base slash.
     expect(result.reliabilityUrl).toBe("https://app.pome.sh/runs/task/scn");
     expect(out.join("\n")).toContain("→ https://app.pome.sh/runs/task/scn");
+  });
+
+  // FDRS-665 — the handoff link carries the agent by construction: with a
+  // registered slug (written by `pome install` / `pome register agent`,
+  // FDRS-669) the CLI prints /agents/<slug>/tasks/<name>?group=grp_… — the
+  // run set's reliability view, never the agent-less empty state. ?group is
+  // forward-compat: the page honors it in M1.
+  it("prints /agents/<slug>/tasks/<name>?group=grp_… when pome.config.json carries the registered slug", async () => {
+    const scenarioPath = await scenarioFixture();
+    const dir = join(scenarioPath, "..");
+    await writeFile(
+      join(dir, "pome.config.json"),
+      JSON.stringify({
+        agentId: "agt_123",
+        agentSlug: "triage-bot",
+        agent: { command: "node agent.js" },
+      }),
+      "utf8",
+    );
+    const cloud = makeFakeClient();
+    const out: string[] = [];
+
+    const result = await runTrialGroup({
+      scenarioPath,
+      agentCommand: "node agent.js",
+      trials: 2,
+      hosted: { baseUrl: "https://api.example", apiKey: "pme_k" },
+      dashboardBaseUrl: "https://app.pome.sh",
+      out: (line) => out.push(line),
+      client: cloud.client,
+      groupId: "grp_C6ptcAyN31L5v58zfmYFq",
+      runScenarioHostedFn: async (options) =>
+        trialResult({
+          sessionId: options.premintedSession!.session_id,
+          satisfaction: 100,
+          exitCode: 0,
+          durationMs: 1000,
+        }),
+    });
+
+    expect(result.reliabilityUrl).toBe(
+      "https://app.pome.sh/agents/triage-bot/tasks/scn?group=grp_C6ptcAyN31L5v58zfmYFq",
+    );
+    expect(out.join("\n")).toContain(
+      "→ https://app.pome.sh/agents/triage-bot/tasks/scn?group=grp_C6ptcAyN31L5v58zfmYFq",
+    );
   });
 
   it("appends ?agent=<agentId> when pome.config.json pins one (page groups per agent)", async () => {


### PR DESCRIPTION
<!-- Closes FDRS-669 -->
<!-- Closes FDRS-663 -->
<!-- Closes FDRS-665 -->

## What

The CLI half of Reliability IA v1 M0 ("Agent is home — virgin path zero-nav"), three coupled tickets on one branch:

- **FDRS-669** — `pome install` registers the agent idempotently (reuses `register.ts` + `POST /v1/agents`; name = repo directory basename; `agentId` + `agentSlug` written to `pome.config.json`; already-registered → no-op, same slug; registration failure warns but never fails the install).
- **FDRS-663** — bounded/lazy minting in `runTrialGroup` ([DECISION] option A): a quota error mid-mint discovers the plan's concurrent-twin bound instead of aborting with exit 4. Trials run at that concurrency (resolves FDRS-636's deferred bounded-parallelism thread), later trials mint lazily as finished trials free slots (2s-pause retries ×5, then an errored row). Provisioning line names the bound; rows render in trial order; first-mint quota errors and non-quota mint failures keep today's abort+rollback.
- **FDRS-665** — the group handoff link prints `/agents/<slug>/tasks/<name>?group=grp_…` when a registered slug exists (decision 1: the URL carries the agent by construction). Fallbacks ride FDRS-668's redirects: `agentId`-only → `/runs/task/<name>?agent=<id>`; unregistered → bare task URL (cloud auto-selects a single agent).

## Why

2026-07-06 live e2e (Reliability IA v1 project description): fresh installs never registered an agent, so runs piled into "Default agent" and the printed handoff link landed on the "This task needs an agent to group by" dead end; bare `pome run` (k=5) hard-failed at the 4th mint on free-tier `concurrentTwins: 3`. FDRS-663 is a named prerequisite of M0's virgin-path acceptance sentence.

## Notes for reviewer

- `runTrialGroup` moves from sequential trials to a worker pool sized by the upfront-mint count — k parallel local agent processes on paid tiers (k ≤ 20). Ports are dynamically allocated and artifacts are keyed by session id, so trials don't collide; agent stdio is piped, and trial rows buffer to render in order.
- TDD per labels: quota-bounding, lazy-retry, retry-exhaustion, ordered-render, and both install-registration behaviors were written red-first (`runTrialGroup.test.ts`, `register.test.ts`, `install-command.test.ts`). Full suite: 497 passed, typecheck + no-eval gate + build clean.
- Deploy order is satisfied: FDRS-668 (pome-cloud #217, the `/agents` routes + redirects) merged before this prints the new URL shape.
- 665's second bullet (run-row task cell should *read* as a link) is a pome-cloud styling change — #217 rerouted the href but kept `no-underline hover:underline`; following up with a small pome-cloud PR.

## Review required

Yes — public OSS CLI behavior: `pome install` now creates a cloud agent by default, and `pome run -n` gains plan-quota-bounded parallelism (touches the billing entitlement seam by design, per the FDRS-663 [DECISION]).

### Founder briefing (3 min)

- **What changed** — `pome install` now registers the repo as a cloud agent (idempotent), trial groups run in parallel up to the plan's concurrent-twin quota instead of sequentially, and the handoff link is `/agents/<slug>/tasks/<name>?group=…`.
- **What it means for your repo / workflow** — control-plane load shape changes: `POST /v1/agents` fires on every fresh install, and k mint requests can arrive concurrently followed by lazy re-mints that intentionally retry through 429s; the `?group` param should be honored by the reliability page in M1 (decision 3).
- **The one thing you must know** — free-tier k=5 no longer exits 4; it silently runs at concurrency 3 with a longer wall-clock and an honest provisioning line — that's the decided reconciliation, not a bug, and `billing-catalog.ts` is untouched.