### PR TITLE
chore(packages): first-publish changelogs and registry metadata

### DIFF
--- a/packages/adapter-claude-sdk/CHANGELOG.md
+++ b/packages/adapter-claude-sdk/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 0.1.0 — 2026-07-09
+
+First npm-published release (F-714). Drop-in adapter for Anthropic's
+`@anthropic-ai/claude-agent-sdk` (peer dependency): `withPome`, `tool`, and
+`query` wrap an agent so its tool calls, subagent spawns, and hook events
+land in the Pome trace format defined by `@pome-sh/shared-types`.
+
 FDRS-410 — outgoing correlation header renamed from `X-Pome-Tool-Call-Id` to lowercase `x-pome-correlation-id` to match the twin recorders' contract (FDRS-402) and HTTP header-name convention. The exported symbol on the index follows: `TOOL_CALL_HEADER` → `CORRELATION_HEADER`. New `test/als-propagation.test.ts` exercises a tool handler that crosses two microtask boundaries before issuing `fetch()`, asserting exact equality between the entry-time `tool_call_id` (read from ALS) and the outgoing `x-pome-correlation-id` header — fails loudly on the silent-`null`-header failure mode that hid FDRS-322 for weeks.
 
 FDRS-409 — `query()` now emits one `SubagentSpawnEvent` the first time it sees a non-null `parent_tool_use_id` on an SDK message. The spawn row's `parent_id` points at the spawning `ToolUseEvent.event_id` (looked up via `tool_use_id == parent_tool_use_id`); subsequent child `ToolUseEvent`s coming from that sub-agent's message stream carry `parent_id` set to the SubagentSpawnEvent's `event_id`, so child rows chain through the spawn row instead of pointing at null. Same single-writer JSONL path (`POME_ADAPTER_SIGNALS_PATH`); shape matches `subagentSpawnEventSchema` in `@pome-sh/shared-types`.

--- a/packages/adapter-claude-sdk/package.json
+++ b/packages/adapter-claude-sdk/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@pome-sh/adapter-claude-sdk",
   "version": "0.1.0",
+  "description": "Pome adapter for Anthropic's Claude Agent SDK — wraps query() and tools so agent traces land in the Pome trace format.",
   "private": false,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.2.0
 
+First npm-published release (F-714). The twin engine: `defineTwin()` +
+`serve()` — HTTP mounting, bearer auth, recorder + redaction, MCP dispatch,
+SQLite driver, and the admin gate behind every first-party twin.
+
 ### Breaking changes
 
 - Removed the deprecated `localhostOnly` re-export from the server surface

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,53 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# @pome-sh/sdk
+
+The twin engine behind [Pome](https://pome.sh) digital twins. A twin is a
+declaration — its domain, tools, and frozen wire shapes — and this engine
+supplies all of the mechanism: HTTP mounting, bearer auth, the trace
+recorder with secret redaction, MCP dispatch, SQLite-backed state, and the
+admin reset/seed gate.
+
+The first-party twins ([`@pome-sh/twin-github`](https://www.npmjs.com/package/@pome-sh/twin-github),
+[`@pome-sh/twin-slack`](https://www.npmjs.com/package/@pome-sh/twin-slack),
+[`@pome-sh/twin-stripe`](https://www.npmjs.com/package/@pome-sh/twin-stripe))
+are thin plugins on this engine.
+
+## Install
+
+```bash
+npm install @pome-sh/sdk
+```
+
+## Usage
+
+```ts
+import { defineTwin } from "@pome-sh/sdk";
+import { serve } from "@pome-sh/sdk/server";
+
+const twin = defineTwin({
+  id: "my-service",
+  version: "0.1.0",
+  domain: ({ db, seed }) => createMyDomain(db, seed),
+  tools: [/* ToolSpec[] — name, zod schema, handler */],
+});
+
+await serve(twin, { port: 3333 });
+// GET /healthz, /s/:sid/* (bearer-gated), MCP surfaces, and /admin/reset
+// are mounted by the engine.
+```
+
+Every engine-booted twin honors the frozen runtime contract in
+[`CONTRACT.md`](https://github.com/pome-sh/pome-twins/blob/main/CONTRACT.md)
+— entry point, env surface, `/healthz` shape, auth, and MCP surfaces.
+
+## Docs
+
+Full documentation at [docs.pome.sh](https://docs.pome.sh). Source and
+issues at [pome-sh/pome-twins](https://github.com/pome-sh/pome-twins).
+
+## License
+
+Apache-2.0

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@pome-sh/sdk",
   "version": "0.2.0",
+  "description": "Twin engine for Pome digital twins — defineTwin() + serve(): HTTP mounting, bearer auth, trace recorder, MCP dispatch, SQLite-backed state.",
   "private": false,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared-types/CHANGELOG.md
+++ b/packages/shared-types/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.6.0
 
+First npm-published release (F-714).
+
 M6 — publish the trace-format contract as the single reusable package surface
 for OSS twins, the CLI, adapters, and pome-cloud consumers.
 

--- a/packages/shared-types/README.md
+++ b/packages/shared-types/README.md
@@ -1,0 +1,43 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# @pome-sh/shared-types
+
+The shared wire-format contract for [Pome](https://pome.sh) — Zod schemas
+and TypeScript types for traces, recorder events, runs, scenario seeds,
+OTel span mapping, and secret redaction. The `pome` CLI, the twin engine
+(`@pome-sh/sdk`), the first-party twins, the Claude adapter, and the Pome
+cloud all speak this vocabulary; the wire format is the contract, not any
+one library.
+
+## Install
+
+```bash
+npm install @pome-sh/shared-types zod
+```
+
+`zod` (^4.1.13) is a peer dependency.
+
+## Usage
+
+```ts
+import { recorderEventSchema, redactSecrets } from "@pome-sh/shared-types";
+import { eventSchema } from "@pome-sh/shared-types/recorder-events";
+
+const event = recorderEventSchema.parse(row);
+const safe = redactSecrets(JSON.stringify(event));
+```
+
+Subpath exports: `recorder-events`, `run`, `otel`, `otel/fixtures`, and
+`redaction`. The machine-readable trace contract ships as
+`trace-contract.json` inside the package.
+
+## Docs
+
+Full documentation at [docs.pome.sh](https://docs.pome.sh). Source and
+issues at [pome-sh/pome-twins](https://github.com/pome-sh/pome-twins).
+
+## License
+
+Apache-2.0

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@pome-sh/shared-types",
   "version": "0.6.0",
+  "description": "Shared wire-format contract for Pome — Zod schemas for traces, recorder events, runs, OTel mapping, and secret redaction.",
   "private": false,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/twin-github/CHANGELOG.md
+++ b/packages/twin-github/CHANGELOG.md
@@ -1,0 +1,28 @@
+# @pome-sh/twin-github — CHANGELOG
+
+All notable changes to the GitHub twin are documented here. The format is
+loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
+the package follows [Semantic Versioning](https://semver.org/).
+
+## 0.1.0 — 2026-07-09
+
+First npm-published release (F-714).
+
+A deterministic GitHub twin for agent testing — REST + MCP surfaces (repos,
+issues, pull requests, reviews, collaborators, checks) over SQLite-backed
+state, gated by the same push-access rules as the live API. Built as a thin
+`@pome-sh/sdk` plugin (F-682): the twin declares its domain, tools, and
+GitHub's frozen wire shapes; the engine owns HTTP mounting, bearer auth, the
+recorder, MCP dispatch, and the admin gate.
+
+### Added
+
+- `twin-github` bin: boots via `node dist/src/server.js` per the twin runtime
+  contract (`/CONTRACT.md`, v1.0.0) — `GET /healthz` within 3 s, refuses
+  non-loopback binds without `TWIN_AUTH_SECRET`.
+- GitHub REST + MCP tool surface with push-access-gated mutations and
+  fidelity-annotated behavior (see `FIDELITY.md`).
+- Seed control: built-in default seed, `POME_SEED_JSON` override,
+  `GITHUB_CLONE_NO_SEED=1`, and `POST /admin/reset|seed`.
+- Library entry point `createGitHubCloneApp` for in-process embedding (used
+  by the `pome` CLI's `--local` harness).

--- a/packages/twin-slack/CHANGELOG.md
+++ b/packages/twin-slack/CHANGELOG.md
@@ -1,0 +1,28 @@
+# @pome-sh/twin-slack — CHANGELOG
+
+All notable changes to the Slack twin are documented here. The format is
+loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
+the package follows [Semantic Versioning](https://semver.org/).
+
+## 0.1.0 — 2026-07-09
+
+First npm-published release (F-714).
+
+A deterministic Slack Web API twin for agent testing — REST + MCP surfaces
+over SQLite-backed state, built as a thin `@pome-sh/sdk` plugin (F-683): the
+twin declares its domain, tools, and Slack's frozen wire shapes
+(`{ok:false, error}` envelopes on HTTP 200, form-or-JSON body parsing); the
+engine owns HTTP mounting, bearer auth, the recorder, MCP dispatch, and the
+admin gate.
+
+### Added
+
+- `twin-slack` bin: boots via `node dist/src/server.js` per the twin runtime
+  contract (`/CONTRACT.md`, v1.0.0) — `GET /healthz` within 3 s, refuses
+  non-loopback binds without `TWIN_AUTH_SECRET`.
+- Slack Web API twin surface (channels, messages, reactions, files) as REST
+  and MCP tools, with `SLACK_DETERMINISTIC_TS` for reproducible timestamps.
+- Seed control: built-in default seed, `POME_SEED_JSON` override,
+  `SLACK_CLONE_NO_SEED=1`, and `POST /admin/reset|seed`.
+- Library entry points `createSlackTwinApp` and `slackTwinDefinition` for
+  in-process embedding (used by the `pome` CLI's `--local` harness).

--- a/packages/twin-stripe/CHANGELOG.md
+++ b/packages/twin-stripe/CHANGELOG.md
@@ -1,0 +1,32 @@
+# @pome-sh/twin-stripe — CHANGELOG
+
+All notable changes to the Stripe twin are documented here. The format is
+loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
+the package follows [Semantic Versioning](https://semver.org/).
+
+## 0.2.0 — 2026-07-09
+
+First npm-published release (F-714).
+
+A deterministic Stripe x402 machine-payments twin for agent testing — REST +
+MCP surfaces (payment intents, refunds, balance) over SQLite-backed,
+balance-consistent state. Built as a thin `@pome-sh/sdk` plugin (F-684): the
+twin declares its domain, tools, and Stripe's frozen wire shapes; the engine
+owns HTTP mounting, bearer auth, the recorder, MCP dispatch, and the admin
+gate.
+
+### Added
+
+- `twin-stripe` bin: boots via `node dist/src/server.js` per the twin runtime
+  contract (`/CONTRACT.md`, v1.0.0) — `GET /healthz` within 3 s, refuses
+  non-loopback binds without `TWIN_AUTH_SECRET`.
+- Stripe x402 REST + MCP tool surface with balance-consistent mutations and
+  fidelity-annotated behavior (see `FIDELITY.md`).
+- Seed control: built-in default seed, `POME_SEED_JSON` override,
+  `STRIPE_CLONE_NO_SEED=1`, and `POST /admin/reset|seed`.
+- Library entry points `createTwinStripeApp` and `StripeDomain` for
+  in-process embedding (used by the `pome` CLI's `--local` harness).
+
+## 0.1.0
+
+Initial internal version (pre-engine, self-contained server). Never published.


### PR DESCRIPTION
<!-- Closes F-714 -->

Executive summary: Changelog groundwork for the first `packages-v` release. The three twins get their first CHANGELOG.md; sdk, shared-types, and adapter-claude-sdk get a first-npm-publish stamp on their current version entries. No code changes.

## What
Adds `CHANGELOG.md` for `twin-github` (0.1.0), `twin-slack` (0.1.0), and `twin-stripe` (0.2.0), and marks the existing `sdk` (0.2.0), `shared-types` (0.6.0), and `adapter-claude-sdk` (0.1.0) changelogs as the first npm-published releases. The adapter's `Unreleased` items are folded into its 0.1.0 entry.

## Why
PACKAGE_RELEASE.md step 1 requires version + changelog entries to land together before the `packages-v` release tag is cut. This is the F-714 prerequisite: the cloud snapshot build resolves the twins' `@pome-sh/sdk` dependency from the public registry, which requires these packages to exist on npm.

## Notes for reviewer
Docs-only. Package versions are untouched (already correct on main); the batch publishes exactly what `scripts/pack-publishable.mjs` produced in the local pre-verify (six tarballs, manifest guard clean, clean-room import + twin-slack `/healthz` boot verified).