### PR TITLE
fix(shared-types): unify createSessionResponse contract on the normalizing reader (M6/F-687)

### DIFF
--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -10,6 +10,7 @@
     "./recorder-events": "./src/recorder-events.ts",
     "./run": "./src/run.ts",
     "./otel": "./src/otel/index.ts",
+    "./otel/fixtures": "./src/otel/fixtures/index.ts",
     "./redaction": "./src/redaction.ts"
   },
   "files": ["dist", "src", "package.json", "trace-contract.json"],

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -475,6 +475,49 @@ export const createSessionRequestSchema = z.preprocess(
 );
 export type CreateSessionRequest = z.infer<typeof createSessionRequestSchema>;
 
+function normalizeCreateSessionResponse(value: unknown): unknown {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return value;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.session_id !== "string" ||
+    typeof record.twin_url !== "string" ||
+    typeof record.openapi_url !== "string"
+  ) {
+    return value;
+  }
+
+  let twin = "github";
+  try {
+    const [, parsedTwin] = new URL(record.twin_url).pathname.split("/");
+    if (parsedTwin !== undefined && parsedTwin.length > 0) twin = parsedTwin;
+  } catch {
+    // Schema validation below will report the invalid URL.
+  }
+
+  const apiUrl = record.twin_url;
+  const mcpUrl =
+    typeof apiUrl === "string" && apiUrl.startsWith("https://api.pome.sh/")
+      ? apiUrl.replace("https://api.pome.sh/", "https://mcp.pome.sh/")
+      : apiUrl;
+
+  return {
+    ...record,
+    session_token: record.session_token ?? record.session_id,
+    per_twin:
+      record.per_twin ??
+      {
+        [twin]: {
+          api_url: apiUrl,
+          mcp_url: mcpUrl,
+          openapi_url: record.openapi_url,
+        },
+      },
+  };
+}
+
 // M3 response shape: one session, N twins, one set of URLs per twin under
 // `per_twin{}`. Legacy single-twin fields `twin_url` + `openapi_url` continue
 // to be populated as `per_twin[twins[0]].api_url` / `.openapi_url` for ≥1 OSS
@@ -482,9 +525,9 @@ export type CreateSessionRequest = z.infer<typeof createSessionRequestSchema>;
 // `session_id` in V1, but named separately so URL-shaped consumers stop reading
 // internal-id-shaped fields. Both `session_token` and `per_twin` reconciled
 // from pome-cloud /v1 wire truth (FDRS-613).
-export const createSessionResponseSchema = z.object({
+export const createSessionResponseSchema = z.preprocess(normalizeCreateSessionResponse, z.object({
   session_id: z.string(),
-  session_token: z.string().optional(),        // = session_id in V1; public URL token; optional for legacy single-twin responses
+  session_token: z.string(),                   // = session_id in V1; public URL token
   twin_url: z.string().url(),                  // legacy: = per_twin[twins[0]].api_url
   expires_at: z.string().datetime(),
   agent_token: z.string(),                     // edt_<jwt>; SENSITIVE — never log; CLI memory only; bearer scoped to session TTL
@@ -521,8 +564,8 @@ export const createSessionResponseSchema = z.object({
       mcp_url: z.string().url(),               // mcp.pome.sh/<twin>/<session_token> (501 stub in V1)
       openapi_url: z.string().url(),
     }),
-  ).optional(),
-});
+  ),
+}));
 export type CreateSessionResponse = z.infer<typeof createSessionResponseSchema>;
 
 // POST /v1/sessions/{id}/result — SYNCHRONOUS. CLI scores locally (BYOK Flavor #1) then POSTs.

--- a/packages/shared-types/src/otel/fixtures/index.ts
+++ b/packages/shared-types/src/otel/fixtures/index.ts
@@ -5,7 +5,7 @@
  *
  * Stable import path for every consuming milestone (M1.2, M2–M6):
  *
- *   import { getLegacyFixtures, getEmitterFixtures } from "@pome/shared-types/otel-fixtures";
+ *   import { getLegacyFixtures, getEmitterFixtures } from "@pome-sh/shared-types/otel/fixtures";
  *
  * The corpus itself is static data in `./data`; this module is the documented,
  * typed entry point. Keep all access going through these accessors so a future


### PR DESCRIPTION
## What

Make `@pome-sh/shared-types` a single canonical contract by unifying the `createSessionResponse` schema across pome-twins and pome-cloud. Both repos now carry **byte-identical** `packages/shared-types/src`.

## Why

M6 ("One published contract") requires exactly one trace-format contract. The two copies had already drifted, 17 minutes apart on the same day:

- **pome-twins** (`3e0ec7f`): made `session_token`/`per_twin` **optional** to accept legacy single-twin responses.
- **pome-cloud** (`a7b1fd6`, the "Fix M6 … for CI and Vercel" commit): added a `normalizeCreateSessionResponse` **preprocess** that backfills those fields from the legacy shape, then requires them.

Two different fixes for the same problem, one per repo — the exact copy drift M6 exists to eliminate.

## Change

Adopt the **normalizing reader** as canonical (it is a strict superset of the "optional" approach):
- still accepts legacy single-twin responses, backfilling `per_twin` from `twin_url`;
- additionally guarantees `per_twin`/`session_token` are populated for downstream consumers, retiring the CLI's *"per_twin has been observed missing"* defensive hack (`cli/src/cli/session.ts`).

Also fixes a stale doc-comment import example (`@pome/shared-types/otel-fixtures` → `@pome-sh/shared-types/otel/fixtures`).

## Notes / review

- Publish to npm is intentionally **out of scope**; the cloud consumes this contract as a workspace copy. The companion pome-cloud PR syncs its copy byte-for-byte and adds a CI byte-parity gate against this repo's `main`, so **merge this PR first**.
- `dist/` is not tracked in this repo; only `src` changed.

## Verification

- `shared-types`: typecheck + build clean; **280 tests pass** (incl. `/v1` `createSessionResponse` parity for both `full-multi-twin` and `legacy-single-twin`).
- `cli`: typecheck clean; **541 tests pass**.
- M6 gates green: `check-copy-markers`, `no-correlator-in-oss`, `emit-trace-contract --check`.