### PR TITLE
feat(sdk): twin-core engine — redaction, db wrapper, F-712 auth, sdk-boot contract proof (FDRS-681)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -37,16 +37,20 @@
       },
       "devDependencies": {
         "@hono/node-server": "^1.19.6",
+        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^25.0.3",
+        "better-sqlite3": "^12.5.0",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^4.0.15",
       },
       "peerDependencies": {
         "@hono/node-server": "^1.19.6",
+        "better-sqlite3": "^12.5.0",
       },
       "optionalPeers": [
         "@hono/node-server",
+        "better-sqlite3",
       ],
     },
     "packages/shared-types": {

--- a/contract/contract.test.mjs
+++ b/contract/contract.test.mjs
@@ -9,239 +9,24 @@
 // divergences that are themselves under review (see FDRS-712). Changing any
 // asserted status or shape is a contract change: update CONTRACT.md in the
 // same PR and coordinate the cross-repo pome-cloud PR per the contract doc.
+// The suite body lives in ./suite.mjs (FDRS-681) so the identical assertions
+// also run against the sdk-booted proof entry (./sdk-boot.test.mjs).
 //
 // Prerequisite: `bun run --filter '@pome-sh/shared-types' build:runtime` and
 // `bun run --filter '@pome-sh/twin-*' build` (the root `test:contract` script
 // chains all three).
 
-import { after, before, describe, it } from "node:test";
-import assert from "node:assert/strict";
-import { TWINS, mintSessionJwt, req, spawnTwin, spawnTwinRaw } from "./helpers.mjs";
-
-const SID = "contract-sid";
-const sPath = (p) => `/s/${SID}${p}`;
-
-// Per-twin frozen expectations, taken from live probes on 2026-07-07.
-const PER_TWIN = {
-  github: {
-    // /healthz carries fidelity + access_control on top of the shared core.
-    healthzFidelity: "semantic",
-    healthzExtras: ["access_control"],
-    sessionHealthz: { status: 200 },
-    // github validates seeds: a garbage body is a 422 GitHub validation error.
-    adminSeedGarbage: { status: 422, check: (b) => b.message === "Validation Failed" },
-    noAuth: { status: 401, check: (b) => b.message === "Bad credentials" },
-    wrongSid: { status: 401, check: (b) => b.message === "Forbidden" },
-    // hono/jwt's verify throws on an expired token before auth.ts's explicit
-    // "Token expired" branch is reached, so the wire says "Bad credentials".
-    expired: { status: 401, check: (b) => b.message === "Bad credentials" },
-    rawToken: { status: 401 },
-    mcpCallUnknown: { status: 422, check: (b) => b.message === "Validation Failed" },
-    unknownSession: { status: 501, check: (b) => b._twin?.fidelity === "unsupported" },
-    unknownRoot: { status: 404 },
-  },
-  slack: {
-    // slack's /healthz carries no fidelity field today.
-    healthzFidelity: undefined,
-    sessionHealthz: { status: 200 },
-    // slack accepts arbitrary seed bodies with 200 {ok:true} (no validation).
-    adminSeedGarbage: { status: 200, check: (b) => b.ok === true },
-    noAuth: { status: 401, check: (b) => b.ok === false && b.error === "not_authed" },
-    wrongSid: { status: 401, check: (b) => b.error === "invalid_auth" },
-    // slack is the only twin distinguishing token_expired from invalid_auth.
-    expired: { status: 401, check: (b) => b.error === "token_expired" },
-    rawToken: { status: 401 },
-    mcpCallUnknown: { status: 404, check: (b) => b.error === "unknown_tool" },
-    unknownSession: {
-      status: 501,
-      check: (b) => b.error === "unsupported_endpoint" && b._twin?.fidelity === "unsupported",
-    },
-    unknownRoot: { status: 404 },
-  },
-  stripe: {
-    healthzFidelity: "semantic",
-    healthzExtras: ["tthw_seconds"],
-    // stripe has no per-session /healthz; the path falls to the 501 catch-all.
-    sessionHealthz: { status: 501 },
-    adminSeedGarbage: { status: 200, check: (b) => b.ok === true },
-    noAuth: { status: 401, check: (b) => b.error?.code === "unauthorized" },
-    // stripe is the only twin answering a sid mismatch with 403 (not 401).
-    wrongSid: { status: 403, check: (b) => b.error?.code === "forbidden" },
-    expired: { status: 401, check: (b) => b.error?.code === "unauthorized" },
-    // stripe accepts a prefix-less bearer (raw JWT) today — FDRS-712 row 4.
-    rawToken: { status: 200 },
-    mcpCallUnknown: { status: 400, check: (b) => b.error?.code === "tool_unknown" },
-    unknownSession: {
-      status: 501,
-      check: (b) => b.error?.code === "endpoint_not_supported" && b.error?.fidelity === "unsupported",
-    },
-    // stripe's root-level unknown paths hit the /v1 auth wall first: 401.
-    unknownRoot: { status: 401 },
-  },
-};
-
-function checkBody(expectation, body, label) {
-  if (expectation.check) assert.ok(expectation.check(body ?? {}), `${label}: body shape — got ${JSON.stringify(body)}`);
-}
+import { describe } from "node:test";
+import { TWINS } from "./helpers.mjs";
+import { PER_TWIN, adminGateCase, bootGuardCase, contractSuite } from "./suite.mjs";
 
 for (const twin of TWINS) {
-  const exp = PER_TWIN[twin.name];
-
-  describe(`contract: ${twin.name}`, () => {
-    let t;
-    let jwt;
-
-    before(async () => {
-      t = await spawnTwin(twin); // asserts /healthz 200 within the 3s bound
-      jwt = mintSessionJwt({ sid: SID });
-    });
-    after(async () => {
-      await t?.close();
-    });
-
-    it("GET /healthz → 200 with the frozen shape (ok, twin, implementation, tools, runtime)", () => {
-      const h = t.healthz;
-      assert.equal(h.ok, true);
-      assert.equal(h.twin, twin.name);
-      assert.equal(typeof h.implementation, "string");
-      assert.equal(typeof h.tools, "number");
-      assert.ok(h.tools > 0, "advertises at least one MCP tool");
-      if (exp.healthzFidelity !== undefined) assert.equal(h.fidelity, exp.healthzFidelity);
-      for (const key of exp.healthzExtras ?? []) assert.ok(key in h, `healthz carries ${key}`);
-      for (const key of ["package", "version", "git_sha", "build_time"]) {
-        assert.equal(typeof h.runtime?.[key], "string", `runtime.${key} is a string`);
-      }
-    });
-
-    it("POST /admin/reset from loopback → 200 {ok:true} (no bearer required)", async () => {
-      const res = await req(t.base, "/admin/reset", { method: "POST" });
-      assert.equal(res.status, 200);
-      assert.equal(res.json?.ok, true);
-    });
-
-    it(`POST /admin/seed with a garbage body → ${exp.adminSeedGarbage.status} (frozen per-twin validation behavior)`, async () => {
-      const res = await req(t.base, "/admin/seed", { method: "POST", body: { definitely: "not-a-seed" } });
-      assert.equal(res.status, exp.adminSeedGarbage.status);
-      checkBody(exp.adminSeedGarbage, res.json, "admin/seed garbage");
-    });
-
-    it("GET /s/:sid/_pome/health|state|events with a valid session JWT → 200", async () => {
-      const health = await req(t.base, sPath("/_pome/health"), { token: jwt });
-      assert.equal(health.status, 200);
-      assert.equal(health.json?.ok, true);
-      assert.equal(health.json?.twin, twin.name);
-
-      const state = await req(t.base, sPath("/_pome/state"), { token: jwt });
-      assert.equal(state.status, 200);
-      assert.ok(state.json && typeof state.json === "object" && !Array.isArray(state.json), "state is a JSON object");
-
-      const events = await req(t.base, sPath("/_pome/events"), { token: jwt });
-      assert.equal(events.status, 200);
-      assert.ok(Array.isArray(events.json), "events is a JSON array");
-    });
-
-    it(`GET /s/:sid/healthz → ${exp.sessionHealthz.status} (frozen; stripe has no per-session healthz)`, async () => {
-      const res = await req(t.base, sPath("/healthz"), { token: jwt });
-      assert.equal(res.status, exp.sessionHealthz.status);
-      if (res.status === 200) {
-        assert.equal(res.json?.ok, true);
-        assert.equal(res.json?.sid, SID);
-      }
-    });
-
-    it("MCP surface: tools list matches healthz.tools; JSON-RPC initialize 200; GET /mcp 405", async () => {
-      const tools = await req(t.base, sPath("/mcp/tools"), { token: jwt });
-      assert.equal(tools.status, 200);
-      assert.ok(Array.isArray(tools.json?.tools));
-      assert.equal(tools.json.tools.length, t.healthz.tools, "healthz.tools equals the MCP tool list length");
-
-      const init = await req(t.base, sPath("/mcp"), {
-        method: "POST",
-        token: jwt,
-        headers: { accept: "application/json, text/event-stream" },
-        body: {
-          jsonrpc: "2.0",
-          id: 1,
-          method: "initialize",
-          params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: "contract-suite", version: "0" } },
-        },
-      });
-      assert.equal(init.status, 200);
-      assert.equal(init.json?.jsonrpc, "2.0");
-      assert.equal(typeof init.json?.result?.serverInfo?.name, "string");
-
-      const get = await req(t.base, sPath("/mcp"), { token: jwt });
-      assert.equal(get.status, 405, "stateless-mode GET /mcp is 405");
-    });
-
-    it("POST /s/:sid/mcp/call with an unknown tool → frozen per-twin error envelope", async () => {
-      const res = await req(t.base, sPath("/mcp/call"), {
-        method: "POST",
-        token: jwt,
-        body: { tool: "definitely_not_a_tool", arguments: {} },
-      });
-      assert.equal(res.status, exp.mcpCallUnknown.status);
-      checkBody(exp.mcpCallUnknown, res.json, "mcp/call unknown tool");
-    });
-
-    it("auth matrix: no token / garbage bearer / wrong-sid JWT / expired JWT / raw token", async () => {
-      const noAuth = await req(t.base, sPath("/_pome/state"));
-      assert.equal(noAuth.status, exp.noAuth.status);
-      checkBody(exp.noAuth, noAuth.json, "no auth");
-
-      const garbage = await req(t.base, sPath("/_pome/state"), { token: "garbage" });
-      assert.equal(garbage.status, 401);
-
-      const wrongSid = await req(t.base, sPath("/_pome/state"), { token: mintSessionJwt({ sid: "other-sid" }) });
-      assert.equal(wrongSid.status, exp.wrongSid.status);
-      checkBody(exp.wrongSid, wrongSid.json, "wrong sid");
-
-      const expired = await req(t.base, sPath("/_pome/state"), { token: mintSessionJwt({ sid: SID, expSeconds: -60 }) });
-      assert.equal(expired.status, exp.expired.status);
-      checkBody(exp.expired, expired.json, "expired");
-
-      const raw = await fetch(`${t.base}${sPath("/_pome/state")}`, {
-        headers: { Authorization: mintSessionJwt({ sid: SID }) },
-      });
-      assert.equal(raw.status, exp.rawToken.status, "raw (prefix-less) bearer behavior is frozen per twin");
-    });
-
-    it("unknown session route → 501 unsupported envelope; unknown root route frozen", async () => {
-      const unknown = await req(t.base, sPath("/definitely/not/a/route"), { token: jwt });
-      assert.equal(unknown.status, exp.unknownSession.status);
-      checkBody(exp.unknownSession, unknown.json, "unknown session route");
-
-      const root = await req(t.base, "/definitely-not-a-route");
-      assert.equal(root.status, exp.unknownRoot.status);
-    });
-  });
+  contractSuite(twin, PER_TWIN[twin.name]);
 }
 
 describe("contract: admin gate token mode + boot guards", () => {
   for (const twin of TWINS) {
-    it(`${twin.name}: TWIN_ADMIN_TOKEN switches /admin/* to token auth (403 without/with-wrong header)`, async () => {
-      const t = await spawnTwin(twin, { env: { TWIN_ADMIN_TOKEN: "contract-admin-token" } });
-      try {
-        const missing = await req(t.base, "/admin/reset", { method: "POST" });
-        assert.equal(missing.status, 403);
-        const wrong = await req(t.base, "/admin/reset", { method: "POST", headers: { "X-Admin-Token": "nope" } });
-        assert.equal(wrong.status, 403);
-        const right = await req(t.base, "/admin/reset", { method: "POST", headers: { "X-Admin-Token": "contract-admin-token" } });
-        assert.equal(right.status, 200);
-        assert.equal(right.json?.ok, true);
-      } finally {
-        await t.close();
-      }
-    });
-
-    it(`${twin.name}: refuses to boot on a non-loopback host without TWIN_AUTH_SECRET`, async () => {
-      const { code, output } = await spawnTwinRaw(twin, {
-        [twin.hostEnv]: "0.0.0.0",
-        PORT: "0",
-        TWIN_AUTH_SECRET: "",
-      });
-      assert.notEqual(code, 0, "process exits non-zero");
-      assert.match(output, /TWIN_AUTH_SECRET/, "error names the missing secret");
-    });
+    adminGateCase(twin);
+    bootGuardCase(twin);
   }
 });

--- a/contract/helpers.mjs
+++ b/contract/helpers.mjs
@@ -46,6 +46,13 @@ export async function freePort() {
   return port;
 }
 
+// A twin descriptor may carry an `entry` (repo-root-relative) to boot an
+// alternate server entry — used by the sdk-boot proof suite (FDRS-681).
+// Default is the contract's own `dist/src/server.js`.
+function entryArgs(twin) {
+  return [twin.entry ? path.join(REPO_ROOT, twin.entry) : "dist/src/server.js"];
+}
+
 /**
  * Spawn a built twin exactly the way the cloud does: `node dist/src/server.js`
  * with cwd = the package root. Resolves once GET /healthz answers 200, which
@@ -56,7 +63,7 @@ export async function spawnTwin(twin, { env = {}, port: portIn, healthzDeadlineM
   const cwd = path.join(REPO_ROOT, twin.pkg);
   // Plain `node` from PATH, never process.execPath: the contract is the cloud's
   // CMD ["node", "dist/src/server.js"], and under `bun run` execPath is bun.
-  const child = spawn("node", ["dist/src/server.js"], {
+  const child = spawn("node", entryArgs(twin), {
     cwd,
     env: {
       ...process.env,
@@ -117,7 +124,7 @@ export async function spawnTwin(twin, { env = {}, port: portIn, healthzDeadlineM
  */
 export async function spawnTwinRaw(twin, env, timeoutMs = 5_000) {
   const cwd = path.join(REPO_ROOT, twin.pkg);
-  const child = spawn("node", ["dist/src/server.js"], {
+  const child = spawn("node", entryArgs(twin), {
     cwd,
     env: { ...process.env, ...env },
     stdio: ["ignore", "pipe", "pipe"],

--- a/contract/proof/slack-sdk-server.mjs
+++ b/contract/proof/slack-sdk-server.mjs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-681 proof-of-harness: the slack twin assembled as a pure domain plugin
+// on the @pome-sh/sdk engine via defineTwin(), booted the exact way the
+// cloud boots a twin (env surface, boot guard, /healthz within 3s). The
+// sdk-boot contract suite (contract/sdk-boot.test.mjs) runs the SAME frozen
+// FDRS-711 assertions against this entry that contract.test.mjs runs
+// against the twin's own dist/src/server.js.
+//
+// This file consumes BUILT dists (sdk + twin-slack) and lives outside the
+// twin packages on purpose: twins cannot depend on the sdk until F-713
+// solves vendoring, and the full port is F-683. Prerequisite builds are
+// chained by contract/run.mjs.
+
+import { createRequire } from "node:module";
+import { defineTwin, openTwinDatabase } from "../../packages/sdk/dist/index.js";
+import {
+  UnknownToolError,
+  formTokenResolver,
+  queryTokenResolver,
+  serve,
+} from "../../packages/sdk/dist/server.js";
+import { migrate } from "../../packages/twin-slack/dist/src/db.js";
+import { SlackDomain } from "../../packages/twin-slack/dist/src/domain.js";
+import { TwinError as SlackTwinError } from "../../packages/twin-slack/dist/src/errors.js";
+import { defaultSeedState, loadSeedFromEnv } from "../../packages/twin-slack/dist/src/seed.js";
+import { executeTool, isMutatingTool, toolDefinitions } from "../../packages/twin-slack/dist/src/tools.js";
+import { unsupportedEnvelope } from "../../packages/twin-slack/dist/src/unsupported-envelope.js";
+
+// This file lives outside the workspace packages, so bare "zod" does not
+// resolve from here — borrow the sdk's own instance.
+const { z } = createRequire(new URL("../../packages/sdk/dist/index.js", import.meta.url))("zod");
+
+const slackError = (code) => ({ ok: false, error: code });
+
+const definition = defineTwin({
+  id: "slack",
+  version: process.env.POME_TWIN_VERSION ?? "0.1.0",
+  implementation: "slack_clone",
+  packageName: "@pome-sh/twin-slack",
+  fidelity: { default: "semantic" },
+  // Slack accepts arbitrary seed bodies (frozen: garbage → 200 {ok:true});
+  // SlackDomain.applySeed does its own tolerant parse.
+  seed: z.record(z.string(), z.unknown()),
+  domain: ({ db }) => {
+    const domain = new SlackDomain(db);
+    if (process.env.SLACK_CLONE_NO_SEED !== "1") {
+      domain.seed(loadSeedFromEnv());
+    }
+    return domain;
+  },
+  state: ({ domain }) => domain.exportState(),
+  admin: {
+    reset: ({ domain }) => {
+      domain.resetToDefault(defaultSeedState);
+      return { ok: true };
+    },
+    seed: ({ domain, seed }) => {
+      domain.applySeed(seed.seed ?? seed);
+      return { ok: true };
+    },
+  },
+  tools: toolDefinitions.map((def) => ({
+    name: def.name,
+    description: def.description,
+    schema: def.schema,
+    mutation: isMutatingTool(def.name),
+    handler: (domain, args) => wrapSlackOk(executeTool(domain, def.name, args)),
+  })),
+  // Frozen healthz shape: {ok, twin, implementation, tools, runtime} — no
+  // version/fidelity extras (slack never carried them).
+  healthz: () => ({}),
+  unsupported: () => unsupportedEnvelope,
+  errorEnvelope: (err) => {
+    if (err instanceof UnknownToolError) return { status: 404, body: slackError("unknown_tool") };
+    if (err instanceof SlackTwinError) {
+      // Application-level Slack errors return HTTP 200 with {ok:false, error}
+      // — matches real Slack; official SDKs treat non-200 as transport failure.
+      return { status: 200, body: { ok: false, error: err.code, ...(err.extra ?? {}) } };
+    }
+    if (err instanceof z.ZodError || (err instanceof Error && err.name === "ZodError")) {
+      return {
+        status: 200,
+        body: {
+          ok: false,
+          error: "invalid_arguments",
+          response_metadata: {
+            messages: err.issues.map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`),
+          },
+        },
+      };
+    }
+    return {
+      status: 500,
+      body: { ok: false, error: "internal_error", warning: err instanceof Error ? err.message : "internal_error" },
+    };
+  },
+  auth: {
+    providerToken: { provider: "slack", prefixes: ["xoxb-pome-", "xoxp-pome-"] },
+    providerSession: () => ({ login: "pome-agent" }),
+    tokenResolvers: [queryTokenResolver("token"), formTokenResolver("token")],
+    unauthorized: (kind) => ({
+      status: 401,
+      body: slackError(kind === "no_token" ? "not_authed" : kind === "expired" ? "token_expired" : "invalid_auth"),
+    }),
+    sidMismatch: () => ({ status: 401, body: slackError("invalid_auth") }),
+    sessionExtras: (claims) =>
+      typeof claims.login === "string" && claims.login.length > 0 ? { login: claims.login } : {},
+  },
+});
+
+function wrapSlackOk(value) {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    if ("ok" in value) return value;
+    return { ok: true, ...value };
+  }
+  return { ok: true, result: value };
+}
+
+const port = Number(process.env.PORT ?? process.env.SLACK_CLONE_PORT ?? 3333);
+const host = process.env.SLACK_CLONE_HOST ?? "127.0.0.1";
+const dbPath = process.env.SLACK_CLONE_DB ?? ".slack_clone/slack.db";
+
+const db = openTwinDatabase(dbPath, { migrate });
+await serve(definition, {
+  port,
+  hostname: host,
+  db,
+  runId: process.env.POME_RUN_ID ?? "spawn",
+});
+
+console.log(`Slack twin (sdk boot) listening at http://${host}:${port}`);

--- a/contract/run.mjs
+++ b/contract/run.mjs
@@ -38,7 +38,9 @@ function cleanRuntimeJs(dir) {
 
 let status = run("bun", ["run", "--filter", "@pome-sh/shared-types", "build:runtime"]);
 if (status === 0) status = run("bun", ["run", "--filter", "@pome-sh/twin-*", "build"]);
-if (status === 0) status = run("node", ["--test", "contract/contract.test.mjs"]);
+// The sdk build feeds the sdk-boot proof suite (FDRS-681).
+if (status === 0) status = run("bun", ["run", "--filter", "@pome-sh/sdk", "build"]);
+if (status === 0) status = run("node", ["--test", "contract/contract.test.mjs", "contract/sdk-boot.test.mjs"]);
 
 const removed = cleanRuntimeJs(SHARED_SRC);
 console.log(`[contract/run] cleaned ${removed} generated runtime .js file(s) from packages/shared-types/src`);

--- a/contract/sdk-boot.test.mjs
+++ b/contract/sdk-boot.test.mjs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-681 proof-of-harness suite: runs the IDENTICAL frozen FDRS-711 slack
+// assertions (contract/suite.mjs) against the slack twin booted through the
+// @pome-sh/sdk engine (contract/proof/slack-sdk-server.mjs) instead of the
+// twin's own dist/src/server.js. Green here means the engine reproduces the
+// twin's frozen control-plane wire behavior end-to-end — the acceptance
+// gate for the defineTwin() harness before the real ports (F-682/683/684).
+//
+// Prerequisite: sdk + shared-types runtime + twin-slack builds (chained by
+// contract/run.mjs via the root `test:contract` script).
+
+import { describe } from "node:test";
+import { PER_TWIN, adminGateCase, bootGuardCase, contractSuite } from "./suite.mjs";
+
+const slackViaSdk = {
+  name: "slack",
+  pkg: "packages/twin-slack",
+  dbEnv: "SLACK_CLONE_DB",
+  hostEnv: "SLACK_CLONE_HOST",
+  entry: "contract/proof/slack-sdk-server.mjs",
+};
+
+contractSuite(slackViaSdk, PER_TWIN.slack, "slack (sdk boot)");
+
+describe("contract: sdk boot — admin gate token mode + boot guard", () => {
+  adminGateCase(slackViaSdk, "slack (sdk boot)");
+  bootGuardCase(slackViaSdk, "slack (sdk boot)");
+});

--- a/contract/suite.mjs
+++ b/contract/suite.mjs
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Reusable body of the black-box twin runtime-contract suite (FDRS-711).
+// Extracted verbatim from contract.test.mjs (FDRS-681) so the same frozen
+// assertions can run against any built twin artifact AND the sdk-booted
+// proof entry (contract/sdk-boot.test.mjs). Changing any asserted status or
+// shape here is a contract change: update CONTRACT.md in the same PR and
+// coordinate the cross-repo pome-cloud PR per the contract doc.
+
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mintSessionJwt, req, spawnTwin, spawnTwinRaw } from "./helpers.mjs";
+
+const SID = "contract-sid";
+const sPath = (p) => `/s/${SID}${p}`;
+
+// Per-twin frozen expectations, taken from live probes on 2026-07-07.
+export const PER_TWIN = {
+  github: {
+    // /healthz carries fidelity + access_control on top of the shared core.
+    healthzFidelity: "semantic",
+    healthzExtras: ["access_control"],
+    sessionHealthz: { status: 200 },
+    // github validates seeds: a garbage body is a 422 GitHub validation error.
+    adminSeedGarbage: { status: 422, check: (b) => b.message === "Validation Failed" },
+    noAuth: { status: 401, check: (b) => b.message === "Bad credentials" },
+    wrongSid: { status: 401, check: (b) => b.message === "Forbidden" },
+    // hono/jwt's verify throws on an expired token before auth.ts's explicit
+    // "Token expired" branch is reached, so the wire says "Bad credentials".
+    expired: { status: 401, check: (b) => b.message === "Bad credentials" },
+    rawToken: { status: 401 },
+    mcpCallUnknown: { status: 422, check: (b) => b.message === "Validation Failed" },
+    unknownSession: { status: 501, check: (b) => b._twin?.fidelity === "unsupported" },
+    unknownRoot: { status: 404 },
+  },
+  slack: {
+    // slack's /healthz carries no fidelity field today.
+    healthzFidelity: undefined,
+    sessionHealthz: { status: 200 },
+    // slack accepts arbitrary seed bodies with 200 {ok:true} (no validation).
+    adminSeedGarbage: { status: 200, check: (b) => b.ok === true },
+    noAuth: { status: 401, check: (b) => b.ok === false && b.error === "not_authed" },
+    wrongSid: { status: 401, check: (b) => b.error === "invalid_auth" },
+    // slack is the only twin distinguishing token_expired from invalid_auth.
+    expired: { status: 401, check: (b) => b.error === "token_expired" },
+    rawToken: { status: 401 },
+    mcpCallUnknown: { status: 404, check: (b) => b.error === "unknown_tool" },
+    unknownSession: {
+      status: 501,
+      check: (b) => b.error === "unsupported_endpoint" && b._twin?.fidelity === "unsupported",
+    },
+    unknownRoot: { status: 404 },
+  },
+  stripe: {
+    healthzFidelity: "semantic",
+    healthzExtras: ["tthw_seconds"],
+    // stripe has no per-session /healthz; the path falls to the 501 catch-all.
+    sessionHealthz: { status: 501 },
+    adminSeedGarbage: { status: 200, check: (b) => b.ok === true },
+    noAuth: { status: 401, check: (b) => b.error?.code === "unauthorized" },
+    // stripe is the only twin answering a sid mismatch with 403 (not 401).
+    wrongSid: { status: 403, check: (b) => b.error?.code === "forbidden" },
+    expired: { status: 401, check: (b) => b.error?.code === "unauthorized" },
+    // stripe accepts a prefix-less bearer (raw JWT) today — FDRS-712 row 4.
+    rawToken: { status: 200 },
+    mcpCallUnknown: { status: 400, check: (b) => b.error?.code === "tool_unknown" },
+    unknownSession: {
+      status: 501,
+      check: (b) => b.error?.code === "endpoint_not_supported" && b.error?.fidelity === "unsupported",
+    },
+    // stripe's root-level unknown paths hit the /v1 auth wall first: 401.
+    unknownRoot: { status: 401 },
+  },
+};
+
+function checkBody(expectation, body, label) {
+  if (expectation.check) assert.ok(expectation.check(body ?? {}), `${label}: body shape — got ${JSON.stringify(body)}`);
+}
+
+/**
+ * The per-twin contract suite. `label` distinguishes multiple runs against
+ * the same twin name (e.g. the sdk-booted proof entry).
+ */
+export function contractSuite(twin, exp, label = twin.name) {
+  describe(`contract: ${label}`, () => {
+    let t;
+    let jwt;
+
+    before(async () => {
+      t = await spawnTwin(twin); // asserts /healthz 200 within the 3s bound
+      jwt = mintSessionJwt({ sid: SID });
+    });
+    after(async () => {
+      await t?.close();
+    });
+
+    it("GET /healthz → 200 with the frozen shape (ok, twin, implementation, tools, runtime)", () => {
+      const h = t.healthz;
+      assert.equal(h.ok, true);
+      assert.equal(h.twin, twin.name);
+      assert.equal(typeof h.implementation, "string");
+      assert.equal(typeof h.tools, "number");
+      assert.ok(h.tools > 0, "advertises at least one MCP tool");
+      if (exp.healthzFidelity !== undefined) assert.equal(h.fidelity, exp.healthzFidelity);
+      for (const key of exp.healthzExtras ?? []) assert.ok(key in h, `healthz carries ${key}`);
+      for (const key of ["package", "version", "git_sha", "build_time"]) {
+        assert.equal(typeof h.runtime?.[key], "string", `runtime.${key} is a string`);
+      }
+    });
+
+    it("POST /admin/reset from loopback → 200 {ok:true} (no bearer required)", async () => {
+      const res = await req(t.base, "/admin/reset", { method: "POST" });
+      assert.equal(res.status, 200);
+      assert.equal(res.json?.ok, true);
+    });
+
+    it(`POST /admin/seed with a garbage body → ${exp.adminSeedGarbage.status} (frozen per-twin validation behavior)`, async () => {
+      const res = await req(t.base, "/admin/seed", { method: "POST", body: { definitely: "not-a-seed" } });
+      assert.equal(res.status, exp.adminSeedGarbage.status);
+      checkBody(exp.adminSeedGarbage, res.json, "admin/seed garbage");
+    });
+
+    it("GET /s/:sid/_pome/health|state|events with a valid session JWT → 200", async () => {
+      const health = await req(t.base, sPath("/_pome/health"), { token: jwt });
+      assert.equal(health.status, 200);
+      assert.equal(health.json?.ok, true);
+      assert.equal(health.json?.twin, twin.name);
+
+      const state = await req(t.base, sPath("/_pome/state"), { token: jwt });
+      assert.equal(state.status, 200);
+      assert.ok(state.json && typeof state.json === "object" && !Array.isArray(state.json), "state is a JSON object");
+
+      const events = await req(t.base, sPath("/_pome/events"), { token: jwt });
+      assert.equal(events.status, 200);
+      assert.ok(Array.isArray(events.json), "events is a JSON array");
+    });
+
+    it(`GET /s/:sid/healthz → ${exp.sessionHealthz.status} (frozen; stripe has no per-session healthz)`, async () => {
+      const res = await req(t.base, sPath("/healthz"), { token: jwt });
+      assert.equal(res.status, exp.sessionHealthz.status);
+      if (res.status === 200) {
+        assert.equal(res.json?.ok, true);
+        assert.equal(res.json?.sid, SID);
+      }
+    });
+
+    it("MCP surface: tools list matches healthz.tools; JSON-RPC initialize 200; GET /mcp 405", async () => {
+      const tools = await req(t.base, sPath("/mcp/tools"), { token: jwt });
+      assert.equal(tools.status, 200);
+      assert.ok(Array.isArray(tools.json?.tools));
+      assert.equal(tools.json.tools.length, t.healthz.tools, "healthz.tools equals the MCP tool list length");
+
+      const init = await req(t.base, sPath("/mcp"), {
+        method: "POST",
+        token: jwt,
+        headers: { accept: "application/json, text/event-stream" },
+        body: {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: "contract-suite", version: "0" } },
+        },
+      });
+      assert.equal(init.status, 200);
+      assert.equal(init.json?.jsonrpc, "2.0");
+      assert.equal(typeof init.json?.result?.serverInfo?.name, "string");
+
+      const get = await req(t.base, sPath("/mcp"), { token: jwt });
+      assert.equal(get.status, 405, "stateless-mode GET /mcp is 405");
+    });
+
+    it("POST /s/:sid/mcp/call with an unknown tool → frozen per-twin error envelope", async () => {
+      const res = await req(t.base, sPath("/mcp/call"), {
+        method: "POST",
+        token: jwt,
+        body: { tool: "definitely_not_a_tool", arguments: {} },
+      });
+      assert.equal(res.status, exp.mcpCallUnknown.status);
+      checkBody(exp.mcpCallUnknown, res.json, "mcp/call unknown tool");
+    });
+
+    it("auth matrix: no token / garbage bearer / wrong-sid JWT / expired JWT / raw token", async () => {
+      const noAuth = await req(t.base, sPath("/_pome/state"));
+      assert.equal(noAuth.status, exp.noAuth.status);
+      checkBody(exp.noAuth, noAuth.json, "no auth");
+
+      const garbage = await req(t.base, sPath("/_pome/state"), { token: "garbage" });
+      assert.equal(garbage.status, 401);
+
+      const wrongSid = await req(t.base, sPath("/_pome/state"), { token: mintSessionJwt({ sid: "other-sid" }) });
+      assert.equal(wrongSid.status, exp.wrongSid.status);
+      checkBody(exp.wrongSid, wrongSid.json, "wrong sid");
+
+      const expired = await req(t.base, sPath("/_pome/state"), { token: mintSessionJwt({ sid: SID, expSeconds: -60 }) });
+      assert.equal(expired.status, exp.expired.status);
+      checkBody(exp.expired, expired.json, "expired");
+
+      const raw = await fetch(`${t.base}${sPath("/_pome/state")}`, {
+        headers: { Authorization: mintSessionJwt({ sid: SID }) },
+      });
+      assert.equal(raw.status, exp.rawToken.status, "raw (prefix-less) bearer behavior is frozen per twin");
+    });
+
+    it("unknown session route → 501 unsupported envelope; unknown root route frozen", async () => {
+      const unknown = await req(t.base, sPath("/definitely/not/a/route"), { token: jwt });
+      assert.equal(unknown.status, exp.unknownSession.status);
+      checkBody(exp.unknownSession, unknown.json, "unknown session route");
+
+      const root = await req(t.base, "/definitely-not-a-route");
+      assert.equal(root.status, exp.unknownRoot.status);
+    });
+  });
+}
+
+/** TWIN_ADMIN_TOKEN switches /admin/* to token auth (403 without/with-wrong header). */
+export function adminGateCase(twin, label = twin.name) {
+  it(`${label}: TWIN_ADMIN_TOKEN switches /admin/* to token auth (403 without/with-wrong header)`, async () => {
+    const t = await spawnTwin(twin, { env: { TWIN_ADMIN_TOKEN: "contract-admin-token" } });
+    try {
+      const missing = await req(t.base, "/admin/reset", { method: "POST" });
+      assert.equal(missing.status, 403);
+      const wrong = await req(t.base, "/admin/reset", { method: "POST", headers: { "X-Admin-Token": "nope" } });
+      assert.equal(wrong.status, 403);
+      const right = await req(t.base, "/admin/reset", { method: "POST", headers: { "X-Admin-Token": "contract-admin-token" } });
+      assert.equal(right.status, 200);
+      assert.equal(right.json?.ok, true);
+    } finally {
+      await t.close();
+    }
+  });
+}
+
+/** Refuses to boot on a non-loopback host without TWIN_AUTH_SECRET. */
+export function bootGuardCase(twin, label = twin.name) {
+  it(`${label}: refuses to boot on a non-loopback host without TWIN_AUTH_SECRET`, async () => {
+    const { code, output } = await spawnTwinRaw(twin, {
+      [twin.hostEnv]: "0.0.0.0",
+      PORT: "0",
+      TWIN_AUTH_SECRET: "",
+    });
+    assert.notEqual(code, 0, "process exits non-zero");
+    assert.match(output, /TWIN_AUTH_SECRET/, "error names the missing secret");
+  });
+}

--- a/knip.json
+++ b/knip.json
@@ -27,7 +27,12 @@
   ],
   "workspaces": {
     ".": {
-      "entry": ["scripts/*.{mjs,sh}", "contract/run.mjs", "contract/contract.test.mjs"],
+      "entry": [
+        "scripts/*.{mjs,sh}",
+        "contract/run.mjs",
+        "contract/*.test.mjs",
+        "contract/proof/*.mjs"
+      ],
       "project": ["scripts/**/*.{mjs,sh}", "contract/**/*.mjs"]
     },
     "packages/*": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -30,13 +30,17 @@
   },
   "bundledDependencies": ["@pome-sh/shared-types"],
   "peerDependencies": {
-    "@hono/node-server": "^1.19.6"
+    "@hono/node-server": "^1.19.6",
+    "better-sqlite3": "^12.5.0"
   },
   "peerDependenciesMeta": {
-    "@hono/node-server": { "optional": true }
+    "@hono/node-server": { "optional": true },
+    "better-sqlite3": { "optional": true }
   },
   "devDependencies": {
     "@hono/node-server": "^1.19.6",
+    "@types/better-sqlite3": "^7.6.13",
+    "better-sqlite3": "^12.5.0",
     "@types/node": "^25.0.3",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -1,18 +1,30 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Bearer-token + localhost-only middleware. Mirrors the semantics of
-// `packages/twin-github/src/auth.ts`: a session JWT must carry `sid` that
-// matches the `/s/:sid` path segment, and admin routes are only reachable
-// from a localhost client.
-import type { MiddlewareHandler } from "hono";
+// Engine auth (F-681). Spec of record: the F-712 [DECISION] — the engine
+// owns the auth *mechanism* (bearer resolution, provider-shaped token
+// verify + minting, JWT verification with expired-vs-invalid
+// classification, the session-id match); each twin declares only its
+// *shape* through `BearerAuthOptions` (token prefixes, error envelopes,
+// extra token locations, raw-bearer and sid-mismatch pins, credential
+// lookup, mount mode). Per-twin wire behavior stays frozen by the
+// contract suite; changing a pin is a deliberate contract change.
+import type { Context, MiddlewareHandler } from "hono";
+import { createHmac, timingSafeEqual } from "node:crypto";
 import { verify } from "hono/jwt";
 import { createAdminGate } from "./admin-gate.js";
+
+/** `team_id` stamped on sessions authenticated by a provider-shaped token. */
+export const PROVIDER_SHAPED_TEAM_ID = "provider-shaped";
 
 export interface SessionClaims {
   sid: string;
   team_id: string;
   exp: number;
+  [claim: string]: unknown;
 }
+
+/** Minimum session value; twins extend it via hooks (login, account_id, …). */
+export type SessionValue = { sid: string } & Record<string, unknown>;
 
 export function resolveAuthSecret(): string {
   const secret = process.env.TWIN_AUTH_SECRET;
@@ -22,8 +34,216 @@ export function resolveAuthSecret(): string {
   return secret ?? "dev-only-insecure-secret";
 }
 
-function unauthorized(message: string) {
-  return Response.json({ message, documentation_url: "" }, { status: 401 });
+// ─── Provider-shaped tokens (F-712 rows 1 + 10) ─────────────────────────────
+//
+// Wire shape (frozen, minted by twins + cloud since before F-681):
+//   <prefix><base64url(sid)>_<sig22>          (legacy, no expiry)
+//   <prefix><base64url(sid)>_<exp>_<sig22>    (expiring)
+// where sig = hmac-sha256(secret, "<provider>:<sid>[:<exp>]") base64url,
+// truncated to 22 chars.
+
+export interface ProviderTokenSpec {
+  /** HMAC domain separator ("github" | "slack" | "stripe" | …). */
+  provider: string;
+  /** Declared token prefixes, e.g. ["xoxb-pome-", "xoxp-pome-"]. */
+  prefixes: readonly string[];
+}
+
+const SIG_LENGTH = 22;
+
+export interface MintProviderTokenOptions {
+  sid: string;
+  /** Unix-seconds expiry. Omit for the legacy non-expiring shape. */
+  exp?: number;
+  /** Defaults to the spec's first declared prefix. */
+  prefix?: string;
+  secret?: string;
+}
+
+/**
+ * Mint a provider-shaped token (F-712 row 10: minting lives in the engine;
+ * CLI + cloud mint through it, parameterized by the twin's declared shape).
+ */
+export function mintProviderToken(
+  spec: ProviderTokenSpec,
+  options: MintProviderTokenOptions
+): string {
+  const prefix = options.prefix ?? spec.prefixes[0];
+  if (!prefix || !spec.prefixes.includes(prefix)) {
+    throw new Error(
+      `mintProviderToken: prefix "${options.prefix ?? "<none>"}" is not declared by provider "${spec.provider}"`
+    );
+  }
+  const secret = options.secret ?? resolveAuthSecret();
+  const encoded = Buffer.from(options.sid, "utf8").toString("base64url");
+  if (options.exp !== undefined && Number.isSafeInteger(options.exp)) {
+    return `${prefix}${encoded}_${options.exp}_${signProviderExp(spec.provider, options.sid, options.exp, secret)}`;
+  }
+  return `${prefix}${encoded}_${signProvider(spec.provider, options.sid, secret)}`;
+}
+
+/**
+ * Verify a provider-shaped token; returns the sid on success.
+ *
+ * The parse is right-anchored — the signature is always the trailing 22
+ * base64url chars, the optional exp is a trailing all-digit segment of the
+ * remainder — and the HMAC disambiguates the exp-vs-sid split. This fixes
+ * the F-712 appendix bug once: the old per-twin `([^_]+)` regexes broke for
+ * any sid whose base64url encoding contains `_` (the alphabet includes it).
+ */
+export function verifyProviderToken(
+  spec: ProviderTokenSpec,
+  token: string,
+  secret = resolveAuthSecret()
+): string | undefined {
+  const prefix = spec.prefixes.find((p) => token.startsWith(p));
+  if (!prefix) return undefined;
+  const rest = token.slice(prefix.length);
+  // Shortest valid form: 1-char encoded sid + "_" + 22-char sig.
+  if (rest.length < SIG_LENGTH + 2) return undefined;
+  if (rest[rest.length - SIG_LENGTH - 1] !== "_") return undefined;
+  const sig = rest.slice(-SIG_LENGTH);
+  const head = rest.slice(0, -(SIG_LENGTH + 1));
+
+  // Candidate 1: expiring shape — head = <encodedSid>_<exp>.
+  const expMatch = head.match(/^(.+)_(\d{1,12})$/);
+  if (expMatch) {
+    const sid = decodeBase64Url(expMatch[1]!);
+    const exp = Number(expMatch[2]!);
+    if (sid !== undefined && Number.isSafeInteger(exp)) {
+      if (safeEqual(sig, signProviderExp(spec.provider, sid, exp, secret))) {
+        return exp >= Math.floor(Date.now() / 1000) ? sid : undefined;
+      }
+    }
+  }
+
+  // Candidate 2: legacy shape — head = <encodedSid>.
+  const sid = decodeBase64Url(head);
+  if (sid === undefined) return undefined;
+  if (safeEqual(sig, signProvider(spec.provider, sid, secret))) return sid;
+  return undefined;
+}
+
+function signProvider(provider: string, sid: string, secret: string) {
+  return createHmac("sha256", secret)
+    .update(`${provider}:${sid}`)
+    .digest("base64url")
+    .slice(0, SIG_LENGTH);
+}
+
+function signProviderExp(provider: string, sid: string, exp: number, secret: string) {
+  return createHmac("sha256", secret)
+    .update(`${provider}:${sid}:${exp}`)
+    .digest("base64url")
+    .slice(0, SIG_LENGTH);
+}
+
+function decodeBase64Url(value: string): string | undefined {
+  try {
+    return Buffer.from(value, "base64url").toString("utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+function safeEqual(a: string, b: string) {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  return ab.length === bb.length && timingSafeEqual(ab, bb);
+}
+
+// ─── Bearer middleware (F-712 rows 2–9) ─────────────────────────────────────
+
+/** Why a request failed auth; rendered by the twin's `unauthorized` hook. */
+export type UnauthorizedKind = "no_token" | "invalid" | "expired";
+
+export interface AuthEnvelope {
+  status: number;
+  body: unknown;
+}
+
+/** Extra token location (F-712 row 3). Returns the token or undefined. */
+export type TokenResolver = (
+  c: Context
+) => string | undefined | Promise<string | undefined>;
+
+/** Accept `?<param>=<token>` in the query string (real Slack behavior). */
+export function queryTokenResolver(param = "token"): TokenResolver {
+  return (c) => {
+    const token = c.req.query(param);
+    return token && token.length > 0 ? token : undefined;
+  };
+}
+
+/**
+ * Accept `<param>=<token>` in a form-encoded POST body (real Slack
+ * behavior). Only parses when the content type is form-encoded, so JSON
+ * streaming reads downstream are never consumed here; `parseBody()` caches
+ * on the Hono context, so downstream handlers see the same object.
+ */
+export function formTokenResolver(param = "token"): TokenResolver {
+  return async (c) => {
+    if (c.req.method !== "POST") return undefined;
+    const contentType = (c.req.header("content-type") ?? "").toLowerCase();
+    if (
+      !contentType.includes("application/x-www-form-urlencoded") &&
+      !contentType.includes("multipart/form-data")
+    ) {
+      return undefined;
+    }
+    try {
+      const body = (await c.req.parseBody()) as Record<string, unknown>;
+      const token = body[param];
+      return typeof token === "string" && token.length > 0 ? token : undefined;
+    } catch {
+      return undefined;
+    }
+  };
+}
+
+export interface BearerAuthOptions {
+  /** Row 1: the twin's provider-shaped token declaration. */
+  providerToken?: ProviderTokenSpec;
+  /** Row 7: extra session fields for provider-shaped sessions. */
+  providerSession?: (sid: string) => Record<string, unknown>;
+  /** Row 3: extra token locations tried after the Authorization header. */
+  tokenResolvers?: readonly TokenResolver[];
+  /**
+   * Row 4 pin: accept a prefix-less bearer and case-insensitive "bearer".
+   * Default false (github/slack); stripe pins true. Flipping a twin is a
+   * contract change (CONTRACT.md + suite + cross-repo PR in one change).
+   */
+  allowRawBearer?: boolean;
+  /**
+   * Row 9: when false, a request with no `:sid` path segment trusts the
+   * bearer alone (stripe's root `/v1/*` SDK-compat mount). Default true.
+   */
+  requirePathSid?: boolean;
+  /** Row 8: DB-backed credential lookup, consulted before provider/JWT. */
+  resolveCredential?: (
+    token: string,
+    c: Context
+  ) => SessionValue | undefined | Promise<SessionValue | undefined>;
+  /** Rows 2 + 6: the twin's 401 envelope, keyed by failure classification. */
+  unauthorized?: (kind: UnauthorizedKind) => AuthEnvelope;
+  /** Row 5 pin: the twin's sid-mismatch envelope (github/slack 401, stripe 403). */
+  sidMismatch?: () => AuthEnvelope;
+  /** Row 7: extra session fields derived from verified JWT claims. */
+  sessionExtras?: (claims: SessionClaims) => Record<string, unknown>;
+}
+
+const defaultUnauthorized = (): AuthEnvelope => ({
+  status: 401,
+  body: { message: "Bad credentials", documentation_url: "" },
+});
+
+const defaultSidMismatch = (): AuthEnvelope => ({
+  status: 401,
+  body: { message: "Forbidden", documentation_url: "" },
+});
+
+function respond(envelope: AuthEnvelope): Response {
+  return Response.json(envelope.body, { status: envelope.status });
 }
 
 function extractSidFromUrl(rawUrl: string): string | undefined {
@@ -36,39 +256,105 @@ function extractSidFromUrl(rawUrl: string): string | undefined {
   }
 }
 
-export function bearerAuth(): MiddlewareHandler {
-  return async (c, next) => {
-    const header = c.req.header("Authorization") ?? c.req.header("authorization");
-    if (!header || !header.startsWith("Bearer ")) {
-      return unauthorized("Bad credentials");
+function bearerHeaderToken(c: Context, allowRaw: boolean): string | undefined {
+  const header = c.req.header("Authorization") ?? c.req.header("authorization");
+  if (!header) return undefined;
+  const trimmed = header.trim();
+  if (allowRaw) {
+    if (trimmed.toLowerCase().startsWith("bearer ")) {
+      const token = trimmed.slice("bearer ".length).trim();
+      return token.length > 0 ? token : undefined;
     }
-    const token = header.slice("Bearer ".length).trim();
-    if (!token) return unauthorized("Bad credentials");
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  if (!trimmed.startsWith("Bearer ")) return undefined;
+  const token = trimmed.slice("Bearer ".length).trim();
+  return token.length > 0 ? token : undefined;
+}
 
+function classifyJwtError(err: unknown): UnauthorizedKind {
+  const name = (err as { name?: string }).name ?? "";
+  const message = err instanceof Error ? err.message : "";
+  return name === "JwtTokenExpired" || /expired/i.test(message) ? "expired" : "invalid";
+}
+
+export function bearerAuth(options: BearerAuthOptions = {}): MiddlewareHandler {
+  const unauthorized = options.unauthorized ?? defaultUnauthorized;
+  const sidMismatch = options.sidMismatch ?? defaultSidMismatch;
+  const requirePathSid = options.requirePathSid ?? true;
+  const allowRawBearer = options.allowRawBearer === true;
+
+  return async (c, next) => {
+    let token = bearerHeaderToken(c, allowRawBearer);
+    if (!token && options.tokenResolvers) {
+      for (const resolveToken of options.tokenResolvers) {
+        token = (await resolveToken(c)) || undefined;
+        if (token) break;
+      }
+    }
+    if (!token) return respond(unauthorized("no_token"));
+
+    const pathSid = c.req.param("sid") ?? extractSidFromUrl(c.req.url);
+    const checkSid = (sid: string): Response | undefined => {
+      if (pathSid) return sid === pathSid ? undefined : respond(sidMismatch());
+      return requirePathSid ? respond(sidMismatch()) : undefined;
+    };
+
+    // Row 8: DB-backed credential lookup (stripe api_keys).
+    if (options.resolveCredential) {
+      const resolved = await options.resolveCredential(token, c);
+      if (resolved) {
+        const mismatch = checkSid(resolved.sid);
+        if (mismatch) return mismatch;
+        c.set("session", resolved);
+        await next();
+        return;
+      }
+    }
+
+    // Row 1: provider-shaped tokens.
+    if (options.providerToken) {
+      const providerSid = verifyProviderToken(options.providerToken, token);
+      if (providerSid) {
+        const mismatch = checkSid(providerSid);
+        if (mismatch) return mismatch;
+        c.set("session", {
+          sid: providerSid,
+          team_id: PROVIDER_SHAPED_TEAM_ID,
+          ...(options.providerSession?.(providerSid) ?? {}),
+        });
+        await next();
+        return;
+      }
+    }
+
+    // Session JWT, with engine-side expired-vs-invalid classification
+    // (row 6). The envelope hook decides how each kind renders on the wire.
     let claims: SessionClaims;
     try {
       claims = (await verify(token, resolveAuthSecret(), "HS256")) as unknown as SessionClaims;
-    } catch {
-      return unauthorized("Bad credentials");
+    } catch (err) {
+      return respond(unauthorized(classifyJwtError(err)));
     }
-
     if (typeof claims.exp === "number" && claims.exp < Math.floor(Date.now() / 1000)) {
-      return unauthorized("Token expired");
+      return respond(unauthorized("expired"));
     }
+    if (!claims.sid) return respond(unauthorized("invalid"));
+    const mismatch = checkSid(claims.sid);
+    if (mismatch) return mismatch;
 
-    const pathSid = c.req.param("sid") ?? extractSidFromUrl(c.req.url);
-    if (!claims.sid || claims.sid !== pathSid) {
-      return Response.json({ message: "Forbidden", documentation_url: "" }, { status: 401 });
-    }
-
-    c.set("session", { sid: claims.sid, team_id: claims.team_id });
+    c.set("session", {
+      sid: claims.sid,
+      team_id: claims.team_id,
+      ...(options.sessionExtras?.(claims) ?? {}),
+    });
     await next();
   };
 }
 
 /**
- * Admin endpoint protection. Thin wrapper over the shared, mirrored
- * admin-gate module (FDRS-587 / FDRS-616) using the default error envelope.
+ * Admin endpoint protection. Thin wrapper over the shared admin-gate module
+ * (FDRS-587 / FDRS-616) using the default error envelope.
  */
 export function requireAdminAuth(): MiddlewareHandler {
   return createAdminGate();

--- a/packages/sdk/src/build-info.ts
+++ b/packages/sdk/src/build-info.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The `/healthz` `runtime` block required by the runtime contract. Values
+// come from the POME_TWIN_* env surface the cloud injects at image build /
+// snapshot time; everything defaults to dev markers locally.
+
+export interface TwinBuildInfo {
+  package: string;
+  version: string;
+  git_sha: string;
+  build_time: string;
+}
+
+export function twinBuildInfo(packageName: string): TwinBuildInfo {
+  return {
+    package: packageName,
+    version: process.env.POME_TWIN_VERSION ?? "0.1.0",
+    git_sha: process.env.POME_TWIN_GIT_SHA ?? process.env.VERCEL_GIT_COMMIT_SHA ?? "dev",
+    build_time: process.env.POME_TWIN_BUILD_TIME ?? "dev",
+  };
+}

--- a/packages/sdk/src/db.ts
+++ b/packages/sdk/src/db.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Engine SQLite driver wrapper (F-681). Twins never import a sqlite driver
+// directly — they call `openTwinDatabase()` and consume the `TwinDatabase`
+// interface below. The interface is a same-shape subset of better-sqlite3
+// (prepare/exec/pragma/transaction/close), which is exactly the surface the
+// M2 node:sqlite swap (F-703) re-implements: swapping the driver is a change
+// to THIS file only. `transaction(fn)` keeps better-sqlite3's shape (returns
+// a callable running fn atomically) because twin domain code has dozens of
+// call sites relying on it and node:sqlite ships no equivalent — the M2
+// implementation backs it with BEGIN IMMEDIATE/COMMIT/ROLLBACK.
+//
+// The driver is loaded lazily via createRequire so @pome-sh/sdk can declare
+// better-sqlite3 as an optional peer dependency: twins that bring their own
+// database never pay for (or compile) the native module.
+
+import { mkdirSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname } from "node:path";
+
+export interface TwinStatement {
+  run(...params: unknown[]): unknown;
+  get(...params: unknown[]): unknown;
+  all(...params: unknown[]): unknown[];
+}
+
+export interface TwinDatabase {
+  prepare(sql: string): TwinStatement;
+  exec(sql: string): void;
+  pragma(statement: string, options?: { simple?: boolean }): unknown;
+  /** Same shape as better-sqlite3: wraps `fn` so calling it runs atomically. */
+  transaction<F extends (...args: never[]) => unknown>(fn: F): F;
+  close(): void;
+}
+
+export interface OpenTwinDatabaseOptions {
+  /** Schema migration hook, run once right after the pragmas are applied. */
+  migrate?: (db: TwinDatabase) => void;
+}
+
+type BetterSqlite3Ctor = new (path: string) => TwinDatabase;
+
+let driver: BetterSqlite3Ctor | undefined;
+
+function loadDriver(): BetterSqlite3Ctor {
+  if (!driver) {
+    const require = createRequire(import.meta.url);
+    driver = require("better-sqlite3") as BetterSqlite3Ctor;
+  }
+  return driver;
+}
+
+/**
+ * Open a twin database with the pome pragma set applied:
+ * `busy_timeout = 5000`, `journal_mode = WAL` (file-backed), and
+ * `foreign_keys = ON` — the exact pragmas every twin's hand-rolled db.ts
+ * applied before F-681 centralized them.
+ */
+export function openTwinDatabase(
+  path = ":memory:",
+  options: OpenTwinDatabaseOptions = {}
+): TwinDatabase {
+  if (path !== ":memory:") {
+    mkdirSync(dirname(path), { recursive: true });
+  }
+  const Database = loadDriver();
+  const db = new Database(path);
+  db.pragma("busy_timeout = 5000");
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+  options.migrate?.(db);
+  return db;
+}

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -18,6 +18,20 @@ export class TwinError extends Error {
   }
 }
 
+/**
+ * Thrown by the SDK's tool dispatch routes (`/mcp/call`,
+ * `/mcp/tools/:name`, JSON-RPC `tools/call`) when the named tool is not in
+ * the registry. A distinct class so a twin's `errorEnvelope` hook can shape
+ * the frozen per-twin wire format (slack 404 `unknown_tool`, stripe 400
+ * `tool_unknown`, …) without string-matching messages.
+ */
+export class UnknownToolError extends TwinError {
+  constructor(readonly tool: string, status = 404) {
+    super(`Unknown tool: ${tool}`, status);
+    this.name = "UnknownToolError";
+  }
+}
+
 export interface ErrorEnvelope {
   status: number;
   body: { message: string; errors?: unknown[] };

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -179,8 +179,16 @@ export class TwinManifestError extends Error {
   }
 }
 
+// Duck-typed on purpose: a twin's schemas may come from its own zod copy
+// (unhoisted workspace installs, community twins bundling zod) — a bare
+// `instanceof z.ZodType` would reject schemas from any zod instance other
+// than the SDK's own.
 const isZodType = (value: unknown): value is z.ZodType =>
-  value instanceof z.ZodType;
+  value instanceof z.ZodType ||
+  (typeof value === "object" &&
+    value !== null &&
+    typeof (value as z.ZodType).parse === "function" &&
+    typeof (value as z.ZodType).safeParse === "function");
 const isFunction = (value: unknown): value is Function =>
   typeof value === "function";
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -21,6 +21,10 @@ import {
 export { recorderEventSchema, recorderFidelitySchema };
 export type { RecorderEvent, RecorderFidelity, TwinId };
 
+export { openTwinDatabase } from "./db.js";
+export type { OpenTwinDatabaseOptions, TwinDatabase, TwinStatement } from "./db.js";
+export { redactEvent, redactSecrets } from "./redaction.js";
+
 // FIDELITY.md uses three tiers (`semantic` | `shape` | `unsupported`); the
 // recording-spec.md v1.0 per-event enum is closed at two (`semantic` |
 // `unsupported`). They serve different purposes — the FIDELITY tier is a
@@ -70,6 +74,11 @@ export interface RecorderHandlerResult {
    * flag (different per call) into the recorder event.
    */
   mutation?: boolean;
+  /**
+   * Optional state delta recorded on the event (`state_delta`). Routes that
+   * know exactly what they changed surface it here; defaults to null.
+   */
+  delta?: RecorderEvent["state_delta"];
 }
 
 export interface RecorderHandle {
@@ -128,6 +137,37 @@ export interface TwinDefinition<
    * envelope.
    */
   errorEnvelope?: (err: unknown) => { status: number; body: unknown };
+  /**
+   * `/healthz` `implementation` field (runtime contract). Defaults to
+   * `"<id>_clone"`.
+   */
+  implementation?: string;
+  /**
+   * npm package name reported in the `/healthz` `runtime` block. Defaults
+   * to `"@pome-sh/twin-<id>"`.
+   */
+  packageName?: string;
+  /**
+   * Extra `/healthz` fields merged over the contract core
+   * `{ok, twin, implementation, tools, runtime}`. When absent the engine
+   * adds `{version, fidelity}`; a twin with a frozen healthz shape supplies
+   * its own extras (possibly `{}` to omit both).
+   */
+  healthz?: () => Record<string, unknown>;
+  /**
+   * The twin's 501 loud-unsupported envelope for unknown session routes.
+   * Defaults to the generic `{message, fidelity, method, path}` body.
+   */
+  unsupported?: (ctx: { method: string; path: string }) => {
+    status: number;
+    body: unknown;
+  };
+  /**
+   * Per-twin auth declarations (F-712): token shape, error envelopes, extra
+   * token locations, raw-bearer / sid-mismatch pins, credential lookup.
+   * Mechanism lives in the engine's `bearerAuth`; this is pure shape.
+   */
+  auth?: import("./auth.js").BearerAuthOptions;
 }
 
 // ─── Meta-validation ────────────────────────────────────────────────────────
@@ -178,6 +218,13 @@ const twinMeta = z.object({
   state: z.custom<Function>(isFunction).optional(),
   admin: adminMeta.optional(),
   errorEnvelope: z.custom<Function>(isFunction).optional(),
+  implementation: z.string().min(1).optional(),
+  packageName: z.string().min(1).optional(),
+  healthz: z.custom<Function>(isFunction).optional(),
+  unsupported: z.custom<Function>(isFunction).optional(),
+  auth: z
+    .custom<object>((value) => typeof value === "object" && value !== null, "auth must be an options object")
+    .optional(),
 });
 
 /**

--- a/packages/sdk/src/mcp-jsonrpc.ts
+++ b/packages/sdk/src/mcp-jsonrpc.ts
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Streamable-HTTP JSON-RPC 2.0 MCP endpoint (`POST /s/:sid/mcp`), stateless
+// mode: GET/DELETE answer 405. Generic over the twin's ToolSpec registry —
+// the per-twin mcp.ts modules this replaces differed only in their tool
+// tables and error envelopes, both of which now come from the manifest.
+
+import { randomUUID } from "node:crypto";
+import type { Context } from "hono";
+import { z } from "zod";
+import type { RecorderHandle, ToolSpec, TwinDefinition } from "./index.js";
+import { UnknownToolError, envelopeFor } from "./errors.js";
+
+const PARSE_ERROR = -32700;
+const INVALID_REQUEST = -32600;
+const METHOD_NOT_FOUND = -32601;
+const INVALID_PARAMS = -32602;
+const INTERNAL_ERROR = -32603;
+
+const DEFAULT_PROTOCOL_VERSION = "2025-06-18";
+const SUPPORTED_PROTOCOL_VERSIONS = new Set(["2024-11-05", "2025-03-26", "2025-06-18"]);
+
+type JsonRpcId = string | number;
+
+type JsonRpcResponse =
+  | { jsonrpc: "2.0"; id: JsonRpcId | null; result: unknown }
+  | { jsonrpc: "2.0"; id: JsonRpcId | null; error: { code: number; message: string; data?: unknown } };
+
+export interface McpJsonRpcDeps<TDb, TSeed, TDomain> {
+  definition: TwinDefinition<TDb, TSeed, TDomain>;
+  domain: TDomain;
+  recorder: RecorderHandle;
+  runId: string;
+}
+
+export function mcpMethodNotAllowed(c: Context): Response {
+  return c.json(
+    { jsonrpc: "2.0", id: null, error: { code: METHOD_NOT_FOUND, message: "Method not allowed in stateless mode" } },
+    405,
+    { Allow: "POST" }
+  );
+}
+
+export async function handleMcpJsonRpc<TDb, TSeed, TDomain>(
+  c: Context,
+  deps: McpJsonRpcDeps<TDb, TSeed, TDomain>
+): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return jsonRpcErrorResponse(null, PARSE_ERROR, "Problems parsing JSON");
+  }
+
+  if (Array.isArray(body)) {
+    if (body.length === 0) {
+      return jsonRpcErrorResponse(null, INVALID_REQUEST, "Invalid Request");
+    }
+    const out: JsonRpcResponse[] = [];
+    for (const message of body) {
+      const response = await dispatch(message, deps, c);
+      if (response) out.push(response);
+    }
+    if (out.length === 0) return new Response(null, { status: 202 });
+    return Response.json(out, { status: 200, headers: { "content-type": "application/json" } });
+  }
+
+  const response = await dispatch(body, deps, c);
+  if (!response) return new Response(null, { status: 202 });
+  return Response.json(response, { status: 200, headers: { "content-type": "application/json" } });
+}
+
+async function dispatch<TDb, TSeed, TDomain>(
+  message: unknown,
+  deps: McpJsonRpcDeps<TDb, TSeed, TDomain>,
+  c: Context
+): Promise<JsonRpcResponse | null> {
+  if (!isObject(message)) return errorEnvelope(null, INVALID_REQUEST, "Invalid Request");
+  if (message.jsonrpc !== "2.0" || typeof message.method !== "string") {
+    return errorEnvelope(idOf(message), INVALID_REQUEST, "Invalid Request");
+  }
+
+  const method = message.method;
+  const params = isObject(message.params) ? (message.params as Record<string, unknown>) : {};
+
+  const rawId = message.id;
+  if (rawId === undefined || rawId === null) return null; // notification
+  if (typeof rawId !== "string" && typeof rawId !== "number") {
+    return errorEnvelope(null, INVALID_REQUEST, "Invalid Request: id must be string or number");
+  }
+  const id: JsonRpcId = rawId;
+
+  try {
+    switch (method) {
+      case "initialize":
+        return { jsonrpc: "2.0", id, result: buildInitializeResult(params, deps.definition) };
+      case "ping":
+        return { jsonrpc: "2.0", id, result: {} };
+      case "tools/list":
+        return {
+          jsonrpc: "2.0",
+          id,
+          result: {
+            tools: deps.definition.tools.map((tool) => ({
+              name: tool.name,
+              description: tool.description,
+              inputSchema: z.toJSONSchema(tool.schema),
+            })),
+          },
+        };
+      case "tools/call":
+        return await handleToolsCall(id, params, deps, c);
+      default:
+        return errorEnvelope(id, METHOD_NOT_FOUND, `Method not found: ${method}`);
+    }
+  } catch (err) {
+    return errorEnvelope(id, INTERNAL_ERROR, err instanceof Error ? err.message : "Internal error");
+  }
+}
+
+function buildInitializeResult<TDb, TSeed, TDomain>(
+  params: Record<string, unknown>,
+  definition: TwinDefinition<TDb, TSeed, TDomain>
+) {
+  const requested = typeof params.protocolVersion === "string" ? params.protocolVersion : undefined;
+  const protocolVersion =
+    requested && SUPPORTED_PROTOCOL_VERSIONS.has(requested) ? requested : DEFAULT_PROTOCOL_VERSION;
+  return {
+    protocolVersion,
+    capabilities: { tools: { listChanged: false } },
+    serverInfo: { name: `twin-${definition.id}`, version: definition.version },
+  };
+}
+
+async function handleToolsCall<TDb, TSeed, TDomain>(
+  id: JsonRpcId,
+  params: Record<string, unknown>,
+  deps: McpJsonRpcDeps<TDb, TSeed, TDomain>,
+  c: Context
+): Promise<JsonRpcResponse> {
+  const name = params.name;
+  const args =
+    params.arguments === undefined || params.arguments === null
+      ? {}
+      : isObject(params.arguments)
+        ? params.arguments
+        : undefined;
+  if (typeof name !== "string" || name.length === 0 || args === undefined) {
+    return errorEnvelope(id, INVALID_PARAMS, "Invalid params: expected { name: string, arguments?: object }");
+  }
+
+  const projectError = deps.definition.errorEnvelope ?? envelopeFor;
+  const tool = deps.definition.tools.find((t): t is ToolSpec<TDomain> => t.name === name);
+
+  const started = Date.now();
+  let status: number;
+  let responseBody: unknown;
+  let toolError: string | null = null;
+  let mutation = false;
+  let mcpResult: { content: { type: "text"; text: string }[]; isError?: boolean };
+
+  if (!tool) {
+    const envelope = projectError(new UnknownToolError(name));
+    status = envelope.status;
+    responseBody = envelope.body;
+    toolError = `Unknown tool: ${name}`;
+    mcpResult = { content: [{ type: "text", text: JSON.stringify(envelope.body) }], isError: true };
+  } else {
+    try {
+      const parsed = tool.schema.parse(args);
+      const value = await tool.handler(deps.domain, parsed);
+      status = 200;
+      responseBody = value;
+      mutation = tool.mutation;
+      mcpResult = { content: [{ type: "text", text: JSON.stringify(value) }] };
+    } catch (err) {
+      const envelope = projectError(err);
+      status = envelope.status;
+      responseBody = envelope.body;
+      toolError = err instanceof Error ? err.message : "tool call failed";
+      mcpResult = { content: [{ type: "text", text: JSON.stringify(envelope.body) }], isError: true };
+    }
+  }
+
+  deps.recorder.record(
+    buildEventCore(c, deps, {
+      started,
+      status,
+      requestBody: { tool: name, arguments: args },
+      responseBody,
+      mutation: status < 400 && mutation,
+      error: toolError,
+    })
+  );
+
+  return { jsonrpc: "2.0", id, result: mcpResult };
+}
+
+function buildEventCore<TDb, TSeed, TDomain>(
+  c: Context,
+  deps: McpJsonRpcDeps<TDb, TSeed, TDomain>,
+  fields: {
+    started: number;
+    status: number;
+    requestBody: unknown;
+    responseBody: unknown;
+    mutation: boolean;
+    error: string | null;
+  }
+) {
+  return {
+    ts: new Date().toISOString(),
+    run_id: deps.runId,
+    twin: deps.definition.id,
+    request_id: `req_${randomUUID()}`,
+    step_id: null,
+    tool_call_id: null,
+    method: c.req.method,
+    path: new URL(c.req.url).pathname,
+    request_body: fields.requestBody,
+    status: fields.status,
+    response_body: fields.responseBody,
+    latency_ms: Date.now() - fields.started,
+    fidelity: "semantic" as const,
+    state_mutation: fields.mutation,
+    state_delta: null,
+    error: fields.error,
+  };
+}
+
+function errorEnvelope(id: JsonRpcId | null, code: number, message: string): JsonRpcResponse {
+  return { jsonrpc: "2.0", id, error: { code, message } };
+}
+
+function jsonRpcErrorResponse(id: JsonRpcId | null, code: number, message: string): Response {
+  return Response.json(errorEnvelope(id, code, message), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function idOf(message: Record<string, unknown>): JsonRpcId | null {
+  const id = message.id;
+  if (typeof id === "string" || typeof id === "number") return id;
+  return null;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/sdk/src/recorder.ts
+++ b/packages/sdk/src/recorder.ts
@@ -18,6 +18,7 @@ import type { Context } from "hono";
 import type { RecorderEvent, TwinId } from "@pome-sh/shared-types";
 import type { RecorderHandle, RecorderHandlerResult } from "./index.js";
 import { envelopeFor } from "./errors.js";
+import { redactEvent } from "./redaction.js";
 
 /**
  * Projects a thrown error into the `{ status, body }` shape a route returns.
@@ -70,7 +71,9 @@ export function createRecorderHandle(options: RecorderHandleOptions): RecorderHa
     fidelity: "semantic" | "unsupported",
     error: string | null
   ) {
-    store.record({
+    // Redaction is unconditional at the engine layer (F-681): every event
+    // that reaches any store — including custom stores — is already scrubbed.
+    store.record(redactEvent({
       ts: new Date().toISOString(),
       run_id: options.runId,
       twin: options.twin,
@@ -85,14 +88,14 @@ export function createRecorderHandle(options: RecorderHandleOptions): RecorderHa
       latency_ms: Date.now() - started,
       fidelity,
       state_mutation: mutation,
-      state_delta: null,
+      state_delta: result.delta ?? null,
       error,
-    });
+    }));
   }
 
   return {
     record(event) {
-      store.record(event);
+      store.record(redactEvent(event));
     },
     events() {
       return store.events();

--- a/packages/sdk/src/redaction.ts
+++ b/packages/sdk/src/redaction.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Engine redaction (F-681). This is the twin-infra implementation applied by
+// the SDK recorder at every event emit and by the `/_pome/state` route, so a
+// twin cannot ship an unredacted tape by forgetting its own copy (the class
+// of bug where one twin redacts and another doesn't). The per-package
+// redaction.ts mirrors (canonical cli/src/recorder/redaction.ts) still cover
+// the not-yet-ported write sites; they are deleted in F-685/F-713 once every
+// consumer reads this module.
+//
+// Two layers, both unconditional:
+//   1. Key-based: any field whose key matches the hard-redact list is replaced
+//      with "[REDACTED]".
+//   2. Regex-based: scrub well-known credential shapes (API key prefixes,
+//      JWTs, PEM blocks) anywhere inside string values, so secrets leaking
+//      through request/response bodies are caught even when the field name
+//      is benign.
+const REDACTED = "[REDACTED]";
+
+const HARD_REDACT_KEYS = new Set([
+  "authorization",
+  "x-api-key",
+  "cookie",
+  "api_key",
+  "client_secret",
+  "webhook_secret",
+  "password",
+  "secret",
+  "token",
+  "access_token",
+  "refresh_token",
+  "session_token",
+  "agent_token",
+  "anthropic_api_key",
+]);
+
+// `sk-...` covers OpenAI + Anthropic (`sk-ant-...`) + variants like `sk-proj-`.
+// The leading boundary avoids mangling benign kebab-case words ending in "sk".
+// `(s|r)k_(test|live)_...` covers Stripe secret/restricted keys — a shorter
+// body threshold than the `pk`/`rk` rule below because seed keys like
+// `sk_test_pome_a` are only a few chars past the prefix.
+// `xapp-...` is a Slack app-level token; `AIza...` is a Google API key.
+// `g` flag matters: a single string may contain multiple secrets.
+const SCRUB_PATTERNS: RegExp[] = [
+  /redaction_fixture_secret_[A-Za-z0-9_-]{8,}/g,
+  /\bsk-[A-Za-z0-9_-]{20,}/g,
+  /\b[rs]k_(?:test|live)_[A-Za-z0-9_]{4,}/g,
+  /ghp_[A-Za-z0-9]{36}/g,
+  /github_pat_[A-Za-z0-9_]{20,}/g,
+  /xox[aboprs]-[A-Za-z0-9-]{20,}/g,
+  /xapp-[A-Za-z0-9-]{10,}/g,
+  /(?:pme|pk|rk)_[A-Za-z0-9_-]{20,}/g,
+  /AIza[0-9A-Za-z_-]{20,}/g,
+  /AKIA[0-9A-Z]{16}/g,
+  /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*/g,
+  /-----BEGIN [A-Z ]+-----[\s\S]*?-----END [A-Z ]+-----/g,
+  /-----BEGIN [A-Z ]+-----/g,
+];
+
+function scrubString(value: string): string {
+  let out = value;
+  for (const pattern of SCRUB_PATTERNS) {
+    out = out.replace(pattern, REDACTED);
+  }
+  return out;
+}
+
+export function redactSecrets(value: unknown): unknown {
+  if (typeof value === "string") return scrubString(value);
+  if (Array.isArray(value)) return value.map(redactSecrets);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, nested]) => [
+        key,
+        HARD_REDACT_KEYS.has(key.toLowerCase()) ? REDACTED : redactSecrets(nested),
+      ]),
+    );
+  }
+  return value;
+}
+
+// Public name used by event-tape writers. Same impl as redactSecrets — the
+// alias exists so write sites read as "redact this event before persisting"
+// rather than the generic "redact secrets."
+export function redactEvent<T>(event: T): T {
+  return redactSecrets(event) as T;
+}

--- a/packages/sdk/src/server.ts
+++ b/packages/sdk/src/server.ts
@@ -29,8 +29,11 @@ import {
   type TwinDefinition,
 } from "./index.js";
 import { bearerAuth, requireAdminAuth } from "./auth.js";
+import { twinBuildInfo } from "./build-info.js";
+import { handleMcpJsonRpc, mcpMethodNotAllowed } from "./mcp-jsonrpc.js";
 import { createRecorderHandle, type RecorderStore } from "./recorder.js";
-import { TwinError } from "./errors.js";
+import { redactSecrets } from "./redaction.js";
+import { TwinError, UnknownToolError } from "./errors.js";
 
 export { createRecorderHandle, createRecorderStore } from "./recorder.js";
 export type { RecorderStore, ErrorEnvelopeFn } from "./recorder.js";
@@ -41,7 +44,27 @@ export { bearerAuth, requireAdminAuth, resolveAuthSecret } from "./auth.js";
 // 403 envelope. See the SECURITY note on setClientIp — never derive the value
 // from request headers.
 export { createAdminGate, setClientIp } from "./admin-gate.js";
-export { TwinError } from "./errors.js";
+export { TwinError, UnknownToolError } from "./errors.js";
+export { redactEvent, redactSecrets } from "./redaction.js";
+export {
+  PROVIDER_SHAPED_TEAM_ID,
+  formTokenResolver,
+  mintProviderToken,
+  queryTokenResolver,
+  verifyProviderToken,
+} from "./auth.js";
+export type {
+  AuthEnvelope,
+  BearerAuthOptions,
+  MintProviderTokenOptions,
+  ProviderTokenSpec,
+  SessionClaims,
+  SessionValue,
+  TokenResolver,
+  UnauthorizedKind,
+} from "./auth.js";
+export { twinBuildInfo } from "./build-info.js";
+export type { TwinBuildInfo } from "./build-info.js";
 
 /**
  * Convenience helper for `recorder.handle` inner functions. Returns a
@@ -134,13 +157,20 @@ export function createApp<TDb, TSeed, TDomain>(
   // 6. Build root app
   const root = new Hono();
 
+  // Contract core: {ok, twin, implementation, tools, runtime}. Extras
+  // default to the pre-F-681 fields; a twin with a frozen healthz shape
+  // supplies its own (possibly empty) extras via `definition.healthz`.
+  const healthzExtras =
+    definition.healthz ??
+    (() => ({ version: definition.version, fidelity: definition.fidelity.default }));
   root.get("/healthz", (c) =>
     c.json({
       ok: true,
       twin: definition.id,
-      version: definition.version,
-      fidelity: definition.fidelity.default,
+      implementation: definition.implementation ?? `${definition.id}_clone`,
       tools: definition.tools.length,
+      runtime: twinBuildInfo(definition.packageName ?? `@pome-sh/twin-${definition.id}`),
+      ...healthzExtras(),
     })
   );
 
@@ -177,9 +207,10 @@ export function createApp<TDb, TSeed, TDomain>(
   );
   root.route("/admin", adminApp);
 
-  // 8. Session sub-app
+  // 8. Session sub-app. Auth mechanism is the engine's; the twin's declared
+  //    shape (F-712) rides in via `definition.auth`.
   const session = new Hono();
-  session.use("*", bearerAuth());
+  session.use("*", bearerAuth(definition.auth));
 
   session.get("/healthz", (c) => c.json({ ok: true, sid: c.req.param("sid") }));
   session.get("/_pome/health", (c) =>
@@ -200,12 +231,19 @@ export function createApp<TDb, TSeed, TDomain>(
         );
       }
       const state = await definition.state({ domain });
-      return { status: 200, body: state };
+      // Central redaction: the state export feeds cloud-side scoring and the
+      // CLI trace; a twin must not be able to leak secrets by omission.
+      return { status: 200, body: redactSecrets(state) };
     })
   );
   session.get("/_pome/events", (c) => c.json(recorder.events()));
 
-  // 9. MCP routes from tool registry
+  // 9. MCP routes from tool registry. `/mcp` is the streamable-HTTP
+  //    JSON-RPC endpoint (stateless — GET/DELETE answer 405); `/mcp/tools`,
+  //    `/mcp/tools/:name`, `/mcp/call` are the legacy dispatch surface.
+  session.post("/mcp", (c) => handleMcpJsonRpc(c, { definition, domain, recorder, runId }));
+  session.get("/mcp", (c) => mcpMethodNotAllowed(c));
+  session.delete("/mcp", (c) => mcpMethodNotAllowed(c));
   session.get("/mcp/tools", (c) =>
     c.json({
       tools: definition.tools.map((tool) => ({
@@ -252,15 +290,19 @@ export function createApp<TDb, TSeed, TDomain>(
   //     gaps in the trace.
   session.all(
     "*",
-    recorder.handle({ mutation: false, fidelity: "unsupported" }, async (c) => ({
-      status: 501,
-      body: {
-        message: `Endpoint not modeled by twin "${definition.id}".`,
-        fidelity: "unsupported",
-        method: c.req.method,
-        path: new URL(c.req.url).pathname,
-      },
-    }))
+    recorder.handle({ mutation: false, fidelity: "unsupported" }, async (c) => {
+      const ctx = { method: c.req.method, path: new URL(c.req.url).pathname };
+      if (definition.unsupported) return definition.unsupported(ctx);
+      return {
+        status: 501,
+        body: {
+          message: `Endpoint not modeled by twin "${definition.id}".`,
+          fidelity: "unsupported",
+          method: ctx.method,
+          path: ctx.path,
+        },
+      };
+    })
   );
 
   root.route("/s/:sid", session);
@@ -295,15 +337,29 @@ export async function serve<TDb, TSeed, TDomain>(
   definition: TwinDefinition<TDb, TSeed, TDomain>,
   options: ServeOptions<TDb, TSeed> = {}
 ): Promise<ServeResult> {
+  const hostname = options.hostname ?? "127.0.0.1";
+  // Contract boot guard: a twin must refuse to serve real traffic with the
+  // dev fallback secret. Checked before the app is built so the process
+  // exits non-zero without ever listening.
+  if (options.port !== undefined && !isLoopbackHost(hostname) && !process.env.TWIN_AUTH_SECRET) {
+    throw new TwinBootError(
+      `TWIN_AUTH_SECRET is required when a twin listens on a non-loopback host (${hostname}).`
+    );
+  }
   const app = createApp(definition, options);
   if (options.port === undefined) {
     return { app, close: async () => undefined };
   }
   const { serve: nodeServe } = await import("@hono/node-server");
-  const server = nodeServe({
-    fetch: app.fetch,
-    port: options.port,
-    hostname: options.hostname ?? "127.0.0.1",
+  const server = await new Promise<ReturnType<typeof nodeServe>>((resolve) => {
+    const bound = nodeServe(
+      {
+        fetch: app.fetch,
+        port: options.port,
+        hostname,
+      },
+      () => resolve(bound)
+    );
   });
   return {
     app,
@@ -315,6 +371,11 @@ export async function serve<TDb, TSeed, TDomain>(
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Hostnames the boot guard treats as loopback binds. */
+export function isLoopbackHost(value: string): boolean {
+  return value === "127.0.0.1" || value === "::1" || value === "localhost";
+}
 
 function shadowedPrefix(routePath: string): string | null {
   for (const prefix of RESERVED_SESSION_PREFIXES) {
@@ -342,7 +403,7 @@ function findTool<TDb, TSeed, TDomain>(
 ): ToolSpec<TDomain> {
   const tool = definition.tools.find((t) => t.name === name);
   if (!tool) {
-    throw new TwinError(`Unknown tool: ${name}`, 404);
+    throw new UnknownToolError(name);
   }
   return tool;
 }

--- a/packages/sdk/test/auth-options.test.ts
+++ b/packages/sdk/test/auth-options.test.ts
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Engine auth option tests (F-681, spec = F-712 [DECISION] rows 2–9).
+// Mechanism lives in the engine; each twin's intended differences are
+// explicit `defineTwin()` auth options, never forks. Each row's pinned
+// behavior is exercised here with the real middleware on a real Hono app.
+import { Hono } from "hono";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  PROVIDER_SHAPED_TEAM_ID,
+  bearerAuth,
+  formTokenResolver,
+  mintProviderToken,
+  queryTokenResolver,
+  type BearerAuthOptions,
+} from "../src/auth.js";
+import { TEST_AUTH_SECRET, TEST_SID, signTestToken, withAuth } from "./_authHelper.js";
+
+const previousSecret = process.env.TWIN_AUTH_SECRET;
+beforeAll(() => {
+  process.env.TWIN_AUTH_SECRET = TEST_AUTH_SECRET;
+});
+afterAll(() => {
+  if (previousSecret === undefined) delete process.env.TWIN_AUTH_SECRET;
+  else process.env.TWIN_AUTH_SECRET = previousSecret;
+});
+
+function sessionApp(options?: BearerAuthOptions) {
+  const app = new Hono();
+  const session = new Hono();
+  session.use("*", bearerAuth(options));
+  session.get("/whoami", (c) => c.json(c.get("session" as never) as Record<string, unknown>));
+  app.route("/s/:sid", session);
+  return app;
+}
+
+const path = `/s/${TEST_SID}/whoami`;
+
+describe("unauthorized(kind) envelope hook (rows 2 + 6)", () => {
+  const slackish: BearerAuthOptions = {
+    unauthorized: (kind) => ({
+      status: 401,
+      body: { ok: false, error: kind === "no_token" ? "not_authed" : kind === "expired" ? "token_expired" : "invalid_auth" },
+    }),
+  };
+
+  it("classifies a missing token as no_token", async () => {
+    const res = await sessionApp(slackish).request(path);
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ ok: false, error: "not_authed" });
+  });
+
+  it("classifies a garbage token as invalid", async () => {
+    const res = await sessionApp(slackish).request(path, withAuth("garbage"));
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ ok: false, error: "invalid_auth" });
+  });
+
+  it("classifies an expired JWT as expired (engine-side classification)", async () => {
+    const expired = await signTestToken({ expSeconds: -60 });
+    const res = await sessionApp(slackish).request(path, withAuth(expired));
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ ok: false, error: "token_expired" });
+  });
+
+  it("defaults to the frozen github-shaped envelope, expired included (github wire: Bad credentials)", async () => {
+    const expired = await signTestToken({ expSeconds: -60 });
+    const res = await sessionApp().request(path, withAuth(expired));
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ message: "Bad credentials", documentation_url: "" });
+  });
+});
+
+describe("raw bearer pin (row 4)", () => {
+  it("rejects a prefix-less bearer by default (github/slack pin)", async () => {
+    const token = await signTestToken();
+    const res = await sessionApp().request(path, { headers: { Authorization: token } });
+    expect(res.status).toBe(401);
+  });
+
+  it("accepts a prefix-less bearer and case-insensitive 'bearer' when allowRawBearer is set (stripe pin)", async () => {
+    const token = await signTestToken();
+    const raw = await sessionApp({ allowRawBearer: true }).request(path, {
+      headers: { Authorization: token },
+    });
+    expect(raw.status).toBe(200);
+    const lower = await sessionApp({ allowRawBearer: true }).request(path, {
+      headers: { Authorization: `bearer ${token}` },
+    });
+    expect(lower.status).toBe(200);
+  });
+});
+
+describe("sid mismatch pin (row 5)", () => {
+  it("defaults to the frozen 401 Forbidden envelope", async () => {
+    const other = await signTestToken({ sid: "other-sid" });
+    const res = await sessionApp().request(path, withAuth(other));
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ message: "Forbidden", documentation_url: "" });
+  });
+
+  it("renders the twin's pinned mismatch envelope (stripe: 403)", async () => {
+    const other = await signTestToken({ sid: "other-sid" });
+    const res = await sessionApp({
+      sidMismatch: () => ({ status: 403, body: { error: { code: "forbidden", message: "Session id mismatch." } } }),
+    }).request(path, withAuth(other));
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe("forbidden");
+  });
+});
+
+describe("token resolvers (row 3)", () => {
+  const resolvers: BearerAuthOptions = {
+    tokenResolvers: [queryTokenResolver("token"), formTokenResolver("token")],
+  };
+
+  it("accepts ?token= in the query string", async () => {
+    const token = await signTestToken();
+    const res = await sessionApp(resolvers).request(`${path}?token=${encodeURIComponent(token)}`);
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts token= in a form-encoded body", async () => {
+    const app = new Hono();
+    const session = new Hono();
+    session.use("*", bearerAuth(resolvers));
+    session.post("/act", (c) => c.json({ ok: true }));
+    app.route("/s/:sid", session);
+    const token = await signTestToken();
+    const res = await app.request(`/s/${TEST_SID}/act`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ token }).toString(),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("still prefers the Authorization header when present", async () => {
+    const token = await signTestToken();
+    const res = await sessionApp(resolvers).request(`${path}?token=garbage`, withAuth(token));
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("provider-shaped tokens in the middleware (rows 1 + 7)", () => {
+  const options: BearerAuthOptions = {
+    providerToken: { provider: "slack", prefixes: ["xoxb-pome-", "xoxp-pome-"] },
+    providerSession: () => ({ login: "pome-agent" }),
+  };
+
+  it("authenticates a minted provider token and marks the session provider-shaped", async () => {
+    const token = mintProviderToken(
+      { provider: "slack", prefixes: ["xoxb-pome-"] },
+      { sid: TEST_SID, secret: TEST_AUTH_SECRET }
+    );
+    const res = await sessionApp(options).request(path, withAuth(token));
+    expect(res.status).toBe(200);
+    const session = (await res.json()) as Record<string, unknown>;
+    expect(session.sid).toBe(TEST_SID);
+    expect(session.team_id).toBe(PROVIDER_SHAPED_TEAM_ID);
+    expect(session.login).toBe("pome-agent");
+  });
+
+  it("rejects a provider token for another session via the mismatch envelope", async () => {
+    const token = mintProviderToken(
+      { provider: "slack", prefixes: ["xoxb-pome-"] },
+      { sid: "other-sid", secret: TEST_AUTH_SECRET }
+    );
+    const res = await sessionApp(options).request(path, withAuth(token));
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ message: "Forbidden", documentation_url: "" });
+  });
+});
+
+describe("resolveCredential hook (row 8)", () => {
+  it("resolves a DB-backed credential before JWT verification", async () => {
+    const res = await sessionApp({
+      resolveCredential: (token) =>
+        token === "sk_test_pome_known" ? { sid: TEST_SID, account_id: "acct_1", via: "api_key" } : undefined,
+    }).request(path, { headers: { Authorization: "Bearer sk_test_pome_known" } });
+    expect(res.status).toBe(200);
+    const session = (await res.json()) as Record<string, unknown>;
+    expect(session.account_id).toBe("acct_1");
+  });
+
+  it("falls through to JWT when the hook returns undefined", async () => {
+    const token = await signTestToken();
+    const res = await sessionApp({ resolveCredential: () => undefined }).request(path, withAuth(token));
+    expect(res.status).toBe(200);
+  });
+
+  it("enforces the path-sid match on hook-resolved sessions", async () => {
+    const res = await sessionApp({
+      resolveCredential: () => ({ sid: "other-sid" }),
+    }).request(path, { headers: { Authorization: "Bearer sk_test_pome_known" } });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("mount mode (row 9)", () => {
+  it("requirePathSid=false trusts the bearer alone on sid-less mounts (stripe /v1)", async () => {
+    const app = new Hono();
+    const v1 = new Hono();
+    v1.use("*", bearerAuth({ requirePathSid: false, allowRawBearer: true }));
+    v1.get("/charges", (c) => c.json(c.get("session" as never) as Record<string, unknown>));
+    app.route("/v1", v1);
+    const token = await signTestToken();
+    const res = await app.request("/v1/charges", { headers: { Authorization: token } });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { sid: string }).sid).toBe(TEST_SID);
+  });
+
+  it("still enforces the match when a path sid IS present", async () => {
+    const other = await signTestToken({ sid: "other-sid" });
+    const res = await sessionApp({ requirePathSid: false }).request(path, withAuth(other));
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("session extras (row 7)", () => {
+  it("copies declared extra claims into the session via sessionExtras", async () => {
+    const token = await signTestToken();
+    // _authHelper signs {sid, team_id, exp}; extras hook derives login.
+    const res = await sessionApp({
+      sessionExtras: (claims) => ({ login: `user-of-${claims.team_id as string}` }),
+    }).request(path, withAuth(token));
+    expect(res.status).toBe(200);
+    const session = (await res.json()) as Record<string, unknown>;
+    expect(session.login).toBe("user-of-tm_test");
+  });
+});

--- a/packages/sdk/test/auth-provider-token.test.ts
+++ b/packages/sdk/test/auth-provider-token.test.ts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Provider-shaped token mechanism tests (F-681, spec = F-712 [DECISION] row 1
+// + row 10 + the appendix bug). The engine owns mint + verify; twins declare
+// only their token shape (prefixes + HMAC provider domain).
+import { createHmac } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  mintProviderToken,
+  verifyProviderToken,
+  type ProviderTokenSpec,
+} from "../src/auth.js";
+
+const SECRET = "provider-test-secret";
+
+const slackSpec: ProviderTokenSpec = {
+  provider: "slack",
+  prefixes: ["xoxb-pome-", "xoxp-pome-"],
+};
+const githubSpec: ProviderTokenSpec = {
+  provider: "github",
+  prefixes: ["github_pat_pome_", "ghp_pome_"],
+};
+
+// The frozen wire construction the twins + cloud already mint today:
+// <prefix><base64url(sid)>_<sig22> / <prefix><base64url(sid)>_<exp>_<sig22>
+// where sig = hmac-sha256(secret, "<provider>:<sid>[:<exp>]") b64url [0,22).
+function legacyMint(prefix: string, provider: string, sid: string, secret: string, exp?: number) {
+  const encoded = Buffer.from(sid, "utf8").toString("base64url");
+  const payload = exp === undefined ? `${provider}:${sid}` : `${provider}:${sid}:${exp}`;
+  const sig = createHmac("sha256", secret).update(payload).digest("base64url").slice(0, 22);
+  return exp === undefined ? `${prefix}${encoded}_${sig}` : `${prefix}${encoded}_${exp}_${sig}`;
+}
+
+describe("mintProviderToken", () => {
+  it("emits the frozen legacy (no-exp) wire shape byte-for-byte", () => {
+    const sid = "session-1";
+    expect(mintProviderToken(slackSpec, { sid, secret: SECRET })).toBe(
+      legacyMint("xoxb-pome-", "slack", sid, SECRET)
+    );
+  });
+
+  it("emits the frozen exp wire shape byte-for-byte", () => {
+    const sid = "session-1";
+    const exp = Math.floor(Date.now() / 1000) + 600;
+    expect(mintProviderToken(slackSpec, { sid, secret: SECRET, exp })).toBe(
+      legacyMint("xoxb-pome-", "slack", sid, SECRET, exp)
+    );
+  });
+
+  it("mints with an alternate declared prefix", () => {
+    const token = mintProviderToken(slackSpec, { sid: "s", secret: SECRET, prefix: "xoxp-pome-" });
+    expect(token.startsWith("xoxp-pome-")).toBe(true);
+    expect(verifyProviderToken(slackSpec, token, SECRET)).toBe("s");
+  });
+
+  it("rejects a prefix the spec does not declare", () => {
+    expect(() =>
+      mintProviderToken(slackSpec, { sid: "s", secret: SECRET, prefix: "xoxa-pome-" })
+    ).toThrow(/prefix/);
+  });
+});
+
+describe("verifyProviderToken", () => {
+  it("round-trips a minted legacy token", () => {
+    const token = mintProviderToken(githubSpec, { sid: "sid-a", secret: SECRET });
+    expect(verifyProviderToken(githubSpec, token, SECRET)).toBe("sid-a");
+  });
+
+  it("round-trips a minted exp token that has not expired", () => {
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+    const token = mintProviderToken(githubSpec, { sid: "sid-a", secret: SECRET, exp });
+    expect(verifyProviderToken(githubSpec, token, SECRET)).toBe("sid-a");
+  });
+
+  it("rejects an expired exp token", () => {
+    const exp = Math.floor(Date.now() / 1000) - 60;
+    const token = mintProviderToken(githubSpec, { sid: "sid-a", secret: SECRET, exp });
+    expect(verifyProviderToken(githubSpec, token, SECRET)).toBeUndefined();
+  });
+
+  it("REGRESSION (F-712 appendix): a sid whose base64url encoding contains '_' round-trips", () => {
+    // '?' (0x3F) + '>' (0x3E) produce a 6-bit group of 63 → '_' in base64url.
+    const sid = "?>?";
+    expect(Buffer.from(sid, "utf8").toString("base64url")).toContain("_");
+    const legacy = mintProviderToken(slackSpec, { sid, secret: SECRET });
+    expect(verifyProviderToken(slackSpec, legacy, SECRET)).toBe(sid);
+    const exp = Math.floor(Date.now() / 1000) + 600;
+    const withExp = mintProviderToken(slackSpec, { sid, secret: SECRET, exp });
+    expect(verifyProviderToken(slackSpec, withExp, SECRET)).toBe(sid);
+  });
+
+  it("REGRESSION: a sid whose encoding ends in an all-digit segment is not mis-parsed as exp", () => {
+    // Search for a sid whose base64url encoding ends "_<digits>" — the
+    // ambiguous shape where a naive parse would strip the digits as an exp
+    // segment. HMAC disambiguation must recover the full sid.
+    // "ab?Ӎ" → utf8 bytes 61 62 3F D3 8D → base64url "YWI_040".
+    const sid = "ab?Ӎ";
+    expect(Buffer.from(sid, "utf8").toString("base64url")).toMatch(/_\d+$/);
+    const token = mintProviderToken(slackSpec, { sid, secret: SECRET });
+    expect(verifyProviderToken(slackSpec, token, SECRET)).toBe(sid);
+  });
+
+  it("rejects a tampered signature", () => {
+    const token = mintProviderToken(slackSpec, { sid: "sid-a", secret: SECRET });
+    const tampered = token.slice(0, -1) + (token.endsWith("A") ? "B" : "A");
+    expect(verifyProviderToken(slackSpec, tampered, SECRET)).toBeUndefined();
+  });
+
+  it("rejects a token minted for a different provider domain", () => {
+    // Same secret, same sid — but the HMAC covers "<provider>:", so a slack
+    // token re-prefixed as github must not verify.
+    const sid = "sid-a";
+    const slackToken = mintProviderToken(slackSpec, { sid, secret: SECRET });
+    const rePrefixed = `ghp_pome_${slackToken.slice("xoxb-pome-".length)}`;
+    expect(verifyProviderToken(githubSpec, rePrefixed, SECRET)).toBeUndefined();
+  });
+
+  it("rejects tokens with an undeclared prefix and non-token strings", () => {
+    expect(verifyProviderToken(slackSpec, "xoxa-pome-abc_def", SECRET)).toBeUndefined();
+    expect(verifyProviderToken(slackSpec, "not-a-token", SECRET)).toBeUndefined();
+    expect(verifyProviderToken(slackSpec, "xoxb-pome-", SECRET)).toBeUndefined();
+    expect(verifyProviderToken(slackSpec, "xoxb-pome-nounderscore", SECRET)).toBeUndefined();
+  });
+
+  it("accepts tokens minted by the pre-F-681 twin code (wire compat)", () => {
+    // Byte-identical to twin-slack's signSlackProviderToken / twin-github's
+    // signProvider — cloud-minted tokens in flight must keep verifying.
+    const sid = "compat-sid";
+    expect(
+      verifyProviderToken(slackSpec, legacyMint("xoxp-pome-", "slack", sid, SECRET), SECRET)
+    ).toBe(sid);
+    const exp = Math.floor(Date.now() / 1000) + 60;
+    expect(
+      verifyProviderToken(
+        githubSpec,
+        legacyMint("github_pat_pome_", "github", sid, SECRET, exp),
+        SECRET
+      )
+    ).toBe(sid);
+  });
+});

--- a/packages/sdk/test/db.test.ts
+++ b/packages/sdk/test/db.test.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Engine db driver wrapper tests (F-681). Twins open SQLite through this
+// wrapper only — `open` + pragmas + a same-shape `transaction()` helper — so
+// the M2 node:sqlite swap (F-703) is a one-file change in the engine.
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { openTwinDatabase, type TwinDatabase } from "../src/db.js";
+
+const tmp = mkdtempSync(join(tmpdir(), "sdk-db-test-"));
+afterAll(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function withDb<T>(fn: (db: TwinDatabase) => T, path = ":memory:"): T {
+  const db = openTwinDatabase(path);
+  try {
+    return fn(db);
+  } finally {
+    db.close();
+  }
+}
+
+describe("openTwinDatabase", () => {
+  it("opens an in-memory database and round-trips rows", () => {
+    withDb((db) => {
+      db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT NOT NULL)");
+      db.prepare("INSERT INTO t (name) VALUES (?)").run("a");
+      const row = db.prepare("SELECT name FROM t WHERE id = 1").get() as { name: string };
+      expect(row.name).toBe("a");
+    });
+  });
+
+  it("applies the twin pragmas: busy_timeout, foreign_keys", () => {
+    withDb((db) => {
+      expect(db.pragma("busy_timeout", { simple: true })).toBe(5000);
+      expect(db.pragma("foreign_keys", { simple: true })).toBe(1);
+    });
+  });
+
+  it("uses WAL journal mode for file-backed databases", () => {
+    const path = join(tmp, "wal", "twin.db");
+    withDb((db) => {
+      expect(db.pragma("journal_mode", { simple: true })).toBe("wal");
+    }, path);
+  });
+
+  it("creates missing parent directories for file paths", () => {
+    const path = join(tmp, "deep", "nested", "twin.db");
+    withDb((db) => {
+      db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)");
+    }, path);
+    expect(existsSync(path)).toBe(true);
+  });
+
+  it("runs the migrate hook at open", () => {
+    const db = openTwinDatabase(":memory:", {
+      migrate: (d) => d.exec("CREATE TABLE migrated (id INTEGER PRIMARY KEY)"),
+    });
+    try {
+      const row = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='migrated'")
+        .get() as { name: string } | undefined;
+      expect(row?.name).toBe("migrated");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("enforces foreign keys (pragma is live, not just reported)", () => {
+    withDb((db) => {
+      db.exec(
+        "CREATE TABLE parent (id INTEGER PRIMARY KEY);" +
+          "CREATE TABLE child (id INTEGER PRIMARY KEY, parent_id INTEGER NOT NULL REFERENCES parent(id));"
+      );
+      expect(() => db.prepare("INSERT INTO child (parent_id) VALUES (999)").run()).toThrow();
+    });
+  });
+});
+
+describe("transaction()", () => {
+  it("has the better-sqlite3 shape: transaction(fn) returns a callable that commits", () => {
+    withDb((db) => {
+      db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT NOT NULL)");
+      const insertMany = db.transaction((names: string[]) => {
+        for (const name of names) db.prepare("INSERT INTO t (name) VALUES (?)").run(name);
+        return names.length;
+      });
+      const count = insertMany(["a", "b", "c"]);
+      expect(count).toBe(3);
+      const row = db.prepare("SELECT COUNT(*) AS n FROM t").get() as { n: number };
+      expect(row.n).toBe(3);
+    });
+  });
+
+  it("rolls back every statement when the wrapped function throws", () => {
+    withDb((db) => {
+      db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT NOT NULL)");
+      const failing = db.transaction(() => {
+        db.prepare("INSERT INTO t (name) VALUES (?)").run("kept?");
+        throw new Error("boom");
+      });
+      expect(() => failing()).toThrow("boom");
+      const row = db.prepare("SELECT COUNT(*) AS n FROM t").get() as { n: number };
+      expect(row.n).toBe(0);
+    });
+  });
+});

--- a/packages/sdk/test/redaction.test.ts
+++ b/packages/sdk/test/redaction.test.ts
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Engine redaction tests (F-681). Redaction lives HERE, in the engine —
+// per-twin recorders must not need their own copy for the tape to be safe
+// (the §5.2 class of bug: one twin redacts, another doesn't).
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createApp } from "../src/server.js";
+import { createRecorderHandle, createRecorderStore } from "../src/recorder.js";
+import { redactEvent, redactSecrets } from "../src/redaction.js";
+import { defineTwin } from "../src/index.js";
+import { TEST_AUTH_SECRET, TEST_SID, signTestToken, withAuth } from "./_authHelper.js";
+
+const previousSecret = process.env.TWIN_AUTH_SECRET;
+let token: string;
+beforeAll(async () => {
+  process.env.TWIN_AUTH_SECRET = TEST_AUTH_SECRET;
+  token = await signTestToken();
+});
+afterAll(() => {
+  if (previousSecret === undefined) delete process.env.TWIN_AUTH_SECRET;
+  else process.env.TWIN_AUTH_SECRET = previousSecret;
+});
+
+describe("redactSecrets", () => {
+  it("replaces hard-redact keys regardless of value", () => {
+    const out = redactSecrets({
+      authorization: "Bearer abc",
+      "x-api-key": "k",
+      cookie: "session=1",
+      token: "t",
+      nested: { access_token: "a", safe: "keep" },
+    }) as Record<string, unknown>;
+    expect(out.authorization).toBe("[REDACTED]");
+    expect(out["x-api-key"]).toBe("[REDACTED]");
+    expect(out.cookie).toBe("[REDACTED]");
+    expect(out.token).toBe("[REDACTED]");
+    expect((out.nested as Record<string, unknown>).access_token).toBe("[REDACTED]");
+    expect((out.nested as Record<string, unknown>).safe).toBe("keep");
+  });
+
+  it("matches hard-redact keys case-insensitively", () => {
+    const out = redactSecrets({ Authorization: "Bearer abc" }) as Record<string, unknown>;
+    expect(out.Authorization).toBe("[REDACTED]");
+  });
+
+  it("scrubs well-known credential shapes inside string values", () => {
+    const ghp = `ghp_${"a".repeat(36)}`;
+    const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzaWQiOiJ4In0.c2ln";
+    const out = redactSecrets({
+      note: `token ${ghp} embedded`,
+      arr: [`sk-${"b".repeat(24)}`, "benign"],
+      jwt,
+      slack: `xoxb-${"c".repeat(24)}`,
+      stripe: "sk_test_pome_abcd",
+    }) as Record<string, unknown>;
+    expect(out.note).toBe("token [REDACTED] embedded");
+    expect((out.arr as string[])[0]).toBe("[REDACTED]");
+    expect((out.arr as string[])[1]).toBe("benign");
+    expect(out.jwt).toBe("[REDACTED]");
+    expect(out.slack).toBe("[REDACTED]");
+    expect(out.stripe).toBe("[REDACTED]");
+  });
+
+  it("scrubs PEM blocks", () => {
+    const pem = "-----BEGIN PRIVATE KEY-----\nMIIB\n-----END PRIVATE KEY-----";
+    expect(redactSecrets(pem)).toBe("[REDACTED]");
+  });
+
+  it("leaves non-secret scalars untouched", () => {
+    expect(redactSecrets(42)).toBe(42);
+    expect(redactSecrets(null)).toBe(null);
+    expect(redactSecrets("hello")).toBe("hello");
+  });
+
+  it("redactEvent is the event-write alias of redactSecrets", () => {
+    const event = { response_body: { api_key: "secret" } };
+    const out = redactEvent(event);
+    expect((out.response_body as Record<string, unknown>).api_key).toBe("[REDACTED]");
+  });
+});
+
+describe("recorder redacts every emitted event", () => {
+  it("scrubs request_body and response_body at emit time", async () => {
+    const store = createRecorderStore();
+    const recorder = createRecorderHandle({ runId: "r", twin: "toy", store });
+    const handler = recorder.handle({ mutation: false }, () => ({
+      status: 200,
+      body: { echo: `ghp_${"a".repeat(36)}`, api_key: "leak" },
+    }));
+    const { Hono } = await import("hono");
+    const app = new Hono();
+    app.post("/x", handler);
+    const res = await app.request("/x", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ password: "hunter2", ok: "fine" }),
+    });
+    expect(res.status).toBe(200);
+    // The HTTP response itself is NOT redacted — only the recorded tape.
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.api_key).toBe("leak");
+
+    const [event] = store.events();
+    expect(event).toBeDefined();
+    const reqBody = event!.request_body as Record<string, unknown>;
+    const resBody = event!.response_body as Record<string, unknown>;
+    expect(reqBody.password).toBe("[REDACTED]");
+    expect(reqBody.ok).toBe("fine");
+    expect(resBody.api_key).toBe("[REDACTED]");
+    expect(resBody.echo).toBe("[REDACTED]");
+  });
+
+  it("scrubs events recorded directly via recorder.record()", () => {
+    const store = createRecorderStore();
+    const recorder = createRecorderHandle({ runId: "r", twin: "toy", store });
+    recorder.record({
+      ts: new Date().toISOString(),
+      run_id: "r",
+      twin: "toy",
+      request_id: "req_1",
+      step_id: null,
+      tool_call_id: null,
+      method: "POST",
+      path: "/x",
+      request_body: { client_secret: "leak" },
+      status: 200,
+      response_body: null,
+      latency_ms: 1,
+      fidelity: "semantic",
+      state_mutation: false,
+      state_delta: null,
+      error: null,
+    });
+    const [event] = store.events();
+    expect((event!.request_body as Record<string, unknown>).client_secret).toBe("[REDACTED]");
+  });
+});
+
+describe("/_pome/state is redacted centrally", () => {
+  it("scrubs secrets from the state export without twin involvement", async () => {
+    const leaky = defineTwin({
+      id: "leaky",
+      version: "0.0.1",
+      fidelity: { default: "semantic" },
+      domain: () => ({}),
+      state: () => ({ webhook_secret: "leak", note: `xapp-${"d".repeat(16)}`, keep: "ok" }),
+      tools: [],
+    });
+    const app = createApp(leaky);
+    const res = await app.request(`/s/${TEST_SID}/_pome/state`, withAuth(token));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.webhook_secret).toBe("[REDACTED]");
+    expect(body.note).toBe("[REDACTED]");
+    expect(body.keep).toBe("ok");
+  });
+});

--- a/packages/sdk/test/serve-contract.test.ts
+++ b/packages/sdk/test/serve-contract.test.ts
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Engine surfaces required by the frozen runtime contract (F-681 / F-711):
+// healthz implementation+runtime block, per-twin healthz extras, the
+// definition-level auth options, JSON-RPC /s/:sid/mcp, the per-twin 501
+// unsupported envelope, state_delta plumbing, and the serve() boot guard.
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { defineTwin } from "../src/index.js";
+import { UnknownToolError } from "../src/errors.js";
+import { createApp, createRecorderStore, serve } from "../src/server.js";
+import { TEST_AUTH_SECRET, TEST_SID, signTestToken, withAuth } from "./_authHelper.js";
+import { toyTwin } from "./_toyTwin.js";
+
+const previousSecret = process.env.TWIN_AUTH_SECRET;
+let token: string;
+beforeAll(async () => {
+  process.env.TWIN_AUTH_SECRET = TEST_AUTH_SECRET;
+  token = await signTestToken();
+});
+afterAll(() => {
+  if (previousSecret === undefined) delete process.env.TWIN_AUTH_SECRET;
+  else process.env.TWIN_AUTH_SECRET = previousSecret;
+});
+
+const base = `/s/${TEST_SID}`;
+
+describe("healthz contract shape", () => {
+  it("carries implementation and the runtime build-info block by default", async () => {
+    const app = createApp(toyTwin);
+    const body = (await (await app.request("/healthz")).json()) as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    expect(body.twin).toBe("toy");
+    expect(body.implementation).toBe("toy_clone");
+    expect(body.tools).toBe(2);
+    const runtime = body.runtime as Record<string, unknown>;
+    for (const key of ["package", "version", "git_sha", "build_time"]) {
+      expect(typeof runtime[key]).toBe("string");
+    }
+    expect(runtime.package).toBe("@pome-sh/twin-toy");
+    // Default extras keep the pre-F-681 fields.
+    expect(body.version).toBe("0.1.0");
+    expect(body.fidelity).toBe("semantic");
+  });
+
+  it("lets a twin replace the healthz extras (e.g. slack omits fidelity/version)", async () => {
+    const slackish = defineTwin({
+      ...toyTwin,
+      id: "slackish",
+      implementation: "slack_clone",
+      packageName: "@pome-sh/twin-slack",
+      healthz: () => ({}),
+    });
+    const app = createApp(slackish);
+    const body = (await (await app.request("/healthz")).json()) as Record<string, unknown>;
+    expect(body.implementation).toBe("slack_clone");
+    expect((body.runtime as Record<string, unknown>).package).toBe("@pome-sh/twin-slack");
+    expect("fidelity" in body).toBe(false);
+    expect("version" in body).toBe(false);
+  });
+});
+
+describe("definition-level auth options", () => {
+  it("wires definition.auth into the session bearer middleware", async () => {
+    const twin = defineTwin({
+      ...toyTwin,
+      id: "authy",
+      auth: {
+        unauthorized: (kind) => ({
+          status: 401,
+          body: { ok: false, error: kind === "no_token" ? "not_authed" : "invalid_auth" },
+        }),
+      },
+    });
+    const app = createApp(twin);
+    const res = await app.request(`${base}/_pome/health`);
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ ok: false, error: "not_authed" });
+  });
+});
+
+describe("JSON-RPC /s/:sid/mcp", () => {
+  function rpc(app: ReturnType<typeof createApp>, body: unknown) {
+    return app.request(
+      `${base}/mcp`,
+      withAuth(token, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      })
+    );
+  }
+
+  it("answers initialize with protocolVersion + serverInfo", async () => {
+    const app = createApp(toyTwin);
+    const res = await rpc(app, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: "t", version: "0" } },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, any>;
+    expect(body.jsonrpc).toBe("2.0");
+    expect(body.result.protocolVersion).toBe("2025-03-26");
+    expect(typeof body.result.serverInfo.name).toBe("string");
+  });
+
+  it("answers ping and tools/list (list length matches healthz.tools)", async () => {
+    const app = createApp(toyTwin);
+    const ping = (await (await rpc(app, { jsonrpc: "2.0", id: 2, method: "ping" })).json()) as any;
+    expect(ping.result).toEqual({});
+    const list = (await (await rpc(app, { jsonrpc: "2.0", id: 3, method: "tools/list" })).json()) as any;
+    expect(list.result.tools).toHaveLength(2);
+  });
+
+  it("executes tools/call and records the event with the tool's mutation flag", async () => {
+    const store = createRecorderStore();
+    const app = createApp(toyTwin, { recorder: store });
+    const res = await rpc(app, {
+      jsonrpc: "2.0",
+      id: 4,
+      method: "tools/call",
+      params: { name: "add_item", arguments: { item: "x" } },
+    });
+    const body = (await res.json()) as any;
+    expect(body.result.isError).toBeUndefined();
+    expect(JSON.parse(body.result.content[0].text)).toMatchObject({ item: "x", total: 1 });
+    const event = store.events().find((e) => e.path.endsWith("/mcp"));
+    expect(event?.state_mutation).toBe(true);
+  });
+
+  it("returns an isError tool result for an unknown tool", async () => {
+    const app = createApp(toyTwin);
+    const res = await rpc(app, {
+      jsonrpc: "2.0",
+      id: 5,
+      method: "tools/call",
+      params: { name: "nope", arguments: {} },
+    });
+    const body = (await res.json()) as any;
+    expect(body.result.isError).toBe(true);
+  });
+
+  it("answers 405 for GET and DELETE (stateless mode)", async () => {
+    const app = createApp(toyTwin);
+    expect((await app.request(`${base}/mcp`, withAuth(token))).status).toBe(405);
+    expect((await app.request(`${base}/mcp`, withAuth(token, { method: "DELETE" }))).status).toBe(405);
+  });
+
+  it("answers 202 for notifications and -32601 for unknown methods", async () => {
+    const app = createApp(toyTwin);
+    const notification = await rpc(app, { jsonrpc: "2.0", method: "notifications/initialized" });
+    expect(notification.status).toBe(202);
+    const unknown = (await (await rpc(app, { jsonrpc: "2.0", id: 6, method: "nope/nope" })).json()) as any;
+    expect(unknown.error.code).toBe(-32601);
+  });
+
+  it("answers -32700 (HTTP 200) for a JSON parse error", async () => {
+    const app = createApp(toyTwin);
+    const res = await app.request(
+      `${base}/mcp`,
+      withAuth(token, { method: "POST", headers: { "content-type": "application/json" }, body: "{nope" })
+    );
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as any).error.code).toBe(-32700);
+  });
+});
+
+describe("unknown-tool envelope via legacy /mcp/call", () => {
+  it("throws UnknownToolError so the twin's errorEnvelope can shape the wire", async () => {
+    const slackish = defineTwin({
+      ...toyTwin,
+      id: "slackish2",
+      errorEnvelope: (err) =>
+        err instanceof UnknownToolError
+          ? { status: 404, body: { ok: false, error: "unknown_tool" } }
+          : { status: 500, body: { message: "boom" } },
+    });
+    const app = createApp(slackish);
+    const res = await app.request(
+      `${base}/mcp/call`,
+      withAuth(token, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ tool: "definitely_not_a_tool", arguments: {} }),
+      })
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ ok: false, error: "unknown_tool" });
+  });
+});
+
+describe("per-twin unsupported envelope", () => {
+  it("uses the twin's 501 envelope for unknown session routes", async () => {
+    const slackish = defineTwin({
+      ...toyTwin,
+      id: "slackish3",
+      unsupported: () => ({
+        status: 501,
+        body: { ok: false, error: "unsupported_endpoint", _twin: { fidelity: "unsupported" } },
+      }),
+    });
+    const app = createApp(slackish);
+    const res = await app.request(`${base}/definitely/not/a/route`, withAuth(token));
+    expect(res.status).toBe(501);
+    const body = (await res.json()) as any;
+    expect(body.error).toBe("unsupported_endpoint");
+    expect(body._twin.fidelity).toBe("unsupported");
+  });
+
+  it("still records the unsupported hit as fidelity:unsupported", async () => {
+    const store = createRecorderStore();
+    const app = createApp(toyTwin, { recorder: store });
+    await app.request(`${base}/definitely/not/a/route`, withAuth(token));
+    const event = store.events().at(-1);
+    expect(event?.fidelity).toBe("unsupported");
+    expect(event?.status).toBe(501);
+  });
+});
+
+describe("state_delta plumbing", () => {
+  it("carries a route-supplied delta into the recorded event", async () => {
+    const store = createRecorderStore();
+    const twin = defineTwin({
+      ...toyTwin,
+      id: "delta",
+      routes: (app, { recorder }) => {
+        app.post(
+          "/mutate",
+          recorder.handle({ mutation: true }, () => ({
+            status: 200,
+            body: { ok: true },
+            delta: { before: null, after: { items: 1 } },
+          }))
+        );
+      },
+    });
+    const app = createApp(twin, { recorder: store });
+    await app.request(`${base}/mutate`, withAuth(token, { method: "POST" }));
+    const event = store.events().at(-1);
+    expect(event?.state_delta).toEqual({ before: null, after: { items: 1 } });
+  });
+});
+
+describe("serve() boot guard", () => {
+  it("refuses a non-loopback bind without TWIN_AUTH_SECRET, naming the variable", async () => {
+    const saved = process.env.TWIN_AUTH_SECRET;
+    delete process.env.TWIN_AUTH_SECRET;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      await expect(serve(toyTwin, { port: 0, hostname: "0.0.0.0" })).rejects.toThrow(
+        /TWIN_AUTH_SECRET/
+      );
+    } finally {
+      process.env.TWIN_AUTH_SECRET = saved;
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("boots on loopback without TWIN_AUTH_SECRET (dev flow)", async () => {
+    const saved = process.env.TWIN_AUTH_SECRET;
+    delete process.env.TWIN_AUTH_SECRET;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      const { close } = await serve(toyTwin, { port: 0, hostname: "127.0.0.1" });
+      await close();
+    } finally {
+      process.env.TWIN_AUTH_SECRET = saved;
+      warnSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
<!-- Closes F-681 -->

## What
Grows `@pome-sh/sdk` into the one twin engine per FDRS-681: centralized redaction (recorder emits + `/_pome/state` are engine-redacted), a SQLite driver wrapper (`openTwinDatabase` + pragmas + same-shape `transaction()` — the F-703 node:sqlite swap becomes a one-file change), the full FDRS-712 auth mechanism (`verifyProviderToken`/`mintProviderToken` + `defineTwin()` shape options), JSON-RPC `POST /s/:sid/mcp`, contract-shaped `/healthz` (implementation + runtime block), per-twin unsupported-envelope hook, `state_delta` plumbing, and the non-loopback boot guard. Proof-of-harness: the slack twin assembled via `defineTwin()` (`contract/proof/slack-sdk-server.mjs`) passes the identical frozen FDRS-711 contract assertions (`contract/sdk-boot.test.mjs`; suite body extracted verbatim to `contract/suite.mjs`).

## Why
FDRS-681 (Better Digital Twins → M1 twin-core): every twin re-rolls ~14 infra modules and they've drifted — auth.ts ×4 with all hashes different, slack's recorder shipped without redaction. Auth spec of record is the FDRS-712 [DECISION]; rows 4/5 (raw bearer, sid-mismatch status) are pinned per twin so the upcoming ports (F-682/683/684) stay zero-wire-diff under the FDRS-711 suite.

## Notes for reviewer
- **FDRS-712 appendix bug fixed in the engine**: provider-token parsing is right-anchored (sig = trailing 22 b64url chars, optional exp segment, HMAC disambiguates) instead of the broken `([^_]+)` sid regex; regression tests cover an underscore-bearing sid and the sid-ends-in-`_<digits>` ambiguity. Minting is byte-identical to the pre-F-681 twin/cloud construction (compat test included).
- Mirror files are untouched (deleted in F-685/F-713); all mirror/copy-marker gates stay green. The engine's `redaction.ts` carries no mirror markers on purpose.
- `better-sqlite3` enters the sdk as an **optional peer dep**, loaded lazily via `createRequire` — the npm-pack clean-room smoke should be unaffected.
- Engine default auth envelopes render an expired JWT as `Bad credentials` (matching the frozen github wire — the old explicit `Token expired` branch was dead code, per FDRS-712 row 6); slack's `token_expired` comes from its `unauthorized(kind)` hook.
- The proof entry consumes built dists from `contract/proof/` — no twin package.json changes, so the CLI vendor pipeline is untouched.
- Engine `_pome/health` adds unasserted fields (`version`, `fidelity`) vs slack's frozen `{ok, twin}`; the suite is the freeze arbiter and stays green. Flagging for awareness.

## Review required
Yes — touches auth (engine now owns the FDRS-712 canonical mechanism) and the twin runtime contract surface (suite refactored into `contract/suite.mjs`, assertions unchanged).

### Founder briefing (3 min)
- **What changed** — the sdk is now the single twin engine (auth/redaction/db/MCP/admin), proven by booting slack through `defineTwin()` against the frozen FDRS-711 contract suite.
- **What it means for your repo / workflow** — pome-cloud sees zero wire change (contract suite green before and after, assertions untouched); the three twin ports can now start and should delete their infra files instead of forking them.
- **The one thing you must know** — provider-token sid parsing had a latent bug in all three twins (base64url sids containing `_` could never authenticate); the engine fixes it while staying byte-compatible with every token minted by today's cloud/CLI code.