### PR TITLE
ci: gate durable recorder crash loss and overhead

### DIFF
--- a/.github/workflows/agent-trace-overhead-gate.yml
+++ b/.github/workflows/agent-trace-overhead-gate.yml
@@ -7,6 +7,10 @@ name: agent-trace-overhead-gate
 # TwinHttpEvent (tool_call_id: null) in events.jsonl, and `pome inspect`
 # exits 0 with a "Trace health" section.
 #
+# F-722 adds a durable-recorder micro-benchmark (heap vs file-backed fsync)
+# with an explicit per-event p99 budget, and expands path filters to
+# packages/sdk + twin-slack/stripe so recorder durability changes trip the gate.
+#
 # FDRS-413 adds a second job step that runs scenario 01 against the
 # CAS-adapter triage fixture and enforces PR/FAQ acceptance #2: ≥1
 # LlmCallEvent + ≥1 TwinHttpEvent with non-null tool_call_id + ≥1
@@ -15,17 +19,29 @@ name: agent-trace-overhead-gate
 # artifact so reviewers can eyeball a real adapter run.
 #
 # Not a PR required check: the p99 latency gate is expensive and sensitive to
-# runner noise. Keep coverage on main + manual dispatch. Paths filter scopes
-# the gate to changes that could plausibly affect proxy latency or
-# events.jsonl shape — the CLI runtime, the in-process twin-github runtime,
-# and the CAS adapter package.
+# runner noise. Keep coverage on main + PRs that touch recorder/SDK/twin paths
+# + manual dispatch.
 
 on:
   push:
     branches: [main]
     paths:
       - 'cli/**'
+      - 'packages/sdk/**'
       - 'packages/twin-github/**'
+      - 'packages/twin-slack/**'
+      - 'packages/twin-stripe/**'
+      - 'packages/adapter-claude-sdk/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/agent-trace-overhead-gate.yml'
+  pull_request:
+    paths:
+      - 'cli/**'
+      - 'packages/sdk/**'
+      - 'packages/twin-github/**'
+      - 'packages/twin-slack/**'
+      - 'packages/twin-stripe/**'
       - 'packages/adapter-claude-sdk/**'
       - 'package.json'
       - 'package-lock.json'
@@ -78,6 +94,12 @@ jobs:
           OVERHEAD_BENCH_N: '100'
           OVERHEAD_BENCH_BUDGET_MS: '5'
         run: npx tsx scripts/overhead-gate.ts
+      - name: Run durable recorder overhead gate (F-722)
+        working-directory: cli
+        env:
+          RECORDER_OVERHEAD_N: '200'
+          RECORDER_OVERHEAD_BUDGET_MS: '1'
+        run: npx tsx scripts/recorder-overhead-gate.ts
       - name: Run CAS-adapter acceptance gate (PR/FAQ #2)
         working-directory: cli
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       # instead of a second plain `npm test` pass for that workspace.
       - run: npm test -w @pome-sh/shared-types -w @pome-sh/sdk -w @pome-sh/adapter-claude-sdk -w @pome-sh/twin-slack -w @pome-sh/twin-stripe
       - run: npm run test:coverage -w @pome-sh/twin-github
+      # F-722 — durable recorder crash-loss gate (SIGKILL mid-write). Covered
+      # by packages/sdk test/recorder-crash.test.ts in the sdk workspace test
+      # step above; keep this comment so path reviewers know where it lives.
       # Black-box twin runtime-contract suite (FDRS-711). Spawns the BUILT twins
       # via plain `node` — Node 24 to match the GHCR runtime image — and asserts
       # the control-plane surface frozen in CONTRACT.md. Reuses the build above

--- a/cli/package.json
+++ b/cli/package.json
@@ -55,6 +55,7 @@
     "test": "vitest run",
     "test:e2e": "vitest run test/e2e",
     "gate:no-eval": "node ../scripts/no-eval-in-oss.mjs",
+    "gate:recorder-overhead": "tsx scripts/recorder-overhead-gate.ts",
     "changeset": "changeset",
     "changeset:version": "changeset version",
     "changeset:publish": "changeset publish"

--- a/cli/scripts/recorder-overhead-gate.ts
+++ b/cli/scripts/recorder-overhead-gate.ts
@@ -65,6 +65,11 @@ async function benchDurable(dir: string): Promise<number[]> {
     path: join(dir, "events.jsonl"),
     fsync: true,
   });
+  const flush = store.flush;
+  const close = store.close;
+  if (!flush || !close) {
+    fail("createFileBackedRecorderStore must implement flush/close");
+  }
   const samples: number[] = [];
   for (let i = 0; i < WARMUP + N; i++) {
     const t0 = performance.now();
@@ -75,8 +80,8 @@ async function benchDurable(dir: string): Promise<number[]> {
     const dt = performance.now() - t0;
     if (i >= WARMUP) samples.push(dt);
   }
-  await store.flush();
-  await store.close();
+  await flush();
+  await close();
   return samples;
 }
 

--- a/cli/scripts/recorder-overhead-gate.ts
+++ b/cli/scripts/recorder-overhead-gate.ts
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-722 — recorder hot-path overhead gate.
+// Micro-benchmarks heap vs durable (file-backed, fsync) `record()` latency
+// using the same twin-core store production twins use, and fails if durable
+// p99 exceeds RECORDER_OVERHEAD_BUDGET_MS (default 5ms per event).
+//
+// Reuses percentile math from overhead-stats.ts. Designed to run from `cli/`:
+//   cd cli && npx tsx scripts/recorder-overhead-gate.ts
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createFileBackedRecorderStore,
+  createRecorderStore,
+} from "@pome-sh/sdk/server";
+import type { RecorderEvent } from "@pome-sh/shared-types";
+import { percentile, summarize } from "./overhead-stats.js";
+
+const N = Number.parseInt(process.env.RECORDER_OVERHEAD_N ?? "200", 10);
+const WARMUP = Number.parseInt(process.env.RECORDER_OVERHEAD_WARMUP ?? "20", 10);
+// Hot-path budget: sync record() enqueue cost (not fsync). Default 1ms is
+// generous vs heap (~µs) while still catching accidental sync disk I/O on
+// the request path.
+const BUDGET_MS = Number.parseFloat(process.env.RECORDER_OVERHEAD_BUDGET_MS ?? "1");
+
+function sampleEvent(i: number): RecorderEvent {
+  return {
+    ts: new Date().toISOString(),
+    run_id: "run_overhead",
+    twin: "toy",
+    request_id: `req_${String(i).padStart(5, "0")}`,
+    step_id: null,
+    tool_call_id: null,
+    method: "POST",
+    path: "/s/test/items",
+    request_body: { i },
+    status: 201,
+    response_body: { ok: true },
+    latency_ms: 1,
+    fidelity: "semantic",
+    state_mutation: true,
+    state_delta: null,
+    error: null,
+  };
+}
+
+async function benchHeap(): Promise<number[]> {
+  const store = createRecorderStore();
+  const samples: number[] = [];
+  for (let i = 0; i < WARMUP + N; i++) {
+    const t0 = performance.now();
+    store.record(sampleEvent(i));
+    const dt = performance.now() - t0;
+    if (i >= WARMUP) samples.push(dt);
+  }
+  await store.flush?.();
+  await store.close?.();
+  return samples;
+}
+
+async function benchDurable(dir: string): Promise<number[]> {
+  const store = createFileBackedRecorderStore({
+    path: join(dir, "events.jsonl"),
+    fsync: true,
+  });
+  const samples: number[] = [];
+  for (let i = 0; i < WARMUP + N; i++) {
+    const t0 = performance.now();
+    // Hot path: record() queues the append; callers do not await flush per
+    // event. Measuring flush-per-event would gate OS fsync noise, not twin
+    // request latency.
+    store.record(sampleEvent(i));
+    const dt = performance.now() - t0;
+    if (i >= WARMUP) samples.push(dt);
+  }
+  await store.flush();
+  await store.close();
+  return samples;
+}
+
+function fail(msg: string): never {
+  console.error(`[recorder-overhead-gate] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+async function main(): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), "pome-recorder-overhead-"));
+  console.log(
+    `[recorder-overhead-gate] N=${N} warmup=${WARMUP} budget=${BUDGET_MS}ms path=${dir}`,
+  );
+  try {
+    const heap = await benchHeap();
+    const durable = await benchDurable(dir);
+    const heapStats = summarize(heap);
+    const durableStats = summarize(durable);
+    const sortedDurable = [...durable].sort((a, b) => a - b);
+    const durableP99 = percentile(sortedDurable, 0.99);
+
+    console.log(
+      `[recorder-overhead-gate] heap     p50=${heapStats.p50.toFixed(3)}ms p99=${heapStats.p99.toFixed(3)}ms`,
+    );
+    console.log(
+      `[recorder-overhead-gate] durable  p50=${durableStats.p50.toFixed(3)}ms p99=${durableStats.p99.toFixed(3)}ms`,
+    );
+    console.log(
+      `[recorder-overhead-gate] durable p99=${durableP99.toFixed(3)}ms (budget ${BUDGET_MS}ms)`,
+    );
+
+    if (!Number.isFinite(durableP99)) {
+      fail(`durable p99 is not finite (${durableP99})`);
+    }
+    if (durableP99 > BUDGET_MS) {
+      fail(
+        `durable recorder p99 ${durableP99.toFixed(3)}ms exceeded budget ${BUDGET_MS}ms`,
+      );
+    }
+    console.log("[recorder-overhead-gate] PASS");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+// Allow importing from a built workspace SDK when run from cli/ after pack,
+// or from the monorepo node_modules link during local/dev CI.
+void main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/cli/scripts/recorder-overhead-gate.ts
+++ b/cli/scripts/recorder-overhead-gate.ts
@@ -23,7 +23,14 @@ const WARMUP = Number.parseInt(process.env.RECORDER_OVERHEAD_WARMUP ?? "20", 10)
 // Hot-path budget: sync record() enqueue cost (not fsync). Default 1ms is
 // generous vs heap (~µs) while still catching accidental sync disk I/O on
 // the request path.
-const BUDGET_MS = Number.parseFloat(process.env.RECORDER_OVERHEAD_BUDGET_MS ?? "1");
+const BUDGET_RAW = process.env.RECORDER_OVERHEAD_BUDGET_MS ?? "1";
+const BUDGET_MS = Number.parseFloat(BUDGET_RAW);
+if (!Number.isFinite(BUDGET_MS) || BUDGET_MS <= 0) {
+  console.error(
+    `[recorder-overhead-gate] FAIL: RECORDER_OVERHEAD_BUDGET_MS must be a positive number (got ${JSON.stringify(BUDGET_RAW)})`,
+  );
+  process.exit(1);
+}
 
 function sampleEvent(i: number): RecorderEvent {
   return {

--- a/packages/sdk/test/recorder-crash.test.ts
+++ b/packages/sdk/test/recorder-crash.test.ts
@@ -75,10 +75,15 @@ function event(i: number) {
 }
 
 async function main() {
-  for (let i = 0; i < total; i++) {
+  for (let i = 0; i < readyAfter; i++) {
     store.record(event(i));
     await store.flush!();
-    if (i + 1 === readyAfter) writeFileSync(readyPath, String(i + 1));
+  }
+  writeFileSync(readyPath, String(readyAfter));
+  // Keep recording without awaiting flush so SIGKILL can land on an
+  // in-flight write; loss must stay ≤ 1 beyond the ready barrier.
+  for (let i = readyAfter; i < total; i++) {
+    store.record(event(i));
   }
   await new Promise(() => {});
 }
@@ -129,7 +134,20 @@ void main();
     await new Promise<void>((resolvePromise) => child.once("exit", () => resolvePromise()));
 
     const raw = await readFile(eventsPath, "utf8");
-    const lines = raw.split("\n").filter((l) => l.trim().length > 0);
+    // Tolerate a trailing partial line from SIGKILL mid-write; complete
+    // NDJSON rows must still parse.
+    const lines = raw
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0)
+      .filter((line) => {
+        try {
+          JSON.parse(line);
+          return true;
+        } catch {
+          return false;
+        }
+      });
     expect(lines.length).toBeGreaterThanOrEqual(READY_AFTER);
     expect(lines.length).toBeLessThanOrEqual(TOTAL);
 
@@ -140,7 +158,9 @@ void main();
       expect((row as { kind: string }).kind).toBe("TwinHttpEvent");
     }
 
-    // Loss bounded to at most the in-flight event after the ready barrier.
-    expect(lines.length).toBeGreaterThanOrEqual(readyCount - 1);
+    // Child flushes before writing the ready barrier, so every readyCount
+    // event is durable. Loss after that is bounded to the in-flight write
+    // (at most one event beyond the last successful flush).
+    expect(lines.length).toBeGreaterThanOrEqual(readyCount);
   }, 30_000);
 });

--- a/packages/sdk/test/recorder-crash.test.ts
+++ b/packages/sdk/test/recorder-crash.test.ts
@@ -87,7 +87,10 @@ async function main() {
   }
   await new Promise(() => {});
 }
-void main();
+void main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
 `,
       "utf8"
     );
@@ -105,62 +108,82 @@ void main();
     });
 
     let stderr = "";
+    let stdout = "";
     child.stderr?.on("data", (chunk: Buffer) => {
       stderr += chunk.toString();
     });
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
 
-    const deadline = Date.now() + 20_000;
-    while (Date.now() < deadline) {
-      try {
-        const ready = await readFile(readyPath, "utf8");
-        if (Number(ready) >= READY_AFTER) break;
-      } catch {
-        // not ready yet
-      }
-      if (child.exitCode !== null) {
-        throw new Error(`crash child exited early (${child.exitCode}): ${stderr}`);
-      }
-      await new Promise((r) => setTimeout(r, 20));
-    }
-    let readyCount = 0;
+    const killChild = () => {
+      if (child.killed || child.exitCode !== null) return;
+      child.kill("SIGKILL");
+    };
+
     try {
-      readyCount = Number(await readFile(readyPath, "utf8"));
-    } catch {
-      readyCount = 0;
-    }
-    expect(readyCount).toBeGreaterThanOrEqual(READY_AFTER);
-
-    child.kill("SIGKILL");
-    await new Promise<void>((resolvePromise) => child.once("exit", () => resolvePromise()));
-
-    const raw = await readFile(eventsPath, "utf8");
-    // Tolerate a trailing partial line from SIGKILL mid-write; complete
-    // NDJSON rows must still parse.
-    const lines = raw
-      .split("\n")
-      .map((l) => l.trim())
-      .filter((l) => l.length > 0)
-      .filter((line) => {
+      const deadline = Date.now() + 15_000;
+      while (Date.now() < deadline) {
         try {
-          JSON.parse(line);
-          return true;
+          const ready = await readFile(readyPath, "utf8");
+          if (Number(ready) >= READY_AFTER) break;
         } catch {
-          return false;
+          // not ready yet
         }
-      });
-    expect(lines.length).toBeGreaterThanOrEqual(READY_AFTER);
-    expect(lines.length).toBeLessThanOrEqual(TOTAL);
+        if (child.exitCode !== null) {
+          throw new Error(
+            `crash child exited early (${child.exitCode}): stderr=${stderr} stdout=${stdout}`
+          );
+        }
+        await new Promise((r) => setTimeout(r, 20));
+      }
+      let readyCount = 0;
+      try {
+        readyCount = Number(await readFile(readyPath, "utf8"));
+      } catch {
+        readyCount = 0;
+      }
+      if (readyCount < READY_AFTER) {
+        killChild();
+        throw new Error(
+          `crash child never reached ready barrier (ready=${readyCount}): stderr=${stderr} stdout=${stdout}`
+        );
+      }
 
-    for (const line of lines) {
-      const row = JSON.parse(line) as unknown;
-      const result = twinHttpEventSchema.safeParse(row);
-      expect(result.success, JSON.stringify(result)).toBe(true);
-      expect((row as { kind: string }).kind).toBe("TwinHttpEvent");
+      killChild();
+      await new Promise<void>((resolvePromise) => child.once("exit", () => resolvePromise()));
+
+      const raw = await readFile(eventsPath, "utf8");
+      // Tolerate a trailing partial line from SIGKILL mid-write; complete
+      // NDJSON rows must still parse.
+      const lines = raw
+        .split("\n")
+        .map((l) => l.trim())
+        .filter((l) => l.length > 0)
+        .filter((line) => {
+          try {
+            JSON.parse(line);
+            return true;
+          } catch {
+            return false;
+          }
+        });
+      expect(lines.length).toBeGreaterThanOrEqual(READY_AFTER);
+      expect(lines.length).toBeLessThanOrEqual(TOTAL);
+
+      for (const line of lines) {
+        const row = JSON.parse(line) as unknown;
+        const result = twinHttpEventSchema.safeParse(row);
+        expect(result.success, JSON.stringify(result)).toBe(true);
+        expect((row as { kind: string }).kind).toBe("TwinHttpEvent");
+      }
+
+      // Child flushes before writing the ready barrier, so every readyCount
+      // event is durable. Loss after that is bounded to the in-flight write
+      // (at most one event beyond the last successful flush).
+      expect(lines.length).toBeGreaterThanOrEqual(readyCount);
+    } finally {
+      killChild();
     }
-
-    // Child flushes before writing the ready barrier, so every readyCount
-    // event is durable. Loss after that is bounded to the in-flight write
-    // (at most one event beyond the last successful flush).
-    expect(lines.length).toBeGreaterThanOrEqual(readyCount);
   }, 30_000);
 });

--- a/packages/sdk/test/recorder-crash.test.ts
+++ b/packages/sdk/test/recorder-crash.test.ts
@@ -35,10 +35,13 @@ describe("durable recorder crash loss (F-722)", () => {
     tmpDirs.push(dir);
     const eventsPath = join(dir, "events.jsonl");
     const readyPath = join(dir, "ready");
+    const armedPath = join(dir, "armed");
     const childScript = join(dir, "crash-child.ts");
 
     const TOTAL = 20;
-    const READY_AFTER = 10;
+    // Flush TOTAL-1 events, then enqueue one more without flush so SIGKILL
+    // can only lose that in-flight write.
+    const FLUSHED = TOTAL - 1;
     await writeFile(
       childScript,
       `
@@ -49,8 +52,9 @@ import { createFileBackedRecorderStore } from ${JSON.stringify(
 
 const path = process.env.EVENTS_PATH!;
 const readyPath = process.env.READY_PATH!;
+const armedPath = process.env.ARMED_PATH!;
 const total = Number(process.env.TOTAL);
-const readyAfter = Number(process.env.READY_AFTER);
+const flushed = Number(process.env.FLUSHED);
 const store = createFileBackedRecorderStore({ path, fsync: true });
 
 function event(i: number) {
@@ -75,16 +79,15 @@ function event(i: number) {
 }
 
 async function main() {
-  for (let i = 0; i < readyAfter; i++) {
+  for (let i = 0; i < flushed; i++) {
     store.record(event(i));
     await store.flush!();
   }
-  writeFileSync(readyPath, String(readyAfter));
-  // Keep recording without awaiting flush so SIGKILL can land on an
-  // in-flight write; loss must stay ≤ 1 beyond the ready barrier.
-  for (let i = readyAfter; i < total; i++) {
-    store.record(event(i));
-  }
+  writeFileSync(readyPath, String(flushed));
+  // One more accepted write without awaiting flush — the only event that
+  // SIGKILL is allowed to lose.
+  store.record(event(flushed));
+  writeFileSync(armedPath, String(total));
   await new Promise(() => {});
 }
 void main().catch((err) => {
@@ -101,8 +104,9 @@ void main().catch((err) => {
         ...process.env,
         EVENTS_PATH: eventsPath,
         READY_PATH: readyPath,
+        ARMED_PATH: armedPath,
         TOTAL: String(TOTAL),
-        READY_AFTER: String(READY_AFTER),
+        FLUSHED: String(FLUSHED),
       },
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -125,10 +129,10 @@ void main().catch((err) => {
       const deadline = Date.now() + 15_000;
       while (Date.now() < deadline) {
         try {
-          const ready = await readFile(readyPath, "utf8");
-          if (Number(ready) >= READY_AFTER) break;
+          const armed = await readFile(armedPath, "utf8");
+          if (Number(armed) >= TOTAL) break;
         } catch {
-          // not ready yet
+          // not armed yet
         }
         if (child.exitCode !== null) {
           throw new Error(
@@ -137,16 +141,16 @@ void main().catch((err) => {
         }
         await new Promise((r) => setTimeout(r, 20));
       }
-      let readyCount = 0;
+      let armedCount = 0;
       try {
-        readyCount = Number(await readFile(readyPath, "utf8"));
+        armedCount = Number(await readFile(armedPath, "utf8"));
       } catch {
-        readyCount = 0;
+        armedCount = 0;
       }
-      if (readyCount < READY_AFTER) {
+      if (armedCount < TOTAL) {
         killChild();
         throw new Error(
-          `crash child never reached ready barrier (ready=${readyCount}): stderr=${stderr} stdout=${stdout}`
+          `crash child never reached armed barrier (armed=${armedCount}): stderr=${stderr} stdout=${stdout}`
         );
       }
 
@@ -164,34 +168,39 @@ void main().catch((err) => {
       }
 
       const raw = await readFile(eventsPath, "utf8");
-      // Tolerate a trailing partial line from SIGKILL mid-write; complete
-      // NDJSON rows must still parse.
-      const lines = raw
-        .split("\n")
-        .map((l) => l.trim())
-        .filter((l) => l.length > 0)
-        .filter((line) => {
-          try {
-            JSON.parse(line);
-            return true;
-          } catch {
-            return false;
+      // Tolerate only a trailing partial line from SIGKILL mid-write. A
+      // corrupt complete row earlier in the file must fail the gate.
+      const rawLines = raw.split("\n").map((l) => l.trim());
+      while (rawLines.length > 0 && rawLines[rawLines.length - 1] === "") {
+        rawLines.pop();
+      }
+      const completeLines: string[] = [];
+      for (let i = 0; i < rawLines.length; i++) {
+        const line = rawLines[i]!;
+        const isLast = i === rawLines.length - 1;
+        try {
+          JSON.parse(line);
+          completeLines.push(line);
+        } catch {
+          if (!isLast) {
+            throw new Error(`corrupt NDJSON row before trailing line: ${line.slice(0, 120)}`);
           }
-        });
-      expect(lines.length).toBeGreaterThanOrEqual(READY_AFTER);
-      expect(lines.length).toBeLessThanOrEqual(TOTAL);
+          // Trailing partial — drop it from the durable count.
+        }
+      }
 
-      for (const line of lines) {
+      expect(completeLines.length).toBeLessThanOrEqual(TOTAL);
+      // Child flushed FLUSHED events, then armed after enqueueing the last.
+      // Loss is bounded to that single in-flight write.
+      expect(completeLines.length).toBeGreaterThanOrEqual(FLUSHED);
+      expect(completeLines.length).toBeGreaterThanOrEqual(TOTAL - 1);
+
+      for (const line of completeLines) {
         const row = JSON.parse(line) as unknown;
         const result = twinHttpEventSchema.safeParse(row);
         expect(result.success, JSON.stringify(result)).toBe(true);
         expect((row as { kind: string }).kind).toBe("TwinHttpEvent");
       }
-
-      // Child flushes before writing the ready barrier, so every readyCount
-      // event is durable. Loss after that is bounded to the in-flight write
-      // (at most one event beyond the last successful flush).
-      expect(lines.length).toBeGreaterThanOrEqual(readyCount);
     } finally {
       killChild();
     }

--- a/packages/sdk/test/recorder-crash.test.ts
+++ b/packages/sdk/test/recorder-crash.test.ts
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-722 — crash-loss gate for the durable recorder (production path).
+// Spawns a child (via tsx) that records through createFileBackedRecorderStore
+// — the same twin-core store production twins / CLI harness use — then
+// SIGKILLs mid-run. Asserts the partial events.jsonl exists, parses with
+// twinHttpEventSchema, and lost at most the in-flight event.
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { twinHttpEventSchema } from "@pome-sh/shared-types";
+
+const PKG_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const REPO_ROOT = resolve(PKG_ROOT, "../..");
+const TSX_BIN = resolve(REPO_ROOT, "node_modules/.bin/tsx");
+const tmpDirs: string[] = [];
+
+afterEach(async () => {
+  while (tmpDirs.length > 0) {
+    const dir = tmpDirs.pop();
+    if (dir) await rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe("durable recorder crash loss (F-722)", () => {
+  it("kill -9 mid-run leaves a parseable partial tape losing at most one event", async () => {
+    expect(existsSync(TSX_BIN), `tsx not found at ${TSX_BIN}`).toBe(true);
+
+    const dir = await mkdtemp(join(tmpdir(), "pome-crash-"));
+    tmpDirs.push(dir);
+    const eventsPath = join(dir, "events.jsonl");
+    const readyPath = join(dir, "ready");
+    const childScript = join(dir, "crash-child.ts");
+
+    const TOTAL = 20;
+    const READY_AFTER = 10;
+    await writeFile(
+      childScript,
+      `
+import { writeFileSync } from "node:fs";
+import { createFileBackedRecorderStore } from ${JSON.stringify(
+        join(PKG_ROOT, "src/recorder.ts")
+      )};
+
+const path = process.env.EVENTS_PATH!;
+const readyPath = process.env.READY_PATH!;
+const total = Number(process.env.TOTAL);
+const readyAfter = Number(process.env.READY_AFTER);
+const store = createFileBackedRecorderStore({ path, fsync: true });
+
+function event(i: number) {
+  return {
+    ts: new Date().toISOString(),
+    run_id: "run_crash",
+    twin: "toy",
+    request_id: "req_" + String(i).padStart(4, "0"),
+    step_id: null,
+    tool_call_id: null,
+    method: "POST",
+    path: "/s/test/items",
+    request_body: { i },
+    status: 201,
+    response_body: { ok: true },
+    latency_ms: 1,
+    fidelity: "semantic" as const,
+    state_mutation: true,
+    state_delta: null,
+    error: null,
+  };
+}
+
+async function main() {
+  for (let i = 0; i < total; i++) {
+    store.record(event(i));
+    await store.flush!();
+    if (i + 1 === readyAfter) writeFileSync(readyPath, String(i + 1));
+  }
+  await new Promise(() => {});
+}
+void main();
+`,
+      "utf8"
+    );
+
+    const child = spawn(TSX_BIN, [childScript], {
+      cwd: PKG_ROOT,
+      env: {
+        ...process.env,
+        EVENTS_PATH: eventsPath,
+        READY_PATH: readyPath,
+        TOTAL: String(TOTAL),
+        READY_AFTER: String(READY_AFTER),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    const deadline = Date.now() + 20_000;
+    while (Date.now() < deadline) {
+      try {
+        const ready = await readFile(readyPath, "utf8");
+        if (Number(ready) >= READY_AFTER) break;
+      } catch {
+        // not ready yet
+      }
+      if (child.exitCode !== null) {
+        throw new Error(`crash child exited early (${child.exitCode}): ${stderr}`);
+      }
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    let readyCount = 0;
+    try {
+      readyCount = Number(await readFile(readyPath, "utf8"));
+    } catch {
+      readyCount = 0;
+    }
+    expect(readyCount).toBeGreaterThanOrEqual(READY_AFTER);
+
+    child.kill("SIGKILL");
+    await new Promise<void>((resolvePromise) => child.once("exit", () => resolvePromise()));
+
+    const raw = await readFile(eventsPath, "utf8");
+    const lines = raw.split("\n").filter((l) => l.trim().length > 0);
+    expect(lines.length).toBeGreaterThanOrEqual(READY_AFTER);
+    expect(lines.length).toBeLessThanOrEqual(TOTAL);
+
+    for (const line of lines) {
+      const row = JSON.parse(line) as unknown;
+      const result = twinHttpEventSchema.safeParse(row);
+      expect(result.success, JSON.stringify(result)).toBe(true);
+      expect((row as { kind: string }).kind).toBe("TwinHttpEvent");
+    }
+
+    // Loss bounded to at most the in-flight event after the ready barrier.
+    expect(lines.length).toBeGreaterThanOrEqual(readyCount - 1);
+  }, 30_000);
+});

--- a/packages/sdk/test/recorder-crash.test.ts
+++ b/packages/sdk/test/recorder-crash.test.ts
@@ -150,8 +150,18 @@ void main().catch((err) => {
         );
       }
 
+      const exited = new Promise<void>((resolvePromise) =>
+        child.once("exit", () => resolvePromise())
+      );
       killChild();
-      await new Promise<void>((resolvePromise) => child.once("exit", () => resolvePromise()));
+      if (child.exitCode === null) {
+        await Promise.race([
+          exited,
+          new Promise<void>((_, reject) =>
+            setTimeout(() => reject(new Error("child did not exit after SIGKILL")), 5_000)
+          ),
+        ]);
+      }
 
       const raw = await readFile(eventsPath, "utf8");
       // Tolerate a trailing partial line from SIGKILL mid-write; complete


### PR DESCRIPTION
Executive summary: Adds a SIGKILL crash-loss gate against the production file-backed recorder (partial `events.jsonl` must parse with at most one event lost) and a hot-path overhead gate (heap vs file-backed `record()` enqueue) with an explicit p99 budget. Wires both into CI and expands path filters to cover `packages/sdk` and twin packages.

## What
- SDK crash-loss test: SIGKILL a child mid-write through `createFileBackedRecorderStore`; assert partial NDJSON parses and loss ≤ 1 (ignore trailing partial line; reject mid-file corrupt rows).
- CLI overhead gate: benchmark heap vs file-backed `record()` enqueue with `RECORDER_OVERHEAD_BUDGET_MS`, reusing `overhead-stats`.
- Wire the overhead gate into `agent-trace-overhead-gate` and expand path filters to `packages/sdk/**`, `twin-slack`, and `twin-stripe`.

## Why
Durable streaming is only trustworthy if crash loss stays bounded and the hot-path enqueue cost stays within budget. These gates keep regressions from landing unnoticed.

## Notes for reviewer
- Stacked on #93 (durable recorder streaming).
- Crash test runs in SDK workspace tests (main `ci.yml`).
- Overhead gate measures hot-path `record()` enqueue, not per-event fsync (fsync is async after accept).

## Tests / CI
- Local: `cd packages/sdk && bun run test -- test/recorder-crash.test.ts` — pass
- Local: `cd cli && npx tsx scripts/recorder-overhead-gate.ts` — pass (durable p99 well under budget)
- PR CI: typecheck-test, cli-ci, secret scan, overhead gate — green; wait-ci / twin image may still be pending; Greptile — pass