### PR TITLE
feat(cli): pome demo abandons orphaned sessions on trial error paths (F-710)

### DIFF
--- a/cli/.changeset/f-710-abandon-orphaned-demo-sessions.md
+++ b/cli/.changeset/f-710-abandon-orphaned-demo-sessions.md
@@ -1,0 +1,14 @@
+---
+"pome-sh": patch
+---
+
+`pome demo` now best-effort abandons a trial's session (`POST
+/v1/sessions/:id/abandon` with a machine `error_code`) on every client-side
+error path after the session was minted — agent timeout, non-zero agent exit,
+gateway/judge at-capacity, and machinery crashes — so the share view flips the
+slot to errored immediately instead of waiting out the staleness window
+(F-710 / F-664 decision 3). A capacity abort also abandons the
+minted-but-never-run remainder of the group. The abandon is silent and
+best-effort: a network failure or non-200 changes neither the exit code nor
+the terminal output, and a trial whose finalize succeeded is never abandoned.
+`pome run -n k` already carried these semantics since FDRS-636.

--- a/cli/src/demo/runDemo.ts
+++ b/cli/src/demo/runDemo.ts
@@ -12,7 +12,12 @@
 //      from that cloud evaluation. The CLI never scores locally.
 //   4. Errored trials are excluded from the verdict fraction; at-capacity
 //      402/429s render as honest labeled states (FDRS-662), never stack
-//      traces, never fabricated completions.
+//      traces, never fabricated completions. Any trial that errors after its
+//      session was minted best-effort ABANDONS that session with a machine
+//      error_code before the CLI exits (F-710 / F-664 decision 3), so the
+//      share view flips the slot to errored immediately instead of waiting
+//      out the staleness window; a capacity abort also abandons the
+//      minted-but-never-run remainder.
 //   5. Output ends with the no-login preview link
 //      {dashboard}/demo/<group_id>.
 
@@ -59,6 +64,7 @@ export type DemoTrialClient = Pick<
   | "requestStateUploadUrl"
   | "requestSignalsUploadUrl"
   | "finalize"
+  | "abandonSession"
 >;
 
 export interface RunDemoOptions {
@@ -161,8 +167,14 @@ export async function runDemo(options: RunDemoOptions): Promise<RunDemoResult> {
   for (let i = 0; i < trials; i += 1) {
     const session = sessions[i]!;
     const trialNumber = i + 1;
+    const client = trialClientFactory(session);
+    const progress = { finalized: false };
 
     let verdict: TrialVerdict;
+    // F-710 — the machine error_code the abandon carries when this trial's
+    // error also aborts the whole demo (capacity); the never-run remainder
+    // below reuses it so every orphaned slot names the same cause.
+    let abortCode: string | null = null;
     try {
       verdict = await runOneTrial({
         trialNumber,
@@ -172,16 +184,19 @@ export async function runDemo(options: RunDemoOptions): Promise<RunDemoResult> {
         artifactsDir,
         apiBase: options.apiBase,
         runScenarioFn,
-        client: trialClientFactory(session),
+        client,
         captureServerCommand: options.captureServerCommand,
         out,
         collectedFailures,
+        progress,
       });
     } catch (err) {
       if (err instanceof DemoCapacityError) {
+        abortCode = err.kind;
         capacityAbort = capacityLabel(err.kind);
         verdict = { kind: "errored", reason: "demo at capacity" };
       } else if (isJudgeCapQuota(err)) {
+        abortCode = "daily_judge_cap";
         capacityAbort = capacityLabel("daily_judge_cap");
         verdict = { kind: "errored", reason: "demo at capacity" };
       } else {
@@ -190,12 +205,31 @@ export async function runDemo(options: RunDemoOptions): Promise<RunDemoResult> {
           reason: shortReason(err instanceof Error ? err.message : String(err)),
         };
       }
+      // F-710 — flip the errored slot on the share view NOW instead of
+      // waiting out the staleness window (F-664 decision 3). Never after a
+      // successful finalize: a judged run row must not race an abandon.
+      if (!progress.finalized) {
+        await abandonQuietly(client, session.session_id, abortCode ?? "trial_crashed");
+      }
     }
 
     verdicts.push(verdict);
     out(trialLine(trialNumber, verdict));
 
-    if (capacityAbort) break;
+    if (capacityAbort) {
+      // F-710 — the abort orphans every minted-but-never-run session; abandon
+      // each with the same capacity code so the share view settles honestly
+      // instead of showing "running" ghosts for the staleness window.
+      for (let j = i + 1; j < trials; j += 1) {
+        const orphan = sessions[j]!;
+        await abandonQuietly(
+          trialClientFactory(orphan),
+          orphan.session_id,
+          abortCode ?? "unknown_capacity",
+        );
+      }
+      break;
+    }
   }
 
   if (capacityAbort) out(capacityAbort);
@@ -228,6 +262,9 @@ interface RunOneTrialInput {
   captureServerCommand?: RunScenarioOptions["captureServerCommand"];
   out: (line: string) => void;
   collectedFailures: string[];
+  /** F-710 — set once finalize succeeds, so the caller's error handling
+   *  never abandons a session that already has a judged run row. */
+  progress: { finalized: boolean };
 }
 
 async function runOneTrial(input: RunOneTrialInput): Promise<TrialVerdict> {
@@ -250,11 +287,15 @@ async function runOneTrial(input: RunOneTrialInput): Promise<TrialVerdict> {
   if (result.exitCode !== 0) {
     const capacityKind = parseCapacityMarker(result.agent.stderr);
     if (capacityKind) {
+      // The caller abandons this session (and the never-run remainder) with
+      // the capacity kind as it handles the abort.
       throw new DemoCapacityError(capacityKind, capacityLabel(capacityKind));
     }
     if (result.agent.timedOut) {
+      await abandonQuietly(input.client, input.session.session_id, "agent_timeout");
       return { kind: "errored", reason: "trial timed out" };
     }
+    await abandonQuietly(input.client, input.session.session_id, "agent_exit_nonzero");
     return {
       kind: "errored",
       reason: shortReason(lastLine(result.agent.stderr) ?? "agent failed"),
@@ -293,6 +334,7 @@ async function runOneTrial(input: RunOneTrialInput): Promise<TrialVerdict> {
     stateInitialStorageKey: uploaded.stateInitialKey ?? undefined,
     stateFinalStorageKey: uploaded.stateFinalKey ?? undefined,
   });
+  input.progress.finalized = true;
 
   const score = scoreFromFinalizeResponse(finalized);
   const status = scoreStatus(score, 100);
@@ -310,6 +352,23 @@ async function runOneTrial(input: RunOneTrialInput): Promise<TrialVerdict> {
   // Un-evaluated: the judge could not produce a verdict for this trace —
   // honest exclusion, not a fabricated word.
   return { kind: "errored", reason: "cloud could not evaluate the trace" };
+}
+
+/** F-710 — best-effort session abandon on a trial error path: flips the
+ *  share-view slot to errored with a machine error_code immediately (F-664
+ *  decision 3). SILENT by contract — a network failure or non-200 must change
+ *  neither the CLI's exit code nor its terminal output; server-side staleness
+ *  (F-664 decision 1) remains the fallback. */
+async function abandonQuietly(
+  client: DemoTrialClient,
+  sessionId: string,
+  errorCode: string,
+): Promise<void> {
+  try {
+    await client.abandonSession(sessionId, { errorCode });
+  } catch {
+    // swallowed — the read-path staleness demotion covers this session
+  }
 }
 
 function isJudgeCapQuota(err: unknown): boolean {

--- a/cli/test/unit/demo/runDemo.test.ts
+++ b/cli/test/unit/demo/runDemo.test.ts
@@ -94,6 +94,8 @@ function criterion(text: string, outcome: "passed" | "failed") {
 function fakeClient(
   finalizeFor: (sessionId: string) => FinalizeResponse | Error,
   finalizeCalls: Array<{ sessionId: string; input: unknown }>,
+  abandonCalls: Array<{ sessionId: string; errorCode?: string }> = [],
+  abandonError?: Error,
 ): (session: DemoSession) => DemoTrialClient {
   return (session) => ({
     requestEventsUploadUrl: vi.fn(async (sessionId: string) => {
@@ -111,6 +113,18 @@ function fakeClient(
       if (out instanceof Error) throw out;
       return out;
     }),
+    abandonSession: vi.fn(
+      async (sessionId: string, input?: { errorCode?: string }) => {
+        abandonCalls.push({ sessionId, errorCode: input?.errorCode });
+        if (abandonError) throw abandonError;
+        return {
+          session_id: sessionId,
+          state: "failed",
+          error_code: input?.errorCode ?? null,
+          abandoned: true,
+        };
+      },
+    ),
   });
 }
 
@@ -307,6 +321,228 @@ describe("runDemo (FDRS-643)", () => {
     expect(result.exitCode).toBe(4);
     const text = out.join("\n");
     expect(text).toContain("daily model budget is exhausted — try again tomorrow");
+  });
+
+  it("abandons the errored trial AND the never-run remainder when the gateway reports capacity mid-run (F-710)", async () => {
+    const out: string[] = [];
+    const abandonCalls: Array<{ sessionId: string; errorCode?: string }> = [];
+    const result = await runDemo({
+      apiBase: "https://api.example.com",
+      dashboardBase: "https://app.pome.sh",
+      trials: 3,
+      out: (line) => out.push(line),
+      agentCommand: "unused-in-test",
+      runScenarioFn: fakeRunScenario(
+        [
+          {
+            exitCode: 3,
+            stderr: "POME_DEMO_CAPACITY:daily_model_cap\nbudget exhausted\n",
+          },
+        ],
+        [],
+      ),
+      mintFn: (async (opts: { count: number }) => sessionsFixture(opts.count)) as never,
+      trialClientFactory: fakeClient(() => new Error("unreachable"), [], abandonCalls),
+      skipTwinWarmup: true,
+    });
+
+    // The erroring trial's slot flips to errored immediately, and the minted
+    // sessions the abort orphaned flip too — no 15-min dishonesty window.
+    expect(abandonCalls).toEqual([
+      { sessionId: "ses_1", errorCode: "daily_model_cap" },
+      { sessionId: "ses_2", errorCode: "daily_model_cap" },
+      { sessionId: "ses_3", errorCode: "daily_model_cap" },
+    ]);
+    expect(result.exitCode).toBe(4);
+  });
+
+  it("abandons with daily_judge_cap when finalize hits the judge cap; the finalized trial is never abandoned (F-710)", async () => {
+    const abandonCalls: Array<{ sessionId: string; errorCode?: string }> = [];
+    const result = await runDemo({
+      apiBase: "https://api.example.com",
+      dashboardBase: "https://app.pome.sh",
+      trials: 3,
+      out: () => undefined,
+      agentCommand: "unused-in-test",
+      runScenarioFn: fakeRunScenario([{ exitCode: 0 }], []),
+      mintFn: (async (opts: { count: number }) => sessionsFixture(opts.count)) as never,
+      trialClientFactory: fakeClient(
+        (sessionId) => {
+          if (sessionId === "ses_1") return finalizeResponse(100, passedResult());
+          return new HostedQuotaError("judge cap", "req_1", {
+            kind: "daily_judge_cap",
+          });
+        },
+        [],
+        abandonCalls,
+      ),
+      skipTwinWarmup: true,
+    });
+
+    expect(abandonCalls).toEqual([
+      { sessionId: "ses_2", errorCode: "daily_judge_cap" },
+      { sessionId: "ses_3", errorCode: "daily_judge_cap" },
+    ]);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("abandons a timed-out trial with agent_timeout and a failed agent with agent_exit_nonzero (F-710)", async () => {
+    const abandonCalls: Array<{ sessionId: string; errorCode?: string }> = [];
+    const result = await runDemo({
+      apiBase: "https://api.example.com",
+      dashboardBase: "https://app.pome.sh",
+      trials: 3,
+      out: () => undefined,
+      agentCommand: "unused-in-test",
+      runScenarioFn: fakeRunScenario(
+        [
+          { exitCode: 0 },
+          { exitCode: 3, timedOut: true },
+          { exitCode: 1, stderr: "boom\n" },
+        ],
+        [],
+      ),
+      mintFn: (async (opts: { count: number }) => sessionsFixture(opts.count)) as never,
+      trialClientFactory: fakeClient(
+        () => finalizeResponse(100, passedResult()),
+        [],
+        abandonCalls,
+      ),
+      skipTwinWarmup: true,
+    });
+
+    expect(abandonCalls).toEqual([
+      { sessionId: "ses_2", errorCode: "agent_timeout" },
+      { sessionId: "ses_3", errorCode: "agent_exit_nonzero" },
+    ]);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("abandons with trial_crashed when upload/finalize machinery throws a non-capacity error (F-710)", async () => {
+    const abandonCalls: Array<{ sessionId: string; errorCode?: string }> = [];
+    const result = await runDemo({
+      apiBase: "https://api.example.com",
+      dashboardBase: "https://app.pome.sh",
+      trials: 2,
+      out: () => undefined,
+      agentCommand: "unused-in-test",
+      runScenarioFn: fakeRunScenario([{ exitCode: 0 }], []),
+      mintFn: (async (opts: { count: number }) => sessionsFixture(opts.count)) as never,
+      trialClientFactory: fakeClient(
+        (sessionId) =>
+          sessionId === "ses_1"
+            ? new Error("storage exploded")
+            : finalizeResponse(100, passedResult()),
+        [],
+        abandonCalls,
+      ),
+      skipTwinWarmup: true,
+    });
+
+    // Non-capacity crash abandons that trial only; the demo continues.
+    expect(abandonCalls).toEqual([
+      { sessionId: "ses_1", errorCode: "trial_crashed" },
+    ]);
+    expect(result.verdicts).toHaveLength(2);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("never abandons a trial whose finalize succeeded, even when the cloud could not evaluate it (F-710)", async () => {
+    const abandonCalls: Array<{ sessionId: string; errorCode?: string }> = [];
+    const result = await runDemo({
+      apiBase: "https://api.example.com",
+      dashboardBase: "https://app.pome.sh",
+      trials: 1,
+      out: () => undefined,
+      agentCommand: "unused-in-test",
+      runScenarioFn: fakeRunScenario([{ exitCode: 0 }], []),
+      mintFn: (async (opts: { count: number }) => sessionsFixture(opts.count)) as never,
+      // criteria_results: [] → unevaluated → errored verdict, but the run
+      // row exists (finalize 200) — abandon must NOT fire.
+      trialClientFactory: fakeClient(
+        () => finalizeResponse(0, []),
+        [],
+        abandonCalls,
+      ),
+      skipTwinWarmup: true,
+    });
+
+    expect(result.verdicts[0]).toMatchObject({ kind: "errored" });
+    expect(abandonCalls).toEqual([]);
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("never abandons when the crash happens AFTER finalize succeeded (F-710)", async () => {
+    const abandonCalls: Array<{ sessionId: string; errorCode?: string }> = [];
+    const result = await runDemo({
+      apiBase: "https://api.example.com",
+      dashboardBase: "https://app.pome.sh",
+      trials: 1,
+      out: () => undefined,
+      agentCommand: "unused-in-test",
+      runScenarioFn: fakeRunScenario([{ exitCode: 0 }], []),
+      mintFn: (async (opts: { count: number }) => sessionsFixture(opts.count)) as never,
+      // Finalize resolves (the run row exists) but the response is corrupt,
+      // so verdict synthesis throws afterwards — post-finalize crashes must
+      // render an errored trial WITHOUT racing an abandon against the row.
+      trialClientFactory: fakeClient(
+        () =>
+          ({
+            ...finalizeResponse(100, passedResult()),
+            criteria_results: "corrupt",
+          }) as never,
+        [],
+        abandonCalls,
+      ),
+      skipTwinWarmup: true,
+    });
+
+    expect(result.verdicts[0]).toMatchObject({ kind: "errored" });
+    expect(abandonCalls).toEqual([]);
+  });
+
+  it("abandon is best-effort: a failing abandon changes neither exit code nor terminal output (F-710)", async () => {
+    const outWithFailingAbandon: string[] = [];
+    const outBaseline: string[] = [];
+    const runOnce = (
+      out: string[],
+      abandonError?: Error,
+    ): ReturnType<typeof runDemo> =>
+      runDemo({
+        apiBase: "https://api.example.com",
+        dashboardBase: "https://app.pome.sh",
+        trials: 2,
+        out: (line) => out.push(line),
+        agentCommand: "unused-in-test",
+        runScenarioFn: fakeRunScenario(
+          [{ exitCode: 0 }, { exitCode: 3, timedOut: true }],
+          [],
+        ),
+        mintFn: (async (opts: { count: number }) => sessionsFixture(opts.count)) as never,
+        trialClientFactory: fakeClient(
+          () => finalizeResponse(100, passedResult()),
+          [],
+          [],
+          abandonError,
+        ),
+        skipTwinWarmup: true,
+      });
+
+    const failing = await runOnce(
+      outWithFailingAbandon,
+      new Error("network down"),
+    );
+    const baseline = await runOnce(outBaseline);
+
+    // The group id and wall-clock durations differ per invocation;
+    // everything else must be identical.
+    const normalize = (lines: string[]): string[] =>
+      lines.map((line) =>
+        line.replace(/grp_[\w-]+/g, "grp_X").replace(/\d+\.\ds/g, "Ts"),
+      );
+    expect(failing.exitCode).toBe(baseline.exitCode);
+    expect(normalize(outWithFailingAbandon)).toEqual(normalize(outBaseline));
+    expect(outWithFailingAbandon.join("\n")).not.toMatch(/abandon/i);
   });
 
   it("boots the packaged demo task's twin for the warm-up line (real seed parse)", async () => {


### PR DESCRIPTION
<!-- Closes F-710 -->

## What

`pome demo` now best-effort calls `POST /v1/sessions/:id/abandon` with a short machine `error_code` on every client-side trial error path after the session was minted — agent timeout (`agent_timeout`), non-zero agent exit (`agent_exit_nonzero`), upload/finalize machinery crashes (`trial_crashed`), and gateway/judge at-capacity stops (the capacity kind, e.g. `daily_model_cap` / `daily_judge_cap`). A capacity abort also abandons the minted-but-never-run remainder of the group with the same code, so the share view settles honestly instead of showing "running" ghosts for the staleness window.

## Why

F-710, spawned from the F-664 [DECISION] (decision 3): a capacity-errored demo trial left its session open, so the share view showed "running / scoring in progress" for the ~15–20 min staleness window at exactly the moment the sharer opens the link. Abandon closes that window to ~0 for graceful failures; server-side staleness (F-664 decision 1, pome-cloud #220) remains the fallback for crash / kill / offline. `pome run -n k` already carried these semantics since FDRS-636 — this PR brings `pome demo` to parity.

## Notes for reviewer

- Abandon is silent by contract: a network failure or non-200 changes neither the exit code nor a single line of terminal output (asserted by a baseline-comparison test). Server-side staleness covers the miss.
- A trial whose finalize succeeded is never abandoned — including the "cloud could not evaluate the trace" errored verdict and a post-finalize crash (guarded by a `progress.finalized` flag; the guard is pinned by a test that fails if removed).
- Abandoning the never-run remainder on a capacity abort goes slightly beyond the ticket's literal Done-when; the interpretation and alternatives are recorded as a [DECISION] on F-710.
- `cli/` only; cloud side is zero work (`routes/abandon.ts` exists since F-636 and accepts the session-scoped demo token).