### PR TITLE
feat(twins): delete every mirror file; copy-marker CI gate now hard-blocking (F-685)

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -9,7 +9,7 @@ This document enumerates everything pome-cloud (and the pome CLI) may rely on wh
 - Entry point: `node dist/src/server.js` with **cwd = the twin package root** (`packages/twin-<name>`).
 - `GET /healthz` answers **200 within 3 seconds** of spawn.
 - The twin **refuses to boot** on a non-loopback bind host without `TWIN_AUTH_SECRET` (exit code ≠ 0; the error names the variable).
-- Runtime dependency arrangement: hoisted `node_modules` + `packages/shared-types` **with its compiled runtime JS** (`bun run --filter '@pome-sh/shared-types' build:runtime`). `@pome-sh/shared-types` exports `./src/index.ts`, so a plain-`node` boot relies on type stripping (**Node ≥ 22.18**) plus the built `src/*.js` files for its `.js` import specifiers. The GHCR runtime image ships `node:24`; the Dockerfiles are the reference implementation of this arrangement.
+- Runtime dependency arrangement: hoisted `node_modules` + `packages/shared-types` **with its compiled runtime JS** + `packages/sdk` **with its built `dist/`** (the twins are engine plugins since F-682/683/684; the runtime image ships the sdk so the hoisted workspace symlink resolves) (`bun run --filter '@pome-sh/shared-types' build:runtime`). `@pome-sh/shared-types` exports `./src/index.ts`, so a plain-`node` boot relies on type stripping (**Node ≥ 22.18**) plus the built `src/*.js` files for its `.js` import specifiers. The GHCR runtime image ships `node:24`; the Dockerfiles are the reference implementation of this arrangement.
 
 ## Environment surface
 

--- a/packages/adapter-claude-sdk/test/redaction.test.ts
+++ b/packages/adapter-claude-sdk/test/redaction.test.ts
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Co-located guard for the byte-identical redaction mirror (FDRS-588 / FDRS-608).
+// Co-located guard for the adapter redaction surface (FDRS-588 / FDRS-608):
+// since M6 it re-exports @pome-sh/shared-types/redaction — these cases pin
+// the shapes the adapter relies on staying redacted.
 import { describe, expect, it } from "vitest";
 import { redactSecrets } from "../src/redaction.js";
 

--- a/packages/sdk/src/server-helpers.ts
+++ b/packages/sdk/src/server-helpers.ts
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Internal helpers for `@pome-sh/sdk/server` (`createApp`/`serve`). Split
+// out of server.ts (F-685) purely for module-size hygiene; everything a twin
+// may import (TwinBootError, isLoopbackHost) is re-exported from server.ts,
+// which stays the only public entry.
+
+import { RESERVED_SESSION_PREFIXES, type ToolSpec, type TwinDefinition } from "./index.js";
+import { UnknownToolError } from "./errors.js";
+
+export class TwinBootError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TwinBootError";
+  }
+}
+
+/** Engine-owned `/_pome/*` route names a twin's `pomeRoutes` may not shadow. */
+export const POME_CORE_ROUTE_NAMES = new Set(["health", "state", "events"]);
+
+export function makeDeltaSink() {
+  let delta: import("@pome-sh/shared-types").RecorderEvent["state_delta"] = null;
+  return {
+    report(d: import("@pome-sh/shared-types").RecorderEvent["state_delta"]) {
+      delta = d;
+    },
+    value() {
+      return delta;
+    },
+  };
+}
+
+/** Hostnames the boot guard treats as loopback binds. */
+export function isLoopbackHost(value: string): boolean {
+  return value === "127.0.0.1" || value === "::1" || value === "localhost";
+}
+
+export function shadowedPrefix(routePath: string): string | null {
+  for (const prefix of RESERVED_SESSION_PREFIXES) {
+    if (routePath === prefix || routePath.startsWith(`${prefix}/`)) return prefix;
+  }
+  return null;
+}
+
+export function assertUniqueToolNames<TDomain>(
+  tools: ReadonlyArray<ToolSpec<TDomain>>,
+  twinId: string
+) {
+  const seen = new Set<string>();
+  for (const tool of tools) {
+    if (seen.has(tool.name)) {
+      throw new TwinBootError(`Twin "${twinId}" has duplicate tool name: ${tool.name}`);
+    }
+    seen.add(tool.name);
+  }
+}
+
+export function findTool<TDb, TSeed, TDomain>(
+  definition: TwinDefinition<TDb, TSeed, TDomain>,
+  name: string
+): ToolSpec<TDomain> {
+  const tool = definition.tools.find((t) => t.name === name);
+  if (!tool) {
+    throw new UnknownToolError(name);
+  }
+  return tool;
+}
+
+export async function readJson(req: Request): Promise<unknown> {
+  try {
+    const cloned = req.clone();
+    const text = await cloned.text();
+    if (!text) return null;
+    return JSON.parse(text);
+  } catch (err) {
+    if (err instanceof SyntaxError) throw err;
+    return null;
+  }
+}
+
+/**
+ * Convenience helper for `recorder.handle` inner functions. Returns a
+ * 200 response with the supplied `mutation` flag (default: false). Mirrors
+ * `packages/twin-github/src/app.ts:ok`.
+ */
+export function ok(body: unknown, mutation = false): { status: 200; body: unknown; mutation: boolean } {
+  return { status: 200, body, mutation };
+}
+
+/**
+ * Convenience helper for `recorder.handle` inner functions. Returns a
+ * 201 response with `mutation: true`. Mirrors
+ * `packages/twin-github/src/app.ts:created`.
+ */
+export function created(body: unknown): { status: 201; body: unknown; mutation: true } {
+  return { status: 201, body, mutation: true };
+}

--- a/packages/sdk/src/server.ts
+++ b/packages/sdk/src/server.ts
@@ -1,4 +1,3 @@
-// file-size: engine surface grew with the per-twin pins (F-682/F-684); the F-685 sweep in this stack splits boot/dispatch helpers into server-helpers.ts
 // SPDX-License-Identifier: Apache-2.0
 //
 // `@pome-sh/sdk/server` — boot a `TwinDefinition` into a Hono app and
@@ -38,6 +37,20 @@ import { handleMcpJsonRpc, mcpMethodNotAllowed } from "./mcp-jsonrpc.js";
 import { createRecorderHandle, type RecorderStore } from "./recorder.js";
 import { redactSecrets } from "./redaction.js";
 import { TwinError, UnknownToolError, envelopeFor } from "./errors.js";
+import {
+  POME_CORE_ROUTE_NAMES,
+  TwinBootError,
+  assertUniqueToolNames,
+  findTool,
+  isLoopbackHost,
+  makeDeltaSink,
+  readJson,
+  shadowedPrefix,
+} from "./server-helpers.js";
+
+// Public boot surface consumed by twin entrypoints
+// (`import { TwinBootError, isLoopbackHost, serve } from "@pome-sh/sdk/server"`).
+export { TwinBootError, isLoopbackHost, created, ok } from "./server-helpers.js";
 
 export { createRecorderHandle, createRecorderStore } from "./recorder.js";
 export type { RecorderStore, ErrorEnvelopeFn } from "./recorder.js";
@@ -84,24 +97,6 @@ export type {
 export { twinBuildInfo } from "./build-info.js";
 export type { TwinBuildInfo } from "./build-info.js";
 
-/**
- * Convenience helper for `recorder.handle` inner functions. Returns a
- * 200 response with the supplied `mutation` flag (default: false). Mirrors
- * `packages/twin-github/src/app.ts:ok`.
- */
-export function ok(body: unknown, mutation = false): { status: 200; body: unknown; mutation: boolean } {
-  return { status: 200, body, mutation };
-}
-
-/**
- * Convenience helper for `recorder.handle` inner functions. Returns a
- * 201 response with `mutation: true`. Mirrors
- * `packages/twin-github/src/app.ts:created`.
- */
-export function created(body: unknown): { status: 201; body: unknown; mutation: true } {
-  return { status: 201, body, mutation: true };
-}
-
 export interface ServeOptions<TDb = unknown, TSeed = unknown> {
   /** Optional. When set, `serve()` binds a Node HTTP server. */
   port?: number;
@@ -115,13 +110,6 @@ export interface ServeOptions<TDb = unknown, TSeed = unknown> {
   recorder?: RecorderStore;
   /** Run identifier embedded in every recorder event. Defaults to "local". */
   runId?: string;
-}
-
-export class TwinBootError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "TwinBootError";
-  }
 }
 
 const jsonRecord = z.record(z.string(), z.unknown());
@@ -496,64 +484,3 @@ export async function serve<TDb, TSeed, TDomain>(
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 /** Engine-owned `/_pome/*` route names a twin's `pomeRoutes` may not shadow. */
-const POME_CORE_ROUTE_NAMES = new Set(["health", "state", "events"]);
-
-function makeDeltaSink() {
-  let delta: import("@pome-sh/shared-types").RecorderEvent["state_delta"] = null;
-  return {
-    report(d: import("@pome-sh/shared-types").RecorderEvent["state_delta"]) {
-      delta = d;
-    },
-    value() {
-      return delta;
-    },
-  };
-}
-
-/** Hostnames the boot guard treats as loopback binds. */
-export function isLoopbackHost(value: string): boolean {
-  return value === "127.0.0.1" || value === "::1" || value === "localhost";
-}
-
-function shadowedPrefix(routePath: string): string | null {
-  for (const prefix of RESERVED_SESSION_PREFIXES) {
-    if (routePath === prefix || routePath.startsWith(`${prefix}/`)) return prefix;
-  }
-  return null;
-}
-
-function assertUniqueToolNames<TDomain>(
-  tools: ReadonlyArray<ToolSpec<TDomain>>,
-  twinId: string
-) {
-  const seen = new Set<string>();
-  for (const tool of tools) {
-    if (seen.has(tool.name)) {
-      throw new TwinBootError(`Twin "${twinId}" has duplicate tool name: ${tool.name}`);
-    }
-    seen.add(tool.name);
-  }
-}
-
-function findTool<TDb, TSeed, TDomain>(
-  definition: TwinDefinition<TDb, TSeed, TDomain>,
-  name: string
-): ToolSpec<TDomain> {
-  const tool = definition.tools.find((t) => t.name === name);
-  if (!tool) {
-    throw new UnknownToolError(name);
-  }
-  return tool;
-}
-
-async function readJson(req: Request): Promise<unknown> {
-  try {
-    const cloned = req.clone();
-    const text = await cloned.text();
-    if (!text) return null;
-    return JSON.parse(text);
-  } catch (err) {
-    if (err instanceof SyntaxError) throw err;
-    return null;
-  }
-}

--- a/packages/twin-github/README.md
+++ b/packages/twin-github/README.md
@@ -86,7 +86,7 @@ bearer-auth contract is unchanged — the JWT `sid` claim (or
 
 Every `tools/call` reaching `/s/:sid/mcp` produces one recorder event whose
 `request_body` is `{ tool, arguments }` and whose `response_body` is the raw
-domain return — byte-identical to what `POST /s/:sid/mcp/call` records. The
+domain return — identical to what `POST /s/:sid/mcp/call` records. The
 only intentional difference is `path`. Run `bun run validate:mcp` to
 regenerate the side-by-side diff in `scripts/validate-mcp.output.txt`.
 

--- a/packages/twin-github/scripts/validate-mcp.output.txt
+++ b/packages/twin-github/scripts/validate-mcp.output.txt
@@ -2772,7 +2772,7 @@ Per-field comparison (excluding volatile ts/request_id/correlation_id/latency_ms
   }
 }
 ✓ Only `path` differs between surfaces (the intentional, surface-identifying field).
-✓ request_body, response_body, state_mutation, state_delta, status, fidelity, error all byte-identical.
+✓ request_body, response_body, state_mutation, state_delta, status, fidelity, error all identical.
 
 ━━━ RESULT ━━━
 ALL VALIDATIONS PASSED ✓

--- a/packages/twin-github/scripts/validate-mcp.ts
+++ b/packages/twin-github/scripts/validate-mcp.ts
@@ -222,7 +222,7 @@ async function main() {
       throw new Error(`unexpected field divergence beyond 'path': ${JSON.stringify(Object.keys(diff))}`);
     }
     record("✓ Only `path` differs between surfaces (the intentional, surface-identifying field).");
-    record("✓ request_body, response_body, state_mutation, state_delta, status, fidelity, error all byte-identical.");
+    record("✓ request_body, response_body, state_mutation, state_delta, status, fidelity, error all identical.");
 
     section("RESULT");
     record("ALL VALIDATIONS PASSED ✓");

--- a/packages/twin-github/test/state-export.test.ts
+++ b/packages/twin-github/test/state-export.test.ts
@@ -125,7 +125,7 @@ describe("state export determinism (F-682)", () => {
     };
     // Wall-clock audit columns and fabricated shas (makeSha salts with a
     // random UUID) are the only intentionally-nondeterministic fields; the
-    // remaining export must be byte-identical across runs.
+    // remaining export must be identical across runs.
     const strip = (s: string) =>
       s
         .replace(/"[a-z_]+_at":("[^"]*"|null)/g, '"<at>":"<ts>"')

--- a/packages/twin-slack/README.md
+++ b/packages/twin-slack/README.md
@@ -154,7 +154,7 @@ bun run agent:claude "<task>"   # Claude-driven smoke flow
 
 Every `tools/call` reaching `/s/:sid/mcp` produces one recorder event whose
 `request_body` is `{ tool, arguments }` and whose `response_body` is the raw
-domain return — byte-identical to what `POST /s/:sid/mcp/call` records. The
+domain return — identical to what `POST /s/:sid/mcp/call` records. The
 only intentional difference is `path`. Run `bun run validate:mcp` to
 exercise the MCP wire protocol end-to-end and dump the round-trip.
 
@@ -192,7 +192,7 @@ via a cross-repo PR.
 - `GET /healthz` returns 200 within ~3s of process start (the snapshot build
   sleeps 3s after `node dist/src/server.js` before probing)
 - All admin routes are localhost-only (`/admin/*`)
-- Bearer auth at `Authorization: Bearer <jwt>` per `src/auth.ts`
+- Bearer auth at `Authorization: Bearer <jwt>` — engine-owned (`@pome-sh/sdk` `bearerAuth`), shape declared in `src/twin.ts`
 
 ### Env
 

--- a/packages/twin-slack/src/util.ts
+++ b/packages/twin-slack/src/util.ts
@@ -121,7 +121,7 @@ export function normalizeTs(value: unknown): string | undefined {
 }
 
 // Base unix seconds for deterministic ts generation. Controlled by
-// SLACK_DETERMINISTIC_TS=1 in tests so output is byte-identical across runs.
+// SLACK_DETERMINISTIC_TS=1 in tests so output is identical across runs.
 export const DETERMINISTIC_TS_BASE_SECONDS = 1735689600; // 2025-01-01 UTC
 
 export function tsBaseSeconds(): number {


### PR DESCRIPTION
<!-- Closes F-685 -->

## What

M1 closeout on top of the three port lanes (this branch merges #63 and #64; #65 was superseded by M6 and closed): `packages/sdk/src/server.ts` split into `server.ts` + `server-helpers.ts` (file-size gate), mirror-marker vocabulary swept to zero outside `packages/shared-types`, stale doc rows fixed (CONTRACT.md Boot arrangement now names the shipped sdk dist; twin-slack README auth row points at the engine).

## Why

F-685 — the milestone's definition of done. Note the goalposts moved under it mid-flight: M6 on main already deleted the mirror-parity scripts, flipped the copy-marker gate to hard-blocking with an EMPTY allowlist (stronger than this ticket's planned 2-entry allowlist), and centralized redaction in shared-types. This PR carries only what remained.

## Notes for reviewer

- **DRAFT until #63 / #64 merge** — integration PR; diff vs #62 currently includes both siblings. Merge order: #62 → #63/#64 → this.
- The five `byte-identical` hits left in `packages/shared-types` OTel files are determinism domain vocabulary in a change-gated package (both-founders, cross-repo) — ruled on the Linear ticket; a literal zero-match needs a small shared-types follow-up under the usual sign-off.
- Integration gauntlet on this branch: contract 64 assertions (61 pass / 3 per-twin skips), 1166 workspace tests, CLI 541/541 via the cli-ci tarball flow, typecheck clean, copy-marker/code-health/no-cloud-imports/knip green.