### PR TITLE
fix(cli): publish tarball hard-link fix via --backend=copyfile (FDRS-717)

### DIFF
--- a/.github/workflows/cli-publish-smoke.yml
+++ b/.github/workflows/cli-publish-smoke.yml
@@ -27,7 +27,9 @@ jobs:
         with:
           node-version: 22
       - run: node scripts/verify-vendor.mjs
-      - run: bun install --frozen-lockfile
+      # Match the release job: copyfile backend so bundleDependencies aren't
+      # hard-linked (npm registry rejects hard-link tar entries with E415).
+      - run: bun install --frozen-lockfile --backend=copyfile
       - run: bun run build
       - name: npm publish --dry-run (packs the real tarball)
         run: npm publish --dry-run --ignore-scripts 2>&1 | tee "$RUNNER_TEMP/pack.log"
@@ -36,6 +38,13 @@ jobs:
           set -euo pipefail
           npm pack --ignore-scripts --pack-destination "$RUNNER_TEMP"
           tgz="$(ls "$RUNNER_TEMP"/pome-sh-*.tgz)"
+          # The npm registry rejects tarballs with hard-link entries (E415).
+          # Fail here rather than at publish time if any slip in.
+          if tar -tvf "$tgz" | grep -qE '^h'; then
+            echo "tarball contains hard links — npm registry would reject (E415):"
+            tar -tvf "$tgz" | grep -E '^h'
+            exit 1
+          fi
           room="$(mktemp -d)"
           cd "$room"
           npm init -y >/dev/null 2>&1

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -39,7 +39,11 @@ jobs:
       - name: Install npm with OIDC trusted publishing support
         run: npm install -g npm@11.5.1
       - run: node scripts/verify-vendor.mjs
-      - run: bun install --frozen-lockfile
+      # --backend=copyfile: bun's default Linux backend hardlinks packages into
+      # node_modules; npm publish then packs the bundleDependencies as hard-link
+      # tar entries, which the registry rejects (E415 "Hard link is not
+      # allowed"). copyfile makes them real files.
+      - run: bun install --frozen-lockfile --backend=copyfile
       - name: Changesets — version PR or publish
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:


### PR DESCRIPTION
<!-- Closes F-717 -->

## What
Installs with `bun install --frozen-lockfile --backend=copyfile` in both the release job and the publish-smoke job, and adds a hard-link assertion to publish-smoke.

## Why
With the npm pin fixed (PR #59), the `0.7.0` publish got all the way through OIDC + provenance signing, then failed at the registry PUT with `E415 — Hard link is not allowed`. Cause: bun's default Linux backend hard-links packages into `node_modules`, so `npm publish` packs the `bundleDependencies` (the 4 vendored `@pome-sh/*` twins) as hard-link tar entries, which the npm registry rejects. `--backend=copyfile` makes them real files. Local `npm pack` never caught this — the hard-link rejection is registry-side only, so publish-smoke now asserts no hard-link entries in the packed tarball. FDRS-717.

## Notes for reviewer
- This PR's `cli-publish-smoke` job runs the copyfile install + the new hard-link assertion on Linux — a green check here is the pre-merge proof.
- Merging re-triggers `cli-release.yml` (0.7.0 still unpublished + zero changesets → publish path), which should finally publish `pome-sh@0.7.0` with provenance.