### PR TITLE
fix(ci): repair the twin-image wait gate and the trace-overhead gate

### DIFF
--- a/.github/workflows/twin-image.yml
+++ b/.github/workflows/twin-image.yml
@@ -35,9 +35,11 @@ jobs:
       - name: Wait for ci workflow on this SHA
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # PRs use the merge commit as github.sha; ci runs against the head SHA.
-          GITHUB_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-        run: bash scripts/ci/wait-for-workflow.sh ci.yml
+        # PRs use the merge commit as github.sha; ci runs are keyed by the head
+        # SHA. Passed as an argument — the runner silently ignores env:
+        # overrides of default GITHUB_* variables, so an `env: GITHUB_SHA:`
+        # form waits on the merge SHA forever and times out on every PR.
+        run: bash scripts/ci/wait-for-workflow.sh ci.yml "${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
 
   publish:
     name: ${{ matrix.twin }}

--- a/cli/scripts/cas-adapter-acceptance.ts
+++ b/cli/scripts/cas-adapter-acceptance.ts
@@ -53,6 +53,11 @@ const ARTIFACT_OUT = process.env.CAS_ACCEPTANCE_ARTIFACT_OUT ?? null;
 // against that root so `pome run` can be spawned from an isolated scaffold dir.
 const CLI_ROOT = process.cwd();
 
+// See overhead-gate.ts: launch the agent via cli's own tsx install, NOT
+// `npx tsx` — from the scaffold cwd (no node_modules) npx resolves tsx from
+// registry.npmjs.org at runtime, which the egress floor refuses (exit 3).
+const TSX_BIN = resolve(CLI_ROOT, "node_modules/.bin/tsx");
+
 // FDRS-641 — `pome run` hard-gates on the doctor wiring checks (config → twin
 // → routing → egress) with no --force. This synthetic gate used to run in a
 // bare `cli/` with no pome.config.json, so post-FDRS-641 it dies at the config
@@ -139,7 +144,7 @@ async function runPome(input: { target: string; scaffold: string }): Promise<str
     "run",
     resolve(CLI_ROOT, SCENARIO_PATH),
     "--agent",
-    `npx tsx ${resolve(CLI_ROOT, AGENT_FIXTURE)}`,
+    `${TSX_BIN} ${resolve(CLI_ROOT, AGENT_FIXTURE)}`,
     "--artifacts-dir",
     artifactsDir,
   ];

--- a/cli/scripts/cas-adapter-acceptance.ts
+++ b/cli/scripts/cas-adapter-acceptance.ts
@@ -144,7 +144,9 @@ async function runPome(input: { target: string; scaffold: string }): Promise<str
     "run",
     resolve(CLI_ROOT, SCENARIO_PATH),
     "--agent",
-    `${TSX_BIN} ${resolve(CLI_ROOT, AGENT_FIXTURE)}`,
+    // Quoted: pome run re-tokenizes this string (splitCommand honors quotes),
+    // so unquoted absolute paths would split on whitespace-containing checkouts.
+    `"${TSX_BIN}" "${resolve(CLI_ROOT, AGENT_FIXTURE)}"`,
     "--artifacts-dir",
     artifactsDir,
   ];

--- a/cli/scripts/overhead-gate.ts
+++ b/cli/scripts/overhead-gate.ts
@@ -42,6 +42,12 @@ const POME_BIN = process.env.OVERHEAD_BENCH_POME ?? "node dist/src/cli/main.js";
 // scaffold directory (see makeDoctorScaffold) with a different cwd.
 const CLI_ROOT = process.cwd();
 
+// The agent must be launched via cli's own tsx install, NOT `npx tsx`: the
+// agent is spawned with cwd = the tmp scaffold (no node_modules), so npx
+// resolves tsx from registry.npmjs.org at runtime — a CONNECT the run's
+// deny-by-default egress floor refuses, killing the agent preflight (exit 3).
+const TSX_BIN = resolve(CLI_ROOT, "node_modules/.bin/tsx");
+
 // FDRS-641 — `pome run` now hard-gates on the doctor wiring checks (config →
 // twin → routing → egress) with no --force. This synthetic benchmark used to
 // run in a bare `cli/` with no pome.config.json, so post-FDRS-641 it dies at
@@ -193,7 +199,7 @@ async function runPome(input: { noCapture: boolean; target: string; scaffold: st
     "run",
     resolve(CLI_ROOT, SCENARIO_PATH),
     "--agent",
-    `npx tsx ${resolve(CLI_ROOT, AGENT_SCRIPT)}`,
+    `${TSX_BIN} ${resolve(CLI_ROOT, AGENT_SCRIPT)}`,
     "--artifacts-dir",
     artifactsDir,
   ];

--- a/cli/scripts/overhead-gate.ts
+++ b/cli/scripts/overhead-gate.ts
@@ -199,7 +199,9 @@ async function runPome(input: { noCapture: boolean; target: string; scaffold: st
     "run",
     resolve(CLI_ROOT, SCENARIO_PATH),
     "--agent",
-    `${TSX_BIN} ${resolve(CLI_ROOT, AGENT_SCRIPT)}`,
+    // Quoted: pome run re-tokenizes this string (splitCommand honors quotes),
+    // so unquoted absolute paths would split on whitespace-containing checkouts.
+    `"${TSX_BIN}" "${resolve(CLI_ROOT, AGENT_SCRIPT)}"`,
     "--artifacts-dir",
     artifactsDir,
   ];


### PR DESCRIPTION
Executive summary: Two CI gates have been failing since the npm migration (#85): `twin-image` times out on every PR, and `agent-trace-overhead-gate` is red on main. Both are environment-resolution bugs, not product regressions — this PR fixes the SHA the image gate waits on and stops the bench agent from dialing the npm registry at runtime.

## What
- `twin-image.yml` `wait-ci`: pass the commit SHA to `wait-for-workflow.sh` as a positional argument. The previous `env: GITHUB_SHA:` override is silently ignored by Actions runners (default `GITHUB_*` variables cannot be overridden), so on `pull_request` events the script polled the ephemeral merge SHA — which never has a `ci` run — and timed out after 30 minutes.
- `overhead-gate.ts` / `cas-adapter-acceptance.ts`: launch the bench agent via `cli/node_modules/.bin/tsx` (absolute path) instead of `npx tsx`. `pome run` spawns the agent from a tmp scaffold directory with no `node_modules`, so `npx` fetched `tsx` from registry.npmjs.org at runtime; the run's deny-by-default egress floor refused that CONNECT and the agent preflight failed with exit 3.

## Why
#85 consolidated the per-twin image workflows and swapped the bench agent command from `bun` (a self-contained binary) to `npx tsx` (a runtime registry resolver). Evidence: `ci.yml` has a successful run keyed by the PR head SHA while zero runs exist for the merge SHA the gate waited on; the overhead-gate job log shows `egress: refused 2 tunnel(s) … registry.npmjs.org:443 ×2` followed by `pome run exited 3`.

## Notes for reviewer
- `wait-for-workflow.sh` already accepted the SHA as `$2`; only the workflow call site changes. Push/tag events pass `github.sha`, identical to the old behavior.
- The agent command is spawned argv-style (no shell), and `.bin/tsx` is a node-shebang launcher, so the absolute-path invocation works on the Linux runners.
- Verified locally by mirroring the CI job end-to-end (root `npm ci` → pack tarballs → rewrite CLI → build → run both gates): overhead gate PASS (p99 delta 1.542ms, no egress refusals), CAS-adapter acceptance PASS, `tsc --noEmit` clean, `actionlint` clean.

## Tests / CI
- `cd cli && npx tsx scripts/overhead-gate.ts` → PASS (previously exit 3 at agent preflight)
- `cd cli && npx tsx scripts/cas-adapter-acceptance.ts` → PASS
- `cd cli && npm run typecheck` → clean
- `actionlint .github/workflows/twin-image.yml` → clean
- The real proof for the wait-ci fix is this PR's own `twin-image` run — it should now find this head SHA's `ci` run instead of timing out.