### PR TITLE
chore(cli): regenerate lockfile against the published packages-v2 batch

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -26,11 +26,11 @@
         "@anthropic-ai/sdk": "^0.110.0",
         "@hono/node-server": "^2.0.6",
         "@openrouter/ai-sdk-provider": "^3.0.0",
-        "@pome-sh/sdk": "0.2.0",
+        "@pome-sh/sdk": "0.3.0",
         "@pome-sh/shared-types": "0.6.0",
-        "@pome-sh/twin-github": "0.1.0",
-        "@pome-sh/twin-slack": "0.1.0",
-        "@pome-sh/twin-stripe": "0.2.0",
+        "@pome-sh/twin-github": "0.1.1",
+        "@pome-sh/twin-slack": "0.1.1",
+        "@pome-sh/twin-stripe": "0.2.1",
         "ai": "^7.0.18",
         "better-sqlite3": "^12.5.0",
         "commander": "^15.0.0",
@@ -448,9 +448,8 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
@@ -460,9 +459,8 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -471,9 +469,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -485,9 +482,8 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "aix"
       ],
@@ -502,9 +498,8 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "android"
       ],
@@ -519,9 +514,8 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "android"
       ],
@@ -536,9 +530,8 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "android"
       ],
@@ -553,9 +546,8 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "darwin"
       ],
@@ -570,9 +562,8 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "darwin"
       ],
@@ -587,9 +578,8 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "freebsd"
       ],
@@ -604,9 +594,8 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "freebsd"
       ],
@@ -621,9 +610,8 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -638,9 +626,8 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -655,9 +642,8 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -672,9 +658,8 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -689,9 +674,8 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -706,9 +690,8 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -723,9 +706,8 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -740,9 +722,8 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -757,9 +738,8 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -774,9 +754,8 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "netbsd"
       ],
@@ -791,9 +770,8 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "netbsd"
       ],
@@ -808,9 +786,8 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "openbsd"
       ],
@@ -825,9 +802,8 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "openbsd"
       ],
@@ -842,9 +818,8 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "openharmony"
       ],
@@ -859,9 +834,8 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "sunos"
       ],
@@ -876,9 +850,8 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "win32"
       ],
@@ -893,9 +866,8 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "win32"
       ],
@@ -910,9 +882,8 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "win32"
       ],
@@ -959,7 +930,7 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT"
     },
     "node_modules/@manypkg/find-root": {
@@ -1038,9 +1009,8 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
       "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.3"
       },
@@ -1108,16 +1078,16 @@
       "version": "0.139.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
       "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@pome-sh/sdk": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@pome-sh/sdk/-/sdk-0.2.0.tgz",
-      "integrity": "sha512-0eDZu/WDatDSIiSkX8JkkayEj+bPmA5yt191YAPSt/l7q+ByBWjARVLjqD2LK1c5P4VKvPSPUHpbgDboIqowRw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/sdk/-/sdk-0.3.0.tgz",
+      "integrity": "sha512-u5mllp1gRJHb4z0m6tdgSiqZUEqoVHMEt/9p9TUMzHEpq20yRLS8VY39lb1d5gLr2UvXf8l1z+zMNhtCq0s6Cg==",
       "inBundle": true,
       "dependencies": {
         "@pome-sh/shared-types": "0.6.0",
@@ -1150,14 +1120,14 @@
       }
     },
     "node_modules/@pome-sh/twin-github": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@pome-sh/twin-github/-/twin-github-0.1.0.tgz",
-      "integrity": "sha512-4Z/hQ4lq3wYDxWqKO/9INecEhTfLxpgFlHjsCcsJ8dqaeR6SnLe3ohslfgJxZPqGN7c/AbQmkB+MRDzerdQxBg==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@pome-sh/twin-github/-/twin-github-0.1.1.tgz",
+      "integrity": "sha512-qnreTWhAni64Fc4s5QB6+7xTTOXhytidUrMPQ2JllH/xfvS1ciBTAAgW6KvP3+NdBeaya7r22lRnFAsVbEOkpw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.8",
-        "@pome-sh/sdk": "0.2.0",
+        "@pome-sh/sdk": "0.3.0",
         "@pome-sh/shared-types": "0.6.0",
         "better-sqlite3": "^12.5.0",
         "hono": "^4.12.27",
@@ -1171,14 +1141,14 @@
       }
     },
     "node_modules/@pome-sh/twin-slack": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@pome-sh/twin-slack/-/twin-slack-0.1.0.tgz",
-      "integrity": "sha512-Sj+U+xpEJfcq5QiRH98JjCHdCYUTNg1v23K0Uagto7LkpUV2WGkwLwE7qO+yMQ0OV9UM0Gje242IM4E4d94KyA==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@pome-sh/twin-slack/-/twin-slack-0.1.1.tgz",
+      "integrity": "sha512-FeZ3/HRLLYdm7JDztg9mrXo4454ekh6B+7HfVweUoBK7YNB450r7LBeaXcgVJqpEV5d71iOZZr9mrZ1TIALqqw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.8",
-        "@pome-sh/sdk": "0.2.0",
+        "@pome-sh/sdk": "0.3.0",
         "@pome-sh/shared-types": "0.6.0",
         "better-sqlite3": "^12.5.0",
         "hono": "^4.12.27",
@@ -1192,14 +1162,14 @@
       }
     },
     "node_modules/@pome-sh/twin-stripe": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@pome-sh/twin-stripe/-/twin-stripe-0.2.0.tgz",
-      "integrity": "sha512-xnKtHHLgIAmz0P12L0I9fgFKROXffSzTCpnkwSq9+3XmQuCPGR8t16sMtmtQ+Yh13U45Yc+nx9m/MORkk3j8ow==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@pome-sh/twin-stripe/-/twin-stripe-0.2.1.tgz",
+      "integrity": "sha512-8WlxAzp/P95qawmPcdafyASnNu8p7mbZLUQ7FJDZiZXgjl29QWsImk8ENDVsRjViJavrR7K6xfJu04SidTTBPQ==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.8",
-        "@pome-sh/sdk": "0.2.0",
+        "@pome-sh/sdk": "0.3.0",
         "@pome-sh/shared-types": "0.6.0",
         "better-sqlite3": "^12.5.0",
         "hono": "^4.12.27",
@@ -1219,9 +1189,8 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "android"
       ],
@@ -1236,9 +1205,8 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "darwin"
       ],
@@ -1253,9 +1221,8 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "darwin"
       ],
@@ -1270,9 +1237,8 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "freebsd"
       ],
@@ -1287,9 +1253,8 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -1304,9 +1269,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -1321,9 +1288,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -1338,9 +1307,11 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
+      "extraneous": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -1355,9 +1326,11 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
+      "extraneous": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -1372,9 +1345,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "extraneous": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -1389,9 +1364,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "extraneous": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -1406,9 +1383,8 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "openharmony"
       ],
@@ -1423,9 +1399,8 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@emnapi/core": "1.11.1",
         "@emnapi/runtime": "1.11.1",
@@ -1442,9 +1417,8 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "win32"
       ],
@@ -1459,9 +1433,8 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "win32"
       ],
@@ -1473,13 +1446,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT"
     },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "extraneous": true,
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
@@ -1492,9 +1466,8 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1513,7 +1486,7 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@types/deep-eql": "*",
@@ -1524,14 +1497,14 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -1557,7 +1530,7 @@
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
       "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
@@ -1575,7 +1548,7 @@
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
       "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/spy": "4.1.10",
@@ -1602,7 +1575,7 @@
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
       "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^3.1.0"
@@ -1615,7 +1588,7 @@
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
       "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/utils": "4.1.10",
@@ -1629,7 +1602,7 @@
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
       "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "4.1.10",
@@ -1645,7 +1618,7 @@
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
       "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -1655,7 +1628,7 @@
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
       "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "4.1.10",
@@ -1703,7 +1676,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1730,7 +1703,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1740,6 +1713,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -1799,6 +1773,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1824,6 +1799,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -1849,7 +1825,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1866,6 +1842,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -1882,14 +1859,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1911,6 +1888,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1927,6 +1905,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1947,6 +1926,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1980,6 +1960,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2004,14 +1985,14 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
       "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "dev": true,
+      "extraneous": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2053,7 +2034,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
+      "extraneous": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -2067,7 +2048,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
@@ -2086,6 +2067,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "extraneous": true,
       "inBundle": true,
       "license": "(MIT OR WTFPL)",
       "engines": {
@@ -2096,7 +2078,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
       "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
-      "dev": true,
+      "extraneous": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
@@ -2130,6 +2112,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "extraneous": true,
       "license": "Unlicense"
     },
     "node_modules/fastq": {
@@ -2180,6 +2163,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -2202,10 +2186,9 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
+      "extraneous": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "darwin"
       ],
@@ -2217,6 +2200,7 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -2302,6 +2286,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -2333,6 +2318,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -2340,6 +2326,7 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -2370,7 +2357,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -2403,7 +2390,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
+      "extraneous": true,
       "license": "ISC"
     },
     "node_modules/js-yaml": {
@@ -2462,7 +2449,7 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
+      "extraneous": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -2495,9 +2482,8 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MPL-2.0",
-      "optional": true,
       "os": [
         "android"
       ],
@@ -2516,9 +2502,8 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MPL-2.0",
-      "optional": true,
       "os": [
         "darwin"
       ],
@@ -2537,9 +2522,8 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MPL-2.0",
-      "optional": true,
       "os": [
         "darwin"
       ],
@@ -2558,9 +2542,8 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MPL-2.0",
-      "optional": true,
       "os": [
         "freebsd"
       ],
@@ -2579,9 +2562,8 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MPL-2.0",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -2600,9 +2582,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -2621,9 +2605,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -2642,9 +2628,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "extraneous": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -2663,9 +2651,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "extraneous": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -2684,9 +2674,8 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MPL-2.0",
-      "optional": true,
       "os": [
         "win32"
       ],
@@ -2705,9 +2694,8 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MPL-2.0",
-      "optional": true,
       "os": [
         "win32"
       ],
@@ -2743,7 +2731,7 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -2777,6 +2765,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2790,6 +2779,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -2800,6 +2790,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -2817,7 +2808,7 @@
       "version": "3.3.15",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
       "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
-      "dev": true,
+      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -2836,6 +2827,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -2843,6 +2835,7 @@
       "version": "3.94.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
       "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2877,7 +2870,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
       "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
-      "dev": true,
+      "extraneous": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
@@ -2891,6 +2884,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -2990,7 +2984,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3010,7 +3004,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -3037,7 +3031,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3078,7 +3072,7 @@
     },
     "node_modules/pomecli/packages/sdk": {
       "name": "@pome-sh/sdk",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "extraneous": true,
       "dependencies": {
         "@pome-sh/shared-types": "0.6.0",
@@ -3126,12 +3120,12 @@
     },
     "node_modules/pomecli/packages/twin-github": {
       "name": "@pome-sh/twin-github",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.8",
-        "@pome-sh/sdk": "0.2.0",
+        "@pome-sh/sdk": "0.3.0",
         "@pome-sh/shared-types": "0.6.0",
         "better-sqlite3": "^12.5.0",
         "hono": "^4.12.27",
@@ -3156,12 +3150,12 @@
     },
     "node_modules/pomecli/packages/twin-slack": {
       "name": "@pome-sh/twin-slack",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.8",
-        "@pome-sh/sdk": "0.2.0",
+        "@pome-sh/sdk": "0.3.0",
         "@pome-sh/shared-types": "0.6.0",
         "better-sqlite3": "^12.5.0",
         "hono": "^4.12.27",
@@ -3186,12 +3180,12 @@
     },
     "node_modules/pomecli/packages/twin-stripe": {
       "name": "@pome-sh/twin-stripe",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.8",
-        "@pome-sh/sdk": "0.2.0",
+        "@pome-sh/sdk": "0.3.0",
         "@pome-sh/shared-types": "0.6.0",
         "better-sqlite3": "^12.5.0",
         "hono": "^4.12.27",
@@ -3217,7 +3211,7 @@
       "version": "8.5.16",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
       "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
-      "dev": true,
+      "extraneous": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3290,6 +3284,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3318,7 +3313,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
+      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -3339,6 +3334,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "extraneous": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "dependencies": {
@@ -3371,7 +3367,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -3381,7 +3377,7 @@
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
       "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -3395,6 +3391,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3431,7 +3428,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
       "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@oxc-project/types": "=0.139.0",
@@ -3489,6 +3486,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -3517,6 +3515,7 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -3530,7 +3529,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -3543,7 +3542,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3553,14 +3552,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-      "dev": true,
+      "extraneous": true,
       "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
+      "extraneous": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -3573,6 +3572,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -3594,6 +3594,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
       "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -3630,7 +3631,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
+      "extraneous": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -3651,14 +3652,14 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
+      "extraneous": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT"
     },
     "node_modules/standardwebhooks": {
@@ -3675,13 +3676,14 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3705,7 +3707,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -3715,6 +3717,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -3725,6 +3728,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
       "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3738,6 +3742,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3768,14 +3773,14 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
       "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3785,7 +3790,7 @@
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -3802,7 +3807,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -3820,7 +3825,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3833,7 +3838,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
       "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -3856,7 +3861,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT"
     },
     "node_modules/ts-algebra": {
@@ -3869,9 +3874,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "extraneous": true,
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.23.0",
@@ -3896,6 +3900,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3940,6 +3945,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -3947,7 +3953,7 @@
       "version": "8.1.4",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
       "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
@@ -4025,7 +4031,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4128,7 +4134,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4141,7 +4147,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
+      "extraneous": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
@@ -4159,7 +4165,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
+      "extraneous": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -4175,7 +4181,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "siginfo": "^2.0.0",
@@ -4192,6 +4198,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },


### PR DESCRIPTION
<!-- Part of F-727 -->

Executive summary: The follow-up PR #97 planned — `cli/package-lock.json` regenerated now that the packages-v2 batch (`@pome-sh/sdk` 0.3.0, twins 0.1.1/0.1.1/0.2.1) is live on the registry. This makes `npm ci` in `cli/` work again from a clean checkout and is the last repo change before the `pomecli@0.1.0` first publish.

## What

Regenerates `cli/package-lock.json` so the `@pome-sh/*` pins resolve to the published registry tarballs (was impossible in #97 — the versions didn't exist yet). Lockfile-only diff.

## Why

PR #97 bumped `cli/package.json` pins ahead of the publish per PACKAGE_RELEASE.md, leaving the lockfile one step behind; without this, `npm ci` in `cli/` fails on the manifest/lock mismatch.

## Tests / CI

Locally against the live registry: `npm ci` clean, `npm run typecheck` clean, 567/567 tests pass — the registry-install path `cli-release` needs is verified end to end.