### PR TITLE
feat(sdk): swap the twin SQLite driver to node:sqlite — zero native deps

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -13,8 +13,6 @@
   "ignoreBinaries": ["docker", "gh", "changeset", "security", "infisical"],
   "ignoreExportsUsedInFile": true,
   "ignoreDependencies": [
-    "better-sqlite3",
-    "@types/better-sqlite3",
     "@ai-sdk/anthropic",
     "@ai-sdk/gateway",
     "@ai-sdk/google",
@@ -39,6 +37,7 @@
       "project": ["src/**/*.ts", "test/**/*.ts", "scripts/**/*.ts"]
     },
     "cli": {
+      "ignoreDependencies": ["better-sqlite3", "@types/better-sqlite3"],
       "entry": [
         "src/cli/main.ts",
         "scripts/*.{mjs,ts}",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1767,16 +1767,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@types/better-sqlite3": {
-      "version": "7.6.13",
-      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
-      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -2067,60 +2057,6 @@
         "proxy-from-env": "^2.1.0"
       }
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/better-sqlite3": {
-      "version": "12.11.1",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
-      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
-      },
-      "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
     "node_modules/body-parser": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
@@ -2173,30 +2109,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -2247,12 +2159,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -2369,30 +2275,6 @@
         }
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -2417,6 +2299,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -2452,15 +2335,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -2616,15 +2490,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/expect-type": {
@@ -2787,12 +2652,6 @@
         }
       }
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2925,12 +2784,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2994,12 +2847,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
@@ -3147,36 +2994,11 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ip-address": {
@@ -3812,32 +3634,15 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -3865,12 +3670,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
-    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -3879,18 +3678,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/node-abi": {
-      "version": "3.94.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
-      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/object-assign": {
@@ -3947,6 +3734,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -4141,33 +3929,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -4190,16 +3951,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
       }
     },
     "node_modules/qs": {
@@ -4268,44 +4019,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/require-from-string": {
@@ -4414,26 +4127,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -4445,6 +4138,7 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4613,51 +4307,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/smol-toml": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
@@ -4717,15 +4366,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
@@ -4768,34 +4408,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
-      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/tinybench": {
@@ -4900,18 +4512,6 @@
         "fsevents": "~2.3.3"
       }
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/type-is": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
@@ -4986,12 +4586,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -5218,6 +4812,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {
@@ -5307,9 +4902,7 @@
       },
       "devDependencies": {
         "@hono/node-server": "^2.0.8",
-        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^26.1.0",
-        "better-sqlite3": "^12.5.0",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^4.1.10"
@@ -5318,14 +4911,10 @@
         "node": ">=24"
       },
       "peerDependencies": {
-        "@hono/node-server": "^2.0.8",
-        "better-sqlite3": "^12.5.0"
+        "@hono/node-server": "^2.0.8"
       },
       "peerDependenciesMeta": {
         "@hono/node-server": {
-          "optional": true
-        },
-        "better-sqlite3": {
           "optional": true
         }
       }
@@ -5379,7 +4968,6 @@
         "@hono/node-server": "^2.0.8",
         "@pome-sh/sdk": "0.3.0",
         "@pome-sh/shared-types": "0.6.0",
-        "better-sqlite3": "^12.5.0",
         "hono": "^4.12.27",
         "zod": "^4.1.13"
       },
@@ -5389,7 +4977,6 @@
       "devDependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@octokit/openapi-types": "^27.0.0",
-        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^26.1.0",
         "@vitest/coverage-v8": "^4.1.10",
         "tsx": "^4.21.0",
@@ -5422,7 +5009,6 @@
         "@hono/node-server": "^2.0.8",
         "@pome-sh/sdk": "0.3.0",
         "@pome-sh/shared-types": "0.6.0",
-        "better-sqlite3": "^12.5.0",
         "hono": "^4.12.27",
         "zod": "^4.1.13"
       },
@@ -5432,7 +5018,6 @@
       "devDependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@slack/web-api": "^7.16.0",
-        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^26.1.0",
         "@vitest/coverage-v8": "4.1.10",
         "tsx": "^4.21.0",
@@ -5465,7 +5050,6 @@
         "@hono/node-server": "^2.0.8",
         "@pome-sh/sdk": "0.3.0",
         "@pome-sh/shared-types": "0.6.0",
-        "better-sqlite3": "^12.5.0",
         "hono": "^4.12.27",
         "zod": "^4.1.13"
       },
@@ -5474,7 +5058,6 @@
       },
       "devDependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^26.1.0",
         "stripe": "22.3.0",
         "tsx": "^4.21.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -37,17 +37,13 @@
     "zod": "^4.1.13"
   },
   "peerDependencies": {
-    "@hono/node-server": "^2.0.8",
-    "better-sqlite3": "^12.5.0"
+    "@hono/node-server": "^2.0.8"
   },
   "peerDependenciesMeta": {
-    "@hono/node-server": { "optional": true },
-    "better-sqlite3": { "optional": true }
+    "@hono/node-server": { "optional": true }
   },
   "devDependencies": {
     "@hono/node-server": "^2.0.8",
-    "@types/better-sqlite3": "^7.6.13",
-    "better-sqlite3": "^12.5.0",
     "@types/node": "^26.1.0",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",

--- a/packages/sdk/src/db.ts
+++ b/packages/sdk/src/db.ts
@@ -1,27 +1,27 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Engine SQLite driver wrapper (F-681). Twins never import a sqlite driver
-// directly — they call `openTwinDatabase()` and consume the `TwinDatabase`
-// interface below. The interface is a same-shape subset of better-sqlite3
-// (prepare/exec/pragma/transaction/close), which is exactly the surface the
-// M2 node:sqlite swap (F-703) re-implements: swapping the driver is a change
-// to THIS file only. `transaction(fn)` keeps better-sqlite3's shape (returns
-// a callable running fn atomically) because twin domain code has dozens of
-// call sites relying on it and node:sqlite ships no equivalent — the M2
-// implementation backs it with BEGIN IMMEDIATE/COMMIT/ROLLBACK.
-//
-// The driver is loaded lazily via createRequire so @pome-sh/sdk can declare
-// better-sqlite3 as an optional peer dependency: twins that bring their own
-// database never pay for (or compile) the native module.
+// Engine SQLite driver wrapper (F-681), backed by node:sqlite since F-703 —
+// zero native deps, no compiler toolchain at install. Twins never import a
+// sqlite driver directly — they call `openTwinDatabase()` and consume the
+// `TwinDatabase` interface below. The interface keeps better-sqlite3's shape
+// (prepare/exec/pragma/transaction/close) because twin domain code has dozens
+// of call sites relying on it; node:sqlite ships no pragma()/transaction()
+// equivalents, so this file emulates them: `pragma()` prepares a `PRAGMA …`
+// statement, `transaction(fn)` (+ `.immediate`) wraps fn in explicit
+// BEGIN [IMMEDIATE]/COMMIT/ROLLBACK at the outermost level and in a SAVEPOINT
+// when called inside an open transaction — better-sqlite3's nesting semantics,
+// which twin-github's seed() relies on (it wraps createIssue et al., each of
+// which opens its own transaction).
 
 import { mkdirSync } from "node:fs";
-import { createRequire } from "node:module";
 import { dirname } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 
 /**
  * Mutation outcome — the shape both better-sqlite3's `RunResult` and
- * node:sqlite's `StatementResultingChanges` return, so the M2 swap (F-703)
- * keeps this interface as-is.
+ * node:sqlite's `StatementResultingChanges` return; `changes` is coerced to
+ * number, `lastInsertRowid` may be a bigint for rowids beyond safe-integer
+ * range.
  */
 export interface TwinRunResult {
   changes: number;
@@ -37,8 +37,7 @@ export interface TwinStatement {
 /**
  * A wrapped transaction function (better-sqlite3's shape). The `.immediate`
  * variant takes the write lock up front (BEGIN IMMEDIATE) — github's domain
- * runs its mutations under it. The M2 node:sqlite implementation backs both
- * call forms with explicit BEGIN [IMMEDIATE]/COMMIT/ROLLBACK.
+ * runs its mutations under it.
  */
 export type TwinTransaction<F extends (...args: never[]) => unknown> = F & { immediate: F };
 
@@ -56,16 +55,85 @@ export interface OpenTwinDatabaseOptions {
   migrate?: (db: TwinDatabase) => void;
 }
 
-type BetterSqlite3Ctor = new (path: string) => TwinDatabase;
+class NodeSqliteTwinDatabase implements TwinDatabase {
+  readonly #db: DatabaseSync;
+  #savepointId = 0;
 
-let driver: BetterSqlite3Ctor | undefined;
-
-function loadDriver(): BetterSqlite3Ctor {
-  if (!driver) {
-    const require = createRequire(import.meta.url);
-    driver = require("better-sqlite3") as BetterSqlite3Ctor;
+  constructor(path: string) {
+    this.#db = new DatabaseSync(path);
   }
-  return driver;
+
+  prepare(sql: string): TwinStatement {
+    const statement = this.#db.prepare(sql);
+    type Params = Parameters<typeof statement.run>;
+    return {
+      run: (...params: unknown[]): TwinRunResult => {
+        const result = statement.run(...(params as Params));
+        return { changes: Number(result.changes), lastInsertRowid: result.lastInsertRowid };
+      },
+      get: (...params: unknown[]): unknown => statement.get(...(params as Params)),
+      all: (...params: unknown[]): unknown[] => statement.all(...(params as Params)),
+    };
+  }
+
+  exec(sql: string): void {
+    this.#db.exec(sql);
+  }
+
+  pragma(statement: string, options: { simple?: boolean } = {}): unknown {
+    const rows = this.#db.prepare(`PRAGMA ${statement}`).all() as Array<Record<string, unknown>>;
+    if (!options.simple) return rows;
+    const row = rows[0];
+    if (row === undefined) return undefined;
+    return row[Object.keys(row)[0] as string];
+  }
+
+  transaction<F extends (...args: never[]) => unknown>(fn: F): TwinTransaction<F> {
+    const wrap = (begin: string): F =>
+      ((...args: never[]) => {
+        if (this.#db.isTransaction) return this.#nested(fn, args);
+        this.#db.exec(begin);
+        try {
+          const out = fn(...args);
+          this.#db.exec("COMMIT");
+          return out;
+        } catch (error) {
+          // Certain failures (e.g. ON CONFLICT ROLLBACK) end the transaction
+          // themselves — only roll back when one is still open.
+          if (this.#db.isTransaction) this.#db.exec("ROLLBACK");
+          throw error;
+        }
+      }) as F;
+    const tx = wrap("BEGIN") as TwinTransaction<F>;
+    tx.immediate = wrap("BEGIN IMMEDIATE");
+    return tx;
+  }
+
+  /**
+   * A transaction function called inside an open transaction joins it under a
+   * SAVEPOINT (better-sqlite3's semantics): success releases the savepoint,
+   * failure rolls back only the inner work. The BEGIN variant is irrelevant
+   * here — the outermost transaction already holds the lock mode.
+   */
+  #nested<F extends (...args: never[]) => unknown>(fn: F, args: never[]): unknown {
+    const name = `_pome_tx_${this.#savepointId++}`;
+    this.#db.exec(`SAVEPOINT ${name}`);
+    try {
+      const out = fn(...args);
+      this.#db.exec(`RELEASE ${name}`);
+      return out;
+    } catch (error) {
+      if (this.#db.isTransaction) {
+        this.#db.exec(`ROLLBACK TO ${name}`);
+        this.#db.exec(`RELEASE ${name}`);
+      }
+      throw error;
+    }
+  }
+
+  close(): void {
+    if (this.#db.isOpen) this.#db.close();
+  }
 }
 
 /**
@@ -81,11 +149,10 @@ export function openTwinDatabase(
   if (path !== ":memory:") {
     mkdirSync(dirname(path), { recursive: true });
   }
-  const Database = loadDriver();
-  const db = new Database(path);
-  db.pragma("busy_timeout = 5000");
-  db.pragma("journal_mode = WAL");
-  db.pragma("foreign_keys = ON");
+  const db = new NodeSqliteTwinDatabase(path);
+  db.exec("PRAGMA busy_timeout = 5000");
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA foreign_keys = ON");
   options.migrate?.(db);
   return db;
 }

--- a/packages/sdk/test/db.test.ts
+++ b/packages/sdk/test/db.test.ts
@@ -4,6 +4,7 @@
 // wrapper only — `open` + pragmas + a same-shape `transaction()` helper — so
 // the M2 node:sqlite swap (F-703) is a one-file change in the engine.
 import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
@@ -22,6 +23,28 @@ function withDb<T>(fn: (db: TwinDatabase) => T, path = ":memory:"): T {
     db.close();
   }
 }
+
+describe("driver (F-703)", () => {
+  it("is backed by node:sqlite — better-sqlite3 never enters the module cache", () => {
+    withDb((db) => {
+      db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT NOT NULL)");
+      db.prepare("INSERT INTO t (name) VALUES (?)").run("a");
+      const row = db.prepare("SELECT name FROM t WHERE id = ?").get(1) as { name: string };
+      expect(row.name).toBe("a");
+    });
+    // node:sqlite is a builtin: opening a database registers it in
+    // process.moduleLoadList ("NativeModule sqlite") and pulls nothing
+    // from node_modules — better-sqlite3 must be absent from the CJS cache.
+    // moduleLoadList is real but undocumented, so @types/node omits it.
+    const { moduleLoadList } = process as unknown as { moduleLoadList: string[] };
+    expect(moduleLoadList).toContain("NativeModule sqlite");
+    const require = createRequire(import.meta.url);
+    const nativeDriver = Object.keys(require.cache ?? {}).filter((path) =>
+      path.includes("better-sqlite3")
+    );
+    expect(nativeDriver).toEqual([]);
+  });
+});
 
 describe("openTwinDatabase", () => {
   it("opens an in-memory database and round-trips rows", () => {
@@ -118,6 +141,32 @@ describe("transaction()", () => {
       expect(() => failing()).toThrow("boom");
       const row = db.prepare("SELECT COUNT(*) AS n FROM t").get() as { n: number };
       expect(row.n).toBe(0);
+    });
+  });
+
+  it("nests like better-sqlite3: inner transactions join via savepoint, inner failure rolls back only inner work (github's seed nests createIssue)", () => {
+    withDb((db) => {
+      db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT NOT NULL)");
+      const inner = db.transaction((name: string) => {
+        db.prepare("INSERT INTO t (name) VALUES (?)").run(name);
+      });
+      const failingInner = db.transaction(() => {
+        db.prepare("INSERT INTO t (name) VALUES (?)").run("inner-rolled-back");
+        throw new Error("inner boom");
+      });
+      const outer = db.transaction(() => {
+        db.prepare("INSERT INTO t (name) VALUES (?)").run("outer");
+        inner.immediate("inner");
+        try {
+          failingInner();
+        } catch {
+          // Swallowed: the outer transaction keeps its own work.
+        }
+        return true;
+      });
+      expect(outer()).toBe(true);
+      const rows = db.prepare("SELECT name FROM t ORDER BY id").all() as Array<{ name: string }>;
+      expect(rows.map((row) => row.name)).toEqual(["outer", "inner"]);
     });
   });
 

--- a/packages/twin-github/README.md
+++ b/packages/twin-github/README.md
@@ -105,7 +105,8 @@ that pins and verifies the new signed digest.
   build regenerates one on each rebuild)
 - `npm run build` exits 0 and emits `dist/src/server.js`
 - Built output is loadable under Node 24 — the snapshot runs `runtime: "node24"`.
-  Uses Node-native `better-sqlite3` (N-API) in the Node 24 runtime image.
+  SQLite is the built-in `node:sqlite` (via the sdk's `openTwinDatabase()`,
+  F-703) — no native modules, no compiler toolchain.
 
 ### Runtime
 

--- a/packages/twin-github/package.json
+++ b/packages/twin-github/package.json
@@ -48,14 +48,12 @@
     "@hono/node-server": "^2.0.8",
     "@pome-sh/sdk": "0.3.0",
     "@pome-sh/shared-types": "0.6.0",
-    "better-sqlite3": "^12.5.0",
     "hono": "^4.12.27",
     "zod": "^4.1.13"
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@octokit/openapi-types": "^27.0.0",
-    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^26.1.0",
     "@vitest/coverage-v8": "^4.1.10",
     "tsx": "^4.21.0",

--- a/packages/twin-slack/package.json
+++ b/packages/twin-slack/package.json
@@ -46,14 +46,12 @@
     "@hono/node-server": "^2.0.8",
     "@pome-sh/sdk": "0.3.0",
     "@pome-sh/shared-types": "0.6.0",
-    "better-sqlite3": "^12.5.0",
     "hono": "^4.12.27",
     "zod": "^4.1.13"
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@slack/web-api": "^7.16.0",
-    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^26.1.0",
     "@vitest/coverage-v8": "4.1.10",
     "tsx": "^4.21.0",

--- a/packages/twin-stripe/README.md
+++ b/packages/twin-stripe/README.md
@@ -182,8 +182,8 @@ that pins and verifies the new signed digest.
   required, the snapshot build regenerates one on each rebuild).
 - `npm run build` exits 0 and emits `dist/src/server.js`.
 - Built output is loadable under Node 24 — the snapshot runs
-  `runtime: "node24"`. Uses Node-native `better-sqlite3` (
-  fine; we install python3 + make + g++ in the Dockerfile build stage).
+  `runtime: "node24"`. SQLite is the built-in `node:sqlite` (via the sdk's
+  `openTwinDatabase()`, F-703) — no native modules, no compiler toolchain.
 
 ### Runtime
 

--- a/packages/twin-stripe/package.json
+++ b/packages/twin-stripe/package.json
@@ -61,13 +61,11 @@
     "@hono/node-server": "^2.0.8",
     "@pome-sh/sdk": "0.3.0",
     "@pome-sh/shared-types": "0.6.0",
-    "better-sqlite3": "^12.5.0",
     "hono": "^4.12.27",
     "zod": "^4.1.13"
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^26.1.0",
     "stripe": "22.3.0",
     "tsx": "^4.21.0",


### PR DESCRIPTION
<!-- Closes F-703 -->

Executive summary: The twin engine's SQLite driver moves from `better-sqlite3` (native, node-gyp) to the `node:sqlite` builtin. The F-681 wrapper made this a one-file swap: `packages/sdk/src/db.ts` held the repo's only real `better-sqlite3` import, and every twin consumes the `TwinDatabase` interface. A fresh clone on plain Node ≥ 24 now installs with **no compiler toolchain and zero native modules** — the root lockfile no longer contains `node-gyp` or `prebuild-install` at all.

## What

`openTwinDatabase()`/`TwinDatabase` reimplemented on `node:sqlite`'s `DatabaseSync`, keeping the better-sqlite3-shaped surface twin code relies on: `transaction(fn)` (+ `.immediate`) backed by explicit `BEGIN [IMMEDIATE]`/`COMMIT`/`ROLLBACK` — joining an already-open transaction via `SAVEPOINT`, matching better-sqlite3's nesting semantics — `pragma()` emulated by preparing `PRAGMA …` statements, pragmas applied via `exec`, and `TwinRunResult` unchanged. `better-sqlite3` + `@types/better-sqlite3` are removed from the sdk's peer/dev dependencies, the three twin package.jsons, and the root knip allowlist. Two twin README lines describing the old native driver are updated.

## Why

Milestone "Zero native deps": the native module was the twins' only compile-at-install dependency — the reason snapshots needed a build toolchain and installs could fall through to node-gyp. Node ≥ 24 ships `node:sqlite` unflagged; the repo's engines floor is already `>=24` (PR #85).

## Notes for reviewer

- **The nesting case is real, not defensive:** twin-github's `seed()` wraps a transaction and calls `createIssue()` et al., each of which opens its own `transaction().immediate()`. A plain BEGIN/COMMIT implementation fails its whole suite with "cannot start a transaction within a transaction"; the SAVEPOINT path is what keeps this a no-domain-code-change swap. Covered by a dedicated nesting test (inner failure rolls back only inner work).
- **knip allowlist is scoped, not deleted:** the CLI ships against the *published* `@pome-sh/sdk` 0.3.0 / twins 0.2.1, which still peer-require `better-sqlite3` at runtime, so `cli/package.json` keeps the dep until the CLI moves over (next ticket). The allowlist entry now lives under the `cli` workspace only — sdk/twins are enforced.
- Package versions are deliberately untouched: per `PACKAGE_RELEASE.md`, non-CLI packages bump in an explicit release-batch PR.
- The three twin Dockerfiles still `apt-get install python3 make g++` "for better-sqlite3" — now dead weight. Left for the no-native-modules CI gate ticket to sweep (image-build blast radius doesn't belong in this PR).
- Twin domain comments that mention "better-sqlite3 transaction" semantics are left as-is (the guarantees still hold through the wrapper; the ticket pins this swap to `db.ts` + tests only).

## Tests / CI

All run on a wiped tree (`rm -rf node_modules && npm install`) under Node 24.18.0:

- `npm install`: 3s, zero native builds (previously better-sqlite3 → prebuild-install/node-gyp).
- `npm run build`: clean.
- `npm test`: 1,181/1,181 across all six workspaces — including the per-twin determinism suites (`state-export.test.ts` ×3) and twin-stripe's atomicity tests.
- `npm run test:contract`: 61 pass / 0 fail — `/_pome/state` payloads stable across the driver swap.
- `npm run typecheck`, `lint:dead-code` (knip), `lint:code-health`, `gate:no-eval`, `lint:copy-markers`: all green.
- New TDD coverage in `packages/sdk/test/db.test.ts`: driver-identity test (node:sqlite loaded, better-sqlite3 absent from the module cache) and the savepoint-nesting test — both watched fail on the old driver first.

## Review required

Yes — engine-level swap under every twin's state; public `main` requires review.