### PR TITLE
feat(sdk): define recorder write-through contract

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -43,6 +43,15 @@ Every engine-booted twin honors the frozen runtime contract in
 [`CONTRACT.md`](https://github.com/pome-sh/pome-twins/blob/main/CONTRACT.md)
 — entry point, env surface, `/healthz` shape, auth, and MCP surfaces.
 
+## Recorder (twin-core home)
+
+The trace recorder lives in this package (`packages/sdk/src/recorder.ts`).
+There is no separate `packages/twin-core` — F-681 folded twin-core into
+`@pome-sh/sdk`. Default boot uses an in-memory store; durable write-through
+semantics (`flush` / `close`, file-backed NDJSON) are defined on
+`RecorderStore` for F-698. Redaction always runs in the handle *before*
+`store.record()`, including for custom stores.
+
 ## Docs
 
 Full documentation at [docs.pome.sh](https://docs.pome.sh). Source and

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -120,6 +120,15 @@ export interface RecorderHandle {
   /** Events dropped by a bounded store (0 for the default unbounded store). */
   dropped(): number;
   /**
+   * Durability barrier (F-720). Forwards to the backing `RecorderStore.flush`
+   * when present. Await before upload/finalize when using a durable store.
+   */
+  flush(): Promise<void>;
+  /**
+   * Flush + release the backing store (F-720). Idempotent.
+   */
+  close(): Promise<void>;
+  /**
    * Wrap a Hono handler with auto-recording. The wrapped function returns
    * `{ status, body }` (not a `Response`); the recorder fills in `ts`,
    * `request_id`, `latency_ms`, `state_mutation`, `error`, then writes the

--- a/packages/sdk/src/recorder.ts
+++ b/packages/sdk/src/recorder.ts
@@ -1,5 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
+// Twin-core recorder (F-681 / F-720). Home: `packages/sdk/src/recorder.ts`
+// (`@pome-sh/sdk`). There is no separate `packages/twin-core` package — the
+// SDK *is* twin-core for recorder ownership. All first-party twins and the
+// CLI harness consume this module.
+//
 // In-memory recorder + `handle()` helper. `handle({mutation}, fn)` wraps a
 // Hono handler so every wrapped route emits a `RecorderEvent` matching
 // `recording-spec.md` v1.0:
@@ -12,8 +17,45 @@
 //   - `error` = response_body.message when status >= 400, null otherwise.
 //   - Memory: bounded by session timeout × max-rps; events live for the
 //     pod's lifetime and are read once via GET /_pome/events at end-of-run.
+//
+// ── Write-through contract (F-720) ──────────────────────────────────────────
+//
+// Acceptance: an event is *accepted* once `RecorderStore.record()` returns.
+// For the in-memory store that means the row is in the heap tape. For a
+// durable/file-backed store it means the row has been queued for append to
+// the NDJSON file (and is visible via `events()`); durability to disk is
+// completed by `flush()` / `close()` (see below). Callers must not treat
+// `record()` alone as a crash-safe fsync.
+//
+// Redaction: `createRecorderHandle` redacts *before* every `store.record()`
+// call — including custom stores and direct `recorder.record()` — so no
+// store ever sees unredacted secrets. Stores must not re-emit raw bodies.
+//
+// Persisted row shape: durable stores write one redacted `RecorderEvent` per
+// NDJSON line (shared-types `recorderEventSchema`). Upload/finalize may wrap
+// legacy rows into `TwinHttpEvent` for the unified `events.jsonl` byte shape;
+// the store itself does not change that uploaded shape (F-698).
+//
+// `flush()`: optional. When present, resolves after every accepted event is
+// durable on the store's backing medium (fsync for file-backed). In-memory
+// stores may omit it (no-op if called via a handle that forwards). Callers
+// that need crash-bounded loss (≤ in-flight event) must await `flush()`
+// before relying on the on-disk tape, or use a store that flushes on each
+// `record()` (F-698 production path).
+//
+// `close()`: optional. When present, flushes pending writes, releases the
+// backing resource, and is idempotent. After `close()`, further `record()`
+// calls are undefined (stores should throw or no-op). Callers must await
+// `close()` (or at least `flush()`) before upload/finalize so the partial
+// tape on disk matches `events()`.
+//
+// Default runtime behavior: `createRecorderStore()` remains heap-only.
+// `createFileBackedRecorderStore()` is the durable skeleton for F-698; twin
+// boot paths do not switch to it in this contract PR.
 
 import { randomUUID } from "node:crypto";
+import { createWriteStream, fsync, mkdirSync, type WriteStream } from "node:fs";
+import { dirname } from "node:path";
 import type { Context } from "hono";
 import type { RecorderEvent, TwinId } from "@pome-sh/shared-types";
 import type { RecorderHandle, RecorderHandlerResult } from "./index.js";
@@ -28,6 +70,12 @@ import { redactEvent } from "./redaction.js";
  */
 export type ErrorEnvelopeFn = (err: unknown) => { status: number; body: unknown };
 
+/**
+ * Backing store for the twin-core recorder.
+ *
+ * `record` / `events` are required. `flush` / `close` are optional so existing
+ * in-memory callers stay source-compatible; durable stores implement them.
+ */
 export interface RecorderStore {
   record(event: RecorderEvent): void;
   events(): RecorderEvent[];
@@ -35,6 +83,15 @@ export interface RecorderStore {
   count?(): number;
   /** Events dropped by a bounded store (stripe pins a 10k cap + dropped counter). */
   dropped?(): number;
+  /**
+   * Durability barrier. Resolves when every previously accepted event is on
+   * the backing medium. Optional for heap-only stores.
+   */
+  flush?(): Promise<void>;
+  /**
+   * Flush + release. Idempotent. Optional for heap-only stores.
+   */
+  close?(): Promise<void>;
 }
 
 export interface RecorderStoreOptions {
@@ -68,6 +125,115 @@ export function createRecorderStore(options: RecorderStoreOptions = {}): Recorde
     },
     dropped() {
       return droppedCount;
+    },
+    async flush() {
+      // Heap-only: accepted === durable for this store.
+    },
+    async close() {
+      // No backing resource.
+    },
+  };
+}
+
+export interface FileBackedRecorderStoreOptions extends RecorderStoreOptions {
+  /**
+   * Path to the NDJSON tape (typically a run's `events.jsonl` or a sidecar).
+   * Parent directories are created if missing. Opens append-mode.
+   */
+  path: string;
+  /**
+   * When true (default), each `record()` waits for the write callback before
+   * returning from the queued write path used by `flush()`. Does not fsync
+   * per event unless `fsync: true`.
+   */
+  fsync?: boolean;
+}
+
+/**
+ * Durable recorder store skeleton (F-720 / F-698).
+ *
+ * Keeps an in-memory mirror for `events()` / `count()` (same API as the heap
+ * store) and appends each accepted redacted `RecorderEvent` as one NDJSON
+ * line. `flush()` drains pending writes; with `fsync: true` it also
+ * `fsync`s the fd so a `kill -9` loses at most the in-flight event.
+ *
+ * Twin boot paths still default to `createRecorderStore()` — wiring this
+ * store into production servers/CLI is F-698.
+ */
+export function createFileBackedRecorderStore(
+  options: FileBackedRecorderStoreOptions
+): RecorderStore {
+  const items: RecorderEvent[] = [];
+  const cap = options.maxEvents !== undefined ? Math.max(1, options.maxEvents) : undefined;
+  let droppedCount = 0;
+  let closed = false;
+  const doFsync = options.fsync === true;
+
+  mkdirSync(dirname(options.path), { recursive: true });
+  const writer: WriteStream = createWriteStream(options.path, { flags: "a" });
+  const pending = new Set<Promise<void>>();
+
+  function enqueueWrite(line: string): void {
+    const write = new Promise<void>((resolve, reject) => {
+      writer.write(line, (err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        if (!doFsync) {
+          resolve();
+          return;
+        }
+        const fd = (writer as WriteStream & { fd?: number }).fd;
+        if (typeof fd !== "number") {
+          resolve();
+          return;
+        }
+        fsync(fd, (fsyncErr) => (fsyncErr ? reject(fsyncErr) : resolve()));
+      });
+    });
+    pending.add(write);
+    void write.finally(() => pending.delete(write));
+  }
+
+  return {
+    record(event) {
+      if (closed) {
+        throw new Error("RecorderStore.record() after close()");
+      }
+      items.push(event);
+      if (cap !== undefined) {
+        while (items.length > cap) {
+          items.shift();
+          droppedCount += 1;
+        }
+      }
+      enqueueWrite(`${JSON.stringify(event)}\n`);
+    },
+    events() {
+      return [...items];
+    },
+    count() {
+      return items.length;
+    },
+    dropped() {
+      return droppedCount;
+    },
+    async flush() {
+      while (pending.size > 0) {
+        await Promise.all([...pending]);
+      }
+    },
+    async close() {
+      if (closed) {
+        await this.flush?.();
+        return;
+      }
+      closed = true;
+      await this.flush?.();
+      await new Promise<void>((resolve, reject) => {
+        writer.end((err: Error | null | undefined) => (err ? reject(err) : resolve()));
+      });
     },
   };
 }
@@ -113,8 +279,9 @@ export function createRecorderHandle(options: RecorderHandleOptions): RecorderHa
     // preserve semantics, tolerant readers accept either).
     const stepId = c.req.header("x-pome-scenario-step-id") ?? null;
     const correlationHeader = c.req.header("x-pome-correlation-id") ?? null;
-    // Redaction is unconditional at the engine layer (F-681): every event
-    // that reaches any store — including custom stores — is already scrubbed.
+    // Redaction is unconditional at the engine layer (F-681 / F-720): every
+    // event that reaches any store — including custom stores — is already
+    // scrubbed.
     store.record(redactEvent({
       ts: new Date().toISOString(),
       run_id: options.runId,
@@ -152,6 +319,12 @@ export function createRecorderHandle(options: RecorderHandleOptions): RecorderHa
     },
     dropped() {
       return store.dropped?.() ?? 0;
+    },
+    async flush() {
+      await store.flush?.();
+    },
+    async close() {
+      await store.close?.();
     },
     handle({ mutation, fidelity = "semantic", errorEnvelope: perCallEnvelope }, fn) {
       const projectError = perCallEnvelope ?? errorEnvelope;

--- a/packages/sdk/src/recorder.ts
+++ b/packages/sdk/src/recorder.ts
@@ -46,8 +46,14 @@
 // `close()`: optional. When present, flushes pending writes, releases the
 // backing resource, and is idempotent. After `close()`, further `record()`
 // calls are undefined (stores should throw or no-op). Callers must await
-// `close()` (or at least `flush()`) before upload/finalize so the partial
-// tape on disk matches `events()`.
+// `close()` (or at least `flush()`) before upload/finalize so every accepted
+// write has either landed on disk or surfaced as a flush/close error.
+//
+// Bounded stores (`maxEvents`): the cap applies only to the in-memory mirror
+// used by `events()` / `GET /_pome/events` (memory pressure). The durable
+// NDJSON tape is append-only and retains every accepted write — including
+// rows later dropped from the heap mirror — so crash-safe upload reads the
+// tape, not `events()`.
 //
 // Default runtime behavior: `createRecorderStore()` remains heap-only.
 // `createFileBackedRecorderStore()` is the durable skeleton for F-698; twin
@@ -106,6 +112,8 @@ export interface RecorderStoreOptions {
    * Bound the in-memory tape: past `maxEvents` the store drops the OLDEST
    * event and increments the `dropped()` counter (stripe's pre-port
    * D-ENG-10/E-10 recorder behavior). Default: unbounded (github/slack).
+   * For file-backed stores this does **not** truncate the NDJSON tape —
+   * durability stays append-only; only `events()` is capped.
    */
   maxEvents?: number;
 }
@@ -161,8 +169,10 @@ export interface FileBackedRecorderStoreOptions extends RecorderStoreOptions {
  *
  * Keeps an in-memory mirror for `events()` / `count()` (same API as the heap
  * store) and appends each accepted redacted `RecorderEvent` as one NDJSON
- * line. `flush()` drains pending writes; with `fsync: true` it also
- * `fsync`s the fd so a `kill -9` loses at most the in-flight event.
+ * line. `flush()` drains pending writes and rethrows the first append/fsync
+ * failure; with `fsync: true` it also `fsync`s the fd so a `kill -9` loses
+ * at most the in-flight event. `maxEvents` caps only the heap mirror — the
+ * NDJSON tape stays append-only.
  *
  * Twin boot paths still default to `createRecorderStore()` — wiring this
  * store into production servers/CLI is F-698.
@@ -183,6 +193,9 @@ export function createFileBackedRecorderStore(
   const fd = openSync(options.path, "a");
   const writer: WriteStream = createWriteStream(options.path, { fd, autoClose: false });
   const pending = new Set<Promise<void>>();
+  // First append/fsync failure is retained so a later flush()/close() still
+  // reports it even after the rejected promise leaves `pending`.
+  let writeFailure: Error | null = null;
 
   function enqueueWrite(line: string): void {
     const write = new Promise<void>((resolve, reject) => {
@@ -199,12 +212,32 @@ export function createFileBackedRecorderStore(
       });
     });
     pending.add(write);
-    void write.finally(() => pending.delete(write));
+    // Handle rejection here so a failed write before flush() is not an
+    // unhandled rejection, and so flush() can still surface the error after
+    // the promise has left `pending`.
+    void write.then(
+      () => {
+        pending.delete(write);
+      },
+      (err: unknown) => {
+        pending.delete(write);
+        if (!writeFailure) {
+          writeFailure = err instanceof Error ? err : new Error(String(err));
+        }
+      }
+    );
   }
 
   async function flush(): Promise<void> {
     while (pending.size > 0) {
-      await Promise.all([...pending]);
+      // allSettled: individual failures are already captured in writeFailure;
+      // awaiting a rejected member of `pending` must not short-circuit drain.
+      await Promise.allSettled([...pending]);
+    }
+    if (writeFailure) {
+      const err = writeFailure;
+      writeFailure = null;
+      throw err;
     }
   }
 

--- a/packages/sdk/src/recorder.ts
+++ b/packages/sdk/src/recorder.ts
@@ -54,7 +54,14 @@
 // boot paths do not switch to it in this contract PR.
 
 import { randomUUID } from "node:crypto";
-import { createWriteStream, fsync, mkdirSync, type WriteStream } from "node:fs";
+import {
+  closeSync,
+  createWriteStream,
+  fsync,
+  mkdirSync,
+  openSync,
+  type WriteStream,
+} from "node:fs";
 import { dirname } from "node:path";
 import type { Context } from "hono";
 import type { RecorderEvent, TwinId } from "@pome-sh/shared-types";
@@ -142,9 +149,9 @@ export interface FileBackedRecorderStoreOptions extends RecorderStoreOptions {
    */
   path: string;
   /**
-   * When true (default), each `record()` waits for the write callback before
-   * returning from the queued write path used by `flush()`. Does not fsync
-   * per event unless `fsync: true`.
+   * When true, each accepted write is `fsync`'d after the append so a
+   * `kill -9` loses at most the in-flight event. Default false in the
+   * F-720 skeleton (opt-in); F-698 flips the production default to true.
    */
   fsync?: boolean;
 }
@@ -170,7 +177,11 @@ export function createFileBackedRecorderStore(
   const doFsync = options.fsync === true;
 
   mkdirSync(dirname(options.path), { recursive: true });
-  const writer: WriteStream = createWriteStream(options.path, { flags: "a" });
+  // Open the fd synchronously so fsync never races createWriteStream's
+  // async open (which can leave `writer.fd` undefined and silently skip
+  // durability on the first write).
+  const fd = openSync(options.path, "a");
+  const writer: WriteStream = createWriteStream(options.path, { fd, autoClose: false });
   const pending = new Set<Promise<void>>();
 
   function enqueueWrite(line: string): void {
@@ -184,16 +195,17 @@ export function createFileBackedRecorderStore(
           resolve();
           return;
         }
-        const fd = (writer as WriteStream & { fd?: number }).fd;
-        if (typeof fd !== "number") {
-          resolve();
-          return;
-        }
         fsync(fd, (fsyncErr) => (fsyncErr ? reject(fsyncErr) : resolve()));
       });
     });
     pending.add(write);
     void write.finally(() => pending.delete(write));
+  }
+
+  async function flush(): Promise<void> {
+    while (pending.size > 0) {
+      await Promise.all([...pending]);
+    }
   }
 
   return {
@@ -219,20 +231,25 @@ export function createFileBackedRecorderStore(
     dropped() {
       return droppedCount;
     },
-    async flush() {
-      while (pending.size > 0) {
-        await Promise.all([...pending]);
-      }
-    },
+    flush,
     async close() {
       if (closed) {
-        await this.flush?.();
+        await flush();
         return;
       }
       closed = true;
-      await this.flush?.();
+      await flush();
       await new Promise<void>((resolve, reject) => {
-        writer.end((err: Error | null | undefined) => (err ? reject(err) : resolve()));
+        writer.end((err: Error | null | undefined) => {
+          try {
+            closeSync(fd);
+          } catch (closeErr) {
+            reject(err ?? (closeErr as Error));
+            return;
+          }
+          if (err) reject(err);
+          else resolve();
+        });
       });
     },
   };

--- a/packages/sdk/src/server.ts
+++ b/packages/sdk/src/server.ts
@@ -52,8 +52,17 @@ import {
 // (`import { TwinBootError, isLoopbackHost, serve } from "@pome-sh/sdk/server"`).
 export { TwinBootError, isLoopbackHost, created, ok } from "./server-helpers.js";
 
-export { createRecorderHandle, createRecorderStore } from "./recorder.js";
-export type { RecorderStore, ErrorEnvelopeFn } from "./recorder.js";
+export {
+  createRecorderHandle,
+  createRecorderStore,
+  createFileBackedRecorderStore,
+} from "./recorder.js";
+export type {
+  RecorderStore,
+  RecorderStoreOptions,
+  FileBackedRecorderStoreOptions,
+  ErrorEnvelopeFn,
+} from "./recorder.js";
 export { bearerAuth, requireAdminAuth, resolveAuthSecret } from "./auth.js";
 // Alternate serving bridges (anything that isn't @hono/node-server) must feed
 // the gate the transport-level peer address via setClientIp from an upstream

--- a/packages/sdk/test/recorder-contract.test.ts
+++ b/packages/sdk/test/recorder-contract.test.ts
@@ -7,14 +7,33 @@
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { recorderEventSchema, type RecorderEvent } from "@pome-sh/shared-types";
-import {
+
+// Optional fsync override so we can assert flush() rethrows a prior failure
+// after the rejected promise has left `pending` (ESM blocks spyOn on node:fs).
+const fsMocks = vi.hoisted(() => ({
+  fsync:
+    null as null | ((fd: number, cb: (err: NodeJS.ErrnoException | null) => void) => void),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    fsync: (fd: number, cb: (err: NodeJS.ErrnoException | null) => void) => {
+      if (fsMocks.fsync) return fsMocks.fsync(fd, cb);
+      return actual.fsync(fd, cb);
+    },
+  };
+});
+
+const {
   createFileBackedRecorderStore,
   createRecorderHandle,
   createRecorderStore,
-  type RecorderStore,
-} from "../src/recorder.js";
+} = await import("../src/recorder.js");
+type RecorderStore = import("../src/recorder.js").RecorderStore;
 
 const tmpDirs: string[] = [];
 
@@ -205,5 +224,44 @@ describe("recorder write-through contract (F-720)", () => {
     const store = createFileBackedRecorderStore({ path: join(dir, "events.jsonl") });
     await store.close?.();
     expect(() => store.record(sampleEvent())).toThrow(/after close/);
+  });
+
+  it("flush surfaces a prior fsync failure after the promise left pending", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pome-recorder-"));
+    tmpDirs.push(dir);
+    const path = join(dir, "events.jsonl");
+    fsMocks.fsync = (_fd, cb) => {
+      queueMicrotask(() => cb(new Error("simulated fsync failure")));
+    };
+    try {
+      const store = createFileBackedRecorderStore({ path, fsync: true });
+      store.record(sampleEvent({ request_id: "req_fail" }));
+      // Let the write+fsync callbacks settle and leave `pending` before flush.
+      await new Promise((r) => setTimeout(r, 30));
+      await expect(store.flush?.()).rejects.toThrow(/simulated fsync failure/);
+    } finally {
+      fsMocks.fsync = null;
+    }
+  });
+
+  it("bounded file-backed store caps events() but keeps all rows on disk", async () => {
+    // maxEvents is a heap-mirror bound (memory pressure), not a durable-tape
+    // truncate. Crash-safe upload reads the NDJSON file, not events().
+    const dir = await mkdtemp(join(tmpdir(), "pome-recorder-"));
+    tmpDirs.push(dir);
+    const path = join(dir, "events.jsonl");
+    const store = createFileBackedRecorderStore({ path, maxEvents: 1 });
+    store.record(sampleEvent({ request_id: "req_old" }));
+    store.record(sampleEvent({ request_id: "req_new" }));
+    expect(store.events()).toHaveLength(1);
+    expect(store.events()[0]?.request_id).toBe("req_new");
+    expect(store.dropped?.()).toBe(1);
+    await store.flush?.();
+    await store.close?.();
+    const raw = await readFile(path, "utf8");
+    const lines = raw.split("\n").filter((l) => l.length > 0);
+    expect(lines).toHaveLength(2);
+    expect(raw).toContain("req_old");
+    expect(raw).toContain("req_new");
   });
 });

--- a/packages/sdk/test/recorder-contract.test.ts
+++ b/packages/sdk/test/recorder-contract.test.ts
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-720 — recorder write-through contract tests.
+// Covers in-memory + file-backed stores: acceptance, flush/close, redaction
+// before persistence, and canonical RecorderEvent NDJSON rows.
+
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { recorderEventSchema, type RecorderEvent } from "@pome-sh/shared-types";
+import {
+  createFileBackedRecorderStore,
+  createRecorderHandle,
+  createRecorderStore,
+  type RecorderStore,
+} from "../src/recorder.js";
+
+const tmpDirs: string[] = [];
+
+afterEach(async () => {
+  while (tmpDirs.length > 0) {
+    const dir = tmpDirs.pop();
+    if (dir) await rm(dir, { recursive: true, force: true });
+  }
+});
+
+function sampleEvent(overrides: Partial<RecorderEvent> = {}): RecorderEvent {
+  return {
+    ts: new Date().toISOString(),
+    run_id: "run_contract",
+    twin: "toy",
+    request_id: `req_${Math.random().toString(36).slice(2, 10)}`,
+    step_id: null,
+    tool_call_id: null,
+    method: "POST",
+    path: "/s/test/items",
+    request_body: { item: "alpha" },
+    status: 201,
+    response_body: { ok: true },
+    latency_ms: 1,
+    fidelity: "semantic",
+    state_mutation: true,
+    state_delta: null,
+    error: null,
+    ...overrides,
+  };
+}
+
+async function assertStoreContract(store: RecorderStore, opts?: { path?: string }) {
+  const event = sampleEvent();
+  store.record(event);
+  expect(store.count?.() ?? store.events().length).toBe(1);
+  expect(store.events()[0]).toMatchObject({
+    run_id: "run_contract",
+    twin: "toy",
+    method: "POST",
+    status: 201,
+  });
+  const parsed = recorderEventSchema.safeParse(store.events()[0]);
+  expect(parsed.success, JSON.stringify(parsed)).toBe(true);
+
+  await store.flush?.();
+  await store.close?.();
+
+  if (opts?.path) {
+    const raw = await readFile(opts.path, "utf8");
+    const lines = raw.split("\n").filter((l) => l.length > 0);
+    expect(lines.length).toBe(1);
+    const row = JSON.parse(lines[0]!) as unknown;
+    const diskParsed = recorderEventSchema.safeParse(row);
+    expect(diskParsed.success, JSON.stringify(diskParsed)).toBe(true);
+    expect(row).toMatchObject({
+      run_id: "run_contract",
+      twin: "toy",
+      method: "POST",
+      status: 201,
+    });
+    // Durable store writes legacy RecorderEvent NDJSON — no kind discriminator
+    // (upload/finalize wraps to TwinHttpEvent; store must not change that shape).
+    expect((row as { kind?: unknown }).kind).toBeUndefined();
+  }
+}
+
+describe("recorder write-through contract (F-720)", () => {
+  it("documents twin-core home as packages/sdk (no packages/twin-core)", () => {
+    // Structural pin: this module *is* the twin-core recorder. Import path
+    // stays @pome-sh/sdk — F-681 did not create packages/twin-core.
+    expect(createRecorderStore).toBeTypeOf("function");
+    expect(createFileBackedRecorderStore).toBeTypeOf("function");
+  });
+
+  it("in-memory store: accept → events → flush/close no-ops", async () => {
+    await assertStoreContract(createRecorderStore());
+  });
+
+  it("file-backed store: accept → NDJSON on disk after flush/close", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pome-recorder-"));
+    tmpDirs.push(dir);
+    const path = join(dir, "events.jsonl");
+    const store = createFileBackedRecorderStore({ path });
+    await assertStoreContract(store, { path });
+  });
+
+  it("file-backed store with fsync: flush drains pending durable writes", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pome-recorder-"));
+    tmpDirs.push(dir);
+    const path = join(dir, "events.jsonl");
+    const store = createFileBackedRecorderStore({ path, fsync: true });
+    store.record(sampleEvent({ request_id: "req_a" }));
+    store.record(sampleEvent({ request_id: "req_b" }));
+    await store.flush?.();
+    const raw = await readFile(path, "utf8");
+    const lines = raw.split("\n").filter((l) => l.length > 0);
+    expect(lines).toHaveLength(2);
+    for (const line of lines) {
+      expect(recorderEventSchema.safeParse(JSON.parse(line)).success).toBe(true);
+    }
+    await store.close?.();
+  });
+
+  it("redacts before any store.record — including custom stores", async () => {
+    const seen: RecorderEvent[] = [];
+    const custom: RecorderStore = {
+      record(event) {
+        seen.push(event);
+      },
+      events() {
+        return [...seen];
+      },
+    };
+    const recorder = createRecorderHandle({ runId: "r", twin: "toy", store: custom });
+    recorder.record(
+      sampleEvent({
+        request_body: { password: "hunter2", ok: "fine" },
+        response_body: { api_key: "leak" },
+      })
+    );
+    expect(seen).toHaveLength(1);
+    const req = seen[0]!.request_body as Record<string, unknown>;
+    const res = seen[0]!.response_body as Record<string, unknown>;
+    expect(req.password).toBe("[REDACTED]");
+    expect(req.ok).toBe("fine");
+    expect(res.api_key).toBe("[REDACTED]");
+  });
+
+  it("file-backed path never persists unredacted secrets", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pome-recorder-"));
+    tmpDirs.push(dir);
+    const path = join(dir, "events.jsonl");
+    const store = createFileBackedRecorderStore({ path });
+    const recorder = createRecorderHandle({ runId: "r", twin: "toy", store });
+    recorder.record(
+      sampleEvent({
+        request_body: { client_secret: "should-not-land-on-disk" },
+      })
+    );
+    await recorder.flush();
+    await recorder.close();
+    const raw = await readFile(path, "utf8");
+    expect(raw).not.toContain("should-not-land-on-disk");
+    expect(raw).toContain("[REDACTED]");
+  });
+
+  it("handle.flush/close forward to the store", async () => {
+    let flushed = 0;
+    let closed = 0;
+    const store: RecorderStore = {
+      record() {},
+      events() {
+        return [];
+      },
+      async flush() {
+        flushed += 1;
+      },
+      async close() {
+        closed += 1;
+      },
+    };
+    const recorder = createRecorderHandle({ runId: "r", twin: "toy", store });
+    await recorder.flush();
+    await recorder.close();
+    expect(flushed).toBe(1);
+    expect(closed).toBe(1);
+  });
+
+  it("record after close throws on file-backed store", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pome-recorder-"));
+    tmpDirs.push(dir);
+    const store = createFileBackedRecorderStore({ path: join(dir, "events.jsonl") });
+    await store.close?.();
+    expect(() => store.record(sampleEvent())).toThrow(/after close/);
+  });
+});

--- a/packages/sdk/test/recorder-contract.test.ts
+++ b/packages/sdk/test/recorder-contract.test.ts
@@ -119,6 +119,21 @@ describe("recorder write-through contract (F-720)", () => {
     await store.close?.();
   });
 
+  it("file-backed fsync path does not silently skip durability on first write", async () => {
+    // Regression: createWriteStream's async open left writer.fd undefined,
+    // so fsync was skipped. Sync openSync + explicit fd must keep the first
+    // fsync'd record on disk after flush.
+    const dir = await mkdtemp(join(tmpdir(), "pome-recorder-"));
+    tmpDirs.push(dir);
+    const path = join(dir, "events.jsonl");
+    const store = createFileBackedRecorderStore({ path, fsync: true });
+    store.record(sampleEvent({ request_id: "req_first_fsync" }));
+    await store.flush?.();
+    const raw = await readFile(path, "utf8");
+    expect(raw).toContain("req_first_fsync");
+    await store.close?.();
+  });
+
   it("redacts before any store.record — including custom stores", async () => {
     const seen: RecorderEvent[] = [];
     const custom: RecorderStore = {


### PR DESCRIPTION
Executive summary: Pins the twin-core recorder write-through contract in `@pome-sh/sdk` — acceptance, `flush`/`close`, and redaction-before-persist — and adds an opt-in file-backed NDJSON store skeleton. Default twin boot stays heap-only; contract tests cover in-memory, file-backed, and custom-store redaction paths.

## What
- Document recorder store acceptance, `flush`/`close`, and redaction-before-persist invariants on the twin-core recorder in `packages/sdk`.
- Add `createFileBackedRecorderStore` (NDJSON append + sync fd/fsync) without changing default twin boot (still heap-only).
- Add contract tests covering in-memory + file-backed paths and custom-store redaction.
- Surface durable append/fsync failures on `flush()`/`close()`, and keep `maxEvents` as a heap-mirror cap only (tape stays append-only).

## Why
Downstream durable streaming needs an explicit store API rather than relying on heap-only behavior. This PR locks the contract and skeleton so production wiring can land on a stable surface.

## Notes for reviewer
- Twin-core recorder home is `packages/sdk` (no separate `packages/twin-core`).
- Default runtime still uses `createRecorderStore()`; durable production wiring is the next PR in the stack (#93).
- Persisted skeleton rows are legacy `RecorderEvent` NDJSON; upload/finalize continues to wrap to `TwinHttpEvent`.

## Tests / CI
- Local: `bun run --filter @pome-sh/sdk test -- test/recorder-contract.test.ts test/recorder.test.ts test/redaction.test.ts` — pass
- Local: `bun run --filter @pome-sh/sdk typecheck` — pass
- PR CI: typecheck-test, cli-ci, secret scan, CodeQL, npm-pack — green; Greptile — pass