### PR TITLE
feat(cli): linearize JWT/PEM redaction scrubs — CodeQL polynomial-redos clean (FDRS-716)

### DIFF
--- a/cli/.changeset/f716-linearize-redaction-scrub.md
+++ b/cli/.changeset/f716-linearize-redaction-scrub.md
@@ -1,0 +1,14 @@
+---
+"pome-sh": patch
+---
+
+The JWT and PEM-block redaction scrubs are rewritten as linear-time scanners
+(F-716), resolving the CodeQL `js/polynomial-redos` alerts surfaced on the
+F-681 engine extraction. Redaction output is byte-identical — boundary
+behavior (JWTs glued mid-base64url-run, `.eyJ` prefixes, nested/incomplete
+PEM blocks) is pinned by regression tests that pass against both the old and
+new implementations, plus a seeded differential fuzz against the legacy
+patterns. The redactor stays a byte-identical mirror across
+`cli/src/recorder/redaction.ts`, `packages/adapter-claude-sdk`,
+`packages/twin-github`, `packages/twin-slack`, and `packages/twin-stripe`,
+with the same fix applied to the engine copy in `packages/sdk`.

--- a/cli/src/recorder/redaction.ts
+++ b/cli/src/recorder/redaction.ts
@@ -39,6 +39,116 @@ const HARD_REDACT_KEYS = new Set([
   "anthropic_api_key",
 ]);
 
+// F-716: the JWT and PEM-block scrubs used to be the regexes
+// `eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*` and
+// `-----BEGIN [A-Z ]+-----[\s\S]*?-----END [A-Z ]+-----`, which CodeQL flags
+// as polynomial ReDoS: a failed attempt rescans the same text for every
+// candidate start inside it (e.g. a long dotless "eyJeyJeyJ…" run). The two
+// scanners below produce byte-identical output in linear time. Equivalence
+// hinges on `.` and `-` being outside the quantified classes, so the old
+// greedy runs could never benefit from backtracking: a match is always
+// maximal-run + required-literal, which is exactly what the scanners test.
+
+function base64UrlRunEnd(value: string, from: number): number {
+  let i = from;
+  while (i < value.length) {
+    const code = value.charCodeAt(i);
+    const isBase64Url =
+      (code >= 48 && code <= 57) || // 0-9
+      (code >= 65 && code <= 90) || // A-Z
+      (code >= 97 && code <= 122) || // a-z
+      code === 45 || // -
+      code === 95; // _
+    if (!isBase64Url) break;
+    i += 1;
+  }
+  return i;
+}
+
+// Replaces every `eyJ<run>.<run>.<run?>` (runs are maximal base64url runs,
+// the first two non-empty) with [REDACTED]. On failure the search resumes at
+// the end of the runs already scanned: every other `eyJ` inside a scanned
+// run shares that run's end, so it provably fails the same check.
+function scrubJwts(value: string): string {
+  let out = "";
+  let copied = 0; // everything before this index is already in `out`
+  let search = 0;
+  while (true) {
+    const start = value.indexOf("eyJ", search);
+    if (start === -1) break;
+    const header = base64UrlRunEnd(value, start + 3);
+    if (header === start + 3) {
+      search = start + 1;
+      continue;
+    }
+    if (value.charCodeAt(header) !== 46 /* . */) {
+      search = header;
+      continue;
+    }
+    const payload = base64UrlRunEnd(value, header + 1);
+    if (payload === header + 1 || value.charCodeAt(payload) !== 46 /* . */) {
+      search = header;
+      continue;
+    }
+    const end = base64UrlRunEnd(value, payload + 1);
+    out += value.slice(copied, start) + REDACTED;
+    copied = end;
+    search = end;
+  }
+  return copied === 0 ? value : out + value.slice(copied);
+}
+
+// Matches `-----BEGIN <label>-----` / `-----END <label>-----` at `at`, where
+// <label> is a maximal non-empty [A-Z ] run followed by five dashes. Returns
+// the index just past the closing dashes, or -1.
+function pemHeaderEnd(value: string, at: number, keyword: string): number {
+  const labelStart = at + keyword.length;
+  let labelEnd = labelStart;
+  while (labelEnd < value.length) {
+    const code = value.charCodeAt(labelEnd);
+    if (!((code >= 65 && code <= 90) || code === 32)) break; // A-Z or space
+    labelEnd += 1;
+  }
+  if (labelEnd === labelStart) return -1;
+  if (!value.startsWith("-----", labelEnd)) return -1;
+  return labelEnd + 5;
+}
+
+// Replaces every `-----BEGIN <label>-----…-----END <label>-----` block (lazy
+// body: the earliest valid END wins) with [REDACTED]. If no valid END exists
+// after a header, no later header can complete a block either (its END
+// search space is a subset), so the scan stops instead of re-walking the
+// tail once per dangling header. Dangling headers are still caught by the
+// bare `-----BEGIN [A-Z ]+-----` pattern that runs after this scanner.
+function scrubPemBlocks(value: string): string {
+  let out = "";
+  let copied = 0;
+  let search = 0;
+  while (true) {
+    const begin = value.indexOf("-----BEGIN ", search);
+    if (begin === -1) break;
+    const bodyStart = pemHeaderEnd(value, begin, "-----BEGIN ");
+    if (bodyStart === -1) {
+      search = begin + 1;
+      continue;
+    }
+    let endSearch = bodyStart;
+    let blockEnd = -1;
+    while (true) {
+      const end = value.indexOf("-----END ", endSearch);
+      if (end === -1) break;
+      blockEnd = pemHeaderEnd(value, end, "-----END ");
+      if (blockEnd !== -1) break;
+      endSearch = end + 1;
+    }
+    if (blockEnd === -1) break;
+    out += value.slice(copied, begin) + REDACTED;
+    copied = blockEnd;
+    search = blockEnd;
+  }
+  return copied === 0 ? value : out + value.slice(copied);
+}
+
 // `sk-...` covers OpenAI + Anthropic (`sk-ant-...`) + variants like `sk-proj-`.
 // The leading boundary avoids mangling benign kebab-case words ending in "sk".
 // `(s|r)k_(test|live)_...` covers Stripe secret/restricted keys (FDRS-588) —
@@ -46,7 +156,10 @@ const HARD_REDACT_KEYS = new Set([
 // `sk_test_pome_a` are only a few chars past the prefix.
 // `xapp-...` is a Slack app-level token; `AIza...` is a Google API key
 // (FDRS-608). `g` flag matters: a single string may contain multiple secrets.
-const SCRUB_PATTERNS: RegExp[] = [
+// Steps run in order; the two function steps are the F-716 linear scanners
+// and must keep their slots (JWT and PEM-block scrub before the bare PEM
+// header scrub).
+const SCRUB_STEPS: ReadonlyArray<RegExp | ((value: string) => string)> = [
   /redaction_fixture_secret_[A-Za-z0-9_-]{8,}/g,
   /\bsk-[A-Za-z0-9_-]{20,}/g,
   /\b[rs]k_(?:test|live)_[A-Za-z0-9_]{4,}/g,
@@ -57,15 +170,15 @@ const SCRUB_PATTERNS: RegExp[] = [
   /(?:pme|pk|rk)_[A-Za-z0-9_-]{20,}/g,
   /AIza[0-9A-Za-z_-]{20,}/g,
   /AKIA[0-9A-Z]{16}/g,
-  /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*/g,
-  /-----BEGIN [A-Z ]+-----[\s\S]*?-----END [A-Z ]+-----/g,
+  scrubJwts,
+  scrubPemBlocks,
   /-----BEGIN [A-Z ]+-----/g,
 ];
 
 function scrubString(value: string): string {
   let out = value;
-  for (const pattern of SCRUB_PATTERNS) {
-    out = out.replace(pattern, REDACTED);
+  for (const step of SCRUB_STEPS) {
+    out = typeof step === "function" ? step(out) : out.replace(step, REDACTED);
   }
   return out;
 }

--- a/cli/test/unit/recorder/redaction.test.ts
+++ b/cli/test/unit/recorder/redaction.test.ts
@@ -154,6 +154,171 @@ describe("redactEvent — provider secret shapes (FDRS-588 / FDRS-608)", () => {
   });
 });
 
+// F-716 boundary pinning. These tests freeze the exact JWT / PEM scrub
+// behavior of the pre-F-716 backtracking regexes: they were run green against
+// the old patterns before the linear-time rewrite landed, and must stay green
+// after. Any diff here is a redaction behavior change, not a refactor.
+describe("redactEvent — F-716 JWT scrub boundary pinning", () => {
+  it("redacts a JWT glued mid-base64url-run from the eyJ onward", () => {
+    expect(redactEvent({ v: "AAAAeyJab.cd.ef" })).toEqual({ v: "AAAA[REDACTED]" });
+  });
+
+  it("redacts a dot-prefixed JWT, leaving the leading dot", () => {
+    expect(redactEvent({ v: ".eyJab.cd.ef" })).toEqual({ v: ".[REDACTED]" });
+  });
+
+  it("consumes an embedded eyJ inside the header segment", () => {
+    expect(redactEvent({ v: "eyJa.eyJb.c" })).toEqual({ v: "[REDACTED]" });
+  });
+
+  it("does not fire when the header segment is empty", () => {
+    expect(redactEvent({ v: "eyJ..x" })).toEqual({ v: "eyJ..x" });
+    expect(redactEvent({ v: "eyJ.a.b" })).toEqual({ v: "eyJ.a.b" });
+  });
+
+  it("does not fire on two-segment shapes", () => {
+    expect(redactEvent({ v: "eyJab.cd" })).toEqual({ v: "eyJab.cd" });
+  });
+
+  it("consumes the trailing dot when the signature segment is empty", () => {
+    expect(redactEvent({ v: "eyJa.b." })).toEqual({ v: "[REDACTED]" });
+  });
+
+  it("stops the signature segment at the first non-base64url char", () => {
+    expect(redactEvent({ v: "eyJa.b.c.d" })).toEqual({ v: "[REDACTED].d" });
+    expect(redactEvent({ v: "eyJa.b.ceyJ" })).toEqual({ v: "[REDACTED]" });
+  });
+
+  it("redacts multiple JWTs in one string", () => {
+    expect(redactEvent({ v: "eyJa.b.c and eyJd.e.f" })).toEqual({
+      v: "[REDACTED] and [REDACTED]",
+    });
+  });
+});
+
+describe("redactEvent — F-716 PEM scrub boundary pinning", () => {
+  it("redacts a complete block as one unit", () => {
+    expect(
+      redactEvent({ v: "-----BEGIN PRIVATE KEY-----\nMIIB\n-----END PRIVATE KEY-----" }),
+    ).toEqual({ v: "[REDACTED]" });
+  });
+
+  it("redacts only the header of an unterminated block", () => {
+    expect(redactEvent({ v: "-----BEGIN RSA PRIVATE KEY-----\nMIIB" })).toEqual({
+      v: "[REDACTED]\nMIIB",
+    });
+  });
+
+  it("redacts a nested block through the first valid END", () => {
+    expect(
+      redactEvent({ v: "-----BEGIN A-----\nx-----BEGIN B-----\ny\n-----END B-----\ntail" }),
+    ).toEqual({ v: "[REDACTED]\ntail" });
+  });
+
+  it("leaves an END without a BEGIN untouched", () => {
+    expect(redactEvent({ v: "data -----END A----- data" })).toEqual({
+      v: "data -----END A----- data",
+    });
+  });
+
+  it("ignores an END with an empty label, then redacts the dangling header", () => {
+    expect(redactEvent({ v: "-----BEGIN A-----x-----END -----" })).toEqual({
+      v: "[REDACTED]x-----END -----",
+    });
+  });
+
+  it("consumes exactly five closing dashes", () => {
+    expect(redactEvent({ v: "-----BEGIN A-----x-----END A------" })).toEqual({
+      v: "[REDACTED]-",
+    });
+  });
+
+  it("redacts a glued header whose closing dashes open the next header", () => {
+    expect(redactEvent({ v: "-----BEGIN A-----BEGIN B-----" })).toEqual({
+      v: "[REDACTED]BEGIN B-----",
+    });
+  });
+
+  it("redacts two complete blocks separately", () => {
+    expect(
+      redactEvent({
+        v: "-----BEGIN A-----x-----END A----- mid -----BEGIN B-----y-----END B-----",
+      }),
+    ).toEqual({ v: "[REDACTED] mid [REDACTED]" });
+  });
+
+  it("redacts a space-only label header", () => {
+    expect(redactEvent({ v: "-----BEGIN  -----" })).toEqual({ v: "[REDACTED]" });
+  });
+
+  it("redacts a whole block whose body contains a JWT", () => {
+    expect(redactEvent({ v: "-----BEGIN K-----\neyJa.b.c\n-----END K-----" })).toEqual({
+      v: "[REDACTED]",
+    });
+  });
+});
+
+describe("redactEvent — F-716 differential fuzz vs the legacy patterns", () => {
+  // The exact pre-F-716 scrub pipeline, kept verbatim as the behavior oracle.
+  // Only run on short fuzz strings, where its quadratic worst case is harmless.
+  const LEGACY_SCRUB_PATTERNS: RegExp[] = [
+    /redaction_fixture_secret_[A-Za-z0-9_-]{8,}/g,
+    /\bsk-[A-Za-z0-9_-]{20,}/g,
+    /\b[rs]k_(?:test|live)_[A-Za-z0-9_]{4,}/g,
+    /ghp_[A-Za-z0-9]{36}/g,
+    /github_pat_[A-Za-z0-9_]{20,}/g,
+    /xox[aboprs]-[A-Za-z0-9-]{20,}/g,
+    /xapp-[A-Za-z0-9-]{10,}/g,
+    /(?:pme|pk|rk)_[A-Za-z0-9_-]{20,}/g,
+    /AIza[0-9A-Za-z_-]{20,}/g,
+    /AKIA[0-9A-Z]{16}/g,
+    /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*/g,
+    /-----BEGIN [A-Z ]+-----[\s\S]*?-----END [A-Z ]+-----/g,
+    /-----BEGIN [A-Z ]+-----/g,
+  ];
+
+  function legacyScrub(value: string): string {
+    let out = value;
+    for (const pattern of LEGACY_SCRUB_PATTERNS) {
+      out = out.replace(pattern, "[REDACTED]");
+    }
+    return out;
+  }
+
+  const PIECES = [
+    "eyJ",
+    ".",
+    "a",
+    "B9",
+    "_",
+    "-",
+    " ",
+    "\n",
+    "-----BEGIN ",
+    "-----END ",
+    "-----",
+    "AB C",
+    "!",
+    "ey",
+    "J",
+  ];
+
+  it("matches the legacy scrub on 2000 seeded fuzz strings", () => {
+    let seed = 0xf716;
+    const next = () => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      return seed;
+    };
+    for (let round = 0; round < 2000; round += 1) {
+      const parts: string[] = [];
+      const length = next() % 24;
+      for (let p = 0; p < length; p += 1) parts.push(PIECES[next() % PIECES.length]!);
+      const input = parts.join("");
+      expect(redactEvent({ v: input })).toEqual({ v: legacyScrub(input) });
+    }
+  });
+});
+
 describe("redactEvent — benign content untouched", () => {
   it("leaves plain strings alone", () => {
     expect(redactEvent({ msg: "hello world" })).toEqual({ msg: "hello world" });

--- a/cli/test/unit/recorder/redaction.test.ts
+++ b/cli/test/unit/recorder/redaction.test.ts
@@ -319,6 +319,25 @@ describe("redactEvent — F-716 differential fuzz vs the legacy patterns", () =>
   });
 });
 
+describe("redactEvent — F-716 adversarial inputs stay linear", () => {
+  // Both inputs drive the pre-F-716 regexes into quadratic backtracking
+  // (minutes of CPU); the linear scanners handle them in milliseconds. The
+  // 1s bound leaves two orders of magnitude of CI headroom.
+  it("survives a 150 KB dotless eyJ run", () => {
+    const input = "eyJ".repeat(50_000);
+    const started = performance.now();
+    expect(redactEvent({ v: input })).toEqual({ v: input });
+    expect(performance.now() - started).toBeLessThan(1_000);
+  });
+
+  it("survives 20k unterminated PEM headers", () => {
+    const input = "-----BEGIN AAAA-----\n".repeat(20_000);
+    const started = performance.now();
+    expect(redactEvent({ v: input })).toEqual({ v: "[REDACTED]\n".repeat(20_000) });
+    expect(performance.now() - started).toBeLessThan(1_000);
+  });
+});
+
 describe("redactEvent — benign content untouched", () => {
   it("leaves plain strings alone", () => {
     expect(redactEvent({ msg: "hello world" })).toEqual({ msg: "hello world" });

--- a/packages/adapter-claude-sdk/src/redaction.ts
+++ b/packages/adapter-claude-sdk/src/redaction.ts
@@ -39,6 +39,116 @@ const HARD_REDACT_KEYS = new Set([
   "anthropic_api_key",
 ]);
 
+// F-716: the JWT and PEM-block scrubs used to be the regexes
+// `eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*` and
+// `-----BEGIN [A-Z ]+-----[\s\S]*?-----END [A-Z ]+-----`, which CodeQL flags
+// as polynomial ReDoS: a failed attempt rescans the same text for every
+// candidate start inside it (e.g. a long dotless "eyJeyJeyJ…" run). The two
+// scanners below produce byte-identical output in linear time. Equivalence
+// hinges on `.` and `-` being outside the quantified classes, so the old
+// greedy runs could never benefit from backtracking: a match is always
+// maximal-run + required-literal, which is exactly what the scanners test.
+
+function base64UrlRunEnd(value: string, from: number): number {
+  let i = from;
+  while (i < value.length) {
+    const code = value.charCodeAt(i);
+    const isBase64Url =
+      (code >= 48 && code <= 57) || // 0-9
+      (code >= 65 && code <= 90) || // A-Z
+      (code >= 97 && code <= 122) || // a-z
+      code === 45 || // -
+      code === 95; // _
+    if (!isBase64Url) break;
+    i += 1;
+  }
+  return i;
+}
+
+// Replaces every `eyJ<run>.<run>.<run?>` (runs are maximal base64url runs,
+// the first two non-empty) with [REDACTED]. On failure the search resumes at
+// the end of the runs already scanned: every other `eyJ` inside a scanned
+// run shares that run's end, so it provably fails the same check.
+function scrubJwts(value: string): string {
+  let out = "";
+  let copied = 0; // everything before this index is already in `out`
+  let search = 0;
+  while (true) {
+    const start = value.indexOf("eyJ", search);
+    if (start === -1) break;
+    const header = base64UrlRunEnd(value, start + 3);
+    if (header === start + 3) {
+      search = start + 1;
+      continue;
+    }
+    if (value.charCodeAt(header) !== 46 /* . */) {
+      search = header;
+      continue;
+    }
+    const payload = base64UrlRunEnd(value, header + 1);
+    if (payload === header + 1 || value.charCodeAt(payload) !== 46 /* . */) {
+      search = header;
+      continue;
+    }
+    const end = base64UrlRunEnd(value, payload + 1);
+    out += value.slice(copied, start) + REDACTED;
+    copied = end;
+    search = end;
+  }
+  return copied === 0 ? value : out + value.slice(copied);
+}
+
+// Matches `-----BEGIN <label>-----` / `-----END <label>-----` at `at`, where
+// <label> is a maximal non-empty [A-Z ] run followed by five dashes. Returns
+// the index just past the closing dashes, or -1.
+function pemHeaderEnd(value: string, at: number, keyword: string): number {
+  const labelStart = at + keyword.length;
+  let labelEnd = labelStart;
+  while (labelEnd < value.length) {
+    const code = value.charCodeAt(labelEnd);
+    if (!((code >= 65 && code <= 90) || code === 32)) break; // A-Z or space
+    labelEnd += 1;
+  }
+  if (labelEnd === labelStart) return -1;
+  if (!value.startsWith("-----", labelEnd)) return -1;
+  return labelEnd + 5;
+}
+
+// Replaces every `-----BEGIN <label>-----…-----END <label>-----` block (lazy
+// body: the earliest valid END wins) with [REDACTED]. If no valid END exists
+// after a header, no later header can complete a block either (its END
+// search space is a subset), so the scan stops instead of re-walking the
+// tail once per dangling header. Dangling headers are still caught by the
+// bare `-----BEGIN [A-Z ]+-----` pattern that runs after this scanner.
+function scrubPemBlocks(value: string): string {
+  let out = "";
+  let copied = 0;
+  let search = 0;
+  while (true) {
+    const begin = value.indexOf("-----BEGIN ", search);
+    if (begin === -1) break;
+    const bodyStart = pemHeaderEnd(value, begin, "-----BEGIN ");
+    if (bodyStart === -1) {
+      search = begin + 1;
+      continue;
+    }
+    let endSearch = bodyStart;
+    let blockEnd = -1;
+    while (true) {
+      const end = value.indexOf("-----END ", endSearch);
+      if (end === -1) break;
+      blockEnd = pemHeaderEnd(value, end, "-----END ");
+      if (blockEnd !== -1) break;
+      endSearch = end + 1;
+    }
+    if (blockEnd === -1) break;
+    out += value.slice(copied, begin) + REDACTED;
+    copied = blockEnd;
+    search = blockEnd;
+  }
+  return copied === 0 ? value : out + value.slice(copied);
+}
+
 // `sk-...` covers OpenAI + Anthropic (`sk-ant-...`) + variants like `sk-proj-`.
 // The leading boundary avoids mangling benign kebab-case words ending in "sk".
 // `(s|r)k_(test|live)_...` covers Stripe secret/restricted keys (FDRS-588) —
@@ -46,7 +156,10 @@ const HARD_REDACT_KEYS = new Set([
 // `sk_test_pome_a` are only a few chars past the prefix.
 // `xapp-...` is a Slack app-level token; `AIza...` is a Google API key
 // (FDRS-608). `g` flag matters: a single string may contain multiple secrets.
-const SCRUB_PATTERNS: RegExp[] = [
+// Steps run in order; the two function steps are the F-716 linear scanners
+// and must keep their slots (JWT and PEM-block scrub before the bare PEM
+// header scrub).
+const SCRUB_STEPS: ReadonlyArray<RegExp | ((value: string) => string)> = [
   /redaction_fixture_secret_[A-Za-z0-9_-]{8,}/g,
   /\bsk-[A-Za-z0-9_-]{20,}/g,
   /\b[rs]k_(?:test|live)_[A-Za-z0-9_]{4,}/g,
@@ -57,15 +170,15 @@ const SCRUB_PATTERNS: RegExp[] = [
   /(?:pme|pk|rk)_[A-Za-z0-9_-]{20,}/g,
   /AIza[0-9A-Za-z_-]{20,}/g,
   /AKIA[0-9A-Z]{16}/g,
-  /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*/g,
-  /-----BEGIN [A-Z ]+-----[\s\S]*?-----END [A-Z ]+-----/g,
+  scrubJwts,
+  scrubPemBlocks,
   /-----BEGIN [A-Z ]+-----/g,
 ];
 
 function scrubString(value: string): string {
   let out = value;
-  for (const pattern of SCRUB_PATTERNS) {
-    out = out.replace(pattern, REDACTED);
+  for (const step of SCRUB_STEPS) {
+    out = typeof step === "function" ? step(out) : out.replace(step, REDACTED);
   }
   return out;
 }

--- a/packages/sdk/src/redaction.ts
+++ b/packages/sdk/src/redaction.ts
@@ -34,6 +34,116 @@ const HARD_REDACT_KEYS = new Set([
   "anthropic_api_key",
 ]);
 
+// F-716: the JWT and PEM-block scrubs used to be the regexes
+// `eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*` and
+// `-----BEGIN [A-Z ]+-----[\s\S]*?-----END [A-Z ]+-----`, which CodeQL flags
+// as polynomial ReDoS: a failed attempt rescans the same text for every
+// candidate start inside it (e.g. a long dotless "eyJeyJeyJ…" run). The two
+// scanners below produce byte-identical output in linear time. Equivalence
+// hinges on `.` and `-` being outside the quantified classes, so the old
+// greedy runs could never benefit from backtracking: a match is always
+// maximal-run + required-literal, which is exactly what the scanners test.
+
+function base64UrlRunEnd(value: string, from: number): number {
+  let i = from;
+  while (i < value.length) {
+    const code = value.charCodeAt(i);
+    const isBase64Url =
+      (code >= 48 && code <= 57) || // 0-9
+      (code >= 65 && code <= 90) || // A-Z
+      (code >= 97 && code <= 122) || // a-z
+      code === 45 || // -
+      code === 95; // _
+    if (!isBase64Url) break;
+    i += 1;
+  }
+  return i;
+}
+
+// Replaces every `eyJ<run>.<run>.<run?>` (runs are maximal base64url runs,
+// the first two non-empty) with [REDACTED]. On failure the search resumes at
+// the end of the runs already scanned: every other `eyJ` inside a scanned
+// run shares that run's end, so it provably fails the same check.
+function scrubJwts(value: string): string {
+  let out = "";
+  let copied = 0; // everything before this index is already in `out`
+  let search = 0;
+  while (true) {
+    const start = value.indexOf("eyJ", search);
+    if (start === -1) break;
+    const header = base64UrlRunEnd(value, start + 3);
+    if (header === start + 3) {
+      search = start + 1;
+      continue;
+    }
+    if (value.charCodeAt(header) !== 46 /* . */) {
+      search = header;
+      continue;
+    }
+    const payload = base64UrlRunEnd(value, header + 1);
+    if (payload === header + 1 || value.charCodeAt(payload) !== 46 /* . */) {
+      search = header;
+      continue;
+    }
+    const end = base64UrlRunEnd(value, payload + 1);
+    out += value.slice(copied, start) + REDACTED;
+    copied = end;
+    search = end;
+  }
+  return copied === 0 ? value : out + value.slice(copied);
+}
+
+// Matches `-----BEGIN <label>-----` / `-----END <label>-----` at `at`, where
+// <label> is a maximal non-empty [A-Z ] run followed by five dashes. Returns
+// the index just past the closing dashes, or -1.
+function pemHeaderEnd(value: string, at: number, keyword: string): number {
+  const labelStart = at + keyword.length;
+  let labelEnd = labelStart;
+  while (labelEnd < value.length) {
+    const code = value.charCodeAt(labelEnd);
+    if (!((code >= 65 && code <= 90) || code === 32)) break; // A-Z or space
+    labelEnd += 1;
+  }
+  if (labelEnd === labelStart) return -1;
+  if (!value.startsWith("-----", labelEnd)) return -1;
+  return labelEnd + 5;
+}
+
+// Replaces every `-----BEGIN <label>-----…-----END <label>-----` block (lazy
+// body: the earliest valid END wins) with [REDACTED]. If no valid END exists
+// after a header, no later header can complete a block either (its END
+// search space is a subset), so the scan stops instead of re-walking the
+// tail once per dangling header. Dangling headers are still caught by the
+// bare `-----BEGIN [A-Z ]+-----` pattern that runs after this scanner.
+function scrubPemBlocks(value: string): string {
+  let out = "";
+  let copied = 0;
+  let search = 0;
+  while (true) {
+    const begin = value.indexOf("-----BEGIN ", search);
+    if (begin === -1) break;
+    const bodyStart = pemHeaderEnd(value, begin, "-----BEGIN ");
+    if (bodyStart === -1) {
+      search = begin + 1;
+      continue;
+    }
+    let endSearch = bodyStart;
+    let blockEnd = -1;
+    while (true) {
+      const end = value.indexOf("-----END ", endSearch);
+      if (end === -1) break;
+      blockEnd = pemHeaderEnd(value, end, "-----END ");
+      if (blockEnd !== -1) break;
+      endSearch = end + 1;
+    }
+    if (blockEnd === -1) break;
+    out += value.slice(copied, begin) + REDACTED;
+    copied = blockEnd;
+    search = blockEnd;
+  }
+  return copied === 0 ? value : out + value.slice(copied);
+}
+
 // `sk-...` covers OpenAI + Anthropic (`sk-ant-...`) + variants like `sk-proj-`.
 // The leading boundary avoids mangling benign kebab-case words ending in "sk".
 // `(s|r)k_(test|live)_...` covers Stripe secret/restricted keys — a shorter
@@ -41,7 +151,10 @@ const HARD_REDACT_KEYS = new Set([
 // `sk_test_pome_a` are only a few chars past the prefix.
 // `xapp-...` is a Slack app-level token; `AIza...` is a Google API key.
 // `g` flag matters: a single string may contain multiple secrets.
-const SCRUB_PATTERNS: RegExp[] = [
+// Steps run in order; the two function steps are the F-716 linear scanners
+// and must keep their slots (JWT and PEM-block scrub before the bare PEM
+// header scrub).
+const SCRUB_STEPS: ReadonlyArray<RegExp | ((value: string) => string)> = [
   /redaction_fixture_secret_[A-Za-z0-9_-]{8,}/g,
   /\bsk-[A-Za-z0-9_-]{20,}/g,
   /\b[rs]k_(?:test|live)_[A-Za-z0-9_]{4,}/g,
@@ -52,15 +165,15 @@ const SCRUB_PATTERNS: RegExp[] = [
   /(?:pme|pk|rk)_[A-Za-z0-9_-]{20,}/g,
   /AIza[0-9A-Za-z_-]{20,}/g,
   /AKIA[0-9A-Z]{16}/g,
-  /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*/g,
-  /-----BEGIN [A-Z ]+-----[\s\S]*?-----END [A-Z ]+-----/g,
+  scrubJwts,
+  scrubPemBlocks,
   /-----BEGIN [A-Z ]+-----/g,
 ];
 
 function scrubString(value: string): string {
   let out = value;
-  for (const pattern of SCRUB_PATTERNS) {
-    out = out.replace(pattern, REDACTED);
+  for (const step of SCRUB_STEPS) {
+    out = typeof step === "function" ? step(out) : out.replace(step, REDACTED);
   }
   return out;
 }

--- a/packages/sdk/test/redaction.test.ts
+++ b/packages/sdk/test/redaction.test.ts
@@ -228,6 +228,25 @@ describe("redactSecrets — F-716 differential fuzz vs the legacy patterns", () 
   });
 });
 
+describe("redactSecrets — F-716 adversarial inputs stay linear", () => {
+  // Both inputs drive the pre-F-716 regexes into quadratic backtracking
+  // (minutes of CPU); the linear scanners handle them in milliseconds. The
+  // 1s bound leaves two orders of magnitude of CI headroom.
+  it("survives a 150 KB dotless eyJ run", () => {
+    const input = "eyJ".repeat(50_000);
+    const started = performance.now();
+    expect(redactSecrets(input)).toBe(input);
+    expect(performance.now() - started).toBeLessThan(1_000);
+  });
+
+  it("survives 20k unterminated PEM headers", () => {
+    const input = "-----BEGIN AAAA-----\n".repeat(20_000);
+    const started = performance.now();
+    expect(redactSecrets(input)).toBe("[REDACTED]\n".repeat(20_000));
+    expect(performance.now() - started).toBeLessThan(1_000);
+  });
+});
+
 describe("recorder redacts every emitted event", () => {
   it("scrubs request_body and response_body at emit time", async () => {
     const store = createRecorderStore();

--- a/packages/sdk/test/redaction.test.ts
+++ b/packages/sdk/test/redaction.test.ts
@@ -79,6 +79,155 @@ describe("redactSecrets", () => {
   });
 });
 
+// F-716 boundary pinning. These tests freeze the exact JWT / PEM scrub
+// behavior of the pre-F-716 backtracking regexes: they were run green against
+// the old patterns before the linear-time rewrite landed, and must stay green
+// after. Any diff here is a redaction behavior change, not a refactor.
+describe("redactSecrets — F-716 JWT scrub boundary pinning", () => {
+  it("redacts a JWT glued mid-base64url-run from the eyJ onward", () => {
+    expect(redactSecrets("AAAAeyJab.cd.ef")).toBe("AAAA[REDACTED]");
+  });
+
+  it("redacts a dot-prefixed JWT, leaving the leading dot", () => {
+    expect(redactSecrets(".eyJab.cd.ef")).toBe(".[REDACTED]");
+  });
+
+  it("consumes an embedded eyJ inside the header segment", () => {
+    expect(redactSecrets("eyJa.eyJb.c")).toBe("[REDACTED]");
+  });
+
+  it("does not fire when the header segment is empty", () => {
+    expect(redactSecrets("eyJ..x")).toBe("eyJ..x");
+    expect(redactSecrets("eyJ.a.b")).toBe("eyJ.a.b");
+  });
+
+  it("does not fire on two-segment shapes", () => {
+    expect(redactSecrets("eyJab.cd")).toBe("eyJab.cd");
+  });
+
+  it("consumes the trailing dot when the signature segment is empty", () => {
+    expect(redactSecrets("eyJa.b.")).toBe("[REDACTED]");
+  });
+
+  it("stops the signature segment at the first non-base64url char", () => {
+    expect(redactSecrets("eyJa.b.c.d")).toBe("[REDACTED].d");
+    expect(redactSecrets("eyJa.b.ceyJ")).toBe("[REDACTED]");
+  });
+
+  it("redacts multiple JWTs in one string", () => {
+    expect(redactSecrets("eyJa.b.c and eyJd.e.f")).toBe("[REDACTED] and [REDACTED]");
+  });
+});
+
+describe("redactSecrets — F-716 PEM scrub boundary pinning", () => {
+  it("redacts a complete block as one unit", () => {
+    expect(redactSecrets("-----BEGIN PRIVATE KEY-----\nMIIB\n-----END PRIVATE KEY-----")).toBe(
+      "[REDACTED]",
+    );
+  });
+
+  it("redacts only the header of an unterminated block", () => {
+    expect(redactSecrets("-----BEGIN RSA PRIVATE KEY-----\nMIIB")).toBe("[REDACTED]\nMIIB");
+  });
+
+  it("redacts a nested block through the first valid END", () => {
+    expect(redactSecrets("-----BEGIN A-----\nx-----BEGIN B-----\ny\n-----END B-----\ntail")).toBe(
+      "[REDACTED]\ntail",
+    );
+  });
+
+  it("leaves an END without a BEGIN untouched", () => {
+    expect(redactSecrets("data -----END A----- data")).toBe("data -----END A----- data");
+  });
+
+  it("ignores an END with an empty label, then redacts the dangling header", () => {
+    expect(redactSecrets("-----BEGIN A-----x-----END -----")).toBe("[REDACTED]x-----END -----");
+  });
+
+  it("consumes exactly five closing dashes", () => {
+    expect(redactSecrets("-----BEGIN A-----x-----END A------")).toBe("[REDACTED]-");
+  });
+
+  it("redacts a glued header whose closing dashes open the next header", () => {
+    expect(redactSecrets("-----BEGIN A-----BEGIN B-----")).toBe("[REDACTED]BEGIN B-----");
+  });
+
+  it("redacts two complete blocks separately", () => {
+    expect(
+      redactSecrets("-----BEGIN A-----x-----END A----- mid -----BEGIN B-----y-----END B-----"),
+    ).toBe("[REDACTED] mid [REDACTED]");
+  });
+
+  it("redacts a space-only label header", () => {
+    expect(redactSecrets("-----BEGIN  -----")).toBe("[REDACTED]");
+  });
+
+  it("redacts a whole block whose body contains a JWT", () => {
+    expect(redactSecrets("-----BEGIN K-----\neyJa.b.c\n-----END K-----")).toBe("[REDACTED]");
+  });
+});
+
+describe("redactSecrets — F-716 differential fuzz vs the legacy patterns", () => {
+  // The exact pre-F-716 scrub pipeline, kept verbatim as the behavior oracle.
+  // Only run on short fuzz strings, where its quadratic worst case is harmless.
+  const LEGACY_SCRUB_PATTERNS: RegExp[] = [
+    /redaction_fixture_secret_[A-Za-z0-9_-]{8,}/g,
+    /\bsk-[A-Za-z0-9_-]{20,}/g,
+    /\b[rs]k_(?:test|live)_[A-Za-z0-9_]{4,}/g,
+    /ghp_[A-Za-z0-9]{36}/g,
+    /github_pat_[A-Za-z0-9_]{20,}/g,
+    /xox[aboprs]-[A-Za-z0-9-]{20,}/g,
+    /xapp-[A-Za-z0-9-]{10,}/g,
+    /(?:pme|pk|rk)_[A-Za-z0-9_-]{20,}/g,
+    /AIza[0-9A-Za-z_-]{20,}/g,
+    /AKIA[0-9A-Z]{16}/g,
+    /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*/g,
+    /-----BEGIN [A-Z ]+-----[\s\S]*?-----END [A-Z ]+-----/g,
+    /-----BEGIN [A-Z ]+-----/g,
+  ];
+
+  function legacyScrub(value: string): string {
+    let out = value;
+    for (const pattern of LEGACY_SCRUB_PATTERNS) {
+      out = out.replace(pattern, "[REDACTED]");
+    }
+    return out;
+  }
+
+  const PIECES = [
+    "eyJ",
+    ".",
+    "a",
+    "B9",
+    "_",
+    "-",
+    " ",
+    "\n",
+    "-----BEGIN ",
+    "-----END ",
+    "-----",
+    "AB C",
+    "!",
+    "ey",
+    "J",
+  ];
+
+  it("matches the legacy scrub on 2000 seeded fuzz strings", () => {
+    let seed = 0xf716;
+    const next = () => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      return seed;
+    };
+    for (let round = 0; round < 2000; round += 1) {
+      const parts: string[] = [];
+      const length = next() % 24;
+      for (let p = 0; p < length; p += 1) parts.push(PIECES[next() % PIECES.length]!);
+      const input = parts.join("");
+      expect(redactSecrets(input)).toBe(legacyScrub(input));
+    }
+  });
+});
+
 describe("recorder redacts every emitted event", () => {
   it("scrubs request_body and response_body at emit time", async () => {
     const store = createRecorderStore();

--- a/packages/twin-github/src/redaction.ts
+++ b/packages/twin-github/src/redaction.ts
@@ -39,6 +39,116 @@ const HARD_REDACT_KEYS = new Set([
   "anthropic_api_key",
 ]);
 
+// F-716: the JWT and PEM-block scrubs used to be the regexes
+// `eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*` and
+// `-----BEGIN [A-Z ]+-----[\s\S]*?-----END [A-Z ]+-----`, which CodeQL flags
+// as polynomial ReDoS: a failed attempt rescans the same text for every
+// candidate start inside it (e.g. a long dotless "eyJeyJeyJ…" run). The two
+// scanners below produce byte-identical output in linear time. Equivalence
+// hinges on `.` and `-` being outside the quantified classes, so the old
+// greedy runs could never benefit from backtracking: a match is always
+// maximal-run + required-literal, which is exactly what the scanners test.
+
+function base64UrlRunEnd(value: string, from: number): number {
+  let i = from;
+  while (i < value.length) {
+    const code = value.charCodeAt(i);
+    const isBase64Url =
+      (code >= 48 && code <= 57) || // 0-9
+      (code >= 65 && code <= 90) || // A-Z
+      (code >= 97 && code <= 122) || // a-z
+      code === 45 || // -
+      code === 95; // _
+    if (!isBase64Url) break;
+    i += 1;
+  }
+  return i;
+}
+
+// Replaces every `eyJ<run>.<run>.<run?>` (runs are maximal base64url runs,
+// the first two non-empty) with [REDACTED]. On failure the search resumes at
+// the end of the runs already scanned: every other `eyJ` inside a scanned
+// run shares that run's end, so it provably fails the same check.
+function scrubJwts(value: string): string {
+  let out = "";
+  let copied = 0; // everything before this index is already in `out`
+  let search = 0;
+  while (true) {
+    const start = value.indexOf("eyJ", search);
+    if (start === -1) break;
+    const header = base64UrlRunEnd(value, start + 3);
+    if (header === start + 3) {
+      search = start + 1;
+      continue;
+    }
+    if (value.charCodeAt(header) !== 46 /* . */) {
+      search = header;
+      continue;
+    }
+    const payload = base64UrlRunEnd(value, header + 1);
+    if (payload === header + 1 || value.charCodeAt(payload) !== 46 /* . */) {
+      search = header;
+      continue;
+    }
+    const end = base64UrlRunEnd(value, payload + 1);
+    out += value.slice(copied, start) + REDACTED;
+    copied = end;
+    search = end;
+  }
+  return copied === 0 ? value : out + value.slice(copied);
+}
+
+// Matches `-----BEGIN <label>-----` / `-----END <label>-----` at `at`, where
+// <label> is a maximal non-empty [A-Z ] run followed by five dashes. Returns
+// the index just past the closing dashes, or -1.
+function pemHeaderEnd(value: string, at: number, keyword: string): number {
+  const labelStart = at + keyword.length;
+  let labelEnd = labelStart;
+  while (labelEnd < value.length) {
+    const code = value.charCodeAt(labelEnd);
+    if (!((code >= 65 && code <= 90) || code === 32)) break; // A-Z or space
+    labelEnd += 1;
+  }
+  if (labelEnd === labelStart) return -1;
+  if (!value.startsWith("-----", labelEnd)) return -1;
+  return labelEnd + 5;
+}
+
+// Replaces every `-----BEGIN <label>-----…-----END <label>-----` block (lazy
+// body: the earliest valid END wins) with [REDACTED]. If no valid END exists
+// after a header, no later header can complete a block either (its END
+// search space is a subset), so the scan stops instead of re-walking the
+// tail once per dangling header. Dangling headers are still caught by the
+// bare `-----BEGIN [A-Z ]+-----` pattern that runs after this scanner.
+function scrubPemBlocks(value: string): string {
+  let out = "";
+  let copied = 0;
+  let search = 0;
+  while (true) {
+    const begin = value.indexOf("-----BEGIN ", search);
+    if (begin === -1) break;
+    const bodyStart = pemHeaderEnd(value, begin, "-----BEGIN ");
+    if (bodyStart === -1) {
+      search = begin + 1;
+      continue;
+    }
+    let endSearch = bodyStart;
+    let blockEnd = -1;
+    while (true) {
+      const end = value.indexOf("-----END ", endSearch);
+      if (end === -1) break;
+      blockEnd = pemHeaderEnd(value, end, "-----END ");
+      if (blockEnd !== -1) break;
+      endSearch = end + 1;
+    }
+    if (blockEnd === -1) break;
+    out += value.slice(copied, begin) + REDACTED;
+    copied = blockEnd;
+    search = blockEnd;
+  }
+  return copied === 0 ? value : out + value.slice(copied);
+}
+
 // `sk-...` covers OpenAI + Anthropic (`sk-ant-...`) + variants like `sk-proj-`.
 // The leading boundary avoids mangling benign kebab-case words ending in "sk".
 // `(s|r)k_(test|live)_...` covers Stripe secret/restricted keys (FDRS-588) —
@@ -46,7 +156,10 @@ const HARD_REDACT_KEYS = new Set([
 // `sk_test_pome_a` are only a few chars past the prefix.
 // `xapp-...` is a Slack app-level token; `AIza...` is a Google API key
 // (FDRS-608). `g` flag matters: a single string may contain multiple secrets.
-const SCRUB_PATTERNS: RegExp[] = [
+// Steps run in order; the two function steps are the F-716 linear scanners
+// and must keep their slots (JWT and PEM-block scrub before the bare PEM
+// header scrub).
+const SCRUB_STEPS: ReadonlyArray<RegExp | ((value: string) => string)> = [
   /redaction_fixture_secret_[A-Za-z0-9_-]{8,}/g,
   /\bsk-[A-Za-z0-9_-]{20,}/g,
   /\b[rs]k_(?:test|live)_[A-Za-z0-9_]{4,}/g,
@@ -57,15 +170,15 @@ const SCRUB_PATTERNS: RegExp[] = [
   /(?:pme|pk|rk)_[A-Za-z0-9_-]{20,}/g,
   /AIza[0-9A-Za-z_-]{20,}/g,
   /AKIA[0-9A-Z]{16}/g,
-  /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*/g,
-  /-----BEGIN [A-Z ]+-----[\s\S]*?-----END [A-Z ]+-----/g,
+  scrubJwts,
+  scrubPemBlocks,
   /-----BEGIN [A-Z ]+-----/g,
 ];
 
 function scrubString(value: string): string {
   let out = value;
-  for (const pattern of SCRUB_PATTERNS) {
-    out = out.replace(pattern, REDACTED);
+  for (const step of SCRUB_STEPS) {
+    out = typeof step === "function" ? step(out) : out.replace(step, REDACTED);
   }
   return out;
 }

--- a/packages/twin-github/test/redaction.test.ts
+++ b/packages/twin-github/test/redaction.test.ts
@@ -58,3 +58,171 @@ describe("redaction mirror — provider secret shapes", () => {
     );
   });
 });
+
+// F-716 boundary pinning. These tests freeze the exact JWT / PEM scrub
+// behavior of the pre-F-716 backtracking regexes: they were run green against
+// the old patterns before the linear-time rewrite landed, and must stay green
+// after. Any diff here is a redaction behavior change, not a refactor.
+describe("redaction mirror — F-716 JWT scrub boundary pinning", () => {
+  it("redacts a JWT glued mid-base64url-run from the eyJ onward", () => {
+    expect(redactSecrets("AAAAeyJab.cd.ef")).toBe("AAAA[REDACTED]");
+  });
+
+  it("redacts a dot-prefixed JWT, leaving the leading dot", () => {
+    expect(redactSecrets(".eyJab.cd.ef")).toBe(".[REDACTED]");
+  });
+
+  it("consumes an embedded eyJ inside the header segment", () => {
+    expect(redactSecrets("eyJa.eyJb.c")).toBe("[REDACTED]");
+  });
+
+  it("does not fire when the header segment is empty", () => {
+    expect(redactSecrets("eyJ..x")).toBe("eyJ..x");
+    expect(redactSecrets("eyJ.a.b")).toBe("eyJ.a.b");
+  });
+
+  it("does not fire on two-segment shapes", () => {
+    expect(redactSecrets("eyJab.cd")).toBe("eyJab.cd");
+  });
+
+  it("consumes the trailing dot when the signature segment is empty", () => {
+    expect(redactSecrets("eyJa.b.")).toBe("[REDACTED]");
+  });
+
+  it("stops the signature segment at the first non-base64url char", () => {
+    expect(redactSecrets("eyJa.b.c.d")).toBe("[REDACTED].d");
+    expect(redactSecrets("eyJa.b.ceyJ")).toBe("[REDACTED]");
+  });
+
+  it("redacts multiple JWTs in one string", () => {
+    expect(redactSecrets("eyJa.b.c and eyJd.e.f")).toBe("[REDACTED] and [REDACTED]");
+  });
+});
+
+describe("redaction mirror — F-716 PEM scrub boundary pinning", () => {
+  it("redacts a complete block as one unit", () => {
+    expect(redactSecrets("-----BEGIN PRIVATE KEY-----\nMIIB\n-----END PRIVATE KEY-----")).toBe(
+      "[REDACTED]",
+    );
+  });
+
+  it("redacts only the header of an unterminated block", () => {
+    expect(redactSecrets("-----BEGIN RSA PRIVATE KEY-----\nMIIB")).toBe("[REDACTED]\nMIIB");
+  });
+
+  it("redacts a nested block through the first valid END", () => {
+    expect(redactSecrets("-----BEGIN A-----\nx-----BEGIN B-----\ny\n-----END B-----\ntail")).toBe(
+      "[REDACTED]\ntail",
+    );
+  });
+
+  it("leaves an END without a BEGIN untouched", () => {
+    expect(redactSecrets("data -----END A----- data")).toBe("data -----END A----- data");
+  });
+
+  it("ignores an END with an empty label, then redacts the dangling header", () => {
+    expect(redactSecrets("-----BEGIN A-----x-----END -----")).toBe("[REDACTED]x-----END -----");
+  });
+
+  it("consumes exactly five closing dashes", () => {
+    expect(redactSecrets("-----BEGIN A-----x-----END A------")).toBe("[REDACTED]-");
+  });
+
+  it("redacts a glued header whose closing dashes open the next header", () => {
+    expect(redactSecrets("-----BEGIN A-----BEGIN B-----")).toBe("[REDACTED]BEGIN B-----");
+  });
+
+  it("redacts two complete blocks separately", () => {
+    expect(
+      redactSecrets("-----BEGIN A-----x-----END A----- mid -----BEGIN B-----y-----END B-----"),
+    ).toBe("[REDACTED] mid [REDACTED]");
+  });
+
+  it("redacts a space-only label header", () => {
+    expect(redactSecrets("-----BEGIN  -----")).toBe("[REDACTED]");
+  });
+
+  it("redacts a whole block whose body contains a JWT", () => {
+    expect(redactSecrets("-----BEGIN K-----\neyJa.b.c\n-----END K-----")).toBe("[REDACTED]");
+  });
+});
+
+describe("redaction mirror — F-716 differential fuzz vs the legacy patterns", () => {
+  // The exact pre-F-716 scrub pipeline, kept verbatim as the behavior oracle.
+  // Only run on short fuzz strings, where its quadratic worst case is harmless.
+  const LEGACY_SCRUB_PATTERNS: RegExp[] = [
+    /redaction_fixture_secret_[A-Za-z0-9_-]{8,}/g,
+    /\bsk-[A-Za-z0-9_-]{20,}/g,
+    /\b[rs]k_(?:test|live)_[A-Za-z0-9_]{4,}/g,
+    /ghp_[A-Za-z0-9]{36}/g,
+    /github_pat_[A-Za-z0-9_]{20,}/g,
+    /xox[aboprs]-[A-Za-z0-9-]{20,}/g,
+    /xapp-[A-Za-z0-9-]{10,}/g,
+    /(?:pme|pk|rk)_[A-Za-z0-9_-]{20,}/g,
+    /AIza[0-9A-Za-z_-]{20,}/g,
+    /AKIA[0-9A-Z]{16}/g,
+    /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*/g,
+    /-----BEGIN [A-Z ]+-----[\s\S]*?-----END [A-Z ]+-----/g,
+    /-----BEGIN [A-Z ]+-----/g,
+  ];
+
+  function legacyScrub(value: string): string {
+    let out = value;
+    for (const pattern of LEGACY_SCRUB_PATTERNS) {
+      out = out.replace(pattern, "[REDACTED]");
+    }
+    return out;
+  }
+
+  const PIECES = [
+    "eyJ",
+    ".",
+    "a",
+    "B9",
+    "_",
+    "-",
+    " ",
+    "\n",
+    "-----BEGIN ",
+    "-----END ",
+    "-----",
+    "AB C",
+    "!",
+    "ey",
+    "J",
+  ];
+
+  it("matches the legacy scrub on 2000 seeded fuzz strings", () => {
+    let seed = 0xf716;
+    const next = () => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      return seed;
+    };
+    for (let round = 0; round < 2000; round += 1) {
+      const parts: string[] = [];
+      const length = next() % 24;
+      for (let p = 0; p < length; p += 1) parts.push(PIECES[next() % PIECES.length]!);
+      const input = parts.join("");
+      expect(redactSecrets(input)).toBe(legacyScrub(input));
+    }
+  });
+});
+
+describe("redaction mirror — F-716 adversarial inputs stay linear", () => {
+  // Both inputs drive the pre-F-716 regexes into quadratic backtracking
+  // (minutes of CPU); the linear scanners handle them in milliseconds. The
+  // 1s bound leaves two orders of magnitude of CI headroom.
+  it("survives a 150 KB dotless eyJ run", () => {
+    const input = "eyJ".repeat(50_000);
+    const started = performance.now();
+    expect(redactSecrets(input)).toBe(input);
+    expect(performance.now() - started).toBeLessThan(1_000);
+  });
+
+  it("survives 20k unterminated PEM headers", () => {
+    const input = "-----BEGIN AAAA-----\n".repeat(20_000);
+    const started = performance.now();
+    expect(redactSecrets(input)).toBe("[REDACTED]\n".repeat(20_000));
+    expect(performance.now() - started).toBeLessThan(1_000);
+  });
+});

--- a/packages/twin-slack/src/redaction.ts
+++ b/packages/twin-slack/src/redaction.ts
@@ -39,6 +39,116 @@ const HARD_REDACT_KEYS = new Set([
   "anthropic_api_key",
 ]);
 
+// F-716: the JWT and PEM-block scrubs used to be the regexes
+// `eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*` and
+// `-----BEGIN [A-Z ]+-----[\s\S]*?-----END [A-Z ]+-----`, which CodeQL flags
+// as polynomial ReDoS: a failed attempt rescans the same text for every
+// candidate start inside it (e.g. a long dotless "eyJeyJeyJ…" run). The two
+// scanners below produce byte-identical output in linear time. Equivalence
+// hinges on `.` and `-` being outside the quantified classes, so the old
+// greedy runs could never benefit from backtracking: a match is always
+// maximal-run + required-literal, which is exactly what the scanners test.
+
+function base64UrlRunEnd(value: string, from: number): number {
+  let i = from;
+  while (i < value.length) {
+    const code = value.charCodeAt(i);
+    const isBase64Url =
+      (code >= 48 && code <= 57) || // 0-9
+      (code >= 65 && code <= 90) || // A-Z
+      (code >= 97 && code <= 122) || // a-z
+      code === 45 || // -
+      code === 95; // _
+    if (!isBase64Url) break;
+    i += 1;
+  }
+  return i;
+}
+
+// Replaces every `eyJ<run>.<run>.<run?>` (runs are maximal base64url runs,
+// the first two non-empty) with [REDACTED]. On failure the search resumes at
+// the end of the runs already scanned: every other `eyJ` inside a scanned
+// run shares that run's end, so it provably fails the same check.
+function scrubJwts(value: string): string {
+  let out = "";
+  let copied = 0; // everything before this index is already in `out`
+  let search = 0;
+  while (true) {
+    const start = value.indexOf("eyJ", search);
+    if (start === -1) break;
+    const header = base64UrlRunEnd(value, start + 3);
+    if (header === start + 3) {
+      search = start + 1;
+      continue;
+    }
+    if (value.charCodeAt(header) !== 46 /* . */) {
+      search = header;
+      continue;
+    }
+    const payload = base64UrlRunEnd(value, header + 1);
+    if (payload === header + 1 || value.charCodeAt(payload) !== 46 /* . */) {
+      search = header;
+      continue;
+    }
+    const end = base64UrlRunEnd(value, payload + 1);
+    out += value.slice(copied, start) + REDACTED;
+    copied = end;
+    search = end;
+  }
+  return copied === 0 ? value : out + value.slice(copied);
+}
+
+// Matches `-----BEGIN <label>-----` / `-----END <label>-----` at `at`, where
+// <label> is a maximal non-empty [A-Z ] run followed by five dashes. Returns
+// the index just past the closing dashes, or -1.
+function pemHeaderEnd(value: string, at: number, keyword: string): number {
+  const labelStart = at + keyword.length;
+  let labelEnd = labelStart;
+  while (labelEnd < value.length) {
+    const code = value.charCodeAt(labelEnd);
+    if (!((code >= 65 && code <= 90) || code === 32)) break; // A-Z or space
+    labelEnd += 1;
+  }
+  if (labelEnd === labelStart) return -1;
+  if (!value.startsWith("-----", labelEnd)) return -1;
+  return labelEnd + 5;
+}
+
+// Replaces every `-----BEGIN <label>-----…-----END <label>-----` block (lazy
+// body: the earliest valid END wins) with [REDACTED]. If no valid END exists
+// after a header, no later header can complete a block either (its END
+// search space is a subset), so the scan stops instead of re-walking the
+// tail once per dangling header. Dangling headers are still caught by the
+// bare `-----BEGIN [A-Z ]+-----` pattern that runs after this scanner.
+function scrubPemBlocks(value: string): string {
+  let out = "";
+  let copied = 0;
+  let search = 0;
+  while (true) {
+    const begin = value.indexOf("-----BEGIN ", search);
+    if (begin === -1) break;
+    const bodyStart = pemHeaderEnd(value, begin, "-----BEGIN ");
+    if (bodyStart === -1) {
+      search = begin + 1;
+      continue;
+    }
+    let endSearch = bodyStart;
+    let blockEnd = -1;
+    while (true) {
+      const end = value.indexOf("-----END ", endSearch);
+      if (end === -1) break;
+      blockEnd = pemHeaderEnd(value, end, "-----END ");
+      if (blockEnd !== -1) break;
+      endSearch = end + 1;
+    }
+    if (blockEnd === -1) break;
+    out += value.slice(copied, begin) + REDACTED;
+    copied = blockEnd;
+    search = blockEnd;
+  }
+  return copied === 0 ? value : out + value.slice(copied);
+}
+
 // `sk-...` covers OpenAI + Anthropic (`sk-ant-...`) + variants like `sk-proj-`.
 // The leading boundary avoids mangling benign kebab-case words ending in "sk".
 // `(s|r)k_(test|live)_...` covers Stripe secret/restricted keys (FDRS-588) —
@@ -46,7 +156,10 @@ const HARD_REDACT_KEYS = new Set([
 // `sk_test_pome_a` are only a few chars past the prefix.
 // `xapp-...` is a Slack app-level token; `AIza...` is a Google API key
 // (FDRS-608). `g` flag matters: a single string may contain multiple secrets.
-const SCRUB_PATTERNS: RegExp[] = [
+// Steps run in order; the two function steps are the F-716 linear scanners
+// and must keep their slots (JWT and PEM-block scrub before the bare PEM
+// header scrub).
+const SCRUB_STEPS: ReadonlyArray<RegExp | ((value: string) => string)> = [
   /redaction_fixture_secret_[A-Za-z0-9_-]{8,}/g,
   /\bsk-[A-Za-z0-9_-]{20,}/g,
   /\b[rs]k_(?:test|live)_[A-Za-z0-9_]{4,}/g,
@@ -57,15 +170,15 @@ const SCRUB_PATTERNS: RegExp[] = [
   /(?:pme|pk|rk)_[A-Za-z0-9_-]{20,}/g,
   /AIza[0-9A-Za-z_-]{20,}/g,
   /AKIA[0-9A-Z]{16}/g,
-  /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*/g,
-  /-----BEGIN [A-Z ]+-----[\s\S]*?-----END [A-Z ]+-----/g,
+  scrubJwts,
+  scrubPemBlocks,
   /-----BEGIN [A-Z ]+-----/g,
 ];
 
 function scrubString(value: string): string {
   let out = value;
-  for (const pattern of SCRUB_PATTERNS) {
-    out = out.replace(pattern, REDACTED);
+  for (const step of SCRUB_STEPS) {
+    out = typeof step === "function" ? step(out) : out.replace(step, REDACTED);
   }
   return out;
 }

--- a/packages/twin-stripe/src/redaction.ts
+++ b/packages/twin-stripe/src/redaction.ts
@@ -39,6 +39,116 @@ const HARD_REDACT_KEYS = new Set([
   "anthropic_api_key",
 ]);
 
+// F-716: the JWT and PEM-block scrubs used to be the regexes
+// `eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*` and
+// `-----BEGIN [A-Z ]+-----[\s\S]*?-----END [A-Z ]+-----`, which CodeQL flags
+// as polynomial ReDoS: a failed attempt rescans the same text for every
+// candidate start inside it (e.g. a long dotless "eyJeyJeyJ…" run). The two
+// scanners below produce byte-identical output in linear time. Equivalence
+// hinges on `.` and `-` being outside the quantified classes, so the old
+// greedy runs could never benefit from backtracking: a match is always
+// maximal-run + required-literal, which is exactly what the scanners test.
+
+function base64UrlRunEnd(value: string, from: number): number {
+  let i = from;
+  while (i < value.length) {
+    const code = value.charCodeAt(i);
+    const isBase64Url =
+      (code >= 48 && code <= 57) || // 0-9
+      (code >= 65 && code <= 90) || // A-Z
+      (code >= 97 && code <= 122) || // a-z
+      code === 45 || // -
+      code === 95; // _
+    if (!isBase64Url) break;
+    i += 1;
+  }
+  return i;
+}
+
+// Replaces every `eyJ<run>.<run>.<run?>` (runs are maximal base64url runs,
+// the first two non-empty) with [REDACTED]. On failure the search resumes at
+// the end of the runs already scanned: every other `eyJ` inside a scanned
+// run shares that run's end, so it provably fails the same check.
+function scrubJwts(value: string): string {
+  let out = "";
+  let copied = 0; // everything before this index is already in `out`
+  let search = 0;
+  while (true) {
+    const start = value.indexOf("eyJ", search);
+    if (start === -1) break;
+    const header = base64UrlRunEnd(value, start + 3);
+    if (header === start + 3) {
+      search = start + 1;
+      continue;
+    }
+    if (value.charCodeAt(header) !== 46 /* . */) {
+      search = header;
+      continue;
+    }
+    const payload = base64UrlRunEnd(value, header + 1);
+    if (payload === header + 1 || value.charCodeAt(payload) !== 46 /* . */) {
+      search = header;
+      continue;
+    }
+    const end = base64UrlRunEnd(value, payload + 1);
+    out += value.slice(copied, start) + REDACTED;
+    copied = end;
+    search = end;
+  }
+  return copied === 0 ? value : out + value.slice(copied);
+}
+
+// Matches `-----BEGIN <label>-----` / `-----END <label>-----` at `at`, where
+// <label> is a maximal non-empty [A-Z ] run followed by five dashes. Returns
+// the index just past the closing dashes, or -1.
+function pemHeaderEnd(value: string, at: number, keyword: string): number {
+  const labelStart = at + keyword.length;
+  let labelEnd = labelStart;
+  while (labelEnd < value.length) {
+    const code = value.charCodeAt(labelEnd);
+    if (!((code >= 65 && code <= 90) || code === 32)) break; // A-Z or space
+    labelEnd += 1;
+  }
+  if (labelEnd === labelStart) return -1;
+  if (!value.startsWith("-----", labelEnd)) return -1;
+  return labelEnd + 5;
+}
+
+// Replaces every `-----BEGIN <label>-----…-----END <label>-----` block (lazy
+// body: the earliest valid END wins) with [REDACTED]. If no valid END exists
+// after a header, no later header can complete a block either (its END
+// search space is a subset), so the scan stops instead of re-walking the
+// tail once per dangling header. Dangling headers are still caught by the
+// bare `-----BEGIN [A-Z ]+-----` pattern that runs after this scanner.
+function scrubPemBlocks(value: string): string {
+  let out = "";
+  let copied = 0;
+  let search = 0;
+  while (true) {
+    const begin = value.indexOf("-----BEGIN ", search);
+    if (begin === -1) break;
+    const bodyStart = pemHeaderEnd(value, begin, "-----BEGIN ");
+    if (bodyStart === -1) {
+      search = begin + 1;
+      continue;
+    }
+    let endSearch = bodyStart;
+    let blockEnd = -1;
+    while (true) {
+      const end = value.indexOf("-----END ", endSearch);
+      if (end === -1) break;
+      blockEnd = pemHeaderEnd(value, end, "-----END ");
+      if (blockEnd !== -1) break;
+      endSearch = end + 1;
+    }
+    if (blockEnd === -1) break;
+    out += value.slice(copied, begin) + REDACTED;
+    copied = blockEnd;
+    search = blockEnd;
+  }
+  return copied === 0 ? value : out + value.slice(copied);
+}
+
 // `sk-...` covers OpenAI + Anthropic (`sk-ant-...`) + variants like `sk-proj-`.
 // The leading boundary avoids mangling benign kebab-case words ending in "sk".
 // `(s|r)k_(test|live)_...` covers Stripe secret/restricted keys (FDRS-588) —
@@ -46,7 +156,10 @@ const HARD_REDACT_KEYS = new Set([
 // `sk_test_pome_a` are only a few chars past the prefix.
 // `xapp-...` is a Slack app-level token; `AIza...` is a Google API key
 // (FDRS-608). `g` flag matters: a single string may contain multiple secrets.
-const SCRUB_PATTERNS: RegExp[] = [
+// Steps run in order; the two function steps are the F-716 linear scanners
+// and must keep their slots (JWT and PEM-block scrub before the bare PEM
+// header scrub).
+const SCRUB_STEPS: ReadonlyArray<RegExp | ((value: string) => string)> = [
   /redaction_fixture_secret_[A-Za-z0-9_-]{8,}/g,
   /\bsk-[A-Za-z0-9_-]{20,}/g,
   /\b[rs]k_(?:test|live)_[A-Za-z0-9_]{4,}/g,
@@ -57,15 +170,15 @@ const SCRUB_PATTERNS: RegExp[] = [
   /(?:pme|pk|rk)_[A-Za-z0-9_-]{20,}/g,
   /AIza[0-9A-Za-z_-]{20,}/g,
   /AKIA[0-9A-Z]{16}/g,
-  /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*/g,
-  /-----BEGIN [A-Z ]+-----[\s\S]*?-----END [A-Z ]+-----/g,
+  scrubJwts,
+  scrubPemBlocks,
   /-----BEGIN [A-Z ]+-----/g,
 ];
 
 function scrubString(value: string): string {
   let out = value;
-  for (const pattern of SCRUB_PATTERNS) {
-    out = out.replace(pattern, REDACTED);
+  for (const step of SCRUB_STEPS) {
+    out = typeof step === "function" ? step(out) : out.replace(step, REDACTED);
   }
   return out;
 }


### PR DESCRIPTION
<!-- Closes F-716 -->

## What
Replaces the two backtracking redaction scrub regexes — the JWT pattern (`eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*`) and the PEM block pattern (`-----BEGIN [A-Z ]+-----[\s\S]*?-----END [A-Z ]+-----`) — with hand-rolled linear-time scanners producing byte-identical output, in the cli canonical + 4 mirrors (byte-parity gate green) and the sdk engine copy. Resolves CodeQL `js/polynomial-redos` alerts #6/#7/#8 surfaced on the F-681 extraction PR (#54).

## Why
FDRS-716: CodeQL flags both patterns as polynomial ReDoS — a failed match attempt rescans the same text once per candidate start inside it (a long dotless `eyJeyJeyJ…` run, or a tape full of unterminated `-----BEGIN …-----` headers). A regex-only fix can't work here: the quadratic comes from overlapping restart positions, and any boundary assertion (`\b`, lookbehind) would stop redacting JWTs glued mid-base64url-run — a behavior the ticket explicitly freezes.

## Notes for reviewer
- **Equivalence argument**: `.` and `-` sit outside the quantified classes (`[A-Za-z0-9_-]`, `[A-Z ]`), so the old greedy quantifiers could never benefit from backtracking — every old match is maximal-run + required-literal, which is exactly what the scanners test. Commit 1 lands the boundary-pinning tests (glued JWTs, `.eyJ` prefixes, nested/incomplete PEM, dash-count edges) **verified green against the old regexes**; commit 2 swaps the implementation with the same tests green, plus a 2000-case seeded differential fuzz against the legacy patterns kept verbatim as oracle.
- **Linearity**: failed candidates resume the search at already-scanned run boundaries (every `eyJ` inside a scanned run shares that run's end, so it provably fails the same check); a PEM header with no valid END terminates the block scan outright (later headers search a subset of the same tail). Adversarial tests pin it: 150 KB of dotless `eyJ` and 20k unterminated PEM headers complete in milliseconds (old: minutes).
- Scrub step order is unchanged (JWT → PEM block → bare PEM header); `SCRUB_PATTERNS` became `SCRUB_STEPS` (regex | function). The bare `-----BEGIN [A-Z ]+-----` header pattern is untouched — CodeQL doesn't flag it (no rejecting suffix after its loop).
- The legacy patterns reappear verbatim in the two test files as the fuzz oracle, exercised only on ≤ ~100-char strings where quadratic cost is harmless. If CodeQL ever flags the test copy, it has no library-input flow — shout and I'll restructure.