### PR TITLE
feat(cli): publish as @pome-sh/cli — npm rejects pomecli under the name-similarity rule

### DIFF
--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -106,7 +106,7 @@ jobs:
         run: |
           set -euo pipefail
           npm pack --ignore-scripts --pack-destination "$RUNNER_TEMP"
-          tgz="$(ls "$RUNNER_TEMP"/pomecli-*.tgz)"
+          tgz="$(ls "$RUNNER_TEMP"/pome-sh-cli-*.tgz)"
           # The npm registry rejects tarballs with hard-link entries (E415).
           # Fail here rather than at publish time if any slip in.
           if tar -tvf "$tgz" | grep -qE '^h'; then
@@ -119,11 +119,11 @@ jobs:
           npm init -y >/dev/null 2>&1
           npm install "$tgz" --no-audit --no-fund --ignore-scripts
           # bin resolves and dist entry is present:
-          test -f node_modules/pomecli/dist/src/cli/main.js
+          test -f node_modules/@pome-sh/cli/dist/src/cli/main.js
           # bundled packages made it into the tarball (must match
           # bundleDependencies in cli/package.json):
           for t in sdk shared-types twin-github twin-slack twin-stripe; do
-            ls node_modules/pomecli/node_modules/@pome-sh/$t/package.json \
+            ls node_modules/@pome-sh/cli/node_modules/@pome-sh/$t/package.json \
               || { echo "MISSING bundled @pome-sh/$t in published tarball"; exit 1; }
           done
           echo "clean-room OK: bin + dist + bundled twins present"

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   release:
-    name: version PR or publish (pomecli)
+    name: version PR or publish (@pome-sh/cli)
     runs-on: ubuntu-latest
     permissions:
       contents: write        # push the version branch / tags
@@ -72,7 +72,7 @@ jobs:
           set -euo pipefail
           npm run build
           npm pack --ignore-scripts --pack-destination "$RUNNER_TEMP"
-          tgz="$(ls "$RUNNER_TEMP"/pomecli-*.tgz)"
+          tgz="$(ls "$RUNNER_TEMP"/pome-sh-cli-*.tgz)"
           # The npm registry rejects tarballs with hard-link entries (E415).
           # Fail here rather than at publish time if any slip in.
           if tar -tvf "$tgz" | grep -qE '^h'; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,12 @@ live at **https://docs.pome.sh**.
   `npm ci` / `npm install`.
 - **The CLI (`cli/`) is not a root workspace** — use `cd cli && npm ...`, not
   `npm run -w` from the root.
+- **`cli/pnpm-workspace.yaml` is not pnpm** — it is only the changesets/manypkg
+  root marker for the single-package changesets setup (npm ignores it). Do not
+  replace it with `"workspaces": ["."]` in `cli/package.json`: that combination
+  breaks npm for scoped package names in this nested layout (F-727).
 
-## CLI releases (`pomecli`)
+## CLI releases (`@pome-sh/cli`)
 
 Releases are automated by `.github/workflows/cli-release.yml` (Changesets +
 npm OIDC Trusted Publishing). To ship a CLI change:
@@ -54,7 +58,7 @@ section in the same PR.
 | No cross-package file copies | [`scripts/check-copy-markers.mjs`](scripts/check-copy-markers.mjs) (empty allowlist) |
 | Dead code / orphan packages = 0 | [`knip.json`](knip.json) via `npm run lint:dead-code` in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) |
 | Package barrels + file-size hygiene | [`scripts/lint-code-health.mjs`](scripts/lint-code-health.mjs) |
-| `pomecli` version never behind npm `latest` — a publish must not retag `latest` backwards (first publish exempt: an E404 baseline passes) | [`scripts/check-cli-version-floor.sh`](scripts/check-cli-version-floor.sh) in [`.github/workflows/cli-ci.yml`](.github/workflows/cli-ci.yml) (PRs) and [`.github/workflows/cli-release.yml`](.github/workflows/cli-release.yml) (pre-publish) |
+| `@pome-sh/cli` version never behind npm `latest` — a publish must not retag `latest` backwards (first publish exempt: an E404 baseline passes) | [`scripts/check-cli-version-floor.sh`](scripts/check-cli-version-floor.sh) in [`.github/workflows/cli-ci.yml`](.github/workflows/cli-ci.yml) (PRs) and [`.github/workflows/cli-release.yml`](.github/workflows/cli-release.yml) (pre-publish) |
 
 ## Public Repo Guardrails
 

--- a/PACKAGE_RELEASE.md
+++ b/PACKAGE_RELEASE.md
@@ -1,6 +1,6 @@
 # Package Release Flow
 
-The CLI package (`pomecli`) keeps using the existing Changesets flow in
+The CLI package (`@pome-sh/cli`) keeps using the existing Changesets flow in
 `cli/`. Non-CLI packages are released as an explicit batch:
 
 1. In a PR, update each changed package's `package.json` version and package

--- a/cli/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/cli/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,7 +23,7 @@ labels: bug
 - `pome --version`:
 - Node version (`node --version`):
 - OS:
-- Install method (e.g. `npm install -g pomecli`, `npx pomecli`):
+- Install method (e.g. `npm install -g @pome-sh/cli`, `npx @pome-sh/cli`):
 
 ## Relevant logs / artifacts
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,11 +6,14 @@ The full product changelog lives at https://docs.pome.sh/changelog. This file tr
 
 ## 0.1.0
 
-First release under the package name **`pomecli`** (F-727). The CLI was
+First release under the package name **`@pome-sh/cli`** (F-727). The CLI was
 previously published as `pome-sh`; that npm package is deprecated in place and
 its 0.5.x–0.8.0 history is preserved below (npm never reuses published version
 numbers, so this line restarts at 0.1.0). Same CLI, same `pome` command — only
-the install name changes: `npx pomecli` / `npm install -g pomecli`.
+the install name changes: `npx @pome-sh/cli` / `npm install -g @pome-sh/cli`.
+The org-scoped name is deliberate: npm's name-similarity rule blocks the
+unscoped `pomecli` (too close to the unrelated, long-abandoned `pome-cli`),
+and scoped names are immune to that class of collision.
 
 Requires Node.js ≥ 24.
 
@@ -79,7 +82,7 @@ does; the verdict comes from Pome's hosted evaluation.
 
 ### Fixed
 
-- `npm install -g pomecli` now installs a runnable `pome` with no manual `chmod`.
+- `npm install -g @pome-sh/cli` now installs a runnable `pome` with no manual `chmod`.
 - Various run-reliability fixes: correct upload format, environment parity
   between local and hosted runs, friendlier capacity messages, and cleanup of
   abandoned sessions on error.
@@ -92,7 +95,7 @@ does; the verdict comes from Pome's hosted evaluation.
 ## Historical releases (published as `pome-sh`)
 
 Everything below shipped on npm under the previous package name `pome-sh`,
-now deprecated in favor of `pomecli`. Those version numbers belong to that
+now deprecated in favor of `@pome-sh/cli`. Those version numbers belong to that
 package and are never reused.
 
 ## 0.8.0

--- a/cli/SECURITY.md
+++ b/cli/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported versions
 
-The latest published `pomecli` CLI line receives security updates. Older versions are not patched (including the deprecated `pome-sh` line this CLI was previously published under).
+The latest published `@pome-sh/cli` CLI line receives security updates. Older versions are not patched (including the deprecated `pome-sh` line this CLI was previously published under).
 
 ## Reporting a vulnerability
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "pomecli",
+  "name": "@pome-sh/cli",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pomecli",
+      "name": "@pome-sh/cli",
       "version": "0.1.0",
       "bundleDependencies": [
         "@pome-sh/sdk",
@@ -15,9 +15,6 @@
         "@pome-sh/twin-stripe"
       ],
       "license": "Apache-2.0",
-      "workspaces": [
-        "."
-      ],
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.9",
         "@ai-sdk/gateway": "^4.0.13",
@@ -448,8 +445,9 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
@@ -459,8 +457,9 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -469,8 +468,9 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -482,8 +482,9 @@
       "cpu": [
         "ppc64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "aix"
       ],
@@ -498,8 +499,9 @@
       "cpu": [
         "arm"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "android"
       ],
@@ -514,8 +516,9 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "android"
       ],
@@ -530,8 +533,9 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "android"
       ],
@@ -546,8 +550,9 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "darwin"
       ],
@@ -562,8 +567,9 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "darwin"
       ],
@@ -578,8 +584,9 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "freebsd"
       ],
@@ -594,8 +601,9 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "freebsd"
       ],
@@ -610,8 +618,9 @@
       "cpu": [
         "arm"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -626,8 +635,9 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -642,8 +652,9 @@
       "cpu": [
         "ia32"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -658,8 +669,9 @@
       "cpu": [
         "loong64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -674,8 +686,9 @@
       "cpu": [
         "mips64el"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -690,8 +703,9 @@
       "cpu": [
         "ppc64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -706,8 +720,9 @@
       "cpu": [
         "riscv64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -722,8 +737,9 @@
       "cpu": [
         "s390x"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -738,8 +754,9 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -754,8 +771,9 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "netbsd"
       ],
@@ -770,8 +788,9 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "netbsd"
       ],
@@ -786,8 +805,9 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "openbsd"
       ],
@@ -802,8 +822,9 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "openbsd"
       ],
@@ -818,8 +839,9 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "openharmony"
       ],
@@ -834,8 +856,9 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "sunos"
       ],
@@ -850,8 +873,9 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "win32"
       ],
@@ -866,8 +890,9 @@
       "cpu": [
         "ia32"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "win32"
       ],
@@ -882,8 +907,9 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "win32"
       ],
@@ -930,7 +956,7 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@manypkg/find-root": {
@@ -1009,8 +1035,9 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
       "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.3"
       },
@@ -1078,7 +1105,7 @@
       "version": "0.139.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
       "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -1189,8 +1216,9 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "android"
       ],
@@ -1205,8 +1233,9 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "darwin"
       ],
@@ -1221,8 +1250,9 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "darwin"
       ],
@@ -1237,8 +1267,9 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "freebsd"
       ],
@@ -1253,8 +1284,9 @@
       "cpu": [
         "arm"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -1269,11 +1301,12 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "libc": [
         "glibc"
       ],
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -1288,11 +1321,12 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "libc": [
         "musl"
       ],
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -1307,11 +1341,12 @@
       "cpu": [
         "ppc64"
       ],
-      "extraneous": true,
+      "dev": true,
       "libc": [
         "glibc"
       ],
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -1326,11 +1361,12 @@
       "cpu": [
         "s390x"
       ],
-      "extraneous": true,
+      "dev": true,
       "libc": [
         "glibc"
       ],
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -1345,11 +1381,12 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "libc": [
         "glibc"
       ],
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -1364,11 +1401,12 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "libc": [
         "musl"
       ],
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -1383,8 +1421,9 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "openharmony"
       ],
@@ -1399,8 +1438,9 @@
       "cpu": [
         "wasm32"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@emnapi/core": "1.11.1",
         "@emnapi/runtime": "1.11.1",
@@ -1417,8 +1457,9 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "win32"
       ],
@@ -1433,8 +1474,9 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "win32"
       ],
@@ -1446,14 +1488,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
-      "extraneous": true,
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
@@ -1466,8 +1507,9 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1486,7 +1528,7 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/deep-eql": "*",
@@ -1497,14 +1539,14 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -1530,7 +1572,7 @@
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
       "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
@@ -1548,7 +1590,7 @@
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
       "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/spy": "4.1.10",
@@ -1575,7 +1617,7 @@
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
       "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^3.1.0"
@@ -1588,7 +1630,7 @@
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
       "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/utils": "4.1.10",
@@ -1602,7 +1644,7 @@
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
       "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "4.1.10",
@@ -1618,7 +1660,7 @@
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
       "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -1628,7 +1670,7 @@
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
       "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "4.1.10",
@@ -1676,7 +1718,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1703,7 +1745,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1713,7 +1755,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -1773,7 +1814,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1799,7 +1839,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -1825,7 +1864,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1842,7 +1881,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -1859,14 +1897,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1888,7 +1926,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1905,7 +1942,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1926,7 +1962,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1960,7 +1995,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1985,14 +2019,14 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
       "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "extraneous": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2034,7 +2068,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "extraneous": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -2048,7 +2082,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
@@ -2067,7 +2101,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "extraneous": true,
       "inBundle": true,
       "license": "(MIT OR WTFPL)",
       "engines": {
@@ -2078,7 +2111,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
       "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
-      "extraneous": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
@@ -2112,7 +2145,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
-      "extraneous": true,
       "license": "Unlicense"
     },
     "node_modules/fastq": {
@@ -2163,7 +2195,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -2186,9 +2217,10 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "extraneous": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "darwin"
       ],
@@ -2200,7 +2232,6 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -2286,7 +2317,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -2318,7 +2348,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -2326,7 +2355,6 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -2357,7 +2385,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -2390,7 +2418,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "extraneous": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/js-yaml": {
@@ -2449,7 +2477,7 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "extraneous": true,
+      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -2482,8 +2510,9 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MPL-2.0",
+      "optional": true,
       "os": [
         "android"
       ],
@@ -2502,8 +2531,9 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MPL-2.0",
+      "optional": true,
       "os": [
         "darwin"
       ],
@@ -2522,8 +2552,9 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MPL-2.0",
+      "optional": true,
       "os": [
         "darwin"
       ],
@@ -2542,8 +2573,9 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MPL-2.0",
+      "optional": true,
       "os": [
         "freebsd"
       ],
@@ -2562,8 +2594,9 @@
       "cpu": [
         "arm"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MPL-2.0",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -2582,11 +2615,12 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "libc": [
         "glibc"
       ],
       "license": "MPL-2.0",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -2605,11 +2639,12 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "libc": [
         "musl"
       ],
       "license": "MPL-2.0",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -2628,11 +2663,12 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "libc": [
         "glibc"
       ],
       "license": "MPL-2.0",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -2651,11 +2687,12 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "libc": [
         "musl"
       ],
       "license": "MPL-2.0",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -2674,8 +2711,9 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MPL-2.0",
+      "optional": true,
       "os": [
         "win32"
       ],
@@ -2694,8 +2732,9 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MPL-2.0",
+      "optional": true,
       "os": [
         "win32"
       ],
@@ -2731,7 +2770,7 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -2765,7 +2804,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2779,7 +2817,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -2790,7 +2827,6 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -2808,7 +2844,7 @@
       "version": "3.3.15",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
       "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
-      "extraneous": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2827,7 +2863,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -2835,7 +2870,6 @@
       "version": "3.94.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
       "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2870,7 +2904,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
       "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
-      "extraneous": true,
+      "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
@@ -2884,7 +2918,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -2984,7 +3017,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3004,7 +3037,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -3031,187 +3064,17 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/pomecli": {
-      "resolved": "",
-      "link": true
-    },
-    "node_modules/pomecli/packages/adapter-claude-sdk": {
-      "name": "@pome-sh/adapter-claude-sdk",
-      "version": "0.1.0",
-      "extraneous": true,
-      "dependencies": {
-        "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/exporter-trace-otlp-http": "^0.220.0",
-        "@opentelemetry/resources": "^2.0.0",
-        "@opentelemetry/sdk-trace-base": "^2.0.0",
-        "@pome-sh/shared-types": "0.6.0"
-      },
-      "devDependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.197",
-        "@types/node": "^26.1.0",
-        "typescript": "^5.9.3",
-        "vitest": "^4.1.10"
-      },
-      "engines": {
-        "node": ">=24"
-      },
-      "peerDependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.197"
-      },
-      "peerDependenciesMeta": {
-        "@anthropic-ai/claude-agent-sdk": {
-          "optional": false
-        }
-      }
-    },
-    "node_modules/pomecli/packages/sdk": {
-      "name": "@pome-sh/sdk",
-      "version": "0.3.0",
-      "extraneous": true,
-      "dependencies": {
-        "@pome-sh/shared-types": "0.6.0",
-        "hono": "^4.12.27",
-        "zod": "^4.1.13"
-      },
-      "devDependencies": {
-        "@hono/node-server": "^2.0.8",
-        "@types/better-sqlite3": "^7.6.13",
-        "@types/node": "^26.1.0",
-        "better-sqlite3": "^12.5.0",
-        "tsx": "^4.21.0",
-        "typescript": "^5.9.3",
-        "vitest": "^4.1.10"
-      },
-      "engines": {
-        "node": ">=24"
-      },
-      "peerDependencies": {
-        "@hono/node-server": "^2.0.8",
-        "better-sqlite3": "^12.5.0"
-      },
-      "peerDependenciesMeta": {
-        "@hono/node-server": {
-          "optional": true
-        },
-        "better-sqlite3": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/pomecli/packages/shared-types": {
-      "name": "@pome-sh/shared-types",
-      "version": "0.6.0",
-      "extraneous": true,
-      "devDependencies": {
-        "@types/node": "^26.1.0",
-        "typescript": "^5.9.3",
-        "vitest": "^4.1.10",
-        "zod": "^4.1.13"
-      },
-      "peerDependencies": {
-        "zod": "^4.1.13"
-      }
-    },
-    "node_modules/pomecli/packages/twin-github": {
-      "name": "@pome-sh/twin-github",
-      "version": "0.1.1",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@hono/node-server": "^2.0.8",
-        "@pome-sh/sdk": "0.3.0",
-        "@pome-sh/shared-types": "0.6.0",
-        "better-sqlite3": "^12.5.0",
-        "hono": "^4.12.27",
-        "zod": "^4.1.13"
-      },
-      "bin": {
-        "twin-github": "dist/src/server.js"
-      },
-      "devDependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0",
-        "@octokit/openapi-types": "^27.0.0",
-        "@types/better-sqlite3": "^7.6.13",
-        "@types/node": "^26.1.0",
-        "@vitest/coverage-v8": "^4.1.10",
-        "tsx": "^4.21.0",
-        "typescript": "^5.9.3",
-        "vitest": "^4.1.10"
-      },
-      "engines": {
-        "node": ">=24"
-      }
-    },
-    "node_modules/pomecli/packages/twin-slack": {
-      "name": "@pome-sh/twin-slack",
-      "version": "0.1.1",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@hono/node-server": "^2.0.8",
-        "@pome-sh/sdk": "0.3.0",
-        "@pome-sh/shared-types": "0.6.0",
-        "better-sqlite3": "^12.5.0",
-        "hono": "^4.12.27",
-        "zod": "^4.1.13"
-      },
-      "bin": {
-        "twin-slack": "dist/src/server.js"
-      },
-      "devDependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0",
-        "@slack/web-api": "^7.16.0",
-        "@types/better-sqlite3": "^7.6.13",
-        "@types/node": "^26.1.0",
-        "@vitest/coverage-v8": "4.1.10",
-        "tsx": "^4.21.0",
-        "typescript": "^5.9.3",
-        "vitest": "^4.1.10"
-      },
-      "engines": {
-        "node": ">=24"
-      }
-    },
-    "node_modules/pomecli/packages/twin-stripe": {
-      "name": "@pome-sh/twin-stripe",
-      "version": "0.2.1",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@hono/node-server": "^2.0.8",
-        "@pome-sh/sdk": "0.3.0",
-        "@pome-sh/shared-types": "0.6.0",
-        "better-sqlite3": "^12.5.0",
-        "hono": "^4.12.27",
-        "zod": "^4.1.13"
-      },
-      "bin": {
-        "twin-stripe": "dist/src/server.js"
-      },
-      "devDependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0",
-        "@types/better-sqlite3": "^7.6.13",
-        "@types/node": "^26.1.0",
-        "stripe": "22.3.0",
-        "tsx": "^4.21.0",
-        "typescript": "^5.9.3",
-        "vitest": "^4.1.10"
-      },
-      "engines": {
-        "node": ">=24"
       }
     },
     "node_modules/postcss": {
       "version": "8.5.16",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
       "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
-      "extraneous": true,
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3284,7 +3147,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3313,7 +3175,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "extraneous": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3334,7 +3196,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "extraneous": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "dependencies": {
@@ -3367,7 +3228,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -3377,7 +3238,7 @@
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
       "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -3391,7 +3252,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3428,7 +3288,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
       "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@oxc-project/types": "=0.139.0",
@@ -3486,7 +3346,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -3515,7 +3374,6 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -3529,7 +3387,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -3542,7 +3400,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3552,14 +3410,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-      "extraneous": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "extraneous": true,
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -3572,7 +3430,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -3594,7 +3451,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
       "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -3631,7 +3487,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "extraneous": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -3652,14 +3508,14 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "extraneous": true,
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/standardwebhooks": {
@@ -3676,14 +3532,13 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3707,7 +3562,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -3717,7 +3572,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -3728,7 +3582,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
       "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3742,7 +3595,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3773,14 +3625,14 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
       "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3790,7 +3642,7 @@
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -3807,7 +3659,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -3825,7 +3677,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3838,7 +3690,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
       "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -3861,7 +3713,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ts-algebra": {
@@ -3874,8 +3726,9 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "extraneous": true,
-      "license": "0BSD"
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tsx": {
       "version": "4.23.0",
@@ -3900,7 +3753,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3945,7 +3797,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -3953,7 +3804,7 @@
       "version": "8.1.4",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
       "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
@@ -4031,7 +3882,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4134,7 +3985,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4147,7 +3998,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "extraneous": true,
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
@@ -4165,7 +4016,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "extraneous": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -4181,7 +4032,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "siginfo": "^2.0.0",
@@ -4198,7 +4049,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pomecli",
+  "name": "@pome-sh/cli",
   "version": "0.1.0",
   "description": "Digital-twin testing for AI agents — run scenarios against resettable local or hosted twins, record tool calls, and score the result.",
   "keywords": [
@@ -27,9 +27,6 @@
   "author": "Pome <founders@pome.sh> (https://pome.sh)",
   "license": "Apache-2.0",
   "type": "module",
-  "workspaces": [
-    "."
-  ],
   "bin": {
     "pome": "./dist/src/cli/main.js"
   },

--- a/cli/pnpm-workspace.yaml
+++ b/cli/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+# NOT a pnpm repo — npm ignores this file entirely (the repo is npm-only,
+# see AGENTS.md). It exists only as the root marker changesets/manypkg use
+# to treat cli/ as a single-package changesets root.
+#
+# The previous marker, `"workspaces": ["."]` in package.json, breaks npm
+# itself for scoped package names in this nested layout: npm resolves the
+# workspace entry against the scoped name as if it were a path and walks
+# out of the repo (ENOENT two directories up). See F-727.
+packages:
+  - "."

--- a/cli/skills/pome-setup/SKILL.md
+++ b/cli/skills/pome-setup/SKILL.md
@@ -32,7 +32,7 @@ Follow these on every step. They are not optional.
 pome version
 ```
 
-If the command is missing, install it (`npm install -g pomecli`), then continue.
+If the command is missing, install it (`npm install -g @pome-sh/cli`), then continue.
 
 Auth — any one of these passing is enough (the macOS Keychain item is service `sh.pome.cli`, account `hosted`):
 

--- a/cli/src/cli/agent-sdk.ts
+++ b/cli/src/cli/agent-sdk.ts
@@ -3,9 +3,9 @@
 // session: detect whether the user's own credentials exist, and lazily
 // provision the SDK driver into ~/.pome/agent-sdk/<version>.
 //
-// The SDK is deliberately NOT a dependency of pomecli: its per-platform
+// The SDK is deliberately NOT a dependency of @pome-sh/cli: its per-platform
 // optionalDependency bundles the Claude Code runtime (~244 MB unpacked),
-// which would sink `npx pomecli demo` cold-start. Instead we install the
+// which would sink `npx @pome-sh/cli demo` cold-start. Instead we install the
 // driver package alone (--omit=optional, a few MB) on first use, and point
 // it at the user's already-installed `claude` binary via
 // `pathToClaudeCodeExecutable` — verified against SDK 0.3.202 driving

--- a/cli/src/cli/skills.ts
+++ b/cli/src/cli/skills.ts
@@ -5,7 +5,7 @@
  *
  * Defaults to symlinking each skill folder to the canonical source inside
  * this pome package install, matching the `npx skills` industry convention:
- * an `npm i -g pomecli@latest` automatically updates every linked skill.
+ * an `npm i -g @pome-sh/cli@latest` automatically updates every linked skill.
  * Pass `--copy` to fall back to independent copies (CI, Windows without
  * symlink permission, or any environment where symlinks aren't suitable).
  */

--- a/cli/src/demo/first-run-demo.md
+++ b/cli/src/demo/first-run-demo.md
@@ -1,7 +1,7 @@
 # first-run-demo
 
 <!--
-FDRS-643 — the packaged `npx pomecli demo` task. This markdown is the
+FDRS-643 — the packaged `npx @pome-sh/cli demo` task. This markdown is the
 CANONICAL source of the demo task content: the cloud's server-owned judge
 definition (pome-cloud apps/control-plane/src/lib/demo.ts,
 DEMO_TASK_DEFINITIONS["first-run-demo"]) is regenerated FROM this file — the

--- a/cli/src/demo/task.ts
+++ b/cli/src/demo/task.ts
@@ -30,7 +30,7 @@ export function demoTaskPath(): string {
   if (!existsSync(candidate)) {
     throw new Error(
       `Packaged demo task not found at ${candidate}. ` +
-        "This is a packaging bug — the demo task markdown ships with pomecli " +
+        "This is a packaging bug — the demo task markdown ships with @pome-sh/cli " +
         "(scripts/copy-prompts.mjs copies src/demo/ into dist/).",
     );
   }

--- a/cli/test/unit/bin-exec-bit.test.ts
+++ b/cli/test/unit/bin-exec-bit.test.ts
@@ -2,7 +2,7 @@
 // FDRS-666 — `npm pack` preserves file modes straight from disk, and a
 // global install's `pome` bin symlink points at dist/src/cli/main.js. tsc
 // emits 644, so without the build script's chmod the published CLI is
-// unresolvable on PATH (`npm i -g pomecli` → `pome` not found until a
+// unresolvable on PATH (`npm i -g @pome-sh/cli` → `pome` not found until a
 // manual `chmod +x`). The npx path and project-local .bin shims exec via
 // node and never caught this. Guard the built artifact's mode here —
 // cli-ci runs `npm run build` before `npm test`, so dist/ exists in CI.

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.3.0 — 2026-07-10
 
 Durable write-through recorder (the CLI's crash-safe local runs build on this;
-unblocks the `pomecli` first publish, F-727).
+unblocks the `@pome-sh/cli` first publish, F-727).
 
 - New server exports: `createFileBackedRecorderStore` — a file-backed
   `RecorderStore` that streams twin HTTP events write-through to the run's

--- a/scripts/check-cli-version-bump.sh
+++ b/scripts/check-cli-version-bump.sh
@@ -37,6 +37,24 @@ if ! grep -qE '^cli/(src|vendor)/' <<<"$changed_files"; then
   exit 0
 fi
 
+# First publish: while the package has never been published (E404), every
+# change ships in the first publish by definition — there is no released
+# behavior to drift from, and a changeset would wrongly bump the first
+# version past its intended base. Same E404-only pattern as
+# check-cli-version-floor.sh; any other registry failure falls through to
+# the normal gate (fail closed). See F-727.
+pkg_name="$(node -p "require('./cli/package.json').name")"
+view_stderr_file="$(mktemp)"
+trap 'rm -f "$view_stderr_file"' EXIT
+set +e
+npm view "$pkg_name" version >/dev/null 2>"$view_stderr_file"
+view_status=$?
+set -e
+if [[ $view_status -ne 0 ]] && grep -q "E404" "$view_stderr_file"; then
+  echo "✅ $pkg_name is not on npm yet (E404) — every change ships in the first publish; version-bump gate skipped."
+  exit 0
+fi
+
 # (a) Was a new changeset file added under cli/.changeset/?
 # Excludes README.md. Only counts ADDED files (not edits to existing ones).
 new_changeset=0

--- a/scripts/check-cli-version-floor.sh
+++ b/scripts/check-cli-version-floor.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 # Fails (exit 1) if cli/package.json version is BEHIND the published npm
-# `latest` of pomecli. npm accepts any never-published version, so a publish
+# `latest` of @pome-sh/cli. npm accepts any never-published version, so a publish
 # from a regressed base (e.g. 0.1.0 while latest is 0.7.0) would ship 0.2.0
-# and retag `latest` backwards — users on `npx pomecli` would silently
+# and retag `latest` backwards — users on `npx @pome-sh/cli` would silently
 # downgrade. See F-724: PR #85 reset the version field to 0.1.0 under the
-# previous package name (`pome-sh`); F-727 renamed the package to `pomecli`
+# previous package name (`pome-sh`); F-727 renamed the package to `@pome-sh/cli`
 # with a fresh 0.1.0 start.
 #
 # local == latest is fine (no-op release; npm rejects an exact republish
 # anyway). Only local < latest fails.
 #
-# First publish: while pomecli does not exist on npm (E404) there is no floor
+# First publish: while @pome-sh/cli does not exist on npm (E404) there is no floor
 # to enforce — pass. Any other registry failure still fails closed.
 #
 # Usage:
@@ -25,24 +25,24 @@ local_version="$(node -p "require('./cli/package.json').version")"
 stderr_file="$(mktemp)"
 trap 'rm -f "$stderr_file"' EXIT
 set +e
-view_stdout="$(npm view pomecli version 2>"$stderr_file")"
+view_stdout="$(npm view @pome-sh/cli version 2>"$stderr_file")"
 view_status=$?
 set -e
 view_stderr="$(cat "$stderr_file")"
 
 if [[ $view_status -ne 0 ]]; then
   if grep -q "E404" <<<"$view_stderr"; then
-    echo "✅ pomecli is not on npm yet (E404) — first publish, no version floor to enforce."
+    echo "✅ @pome-sh/cli is not on npm yet (E404) — first publish, no version floor to enforce."
     exit 0
   fi
-  echo "❌ Could not resolve published pomecli version from the npm registry." >&2
+  echo "❌ Could not resolve published @pome-sh/cli version from the npm registry." >&2
   echo "   Refusing to pass the floor check without a baseline." >&2
   exit 2
 fi
 
 published_version="$view_stdout"
 
-# Plain x.y.z numeric compare — pomecli has never published prerelease tags.
+# Plain x.y.z numeric compare — @pome-sh/cli has never published prerelease tags.
 # Fail closed on anything that isn't plain x.y.z (a prerelease suffix would
 # turn segments into NaN and slip past a naive compare).
 behind="$(node -e "


### PR DESCRIPTION
<!-- Part of F-727 -->

Executive summary: The `pomecli@0.1.0` first publish was refused by the registry with E403 "Package name too similar to existing package `pome-cli`" — an unrelated package abandoned since 2016. npm's similarity (moniker) rule blocks the unscoped name for everyone, permanently, and only trips at publish time (`npm view` 404 said nothing). Org-scoped names are immune, so the CLI ships as **`@pome-sh/cli`** — the documented runner-up in the F-727 naming decision. The `pome` bin is unchanged.

## What

Renames every `pomecli` reference to `@pome-sh/cli`: package name, version-floor script, workflow tarball globs (`pome-sh-cli-*.tgz` — npm pack flattens scoped names), clean-room install paths, and all install/`npx` copy. Regenerates the CLI lockfile under the scoped name.

One structural change: `"workspaces": ["."]` is dropped from `cli/package.json`. With a scoped package name in this nested-repo layout, npm resolves that workspace entry against the name as if it were a path and walks out of the repo — `ENOENT .../pome-twins/package.json`, two directories above the repo — breaking every `npm install`/`ci` (reproduced on npm 11.5.1 and 12.0.0; A/B test isolates the scoped name as the trigger). The field only existed as the changesets/manypkg root marker, so that role moves to a heavily-commented `cli/pnpm-workspace.yaml` (npm ignores it; the repo stays npm-only). AGENTS.md documents the trap.

## Why

F-727's rename to `pomecli` (PRs #96–98) could not be completed: the registry rejects the name. Founder decision after reviewing the options (`pome-cli` squatted, `pome` taken, both by the same abandoned 2016 account; formal npm name disputes have been suspended since 2021): go scoped, matching the `@angular/cli` / `@nestjs/cli` / `@shopify/cli` pattern.

## Notes for reviewer

- `npm pack` under the scoped name emits `pome-sh-cli-0.1.0.tgz`; both workflow globs updated accordingly. No collision with the `pome-sh-<pkg>-*` batch tarballs — those live in a separate directory in each job.
- `changeset status` verified working against the new marker (resolves `cli/` as the single-package root).
- `packages/sdk/CHANGELOG.md` gets the name fixed in its 0.3.0 entry; the copy inside the already-published sdk tarball keeps the stale name (cosmetic, history).

## Tests / CI

Locally against the live registry: lockfile generation clean, `npm ci` clean, `npm run typecheck` clean, 567/567 tests. `scripts/check-cli-version-floor.sh` E404-passes for `@pome-sh/cli`. `npm pack --dry-run` emits the expected scoped tarball.

## Review required

Yes — renames the published npm package and touches the release pipeline.