### PR TITLE
Add M8 twin supply chain guardrails

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,43 @@
+name: secret scan
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '23 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  trufflehog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - name: Scan verified secrets in changed history
+        if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
+        uses: trufflesecurity/trufflehog@v3.88.13
+        with:
+          path: ./
+          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head: ${{ github.sha }}
+          extra_args: --only-verified
+      - name: Scan verified secrets in full history
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+        uses: trufflesecurity/trufflehog@v3.88.13
+        with:
+          path: ./
+          extra_args: --only-verified

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -33,8 +33,8 @@ jobs:
           mkdir -p "$HOME/.local/bin"
           install "$tmp/gitleaks" "$HOME/.local/bin/gitleaks"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-      - name: Scan repository with gitleaks
-        run: gitleaks detect --source . --redact --verbose
+      - name: Scan current tree with gitleaks
+        run: gitleaks detect --source . --no-git --redact --verbose --config .gitleaks.toml
 
   trufflehog:
     runs-on: ubuntu-latest

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+env:
+  GITLEAKS_VERSION: 8.24.3
+  GITLEAKS_SHA256: 9991e0b2903da4c8f6122b5c3186448b927a5da4deef1fe45271c3793f4ee29c
+
 jobs:
   gitleaks:
     runs-on: ubuntu-latest
@@ -17,9 +21,20 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install gitleaks CLI
+        run: |
+          set -euo pipefail
+          archive="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          tmp="$(mktemp -d)"
+          trap 'rm -rf "$tmp"' EXIT
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${archive}" -o "$tmp/$archive"
+          printf '%s  %s\n' "$GITLEAKS_SHA256" "$tmp/$archive" | sha256sum -c -
+          tar -xzf "$tmp/$archive" -C "$tmp" gitleaks
+          mkdir -p "$HOME/.local/bin"
+          install "$tmp/gitleaks" "$HOME/.local/bin/gitleaks"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Scan repository with gitleaks
+        run: gitleaks detect --source . --redact --verbose
 
   trufflehog:
     runs-on: ubuntu-latest
@@ -29,7 +44,7 @@ jobs:
           fetch-depth: 0
       - name: Scan verified secrets in changed history
         if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
-        uses: trufflesecurity/trufflehog@v3.88.13
+        uses: trufflesecurity/trufflehog@f7ff9980e3980dac3fa0ce9a299c5516565a903c # v3.88.13
         with:
           path: ./
           base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
@@ -37,7 +52,7 @@ jobs:
           extra_args: --only-verified
       - name: Scan verified secrets in full history
         if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-        uses: trufflesecurity/trufflehog@v3.88.13
+        uses: trufflesecurity/trufflehog@f7ff9980e3980dac3fa0ce9a299c5516565a903c # v3.88.13
         with:
           path: ./
           extra_args: --only-verified

--- a/.github/workflows/twin-github-image.yml
+++ b/.github/workflows/twin-github-image.yml
@@ -40,6 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
       packages: write
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -92,6 +93,15 @@ jobs:
           exit-code: '1'
           ignore-unfixed: true
           trivyignores: .trivyignore
+      - name: Generate image SBOM
+        uses: anchore/sbom-action@v0.20.6
+        with:
+          image: twin-github:scan
+          format: spdx-json
+          output-file: twin-github.spdx.json
+          upload-artifact: true
+      - uses: sigstore/cosign-installer@v3.9.2
+        if: ${{ github.event_name != 'pull_request' }}
       # Push the EXACT image built + scanned above (already loaded into the local
       # daemon under every steps.meta.outputs.tags) — no second build, so the
       # published artifact is byte-identical to the one Trivy scanned. PR builds
@@ -106,4 +116,21 @@ jobs:
             [ -n "$tag" ] || continue
             echo "pushing $tag"
             docker push "$tag"
+          done
+      - name: Sign pushed image digests and attest SBOM
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### Signed twin-github image digests"
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+          printf '%s\n' "${{ steps.meta.outputs.tags }}" | while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            digest="$(docker buildx imagetools inspect "$tag" --format '{{.Manifest.Digest}}')"
+            ref="${tag}@${digest}"
+            echo "signing $ref"
+            cosign sign --yes "$ref"
+            cosign attest --yes --predicate twin-github.spdx.json --type spdx "$ref"
+            echo "- \`$ref\`" >> "$GITHUB_STEP_SUMMARY"
           done

--- a/.github/workflows/twin-github-image.yml
+++ b/.github/workflows/twin-github-image.yml
@@ -43,7 +43,7 @@ jobs:
       id-token: write
       packages: write
     outputs:
-      tags: ${{ steps.meta.outputs.tags }}
+      signed-digests: ${{ steps.sign.outputs.signed_digests }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -94,13 +94,13 @@ jobs:
           ignore-unfixed: true
           trivyignores: .trivyignore
       - name: Generate image SBOM
-        uses: anchore/sbom-action@v0.20.6
+        uses: anchore/sbom-action@f8bdd1d8ac5e901a77a92f111440fdb1b593736b # v0.20.6
         with:
           image: twin-github:scan
           format: spdx-json
           output-file: twin-github.spdx.json
           upload-artifact: true
-      - uses: sigstore/cosign-installer@v3.9.2
+      - uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
         if: ${{ github.event_name != 'pull_request' }}
       # Push the EXACT image built + scanned above (already loaded into the local
       # daemon under every steps.meta.outputs.tags) — no second build, so the
@@ -118,19 +118,9 @@ jobs:
             docker push "$tag"
           done
       - name: Sign pushed image digests and attest SBOM
+        id: sign
         if: ${{ github.event_name != 'pull_request' }}
+        env:
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
         run: |
-          set -euo pipefail
-          {
-            echo "### Signed twin-github image digests"
-            echo
-          } >> "$GITHUB_STEP_SUMMARY"
-          printf '%s\n' "${{ steps.meta.outputs.tags }}" | while IFS= read -r tag; do
-            [ -n "$tag" ] || continue
-            digest="$(docker buildx imagetools inspect "$tag" --format '{{.Manifest.Digest}}')"
-            ref="${tag}@${digest}"
-            echo "signing $ref"
-            cosign sign --yes "$ref"
-            cosign attest --yes --predicate twin-github.spdx.json --type spdx "$ref"
-            echo "- \`$ref\`" >> "$GITHUB_STEP_SUMMARY"
-          done
+          bash scripts/ci/sign-image-digests.sh "Signed twin-github image digests" twin-github.spdx.json

--- a/.github/workflows/twin-slack-image.yml
+++ b/.github/workflows/twin-slack-image.yml
@@ -40,6 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
       packages: write
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -92,6 +93,15 @@ jobs:
           exit-code: '1'
           ignore-unfixed: true
           trivyignores: .trivyignore
+      - name: Generate image SBOM
+        uses: anchore/sbom-action@v0.20.6
+        with:
+          image: twin-slack:scan
+          format: spdx-json
+          output-file: twin-slack.spdx.json
+          upload-artifact: true
+      - uses: sigstore/cosign-installer@v3.9.2
+        if: ${{ github.event_name != 'pull_request' }}
       # Push the EXACT image built + scanned above (already loaded into the local
       # daemon under every steps.meta.outputs.tags) — no second build, so the
       # published artifact is byte-identical to the one Trivy scanned. PR builds
@@ -106,4 +116,21 @@ jobs:
             [ -n "$tag" ] || continue
             echo "pushing $tag"
             docker push "$tag"
+          done
+      - name: Sign pushed image digests and attest SBOM
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### Signed twin-slack image digests"
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+          printf '%s\n' "${{ steps.meta.outputs.tags }}" | while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            digest="$(docker buildx imagetools inspect "$tag" --format '{{.Manifest.Digest}}')"
+            ref="${tag}@${digest}"
+            echo "signing $ref"
+            cosign sign --yes "$ref"
+            cosign attest --yes --predicate twin-slack.spdx.json --type spdx "$ref"
+            echo "- \`$ref\`" >> "$GITHUB_STEP_SUMMARY"
           done

--- a/.github/workflows/twin-slack-image.yml
+++ b/.github/workflows/twin-slack-image.yml
@@ -43,7 +43,7 @@ jobs:
       id-token: write
       packages: write
     outputs:
-      tags: ${{ steps.meta.outputs.tags }}
+      signed-digests: ${{ steps.sign.outputs.signed_digests }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -94,13 +94,13 @@ jobs:
           ignore-unfixed: true
           trivyignores: .trivyignore
       - name: Generate image SBOM
-        uses: anchore/sbom-action@v0.20.6
+        uses: anchore/sbom-action@f8bdd1d8ac5e901a77a92f111440fdb1b593736b # v0.20.6
         with:
           image: twin-slack:scan
           format: spdx-json
           output-file: twin-slack.spdx.json
           upload-artifact: true
-      - uses: sigstore/cosign-installer@v3.9.2
+      - uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
         if: ${{ github.event_name != 'pull_request' }}
       # Push the EXACT image built + scanned above (already loaded into the local
       # daemon under every steps.meta.outputs.tags) — no second build, so the
@@ -118,19 +118,9 @@ jobs:
             docker push "$tag"
           done
       - name: Sign pushed image digests and attest SBOM
+        id: sign
         if: ${{ github.event_name != 'pull_request' }}
+        env:
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
         run: |
-          set -euo pipefail
-          {
-            echo "### Signed twin-slack image digests"
-            echo
-          } >> "$GITHUB_STEP_SUMMARY"
-          printf '%s\n' "${{ steps.meta.outputs.tags }}" | while IFS= read -r tag; do
-            [ -n "$tag" ] || continue
-            digest="$(docker buildx imagetools inspect "$tag" --format '{{.Manifest.Digest}}')"
-            ref="${tag}@${digest}"
-            echo "signing $ref"
-            cosign sign --yes "$ref"
-            cosign attest --yes --predicate twin-slack.spdx.json --type spdx "$ref"
-            echo "- \`$ref\`" >> "$GITHUB_STEP_SUMMARY"
-          done
+          bash scripts/ci/sign-image-digests.sh "Signed twin-slack image digests" twin-slack.spdx.json

--- a/.github/workflows/twin-stripe-image.yml
+++ b/.github/workflows/twin-stripe-image.yml
@@ -40,6 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
       packages: write
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -92,6 +93,15 @@ jobs:
           exit-code: '1'
           ignore-unfixed: true
           trivyignores: .trivyignore
+      - name: Generate image SBOM
+        uses: anchore/sbom-action@v0.20.6
+        with:
+          image: twin-stripe:scan
+          format: spdx-json
+          output-file: twin-stripe.spdx.json
+          upload-artifact: true
+      - uses: sigstore/cosign-installer@v3.9.2
+        if: ${{ github.event_name != 'pull_request' }}
       # Push the EXACT image built + scanned above (already loaded into the local
       # daemon under every steps.meta.outputs.tags) — no second build, so the
       # published artifact is byte-identical to the one Trivy scanned. PR builds
@@ -106,4 +116,21 @@ jobs:
             [ -n "$tag" ] || continue
             echo "pushing $tag"
             docker push "$tag"
+          done
+      - name: Sign pushed image digests and attest SBOM
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### Signed twin-stripe image digests"
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+          printf '%s\n' "${{ steps.meta.outputs.tags }}" | while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            digest="$(docker buildx imagetools inspect "$tag" --format '{{.Manifest.Digest}}')"
+            ref="${tag}@${digest}"
+            echo "signing $ref"
+            cosign sign --yes "$ref"
+            cosign attest --yes --predicate twin-stripe.spdx.json --type spdx "$ref"
+            echo "- \`$ref\`" >> "$GITHUB_STEP_SUMMARY"
           done

--- a/.github/workflows/twin-stripe-image.yml
+++ b/.github/workflows/twin-stripe-image.yml
@@ -43,7 +43,7 @@ jobs:
       id-token: write
       packages: write
     outputs:
-      tags: ${{ steps.meta.outputs.tags }}
+      signed-digests: ${{ steps.sign.outputs.signed_digests }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -94,13 +94,13 @@ jobs:
           ignore-unfixed: true
           trivyignores: .trivyignore
       - name: Generate image SBOM
-        uses: anchore/sbom-action@v0.20.6
+        uses: anchore/sbom-action@f8bdd1d8ac5e901a77a92f111440fdb1b593736b # v0.20.6
         with:
           image: twin-stripe:scan
           format: spdx-json
           output-file: twin-stripe.spdx.json
           upload-artifact: true
-      - uses: sigstore/cosign-installer@v3.9.2
+      - uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
         if: ${{ github.event_name != 'pull_request' }}
       # Push the EXACT image built + scanned above (already loaded into the local
       # daemon under every steps.meta.outputs.tags) — no second build, so the
@@ -118,19 +118,9 @@ jobs:
             docker push "$tag"
           done
       - name: Sign pushed image digests and attest SBOM
+        id: sign
         if: ${{ github.event_name != 'pull_request' }}
+        env:
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
         run: |
-          set -euo pipefail
-          {
-            echo "### Signed twin-stripe image digests"
-            echo
-          } >> "$GITHUB_STEP_SUMMARY"
-          printf '%s\n' "${{ steps.meta.outputs.tags }}" | while IFS= read -r tag; do
-            [ -n "$tag" ] || continue
-            digest="$(docker buildx imagetools inspect "$tag" --format '{{.Manifest.Digest}}')"
-            ref="${tag}@${digest}"
-            echo "signing $ref"
-            cosign sign --yes "$ref"
-            cosign attest --yes --predicate twin-stripe.spdx.json --type spdx "$ref"
-            echo "- \`$ref\`" >> "$GITHUB_STEP_SUMMARY"
-          done
+          bash scripts/ci/sign-image-digests.sh "Signed twin-stripe image digests" twin-stripe.spdx.json

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,10 @@
+[allowlist]
+description = "Synthetic credentials used by tests and public documentation examples"
+paths = [
+  '''^cli/test/''',
+  '''^contract/''',
+  '''^packages/.*/test/''',
+  '''^packages/.*/README\.md$''',
+  '''^packages/.*/FIDELITY\.md$''',
+  '''^CONTRACT\.md$''',
+]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,21 @@ section in the same PR.
 | Dead code / orphan packages = 0 | [`knip.json`](knip.json) via `bun run lint:dead-code` in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) |
 | Package barrels + file-size hygiene | [`scripts/lint-code-health.mjs`](scripts/lint-code-health.mjs) |
 
+## Public Repo Guardrails
+
+The public `main` branch requires reviewed PRs and green required checks before
+merge. Direct pushes are reserved for release automation only.
+
+Secret scanning runs in CI via [`.github/workflows/secret-scan.yml`](.github/workflows/secret-scan.yml)
+with both gitleaks and TruffleHog. Install the local hook with
+`bash scripts/hooks/install.sh`; staged changes are blocked unless the same
+boundary gates pass and installed secret scanners find no verified secrets.
+
+Twin images publish only after package tests and Trivy scans pass. Published
+GHCR digests are cosign-signed with GitHub OIDC, and each digest receives an
+SPDX SBOM attestation. Downstream cloud snapshot promotion must pin and verify
+those signed digests before rebuilding runtime snapshots.
+
 Everything else — architecture, per-package details, and the CI gotchas
 (changeset gate, no-cloud-imports, twin Docker build) — is documented at
 https://docs.pome.sh.

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -2,7 +2,7 @@
 
 **Version 1.0.0** — frozen 2026-07-07 (FDRS-711), verified by the black-box suite in [`contract/`](./contract/).
 
-This document enumerates everything pome-cloud (and the pome CLI) may rely on when booting and driving a twin. **Changing any item below is a breaking contract change**: update this document and the suite in the same PR, and open the coordinated cross-repo PR to pome-cloud (rule of record: `packages/twin-github/README.md`, runtime-contract section).
+This document enumerates everything pome-cloud (and the pome CLI) may rely on when booting and driving a twin. **Changing any item below is a breaking contract change**: update this document and the suite in the same PR, then open the matching pome-cloud consumer PR that pins and verifies the new signed twin artifact (rule of record: `packages/twin-github/README.md`, runtime-contract section).
 
 ## Boot
 

--- a/PACKAGE_RELEASE.md
+++ b/PACKAGE_RELEASE.md
@@ -15,5 +15,10 @@ The CLI package (`pome-sh`) keeps using the existing Changesets flow in
 4. Publish the CLI only after the exact package versions in `cli/package.json`
    exist on npm.
 
+Twin image workflows publish GHCR digests only after tests and Trivy pass. Each
+published digest is cosign-signed with GitHub OIDC and receives an SPDX SBOM
+attestation; the pome-cloud snapshot promotion PR must pin and verify one of
+those digests before rebuilding hosted snapshots.
+
 Do not store `NPM_TOKEN` for these packages. Trusted Publishing must be
 configured in npm for each `@pome-sh/*` package.

--- a/cli/SECURITY.md
+++ b/cli/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported versions
 
-The latest published `v0.5.x` line of `pome-sh/cli` receives security updates. Older versions are not patched.
+The latest published `pome-sh` CLI line receives security updates. Older versions are not patched.
 
 ## Reporting a vulnerability
 
@@ -10,7 +10,7 @@ Please **do not** open a public GitHub issue for a suspected vulnerability.
 
 Use GitHub's private vulnerability reporting:
 
-1. Go to https://github.com/pome-sh/cli/security/advisories/new
+1. Go to https://github.com/pome-sh/pome-twins/security/advisories/new
 2. Fill in the form. We get a private notification.
 
 Alternatively, email `founders@pome.sh`.

--- a/contract/contract.test.mjs
+++ b/contract/contract.test.mjs
@@ -8,7 +8,7 @@
 // These assertions FREEZE observed wire behavior — including per-twin
 // divergences that are themselves under review (see FDRS-712). Changing any
 // asserted status or shape is a contract change: update CONTRACT.md in the
-// same PR and coordinate the cross-repo pome-cloud PR per the contract doc.
+// same PR and coordinate the pome-cloud consumer PR per the contract doc.
 // The suite body lives in ./suite.mjs (FDRS-681) so the identical assertions
 // also run against the sdk-booted proof entry (./sdk-boot.test.mjs).
 //

--- a/contract/suite.mjs
+++ b/contract/suite.mjs
@@ -5,7 +5,7 @@
 // assertions can run against any built twin artifact AND the sdk-booted
 // proof entry (contract/sdk-boot.test.mjs). Changing any asserted status or
 // shape here is a contract change: update CONTRACT.md in the same PR and
-// coordinate the cross-repo pome-cloud PR per the contract doc.
+// coordinate the pome-cloud consumer PR per the contract doc.
 
 import { after, before, describe, it } from "node:test";
 import assert from "node:assert/strict";

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -225,7 +225,7 @@ export interface BearerAuthOptions {
   /**
    * Row 4 pin: accept a prefix-less bearer and case-insensitive "bearer".
    * Default false (github/slack); stripe pins true. Flipping a twin is a
-   * contract change (CONTRACT.md + suite + cross-repo PR in one change).
+   * contract change (CONTRACT.md + suite, then a cloud consumer PR).
    */
   allowRawBearer?: boolean;
   /**

--- a/packages/shared-types/CHANGELOG.md
+++ b/packages/shared-types/CHANGELOG.md
@@ -117,8 +117,8 @@ JS/`.d.ts` so npm consumers (SDK / adapter) can vendor a published tarball
 ## Unreleased
 
 FDRS-480/481/482 — OpenTelemetry-native trace format (M1). Canonical home of the
-OTel surface; `pome-cloud` mirrors `src/otel/` verbatim (its earlier cloud-only
-copy collapses into this mirror).
+OTel surface; `pome-cloud` consumes the published package surface instead of
+mirroring `src/otel/` source files.
 
 ### Added
 
@@ -144,9 +144,8 @@ copy collapses into this mirror).
 - Additive only — `eventSchema` / `recorderEventSchema` and every existing export
   are untouched. Patterns are zod 3+4 compatible (cloud is on zod 3).
 - No version bump: accumulates under `## Unreleased` per this changelog's
-  convention. The coordinated `@pome/shared-types` ↔ `@pome-sh/shared-types`
-  version bump is a founder decision (bi-repo version lockstep) when this lands
-  alongside the cloud mirror.
+  convention. Downstream consumers pick this up through the next
+  `@pome-sh/shared-types` publish.
 
 ---
 
@@ -198,5 +197,7 @@ FDRS-318 — file split + correlator/state-inspector field surface for M1+M2.
 
 ### Notes
 
-- Pre-Stage-1, `pome-cloud/packages/shared-types/` is the mirror copy. This PR requires a paired PR there with the identical diff.
+- Pre-Stage-1, the cloud carried a temporary mirror copy. M8 retires source
+  mirroring; downstream consumers should use the published `@pome-sh/shared-types`
+  package contract.
 - FDRS-318's description says `Run.events_jsonl_url: string`, FDRS-327 says nullable. Aligned with FDRS-327 (nullable) — see [DECISION] comment on FDRS-318.

--- a/packages/shared-types/test/fixtures/v1/README.md
+++ b/packages/shared-types/test/fixtures/v1/README.md
@@ -1,11 +1,10 @@
 # /v1 wire fixture corpus (FDRS-613)
 
 A shared, framework-agnostic JSON corpus of representative `/v1` wire payloads.
-It is the parity anchor between `pome-sh/pome-twins` (this repo, zod 4) and
-`pome-sh/pome-cloud` (zod 3). Both repos parse **the same JSON files** against
-their own copy of the schema; if a represented payload becomes incompatible on
-either `/v1` surface, one side starts failing to parse a fixture the other side
-still accepts.
+`pome-sh/pome-twins` is the canonical home for these fixtures and the
+`@pome-sh/shared-types` package that parses them. Cloud consumers validate
+against the published package contract; they no longer mirror this source tree
+as a second owner.
 
 ## Layout
 
@@ -30,23 +29,20 @@ Shared-types 0.5.0 renamed everything "scenario" to "task" on the wire (and
 criterion kinds `D`/`P` to `code`/`model`) behind a tolerant reader. The
 original dirs deliberately KEEP their 0.3.0-era payloads: they are the proof
 that 0.3.0 artifacts (and shipped CLIs vendoring shared-types 0.3.0) still
-parse. The `*TaskVocab` dirs hold new-vocabulary payloads. The cloud-side
-parity map gains the `*TaskVocab` dirs at the FDRS-654 consumer swap (its
-schema is 0.3.0-era until then and iterates only its own dir list, so the new
-dirs are invisible to it in the meantime — do NOT add new-vocab payloads to
-the original dirs before FDRS-654 lands).
+parse. The `*TaskVocab` dirs hold new-vocabulary payloads. Do NOT add
+new-vocab payloads to the original dirs; those directories remain the
+tolerant-reader compatibility corpus.
 
 ## Scope
 
 Deliberately scoped to the `/v1` wire surface (`planTier`, `createSession`,
 `usage`, `run`). It is **not** whole-file byte parity, whole-schema equality, or
 a guard for every possible loosening/removal, and it does **not** cover
-cloud-only billing schemas. Note the two repos pin different zod majors (twins
-`^4`, cloud `^3`), so byte-for-byte file parity is a non-goal — represented
-fixture parse parity via this corpus is the contract.
+cloud-only billing schemas. Byte-for-byte repo parity is a non-goal after M8;
+represented fixture parsing through the published package is the contract.
 
-## How each repo consumes it
+## How this repo consumes it
 
-- twins: `packages/shared-types/test/v1-fixture-parity.test.ts`
-- cloud: fetched by `.github/workflows/shared-types-v1-parity.yml` and parsed
-  against the cloud schema; injected drift fails the job.
+`packages/shared-types/test/v1-fixture-parity.test.ts` parses every fixture under
+the mapped schema. Downstream repos should consume the published
+`@pome-sh/shared-types` package instead of vendoring or mirroring this corpus.

--- a/packages/shared-types/test/v1-fixture-parity.test.ts
+++ b/packages/shared-types/test/v1-fixture-parity.test.ts
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// FDRS-613 — /v1 wire fixture-corpus parity.
+// FDRS-613 / M8 — canonical /v1 wire fixture corpus.
 //
 // Every JSON fixture under `test/fixtures/v1/<schema>/` MUST parse successfully
-// under the twins schema keyed by its directory name. The SAME corpus is fetched
-// and parsed by pome-cloud's `shared-types-v1-parity` CI job against the cloud
-// schema. This is intentionally parse-only: it catches represented required
-// fields, enum narrowing, and other fixture-level wire incompatibilities, but it
-// is not a proof of whole-schema equality.
+// under the twins schema keyed by its directory name. pome-twins is the source
+// of truth for this corpus; cloud consumers validate against the published
+// package contract instead of mirroring source bytes. This is intentionally
+// parse-only: it catches represented required fields, enum narrowing, and other
+// fixture-level wire incompatibilities, but it is not a proof of whole-schema
+// equality.
 import { readFileSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
@@ -24,15 +25,12 @@ import { runSchema } from "../src/run.js";
 const here = dirname(fileURLToPath(import.meta.url));
 const corpusRoot = join(here, "fixtures", "v1");
 
-// Directory name → schema. Keep in lockstep with fixtures/v1/README.md and the
-// cloud-side schema map.
+// Directory name → schema. Keep in lockstep with fixtures/v1/README.md.
 //
 // The `*TaskVocab` dirs (FDRS-653) hold NEW-vocabulary payloads (task_name /
 // task_source / criterion code|model). They are twins-only until the FDRS-654
-// consumer swap adds them to the cloud-side map — the cloud parity gate
-// iterates its own dir list, so the extra dirs are ignored there until then.
-// The original dirs keep their 0.3.0-era (scenario_*) payloads on purpose:
-// they now double as tolerant-reader proof.
+// consumer swap. The original dirs keep their 0.3.0-era (scenario_*) payloads
+// on purpose: they now double as tolerant-reader proof.
 const SCHEMA_BY_DIR: Record<string, ZodTypeAny> = {
   planTier: planTierSchema,
   createSessionRequest: createSessionRequestSchema,

--- a/packages/twin-github/FIDELITY.md
+++ b/packages/twin-github/FIDELITY.md
@@ -24,12 +24,12 @@ The bar Pome aims for is: **agents written against real GitHub run unchanged
 against the local twin for the surfaces below**, and trip a loud failure for
 anything outside them.
 
-For the build / runtime / cross-repo invariants the hosted snapshot build
+For the build / runtime / cloud consumer invariants the hosted snapshot build
 depends on (port `:3333`, `/healthz`, `GITHUB_CLONE_HOST`, `npm install`-able
 package, `node dist/src/server.js`), see
 [Runtime contract (for snapshot consumers)](README.md#runtime-contract-for-snapshot-consumers)
 in the package README. Changing any of those is a breaking change for
-`pome-cloud` and goes via a cross-repo PR.
+`pome-cloud` and requires a matching cloud consumer PR.
 
 ## MCP Tools
 

--- a/packages/twin-github/README.md
+++ b/packages/twin-github/README.md
@@ -92,10 +92,11 @@ regenerate the side-by-side diff in `scripts/validate-mcp.output.txt`.
 
 ## Runtime contract (for snapshot consumers)
 
-`pome-cloud` builds a Vercel Sandbox snapshot from this package's source. The
-following constraints must hold for that build to succeed and for the resulting
-snapshot to boot. Changing any of these is a breaking change for hosted; coordinate
-via a cross-repo PR.
+`pome-cloud` builds a Vercel Sandbox snapshot from this package's signed source
+artifact. The following constraints must hold for that build to succeed and for
+the resulting snapshot to boot. Changing any of these is a breaking change for
+hosted; land the producer change here first, then open the cloud consumer PR
+that pins and verifies the new signed digest.
 
 ### Build
 
@@ -117,13 +118,14 @@ via a cross-repo PR.
 - All admin routes are localhost-only (`/admin/*`)
 - Bearer auth at `Authorization: Bearer <jwt>` — engine mechanism (`@pome-sh/sdk`), shape pinned in `src/twin.ts` (F-712)
 
-### Cross-repo coordination
+### Cloud consumer coordination
 
-- Bumping any of the above = open a cross-repo PR (this repo + `pome-cloud`)
+- Bumping any of the above = publish a signed twin digest and open the matching
+  `pome-cloud` consumer PR.
 - The cloud-side snapshot build script lives at
-  `pome-cloud/notes/poc-vercel-sandbox/build-twin-github-template.ts`
-- The snapshot manifest at `pome-cloud/notes/poc-vercel-sandbox/twin-snapshot.json`
-  records the OSS git sha each snapshot was built from
+  `pome-cloud/notes/build-twin-github-template.ts`
+- The snapshot manifest at `pome-cloud/infra/twin-github-snapshot.json`
+  records the OSS git sha and signed OCI digest each snapshot was built from.
 
 ## Review harness
 
@@ -147,7 +149,7 @@ Keep agent assertions behavior-based: compare invariants (PR merged, stale `sha`
 1. Install and start the twin:
 
 ```bash
-cd ~/pome/packages/twin-github
+cd ~/pome-twins/packages/twin-github
 bun install
 GITHUB_CLONE_DB=.github_clone/my-project.db bun run dev
 ```

--- a/packages/twin-slack/FIDELITY.md
+++ b/packages/twin-slack/FIDELITY.md
@@ -25,12 +25,12 @@ The bar is: **agents written against real Slack run unchanged against the
 local twin for the surfaces below**, and trip a loud failure for anything
 outside them.
 
-For the build / runtime / cross-repo invariants the hosted snapshot build
+For the build / runtime / cloud consumer invariants the hosted snapshot build
 depends on (port `:3333`, `/healthz`, `SLACK_CLONE_HOST`, `npm install`-able
 package, `node dist/src/server.js`), see
 [Runtime contract (for snapshot consumers)](README.md#runtime-contract-for-snapshot-consumers)
 in the package README. Changing any of those is a breaking change for
-`pome-cloud` and goes via a cross-repo PR.
+`pome-cloud` and requires a matching cloud consumer PR.
 
 ## MCP Tools
 

--- a/packages/twin-slack/README.md
+++ b/packages/twin-slack/README.md
@@ -169,10 +169,11 @@ exercise the MCP wire protocol end-to-end and dump the round-trip.
 
 ## Runtime contract (for snapshot consumers)
 
-`pome-cloud` builds a Vercel Sandbox snapshot from this package's source. The
-following constraints must hold for that build to succeed and for the resulting
-snapshot to boot. Changing any of these is a breaking change for hosted; coordinate
-via a cross-repo PR.
+`pome-cloud` builds a Vercel Sandbox snapshot from this package's signed source
+artifact. The following constraints must hold for that build to succeed and for
+the resulting snapshot to boot. Changing any of these is a breaking change for
+hosted; land the producer change here first, then open the cloud consumer PR
+that pins and verifies the new signed digest.
 
 ### Build
 
@@ -204,10 +205,11 @@ via a cross-repo PR.
 - `POME_RUN_ID` — recorder correlation id (default `spawn`).
 - `SLACK_DETERMINISTIC_TS` — set to `1` for deterministic message timestamps in tests.
 
-### Cross-repo coordination
+### Cloud consumer coordination
 
-- Bumping any of the above = open a cross-repo PR (this repo + `pome-cloud`)
+- Bumping any of the above = publish a signed twin digest and open the matching
+  `pome-cloud` consumer PR.
 - The cloud-side snapshot build script lives at
   `pome-cloud/notes/build-twin-slack-template.ts`
 - The snapshot manifest at `pome-cloud/infra/twin-slack-snapshot.json`
-  records the OSS git sha each snapshot was built from
+  records the OSS git sha and signed OCI digest each snapshot was built from.

--- a/packages/twin-stripe/FIDELITY.md
+++ b/packages/twin-stripe/FIDELITY.md
@@ -27,12 +27,12 @@ The bar Pome aims for: **agents written against real Stripe x402 run
 unchanged against this twin**, and trip a loud failure for anything
 outside the documented surface.
 
-For the build / runtime / cross-repo invariants the hosted snapshot
+For the build / runtime / cloud consumer invariants the hosted snapshot
 build depends on (port `:3333`, `/healthz`, `STRIPE_CLONE_HOST`,
 `npm install`-able package, `node dist/src/server.js`), see
 [Runtime contract](./README.md#runtime-contract-for-snapshot-consumers)
 in the package README. Changing any of those is a breaking change for
-`pome-cloud` and goes via a cross-repo PR.
+`pome-cloud` and requires a matching cloud consumer PR.
 
 ## REST routes (v1 = 12 semantic + everything else loud 501)
 

--- a/packages/twin-stripe/README.md
+++ b/packages/twin-stripe/README.md
@@ -23,8 +23,8 @@ To run the twin yourself locally (e.g., in CI or against an offline
 agent), clone this repo and run:
 
 ```bash
-git clone https://github.com/pome-sh/pome.git
-cd pome && bun install
+git clone https://github.com/pome-sh/pome-twins.git
+cd pome-twins && bun install
 bun run --filter @pome-sh/twin-stripe dev &   # starts on :3333
 sleep 2
 
@@ -169,10 +169,11 @@ curl -s -X POST http://127.0.0.1:3333/s/default/mcp/call \
 
 ## Runtime contract (for snapshot consumers)
 
-`pome-cloud` builds a Vercel Sandbox snapshot from this package's source.
-The following constraints must hold for that build to succeed and for
-the resulting snapshot to boot. Changing any of these is a breaking
-change for hosted; coordinate via a cross-repo PR.
+`pome-cloud` builds a Vercel Sandbox snapshot from this package's signed source
+artifact. The following constraints must hold for that build to succeed and for
+the resulting snapshot to boot. Changing any of these is a breaking change for
+hosted; land the producer change here first, then open the cloud consumer PR
+that pins and verifies the new signed digest.
 
 ### Build
 
@@ -195,13 +196,14 @@ change for hosted; coordinate via a cross-repo PR.
 - All admin routes (`/admin/*`) are localhost-only.
 - Bearer auth at `Authorization: Bearer <jwt>` or `Bearer sk_test_pome_<sid>`.
 
-### Cross-repo coordination
+### Cloud consumer coordination
 
-- Bumping any of the above = open a cross-repo PR (this repo + `pome-cloud`).
+- Bumping any of the above = publish a signed twin digest and open the matching
+  `pome-cloud` consumer PR.
 - The cloud-side snapshot build script lives at
-  `pome-cloud/notes/poc-vercel-sandbox/build-twin-stripe-template.ts`.
+  `pome-cloud/notes/build-twin-stripe-template.ts`.
 - The snapshot manifest at `pome-cloud/infra/twin-stripe-snapshot.json`
-  records the OSS git sha each snapshot was built from.
+  records the OSS git sha and signed OCI digest each snapshot was built from.
 
 ## What v1 does NOT do
 
@@ -248,8 +250,8 @@ this monorepo and shell out to `bun run dev` from your test setup:
 import { spawn } from "node:child_process";
 import { join } from "node:path";
 
-// Path to where you cloned pome-sh/pome on disk
-const POME_REPO = process.env.POME_REPO ?? "/path/to/pome";
+// Path to where you cloned pome-sh/pome-twins on disk
+const POME_REPO = process.env.POME_REPO ?? "/path/to/pome-twins";
 
 const twin = spawn("bun", ["run", "dev"], {
   cwd: join(POME_REPO, "packages/twin-stripe"),

--- a/packages/twin-stripe/README.md
+++ b/packages/twin-stripe/README.md
@@ -277,8 +277,7 @@ deterministic-enough for tests but not identical to real Stripe.
 
 ## Pome Cloud (twin selector)
 
-Once `pome-sh/pome-cloud` ships the matching FDRS-275/276 changes, the
-hosted dashboard exposes a **stripe x402** button next to GitHub.
-Clicking it spawns a per-session Vercel Sandbox running this exact
-package. The agent in your session sees the same surface this README
-describes; URLs are path-routed (`https://twins.pome.sh/s/<sid>/...`).
+The hosted dashboard exposes a **Stripe x402** button next to GitHub.
+Clicking it spawns a per-session Vercel Sandbox running this exact package.
+The agent in your session sees the same surface this README describes; URLs
+are path-routed (`https://twins.pome.sh/s/<sid>/...`).

--- a/scripts/ci/sign-image-digests.sh
+++ b/scripts/ci/sign-image-digests.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+summary_title="${1:?usage: sign-image-digests.sh <summary-title> <sbom-file>}"
+sbom_file="${2:?usage: sign-image-digests.sh <summary-title> <sbom-file>}"
+
+if [ ! -f "$sbom_file" ]; then
+  echo "SBOM predicate not found: $sbom_file" >&2
+  exit 1
+fi
+
+if [ -z "${IMAGE_TAGS:-}" ]; then
+  echo "IMAGE_TAGS is required" >&2
+  exit 1
+fi
+
+issuer="https://token.actions.githubusercontent.com"
+identity_regexp="^https://github.com/${GITHUB_REPOSITORY:?}/\\.github/workflows/.*@refs/(heads|tags)/.*$"
+signed_refs="$(mktemp)"
+trap 'rm -f "$signed_refs"' EXIT
+
+{
+  echo "### $summary_title"
+  echo
+} >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+while IFS= read -r tag || [ -n "$tag" ]; do
+  [ -n "$tag" ] || continue
+
+  digest="$(docker buildx imagetools inspect "$tag" --format '{{.Manifest.Digest}}')"
+  ref="${tag}@${digest}"
+
+  echo "signing $ref"
+  cosign sign --yes "$ref"
+  cosign attest --yes --predicate "$sbom_file" --type spdx "$ref"
+
+  echo "verifying $ref"
+  cosign verify \
+    --certificate-identity-regexp "$identity_regexp" \
+    --certificate-oidc-issuer "$issuer" \
+    "$ref" >/dev/null
+  cosign verify-attestation \
+    --type spdx \
+    --certificate-identity-regexp "$identity_regexp" \
+    --certificate-oidc-issuer "$issuer" \
+    "$ref" >/dev/null
+
+  echo "- \`$ref\`" >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+  echo "$ref" >> "$signed_refs"
+done <<< "$IMAGE_TAGS"
+
+if [ ! -s "$signed_refs" ]; then
+  echo "No image refs were signed" >&2
+  exit 1
+fi
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  {
+    echo "signed_digests<<EOF"
+    cat "$signed_refs"
+    echo "EOF"
+  } >> "$GITHUB_OUTPUT"
+fi

--- a/scripts/hooks/install.sh
+++ b/scripts/hooks/install.sh
@@ -13,4 +13,5 @@ chmod +x scripts/hooks/pre-commit
 git config core.hooksPath scripts/hooks
 
 echo "✅ git hooks installed (core.hooksPath = scripts/hooks)"
-echo "   pre-commit will run the open-core boundary + twin-only namespace lints."
+echo "   pre-commit will run OSS boundary, copy-marker, and staged secret scans."
+echo "   Install gitleaks + trufflehog locally before committing staged changes."

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
-# Pome repo pre-commit hook. Belt to CI's suspenders — the same lints run in
+# Pome repo pre-commit hook. Belt to CI's suspenders — the same gates run in
 # .github/workflows/ci.yml, so a `--no-verify` commit is still caught on PR.
 #
 # Install with:  bash scripts/hooks/install.sh
 #
-# Lints:
+# Gates:
 #  - ADR-002 open-core boundary: no `pome-cloud` imports in packages/.
+#  - Capture-only OSS boundary: no local eval/scoring/judging/correlation.
+#  - No cross-package file-copy markers.
+#  - Secret scan staged changes when gitleaks/trufflehog are installed.
 
 set -euo pipefail
 
@@ -14,3 +17,33 @@ cd "$repo_root"
 
 echo "pre-commit: open-core boundary lint"
 bash scripts/lint-no-cloud-imports.sh
+
+echo "pre-commit: no local eval gate"
+bun run gate:no-eval
+
+echo "pre-commit: copy-marker gate"
+bun run lint:copy-markers
+
+staged_count="$(git diff --cached --name-only --diff-filter=ACMR | wc -l | tr -d ' ')"
+if [ "$staged_count" = "0" ]; then
+  echo "pre-commit: no staged files for secret scan"
+  exit 0
+fi
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "pre-commit: gitleaks is required for staged secret scans." >&2
+  echo "Install it from https://github.com/gitleaks/gitleaks, then retry." >&2
+  exit 1
+fi
+
+if ! command -v trufflehog >/dev/null 2>&1; then
+  echo "pre-commit: trufflehog is required for staged secret scans." >&2
+  echo "Install it from https://github.com/trufflesecurity/trufflehog, then retry." >&2
+  exit 1
+fi
+
+echo "pre-commit: gitleaks staged scan"
+gitleaks protect --staged --verbose
+
+echo "pre-commit: trufflehog verified-secret scan"
+trufflehog filesystem --only-verified --fail .

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -8,7 +8,7 @@
 #  - ADR-002 open-core boundary: no `pome-cloud` imports in packages/.
 #  - Capture-only OSS boundary: no local eval/scoring/judging/correlation.
 #  - No cross-package file-copy markers.
-#  - Secret scan staged file contents when gitleaks/trufflehog are installed.
+#  - Secret scan staged file contents (requires gitleaks + trufflehog).
 
 set -euo pipefail
 
@@ -43,7 +43,7 @@ if ! command -v trufflehog >/dev/null 2>&1; then
 fi
 
 echo "pre-commit: gitleaks staged scan"
-gitleaks protect --staged --verbose
+gitleaks protect --staged --verbose --config .gitleaks.toml
 
 staged_snapshot="$(mktemp -d)"
 staged_list="$(mktemp)"

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -8,7 +8,7 @@
 #  - ADR-002 open-core boundary: no `pome-cloud` imports in packages/.
 #  - Capture-only OSS boundary: no local eval/scoring/judging/correlation.
 #  - No cross-package file-copy markers.
-#  - Secret scan staged changes when gitleaks/trufflehog are installed.
+#  - Secret scan staged file contents when gitleaks/trufflehog are installed.
 
 set -euo pipefail
 
@@ -45,5 +45,20 @@ fi
 echo "pre-commit: gitleaks staged scan"
 gitleaks protect --staged --verbose
 
-echo "pre-commit: trufflehog verified-secret scan"
-trufflehog filesystem --only-verified --fail .
+staged_snapshot="$(mktemp -d)"
+staged_list="$(mktemp)"
+cleanup_secret_scan_snapshot() {
+  rm -rf "$staged_snapshot" "$staged_list"
+}
+trap cleanup_secret_scan_snapshot EXIT
+
+git diff --cached --name-only --diff-filter=ACMR -z > "$staged_list"
+while IFS= read -r -d '' path; do
+  [ -f "$path" ] || continue
+  target="$staged_snapshot/$path"
+  mkdir -p "$(dirname "$target")"
+  git show ":$path" > "$target"
+done < "$staged_list"
+
+echo "pre-commit: trufflehog staged verified-secret scan"
+trufflehog filesystem --only-verified --fail "$staged_snapshot"


### PR DESCRIPTION
Executive summary: This PR adds supply-chain guardrails for the public twin image pipeline and tightens secret scanning for CI and local contributors. It also refreshes public-facing docs so `pome-twins` is described as the canonical twin producer and downstream consumers rely on signed, pinned digests.

## What
- Add a secret scanning workflow that runs a checksum-verified gitleaks tree scan and a pinned TruffleHog history scan.
- Generate SPDX SBOMs for the GitHub, Slack, and Stripe twin images, then sign and attest pushed GHCR digests with cosign keyless signing before exposing them as workflow outputs.
- Extend the local pre-commit hook to run the OSS boundary gates plus staged gitleaks and TruffleHog scans.
- Update public docs and fixtures to remove stale mirror/archive language and clarify the signed-digest producer/consumer model.

## Why
These changes make published twin artifacts traceable and verifiable before downstream use, while reducing the chance that synthetic or real credentials are accidentally committed. The doc cleanup keeps the public repository contract aligned with how the twin images are produced and consumed.

## Notes for reviewer
New third-party GitHub Actions are pinned to full commit SHAs with version comments. The image publish jobs only emit `signed-digests` after `cosign sign`, `cosign attest`, `cosign verify`, and `cosign verify-attestation` all succeed.

## Tests / CI
- `bash -n scripts/ci/sign-image-digests.sh scripts/hooks/pre-commit`
- `git diff --check`
- workflow YAML parse for `secret-scan.yml` and the three twin image workflows
- local gitleaks current-tree scan with `.gitleaks.toml`
- `bun run test:contract`
- `bun run gate:no-eval`
- `bun run lint:no-cloud-imports`
- `bun run lint:copy-markers`
- `bun run test` (initial run hit a Slack performance-budget flake only)
- `bun run --filter @pome-sh/twin-slack test -- test/performance.test.ts` (rerun passed)
- `gh pr checks 83 --watch`
- `bash -n scripts/hooks/pre-commit && git diff --check`

## Review required
Maintainer review is required before merge per this public repository's PR guardrails.