### PR TITLE
feat(cli): pome install terminal diff gate — embedded headless agent (FDRS-661)

### DIFF
--- a/cli/.changeset/fdrs-661-terminal-diff-gate.md
+++ b/cli/.changeset/fdrs-661-terminal-diff-gate.md
@@ -1,0 +1,17 @@
+---
+"pome-sh": minor
+---
+
+**`pome install` now gates the wiring behind a terminal diff — nothing is written until you approve it.**
+
+The default flow embeds the wiring agent headless on your own Claude
+credentials (a one-time few-MB Claude Agent SDK driver download drives your
+installed `claude` binary), stages its edits in an isolated shadow copy of
+the repo, and renders the full file list + unified diff in pome's terminal.
+The working tree changes only on `[y]`; dependencies the diff adds are
+installed by pome afterwards, then `pome doctor` verifies to green. A
+session that produces no applicable diff exits with the agent's named
+reason, never a silent no-op. `pome install --interactive` keeps the
+previous flow: a live agent session with approval in the agent's own
+edit-approval UI (also the automatic fallback when no Claude credentials
+are present or the driver download is declined).

--- a/cli/src/cli/agent-sdk.ts
+++ b/cli/src/cli/agent-sdk.ts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-661 — Claude Agent SDK access for the embedded (headless) wiring
+// session: detect whether the user's own credentials exist, and lazily
+// provision the SDK driver into ~/.pome/agent-sdk/<version>.
+//
+// The SDK is deliberately NOT a dependency of pome-sh: its per-platform
+// optionalDependency bundles the Claude Code runtime (~244 MB unpacked),
+// which would sink `npx pome-sh demo` cold-start. Instead we install the
+// driver package alone (--omit=optional, a few MB) on first use, and point
+// it at the user's already-installed `claude` binary via
+// `pathToClaudeCodeExecutable` — verified against SDK 0.3.202 driving
+// Claude Code 2.1.201.
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+/** Pinned driver version — bump deliberately, in lockstep with a re-test
+ *  against the oldest Claude Code binary we expect on user machines. */
+export const AGENT_SDK_VERSION = "0.3.202";
+
+/** macOS keychain service Claude Code stores its `/login` credential under.
+ *  Existence-only probe (no `-w`): the secret is never read or printed. */
+const CLAUDE_KEYCHAIN_SERVICE = "Claude Code-credentials";
+
+/**
+ * True when the machine has credentials the Claude Code binary can
+ * authenticate with on its own: a stored `/login` session (keychain or
+ * `$CLAUDE_CONFIG_DIR/.credentials.json`) or an explicit env credential.
+ * Mirrors the SDK's own resolution; pome never reads the secret values.
+ */
+export function detectClaudeLogin(
+  env: Record<string, string | undefined> = process.env,
+  home: string = homedir(),
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if (env.ANTHROPIC_API_KEY || env.CLAUDE_CODE_OAUTH_TOKEN || env.ANTHROPIC_AUTH_TOKEN) {
+    return true;
+  }
+
+  const configDir = env.CLAUDE_CONFIG_DIR || join(home, ".claude");
+  try {
+    if (existsSync(join(configDir, ".credentials.json"))) return true;
+  } catch {
+    /* unreadable — treat as absent */
+  }
+
+  if (platform === "darwin") {
+    try {
+      const res = spawnSync(
+        "security",
+        ["find-generic-password", "-s", CLAUDE_KEYCHAIN_SERVICE],
+        { stdio: "ignore", timeout: 5000 },
+      );
+      if (res.status === 0) return true;
+    } catch {
+      /* lookup failed — treat as absent */
+    }
+  }
+
+  return false;
+}
+
+/** Directory the pinned SDK driver is provisioned into. */
+export function agentSdkDir(home: string = homedir()): string {
+  return join(home, ".pome", "agent-sdk", AGENT_SDK_VERSION);
+}
+
+function sdkEntryPath(dir: string): string {
+  return join(dir, "node_modules", "@anthropic-ai", "claude-agent-sdk", "sdk.mjs");
+}
+
+export function isAgentSdkProvisioned(dir: string = agentSdkDir()): boolean {
+  return existsSync(sdkEntryPath(dir));
+}
+
+/** Minimal structural view of the SDK's query() — the driver is loaded at
+ *  runtime, so pome compiles against this shape, not the SDK's types. */
+export type AgentSdkQueryFn = (args: {
+  prompt: string;
+  options: Record<string, unknown>;
+}) => AsyncIterable<Record<string, unknown>>;
+
+export interface AgentSdkModule {
+  query: AgentSdkQueryFn;
+}
+
+/**
+ * Install the pinned driver into `dir` using whichever package manager is
+ * on PATH. `--omit=optional` skips the ~244 MB platform runtime — the
+ * session runs on the user's own `claude` binary instead.
+ * Returns null (with a printed reason) when no package manager is found
+ * or the install fails; callers fall back to the interactive session.
+ */
+export async function provisionAgentSdk(dir: string = agentSdkDir()): Promise<boolean> {
+  await mkdir(dir, { recursive: true });
+  const manifest = join(dir, "package.json");
+  if (!existsSync(manifest)) {
+    await writeFile(manifest, JSON.stringify({ name: "pome-agent-sdk", private: true }, null, 2));
+  }
+
+  const spec = `@anthropic-ai/claude-agent-sdk@${AGENT_SDK_VERSION}`;
+  const attempts: Array<[string, string[]]> = [
+    ["npm", ["install", "--omit=optional", "--no-audit", "--no-fund", spec]],
+    ["bun", ["add", "--omit=optional", spec]],
+  ];
+
+  for (const [bin, args] of attempts) {
+    const probe = spawnSync(bin, ["--version"], { stdio: "ignore", timeout: 10_000 });
+    if (probe.error || probe.status !== 0) continue;
+    console.error(`downloading the Claude Agent SDK driver (${spec}, a few MB, one-time) …`);
+    const res = spawnSync(bin, args, { cwd: dir, stdio: "ignore", timeout: 300_000 });
+    if (res.status === 0 && isAgentSdkProvisioned(dir)) return true;
+    console.error(`(${bin} install of ${spec} failed)`);
+  }
+
+  console.error("couldn't provision the Claude Agent SDK driver (is npm or bun on PATH?).");
+  return false;
+}
+
+/** Import the provisioned driver. Returns null when not provisioned. */
+export async function loadAgentSdk(dir: string = agentSdkDir()): Promise<AgentSdkModule | null> {
+  const entry = sdkEntryPath(dir);
+  if (!existsSync(entry)) return null;
+  const mod = (await import(pathToFileURL(entry).href)) as { query?: unknown };
+  if (typeof mod.query !== "function") return null;
+  return { query: mod.query as AgentSdkQueryFn };
+}

--- a/cli/src/cli/embedded-wiring.ts
+++ b/cli/src/cli/embedded-wiring.ts
@@ -163,7 +163,11 @@ export async function runEmbeddedWiring(
     return {
       kind: "applied",
       files: changes.length,
-      packageJsonChanged: changes.some((c) => c.path === "package.json"),
+      // Any package.json in the tree, not just the root — in a workspace the
+      // wiring may add the adapter to a nested package's manifest.
+      packageJsonChanged: changes.some(
+        (c) => c.path === "package.json" || c.path.endsWith("/package.json"),
+      ),
     };
   } finally {
     await rm(shadow, { recursive: true, force: true });

--- a/cli/src/cli/embedded-wiring.ts
+++ b/cli/src/cli/embedded-wiring.ts
@@ -1,0 +1,507 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-661 — the terminal diff gate: run the wiring agent headless in a
+// SHADOW copy of the repo, collect its edits as one git diff, render the
+// moment-02 file list + unified diff in pome's own terminal, and touch the
+// real working tree only after an explicit [y].
+//
+// Why a shadow workspace instead of canUseTool-deny-and-record: a denied
+// Edit looks like a failure to the agent, which then retries; letting the
+// edits land in an isolated copy keeps the session self-consistent (its
+// Reads see its own writes) and the diff comes from git afterwards, exact
+// and binary-safe. canUseTool still runs on every call — it confines all
+// file paths to the shadow root (a live probe caught the model reaching
+// for $HOME on turn one) and refuses tools outside the whitelist.
+//
+// The user's `.claude/` is deliberately NOT copied into the shadow:
+// settings-file allow rules would shadow the canUseTool gate (the SDK
+// warns about exactly this), and the only skill the session needs is the
+// pome-setup skill pome injects itself.
+
+import { execFile } from "node:child_process";
+import { existsSync, realpathSync } from "node:fs";
+import { cp, lstat, mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import { promisify } from "node:util";
+
+import type { AgentSdkQueryFn } from "./agent-sdk.js";
+
+const execFileAsync = promisify(execFile);
+
+/** Tools the staging session may use. Everything else — Bash above all —
+ *  is refused: package installs and verification are pome's job, after
+ *  the diff is approved. NOTE: never mirror these into `allowedTools`;
+ *  bare allowedTools entries auto-approve before canUseTool is consulted. */
+export const STAGING_TOOLS = ["Read", "Edit", "Write", "Glob", "Grep"] as const;
+
+/** First message of the headless session. The pome-setup skill (injected
+ *  into the shadow's .claude/skills) carries the wiring knowledge; this
+ *  adapts its interactive contract to staging: edits land automatically,
+ *  the human approves ONE combined diff in pome's terminal afterwards. */
+export const EMBEDDED_KICKOFF_PROMPT = [
+  "Use the pome-setup skill to wire this repository to pome (adapter-first:",
+  "withPome() + env-injected base URL). You are running non-interactively",
+  "inside a staged copy of the repo:",
+  "- There is no user to ask questions mid-session. Where the skill says to",
+  "  pause and confirm, proceed with the best-evidence interpretation and",
+  "  note the assumption in your final summary.",
+  "- Your edits are staged automatically; pome renders the combined diff for",
+  "  the user's approval after this session. That is the skill's diff-approval",
+  "  gate — do not wait for per-edit approval.",
+  "- Do not run package installs or shell commands: add dependencies by",
+  "  editing package.json only. pome runs the install after the diff is",
+  "  applied.",
+  "- Do not run pome doctor — pome verifies the wiring itself after applying.",
+  "When the wiring edits are complete, end the session with a one-line",
+  "summary. If you cannot produce the wiring, make no edits and end with a",
+  "short explanation of why.",
+].join("\n");
+
+export type EmbeddedWiringOutcome =
+  | { kind: "applied"; files: number; packageJsonChanged: boolean }
+  | { kind: "declined" }
+  | { kind: "no-diff"; reason: string }
+  | { kind: "session-error"; reason: string };
+
+export interface EmbeddedWiringOptions {
+  /** The real repo root the approved diff is applied to. */
+  cwd: string;
+  /** The user's Claude Code binary — passed as pathToClaudeCodeExecutable. */
+  claudePath: string;
+  /** Packaged pome-setup skill directory (contains SKILL.md). */
+  skillSourceDir: string;
+  /** The provisioned SDK's query(). Injected — the test seam. */
+  query: AgentSdkQueryFn;
+  /** [y/N] prompt. */
+  confirm: (question: string) => Promise<boolean>;
+  /** Line sink, default console.error. */
+  log?: (line: string) => void;
+}
+
+export async function runEmbeddedWiring(
+  options: EmbeddedWiringOptions,
+): Promise<EmbeddedWiringOutcome> {
+  const log = options.log ?? ((line: string) => console.error(line));
+  const shadow = await mkdtemp(join(tmpdir(), "pome-install-staging-"));
+  try {
+    const skippedLinks = await populateShadow(options.cwd, shadow);
+    if (skippedLinks.length > 0) {
+      log(
+        `(symlinks stay out of the staged copy: ${skippedLinks.slice(0, 3).join(", ")}${
+          skippedLinks.length > 3 ? ` +${skippedLinks.length - 3} more` : ""
+        })`,
+      );
+    }
+    await mkdir(join(shadow, ".claude", "skills"), { recursive: true });
+    await cp(options.skillSourceDir, join(shadow, ".claude", "skills", "pome-setup"), {
+      recursive: true,
+    });
+    await gitIn(shadow, ["init", "-q"]);
+    await gitIn(shadow, ["add", "-A"]);
+    await gitIn(shadow, ["commit", "-q", "-m", "pome staging baseline"]);
+
+    const session = await runStagingSession(options, shadow, log);
+    if (session.kind === "session-error") return session;
+
+    // Everything the session staged, as one diff — the injected .claude/
+    // (skill + any settings the agent might have written) never leaves
+    // the shadow.
+    await gitIn(shadow, ["add", "-A"]);
+    const exclude = [".", `:(exclude).claude`];
+    const { stdout: nameStatus } = await gitIn(shadow, [
+      "diff",
+      "--staged",
+      "--name-status",
+      "-M",
+      "--",
+      ...exclude,
+    ]);
+    const changes = parseNameStatus(nameStatus);
+    if (changes.length === 0) {
+      return {
+        kind: "no-diff",
+        reason: session.summary || "the agent session ended without staging any edits",
+      };
+    }
+
+    const { stdout: numstat } = await gitIn(shadow, [
+      "diff",
+      "--staged",
+      "--numstat",
+      "-M",
+      "--",
+      ...exclude,
+    ]);
+    const { stdout: patch } = await gitIn(shadow, [
+      "diff",
+      "--staged",
+      "--binary",
+      "-M",
+      "--",
+      ...exclude,
+    ]);
+
+    log("");
+    log("here's what it will change:");
+    log("");
+    for (const line of renderFileList(changes, parseNumstat(numstat))) log(line);
+    log("");
+    for (const line of renderUnifiedDiff(patch)) log(line);
+    log("");
+
+    if (!(await options.confirm("apply these changes? [y/N] "))) {
+      return { kind: "declined" };
+    }
+
+    const patchFile = join(shadow, ".pome-staged.patch");
+    await writeFile(patchFile, patch);
+    await execFileAsync("git", ["apply", "--whitespace=nowarn", patchFile], {
+      cwd: options.cwd,
+    });
+    log(`✓ wrote ${changes.length} file${changes.length === 1 ? "" : "s"}`);
+
+    return {
+      kind: "applied",
+      files: changes.length,
+      packageJsonChanged: changes.some((c) => c.path === "package.json"),
+    };
+  } finally {
+    await rm(shadow, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shadow population
+
+/** Copy the repo into the shadow: tracked + untracked-but-not-ignored files
+ *  when git is available, a filtered walk otherwise. `.git` and `.claude`
+ *  never cross (see module header), and neither do SYMLINKS: a tracked link
+ *  copied verbatim would carry a pointer out of the shadow that the agent's
+ *  Read/Write could follow past the canUseTool path fence. Skipped links
+ *  are returned so the caller can say so instead of silently dropping them.
+ */
+async function populateShadow(cwd: string, shadow: string): Promise<string[]> {
+  const skippedLinks: string[] = [];
+  let files: string[] | null = null;
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["ls-files", "-co", "--exclude-standard", "-z"],
+      { cwd, maxBuffer: 64 * 1024 * 1024 },
+    );
+    files = stdout.split("\0").filter(Boolean);
+  } catch {
+    files = null; // not a git repo (or no git) — fall through to the walk
+  }
+
+  if (files) {
+    for (const file of files) {
+      if (file === ".claude" || file.startsWith(`.claude${sep}`) || file.startsWith(".claude/")) {
+        continue;
+      }
+      const from = join(cwd, file);
+      let stat;
+      try {
+        stat = await lstat(from);
+      } catch {
+        continue; // ls-files can list deleted-but-tracked paths
+      }
+      if (stat.isSymbolicLink()) {
+        skippedLinks.push(file);
+        continue;
+      }
+      if (!stat.isFile()) continue;
+      const to = join(shadow, file);
+      await mkdir(join(to, ".."), { recursive: true });
+      await cp(from, to, { recursive: false, verbatimSymlinks: true });
+    }
+    return skippedLinks;
+  }
+
+  const SKIP = new Set([".git", ".claude", "node_modules"]);
+  const walk = async (rel: string): Promise<void> => {
+    const entries = await readdir(join(cwd, rel), { withFileTypes: true });
+    for (const entry of entries) {
+      if (SKIP.has(entry.name)) continue;
+      const childRel = rel ? join(rel, entry.name) : entry.name;
+      if (entry.isSymbolicLink()) {
+        // Dirent methods don't dereference — mirror the git branch: skip
+        // links (whether they point at files or directories) and say so.
+        skippedLinks.push(childRel);
+      } else if (entry.isDirectory()) {
+        await mkdir(join(shadow, childRel), { recursive: true });
+        await walk(childRel);
+      } else if (entry.isFile()) {
+        await mkdir(join(shadow, childRel, ".."), { recursive: true });
+        await cp(join(cwd, childRel), join(shadow, childRel));
+      }
+    }
+  };
+  await walk("");
+  return skippedLinks;
+}
+
+function gitIn(cwd: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
+  return execFileAsync(
+    "git",
+    [
+      // The shadow is throwaway: never touch the user's git identity/config.
+      "-c",
+      "user.email=install@pome.sh",
+      "-c",
+      "user.name=pome install",
+      "-c",
+      "commit.gpgsign=false",
+      "-c",
+      "core.autocrlf=false",
+      ...args,
+    ],
+    { cwd, maxBuffer: 64 * 1024 * 1024 },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// The staging session
+
+async function runStagingSession(
+  options: EmbeddedWiringOptions,
+  shadow: string,
+  log: (line: string) => void,
+): Promise<{ kind: "ok"; summary: string } | { kind: "session-error"; reason: string }> {
+  const canUseTool = buildStagingCanUseTool(shadow, log);
+  let summary = "";
+  let sessionError: string | null = null;
+
+  const iterator = options.query({
+    prompt: EMBEDDED_KICKOFF_PROMPT,
+    options: {
+      cwd: shadow,
+      pathToClaudeCodeExecutable: options.claudePath,
+      permissionMode: "default",
+      systemPrompt: { type: "preset", preset: "claude_code" },
+      // Load the injected pome-setup skill from the shadow's .claude/skills.
+      settingSources: ["project"],
+      skills: "all",
+      tools: [...STAGING_TOOLS],
+      maxTurns: 80,
+      canUseTool,
+    },
+  });
+
+  try {
+    for await (const message of iterator) {
+      const type = message.type as string | undefined;
+      if (type === "assistant") {
+        for (const line of assistantTextLines(message)) log(dim(`  ${line}`));
+      } else if (type === "result") {
+        const subtype = message.subtype as string | undefined;
+        if (subtype === "success") {
+          summary = typeof message.result === "string" ? message.result.trim() : "";
+        } else {
+          const errors = Array.isArray(message.errors) ? message.errors.join("; ") : subtype;
+          sessionError = `agent session ended without finishing: ${errors ?? "unknown error"}`;
+        }
+      }
+    }
+  } catch (err) {
+    // The SDK's iterator throws after error results (max turns, process
+    // exit). The result message above is the source of truth when we got
+    // one; otherwise surface the thrown reason.
+    if (!sessionError && !summary) {
+      sessionError = `agent session failed: ${err instanceof Error ? err.message : String(err)}`;
+    }
+  }
+
+  if (sessionError) return { kind: "session-error", reason: sessionError };
+  return { kind: "ok", summary };
+}
+
+/** Path-confining permission gate. Exported for direct unit tests. */
+export function buildStagingCanUseTool(
+  shadowRoot: string,
+  log: (line: string) => void,
+): (
+  toolName: string,
+  input: Record<string, unknown>,
+) => Promise<
+  | { behavior: "allow"; updatedInput: Record<string, unknown> }
+  | { behavior: "deny"; message: string }
+> {
+  const allowed = new Set<string>(STAGING_TOOLS);
+  const resolvedRoot = resolve(shadowRoot);
+
+  // Compare in canonical (symlink-resolved) space on both sides — on macOS
+  // the tmpdir shadow itself sits behind /var → /private/var. For paths that
+  // don't exist yet (a Write creating a file), canonicalize the nearest
+  // existing ancestor and re-append the remainder.
+  const canonicalize = (abs: string): string => {
+    let probe = abs;
+    while (!existsSync(probe)) {
+      const parent = resolve(probe, "..");
+      if (parent === probe) break;
+      probe = parent;
+    }
+    return join(realpathSync(probe), relative(probe, abs));
+  };
+  const root = existsSync(resolvedRoot) ? realpathSync(resolvedRoot) : resolvedRoot;
+
+  const contained = (abs: string): boolean => {
+    const rel = relative(root, abs);
+    return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+  };
+
+  const insideShadow = (p: unknown): boolean => {
+    if (typeof p !== "string" || p.length === 0) return true; // no path arg — cwd-scoped
+    const abs = isAbsolute(p) ? resolve(p) : resolve(resolvedRoot, p);
+    // Defense in depth: symlinks never cross into the shadow (populateShadow
+    // skips them), but canonicalizing means a link that appears anyway can't
+    // smuggle the operation outside.
+    try {
+      return contained(canonicalize(abs));
+    } catch {
+      return false;
+    }
+  };
+
+  return async (toolName, input) => {
+    if (!allowed.has(toolName)) {
+      return {
+        behavior: "deny",
+        message:
+          `${toolName} is not available in this pome staging session. ` +
+          "Make wiring edits with Read/Edit/Write only; pome runs installs and " +
+          "verification after the diff is approved.",
+      };
+    }
+    for (const key of ["file_path", "notebook_path", "path"]) {
+      if (key in input && !insideShadow(input[key])) {
+        return {
+          behavior: "deny",
+          message:
+            `${String(input[key])} is outside the repository being wired. ` +
+            "Only files inside the working directory may be read or edited.",
+        };
+      }
+    }
+    if (toolName === "Edit" || toolName === "Write") {
+      const p = String(input.file_path ?? "");
+      const abs = isAbsolute(p) ? resolve(p) : resolve(resolvedRoot, p);
+      let rel: string;
+      try {
+        rel = relative(root, canonicalize(abs));
+      } catch {
+        rel = p;
+      }
+      log(dim(`  staged ${rel}`));
+    }
+    return { behavior: "allow", updatedInput: input };
+  };
+}
+
+function assistantTextLines(message: Record<string, unknown>): string[] {
+  const inner = message.message as { content?: unknown } | undefined;
+  if (!inner || !Array.isArray(inner.content)) return [];
+  const lines: string[] = [];
+  for (const block of inner.content) {
+    if (block && typeof block === "object" && (block as { type?: string }).type === "text") {
+      const text = (block as { text?: string }).text ?? "";
+      for (const line of text.split("\n")) {
+        if (line.trim()) lines.push(line.trimEnd());
+      }
+    }
+  }
+  return lines;
+}
+
+// ---------------------------------------------------------------------------
+// Rendering (CLI moments 02)
+
+interface Change {
+  status: "modified" | "new file" | "deleted" | "renamed";
+  path: string;
+  from?: string;
+}
+
+function parseNameStatus(out: string): Change[] {
+  const changes: Change[] = [];
+  for (const line of out.split("\n")) {
+    if (!line.trim()) continue;
+    const parts = line.split("\t");
+    const code = parts[0] ?? "";
+    if (code.startsWith("R")) {
+      changes.push({ status: "renamed", from: parts[1], path: parts[2] ?? "" });
+    } else if (code === "A") {
+      changes.push({ status: "new file", path: parts[1] ?? "" });
+    } else if (code === "D") {
+      changes.push({ status: "deleted", path: parts[1] ?? "" });
+    } else {
+      changes.push({ status: "modified", path: parts[1] ?? "" });
+    }
+  }
+  return changes;
+}
+
+function parseNumstat(out: string): Map<string, { added: number; removed: number }> {
+  const stats = new Map<string, { added: number; removed: number }>();
+  for (const line of out.split("\n")) {
+    if (!line.trim()) continue;
+    const [added, removed, ...rest] = line.split("\t");
+    let path = rest.join("\t");
+    // Renames appear as "old => new" or "prefix{old => new}suffix" — key by
+    // the new path, matching name-status.
+    const arrow = path.match(/^(.*)\{(.*) => (.*)\}(.*)$/);
+    if (arrow) path = `${arrow[1]}${arrow[3]}${arrow[4]}`;
+    else if (path.includes(" => ")) path = path.split(" => ")[1] ?? path;
+    stats.set(path, {
+      added: added === "-" ? 0 : Number(added),
+      removed: removed === "-" ? 0 : Number(removed),
+    });
+  }
+  return stats;
+}
+
+function renderFileList(
+  changes: Change[],
+  stats: Map<string, { added: number; removed: number }>,
+): string[] {
+  const width = Math.max(...changes.map((c) => c.status.length));
+  return changes.map((c) => {
+    const stat = stats.get(c.path);
+    const counts = stat
+      ? [stat.added > 0 ? `+${stat.added}` : "", stat.removed > 0 ? `−${stat.removed}` : ""]
+          .filter(Boolean)
+          .join(" ")
+      : "";
+    const name = c.status === "renamed" && c.from ? `${c.from} → ${c.path}` : c.path;
+    return `  ${c.status.padEnd(width)}  ${name}${counts ? `  ${counts}` : ""}`;
+  });
+}
+
+function useColor(): boolean {
+  return Boolean(process.stderr.isTTY && !process.env.NO_COLOR);
+}
+
+function dim(s: string): string {
+  return useColor() ? `\x1b[2m${s}\x1b[0m` : s;
+}
+
+function renderUnifiedDiff(patch: string): string[] {
+  const color = useColor();
+  const paint = (line: string): string => {
+    if (!color) return line;
+    if (line.startsWith("+++") || line.startsWith("---") || line.startsWith("diff --git")) {
+      return `\x1b[1m${line}\x1b[0m`;
+    }
+    if (line.startsWith("@@")) return `\x1b[36m${line}\x1b[0m`;
+    if (line.startsWith("+")) return `\x1b[32m${line}\x1b[0m`;
+    if (line.startsWith("-")) return `\x1b[31m${line}\x1b[0m`;
+    if (line.startsWith("index ") || line.startsWith("new file") || line.startsWith("deleted")) {
+      return `\x1b[2m${line}\x1b[0m`;
+    }
+    return line;
+  };
+  return patch
+    .split("\n")
+    .filter((line, i, arr) => !(line === "" && i === arr.length - 1))
+    .map(paint);
+}

--- a/cli/src/cli/install.ts
+++ b/cli/src/cli/install.ts
@@ -411,16 +411,31 @@ async function acquireAgentSdkWithConsent(
   return sdk;
 }
 
+/** The package manager a lockfile in `dir` names, or null. Exported for tests. */
+export function lockfilePackageManager(dir: string): "bun" | "pnpm" | "yarn" | "npm" | null {
+  if (existsSync(join(dir, "bun.lock")) || existsSync(join(dir, "bun.lockb"))) return "bun";
+  if (existsSync(join(dir, "pnpm-lock.yaml"))) return "pnpm";
+  if (existsSync(join(dir, "yarn.lock"))) return "yarn";
+  if (existsSync(join(dir, "package-lock.json"))) return "npm";
+  return null;
+}
+
 /** Install dependencies the staged diff added to package.json, with the
- *  repo's own package manager (lockfile tells us which). */
+ *  repo's own package manager. The lockfile names it — checked in `cwd`
+ *  first, then up the ancestor chain, because in a workspace the lockfile
+ *  lives at the workspace root, not the package being wired. The install
+ *  itself still runs in `cwd`; every manager resolves its own workspace
+ *  root upward from there. */
 async function runPackageInstall(cwd: string): Promise<void> {
-  const pm = existsSync(join(cwd, "bun.lock")) || existsSync(join(cwd, "bun.lockb"))
-    ? "bun"
-    : existsSync(join(cwd, "pnpm-lock.yaml"))
-      ? "pnpm"
-      : existsSync(join(cwd, "yarn.lock"))
-        ? "yarn"
-        : "npm";
+  let pm: "bun" | "pnpm" | "yarn" | "npm" | null = null;
+  for (let dir = cwd; ; ) {
+    pm = lockfilePackageManager(dir);
+    if (pm) break;
+    const parent = join(dir, "..");
+    if (parent === dir) break;
+    dir = parent;
+  }
+  pm ??= "npm";
   console.error("");
   console.error(`package.json changed — running ${pm} install …`);
   const exit = await new Promise<number>((resolvePromise, rejectPromise) => {

--- a/cli/src/cli/install.ts
+++ b/cli/src/cli/install.ts
@@ -13,19 +13,35 @@
 //
 // No coding agent on PATH → print manual wiring steps + a paste-into-any-
 // agent prompt and exit 0 (the designed fallback, not a failure). Doctor
-// red after the session → named cause + fix, exit 1. The terminal-rendered
-// file-list + diff + [y/N] gate from moment 02 is deferred to FDRS-661; the
-// pome-setup skill written for this cut is the knowledge layer both reuse.
+// red after the session → named cause + fix, exit 1.
+//
+// FDRS-661 layers the terminal diff gate from moment 02 on top: when the
+// machine has Claude credentials, the default flow embeds the agent
+// HEADLESS (Claude Agent SDK driver on the user's own credentials + the
+// user's own `claude` binary), stages its edits in a shadow copy, and
+// renders the file list + unified diff in pome's terminal — the working
+// tree changes only on [y]. The interactive handoff above survives as the
+// fallback (no credentials, declined SDK download, or --interactive).
 
 import { execFile, spawn } from "node:child_process";
-import { accessSync, constants, statSync } from "node:fs";
+import { accessSync, constants, existsSync, statSync } from "node:fs";
 import { delimiter, join } from "node:path";
 import { createInterface } from "node:readline";
 import { promisify } from "node:util";
 
 import { HostedAuthError } from "../hosted/errors.js";
+import {
+  agentSdkDir,
+  detectClaudeLogin,
+  isAgentSdkProvisioned,
+  loadAgentSdk,
+  provisionAgentSdk,
+  type AgentSdkModule,
+} from "./agent-sdk.js";
 import { resolveCredentials } from "./credentials.js";
+import { runEmbeddedWiring } from "./embedded-wiring.js";
 import { loginWithClerk, type LoginOptions } from "./login.js";
+import { resolvePackageRoot } from "./resolve-package-root.js";
 import { runSkillsInstall } from "./skills.js";
 
 const execFileAsync = promisify(execFile);
@@ -56,6 +72,9 @@ export const PASTE_PROMPT = [
 export interface InstallOptions {
   apiUrl: string;
   dashboardUrl: string;
+  /** Force the interactive agent-session handoff (skip the headless
+   *  staged-diff flow). */
+  interactive?: boolean;
   /** Repo root the session wires. Defaults to process.cwd(). */
   cwd?: string;
   /** Test seam — forwarded to resolveCredentials. */
@@ -66,6 +85,13 @@ export interface InstallOptions {
   confirm?: (question: string) => Promise<boolean>;
   /** Test seam — defaults to loginWithClerk (opens a browser). */
   login?: (options: LoginOptions) => Promise<void>;
+  /** Test seam — defaults to detectClaudeLogin (keychain/credentials/env). */
+  hasClaudeLogin?: () => boolean;
+  /** Test seam — defaults to the consent-gated provision + import of the
+   *  Claude Agent SDK driver. */
+  acquireSdk?: (
+    confirm: (question: string) => Promise<boolean>,
+  ) => Promise<AgentSdkModule | null>;
 }
 
 export async function runInstall(options: InstallOptions): Promise<void> {
@@ -146,35 +172,109 @@ export async function runInstall(options: InstallOptions): Promise<void> {
     }
   }
 
-  // 4. Ensure the pome-setup skill is where the agent looks for it
-  // (~/.claude/skills/, symlinked to this install; skips if present).
-  console.error("");
-  await runSkillsInstall({});
-  if (process.exitCode === 2) {
-    // runSkillsInstall signals failure (no ~/.claude, packaging problem) via
-    // exitCode — the session would run without the skill, so hand the user
-    // the manual path instead. Keep exit 2: unlike the no-agent fallback,
-    // this is a real environment problem.
-    console.error("");
-    console.error("couldn't install the pome-setup skill — falling back to manual steps.");
-    printManualFallback();
-    return;
+  // 4. The default path: embed the agent headless and gate its edits behind
+  // pome's own terminal diff (moment 02). Falls back to the interactive
+  // handoff when the pieces aren't there or the user asked for it.
+  let stagedApplied = false;
+  if (!options.interactive) {
+    const hasLogin = options.hasClaudeLogin ?? (() => detectClaudeLogin());
+    if (!hasLogin()) {
+      console.error("");
+      console.error(
+        "no Claude login or ANTHROPIC_API_KEY found for the headless staged-diff flow —",
+      );
+      console.error("handing off to an interactive session instead.");
+    } else {
+      const skillSourceDir = packagedSkillDir();
+      const acquireSdk = options.acquireSdk ?? acquireAgentSdkWithConsent;
+      const sdk = skillSourceDir ? await acquireSdk(confirm) : null;
+      if (!skillSourceDir) {
+        console.error("");
+        console.error(
+          "bundled pome-setup skill missing from this install — using the interactive session.",
+        );
+      } else if (!sdk) {
+        console.error("continuing with the interactive session instead.");
+      } else {
+        console.error("");
+        console.error(
+          `wiring with ${agent.label} (headless) — nothing is written until you approve the diff.`,
+        );
+        const outcome = await runEmbeddedWiring({
+          cwd,
+          claudePath: agent.path,
+          skillSourceDir,
+          query: sdk.query,
+          confirm,
+        });
+        if (outcome.kind === "declined") {
+          console.error(
+            "aborted — nothing changed. re-run pome install to try again, or",
+          );
+          console.error("`pome install --interactive` to drive the session yourself.");
+          return;
+        }
+        if (outcome.kind === "no-diff") {
+          // Never a silent no-op: name the reason the session produced no
+          // applicable diff (Done-when bullet 2).
+          console.error("");
+          console.error("the session staged no changes — nothing to apply.");
+          console.error(`reason: ${outcome.reason}`);
+          console.error(
+            "re-run pome install, or `pome install --interactive` to drive the session yourself.",
+          );
+          process.exitCode = 1;
+          return;
+        }
+        if (outcome.kind === "session-error") {
+          console.error("");
+          console.error(outcome.reason);
+          console.error(
+            "re-run pome install, or `pome install --interactive` to drive the session yourself.",
+          );
+          process.exitCode = 1;
+          return;
+        }
+        // applied — the session never runs installs itself (no Bash in the
+        // staging tool set); dependencies it added land here, before doctor.
+        if (outcome.packageJsonChanged) {
+          await runPackageInstall(cwd);
+        }
+        stagedApplied = true;
+      }
+    }
   }
 
-  // 5. Hand off. stdio inherit = the user drives the agent in this terminal;
-  // the diff gate is the agent's own edit-approval UI (deliberately no
-  // --permission-mode override).
-  console.error("");
-  console.error(
-    `handing off to ${agent.label} — review and approve its edits in the session.`,
-  );
-  console.error("exit the session when the wiring is done; pome verifies it after.");
-  console.error("");
-  const sessionExit = await runAgentSession(agent.path, [KICKOFF_PROMPT], cwd);
-  if (sessionExit !== 0) {
+  if (!stagedApplied) {
+    // 4b. Interactive fallback — the FDRS-642 flow, unchanged: ensure the
+    // pome-setup skill where the agent looks for it (~/.claude/skills/),
+    // then hand this terminal to the agent; the diff gate is the agent's
+    // own edit-approval UI.
+    console.error("");
+    await runSkillsInstall({});
+    if (process.exitCode === 2) {
+      // runSkillsInstall signals failure (no ~/.claude, packaging problem) via
+      // exitCode — the session would run without the skill, so hand the user
+      // the manual path instead. Keep exit 2: unlike the no-agent fallback,
+      // this is a real environment problem.
+      console.error("");
+      console.error("couldn't install the pome-setup skill — falling back to manual steps.");
+      printManualFallback();
+      return;
+    }
+
+    console.error("");
     console.error(
-      `(${agent.label} exited ${sessionExit} — verifying anyway; doctor is the source of truth.)`,
+      `handing off to ${agent.label} — review and approve its edits in the session.`,
     );
+    console.error("exit the session when the wiring is done; pome verifies it after.");
+    console.error("");
+    const sessionExit = await runAgentSession(agent.path, [KICKOFF_PROMPT], cwd);
+    if (sessionExit !== 0) {
+      console.error(
+        `(${agent.label} exited ${sessionExit} — verifying anyway; doctor is the source of truth.)`,
+      );
+    }
   }
 
   // 6. The ending pome's terminal owns: doctor verify to green (moment 02).
@@ -280,6 +380,57 @@ function runAgentSession(
       resolvePromise(code ?? (signal ? 1 : 0));
     });
   });
+}
+
+/** The bundled pome-setup skill inside this pome install — the knowledge
+ *  layer the embedded session loads from the shadow's .claude/skills. */
+function packagedSkillDir(): string | null {
+  const root = resolvePackageRoot(import.meta.url);
+  if (!root) return null;
+  const dir = join(root, "skills", "pome-setup");
+  return existsSync(dir) ? dir : null;
+}
+
+/** Consent-gated one-time download of the Claude Agent SDK driver into
+ *  ~/.pome/agent-sdk (a few MB — the ~244 MB platform runtime is skipped;
+ *  the session runs on the user's own `claude` binary). */
+async function acquireAgentSdkWithConsent(
+  confirm: (question: string) => Promise<boolean>,
+): Promise<AgentSdkModule | null> {
+  const dir = agentSdkDir();
+  if (!isAgentSdkProvisioned(dir)) {
+    console.error("");
+    console.error("pome can run the wiring headless and show you one reviewable diff before");
+    console.error("anything is written. this needs a one-time download of the Claude Agent");
+    console.error(`SDK driver (a few MB) into ${dir}.`);
+    if (!(await confirm("download it now? [y/N] "))) return null;
+    if (!(await provisionAgentSdk(dir))) return null;
+  }
+  const sdk = await loadAgentSdk(dir);
+  if (!sdk) console.error("couldn't load the Claude Agent SDK driver.");
+  return sdk;
+}
+
+/** Install dependencies the staged diff added to package.json, with the
+ *  repo's own package manager (lockfile tells us which). */
+async function runPackageInstall(cwd: string): Promise<void> {
+  const pm = existsSync(join(cwd, "bun.lock")) || existsSync(join(cwd, "bun.lockb"))
+    ? "bun"
+    : existsSync(join(cwd, "pnpm-lock.yaml"))
+      ? "pnpm"
+      : existsSync(join(cwd, "yarn.lock"))
+        ? "yarn"
+        : "npm";
+  console.error("");
+  console.error(`package.json changed — running ${pm} install …`);
+  const exit = await new Promise<number>((resolvePromise, rejectPromise) => {
+    const child = spawn(pm, ["install"], { cwd, stdio: "inherit" });
+    child.once("error", rejectPromise);
+    child.once("exit", (code, signal) => resolvePromise(code ?? (signal ? 1 : 0)));
+  }).catch(() => 1);
+  if (exit !== 0) {
+    console.error(`(${pm} install exited ${exit} — doctor will name what's missing.)`);
+  }
 }
 
 function printManualFallback(): void {

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -218,7 +218,11 @@ export function createProgram() {
   program
     .command("install")
     .description(
-      "Wire this repo to pome with your own coding agent: checks auth (routes through pome login when needed), hands off to an interactive agent session — you approve its edits in the agent's own UI — then verifies with pome doctor. No coding agent on PATH → prints manual wiring steps + a paste-into-any-agent prompt.",
+      "Wire this repo to pome with your own coding agent: checks auth (routes through pome login when needed), runs the wiring headless on your own Claude credentials, shows the full diff in this terminal, and applies it only on [y] — then verifies with pome doctor. --interactive hands off to a live agent session instead; no coding agent on PATH → prints manual wiring steps + a paste-into-any-agent prompt.",
+    )
+    .option(
+      "--interactive",
+      "Hand off to an interactive agent session (approve edits in the agent's own UI) instead of the headless staged-diff flow.",
     )
     .option(
       "--api-url <url>",
@@ -230,11 +234,15 @@ export function createProgram() {
       "App URL for Clerk sign-in (must serve /cli/login).",
       process.env.POME_DASHBOARD_URL ?? DEFAULT_DASHBOARD_URL,
     )
-    .action(async (opts: { apiUrl: string; dashboardUrl: string }) => {
+    .action(async (opts: { apiUrl: string; dashboardUrl: string; interactive?: boolean }) => {
       // Dynamic import mirrors the doctor/run commands: keep install's
       // dependency graph out of every other command's startup path.
       const { runInstall } = await import("./install.js");
-      await runInstall({ apiUrl: opts.apiUrl, dashboardUrl: opts.dashboardUrl });
+      await runInstall({
+        apiUrl: opts.apiUrl,
+        dashboardUrl: opts.dashboardUrl,
+        interactive: opts.interactive,
+      });
     });
 
   program

--- a/cli/test/unit/embedded-wiring.test.ts
+++ b/cli/test/unit/embedded-wiring.test.ts
@@ -270,6 +270,30 @@ describe("runEmbeddedWiring (FDRS-661)", () => {
     expect(outcome).toEqual({ kind: "applied", files: 1, packageJsonChanged: true });
   });
 
+  it("flags a nested package.json too (workspace wiring)", async () => {
+    const repo = await fixtureRepo();
+    await mkdir(join(repo, "packages", "app"), { recursive: true });
+    await writeFile(join(repo, "packages", "app", "package.json"), '{ "name": "app" }\n');
+    const skill = await fakeSkillDir();
+    const h = harness();
+
+    const outcome = await runEmbeddedWiring({
+      cwd: repo,
+      claudePath: "/fake/claude",
+      skillSourceDir: skill,
+      confirm: h.confirm(true),
+      log: h.log,
+      query: scriptedQuery({}, async (shadow) => {
+        await writeFile(
+          join(shadow, "packages", "app", "package.json"),
+          '{ "name": "app", "dependencies": { "@pome-sh/adapter-claude-sdk": "^0.1.0" } }\n',
+        );
+      }),
+    });
+
+    expect(outcome).toEqual({ kind: "applied", files: 1, packageJsonChanged: true });
+  });
+
   it("respects .gitignore when the repo is a git repo (secrets never reach the shadow)", async () => {
     const repo = await fixtureRepo();
     await writeFile(join(repo, ".gitignore"), ".env\n");

--- a/cli/test/unit/embedded-wiring.test.ts
+++ b/cli/test/unit/embedded-wiring.test.ts
@@ -1,0 +1,383 @@
+// SPDX-License-Identifier: Apache-2.0
+// FDRS-661 — the terminal diff gate: shadow staging, the moment-02 render,
+// [y/N] apply, path confinement, and the named-reason no-op.
+//
+// The SDK is faked at the query() seam: the "session" is a script that
+// edits files inside whatever cwd the wiring hands it (the shadow), then
+// yields SDK-shaped messages. Everything else — shadow population, git
+// baseline/diff/apply, rendering — runs for real.
+
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { AgentSdkQueryFn } from "../../src/cli/agent-sdk.js";
+import {
+  buildStagingCanUseTool,
+  EMBEDDED_KICKOFF_PROMPT,
+  runEmbeddedWiring,
+  STAGING_TOOLS,
+} from "../../src/cli/embedded-wiring.js";
+
+const execFileAsync = promisify(execFile);
+
+const tempDirs: string[] = [];
+
+async function tempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+async function fixtureRepo(): Promise<string> {
+  const dir = await tempDir("pome-embed-repo-");
+  await mkdir(join(dir, "src"), { recursive: true });
+  await writeFile(join(dir, "src/agent.ts"), 'const gh = "https://api.github.com";\n');
+  await writeFile(join(dir, "package.json"), '{\n  "name": "fixture"\n}\n');
+  return dir;
+}
+
+async function fakeSkillDir(): Promise<string> {
+  const dir = await tempDir("pome-embed-skill-");
+  await writeFile(join(dir, "SKILL.md"), "# pome-setup (test copy)\n");
+  return dir;
+}
+
+interface SessionCapture {
+  prompt?: string;
+  options?: Record<string, unknown>;
+  shadow?: string;
+}
+
+/** SDK-shaped fake: run `script` against the shadow, then yield a result. */
+function scriptedQuery(
+  capture: SessionCapture,
+  script: (shadow: string) => Promise<void>,
+  end: Record<string, unknown> = { type: "result", subtype: "success", result: "wired" },
+): AgentSdkQueryFn {
+  return ({ prompt, options }) => ({
+    async *[Symbol.asyncIterator]() {
+      capture.prompt = prompt;
+      capture.options = options;
+      capture.shadow = options.cwd as string;
+      await script(options.cwd as string);
+      yield {
+        type: "assistant",
+        message: { content: [{ type: "text", text: "staging the wiring edits" }] },
+      };
+      yield end;
+    },
+  });
+}
+
+function harness() {
+  const lines: string[] = [];
+  const questions: string[] = [];
+  return {
+    lines,
+    questions,
+    log: (line: string) => lines.push(line),
+    text: () => lines.join("\n"),
+    confirm: (answer: boolean) => async (q: string) => {
+      questions.push(q);
+      return answer;
+    },
+  };
+}
+
+describe("runEmbeddedWiring (FDRS-661)", () => {
+  it("stages edits in a shadow, renders the file list + diff, and applies on [y]", async () => {
+    const repo = await fixtureRepo();
+    const skill = await fakeSkillDir();
+    const capture: SessionCapture = {};
+    const h = harness();
+
+    const outcome = await runEmbeddedWiring({
+      cwd: repo,
+      claudePath: "/fake/claude",
+      skillSourceDir: skill,
+      confirm: h.confirm(true),
+      log: h.log,
+      query: scriptedQuery(capture, async (shadow) => {
+        // The injected knowledge layer is in place before the session runs.
+        expect(existsSync(join(shadow, ".claude", "skills", "pome-setup", "SKILL.md"))).toBe(
+          true,
+        );
+        // Repo files crossed into the shadow.
+        expect(existsSync(join(shadow, "src", "agent.ts"))).toBe(true);
+        await writeFile(
+          join(shadow, "src", "agent.ts"),
+          "const baseUrl = process.env.POME_GITHUB_REST_URL;\n",
+        );
+        await writeFile(join(shadow, "pome.config.json"), '{ "agent": {} }\n');
+      }),
+    });
+
+    expect(outcome).toEqual({ kind: "applied", files: 2, packageJsonChanged: false });
+
+    // The session ran in the shadow, not the repo, with the verified options.
+    expect(capture.shadow).not.toBe(repo);
+    expect(capture.prompt).toBe(EMBEDDED_KICKOFF_PROMPT);
+    expect(capture.options).toMatchObject({
+      pathToClaudeCodeExecutable: "/fake/claude",
+      permissionMode: "default",
+      settingSources: ["project"],
+      skills: "all",
+      tools: [...STAGING_TOOLS],
+    });
+    expect(capture.options?.tools).not.toContain("Bash");
+
+    // Moment 02: file list, unified diff, the gate, the write confirmation.
+    const text = h.text();
+    expect(text).toContain("here's what it will change:");
+    expect(text).toContain("modified");
+    expect(text).toContain("src/agent.ts");
+    expect(text).toContain("new file");
+    expect(text).toContain("pome.config.json");
+    expect(text).toContain("+const baseUrl = process.env.POME_GITHUB_REST_URL;");
+    expect(text).toContain("✓ wrote 2 files");
+    expect(h.questions).toEqual(["apply these changes? [y/N] "]);
+
+    // The real tree changed only after the [y].
+    expect(await readFile(join(repo, "src/agent.ts"), "utf8")).toContain(
+      "POME_GITHUB_REST_URL",
+    );
+    expect(existsSync(join(repo, "pome.config.json"))).toBe(true);
+  });
+
+  it("leaves the repo untouched on [N]", async () => {
+    const repo = await fixtureRepo();
+    const skill = await fakeSkillDir();
+    const h = harness();
+
+    const outcome = await runEmbeddedWiring({
+      cwd: repo,
+      claudePath: "/fake/claude",
+      skillSourceDir: skill,
+      confirm: h.confirm(false),
+      log: h.log,
+      query: scriptedQuery({}, async (shadow) => {
+        await writeFile(join(shadow, "src", "agent.ts"), "changed\n");
+      }),
+    });
+
+    expect(outcome).toEqual({ kind: "declined" });
+    expect(await readFile(join(repo, "src/agent.ts"), "utf8")).toContain("api.github.com");
+  });
+
+  it("returns the agent's named reason when the session stages no changes", async () => {
+    const repo = await fixtureRepo();
+    const skill = await fakeSkillDir();
+    const h = harness();
+
+    const outcome = await runEmbeddedWiring({
+      cwd: repo,
+      claudePath: "/fake/claude",
+      skillSourceDir: skill,
+      confirm: h.confirm(true),
+      log: h.log,
+      query: scriptedQuery({}, async () => {}, {
+        type: "result",
+        subtype: "success",
+        result: "this repository is already wired — pome doctor should be green.",
+      }),
+    });
+
+    expect(outcome).toEqual({
+      kind: "no-diff",
+      reason: "this repository is already wired — pome doctor should be green.",
+    });
+    expect(h.questions).toEqual([]); // never asked to apply nothing
+  });
+
+  it("surfaces a session error result instead of applying anything", async () => {
+    const repo = await fixtureRepo();
+    const skill = await fakeSkillDir();
+    const h = harness();
+
+    const outcome = await runEmbeddedWiring({
+      cwd: repo,
+      claudePath: "/fake/claude",
+      skillSourceDir: skill,
+      confirm: h.confirm(true),
+      log: h.log,
+      query: scriptedQuery(
+        {},
+        async (shadow) => {
+          await writeFile(join(shadow, "src", "agent.ts"), "half-finished\n");
+        },
+        { type: "result", subtype: "error_max_turns", errors: ["Reached maximum turns"] },
+      ),
+    });
+
+    expect(outcome).toMatchObject({ kind: "session-error" });
+    expect((outcome as { reason: string }).reason).toContain("Reached maximum turns");
+    expect(await readFile(join(repo, "src/agent.ts"), "utf8")).toContain("api.github.com");
+  });
+
+  it("keeps .claude writes out of the diff and off the real repo", async () => {
+    const repo = await fixtureRepo();
+    const skill = await fakeSkillDir();
+    const h = harness();
+
+    const outcome = await runEmbeddedWiring({
+      cwd: repo,
+      claudePath: "/fake/claude",
+      skillSourceDir: skill,
+      confirm: h.confirm(true),
+      log: h.log,
+      query: scriptedQuery({}, async (shadow) => {
+        await writeFile(join(shadow, ".claude", "settings.json"), '{ "sneaky": true }\n');
+        await writeFile(join(shadow, "src", "agent.ts"), "wired\n");
+      }),
+    });
+
+    expect(outcome).toEqual({ kind: "applied", files: 1, packageJsonChanged: false });
+    expect(existsSync(join(repo, ".claude"))).toBe(false);
+    expect(h.text()).not.toContain("settings.json");
+  });
+
+  it("reports packageJsonChanged so install can run the package manager", async () => {
+    const repo = await fixtureRepo();
+    const skill = await fakeSkillDir();
+    const h = harness();
+
+    const outcome = await runEmbeddedWiring({
+      cwd: repo,
+      claudePath: "/fake/claude",
+      skillSourceDir: skill,
+      confirm: h.confirm(true),
+      log: h.log,
+      query: scriptedQuery({}, async (shadow) => {
+        await writeFile(
+          join(shadow, "package.json"),
+          '{\n  "name": "fixture",\n  "dependencies": { "@pome-sh/adapter-claude-sdk": "^0.1.0" }\n}\n',
+        );
+      }),
+    });
+
+    expect(outcome).toEqual({ kind: "applied", files: 1, packageJsonChanged: true });
+  });
+
+  it("respects .gitignore when the repo is a git repo (secrets never reach the shadow)", async () => {
+    const repo = await fixtureRepo();
+    await writeFile(join(repo, ".gitignore"), ".env\n");
+    await writeFile(join(repo, ".env"), "SECRET=1\n");
+    await writeFile(join(repo, "untracked-note.md"), "untracked but not ignored\n");
+    await execFileAsync("git", ["init", "-q"], { cwd: repo });
+    const skill = await fakeSkillDir();
+    const h = harness();
+    let sawEnv: boolean | null = null;
+    let sawUntracked: boolean | null = null;
+
+    await runEmbeddedWiring({
+      cwd: repo,
+      claudePath: "/fake/claude",
+      skillSourceDir: skill,
+      confirm: h.confirm(false),
+      log: h.log,
+      query: scriptedQuery({}, async (shadow) => {
+        sawEnv = existsSync(join(shadow, ".env"));
+        sawUntracked = existsSync(join(shadow, "untracked-note.md"));
+        await writeFile(join(shadow, "src", "agent.ts"), "changed\n");
+      }),
+    });
+
+    expect(sawEnv).toBe(false);
+    expect(sawUntracked).toBe(true);
+  });
+
+  it("never copies symlinks into the shadow (git and non-git repos alike)", async () => {
+    // A tracked symlink copied verbatim would carry a pointer out of the
+    // shadow that Read/Write could follow past the path fence.
+    const outside = await tempDir("pome-embed-outside-");
+    await writeFile(join(outside, "secret.txt"), "outside the shadow\n");
+    const skill = await fakeSkillDir();
+
+    for (const gitRepo of [false, true]) {
+      const repo = await fixtureRepo();
+      const { symlink } = await import("node:fs/promises");
+      await symlink(join(outside, "secret.txt"), join(repo, "leak.txt"));
+      if (gitRepo) {
+        await execFileAsync("git", ["init", "-q"], { cwd: repo });
+      }
+      const h = harness();
+      let sawLink: boolean | null = null;
+
+      await runEmbeddedWiring({
+        cwd: repo,
+        claudePath: "/fake/claude",
+        skillSourceDir: skill,
+        confirm: h.confirm(false),
+        log: h.log,
+        query: scriptedQuery({}, async (shadow) => {
+          sawLink = existsSync(join(shadow, "leak.txt"));
+          await writeFile(join(shadow, "src", "agent.ts"), "changed\n");
+        }),
+      });
+
+      expect(sawLink).toBe(false);
+      expect(h.text()).toContain("symlinks stay out of the staged copy");
+      expect(h.text()).toContain("leak.txt");
+    }
+  });
+});
+
+describe("buildStagingCanUseTool", () => {
+  it("confines file paths to the shadow root", async () => {
+    const root = await tempDir("pome-shadow-gate-");
+    const gate = buildStagingCanUseTool(root, () => {});
+    await expect(
+      gate("Read", { file_path: join(root, "src/agent.ts") }),
+    ).resolves.toMatchObject({ behavior: "allow" });
+    await expect(gate("Read", { file_path: "/Users/someone/hello.txt" })).resolves.toMatchObject(
+      { behavior: "deny" },
+    );
+    await expect(gate("Edit", { file_path: join(root, "..", "escape.txt") })).resolves.toMatchObject(
+      { behavior: "deny" },
+    );
+    await expect(gate("Write", { file_path: "relative/inside.txt" })).resolves.toMatchObject({
+      behavior: "allow",
+    });
+
+    // Defense in depth: a symlink that somehow appears inside the shadow
+    // can't smuggle the operation outside — paths are canonicalized.
+    const outside = await tempDir("pome-shadow-outside-");
+    await writeFile(join(outside, "secret.txt"), "secret\n");
+    const { symlink } = await import("node:fs/promises");
+    await symlink(join(outside, "secret.txt"), join(root, "sneaky-link"));
+    await expect(gate("Read", { file_path: join(root, "sneaky-link") })).resolves.toMatchObject({
+      behavior: "deny",
+    });
+  });
+
+  it("refuses tools outside the staging whitelist, Bash above all", async () => {
+    const root = await tempDir("pome-shadow-gate-");
+    const gate = buildStagingCanUseTool(root, () => {});
+    const bash = await gate("Bash", { command: "npm install" });
+    expect(bash).toMatchObject({ behavior: "deny" });
+    expect((bash as { message: string }).message).toContain("staging session");
+    await expect(gate("WebFetch", { url: "https://example.com" })).resolves.toMatchObject({
+      behavior: "deny",
+    });
+  });
+
+  it("logs a staged line for approved edits", async () => {
+    const root = await tempDir("pome-shadow-gate-");
+    const lines: string[] = [];
+    const gate = buildStagingCanUseTool(root, (l) => lines.push(l));
+    await gate("Edit", { file_path: join(root, "src/agent.ts") });
+    expect(lines.join("\n")).toContain("staged src/agent.ts");
+  });
+});

--- a/cli/test/unit/install-command.test.ts
+++ b/cli/test/unit/install-command.test.ts
@@ -20,6 +20,7 @@ import type { AgentSdkQueryFn } from "../../src/cli/agent-sdk.js";
 import {
   detectAgent,
   KICKOFF_PROMPT,
+  lockfilePackageManager,
   PASTE_PROMPT,
   runInstall,
 } from "../../src/cli/install.js";
@@ -461,5 +462,14 @@ describe("pome install (FDRS-642)", () => {
   it("registers the --interactive flag on the install command", () => {
     const install = createProgram().commands.find((c) => c.name() === "install");
     expect(install!.options.map((o) => o.long)).toContain("--interactive");
+  });
+
+  it("names the package manager from the lockfile, per directory", async () => {
+    const dir = await tempDir("pome-install-lock-");
+    expect(lockfilePackageManager(dir)).toBeNull();
+    await writeFile(join(dir, "pnpm-lock.yaml"), "");
+    expect(lockfilePackageManager(dir)).toBe("pnpm");
+    await writeFile(join(dir, "bun.lock"), "");
+    expect(lockfilePackageManager(dir)).toBe("bun"); // bun wins over pnpm
   });
 });

--- a/cli/test/unit/install-command.test.ts
+++ b/cli/test/unit/install-command.test.ts
@@ -16,6 +16,7 @@ import { delimiter, join } from "node:path";
 import { promisify } from "node:util";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { AgentSdkQueryFn } from "../../src/cli/agent-sdk.js";
 import {
   detectAgent,
   KICKOFF_PROMPT,
@@ -223,6 +224,10 @@ describe("pome install (FDRS-642)", () => {
       stdinIsTTY: true,
       cwd: repo,
       confirm,
+      // This test exercises the FDRS-642 interactive path — opt out of the
+      // FDRS-661 headless default explicitly (the machine running the tests
+      // may well have a real Claude login).
+      hasClaudeLogin: () => false,
     });
 
     // The no-undo warning fired and was accepted.
@@ -257,6 +262,8 @@ describe("pome install (FDRS-642)", () => {
       stdinIsTTY: true,
       cwd: repo,
       confirm: async () => true,
+      // FDRS-642 interactive path — opt out of the headless default.
+      hasClaudeLogin: () => false,
     });
 
     const text = stderrText();
@@ -266,4 +273,193 @@ describe("pome install (FDRS-642)", () => {
     expect(text).toContain("re-run pome install");
     expect(process.exitCode).toBe(1);
   }, 60_000);
+
+  // -------------------------------------------------------------------------
+  // FDRS-661 — the headless staged-diff default and its fallbacks.
+
+  /** SDK-shaped fake: edit the shadow, then yield a result message. */
+  function scriptedQuery(
+    script: (shadow: string) => Promise<void>,
+    end: Record<string, unknown> = { type: "result", subtype: "success", result: "wired" },
+  ): AgentSdkQueryFn {
+    return ({ options }) => ({
+      async *[Symbol.asyncIterator]() {
+        await script(options.cwd as string);
+        yield end;
+      },
+    });
+  }
+
+  /** PATH with the fake claude first (wins detection) and the real PATH
+   *  behind it — the shadow staging needs a real `git`. */
+  function stubEmbeddedEnv(binDir: string, home: string): void {
+    vi.stubEnv("PATH", `${binDir}${delimiter}${process.env.PATH ?? ""}`);
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("POME_API_KEY", "pme_test");
+    vi.stubEnv("POME_CLI_DISABLE_KEYCHAIN", "1");
+  }
+
+  it("defaults to the headless staged-diff flow and verifies to green after [y]", async () => {
+    const { binDir, argsFile } = await fakeClaudeBin();
+    const home = await fakeHome();
+    const repo = await fixtureRepo(UNWIRED_SOURCE);
+    stubEmbeddedEnv(binDir, home);
+    const confirm = vi.fn(async () => true);
+
+    await runInstall({
+      apiUrl: API_URL,
+      dashboardUrl: DASHBOARD_URL,
+      stdinIsTTY: true,
+      cwd: repo,
+      confirm,
+      hasClaudeLogin: () => true,
+      acquireSdk: async () => ({
+        query: scriptedQuery(async (shadow) => {
+          await writeFile(join(shadow, "src/agent.ts"), WIRED_SOURCE);
+        }),
+      }),
+    });
+
+    const text = stderrText();
+    // The staged session ran instead of the interactive handoff.
+    expect(text).toContain("nothing is written until you approve the diff");
+    expect(existsSync(argsFile)).toBe(false);
+    // Moment 02: diff gate, then the write, then doctor to green.
+    expect(text).toContain("here's what it will change:");
+    expect(text).toContain("modified");
+    expect(text).toContain("src/agent.ts");
+    expect(text).toContain("✓ wrote 1 file");
+    expect(text).toContain("verifying the wiring …");
+    expect(text).toContain("wiring verified — your agent is ready.");
+    // The [y] actually landed the wiring in the real repo.
+    expect(await readFile(join(repo, "src/agent.ts"), "utf8")).toBe(WIRED_SOURCE);
+    expect(process.exitCode).toBeFalsy();
+  }, 60_000);
+
+  it("declining the diff aborts with nothing changed", async () => {
+    const { binDir } = await fakeClaudeBin();
+    const home = await fakeHome();
+    const repo = await fixtureRepo(UNWIRED_SOURCE);
+    stubEmbeddedEnv(binDir, home);
+    // Accept the no-undo guard, decline the diff.
+    const answers = [true, false];
+    const confirm = vi.fn(async () => answers.shift() ?? false);
+
+    await runInstall({
+      apiUrl: API_URL,
+      dashboardUrl: DASHBOARD_URL,
+      stdinIsTTY: true,
+      cwd: repo,
+      confirm,
+      hasClaudeLogin: () => true,
+      acquireSdk: async () => ({
+        query: scriptedQuery(async (shadow) => {
+          await writeFile(join(shadow, "src/agent.ts"), WIRED_SOURCE);
+        }),
+      }),
+    });
+
+    const text = stderrText();
+    expect(text).toContain("aborted — nothing changed");
+    expect(text).not.toContain("verifying the wiring");
+    expect(await readFile(join(repo, "src/agent.ts"), "utf8")).toBe(UNWIRED_SOURCE);
+    expect(process.exitCode).toBeFalsy();
+  });
+
+  it("a session that stages nothing exits 1 with the agent's named reason", async () => {
+    const { binDir } = await fakeClaudeBin();
+    const home = await fakeHome();
+    const repo = await fixtureRepo(WIRED_SOURCE);
+    stubEmbeddedEnv(binDir, home);
+
+    await runInstall({
+      apiUrl: API_URL,
+      dashboardUrl: DASHBOARD_URL,
+      stdinIsTTY: true,
+      cwd: repo,
+      confirm: async () => true,
+      hasClaudeLogin: () => true,
+      acquireSdk: async () => ({
+        query: scriptedQuery(async () => {}, {
+          type: "result",
+          subtype: "success",
+          result: "already wired — nothing to change.",
+        }),
+      }),
+    });
+
+    const text = stderrText();
+    expect(text).toContain("the session staged no changes");
+    expect(text).toContain("reason: already wired — nothing to change.");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("--interactive forces the agent-session handoff even with credentials", async () => {
+    const { binDir, argsFile } = await fakeClaudeBin();
+    const home = await fakeHome();
+    const repo = await fixtureRepo(WIRED_SOURCE);
+    stubEmbeddedEnv(binDir, home);
+    const acquireSdk = vi.fn();
+
+    await runInstall({
+      apiUrl: API_URL,
+      dashboardUrl: DASHBOARD_URL,
+      stdinIsTTY: true,
+      interactive: true,
+      cwd: repo,
+      confirm: async () => true,
+      hasClaudeLogin: () => true,
+      acquireSdk,
+    });
+
+    expect(acquireSdk).not.toHaveBeenCalled();
+    expect(await readFile(argsFile, "utf8")).toBe(KICKOFF_PROMPT);
+    expect(stderrText()).toContain("handing off to Claude Code");
+  }, 60_000);
+
+  it("falls back to the interactive handoff when no Claude credentials exist", async () => {
+    const { binDir, argsFile } = await fakeClaudeBin();
+    const home = await fakeHome();
+    const repo = await fixtureRepo(WIRED_SOURCE);
+    stubEmbeddedEnv(binDir, home);
+
+    await runInstall({
+      apiUrl: API_URL,
+      dashboardUrl: DASHBOARD_URL,
+      stdinIsTTY: true,
+      cwd: repo,
+      confirm: async () => true,
+      hasClaudeLogin: () => false,
+    });
+
+    const text = stderrText();
+    expect(text).toContain("no Claude login or ANTHROPIC_API_KEY found");
+    expect(await readFile(argsFile, "utf8")).toBe(KICKOFF_PROMPT);
+  }, 60_000);
+
+  it("falls back to the interactive handoff when the SDK download is declined", async () => {
+    const { binDir, argsFile } = await fakeClaudeBin();
+    const home = await fakeHome();
+    const repo = await fixtureRepo(WIRED_SOURCE);
+    stubEmbeddedEnv(binDir, home);
+
+    await runInstall({
+      apiUrl: API_URL,
+      dashboardUrl: DASHBOARD_URL,
+      stdinIsTTY: true,
+      cwd: repo,
+      confirm: async () => true,
+      hasClaudeLogin: () => true,
+      acquireSdk: async () => null,
+    });
+
+    const text = stderrText();
+    expect(text).toContain("continuing with the interactive session instead");
+    expect(await readFile(argsFile, "utf8")).toBe(KICKOFF_PROMPT);
+  }, 60_000);
+
+  it("registers the --interactive flag on the install command", () => {
+    const install = createProgram().commands.find((c) => c.name() === "install");
+    expect(install!.options.map((o) => o.long)).toContain("--interactive");
+  });
 });


### PR DESCRIPTION
<!-- Closes FDRS-661 -->

## What

`pome install` now defaults to the moment-02 terminal diff gate: the wiring agent runs headless on the user's own Claude credentials (a one-time few-MB Claude Agent SDK driver download drives the user's installed `claude` binary), its edits are staged in an isolated shadow copy of the repo, and pome renders the full file list + unified diff in its own terminal — the working tree changes only on `[y]`, then pome runs the package install (if package.json changed) and doctor to green. A session that stages nothing exits with the agent's named reason, never a silent no-op. The FDRS-642 interactive handoff survives unchanged behind `--interactive` and as the automatic fallback (no Claude credentials, or driver download declined).

## Why

FDRS-661 — restores the in-terminal file-list + diff + [y/N] gate from `CLI moments.dc.html` moment 02 that FDRS-642's scope re-cut deferred (its v1 delegated approval to the coding agent's own edit-approval UI). The `pome-setup` skill is reused unchanged as the knowledge layer; the embedded kickoff prompt only adapts its interactive contract to staging.

## Notes for reviewer

- **Why shadow-workspace instead of literal canUseTool deny-and-record:** a denied Edit reads as a failure to the agent (it retries); edits landing in an isolated copy keep the session self-consistent, and the diff comes from `git diff --binary --staged` afterwards — exact, rename/binary-safe, applied with `git apply` (which rejects `../` traversal by default).
- **Two live-probe findings shaped the security posture:** (1) bare `allowedTools` entries auto-approve *before* `canUseTool` is consulted (SDK warns `CLAUDE_SDK_CAN_USE_TOOL_SHADOWED`) — the whitelist therefore lives in `tools`, never `allowedTools`; (2) the model reached for `$HOME` on turn one in a probe — the canUseTool path fence is load-bearing. Additionally: the user's `.claude/` is never copied into the shadow (settings allow-rules would shadow the callback), and symlinks never cross into the shadow (a tracked link copied verbatim would let Read/Write follow it past the fence; paths are also canonicalized before the containment check).
- **Dependency weight:** `@anthropic-ai/claude-agent-sdk`'s platform optionalDependency unpacks to ~244 MB — deliberately NOT added to `pome-sh` dependencies. The driver alone (~4 MB, `--omit=optional`) is consent-gated into `~/.pome/agent-sdk/<pinned>` and pointed at the user's `claude` via `pathToClaudeCodeExecutable` (verified live: SDK 0.3.202 ↔ Claude Code 2.1.201).
- **Live acceptance ran end-to-end** on the FDRS-642 unwired fixture: consent → driver download → headless session on real credentials → staged diff (`pome.config.json` new +7, `src/index.ts` +12 −6, adapter-first) → `[y]` → `✓ wrote 2 files` → doctor 4/4 green, exit 0. Verified against the fixture's real `git diff`, not the agent's self-report.
- Tests: 72 files / 503 tests green (`cd cli && bun run test`), typecheck green. New: `embedded-wiring.test.ts` (staging, gate, symlink/.claude exclusion, named-reason no-op) + 7 branching tests in `install-command.test.ts`.

## Review required

Yes — public OSS CLI surface: `pome install`'s default flow changes (headless staged-diff instead of interactive handoff).

### Founder briefing (3 min)

- **What changed** — `pome install` now stages the wiring headless and asks for one [y/N] on a terminal-rendered diff before touching the tree; the interactive session became `--interactive` / the fallback.
- **What it means for your repo / workflow** — nothing to change in pome-cloud; the demo → install → run journey copy stays valid, but any docs/videos showing the interactive handoff as the default should show the diff gate instead.
- **The one thing you must know** — the first headless run downloads a pinned ~4 MB Claude Agent SDK driver into `~/.pome/agent-sdk` (consent-gated) and runs on the *user's* Claude credentials/binary — pome still hosts no LLM gateway and pays no tokens.