### PR TITLE
feat(cli): rename published npm package pome-sh → pomecli

### DIFF
--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -120,8 +120,9 @@ jobs:
           npm install "$tgz" --no-audit --no-fund --ignore-scripts
           # bin resolves and dist entry is present:
           test -f node_modules/pomecli/dist/src/cli/main.js
-          # bundled twins made it into the tarball:
-          for t in shared-types twin-github twin-slack twin-stripe; do
+          # bundled packages made it into the tarball (must match
+          # bundleDependencies in cli/package.json):
+          for t in sdk shared-types twin-github twin-slack twin-stripe; do
             ls node_modules/pomecli/node_modules/@pome-sh/$t/package.json \
               || { echo "MISSING bundled @pome-sh/$t in published tarball"; exit 1; }
           done

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -106,7 +106,7 @@ jobs:
         run: |
           set -euo pipefail
           npm pack --ignore-scripts --pack-destination "$RUNNER_TEMP"
-          tgz="$(ls "$RUNNER_TEMP"/pome-sh-*.tgz)"
+          tgz="$(ls "$RUNNER_TEMP"/pomecli-*.tgz)"
           # The npm registry rejects tarballs with hard-link entries (E415).
           # Fail here rather than at publish time if any slip in.
           if tar -tvf "$tgz" | grep -qE '^h'; then
@@ -119,10 +119,10 @@ jobs:
           npm init -y >/dev/null 2>&1
           npm install "$tgz" --no-audit --no-fund --ignore-scripts
           # bin resolves and dist entry is present:
-          test -f node_modules/pome-sh/dist/src/cli/main.js
+          test -f node_modules/pomecli/dist/src/cli/main.js
           # bundled twins made it into the tarball:
           for t in shared-types twin-github twin-slack twin-stripe; do
-            ls node_modules/pome-sh/node_modules/@pome-sh/$t/package.json \
+            ls node_modules/pomecli/node_modules/@pome-sh/$t/package.json \
               || { echo "MISSING bundled @pome-sh/$t in published tarball"; exit 1; }
           done
           echo "clean-room OK: bin + dist + bundled twins present"

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   release:
-    name: version PR or publish (pome-sh)
+    name: version PR or publish (pomecli)
     runs-on: ubuntu-latest
     permissions:
       contents: write        # push the version branch / tags
@@ -71,7 +71,7 @@ jobs:
           set -euo pipefail
           npm run build
           npm pack --ignore-scripts --pack-destination "$RUNNER_TEMP"
-          tgz="$(ls "$RUNNER_TEMP"/pome-sh-*.tgz)"
+          tgz="$(ls "$RUNNER_TEMP"/pomecli-*.tgz)"
           # The npm registry rejects tarballs with hard-link entries (E415).
           # Fail here rather than at publish time if any slip in.
           if tar -tvf "$tgz" | grep -qE '^h'; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ live at **https://docs.pome.sh**.
 - **The CLI (`cli/`) is not a root workspace** — use `cd cli && npm ...`, not
   `npm run -w` from the root.
 
-## CLI releases (`pome-sh`)
+## CLI releases (`pomecli`)
 
 Releases are automated by `.github/workflows/cli-release.yml` (Changesets +
 npm OIDC Trusted Publishing). To ship a CLI change:
@@ -54,7 +54,7 @@ section in the same PR.
 | No cross-package file copies | [`scripts/check-copy-markers.mjs`](scripts/check-copy-markers.mjs) (empty allowlist) |
 | Dead code / orphan packages = 0 | [`knip.json`](knip.json) via `npm run lint:dead-code` in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) |
 | Package barrels + file-size hygiene | [`scripts/lint-code-health.mjs`](scripts/lint-code-health.mjs) |
-| `pome-sh` version never behind npm `latest` — a publish must not retag `latest` backwards | [`scripts/check-cli-version-floor.sh`](scripts/check-cli-version-floor.sh) in [`.github/workflows/cli-ci.yml`](.github/workflows/cli-ci.yml) (PRs) and [`.github/workflows/cli-release.yml`](.github/workflows/cli-release.yml) (pre-publish) |
+| `pomecli` version never behind npm `latest` — a publish must not retag `latest` backwards (first publish exempt: an E404 baseline passes) | [`scripts/check-cli-version-floor.sh`](scripts/check-cli-version-floor.sh) in [`.github/workflows/cli-ci.yml`](.github/workflows/cli-ci.yml) (PRs) and [`.github/workflows/cli-release.yml`](.github/workflows/cli-release.yml) (pre-publish) |
 
 ## Public Repo Guardrails
 

--- a/PACKAGE_RELEASE.md
+++ b/PACKAGE_RELEASE.md
@@ -1,6 +1,6 @@
 # Package Release Flow
 
-The CLI package (`pome-sh`) keeps using the existing Changesets flow in
+The CLI package (`pomecli`) keeps using the existing Changesets flow in
 `cli/`. Non-CLI packages are released as an explicit batch:
 
 1. In a PR, update each changed package's `package.json` version and package

--- a/cli/.changeset/f-698-durable-recorder.md
+++ b/cli/.changeset/f-698-durable-recorder.md
@@ -1,5 +1,0 @@
----
-"pome-sh": patch
----
-
-Stream twin HTTP events to the run `events.jsonl` via the twin-core durable recorder so local runs survive process death without duplicating finalize rows.

--- a/cli/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/cli/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,7 +23,7 @@ labels: bug
 - `pome --version`:
 - Node version (`node --version`):
 - OS:
-- Install method (e.g. `npm install -g github:pome-sh/cli#v0.5.1`):
+- Install method (e.g. `npm install -g pomecli`, `npx pomecli`):
 
 ## Relevant logs / artifacts
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,38 +1,18 @@
 # Changelog
 
-## 0.8.0
-
-### Minor Changes
-
-- [#82](https://github.com/pome-sh/pome-twins/pull/82) [`427d44e`](https://github.com/pome-sh/pome-twins/commit/427d44e46eec0c6ee3867e3273fe54ad12e6db4c) Thanks [@GaganSD](https://github.com/GaganSD)! - Capture-only run-dir trim and meta.json contract.
-
-  A completed run directory now contains exactly six files: `meta.json`, `events.jsonl`, `state_initial.json`, `state_final.json`, `stdout.txt`, and `stderr.log`. The intermediate correlation sidecars this CLI used to also write — `tool_calls.jsonl`, `state-before.json`, `state-after.json`, and `state-diff.json` — have been removed. They duplicated data already in `events.jsonl` / `state_initial.json` / `state_final.json` and only ever fed the local correlator/evaluator, which no longer runs in the OSS CLI. Consumers reading the removed files should read `events.jsonl` for the tool-call trace and `state_initial.json` / `state_final.json` for pre/post state.
-
-  `meta.json` gains two additive fields: `spec_version` (the meta.json shape version) and `twin_versions` (a map of the installed twin package versions that produced the run). Older readers that ignore unknown keys are unaffected.
-
-  `meta.json` is now uploaded alongside the trace and state blobs on the hosted `pome run`, `pome eval`, and `pome demo` paths (best-effort; a control plane that predates the meta upload route is tolerated).
-
-- [#84](https://github.com/pome-sh/pome-twins/pull/84) [`f21c05a`](https://github.com/pome-sh/pome-twins/commit/f21c05aba95a073c81d691ceac81c23df621f633) Thanks [@GaganSD](https://github.com/GaganSD)! - BREAKING: requires Node.js ≥ 24 (previously ≥ 20). `engines.node` is now `>=24`. npm only warns on an engine mismatch, so on an older Node the CLI may still install but can fail at runtime — upgrade to Node 24 before updating. Provider dependencies are refreshed in the same release.
-
-### Patch Changes
-
-- [#63](https://github.com/pome-sh/pome-twins/pull/63) [`9ad94e1`](https://github.com/pome-sh/pome-twins/commit/9ad94e1a0333a8aacc23a7a1c26a652454f8281f) Thanks [@AFFFPupu](https://github.com/AFFFPupu)! - Conform the CLI to the engine-based twin-github: local Recorder interface replaces the twin's deleted type export; the standalone twin server signs with its env-pinned secret.
-
-- [#62](https://github.com/pome-sh/pome-twins/pull/62) [`b967830`](https://github.com/pome-sh/pome-twins/commit/b967830ef25517be076cb49fe89b5d5d1f1d7c1d) Thanks [@AFFFPupu](https://github.com/AFFFPupu)! - Type the local slack twin harness recorder against the engine surface (the ported twin no longer exports a per-twin Recorder type).
-
-- [#64](https://github.com/pome-sh/pome-twins/pull/64) [`7be004f`](https://github.com/pome-sh/pome-twins/commit/7be004f6aa92f46dde08c4e30ba3894a3718931a) Thanks [@AFFFPupu](https://github.com/AFFFPupu)! - Conform the local twin harness to the engine-based twin-stripe: the factory owns middleware, MCP mount, and the failure-injection store; the shared CLI recorder replaces the twin's deleted recorder exports.
-
-- [#61](https://github.com/pome-sh/pome-twins/pull/61) [`91eb11a`](https://github.com/pome-sh/pome-twins/commit/91eb11a9d63ccb1effa39d5140eb2471acb2ded9) Thanks [@GaganSD](https://github.com/GaganSD)! - Use exact published `@pome-sh/*` package dependencies instead of vendored tarballs.
-
-- [#85](https://github.com/pome-sh/pome-twins/pull/85) [`2b1142b`](https://github.com/pome-sh/pome-twins/commit/2b1142bffe05f798a1cf94b942502e0aa6e13a17) Thanks [@GaganSD](https://github.com/GaganSD)! - Point doctor/help copy at npm (and tsx) instead of Bun after the package-manager migration.
-
 All notable changes to the `pome` CLI are documented here. The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project follows [Semantic Versioning](https://semver.org/).
 
 The full product changelog lives at https://docs.pome.sh/changelog. This file tracks CLI-package releases specifically.
 
-## [Unreleased]
+## 0.1.0
 
-## [0.1.0] — 2026-07-XX
+First release under the package name **`pomecli`** (F-727). The CLI was
+previously published as `pome-sh`; that npm package is deprecated in place and
+its 0.5.x–0.8.0 history is preserved below (npm never reuses published version
+numbers, so this line restarts at 0.1.0). Same CLI, same `pome` command — only
+the install name changes: `npx pomecli` / `npm install -g pomecli`.
+
+Requires Node.js ≥ 24.
 
 First public release of the `pome` CLI — a capture-only tool for testing AI
 agents against resettable digital twins. `pome run` records what your agent
@@ -74,6 +54,9 @@ does; the verdict comes from Pome's hosted evaluation.
 - **Capture-only.** The CLI records traces; it no longer scores runs locally.
   `pome fix-prompt` now assembles a ready-to-paste prompt from a recorded trace
   instead of calling an LLM.
+- **Durable recording.** Twin HTTP events stream to the run's `events.jsonl`
+  via the twin-core durable recorder, so local runs survive process death
+  without duplicating finalize rows.
 - **Bundled twins.** The GitHub, Slack, and Stripe twins ship as packaged
   dependencies, so local and Docker runs behave identically.
 - **Exit codes** follow a documented `0–5` contract across pre-flight and
@@ -96,7 +79,7 @@ does; the verdict comes from Pome's hosted evaluation.
 
 ### Fixed
 
-- `npm install -g pome-sh` now installs a runnable `pome` with no manual `chmod`.
+- `npm install -g pomecli` now installs a runnable `pome` with no manual `chmod`.
 - Various run-reliability fixes: correct upload format, environment parity
   between local and hosted runs, friendlier capacity messages, and cleanup of
   abandoned sessions on error.
@@ -105,6 +88,38 @@ does; the verdict comes from Pome's hosted evaluation.
 
 - Local scoring, the built-in judge, and the `pome matrix`, `pome matrix-html`,
   and `pome eval-report` commands, superseded by the capture-only model.
+
+## Historical releases (published as `pome-sh`)
+
+Everything below shipped on npm under the previous package name `pome-sh`,
+now deprecated in favor of `pomecli`. Those version numbers belong to that
+package and are never reused.
+
+## 0.8.0
+
+### Minor Changes
+
+- [#82](https://github.com/pome-sh/pome-twins/pull/82) [`427d44e`](https://github.com/pome-sh/pome-twins/commit/427d44e46eec0c6ee3867e3273fe54ad12e6db4c) Thanks [@GaganSD](https://github.com/GaganSD)! - Capture-only run-dir trim and meta.json contract.
+
+  A completed run directory now contains exactly six files: `meta.json`, `events.jsonl`, `state_initial.json`, `state_final.json`, `stdout.txt`, and `stderr.log`. The intermediate correlation sidecars this CLI used to also write — `tool_calls.jsonl`, `state-before.json`, `state-after.json`, and `state-diff.json` — have been removed. They duplicated data already in `events.jsonl` / `state_initial.json` / `state_final.json` and only ever fed the local correlator/evaluator, which no longer runs in the OSS CLI. Consumers reading the removed files should read `events.jsonl` for the tool-call trace and `state_initial.json` / `state_final.json` for pre/post state.
+
+  `meta.json` gains two additive fields: `spec_version` (the meta.json shape version) and `twin_versions` (a map of the installed twin package versions that produced the run). Older readers that ignore unknown keys are unaffected.
+
+  `meta.json` is now uploaded alongside the trace and state blobs on the hosted `pome run`, `pome eval`, and `pome demo` paths (best-effort; a control plane that predates the meta upload route is tolerated).
+
+- [#84](https://github.com/pome-sh/pome-twins/pull/84) [`f21c05a`](https://github.com/pome-sh/pome-twins/commit/f21c05aba95a073c81d691ceac81c23df621f633) Thanks [@GaganSD](https://github.com/GaganSD)! - BREAKING: requires Node.js ≥ 24 (previously ≥ 20). `engines.node` is now `>=24`. npm only warns on an engine mismatch, so on an older Node the CLI may still install but can fail at runtime — upgrade to Node 24 before updating. Provider dependencies are refreshed in the same release.
+
+### Patch Changes
+
+- [#63](https://github.com/pome-sh/pome-twins/pull/63) [`9ad94e1`](https://github.com/pome-sh/pome-twins/commit/9ad94e1a0333a8aacc23a7a1c26a652454f8281f) Thanks [@AFFFPupu](https://github.com/AFFFPupu)! - Conform the CLI to the engine-based twin-github: local Recorder interface replaces the twin's deleted type export; the standalone twin server signs with its env-pinned secret.
+
+- [#62](https://github.com/pome-sh/pome-twins/pull/62) [`b967830`](https://github.com/pome-sh/pome-twins/commit/b967830ef25517be076cb49fe89b5d5d1f1d7c1d) Thanks [@AFFFPupu](https://github.com/AFFFPupu)! - Type the local slack twin harness recorder against the engine surface (the ported twin no longer exports a per-twin Recorder type).
+
+- [#64](https://github.com/pome-sh/pome-twins/pull/64) [`7be004f`](https://github.com/pome-sh/pome-twins/commit/7be004f6aa92f46dde08c4e30ba3894a3718931a) Thanks [@AFFFPupu](https://github.com/AFFFPupu)! - Conform the local twin harness to the engine-based twin-stripe: the factory owns middleware, MCP mount, and the failure-injection store; the shared CLI recorder replaces the twin's deleted recorder exports.
+
+- [#61](https://github.com/pome-sh/pome-twins/pull/61) [`91eb11a`](https://github.com/pome-sh/pome-twins/commit/91eb11a9d63ccb1effa39d5140eb2471acb2ded9) Thanks [@GaganSD](https://github.com/GaganSD)! - Use exact published `@pome-sh/*` package dependencies instead of vendored tarballs.
+
+- [#85](https://github.com/pome-sh/pome-twins/pull/85) [`2b1142b`](https://github.com/pome-sh/pome-twins/commit/2b1142bffe05f798a1cf94b942502e0aa6e13a17) Thanks [@GaganSD](https://github.com/GaganSD)! - Point doctor/help copy at npm (and tsx) instead of Bun after the package-manager migration.
 
 ## [0.5.1] — 2026-05-20
 

--- a/cli/SECURITY.md
+++ b/cli/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported versions
 
-The latest published `pome-sh` CLI line receives security updates. Older versions are not patched.
+The latest published `pomecli` CLI line receives security updates. Older versions are not patched (including the deprecated `pome-sh` line this CLI was previously published under).
 
 ## Reporting a vulnerability
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,13 +1,14 @@
 {
-  "name": "pome-sh",
-  "version": "0.7.0",
+  "name": "pomecli",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pome-sh",
-      "version": "0.7.0",
+      "name": "pomecli",
+      "version": "0.1.0",
       "bundleDependencies": [
+        "@pome-sh/sdk",
         "@pome-sh/shared-types",
         "@pome-sh/twin-github",
         "@pome-sh/twin-slack",
@@ -25,6 +26,7 @@
         "@anthropic-ai/sdk": "^0.110.0",
         "@hono/node-server": "^2.0.6",
         "@openrouter/ai-sdk-provider": "^3.0.0",
+        "@pome-sh/sdk": "0.2.0",
         "@pome-sh/shared-types": "0.6.0",
         "@pome-sh/twin-github": "0.1.0",
         "@pome-sh/twin-slack": "0.1.0",
@@ -2260,9 +2262,9 @@
       "license": "ISC"
     },
     "node_modules/hono": {
-      "version": "4.12.28",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.28.tgz",
-      "integrity": "sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==",
+      "version": "4.12.29",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.29.tgz",
+      "integrity": "sha512-1hNiRjawYrLq/4m3DQQjPGFg0VZkk4RjQJDff/excI6Dm9BiL75qxGrd7/c6YOxPdq6AscP3LiXhQ6fKFC1Waw==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -3041,11 +3043,11 @@
         "node": ">=6"
       }
     },
-    "node_modules/pome-sh": {
+    "node_modules/pomecli": {
       "resolved": "",
       "link": true
     },
-    "node_modules/pome-sh/packages/adapter-claude-sdk": {
+    "node_modules/pomecli/packages/adapter-claude-sdk": {
       "name": "@pome-sh/adapter-claude-sdk",
       "version": "0.1.0",
       "extraneous": true,
@@ -3074,7 +3076,7 @@
         }
       }
     },
-    "node_modules/pome-sh/packages/sdk": {
+    "node_modules/pomecli/packages/sdk": {
       "name": "@pome-sh/sdk",
       "version": "0.2.0",
       "extraneous": true,
@@ -3108,7 +3110,7 @@
         }
       }
     },
-    "node_modules/pome-sh/packages/shared-types": {
+    "node_modules/pomecli/packages/shared-types": {
       "name": "@pome-sh/shared-types",
       "version": "0.6.0",
       "extraneous": true,
@@ -3122,7 +3124,7 @@
         "zod": "^4.1.13"
       }
     },
-    "node_modules/pome-sh/packages/twin-github": {
+    "node_modules/pomecli/packages/twin-github": {
       "name": "@pome-sh/twin-github",
       "version": "0.1.0",
       "extraneous": true,
@@ -3152,7 +3154,7 @@
         "node": ">=24"
       }
     },
-    "node_modules/pome-sh/packages/twin-slack": {
+    "node_modules/pomecli/packages/twin-slack": {
       "name": "@pome-sh/twin-slack",
       "version": "0.1.0",
       "extraneous": true,
@@ -3182,7 +3184,7 @@
         "node": ">=24"
       }
     },
-    "node_modules/pome-sh/packages/twin-stripe": {
+    "node_modules/pomecli/packages/twin-stripe": {
       "name": "@pome-sh/twin-stripe",
       "version": "0.2.0",
       "extraneous": true,

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "pome-sh",
-  "version": "0.8.0",
+  "name": "pomecli",
+  "version": "0.1.0",
   "description": "Digital-twin testing for AI agents — run scenarios against resettable local or hosted twins, record tool calls, and score the result.",
   "keywords": [
     "ai",

--- a/cli/skills/pome-setup/SKILL.md
+++ b/cli/skills/pome-setup/SKILL.md
@@ -32,7 +32,7 @@ Follow these on every step. They are not optional.
 pome version
 ```
 
-If the command is missing, install it (`npm install -g pome-sh`), then continue.
+If the command is missing, install it (`npm install -g pomecli`), then continue.
 
 Auth — any one of these passing is enough (the macOS Keychain item is service `sh.pome.cli`, account `hosted`):
 

--- a/cli/src/cli/agent-sdk.ts
+++ b/cli/src/cli/agent-sdk.ts
@@ -3,9 +3,9 @@
 // session: detect whether the user's own credentials exist, and lazily
 // provision the SDK driver into ~/.pome/agent-sdk/<version>.
 //
-// The SDK is deliberately NOT a dependency of pome-sh: its per-platform
+// The SDK is deliberately NOT a dependency of pomecli: its per-platform
 // optionalDependency bundles the Claude Code runtime (~244 MB unpacked),
-// which would sink `npx pome-sh demo` cold-start. Instead we install the
+// which would sink `npx pomecli demo` cold-start. Instead we install the
 // driver package alone (--omit=optional, a few MB) on first use, and point
 // it at the user's already-installed `claude` binary via
 // `pathToClaudeCodeExecutable` — verified against SDK 0.3.202 driving

--- a/cli/src/cli/skills.ts
+++ b/cli/src/cli/skills.ts
@@ -5,7 +5,7 @@
  *
  * Defaults to symlinking each skill folder to the canonical source inside
  * this pome package install, matching the `npx skills` industry convention:
- * an `npm i -g pome-sh@latest` automatically updates every linked skill.
+ * an `npm i -g pomecli@latest` automatically updates every linked skill.
  * Pass `--copy` to fall back to independent copies (CI, Windows without
  * symlink permission, or any environment where symlinks aren't suitable).
  */

--- a/cli/src/demo/first-run-demo.md
+++ b/cli/src/demo/first-run-demo.md
@@ -1,7 +1,7 @@
 # first-run-demo
 
 <!--
-FDRS-643 — the packaged `npx pome-sh demo` task. This markdown is the
+FDRS-643 — the packaged `npx pomecli demo` task. This markdown is the
 CANONICAL source of the demo task content: the cloud's server-owned judge
 definition (pome-cloud apps/control-plane/src/lib/demo.ts,
 DEMO_TASK_DEFINITIONS["first-run-demo"]) is regenerated FROM this file — the

--- a/cli/src/demo/task.ts
+++ b/cli/src/demo/task.ts
@@ -30,7 +30,7 @@ export function demoTaskPath(): string {
   if (!existsSync(candidate)) {
     throw new Error(
       `Packaged demo task not found at ${candidate}. ` +
-        "This is a packaging bug — the demo task markdown ships with pome-sh " +
+        "This is a packaging bug — the demo task markdown ships with pomecli " +
         "(scripts/copy-prompts.mjs copies src/demo/ into dist/).",
     );
   }

--- a/cli/test/unit/bin-exec-bit.test.ts
+++ b/cli/test/unit/bin-exec-bit.test.ts
@@ -2,7 +2,7 @@
 // FDRS-666 — `npm pack` preserves file modes straight from disk, and a
 // global install's `pome` bin symlink points at dist/src/cli/main.js. tsc
 // emits 644, so without the build script's chmod the published CLI is
-// unresolvable on PATH (`npm i -g pome-sh` → `pome` not found until a
+// unresolvable on PATH (`npm i -g pomecli` → `pome` not found until a
 // manual `chmod +x`). The npx path and project-local .bin shims exec via
 // node and never caught this. Guard the built artifact's mode here —
 // cli-ci runs `npm run build` before `npm test`, so dist/ exists in CI.

--- a/scripts/check-cli-version-floor.sh
+++ b/scripts/check-cli-version-floor.sh
@@ -20,13 +20,18 @@ set -euo pipefail
 
 local_version="$(node -p "require('./cli/package.json').version")"
 
+# Keep stdout (the version) separate from stderr: npm writes notices and
+# warnings to stderr even on success, and E404 details on failure.
+stderr_file="$(mktemp)"
+trap 'rm -f "$stderr_file"' EXIT
 set +e
-view_output="$(npm view pomecli version 2>&1)"
+view_stdout="$(npm view pomecli version 2>"$stderr_file")"
 view_status=$?
 set -e
+view_stderr="$(cat "$stderr_file")"
 
 if [[ $view_status -ne 0 ]]; then
-  if grep -q "E404" <<<"$view_output"; then
+  if grep -q "E404" <<<"$view_stderr"; then
     echo "✅ pomecli is not on npm yet (E404) — first publish, no version floor to enforce."
     exit 0
   fi
@@ -35,7 +40,7 @@ if [[ $view_status -ne 0 ]]; then
   exit 2
 fi
 
-published_version="$view_output"
+published_version="$view_stdout"
 
 # Plain x.y.z numeric compare — pomecli has never published prerelease tags.
 # Fail closed on anything that isn't plain x.y.z (a prerelease suffix would

--- a/scripts/check-cli-version-floor.sh
+++ b/scripts/check-cli-version-floor.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 # Fails (exit 1) if cli/package.json version is BEHIND the published npm
-# `latest` of pome-sh. npm accepts any never-published version, so a publish
+# `latest` of pomecli. npm accepts any never-published version, so a publish
 # from a regressed base (e.g. 0.1.0 while latest is 0.7.0) would ship 0.2.0
-# and retag `latest` backwards — users on `npx pome-sh` would silently
-# downgrade. See F-724: PR #85 reset the version field to 0.1.0.
+# and retag `latest` backwards — users on `npx pomecli` would silently
+# downgrade. See F-724: PR #85 reset the version field to 0.1.0 under the
+# previous package name (`pome-sh`); F-727 renamed the package to `pomecli`
+# with a fresh 0.1.0 start.
 #
 # local == latest is fine (no-op release; npm rejects an exact republish
 # anyway). Only local < latest fails.
+#
+# First publish: while pomecli does not exist on npm (E404) there is no floor
+# to enforce — pass. Any other registry failure still fails closed.
 #
 # Usage:
 #   scripts/check-cli-version-floor.sh
@@ -15,14 +20,24 @@ set -euo pipefail
 
 local_version="$(node -p "require('./cli/package.json').version")"
 
-published_version="$(npm view pome-sh version 2>/dev/null || echo "")"
-if [[ -z "$published_version" ]]; then
-  echo "❌ Could not resolve published pome-sh version from the npm registry." >&2
+set +e
+view_output="$(npm view pomecli version 2>&1)"
+view_status=$?
+set -e
+
+if [[ $view_status -ne 0 ]]; then
+  if grep -q "E404" <<<"$view_output"; then
+    echo "✅ pomecli is not on npm yet (E404) — first publish, no version floor to enforce."
+    exit 0
+  fi
+  echo "❌ Could not resolve published pomecli version from the npm registry." >&2
   echo "   Refusing to pass the floor check without a baseline." >&2
   exit 2
 fi
 
-# Plain x.y.z numeric compare — pome-sh has never published prerelease tags.
+published_version="$view_output"
+
+# Plain x.y.z numeric compare — pomecli has never published prerelease tags.
 # Fail closed on anything that isn't plain x.y.z (a prerelease suffix would
 # turn segments into NaN and slip past a naive compare).
 behind="$(node -e "
@@ -53,8 +68,9 @@ The local version is BEHIND the published latest. Publishing from this base
 would move npm's \`latest\` dist-tag backwards (npm accepts any never-published
 version). Restore cli/package.json to at least $published_version first.
 
-Why: PR #85 reset the version to 0.1.0 while npm latest was 0.7.0; a publish
-would have shipped 0.2.0 and downgraded every \`npx pome-sh\` user. See F-724.
+Why: PR #85 reset the version to 0.1.0 while npm latest was 0.7.0 (then named
+\`pome-sh\`); a publish would have shipped 0.2.0 and downgraded every user on
+\`latest\`. See F-724.
 EOF
   exit 1
 fi


### PR DESCRIPTION
<!-- Part of F-727 — the ticket also covers post-merge npm steps and a pome-cloud follow-up PR; do not auto-close on merge -->

Executive summary: The published CLI package restarts as `pomecli@0.1.0` on npm, replacing `pome-sh` (whose 0.6.6–0.8.0 history stays published and gets deprecated in place). The `pome` bin command is unchanged — only the install/`npx` name moves. This PR migrates every in-repo reference and makes the release pipeline first-publish-safe; the npm-side steps (trusted-publisher config, deprecation) happen after merge.

## What

Renames `cli/package.json` to `pomecli` at version `0.1.0`, folds the pending durable-recorder changeset into a hand-written 0.1.0 changelog entry (with the `pome-sh` history preserved in a historical section), regenerates the CLI lockfile (was stale at `pome-sh@0.7.0`), updates the version-floor gate to check `pomecli` and pass on E404 (no published baseline = first publish), and migrates tarball globs, clean-room install paths, and all install/`npx` copy across workflows, skills, demo, and docs.

## Why

PR #85 intentionally reset the CLI to 0.1.0 but collided with the already-published `pome-sh` 0.6.6–0.8.0 (npm never reuses published version numbers, and walking `latest` backwards is a standing operational tax). Resolution: fresh 0.1.0 start under a new name. `pomecli` was confirmed free on npm; `pome-cli` is taken by an unrelated package.

## Notes for reviewer

- **Deliberate convention deviation:** `cli/package.json` `version` is hand-edited (release bot normally owns it). A rename cut cannot be expressed as a changeset bump from 0.8.0.
- `scripts/check-cli-version-floor.sh` now distinguishes E404 (first publish → pass) from other registry failures (still fail closed, exit 2).
- The version-bump gate passes via the version change (0.8.0 → 0.1.0 is `head != base`).
- Not touched, on purpose: `@pome-sh/*` scoped dependencies, GitHub org paths, GHCR image refs, the `pome` bin, and the `pome-sh/calculator` twin fixture.
- Post-merge, before the release workflow can publish: create the npm trusted-publisher config for `pomecli` (and per the `@pome-sh/*` precedent the very first publish may need to be done locally), then `npm deprecate pome-sh`. Dashboard/docs copy in the cloud repo migrates in a follow-up PR.

## Tests / CI

- `cli`: `npm run typecheck` clean; `npm test` 567/567 passed (74 files), using the same local-tarball dep rewrite CI uses.
- `scripts/check-cli-version-floor.sh` run locally: hits the new E404 first-publish branch and exits 0.
- `BASE_REF=origin/main scripts/check-cli-version-bump.sh`: passes (version change detected).

## Review required

Yes — renames the published npm package and touches the release pipeline (self-host packaging / public install surface).
