### PR TITLE
feat(infra): bake build provenance into published twin images

### DIFF
--- a/.github/workflows/twin-image.yml
+++ b/.github/workflows/twin-image.yml
@@ -77,6 +77,11 @@ jobs:
             type=semver,pattern=${{ matrix.twin }}-{{version}}
             type=semver,pattern=${{ matrix.twin }}-v{{version}}
             type=sha,prefix=${{ matrix.twin }}-,format=short
+      # /healthz reports these via the Dockerfiles' GIT_SHA/BUILD_TIME args;
+      # without them every published image says git_sha:"dev".
+      - name: Resolve build provenance
+        id: buildinfo
+        run: echo "time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
       # Build once and load into the local daemon so Trivy can scan the exact
       # image before it is pushed. Also tag it locally for the scan ref.
       - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
@@ -91,6 +96,9 @@ jobs:
             twin-${{ matrix.twin }}:scan
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
+          build-args: |
+            GIT_SHA=${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+            BUILD_TIME=${{ steps.buildinfo.outputs.time }}
       # Fail the publish on fixable HIGH/CRITICAL CVEs. `ignore-unfixed` drops
       # vulns with no upstream fix (nothing actionable); documented, reviewed
       # exceptions go in `.trivyignore` at the repo root.

--- a/packages/twin-github/Dockerfile
+++ b/packages/twin-github/Dockerfile
@@ -36,5 +36,13 @@ COPY --from=build /repo/packages/sdk/package.json ./packages/sdk/package.json
 COPY --from=build /repo/packages/sdk/dist ./packages/sdk/dist
 COPY --from=build /repo/packages/twin-github/package.json ./packages/twin-github/package.json
 COPY --from=build /repo/packages/twin-github/dist ./packages/twin-github/dist
+# Bake build provenance into the /healthz `runtime` block (read by the sdk's
+# build-info env surface). CI passes the real values; local builds keep the
+# "dev" markers. Placed after the COPY layers so a new SHA never invalidates
+# the copied-artifact cache.
+ARG GIT_SHA=dev
+ARG BUILD_TIME=dev
+ENV POME_TWIN_GIT_SHA=$GIT_SHA
+ENV POME_TWIN_BUILD_TIME=$BUILD_TIME
 EXPOSE 3333
 CMD ["node", "packages/twin-github/dist/src/server.js"]

--- a/packages/twin-slack/Dockerfile
+++ b/packages/twin-slack/Dockerfile
@@ -36,5 +36,13 @@ COPY --from=build /repo/packages/sdk/package.json ./packages/sdk/package.json
 COPY --from=build /repo/packages/sdk/dist ./packages/sdk/dist
 COPY --from=build /repo/packages/twin-slack/package.json ./packages/twin-slack/package.json
 COPY --from=build /repo/packages/twin-slack/dist ./packages/twin-slack/dist
+# Bake build provenance into the /healthz `runtime` block (read by the sdk's
+# build-info env surface). CI passes the real values; local builds keep the
+# "dev" markers. Placed after the COPY layers so a new SHA never invalidates
+# the copied-artifact cache.
+ARG GIT_SHA=dev
+ARG BUILD_TIME=dev
+ENV POME_TWIN_GIT_SHA=$GIT_SHA
+ENV POME_TWIN_BUILD_TIME=$BUILD_TIME
 EXPOSE 3333
 CMD ["node", "packages/twin-slack/dist/src/server.js"]

--- a/packages/twin-stripe/Dockerfile
+++ b/packages/twin-stripe/Dockerfile
@@ -36,5 +36,13 @@ COPY --from=build /repo/packages/sdk/package.json ./packages/sdk/package.json
 COPY --from=build /repo/packages/sdk/dist ./packages/sdk/dist
 COPY --from=build /repo/packages/twin-stripe/package.json ./packages/twin-stripe/package.json
 COPY --from=build /repo/packages/twin-stripe/dist ./packages/twin-stripe/dist
+# Bake build provenance into the /healthz `runtime` block (read by the sdk's
+# build-info env surface). CI passes the real values; local builds keep the
+# "dev" markers. Placed after the COPY layers so a new SHA never invalidates
+# the copied-artifact cache.
+ARG GIT_SHA=dev
+ARG BUILD_TIME=dev
+ENV POME_TWIN_GIT_SHA=$GIT_SHA
+ENV POME_TWIN_BUILD_TIME=$BUILD_TIME
 EXPOSE 3333
 CMD ["node", "packages/twin-stripe/dist/src/server.js"]


### PR DESCRIPTION
Executive summary: Published GHCR twin images report `git_sha:"dev"` / `build_time:"dev"` in the `/healthz` runtime block — a follow-up surfaced during the F-714 cloud-artifact verification. This PR passes real provenance into the image build so every published image identifies the commit and time it was built from.

## What
Add `GIT_SHA`/`BUILD_TIME` build args to the three twin Dockerfiles, exported as `POME_TWIN_GIT_SHA`/`POME_TWIN_BUILD_TIME` (the env surface `@pome-sh/sdk`'s `twinBuildInfo()` already reads), and pass the head SHA plus a UTC timestamp from `twin-image.yml`. Args default to the existing `"dev"` markers, so local builds and other build paths (quickstart-smoke, cloud snapshot builds) are unchanged.

## Why
Image provenance was invisible at runtime: you could not tell from a running twin which commit produced it. The cloud snapshot path injects these vars at snapshot build; the GHCR image path never did.

## Notes for reviewer
- The `ARG`/`ENV` lines sit after the COPY layers in the runtime stage, so a changing SHA doesn't invalidate the copied-artifact layer cache.
- Verified locally: built the github image with test args and confirmed via `docker inspect` that `POME_TWIN_GIT_SHA`/`POME_TWIN_BUILD_TIME` land in the image env, and that `twinBuildInfo()` returns them in the healthz shape. (A full local boot isn't possible on an arm64 host — pre-existing better-sqlite3 arch issue; CI builds amd64.)
- This PR's own `twin-image` run builds all three images with the new args.

## Tests / CI
- `actionlint .github/workflows/twin-image.yml` clean
- `docker inspect` on a locally built image shows the baked env values
- `POME_TWIN_GIT_SHA=… node` against `packages/sdk/dist/build-info.js` returns the values in the runtime block