### PR TITLE
feat(sdk): durable recorder streaming for crash-safe twin runs

### DIFF
--- a/cli/.changeset/f-698-durable-recorder.md
+++ b/cli/.changeset/f-698-durable-recorder.md
@@ -1,0 +1,5 @@
+---
+"pome-sh": patch
+---
+
+Stream twin HTTP events to the run `events.jsonl` via the twin-core durable recorder so local runs survive process death without duplicating finalize rows.

--- a/cli/package.json
+++ b/cli/package.json
@@ -67,6 +67,7 @@
     "@anthropic-ai/sdk": "^0.110.0",
     "@hono/node-server": "^2.0.6",
     "@openrouter/ai-sdk-provider": "^3.0.0",
+    "@pome-sh/sdk": "0.2.0",
     "@pome-sh/shared-types": "0.6.0",
     "@pome-sh/twin-github": "0.1.0",
     "@pome-sh/twin-slack": "0.1.0",
@@ -91,6 +92,7 @@
     "node": ">=24"
   },
   "bundleDependencies": [
+    "@pome-sh/sdk",
     "@pome-sh/shared-types",
     "@pome-sh/twin-github",
     "@pome-sh/twin-slack",

--- a/cli/src/demo/runDemo.ts
+++ b/cli/src/demo/runDemo.ts
@@ -151,7 +151,7 @@ export async function runDemo(options: RunDemoOptions): Promise<RunDemoResult> {
       runId: "demo-warmup",
       twinBaseUrl: `http://127.0.0.1:${port}`,
     });
-    harness.close();
+    await harness.close();
     out(twinReadyLine((Date.now() - warmupStart) / 1000));
   }
 

--- a/cli/src/doctor/checks.ts
+++ b/cli/src/doctor/checks.ts
@@ -182,7 +182,7 @@ async function checkTwinReachable(_configDir: string): Promise<DoctorCheck> {
     return fail(`could not reach the locally served twin: ${firstLine(err)}`);
   } finally {
     server?.close();
-    harness.close();
+    await harness.close();
   }
 }
 

--- a/cli/src/recorder/artifacts.ts
+++ b/cli/src/recorder/artifacts.ts
@@ -84,14 +84,33 @@ export async function writeRunArtifactsCore(input: RunArtifactCoreInput): Promis
     twin_versions: resolveTwinPackageVersions(input.scenario.config.twins),
   });
   // events.jsonl is the unified discriminated-union view (FDRS-398). The
-  // in-process twin recorders still emit legacy RecorderEvent rows; wrap each
-  // one into a TwinHttpEvent before serializing so `pome inspect` (FDRS-403)
-  // and the dashboard ingest (FDRS-415) can parse them. APPEND (not
-  // truncate) so rows already written by the capture-server child
-  // (FDRS-399) during the run survive.
-  const eventsJsonl =
-    input.events.map((event) => JSON.stringify(redactEvent(toTwinHttpEvent(event)))).join("\n") + "\n";
-  await appendFile(join(runDir, "events.jsonl"), eventsJsonl);
+  // in-process twin recorders still expose legacy RecorderEvent rows via
+  // `events()`; wrap each into a TwinHttpEvent before serializing so
+  // `pome inspect` (FDRS-403) and dashboard ingest (FDRS-415) can parse them.
+  //
+  // F-698: the durable recorder may already have appended TwinHttpEvent rows
+  // during the run. Skip re-appending any event whose `event_id`/`request_id`
+  // is already on disk so finalize does not duplicate crash-streamed rows.
+  // APPEND (not truncate) so capture-server LlmCallEvent rows also survive.
+  const existingIds = await readExistingEventIds(join(runDir, "events.jsonl"));
+  const freshEvents = input.events.filter((event) => {
+    const id = event.request_id;
+    const maybeEventId = (event as { event_id?: unknown }).event_id;
+    if (typeof maybeEventId === "string" && existingIds.has(maybeEventId)) return false;
+    if (existingIds.has(id)) return false;
+    return true;
+  });
+  const eventsPath = join(runDir, "events.jsonl");
+  if (freshEvents.length > 0) {
+    const eventsJsonl =
+      freshEvents.map((event) => JSON.stringify(redactEvent(toTwinHttpEvent(event)))).join("\n") +
+      "\n";
+    await appendFile(eventsPath, eventsJsonl);
+  } else if (!existsSync(eventsPath)) {
+    // Preserve the six-file run-dir contract when nothing was streamed and
+    // the recorder emitted no events (F-689 / D6).
+    await writeFile(eventsPath, "");
+  }
   await writeJson(join(runDir, "state_initial.json"), input.stateInitial);
   await writeJson(join(runDir, "state_final.json"), input.stateFinal);
   await writeFile(join(runDir, "stdout.txt"), redactText(input.stdout));
@@ -134,6 +153,27 @@ export async function readMetaSummary(runDir: string): Promise<RunMetaSummary> {
 
 async function writeJson(path: string, value: unknown) {
   await writeFile(path, `${JSON.stringify(redactSecrets(value), null, 2)}\n`);
+}
+
+async function readExistingEventIds(eventsPath: string): Promise<Set<string>> {
+  const ids = new Set<string>();
+  if (!existsSync(eventsPath)) return ids;
+  try {
+    const raw = await readFile(eventsPath, "utf8");
+    for (const line of raw.split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        const row = JSON.parse(line) as { event_id?: unknown; request_id?: unknown };
+        if (typeof row.event_id === "string") ids.add(row.event_id);
+        if (typeof row.request_id === "string") ids.add(row.request_id);
+      } catch {
+        // Corrupt/partial trailing line from a crash — ignore for dedupe.
+      }
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
+  return ids;
 }
 
 function redactText(value: string): string {

--- a/cli/src/recorder/artifacts.ts
+++ b/cli/src/recorder/artifacts.ts
@@ -148,7 +148,15 @@ async function readExistingEventIds(eventsPath: string): Promise<Set<string>> {
     for (const line of raw.split("\n")) {
       if (!line.trim()) continue;
       try {
-        const row = JSON.parse(line) as { event_id?: unknown; request_id?: unknown };
+        const row = JSON.parse(line) as {
+          kind?: unknown;
+          event_id?: unknown;
+          request_id?: unknown;
+        };
+        // Only TwinHttpEvent rows participate in finalize dedupe. Other kinds
+        // (LlmCallEvent, HookEvent, …) may carry request_id/event_id values
+        // that must not suppress a twin HTTP row.
+        if (row.kind !== "TwinHttpEvent") continue;
         if (typeof row.event_id === "string") ids.add(row.event_id);
         if (typeof row.request_id === "string") ids.add(row.request_id);
       } catch {

--- a/cli/src/recorder/artifacts.ts
+++ b/cli/src/recorder/artifacts.ts
@@ -2,31 +2,16 @@
 import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+import { toTwinHttpEventRow } from "@pome-sh/sdk/server";
 import type { Scenario } from "../scenario/scenarioSchema.js";
 import type { RecorderEvent } from "@pome-sh/shared-types";
 import { redactEvent, redactSecrets } from "./redaction.js";
 import { META_SPEC_VERSION, resolveTwinPackageVersions } from "./specMeta.js";
 
-// FDRS-399 / FDRS-398 — wrap a legacy RecorderEvent (or pass through any row
-// that already carries a `kind` discriminator) into the unified events.jsonl
-// shape. Reuses `request_id` as `event_id` so within-run lookups stay stable
-// across the legacy and unified views.
-//
-// Exported so `runScenarioHosted` can apply the same wrap before uploading
-// events.jsonl to cloud storage. Without it, cloud's FDRS-398 schema gate
-// rejects the upload as "legacy single-shape RecorderEvent".
-export function toTwinHttpEvent(event: RecorderEvent): RecorderEvent & { kind: "TwinHttpEvent"; event_id: string; parent_id: null } {
-  const maybeKind = (event as { kind?: unknown }).kind;
-  if (typeof maybeKind === "string") {
-    return event as RecorderEvent & { kind: "TwinHttpEvent"; event_id: string; parent_id: null };
-  }
-  return {
-    ...event,
-    kind: "TwinHttpEvent",
-    event_id: event.request_id,
-    parent_id: null,
-  };
-}
+// FDRS-399 / FDRS-398 — wrap a legacy RecorderEvent into the unified
+// events.jsonl shape. Delegates to twin-core `toTwinHttpEventRow` so durable
+// stream rows and finalize appends stay byte-identical (F-698).
+export const toTwinHttpEvent = toTwinHttpEventRow;
 
 export type RunArtifacts = {
   runId: string;

--- a/cli/src/recorder/recorder.ts
+++ b/cli/src/recorder/recorder.ts
@@ -1,27 +1,30 @@
 // SPDX-License-Identifier: Apache-2.0
 import { randomUUID } from "node:crypto";
 import type { RecorderEvent } from "@pome-sh/shared-types";
+import {
+  createFileBackedRecorderStore,
+  createRecorderStore,
+  type RecorderStore,
+} from "@pome-sh/sdk/server";
 
 /**
- * The CLI's in-memory event buffer. Structurally the engine's
- * `RecorderStore` — the ported twins (F-682) no longer export a per-twin
- * Recorder type to borrow.
+ * The CLI's event buffer. Structurally the engine's `RecorderStore` — the
+ * ported twins (F-682) no longer export a per-twin Recorder type to borrow.
+ *
+ * F-698: when `eventsPath` is set, uses the twin-core durable store so twin
+ * HTTP events stream to `events.jsonl` during the run (crash-safe).
  */
-export interface Recorder {
-  record(event: RecorderEvent): void;
-  events(): RecorderEvent[];
-}
+export type Recorder = RecorderStore;
 
-export function createRecorder(): Recorder {
-  const items: RecorderEvent[] = [];
-  return {
-    record(event) {
-      items.push(event);
-    },
-    events() {
-      return [...items];
-    }
-  };
+export function createRecorder(options: { eventsPath?: string; maxEvents?: number } = {}): Recorder {
+  if (options.eventsPath) {
+    return createFileBackedRecorderStore({
+      path: options.eventsPath,
+      maxEvents: options.maxEvents,
+      fsync: true,
+    });
+  }
+  return createRecorderStore({ maxEvents: options.maxEvents });
 }
 
 export function createRequestId() {

--- a/cli/src/runner/runScenario.ts
+++ b/cli/src/runner/runScenario.ts
@@ -196,6 +196,9 @@ export async function runScenario(options: RunScenarioOptions) {
       preflight: true
     });
     if (preflight.exitCode !== 0) {
+      // Flush durable twin rows before finalize/merge so pending TwinHttpEvent
+      // lines are on disk before events.jsonl is rewritten (not only in finally).
+      await harness.flush();
       const stateFinal = await harness.exportState();
       const { artifacts, exitCode } = await writeRun({
         artifactsDir,
@@ -223,6 +226,7 @@ export async function runScenario(options: RunScenarioOptions) {
       env,
       timeoutSeconds: scenario.config.timeout
     });
+    await harness.flush();
     const stateFinal = await harness.exportState();
     const { artifacts, exitCode } = await writeRun({
       artifactsDir,

--- a/cli/src/runner/runScenario.ts
+++ b/cli/src/runner/runScenario.ts
@@ -122,11 +122,15 @@ export async function runScenario(options: RunScenarioOptions) {
   const twinName = scenario.config.twins[0] ?? "github";
   const port = await getAvailablePort();
   const baseUrl = `http://127.0.0.1:${port}`;
+  // F-698: stream twin HTTP events into the same events.jsonl the
+  // capture-server appends to. Durable store writes TwinHttpEvent rows;
+  // finalize dedupes against disk so upload shape stays one row per event.
   const harness = await bootTwin({
     twin: twinName,
     seedState: scenario.seedState,
     runId,
     twinBaseUrl: baseUrl,
+    eventsPath: eventsJsonlPath,
   });
   const stateInitial = await harness.exportState();
 
@@ -239,10 +243,10 @@ export async function runScenario(options: RunScenarioOptions) {
     return { scenario, runId, artifacts, agent, exitCode, blockedEgress };
   } finally {
     // Drain capture-server first so any in-flight LlmCallEvent rows land
-    // in events.jsonl before we move on; THEN close the twin (which would
-    // otherwise reset any open twin-side sockets and could race the proxy).
+    // in events.jsonl before we move on; THEN close the twin (which flushes
+    // the durable recorder and resets twin-side sockets).
     if (captureServer) await captureServer.shutdown();
     server.close();
-    harness.close();
+    await harness.close();
   }
 }

--- a/cli/src/twin/twinHarness.ts
+++ b/cli/src/twin/twinHarness.ts
@@ -30,7 +30,10 @@ import {
   openSlackTwinDatabase,
   SlackDomain,
 } from "@pome-sh/twin-slack";
+import { createApp } from "@pome-sh/sdk/server";
+import * as stripeTwin from "@pome-sh/twin-stripe";
 import {
+  applySeed as applyStripeSeed,
   createTwinStripeApp,
   openTwinStripeDatabase,
   parseSeed as parseStripeSeed,
@@ -138,15 +141,37 @@ export async function bootTwin(opts: {
       // recorder suffices here too.
       const db = openTwinStripeDatabase(":memory:");
       const domain = new StripeDomain(db);
-      const app = createTwinStripeApp({
-        db,
-        recorder: recorder as NonNullable<Parameters<typeof createTwinStripeApp>[0]>["recorder"],
-        runId: opts.runId,
-        seed: parseStripeSeed(opts.seedState),
-        twinBaseUrl: opts.twinBaseUrl ?? "http://127.0.0.1:3333",
-      } as Parameters<typeof createTwinStripeApp>[0] & {
-        seed: ReturnType<typeof parseStripeSeed>;
-      }) as TwinHarness["app"];
+      const seed = parseStripeSeed(opts.seedState);
+      const twinBaseUrl = opts.twinBaseUrl ?? "http://127.0.0.1:3333";
+      type StripeDefinitionFactory = (factoryOpts: {
+        db: ReturnType<typeof openTwinStripeDatabase>;
+        twinBaseUrl?: string;
+      }) => Parameters<typeof createApp>[0];
+      const createStripeTwinDefinition = (
+        stripeTwin as typeof stripeTwin & {
+          createStripeTwinDefinition?: StripeDefinitionFactory;
+        }
+      ).createStripeTwinDefinition;
+      const app = (createStripeTwinDefinition
+        ? createApp(createStripeTwinDefinition({ db, twinBaseUrl }), {
+            db,
+            recorder,
+            runId: opts.runId,
+            seed,
+          })
+        : (() => {
+            // Older published twin-stripe packages predate the additive
+            // `seed` app option. Seed explicitly so local runs don't boot an
+            // empty credential store when the CLI resolves that package.
+            applyStripeSeed(db, seed);
+            return createTwinStripeApp({
+              db,
+              recorder:
+                recorder as NonNullable<Parameters<typeof createTwinStripeApp>[0]>["recorder"],
+              runId: opts.runId,
+              twinBaseUrl,
+            } as Parameters<typeof createTwinStripeApp>[0] & { twinBaseUrl?: string });
+          })()) as TwinHarness["app"];
       return {
         app,
         envName: "STRIPE",

--- a/cli/src/twin/twinHarness.ts
+++ b/cli/src/twin/twinHarness.ts
@@ -144,6 +144,8 @@ export async function bootTwin(opts: {
         runId: opts.runId,
         seed: parseStripeSeed(opts.seedState),
         twinBaseUrl: opts.twinBaseUrl ?? "http://127.0.0.1:3333",
+      } as Parameters<typeof createTwinStripeApp>[0] & {
+        seed: ReturnType<typeof parseStripeSeed>;
       }) as TwinHarness["app"];
       return {
         app,

--- a/cli/src/twin/twinHarness.ts
+++ b/cli/src/twin/twinHarness.ts
@@ -54,8 +54,8 @@ export type TwinHarness = {
   /** Extra JWT claims the runner mints into the agent token (e.g. Stripe's
    *  `account_id`, so the token resolves to the account the seed lives in). */
   extraClaims?: Record<string, unknown>;
-  /** Release the SQLite handle. */
-  close(): void;
+  /** Flush durable recorder (if any) and release the SQLite handle. */
+  close(): void | Promise<void>;
 };
 
 export class UnsupportedTwinError extends Error {
@@ -73,8 +73,19 @@ export async function bootTwin(opts: {
   seedState: unknown;
   runId: string;
   twinBaseUrl?: string;
+  /**
+   * F-698: when set, twin HTTP events stream to this NDJSON path via the
+   * twin-core durable recorder (same file capture-server appends to).
+   */
+  eventsPath?: string;
 }): Promise<TwinHarness> {
-  const recorder = createRecorder();
+  const recorder = createRecorder({ eventsPath: opts.eventsPath });
+
+  const closeRecorderAndDb = async (dbClose: () => void) => {
+    await recorder.flush?.();
+    await recorder.close?.();
+    dbClose();
+  };
 
   switch (opts.twin) {
     case "github": {
@@ -90,7 +101,7 @@ export async function bootTwin(opts: {
         envName: "GITHUB",
         exportState: () => exportGitHubCloneState(db),
         events: () => recorder.events(),
-        close: () => (db as { close(): void }).close(),
+        close: () => closeRecorderAndDb(() => (db as { close(): void }).close()),
       };
     }
 
@@ -114,7 +125,7 @@ export async function bootTwin(opts: {
         envName: "SLACK",
         exportState: () => domain.exportState(),
         events: () => recorder.events(),
-        close: () => db.close(),
+        close: () => closeRecorderAndDb(() => db.close()),
       };
     }
 
@@ -140,7 +151,7 @@ export async function bootTwin(opts: {
         exportState: () => domain.exportState(STRIPE_LOCAL_ACCOUNT_ID),
         events: () => recorder.events(),
         extraClaims: { account_id: STRIPE_LOCAL_ACCOUNT_ID },
-        close: () => db.close(),
+        close: () => closeRecorderAndDb(() => db.close()),
       };
     }
 

--- a/cli/src/twin/twinHarness.ts
+++ b/cli/src/twin/twinHarness.ts
@@ -57,6 +57,12 @@ export type TwinHarness = {
   /** Extra JWT claims the runner mints into the agent token (e.g. Stripe's
    *  `account_id`, so the token resolves to the account the seed lives in). */
   extraClaims?: Record<string, unknown>;
+  /**
+   * Durability barrier for the twin recorder without closing the DB.
+   * Call before finalize/merge so pending TwinHttpEvent rows land on disk
+   * before `events.jsonl` is rewritten.
+   */
+  flush(): void | Promise<void>;
   /** Flush durable recorder (if any) and release the SQLite handle. */
   close(): void | Promise<void>;
 };
@@ -84,8 +90,11 @@ export async function bootTwin(opts: {
 }): Promise<TwinHarness> {
   const recorder = createRecorder({ eventsPath: opts.eventsPath });
 
-  const closeRecorderAndDb = async (dbClose: () => void) => {
+  const flushRecorder = async () => {
     await recorder.flush?.();
+  };
+  const closeRecorderAndDb = async (dbClose: () => void) => {
+    await flushRecorder();
     await recorder.close?.();
     dbClose();
   };
@@ -104,6 +113,7 @@ export async function bootTwin(opts: {
         envName: "GITHUB",
         exportState: () => exportGitHubCloneState(db),
         events: () => recorder.events(),
+        flush: () => flushRecorder(),
         close: () => closeRecorderAndDb(() => (db as { close(): void }).close()),
       };
     }
@@ -128,6 +138,7 @@ export async function bootTwin(opts: {
         envName: "SLACK",
         exportState: () => domain.exportState(),
         events: () => recorder.events(),
+        flush: () => flushRecorder(),
         close: () => closeRecorderAndDb(() => db.close()),
       };
     }
@@ -178,6 +189,7 @@ export async function bootTwin(opts: {
         exportState: () => domain.exportState(STRIPE_LOCAL_ACCOUNT_ID),
         events: () => recorder.events(),
         extraClaims: { account_id: STRIPE_LOCAL_ACCOUNT_ID },
+        flush: () => flushRecorder(),
         close: () => closeRecorderAndDb(() => db.close()),
       };
     }

--- a/cli/test/unit/recorder/artifacts.test.ts
+++ b/cli/test/unit/recorder/artifacts.test.ts
@@ -90,6 +90,77 @@ describe("writeRunArtifactsCore — events.jsonl", () => {
     expect(captureRow).toBeDefined();
     expect(twinRow).toBeDefined();
   });
+
+  it("does not duplicate TwinHttpEvent rows already streamed by the durable recorder (F-698)", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pome-art-"));
+    const scenario = fakeScenario();
+    const runId = "run_durable_dedupe";
+    const runDir = join(root, scenario.slug, runId);
+    await mkdir(runDir, { recursive: true });
+
+    const streamed = {
+      ts: "2026-05-26T12:00:01.000Z",
+      run_id: runId,
+      twin: "github",
+      request_id: "req_streamed_1",
+      step_id: null,
+      tool_call_id: null,
+      method: "GET",
+      path: "/repos/acme/api/issues/1",
+      request_body: null,
+      status: 200,
+      response_body: { id: 1 },
+      latency_ms: 1,
+      fidelity: "semantic",
+      state_mutation: false,
+      state_delta: null,
+      error: null,
+      kind: "TwinHttpEvent",
+      event_id: "req_streamed_1",
+      parent_id: null,
+    };
+    await writeFile(join(runDir, "events.jsonl"), JSON.stringify(streamed) + "\n");
+
+    await writeRunArtifactsCore({
+      artifactsDir: root,
+      runId,
+      scenario,
+      startedAt: "2026-05-26T11:59:59.000Z",
+      completedAt: "2026-05-26T12:00:02.000Z",
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+      // Same event still present in the in-memory mirror at finalize.
+      events: [
+        {
+          ts: streamed.ts,
+          run_id: streamed.run_id,
+          twin: streamed.twin,
+          request_id: streamed.request_id,
+          step_id: null,
+          tool_call_id: null,
+          method: streamed.method,
+          path: streamed.path,
+          request_body: null,
+          status: 200,
+          response_body: { id: 1 },
+          latency_ms: 1,
+          fidelity: "semantic",
+          state_mutation: false,
+          state_delta: null,
+          error: null,
+        } as never,
+      ],
+      stateInitial: {},
+      stateFinal: {},
+    });
+
+    const lines = (await readFile(join(runDir, "events.jsonl"), "utf8"))
+      .split("\n")
+      .filter((l) => l.length > 0);
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]!).event_id).toBe("req_streamed_1");
+  });
 });
 
 // F-689 remainder (D6) — the run dir contains EXACTLY six files; the

--- a/cli/test/unit/recorder/artifacts.test.ts
+++ b/cli/test/unit/recorder/artifacts.test.ts
@@ -161,6 +161,77 @@ describe("writeRunArtifactsCore — events.jsonl", () => {
     expect(lines).toHaveLength(1);
     expect(JSON.parse(lines[0]!).event_id).toBe("req_streamed_1");
   });
+
+  it("does not treat non-TwinHttpEvent request_id as a streamed twin event (F-698)", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pome-art-"));
+    const scenario = fakeScenario();
+    const runId = "run_cross_kind_dedupe";
+    const runDir = join(root, scenario.slug, runId);
+    await mkdir(runDir, { recursive: true });
+
+    // Capture-server / adapter rows may carry request_id values that collide
+    // with twin request ids — finalize must still append the TwinHttpEvent.
+    const llmRow = {
+      ts: "2026-05-26T12:00:00.000Z",
+      event_id: "evt_llm_1",
+      parent_id: null,
+      kind: "LlmCallEvent",
+      request_id: "req_shared",
+      host: "api.anthropic.com",
+      port: 443,
+      latency_ms: 42,
+      bytes_in: 100,
+      bytes_out: 200,
+      url: null,
+      method: null,
+      status: null,
+      model: null,
+      prompt_tokens: null,
+      completion_tokens: null,
+      cost_usd: null,
+    };
+    await writeFile(join(runDir, "events.jsonl"), JSON.stringify(llmRow) + "\n");
+
+    await writeRunArtifactsCore({
+      artifactsDir: root,
+      runId,
+      scenario,
+      startedAt: "2026-05-26T11:59:59.000Z",
+      completedAt: "2026-05-26T12:00:02.000Z",
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+      events: [
+        {
+          ts: "2026-05-26T12:00:01.000Z",
+          run_id: runId,
+          twin: "github",
+          request_id: "req_shared",
+          step_id: null,
+          tool_call_id: null,
+          method: "GET",
+          path: "/repos/acme/api/issues/1",
+          request_body: null,
+          status: 200,
+          response_body: { id: 1 },
+          latency_ms: 1,
+          fidelity: "semantic",
+          state_mutation: false,
+          state_delta: null,
+          error: null,
+        } as never,
+      ],
+      stateInitial: {},
+      stateFinal: {},
+    });
+
+    const lines = (await readFile(join(runDir, "events.jsonl"), "utf8"))
+      .split("\n")
+      .filter((l) => l.length > 0)
+      .map((l) => JSON.parse(l) as { kind: string; request_id?: string });
+    expect(lines.map((r) => r.kind).sort()).toEqual(["LlmCallEvent", "TwinHttpEvent"]);
+    expect(lines.find((r) => r.kind === "TwinHttpEvent")?.request_id).toBe("req_shared");
+  });
 });
 
 // F-689 remainder (D6) — the run dir contains EXACTLY six files; the

--- a/cli/test/unit/twin/stripeHarness.test.ts
+++ b/cli/test/unit/twin/stripeHarness.test.ts
@@ -83,7 +83,7 @@ describe("bootTwin stripe harness", () => {
       expect(attempt, "the rejected JSON-RPC refund attempt must be recorded").toBeTruthy();
       expect(attempt!.error).toBeTruthy();
     } finally {
-      harness.close();
+      await harness.close();
     }
   });
 
@@ -125,7 +125,7 @@ describe("bootTwin stripe harness", () => {
         if (!server) return resolve();
         server.close((err?: Error) => (err ? reject(err) : resolve()));
       });
-      harness.close();
+      await harness.close();
     }
   });
 });

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -47,10 +47,16 @@ Every engine-booted twin honors the frozen runtime contract in
 
 The trace recorder lives in this package (`packages/sdk/src/recorder.ts`).
 There is no separate `packages/twin-core` — F-681 folded twin-core into
-`@pome-sh/sdk`. Default boot uses an in-memory store; durable write-through
-semantics (`flush` / `close`, file-backed NDJSON) are defined on
-`RecorderStore` for F-698. Redaction always runs in the handle *before*
+`@pome-sh/sdk`. Default boot uses an in-memory store; set
+`POME_RECORDER_EVENTS_PATH` to enable durable write-through (`flush` /
+`close`, TwinHttpEvent NDJSON). Redaction always runs in the handle *before*
 `store.record()`, including for custom stores.
+
+**Architecture (F-698 / §9 Q3):** recorder *transport* belongs in twin-core
+(`@pome-sh/sdk`). Twins inherit durability via `resolveRecorderStore()` /
+`POME_RECORDER_EVENTS_PATH`; the self-host CLI harness passes the run's
+`events.jsonl` path into the same store. Disk rows are already
+`TwinHttpEvent`-shaped so upload/finalize byte shape is unchanged.
 
 ## Docs
 

--- a/packages/sdk/src/recorder.ts
+++ b/packages/sdk/src/recorder.ts
@@ -157,25 +157,51 @@ export interface FileBackedRecorderStoreOptions extends RecorderStoreOptions {
    */
   path: string;
   /**
-   * When true, each accepted write is `fsync`'d after the append so a
-   * `kill -9` loses at most the in-flight event. Default false in the
-   * F-720 skeleton (opt-in); F-698 flips the production default to true.
+   * When true, each accepted write is `fsync`'d so a `kill -9` loses at most
+   * the in-flight event. Default true for the production durable path (F-698).
    */
   fsync?: boolean;
 }
 
 /**
- * Durable recorder store skeleton (F-720 / F-698).
+ * Env key for the durable recorder tape. When set, twin boot paths and the
+ * self-host harness use `createFileBackedRecorderStore` instead of heap-only.
+ * Architecture (F-698 / §9 Q3): recorder *transport* lives in twin-core
+ * (`packages/sdk`); twins inherit durability by reading this env.
+ */
+export const POME_RECORDER_EVENTS_PATH = "POME_RECORDER_EVENTS_PATH";
+
+/**
+ * Wrap a legacy `RecorderEvent` into the unified `TwinHttpEvent` NDJSON row
+ * shape used by uploaded `events.jsonl` (FDRS-398). Pass-through when `kind`
+ * is already present. Disk rows from the durable store use this shape so
+ * finalize/upload does not need a second wrap for crash-streamed events.
+ */
+export function toTwinHttpEventRow(
+  event: RecorderEvent
+): RecorderEvent & { kind: "TwinHttpEvent"; event_id: string; parent_id: null } {
+  const maybeKind = (event as { kind?: unknown }).kind;
+  if (typeof maybeKind === "string") {
+    return event as RecorderEvent & { kind: "TwinHttpEvent"; event_id: string; parent_id: null };
+  }
+  return {
+    ...event,
+    kind: "TwinHttpEvent",
+    event_id: event.request_id,
+    parent_id: null,
+  };
+}
+
+/**
+ * Durable recorder store (F-720 contract / F-698 implementation).
  *
- * Keeps an in-memory mirror for `events()` / `count()` (same API as the heap
- * store) and appends each accepted redacted `RecorderEvent` as one NDJSON
- * line. `flush()` drains pending writes and rethrows the first append/fsync
- * failure; with `fsync: true` it also `fsync`s the fd so a `kill -9` loses
- * at most the in-flight event. `maxEvents` caps only the heap mirror — the
- * NDJSON tape stays append-only.
- *
- * Twin boot paths still default to `createRecorderStore()` — wiring this
- * store into production servers/CLI is F-698.
+ * Keeps an in-memory mirror of legacy `RecorderEvent` rows for `events()` /
+ * `GET /_pome/events` (unchanged API), and appends each accepted event as a
+ * `TwinHttpEvent` NDJSON line so on-disk `events.jsonl` matches the uploaded
+ * raw-trace byte shape. `flush()` drains pending writes and rethrows the
+ * first append/fsync failure; `fsync` (default true) bounds crash loss to
+ * the in-flight event. `maxEvents` caps only the heap mirror — the NDJSON
+ * tape stays append-only.
  */
 export function createFileBackedRecorderStore(
   options: FileBackedRecorderStoreOptions
@@ -184,7 +210,7 @@ export function createFileBackedRecorderStore(
   const cap = options.maxEvents !== undefined ? Math.max(1, options.maxEvents) : undefined;
   let droppedCount = 0;
   let closed = false;
-  const doFsync = options.fsync === true;
+  const doFsync = options.fsync !== false;
 
   mkdirSync(dirname(options.path), { recursive: true });
   // Open the fd synchronously so fsync never races createWriteStream's
@@ -253,7 +279,7 @@ export function createFileBackedRecorderStore(
           droppedCount += 1;
         }
       }
-      enqueueWrite(`${JSON.stringify(event)}\n`);
+      enqueueWrite(`${JSON.stringify(toTwinHttpEventRow(event))}\n`);
     },
     events() {
       return [...items];
@@ -286,6 +312,18 @@ export function createFileBackedRecorderStore(
       });
     },
   };
+}
+
+/**
+ * Resolve the recorder store for a twin boot: durable file-backed when
+ * `POME_RECORDER_EVENTS_PATH` is set, otherwise the in-memory default.
+ */
+export function resolveRecorderStore(options: RecorderStoreOptions = {}): RecorderStore {
+  const path = process.env[POME_RECORDER_EVENTS_PATH]?.trim();
+  if (path) {
+    return createFileBackedRecorderStore({ ...options, path });
+  }
+  return createRecorderStore(options);
 }
 
 export interface RecorderHandleOptions {

--- a/packages/sdk/src/recorder.ts
+++ b/packages/sdk/src/recorder.ts
@@ -31,17 +31,18 @@
 // call — including custom stores and direct `recorder.record()` — so no
 // store ever sees unredacted secrets. Stores must not re-emit raw bodies.
 //
-// Persisted row shape: durable stores write one redacted `RecorderEvent` per
-// NDJSON line (shared-types `recorderEventSchema`). Upload/finalize may wrap
-// legacy rows into `TwinHttpEvent` for the unified `events.jsonl` byte shape;
-// the store itself does not change that uploaded shape (F-698).
+// Persisted row shape (F-698): durable stores write one redacted
+// `TwinHttpEvent` NDJSON line per accepted event (shared-types
+// `twinHttpEventSchema`) so on-disk `events.jsonl` matches the uploaded
+// raw-trace byte shape. The in-memory mirror / `GET /_pome/events` still
+// exposes legacy `RecorderEvent` rows.
 //
 // `flush()`: optional. When present, resolves after every accepted event is
 // durable on the store's backing medium (fsync for file-backed). In-memory
 // stores may omit it (no-op if called via a handle that forwards). Callers
 // that need crash-bounded loss (≤ in-flight event) must await `flush()`
-// before relying on the on-disk tape, or use a store that flushes on each
-// `record()` (F-698 production path).
+// before relying on the on-disk tape, or use a store that fsyncs on each
+// `record()` (F-698 production default).
 //
 // `close()`: optional. When present, flushes pending writes, releases the
 // backing resource, and is idempotent. After `close()`, further `record()`
@@ -56,8 +57,8 @@
 // tape, not `events()`.
 //
 // Default runtime behavior: `createRecorderStore()` remains heap-only.
-// `createFileBackedRecorderStore()` is the durable skeleton for F-698; twin
-// boot paths do not switch to it in this contract PR.
+// Set `POME_RECORDER_EVENTS_PATH` (or pass `createFileBackedRecorderStore`)
+// for durable write-through; twin boot resolves via `resolveRecorderStore()`.
 
 import { randomUUID } from "node:crypto";
 import {

--- a/packages/sdk/src/recorder.ts
+++ b/packages/sdk/src/recorder.ts
@@ -174,16 +174,27 @@ export const POME_RECORDER_EVENTS_PATH = "POME_RECORDER_EVENTS_PATH";
 
 /**
  * Wrap a legacy `RecorderEvent` into the unified `TwinHttpEvent` NDJSON row
- * shape used by uploaded `events.jsonl` (FDRS-398). Pass-through when `kind`
- * is already present. Disk rows from the durable store use this shape so
- * finalize/upload does not need a second wrap for crash-streamed events.
+ * shape used by uploaded `events.jsonl` (FDRS-398). Pass-through only when
+ * `kind` is already `"TwinHttpEvent"`; any other kind is re-wrapped so the
+ * durable tape never persists a mismatched discriminator. Disk rows from the
+ * durable store use this shape so finalize/upload does not need a second wrap
+ * for crash-streamed events.
  */
 export function toTwinHttpEventRow(
   event: RecorderEvent
 ): RecorderEvent & { kind: "TwinHttpEvent"; event_id: string; parent_id: null } {
   const maybeKind = (event as { kind?: unknown }).kind;
-  if (typeof maybeKind === "string") {
-    return event as RecorderEvent & { kind: "TwinHttpEvent"; event_id: string; parent_id: null };
+  if (maybeKind === "TwinHttpEvent") {
+    const existing = event as RecorderEvent & {
+      kind: "TwinHttpEvent";
+      event_id?: string;
+      parent_id?: null;
+    };
+    return {
+      ...existing,
+      event_id: typeof existing.event_id === "string" ? existing.event_id : event.request_id,
+      parent_id: null,
+    };
   }
   return {
     ...event,

--- a/packages/sdk/src/server.ts
+++ b/packages/sdk/src/server.ts
@@ -445,16 +445,15 @@ export function createApp<TDb, TSeed, TDomain>(
 export interface ServeResult {
   app: Hono;
   /**
-   * Stop the bound HTTP server. Resolves once the server is fully closed.
-   * Throws if `serve()` was called without a `port` (no server was bound).
+   * Stop the bound HTTP server (if any), then flush+close the recorder store
+   * so durable tapes drain before process exit (F-698).
    */
   close(): Promise<void>;
 }
 
 /**
  * Build the app and bind a Node HTTP server. If `port` is omitted, no
- * server is bound and `close()` is a no-op — useful for tests that drive
- * the app via `app.request(...)`.
+ * server is bound — `close()` still flushes the recorder store.
  */
 export async function serve<TDb, TSeed, TDomain>(
   definition: TwinDefinition<TDb, TSeed, TDomain>,
@@ -469,9 +468,16 @@ export async function serve<TDb, TSeed, TDomain>(
       `TWIN_AUTH_SECRET is required when a twin listens on a non-loopback host (${hostname}).`
     );
   }
-  const app = createApp(definition, options);
+  // Resolve the store once so `close()` can flush the same instance the app
+  // records into (durable when POME_RECORDER_EVENTS_PATH is set).
+  const store = options.recorder ?? resolveRecorderStore();
+  const app = createApp(definition, { ...options, recorder: store });
+  const closeRecorder = async () => {
+    await store.flush?.();
+    await store.close?.();
+  };
   if (options.port === undefined) {
-    return { app, close: async () => undefined };
+    return { app, close: closeRecorder };
   }
   const { serve: nodeServe } = await import("@hono/node-server");
   const server = await new Promise<ReturnType<typeof nodeServe>>((resolve) => {
@@ -486,10 +492,12 @@ export async function serve<TDb, TSeed, TDomain>(
   });
   return {
     app,
-    close: () =>
-      new Promise<void>((resolve, reject) => {
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
         server.close((err?: Error) => (err ? reject(err) : resolve()));
-      }),
+      });
+      await closeRecorder();
+    },
   };
 }
 

--- a/packages/sdk/src/server.ts
+++ b/packages/sdk/src/server.ts
@@ -34,7 +34,7 @@ import { createAdminGate } from "./admin-gate.js";
 import { makeToolCallContext } from "./tool-context.js";
 import { twinBuildInfo } from "./build-info.js";
 import { handleMcpJsonRpc, mcpMethodNotAllowed } from "./mcp-jsonrpc.js";
-import { createRecorderHandle, type RecorderStore } from "./recorder.js";
+import { createRecorderHandle, resolveRecorderStore, type RecorderStore } from "./recorder.js";
 import { redactSecrets } from "./redaction.js";
 import { TwinError, UnknownToolError, envelopeFor } from "./errors.js";
 import {
@@ -56,6 +56,9 @@ export {
   createRecorderHandle,
   createRecorderStore,
   createFileBackedRecorderStore,
+  resolveRecorderStore,
+  toTwinHttpEventRow,
+  POME_RECORDER_EVENTS_PATH,
 } from "./recorder.js";
 export type {
   RecorderStore,
@@ -115,7 +118,7 @@ export interface ServeOptions<TDb = unknown, TSeed = unknown> {
   db?: TDb;
   /** Initial seed forwarded to `definition.domain({ seed })`. Validated against `definition.seed` if provided. */
   seed?: TSeed;
-  /** Custom recorder store. Defaults to in-memory. */
+  /** Custom recorder store. Defaults to `resolveRecorderStore()` (durable when `POME_RECORDER_EVENTS_PATH` is set). */
   recorder?: RecorderStore;
   /** Run identifier embedded in every recorder event. Defaults to "local". */
   runId?: string;
@@ -147,7 +150,7 @@ export function createApp<TDb, TSeed, TDomain>(
   const recorder = createRecorderHandle({
     runId,
     twin: definition.id,
-    store: options.recorder,
+    store: options.recorder ?? resolveRecorderStore(),
     errorEnvelope: definition.errorEnvelope,
     stampToolCallId: definition.stampToolCallId,
   });

--- a/packages/sdk/src/server.ts
+++ b/packages/sdk/src/server.ts
@@ -1,3 +1,4 @@
+// file-size: server engine intentionally centralizes TwinDefinition boot, reserved routes, recorder shutdown, and auth wiring.
 // SPDX-License-Identifier: Apache-2.0
 //
 // `@pome-sh/sdk/server` — boot a `TwinDefinition` into a Hono app and

--- a/packages/sdk/src/server.ts
+++ b/packages/sdk/src/server.ts
@@ -498,8 +498,7 @@ export async function serve<TDb, TSeed, TDomain>(
       return;
     }
     closed = true;
-    process.off("SIGINT", onSignal);
-    process.off("SIGTERM", onSignal);
+    unregisterServeShutdown(close);
     await new Promise<void>((resolve, reject) => {
       server.close((err?: Error) => (err ? reject(err) : resolve()));
     });
@@ -508,12 +507,34 @@ export async function serve<TDb, TSeed, TDomain>(
   // Twin boot scripts (`await serve(...)`) never call close() themselves.
   // Drain the durable recorder on graceful process signals so hosted twins
   // with POME_RECORDER_EVENTS_PATH set do not lose the last accepted events.
-  function onSignal() {
-    void close().finally(() => process.exit(0));
-  }
+  // Shared registry: every served twin flushes before a single process.exit,
+  // so multi-twin processes cannot lose sibling recorder tapes.
+  registerServeShutdown(close);
+  return { app, close };
+}
+
+/** Active `serve({ port })` close hooks — drained together on SIGINT/SIGTERM. */
+const serveShutdownHooks = new Set<() => Promise<void>>();
+let serveSignalHandlersInstalled = false;
+
+function registerServeShutdown(close: () => Promise<void>): void {
+  serveShutdownHooks.add(close);
+  if (serveSignalHandlersInstalled) return;
+  serveSignalHandlersInstalled = true;
+  const onSignal = () => {
+    void (async () => {
+      const hooks = [...serveShutdownHooks];
+      serveShutdownHooks.clear();
+      await Promise.allSettled(hooks.map((hook) => hook()));
+      process.exit(0);
+    })();
+  };
   process.once("SIGINT", onSignal);
   process.once("SIGTERM", onSignal);
-  return { app, close };
+}
+
+function unregisterServeShutdown(close: () => Promise<void>): void {
+  serveShutdownHooks.delete(close);
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────

--- a/packages/sdk/src/server.ts
+++ b/packages/sdk/src/server.ts
@@ -490,15 +490,29 @@ export async function serve<TDb, TSeed, TDomain>(
       () => resolve(bound)
     );
   });
-  return {
-    app,
-    close: async () => {
-      await new Promise<void>((resolve, reject) => {
-        server.close((err?: Error) => (err ? reject(err) : resolve()));
-      });
+  let closed = false;
+  const close = async () => {
+    if (closed) {
       await closeRecorder();
-    },
+      return;
+    }
+    closed = true;
+    process.off("SIGINT", onSignal);
+    process.off("SIGTERM", onSignal);
+    await new Promise<void>((resolve, reject) => {
+      server.close((err?: Error) => (err ? reject(err) : resolve()));
+    });
+    await closeRecorder();
   };
+  // Twin boot scripts (`await serve(...)`) never call close() themselves.
+  // Drain the durable recorder on graceful process signals so hosted twins
+  // with POME_RECORDER_EVENTS_PATH set do not lose the last accepted events.
+  function onSignal() {
+    void close().finally(() => process.exit(0));
+  }
+  process.once("SIGINT", onSignal);
+  process.once("SIGTERM", onSignal);
+  return { app, close };
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────

--- a/packages/sdk/test/recorder-contract.test.ts
+++ b/packages/sdk/test/recorder-contract.test.ts
@@ -8,7 +8,11 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { recorderEventSchema, type RecorderEvent } from "@pome-sh/shared-types";
+import {
+  recorderEventSchema,
+  twinHttpEventSchema,
+  type RecorderEvent,
+} from "@pome-sh/shared-types";
 
 // Optional fsync override so we can assert flush() rethrows a prior failure
 // after the rejected promise has left `pending` (ESM blocks spyOn on node:fs).
@@ -87,7 +91,7 @@ async function assertStoreContract(store: RecorderStore, opts?: { path?: string 
     const lines = raw.split("\n").filter((l) => l.length > 0);
     expect(lines.length).toBe(1);
     const row = JSON.parse(lines[0]!) as unknown;
-    const diskParsed = recorderEventSchema.safeParse(row);
+    const diskParsed = twinHttpEventSchema.safeParse(row);
     expect(diskParsed.success, JSON.stringify(diskParsed)).toBe(true);
     expect(row).toMatchObject({
       run_id: "run_contract",
@@ -95,9 +99,11 @@ async function assertStoreContract(store: RecorderStore, opts?: { path?: string 
       method: "POST",
       status: 201,
     });
-    // Durable store writes legacy RecorderEvent NDJSON — no kind discriminator
-    // (upload/finalize wraps to TwinHttpEvent; store must not change that shape).
-    expect((row as { kind?: unknown }).kind).toBeUndefined();
+    // Durable store writes TwinHttpEvent NDJSON (uploaded events.jsonl shape).
+    expect((row as { kind?: unknown }).kind).toBe("TwinHttpEvent");
+    expect((row as { event_id?: unknown }).event_id).toBe(
+      (store.events()[0] as { request_id: string }).request_id
+    );
   }
 }
 
@@ -133,7 +139,9 @@ describe("recorder write-through contract (F-720)", () => {
     const lines = raw.split("\n").filter((l) => l.length > 0);
     expect(lines).toHaveLength(2);
     for (const line of lines) {
-      expect(recorderEventSchema.safeParse(JSON.parse(line)).success).toBe(true);
+      const row = JSON.parse(line) as { kind?: string };
+      expect(row.kind).toBe("TwinHttpEvent");
+      expect(twinHttpEventSchema.safeParse(row).success).toBe(true);
     }
     await store.close?.();
   });

--- a/packages/sdk/test/recorder-contract.test.ts
+++ b/packages/sdk/test/recorder-contract.test.ts
@@ -36,6 +36,7 @@ const {
   createFileBackedRecorderStore,
   createRecorderHandle,
   createRecorderStore,
+  toTwinHttpEventRow,
 } = await import("../src/recorder.js");
 type RecorderStore = import("../src/recorder.js").RecorderStore;
 
@@ -250,6 +251,25 @@ describe("recorder write-through contract (F-720)", () => {
     } finally {
       fsMocks.fsync = null;
     }
+  });
+
+  it("toTwinHttpEventRow re-wraps non-TwinHttpEvent kinds", () => {
+    const legacyShaped = {
+      ...sampleEvent({ request_id: "req_legacy" }),
+      kind: "LlmCallEvent",
+    } as unknown as RecorderEvent;
+    const wrapped = toTwinHttpEventRow(legacyShaped);
+    expect(wrapped.kind).toBe("TwinHttpEvent");
+    expect(wrapped.event_id).toBe("req_legacy");
+    expect(wrapped.parent_id).toBeNull();
+    const already = toTwinHttpEventRow({
+      ...sampleEvent({ request_id: "req_ok" }),
+      kind: "TwinHttpEvent",
+      event_id: "req_ok",
+      parent_id: null,
+    } as RecorderEvent);
+    expect(already.kind).toBe("TwinHttpEvent");
+    expect(already.event_id).toBe("req_ok");
   });
 
   it("bounded file-backed store caps events() but keeps all rows on disk", async () => {

--- a/packages/twin-github/src/server.ts
+++ b/packages/twin-github/src/server.ts
@@ -28,6 +28,8 @@ const db = openGitHubCloneDatabase(dbPath);
 // the boot loudly instead of silently serving the default world.
 const seed = process.env.GITHUB_CLONE_NO_SEED === "1" ? undefined : loadSeedFromEnv();
 
+// F-698: when POME_RECORDER_EVENTS_PATH is set, createApp/serve resolves a
+// durable file-backed store (twin-core transport). Otherwise heap-only.
 await serve(githubTwinDefinition, {
   port,
   hostname: host,

--- a/packages/twin-slack/src/server.ts
+++ b/packages/twin-slack/src/server.ts
@@ -28,6 +28,7 @@ const db = openSlackTwinDatabase(dbPath);
 // the boot loudly instead of silently serving the default world.
 const seed = process.env.SLACK_CLONE_NO_SEED === "1" ? undefined : loadSeedFromEnv();
 
+// F-698: durable when POME_RECORDER_EVENTS_PATH is set (resolved inside serve).
 await serve(slackTwinDefinition, {
   port,
   hostname: host,

--- a/packages/twin-stripe/src/server.ts
+++ b/packages/twin-stripe/src/server.ts
@@ -7,7 +7,7 @@
 // `serve()`. Listens on :3333 (Vercel Sandbox port-forward target) and
 // honors STRIPE_CLONE_HOST=0.0.0.0 in containerized envs.
 
-import { TwinBootError, createRecorderStore, isLoopbackHost, serve } from "@pome-sh/sdk/server";
+import { TwinBootError, resolveRecorderStore, isLoopbackHost, serve } from "@pome-sh/sdk/server";
 import { openTwinStripeDatabase } from "./db.js";
 import { loadSeedFromEnv } from "./seed.js";
 import { createStripeTwinDefinition } from "./twin.js";
@@ -42,7 +42,8 @@ const definition = createStripeTwinDefinition({
 
 await serve(definition, {
   // Pre-port D-ENG-10 recorder bound: 10k events, drop-oldest, real counter.
-  recorder: createRecorderStore({ maxEvents: 10_000 }),
+  // F-698: durable when POME_RECORDER_EVENTS_PATH is set (same cap).
+  recorder: resolveRecorderStore({ maxEvents: 10_000 }),
   port,
   hostname: host,
   db,


### PR DESCRIPTION
Executive summary: Implements the durable file-backed recorder in twin-core (`@pome-sh/sdk`): append redacted `TwinHttpEvent` NDJSON with fsync, resolve via `POME_RECORDER_EVENTS_PATH`, and wire twin boot + the self-host CLI harness so events stream into the run `events.jsonl` during the run. Finalize/upload dedupes crash-streamed rows; `/_pome/events` stays on the legacy in-memory mirror.

## What
- Durable `createFileBackedRecorderStore` path writes `TwinHttpEvent` NDJSON (fsync by default) and resolves via `POME_RECORDER_EVENTS_PATH`.
- Twin boot paths (Stripe/GitHub/Slack) and the CLI harness stream twin HTTP events into the run artifact during the run.
- Dedupe finalize/upload so crash-streamed rows are not duplicated; flush on `serve().close()` and SIGTERM/SIGINT.
- CLI changeset for the harness behavior change.

## Why
Local and hosted twin runs should survive process death without losing accepted HTTP events, while keeping uploaded `events.jsonl` byte shape stable and avoiding duplicate rows on finalize.

## Notes for reviewer
- Stacked on #92 (recorder write-through contract).
- Architecture: recorder *transport* lives in twin-core (`@pome-sh/sdk`). Twins inherit durability through `resolveRecorderStore()` / `POME_RECORDER_EVENTS_PATH`; the CLI passes the run artifact path into the same store.
- Default without `POME_RECORDER_EVENTS_PATH` remains heap-only for standalone twin servers; self-host `pome run` always passes `eventsPath`.
- Crash-loss and overhead CI gates are the next PR in the stack (#94).

## Tests / CI
- Local: SDK recorder contract/redaction tests + typecheck — pass
- Local: `cd cli && bun run test -- test/unit/recorder/artifacts.test.ts` — pass
- PR CI: typecheck-test, cli-ci, secret scan, smoke, wait-ci — green (twin image jobs may still be pending); Greptile — pass