### PR TITLE
feat(twins): freeze twin runtime contract — CONTRACT.md + black-box suite (FDRS-711)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,21 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - run: bash scripts/lint-no-cloud-imports.sh
+
+  # Black-box twin runtime-contract suite (FDRS-711). Spawns the BUILT twins
+  # via plain `node` — Node 24 to match the GHCR runtime image — and asserts
+  # the control-plane surface frozen in CONTRACT.md.
+  contract:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.13
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+      - run: bun install --frozen-lockfile --filter '*'
+      - run: bun run test:contract

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -1,0 +1,67 @@
+# Twin Runtime Contract
+
+**Version 1.0.0** — frozen 2026-07-07 (FDRS-711), verified by the black-box suite in [`contract/`](./contract/).
+
+This document enumerates everything pome-cloud (and the pome CLI) may rely on when booting and driving a twin. **Changing any item below is a breaking contract change**: update this document and the suite in the same PR, and open the coordinated cross-repo PR to pome-cloud (rule of record: `packages/twin-github/README.md`, runtime-contract section).
+
+## Boot
+
+- Entry point: `node dist/src/server.js` with **cwd = the twin package root** (`packages/twin-<name>`).
+- `GET /healthz` answers **200 within 3 seconds** of spawn.
+- The twin **refuses to boot** on a non-loopback bind host without `TWIN_AUTH_SECRET` (exit code ≠ 0; the error names the variable).
+- Runtime dependency arrangement: hoisted `node_modules` + `packages/shared-types` **with its compiled runtime JS** (`bun run --filter '@pome-sh/shared-types' build:runtime`). `@pome-sh/shared-types` exports `./src/index.ts`, so a plain-`node` boot relies on type stripping (**Node ≥ 22.18**) plus the built `src/*.js` files for its `.js` import specifiers. The GHCR runtime image ships `node:24`; the Dockerfiles are the reference implementation of this arrangement.
+
+## Environment surface
+
+| Variable | Meaning | Default |
+|---|---|---|
+| `PORT` / `<TWIN>_CLONE_PORT` | listen port | `3333` |
+| `GITHUB_CLONE_HOST` / `SLACK_CLONE_HOST` / `STRIPE_CLONE_HOST` | bind host | `127.0.0.1` |
+| `GITHUB_CLONE_DB` / `SLACK_CLONE_DB` / `STRIPE_CLONE_DB` | SQLite path or `:memory:` | `.<twin>_clone/<twin>.db` |
+| `<TWIN>_CLONE_NO_SEED=1` | skip the default seed at boot | seed applied |
+| `POME_SEED_JSON` | cloud-supplied seed applied at boot (FDRS-353) | default seed |
+| `TWIN_AUTH_SECRET` | HS256 secret for session JWTs + provider-shaped tokens | dev-only fallback; **required** in production / on non-loopback hosts |
+| `TWIN_ADMIN_TOKEN` | switches `/admin/*` to `X-Admin-Token` auth (timing-safe compare) | loopback-only socket check |
+| `POME_RUN_ID` | recorder run id stamped on events | `"spawn"` |
+| `POME_TWIN_VERSION` / `POME_TWIN_GIT_SHA` / `POME_TWIN_BUILD_TIME` | `/healthz` `runtime` block | `0.1.0` / `dev` / `dev` |
+| `SLACK_DETERMINISTIC_TS` | deterministic Slack message timestamps | — |
+| `NODE_ENV=production` | strict secret requirement; admin gate denies unknown peer addresses | — |
+
+## Control plane (all twins)
+
+- `GET /healthz` — root, **no auth**: `{ok: true, twin, implementation, tools, runtime: {package, version, git_sha, build_time}}`, `tools` > 0. Invariant: `healthz.tools` equals the length of the MCP tool list.
+- `POST /admin/reset`, `POST /admin/seed` — **no bearer**. Gate: `TWIN_ADMIN_TOKEN` mode (header `X-Admin-Token`, 403 when missing/wrong) or loopback-only **socket** check — proxy/client headers are never trusted (`packages/sdk/src/admin-gate.ts`); with `NODE_ENV=production` an unknown peer address is denied.
+- Session mount `/s/:sid/*` — bearer JWT, HS256 over `TWIN_AUTH_SECRET`, claims `{sid, team_id, exp, …}`; the `sid` claim must equal the path `:sid`. Provider-shaped tokens (`ghp_/github_pat_pome_*`, `xox[bp]-pome-*`, `sk_test_pome_*`) are also accepted per twin.
+- `GET /s/:sid/_pome/health` → 200 `{ok: true, twin, …}`.
+- `GET /s/:sid/_pome/state` → 200 JSON object — the redacted state export that feeds cloud-side `[D]` scoring.
+- `GET /s/:sid/_pome/events` → 200 JSON array — the recorder tape fetched at end of run.
+- MCP: `GET /s/:sid/mcp/tools` → `{tools: […]}`; `POST /s/:sid/mcp` (streamable-HTTP JSON-RPC, stateless — `GET`/`DELETE` answer 405); legacy `POST /s/:sid/mcp/tools/:name` and `POST /s/:sid/mcp/call` (`{tool, arguments}`).
+- Reserved prefixes: `/_pome/*` and `/mcp/*` under the session mount belong to the platform (OQ-B6); domain routes must not shadow them.
+- Unknown **session** routes → **501** loud-unsupported envelope advertising `fidelity: "unsupported"` and the supported surfaces.
+
+## Per-twin frozen differences (as observed 2026-07-07)
+
+Several rows are under active ruling in FDRS-712. They are frozen **as-is**: changing them later is a deliberate contract change, never a port side effect.
+
+| Surface | github | slack | stripe |
+|---|---|---|---|
+| `/healthz` `fidelity` field | `"semantic"` | absent | `"semantic"` |
+| `/healthz` extras | `access_control` | — | `tthw_seconds` |
+| `GET /s/:sid/healthz` | 200 `{ok, sid}` | 200 `{ok, sid}` | **501** (route absent) |
+| `/admin/seed` with garbage body | **422** validation error | 200 accepted | 200 accepted |
+| no / invalid bearer | 401 `{message: "Bad credentials"}` | 401 `{ok:false, error:"not_authed"/"invalid_auth"}` | 401 `{error:{code:"unauthorized"}}` |
+| expired JWT | 401 `"Bad credentials"` | 401 `error:"token_expired"` | 401 `unauthorized` |
+| sid mismatch | 401 `{message:"Forbidden"}` | 401 `invalid_auth` | **403** `{error:{code:"forbidden"}}` |
+| raw bearer (no `Bearer ` prefix) | 401 rejected | 401 rejected | **200 accepted** |
+| unknown tool via `/mcp/call` | 422 validation | 404 `unknown_tool` | 400 `tool_unknown` |
+| unknown **root** route | 404 | 404 | **401** (the `/v1` auth wall answers first) |
+| root `/v1/*` SDK-compat mount (no path sid; bearer alone) | — | — | yes |
+| extra session routes | `/_pome/access-control` | — | — |
+
+## Verifying
+
+```
+bun run test:contract
+```
+
+builds the shared-types runtime + the three twins, then runs `node --test contract/contract.test.mjs`. The suite is dependency-free (node:test, global fetch, node:crypto) so the same file can be pointed at any built twin artifact — including a cloud-built snapshot (FDRS-714).

--- a/contract/contract.test.mjs
+++ b/contract/contract.test.mjs
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Black-box twin runtime-contract suite (FDRS-711). Spawns each BUILT twin
+// exactly the way pome-cloud does (`node dist/src/server.js`, cwd = package
+// root, TWIN_AUTH_SECRET/PORT injected) and asserts the control-plane surface
+// documented in /CONTRACT.md from outside the process.
+//
+// These assertions FREEZE observed wire behavior — including per-twin
+// divergences that are themselves under review (see FDRS-712). Changing any
+// asserted status or shape is a contract change: update CONTRACT.md in the
+// same PR and coordinate the cross-repo pome-cloud PR per the contract doc.
+//
+// Prerequisite: `bun run --filter '@pome-sh/shared-types' build:runtime` and
+// `bun run --filter '@pome-sh/twin-*' build` (the root `test:contract` script
+// chains all three).
+
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { TWINS, mintSessionJwt, req, spawnTwin, spawnTwinRaw } from "./helpers.mjs";
+
+const SID = "contract-sid";
+const sPath = (p) => `/s/${SID}${p}`;
+
+// Per-twin frozen expectations, taken from live probes on 2026-07-07.
+const PER_TWIN = {
+  github: {
+    // /healthz carries fidelity + access_control on top of the shared core.
+    healthzFidelity: "semantic",
+    healthzExtras: ["access_control"],
+    sessionHealthz: { status: 200 },
+    // github validates seeds: a garbage body is a 422 GitHub validation error.
+    adminSeedGarbage: { status: 422, check: (b) => b.message === "Validation Failed" },
+    noAuth: { status: 401, check: (b) => b.message === "Bad credentials" },
+    wrongSid: { status: 401, check: (b) => b.message === "Forbidden" },
+    // hono/jwt's verify throws on an expired token before auth.ts's explicit
+    // "Token expired" branch is reached, so the wire says "Bad credentials".
+    expired: { status: 401, check: (b) => b.message === "Bad credentials" },
+    rawToken: { status: 401 },
+    mcpCallUnknown: { status: 422, check: (b) => b.message === "Validation Failed" },
+    unknownSession: { status: 501, check: (b) => b._twin?.fidelity === "unsupported" },
+    unknownRoot: { status: 404 },
+  },
+  slack: {
+    // slack's /healthz carries no fidelity field today.
+    healthzFidelity: undefined,
+    sessionHealthz: { status: 200 },
+    // slack accepts arbitrary seed bodies with 200 {ok:true} (no validation).
+    adminSeedGarbage: { status: 200, check: (b) => b.ok === true },
+    noAuth: { status: 401, check: (b) => b.ok === false && b.error === "not_authed" },
+    wrongSid: { status: 401, check: (b) => b.error === "invalid_auth" },
+    // slack is the only twin distinguishing token_expired from invalid_auth.
+    expired: { status: 401, check: (b) => b.error === "token_expired" },
+    rawToken: { status: 401 },
+    mcpCallUnknown: { status: 404, check: (b) => b.error === "unknown_tool" },
+    unknownSession: {
+      status: 501,
+      check: (b) => b.error === "unsupported_endpoint" && b._twin?.fidelity === "unsupported",
+    },
+    unknownRoot: { status: 404 },
+  },
+  stripe: {
+    healthzFidelity: "semantic",
+    healthzExtras: ["tthw_seconds"],
+    // stripe has no per-session /healthz; the path falls to the 501 catch-all.
+    sessionHealthz: { status: 501 },
+    adminSeedGarbage: { status: 200, check: (b) => b.ok === true },
+    noAuth: { status: 401, check: (b) => b.error?.code === "unauthorized" },
+    // stripe is the only twin answering a sid mismatch with 403 (not 401).
+    wrongSid: { status: 403, check: (b) => b.error?.code === "forbidden" },
+    expired: { status: 401, check: (b) => b.error?.code === "unauthorized" },
+    // stripe accepts a prefix-less bearer (raw JWT) today — FDRS-712 row 4.
+    rawToken: { status: 200 },
+    mcpCallUnknown: { status: 400, check: (b) => b.error?.code === "tool_unknown" },
+    unknownSession: {
+      status: 501,
+      check: (b) => b.error?.code === "endpoint_not_supported" && b.error?.fidelity === "unsupported",
+    },
+    // stripe's root-level unknown paths hit the /v1 auth wall first: 401.
+    unknownRoot: { status: 401 },
+  },
+};
+
+function checkBody(expectation, body, label) {
+  if (expectation.check) assert.ok(expectation.check(body ?? {}), `${label}: body shape — got ${JSON.stringify(body)}`);
+}
+
+for (const twin of TWINS) {
+  const exp = PER_TWIN[twin.name];
+
+  describe(`contract: ${twin.name}`, () => {
+    let t;
+    let jwt;
+
+    before(async () => {
+      t = await spawnTwin(twin); // asserts /healthz 200 within the 3s bound
+      jwt = mintSessionJwt({ sid: SID });
+    });
+    after(async () => {
+      await t?.close();
+    });
+
+    it("GET /healthz → 200 with the frozen shape (ok, twin, implementation, tools, runtime)", () => {
+      const h = t.healthz;
+      assert.equal(h.ok, true);
+      assert.equal(h.twin, twin.name);
+      assert.equal(typeof h.implementation, "string");
+      assert.equal(typeof h.tools, "number");
+      assert.ok(h.tools > 0, "advertises at least one MCP tool");
+      if (exp.healthzFidelity !== undefined) assert.equal(h.fidelity, exp.healthzFidelity);
+      for (const key of exp.healthzExtras ?? []) assert.ok(key in h, `healthz carries ${key}`);
+      for (const key of ["package", "version", "git_sha", "build_time"]) {
+        assert.equal(typeof h.runtime?.[key], "string", `runtime.${key} is a string`);
+      }
+    });
+
+    it("POST /admin/reset from loopback → 200 {ok:true} (no bearer required)", async () => {
+      const res = await req(t.base, "/admin/reset", { method: "POST" });
+      assert.equal(res.status, 200);
+      assert.equal(res.json?.ok, true);
+    });
+
+    it(`POST /admin/seed with a garbage body → ${exp.adminSeedGarbage.status} (frozen per-twin validation behavior)`, async () => {
+      const res = await req(t.base, "/admin/seed", { method: "POST", body: { definitely: "not-a-seed" } });
+      assert.equal(res.status, exp.adminSeedGarbage.status);
+      checkBody(exp.adminSeedGarbage, res.json, "admin/seed garbage");
+    });
+
+    it("GET /s/:sid/_pome/health|state|events with a valid session JWT → 200", async () => {
+      const health = await req(t.base, sPath("/_pome/health"), { token: jwt });
+      assert.equal(health.status, 200);
+      assert.equal(health.json?.ok, true);
+      assert.equal(health.json?.twin, twin.name);
+
+      const state = await req(t.base, sPath("/_pome/state"), { token: jwt });
+      assert.equal(state.status, 200);
+      assert.ok(state.json && typeof state.json === "object" && !Array.isArray(state.json), "state is a JSON object");
+
+      const events = await req(t.base, sPath("/_pome/events"), { token: jwt });
+      assert.equal(events.status, 200);
+      assert.ok(Array.isArray(events.json), "events is a JSON array");
+    });
+
+    it(`GET /s/:sid/healthz → ${exp.sessionHealthz.status} (frozen; stripe has no per-session healthz)`, async () => {
+      const res = await req(t.base, sPath("/healthz"), { token: jwt });
+      assert.equal(res.status, exp.sessionHealthz.status);
+      if (res.status === 200) {
+        assert.equal(res.json?.ok, true);
+        assert.equal(res.json?.sid, SID);
+      }
+    });
+
+    it("MCP surface: tools list matches healthz.tools; JSON-RPC initialize 200; GET /mcp 405", async () => {
+      const tools = await req(t.base, sPath("/mcp/tools"), { token: jwt });
+      assert.equal(tools.status, 200);
+      assert.ok(Array.isArray(tools.json?.tools));
+      assert.equal(tools.json.tools.length, t.healthz.tools, "healthz.tools equals the MCP tool list length");
+
+      const init = await req(t.base, sPath("/mcp"), {
+        method: "POST",
+        token: jwt,
+        headers: { accept: "application/json, text/event-stream" },
+        body: {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: "contract-suite", version: "0" } },
+        },
+      });
+      assert.equal(init.status, 200);
+      assert.equal(init.json?.jsonrpc, "2.0");
+      assert.equal(typeof init.json?.result?.serverInfo?.name, "string");
+
+      const get = await req(t.base, sPath("/mcp"), { token: jwt });
+      assert.equal(get.status, 405, "stateless-mode GET /mcp is 405");
+    });
+
+    it("POST /s/:sid/mcp/call with an unknown tool → frozen per-twin error envelope", async () => {
+      const res = await req(t.base, sPath("/mcp/call"), {
+        method: "POST",
+        token: jwt,
+        body: { tool: "definitely_not_a_tool", arguments: {} },
+      });
+      assert.equal(res.status, exp.mcpCallUnknown.status);
+      checkBody(exp.mcpCallUnknown, res.json, "mcp/call unknown tool");
+    });
+
+    it("auth matrix: no token / garbage bearer / wrong-sid JWT / expired JWT / raw token", async () => {
+      const noAuth = await req(t.base, sPath("/_pome/state"));
+      assert.equal(noAuth.status, exp.noAuth.status);
+      checkBody(exp.noAuth, noAuth.json, "no auth");
+
+      const garbage = await req(t.base, sPath("/_pome/state"), { token: "garbage" });
+      assert.equal(garbage.status, 401);
+
+      const wrongSid = await req(t.base, sPath("/_pome/state"), { token: mintSessionJwt({ sid: "other-sid" }) });
+      assert.equal(wrongSid.status, exp.wrongSid.status);
+      checkBody(exp.wrongSid, wrongSid.json, "wrong sid");
+
+      const expired = await req(t.base, sPath("/_pome/state"), { token: mintSessionJwt({ sid: SID, expSeconds: -60 }) });
+      assert.equal(expired.status, exp.expired.status);
+      checkBody(exp.expired, expired.json, "expired");
+
+      const raw = await fetch(`${t.base}${sPath("/_pome/state")}`, {
+        headers: { Authorization: mintSessionJwt({ sid: SID }) },
+      });
+      assert.equal(raw.status, exp.rawToken.status, "raw (prefix-less) bearer behavior is frozen per twin");
+    });
+
+    it("unknown session route → 501 unsupported envelope; unknown root route frozen", async () => {
+      const unknown = await req(t.base, sPath("/definitely/not/a/route"), { token: jwt });
+      assert.equal(unknown.status, exp.unknownSession.status);
+      checkBody(exp.unknownSession, unknown.json, "unknown session route");
+
+      const root = await req(t.base, "/definitely-not-a-route");
+      assert.equal(root.status, exp.unknownRoot.status);
+    });
+  });
+}
+
+describe("contract: admin gate token mode + boot guards", () => {
+  for (const twin of TWINS) {
+    it(`${twin.name}: TWIN_ADMIN_TOKEN switches /admin/* to token auth (403 without/with-wrong header)`, async () => {
+      const t = await spawnTwin(twin, { env: { TWIN_ADMIN_TOKEN: "contract-admin-token" } });
+      try {
+        const missing = await req(t.base, "/admin/reset", { method: "POST" });
+        assert.equal(missing.status, 403);
+        const wrong = await req(t.base, "/admin/reset", { method: "POST", headers: { "X-Admin-Token": "nope" } });
+        assert.equal(wrong.status, 403);
+        const right = await req(t.base, "/admin/reset", { method: "POST", headers: { "X-Admin-Token": "contract-admin-token" } });
+        assert.equal(right.status, 200);
+        assert.equal(right.json?.ok, true);
+      } finally {
+        await t.close();
+      }
+    });
+
+    it(`${twin.name}: refuses to boot on a non-loopback host without TWIN_AUTH_SECRET`, async () => {
+      const { code, output } = await spawnTwinRaw(twin, {
+        [twin.hostEnv]: "0.0.0.0",
+        PORT: "0",
+        TWIN_AUTH_SECRET: "",
+      });
+      assert.notEqual(code, 0, "process exits non-zero");
+      assert.match(output, /TWIN_AUTH_SECRET/, "error names the missing secret");
+    });
+  }
+});

--- a/contract/helpers.mjs
+++ b/contract/helpers.mjs
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Zero-dependency helpers for the black-box twin contract suite (FDRS-711).
+// Plain node:child_process + node:crypto + global fetch, so the same suite
+// can run against any built twin artifact — the workspace dist today, a
+// cloud-built snapshot tomorrow (FDRS-714) — without installing this repo's
+// dependencies. The wire format is the contract, not a library.
+
+import { spawn } from "node:child_process";
+import { createHmac } from "node:crypto";
+import { once } from "node:events";
+import { createServer } from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+export const AUTH_SECRET = "contract-suite-secret-0123456789abcdef";
+
+export const TWINS = [
+  { name: "github", pkg: "packages/twin-github", dbEnv: "GITHUB_CLONE_DB", hostEnv: "GITHUB_CLONE_HOST" },
+  { name: "slack", pkg: "packages/twin-slack", dbEnv: "SLACK_CLONE_DB", hostEnv: "SLACK_CLONE_HOST" },
+  { name: "stripe", pkg: "packages/twin-stripe", dbEnv: "STRIPE_CLONE_DB", hostEnv: "STRIPE_CLONE_HOST" },
+];
+
+function b64url(value) {
+  return Buffer.from(value).toString("base64url");
+}
+
+/** Hand-minted HS256 session JWT — claims shape: { sid, team_id, exp, ...extra }. */
+export function mintSessionJwt({ sid, teamId = "tm_contract", expSeconds = 3600, secret = AUTH_SECRET, extra = {} }) {
+  const header = b64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const payload = b64url(
+    JSON.stringify({ sid, team_id: teamId, exp: Math.floor(Date.now() / 1000) + expSeconds, ...extra })
+  );
+  const sig = createHmac("sha256", secret).update(`${header}.${payload}`).digest("base64url");
+  return `${header}.${payload}.${sig}`;
+}
+
+export async function freePort() {
+  const srv = createServer();
+  srv.listen(0, "127.0.0.1");
+  await once(srv, "listening");
+  const { port } = srv.address();
+  await new Promise((resolve) => srv.close(resolve));
+  return port;
+}
+
+/**
+ * Spawn a built twin exactly the way the cloud does: `node dist/src/server.js`
+ * with cwd = the package root. Resolves once GET /healthz answers 200, which
+ * the contract requires within 3 seconds of spawn.
+ */
+export async function spawnTwin(twin, { env = {}, port: portIn, healthzDeadlineMs = 3_000 } = {}) {
+  const port = portIn ?? (await freePort());
+  const cwd = path.join(REPO_ROOT, twin.pkg);
+  // Plain `node` from PATH, never process.execPath: the contract is the cloud's
+  // CMD ["node", "dist/src/server.js"], and under `bun run` execPath is bun.
+  const child = spawn("node", ["dist/src/server.js"], {
+    cwd,
+    env: {
+      ...process.env,
+      PORT: String(port),
+      TWIN_AUTH_SECRET: AUTH_SECRET,
+      [twin.dbEnv]: ":memory:",
+      ...env,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let output = "";
+  child.stdout.on("data", (chunk) => { output += chunk; });
+  child.stderr.on("data", (chunk) => { output += chunk; });
+  const exited = new Promise((resolve) => child.once("exit", (code) => resolve(code)));
+
+  const base = `http://127.0.0.1:${port}`;
+  const deadline = Date.now() + healthzDeadlineMs;
+  let healthz;
+  for (;;) {
+    try {
+      const res = await fetch(`${base}/healthz`);
+      if (res.status === 200) {
+        healthz = await res.json();
+        break;
+      }
+    } catch {
+      // not listening yet
+    }
+    if (Date.now() > deadline) {
+      child.kill("SIGKILL");
+      await exited;
+      throw new Error(
+        `${twin.name}: GET /healthz did not answer 200 within ${healthzDeadlineMs}ms of spawn (contract bound).\n--- twin output ---\n${output}`
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 40));
+  }
+
+  return {
+    twin,
+    base,
+    port,
+    healthz,
+    output: () => output,
+    exited,
+    async close() {
+      child.kill("SIGTERM");
+      const hardKill = setTimeout(() => child.kill("SIGKILL"), 2_000);
+      await exited;
+      clearTimeout(hardKill);
+    },
+  };
+}
+
+/**
+ * Spawn the twin entry WITHOUT the helper's default env (no auth secret
+ * injection) — for boot-guard assertions. Resolves with { code, output }.
+ */
+export async function spawnTwinRaw(twin, env, timeoutMs = 5_000) {
+  const cwd = path.join(REPO_ROOT, twin.pkg);
+  const child = spawn("node", ["dist/src/server.js"], {
+    cwd,
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let output = "";
+  child.stdout.on("data", (chunk) => { output += chunk; });
+  child.stderr.on("data", (chunk) => { output += chunk; });
+  const code = await Promise.race([
+    new Promise((resolve) => child.once("exit", (c) => resolve(c))),
+    new Promise((resolve) => setTimeout(() => { child.kill("SIGKILL"); resolve("timeout"); }, timeoutMs)),
+  ]);
+  return { code, output };
+}
+
+export async function req(base, pathname, { method = "GET", token, headers = {}, body } = {}) {
+  const finalHeaders = { ...headers };
+  if (token) finalHeaders.Authorization = `Bearer ${token}`;
+  if (body !== undefined && !finalHeaders["content-type"]) finalHeaders["content-type"] = "application/json";
+  const res = await fetch(`${base}${pathname}`, {
+    method,
+    headers: finalHeaders,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  let json;
+  try {
+    json = text.length > 0 ? JSON.parse(text) : null;
+  } catch {
+    json = undefined;
+  }
+  return { status: res.status, json, text };
+}

--- a/contract/run.mjs
+++ b/contract/run.mjs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Orchestrator for the twin runtime-contract suite (FDRS-711): build the
+// shared-types runtime JS + the three twins, run the black-box suite with
+// plain `node`, then remove the runtime JS that build:runtime emits next to
+// packages/shared-types/src/*.ts. Those files are untracked (the Docker
+// builds emit them in-image only); left behind they shadow the .ts sources
+// and break `lint:dead-code`.
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync, rmSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const SHARED_SRC = path.join(REPO_ROOT, "packages", "shared-types", "src");
+
+function run(cmd, args) {
+  const res = spawnSync(cmd, args, { cwd: REPO_ROOT, stdio: "inherit" });
+  return res.status ?? 1;
+}
+
+// Only remove `X.js` when `X.ts` sits next to it — the exact inverse of
+// tsconfig.runtime.json's in-place emit. Nothing else is touched.
+function cleanRuntimeJs(dir) {
+  let removed = 0;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      removed += cleanRuntimeJs(full);
+    } else if (entry.name.endsWith(".js") && existsSync(`${full.slice(0, -3)}.ts`)) {
+      rmSync(full);
+      removed += 1;
+    }
+  }
+  return removed;
+}
+
+let status = run("bun", ["run", "--filter", "@pome-sh/shared-types", "build:runtime"]);
+if (status === 0) status = run("bun", ["run", "--filter", "@pome-sh/twin-*", "build"]);
+if (status === 0) status = run("node", ["--test", "contract/contract.test.mjs"]);
+
+const removed = cleanRuntimeJs(SHARED_SRC);
+console.log(`[contract/run] cleaned ${removed} generated runtime .js file(s) from packages/shared-types/src`);
+process.exit(status);

--- a/knip.json
+++ b/knip.json
@@ -27,8 +27,8 @@
   ],
   "workspaces": {
     ".": {
-      "entry": ["scripts/*.{mjs,sh}"],
-      "project": ["scripts/**/*.{mjs,sh}"]
+      "entry": ["scripts/*.{mjs,sh}", "contract/run.mjs", "contract/contract.test.mjs"],
+      "project": ["scripts/**/*.{mjs,sh}", "contract/**/*.mjs"]
     },
     "packages/*": {
       "entry": ["src/index.ts", "src/server.ts", "scripts/**/*.ts"],

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "preinstall": "node -e \"const ua=process.env.npm_config_user_agent||''; if (!ua.includes('bun/')) { console.error('Use bun install (this repo is bun-only).'); process.exit(1); }\"",
     "build": "bun run --filter '*' build",
     "test": "bun run --filter '*' test",
+    "test:contract": "node contract/run.mjs",
     "typecheck": "bun run --filter '*' typecheck",
     "lint:no-cloud-imports": "bash scripts/lint-no-cloud-imports.sh",
     "lint:redaction-mirrors": "node scripts/check-redaction-mirrors.mjs",


### PR DESCRIPTION
<!-- Closes FDRS-711 -->

## What
Freezes the twin runtime contract before the M1 twin-core extraction: a versioned `CONTRACT.md` at the repo root (boot, env surface, control-plane routes, per-twin frozen differences) plus a dependency-free black-box suite (`contract/`, 33 assertions) that spawns each **built** twin via plain `node dist/src/server.js` — exactly the cloud's arrangement — and asserts the surface from outside the process. New root script `bun run test:contract`; new `contract` job in ci.yml (Node 24, matching the GHCR runtime image).

## Why
FDRS-711 — M1's freeze-before-surgery gate. Three upcoming milestones (engine extraction, node:sqlite swap, Docker-free front door) operate directly on the surface pome-cloud consumes (`/healthz`, `/admin/*`, `/s/:sid/_pome/*`, MCP routes, bearer JWT + `TWIN_AUTH_SECRET`). The suite is green against today's twins, so every extraction PR must show it green before and after — control-plane parity enforced in CI instead of promised in prose.

## Notes for reviewer
- Assertions encode **observed** wire reality (probed live 2026-07-07), including warts frozen deliberately: stripe accepts a prefix-less bearer (200), slack/stripe accept garbage `/admin/seed` bodies (200 vs github's 422), github answers expired JWTs with "Bad credentials" (its explicit "Token expired" branch is dead code — hono/jwt throws first), stripe answers sid mismatch with 403 vs 401 elsewhere. These rows are inventoried for ruling in FDRS-712; changing them later is a deliberate contract change, not a port side effect.
- `contract/run.mjs` builds shared-types' runtime JS first (`build:runtime` emits untracked `.js` beside `src/*.ts` — the Docker in-image arrangement), runs the suite, then removes exactly those files; leaving them behind shadows the `.ts` sources and breaks `lint:dead-code` locally.
- Negative check performed: renaming `/_pome/state` in twin-github's dist turns exactly one test red (32 pass / 1 fail), rebuild → 33/33 green.
- A plain-`node` twin boot needs Node ≥ 22.18 today (shared-types exports `./src/index.ts`; type stripping) — one more datum for the M2 engines-bump audit.

## Review required
Yes — establishes the twin runtime-contract artifact (public OSS API / twin fidelity contract) and adds a CI gate every M1 port must satisfy.

### Founder briefing (3 min)
- **What changed** — the twin control-plane surface is now a frozen, versioned contract (`CONTRACT.md`) enforced by a black-box CI suite that boots the built twins the way the cloud does.
- **What it means for your repo / workflow** — the M1 port tickets (F-681…F-685) must keep `bun run test:contract` green before **and** after each port; any intentional wire change now means editing CONTRACT.md + the suite in the same PR and coordinating the cross-repo pome-cloud PR.
- **The one thing you must know** — the suite deliberately froze several behaviors we may later rule as bugs (stripe raw-bearer 200, seed-validation asymmetry, sid-mismatch 401 vs 403); they're queued for explicit ruling in FDRS-712 — don't "fix" them mid-port or the gate goes red.