### PR TITLE
fix(cli): pin release npm to 11.5.1 to unblock OIDC publish (FDRS-717)

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -33,8 +33,11 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
       # OIDC Trusted Publishing needs npm >= 11.5.1; Node 22 ships npm 10.
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+      # Pinned (not @latest): npm 11.18.0 crashes with "Exit handler never
+      # called!" on the OIDC provenance publish path. 11.5.1 is the GA release
+      # for trusted publishing and publishes cleanly.
+      - name: Install npm with OIDC trusted publishing support
+        run: npm install -g npm@11.5.1
       - run: node scripts/verify-vendor.mjs
       - run: bun install --frozen-lockfile
       - name: Changesets — version PR or publish


### PR DESCRIPTION
<!-- Closes F-717 -->

## What
Pins the `cli-release.yml` publish job to `npm@11.5.1` instead of `npm@latest`.

## Why
The first `0.7.0` publish reached npm OIDC trusted publishing successfully ("using npm trusted publishing") but then crashed with `npm error Exit handler never called! — This is an error with npm itself`. `npm@latest` resolved to `11.18.0`, which has this internal crash on the provenance/OIDC publish path. `11.5.1` is the GA release for trusted publishing and publishes cleanly. Not an auth or config issue. FDRS-717.

## Notes for reviewer
- Workflow-only change; merging re-triggers `cli-release.yml` (version 0.7.0 is still unpublished + zero changesets → publish path), which should now publish `pome-sh@0.7.0` with provenance.