### PR TITLE
fix(cli): restore 0.7.0 version base and gate publishes against npm latest

### DIFF
--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -13,6 +13,7 @@ on:
       - 'scripts/pack-publishable.mjs'
       - 'scripts/use-local-pome-tarballs.mjs'
       - 'scripts/check-cli-version-bump.sh'
+      - 'scripts/check-cli-version-floor.sh'
       - '.github/workflows/cli-ci.yml'
   push:
     branches: [main]
@@ -28,6 +29,7 @@ on:
       - 'scripts/pack-publishable.mjs'
       - 'scripts/use-local-pome-tarballs.mjs'
       - 'scripts/check-cli-version-bump.sh'
+      - 'scripts/check-cli-version-floor.sh'
       - '.github/workflows/cli-ci.yml'
   workflow_dispatch:
 
@@ -56,6 +58,11 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         working-directory: ${{ github.workspace }}
         run: BASE_REF="origin/${{ github.event.pull_request.base.ref }}" scripts/check-cli-version-bump.sh
+      # F-724 — cli/package.json must never sit behind npm's published latest;
+      # publishing from a regressed base retags `latest` backwards.
+      - name: CLI version not behind npm latest
+        working-directory: ${{ github.workspace }}
+        run: scripts/check-cli-version-floor.sh
       # FDRS-652/658 — Node 24, not 20. `npm ci` builds better-sqlite3,
       # whose install falls through to `node-gyp@latest`; that node-gyp bundles
       # an undici needing `webidl.util.markAsUncloneable`, absent from Node 20's

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -80,6 +80,12 @@ jobs:
             exit 1
           fi
           echo "E415 hard-link check OK: $tgz"
+      # F-724 — last line of defense: never publish (or open a Version PR)
+      # from a version base behind npm's published latest.
+      - name: CLI version not behind npm latest
+        if: steps.package-deps.outputs.ready == 'true'
+        working-directory: ${{ github.workspace }}
+        run: scripts/check-cli-version-floor.sh
       - name: Changesets — version PR or publish
         if: steps.package-deps.outputs.ready == 'true'
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ section in the same PR.
 | No cross-package file copies | [`scripts/check-copy-markers.mjs`](scripts/check-copy-markers.mjs) (empty allowlist) |
 | Dead code / orphan packages = 0 | [`knip.json`](knip.json) via `npm run lint:dead-code` in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) |
 | Package barrels + file-size hygiene | [`scripts/lint-code-health.mjs`](scripts/lint-code-health.mjs) |
+| `pome-sh` version never behind npm `latest` — a publish must not retag `latest` backwards | [`scripts/check-cli-version-floor.sh`](scripts/check-cli-version-floor.sh) in [`.github/workflows/cli-ci.yml`](.github/workflows/cli-ci.yml) (PRs) and [`.github/workflows/cli-release.yml`](.github/workflows/cli-release.yml) (pre-publish) |
 
 ## Public Repo Guardrails
 

--- a/cli/.changeset/node-24-dependency-refresh.md
+++ b/cli/.changeset/node-24-dependency-refresh.md
@@ -1,5 +1,5 @@
 ---
-"pome-sh": patch
+"pome-sh": minor
 ---
 
-Raise the CLI's minimum Node.js version to 24 and refresh provider dependencies.
+BREAKING: requires Node.js ≥ 24 (previously ≥ 20). `engines.node` is now `>=24`. npm only warns on an engine mismatch, so on an older Node the CLI may still install but can fail at runtime — upgrade to Node 24 before updating. Provider dependencies are refreshed in the same release.

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pome-sh",
-  "version": "0.1.0",
+  "version": "0.7.0",
   "description": "Digital-twin testing for AI agents — run scenarios against resettable local or hosted twins, record tool calls, and score the result.",
   "keywords": [
     "ai",

--- a/scripts/check-cli-version-floor.sh
+++ b/scripts/check-cli-version-floor.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Fails (exit 1) if cli/package.json version is BEHIND the published npm
+# `latest` of pome-sh. npm accepts any never-published version, so a publish
+# from a regressed base (e.g. 0.1.0 while latest is 0.7.0) would ship 0.2.0
+# and retag `latest` backwards — users on `npx pome-sh` would silently
+# downgrade. See F-724: PR #85 reset the version field to 0.1.0.
+#
+# local == latest is fine (no-op release; npm rejects an exact republish
+# anyway). Only local < latest fails.
+#
+# Usage:
+#   scripts/check-cli-version-floor.sh
+
+set -euo pipefail
+
+local_version="$(node -p "require('./cli/package.json').version")"
+
+published_version="$(npm view pome-sh version 2>/dev/null || echo "")"
+if [[ -z "$published_version" ]]; then
+  echo "❌ Could not resolve published pome-sh version from the npm registry." >&2
+  echo "   Refusing to pass the floor check without a baseline." >&2
+  exit 2
+fi
+
+# Plain x.y.z numeric compare — pome-sh has never published prerelease tags.
+behind="$(node -e "
+  const parse = v => v.split('.').map(Number);
+  const [l, p] = [parse('$local_version'), parse('$published_version')];
+  for (let i = 0; i < 3; i++) {
+    if (l[i] > p[i]) { console.log('no'); process.exit(0); }
+    if (l[i] < p[i]) { console.log('yes'); process.exit(0); }
+  }
+  console.log('no');
+")"
+
+if [[ "$behind" == "yes" ]]; then
+  cat >&2 <<EOF
+❌ CLI version floor check failed.
+
+  cli/package.json:  $local_version
+  npm latest:        $published_version
+
+The local version is BEHIND the published latest. Publishing from this base
+would move npm's \`latest\` dist-tag backwards (npm accepts any never-published
+version). Restore cli/package.json to at least $published_version first.
+
+Why: PR #85 reset the version to 0.1.0 while npm latest was 0.7.0; a publish
+would have shipped 0.2.0 and downgraded every \`npx pome-sh\` user. See F-724.
+EOF
+  exit 1
+fi
+
+echo "✅ CLI version floor OK: local $local_version ≥ npm latest $published_version"

--- a/scripts/check-cli-version-floor.sh
+++ b/scripts/check-cli-version-floor.sh
@@ -23,15 +23,24 @@ if [[ -z "$published_version" ]]; then
 fi
 
 # Plain x.y.z numeric compare — pome-sh has never published prerelease tags.
+# Fail closed on anything that isn't plain x.y.z (a prerelease suffix would
+# turn segments into NaN and slip past a naive compare).
 behind="$(node -e "
-  const parse = v => v.split('.').map(Number);
+  const parse = v => {
+    const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(v);
+    if (!m) { console.error('unparseable version: ' + v); process.exit(2); }
+    return m.slice(1).map(Number);
+  };
   const [l, p] = [parse('$local_version'), parse('$published_version')];
   for (let i = 0; i < 3; i++) {
     if (l[i] > p[i]) { console.log('no'); process.exit(0); }
     if (l[i] < p[i]) { console.log('yes'); process.exit(0); }
   }
   console.log('no');
-")"
+")" || {
+  echo "❌ Refusing to certify: version is not plain x.y.z (local $local_version, npm $published_version)." >&2
+  exit 2
+}
 
 if [[ "$behind" == "yes" ]]; then
   cat >&2 <<EOF


### PR DESCRIPTION
Closes F-724

Executive summary: `cli/package.json` was reset to 0.1.0 by PR #85 while npm's published `latest` is 0.7.0 — the next `changeset version`/`publish` cycle would have shipped 0.2.0 and retagged npm `latest` backwards, silently downgrading every `npx pome-sh` user. This PR restores the version base, adds a CI floor gate so a regressed base can never publish again, and upgrades the pending Node-24 changeset to a breaking minor so the next release is 0.8.0 with a changelog that leads with the requirement.

## What
- Restore `cli/package.json` version 0.1.0 → 0.7.0 (matches npm `latest`).
- New `scripts/check-cli-version-floor.sh`: fails if the local CLI version is behind `npm view pome-sh version`; wired into `cli-ci` (every PR) and `cli-release` (right before the changesets version/publish step). Registered in the AGENTS.md invariants table.
- Reword `cli/.changeset/node-24-dependency-refresh.md` from `patch` to `minor`, changelog entry now leads with "BREAKING: requires Node.js ≥ 24 (previously ≥ 20)".

## Why
npm accepts any never-published version, so publishing from the regressed base was a live hazard (only 0.6.6/0.6.7/0.7.0 exist — 0.2.0 would have been accepted and become `latest`). The engines bump to `>=24` is already merged on main but unpublished; the release that carries it must be unmistakably breaking in the changelog, and 0.x convention puts breaking changes in the minor slot — hence 0.8.0.

## Notes for reviewer
- This hand-edits `cli/package.json` `version`, which AGENTS.md forbids — deliberate one-time exception: the field was clobbered to a value *behind* the published latest, and the release bot can only bump forward from whatever base it finds. The new floor gate is what makes this class of regression impossible to repeat.
- `changeset status` confirms a single `minor` release for `pome-sh` → 0.8.0 from the restored base.
- The floor check exits 2 (fail-closed) if the npm registry is unreachable, rather than passing without a baseline.
- Merging this PR triggers `cli-release`, which opens the changesets "Version Packages" PR (0.8.0). Publishing only happens when that Version PR merges — hold it until the Node-24 floor sign-off gate clears.

## Tests / CI
- `bash scripts/check-cli-version-floor.sh` locally: `✅ CLI version floor OK: local 0.7.0 ≥ npm latest 0.7.0`.
- `npx @changesets/cli status` in `cli/`: pome-sh bumped at minor, nothing at patch/major.
- No `cli/src/**` changes, so the version-bump gate skips; `cli-ci` runs the new floor step on this PR.