### PR TITLE
Republish sdk + twins on node:sqlite — packages-v3 batch (sdk 0.3.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4894,7 +4894,7 @@
     },
     "packages/sdk": {
       "name": "@pome-sh/sdk",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@pome-sh/shared-types": "0.6.0",
         "hono": "^4.12.27",
@@ -4962,11 +4962,11 @@
     },
     "packages/twin-github": {
       "name": "@pome-sh/twin-github",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.8",
-        "@pome-sh/sdk": "0.3.0",
+        "@pome-sh/sdk": "0.3.1",
         "@pome-sh/shared-types": "0.6.0",
         "hono": "^4.12.27",
         "zod": "^4.1.13"
@@ -5003,11 +5003,11 @@
     },
     "packages/twin-slack": {
       "name": "@pome-sh/twin-slack",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.8",
-        "@pome-sh/sdk": "0.3.0",
+        "@pome-sh/sdk": "0.3.1",
         "@pome-sh/shared-types": "0.6.0",
         "hono": "^4.12.27",
         "zod": "^4.1.13"
@@ -5044,11 +5044,11 @@
     },
     "packages/twin-stripe": {
       "name": "@pome-sh/twin-stripe",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.8",
-        "@pome-sh/sdk": "0.3.0",
+        "@pome-sh/sdk": "0.3.1",
         "@pome-sh/shared-types": "0.6.0",
         "hono": "^4.12.27",
         "zod": "^4.1.13"

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @pome-sh/sdk
 
+## 0.3.1 — 2026-07-10
+
+SQLite driver swapped from `better-sqlite3` to the `node:sqlite` builtin
+(F-703) — zero native dependencies; a fresh install needs no compiler
+toolchain.
+
+- `openTwinDatabase()` / `TwinDatabase` reimplemented on `node:sqlite`:
+  same-shape `transaction(fn)` (+ `.immediate`) backed by
+  `BEGIN [IMMEDIATE]`/`COMMIT`/`ROLLBACK`, joining an already-open
+  transaction via `SAVEPOINT` (better-sqlite3's nesting semantics).
+  `TwinRunResult` shape unchanged.
+- `better-sqlite3` dropped from `peerDependencies` — nothing native to
+  install, optional or otherwise.
+
+No API changes.
+
 ## 0.3.0 — 2026-07-10
 
 Durable write-through recorder (the CLI's crash-safe local runs build on this;

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/sdk",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Twin engine for Pome digital twins — defineTwin() + serve(): HTTP mounting, bearer auth, trace recorder, MCP dispatch, SQLite-backed state.",
   "private": false,
   "type": "module",

--- a/packages/twin-github/CHANGELOG.md
+++ b/packages/twin-github/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the GitHub twin are documented here. The format is
 loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 the package follows [Semantic Versioning](https://semver.org/).
 
+## 0.1.2 — 2026-07-10
+
+Dependency-only release for the node:sqlite driver swap (F-703):
+`@pome-sh/sdk` pinned to 0.3.1 and the direct `better-sqlite3` dependency
+dropped — the twin's install closure now has zero native modules. No twin
+behavior changes.
+
 ## 0.1.1 — 2026-07-10
 
 Dependency-only release: `@pome-sh/sdk` pinned to 0.3.0 (durable write-through

--- a/packages/twin-github/package.json
+++ b/packages/twin-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-github",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Deterministic GitHub-shaped twin for agent testing — REST + MCP, SQLite-backed state.",
   "private": false,
   "type": "module",
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^2.0.8",
-    "@pome-sh/sdk": "0.3.0",
+    "@pome-sh/sdk": "0.3.1",
     "@pome-sh/shared-types": "0.6.0",
     "hono": "^4.12.27",
     "zod": "^4.1.13"

--- a/packages/twin-slack/CHANGELOG.md
+++ b/packages/twin-slack/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the Slack twin are documented here. The format is
 loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 the package follows [Semantic Versioning](https://semver.org/).
 
+## 0.1.2 — 2026-07-10
+
+Dependency-only release for the node:sqlite driver swap (F-703):
+`@pome-sh/sdk` pinned to 0.3.1 and the direct `better-sqlite3` dependency
+dropped — the twin's install closure now has zero native modules. No twin
+behavior changes.
+
 ## 0.1.1 — 2026-07-10
 
 Dependency-only release: `@pome-sh/sdk` pinned to 0.3.0 (durable write-through

--- a/packages/twin-slack/package.json
+++ b/packages/twin-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-slack",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Deterministic Slack Web API twin for agent testing — REST + MCP, SQLite-backed state.",
   "private": false,
   "type": "module",
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^2.0.8",
-    "@pome-sh/sdk": "0.3.0",
+    "@pome-sh/sdk": "0.3.1",
     "@pome-sh/shared-types": "0.6.0",
     "hono": "^4.12.27",
     "zod": "^4.1.13"

--- a/packages/twin-stripe/CHANGELOG.md
+++ b/packages/twin-stripe/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the Stripe twin are documented here. The format is
 loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 the package follows [Semantic Versioning](https://semver.org/).
 
+## 0.2.2 — 2026-07-10
+
+Dependency-only release for the node:sqlite driver swap (F-703):
+`@pome-sh/sdk` pinned to 0.3.1 and the direct `better-sqlite3` dependency
+dropped — the twin's install closure now has zero native modules. No twin
+behavior changes.
+
 ## 0.2.1 — 2026-07-10
 
 Dependency-only release: `@pome-sh/sdk` pinned to 0.3.0 (durable write-through

--- a/packages/twin-stripe/package.json
+++ b/packages/twin-stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-stripe",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Deterministic test double for Stripe x402 machine payments \u2014 stateful clone agents can drive without burning sandbox quota or real chain gas.",
   "private": false,
   "type": "module",
@@ -59,7 +59,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@hono/node-server": "^2.0.8",
-    "@pome-sh/sdk": "0.3.0",
+    "@pome-sh/sdk": "0.3.1",
     "@pome-sh/shared-types": "0.6.0",
     "hono": "^4.12.27",
     "zod": "^4.1.13"


### PR DESCRIPTION
## Summary

The F-703 driver swap (#101) merged **after** the `packages-v2` publish, so the registry still serves the better-sqlite3 driver: `@pome-sh/sdk@0.3.0`'s dist imports `better-sqlite3`, and the published twins (`0.1.1/0.1.1/0.2.1`) hard-depend on it. This batch (per `PACKAGE_RELEASE.md`) republishes the swap so the registry closure is zero-native:

- **@pome-sh/sdk 0.3.1** — dist built from the node:sqlite driver on main; the better-sqlite3 peer is gone. No API changes; `TwinRunResult` shape unchanged.
- **@pome-sh/twin-github 0.1.2, twin-slack 0.1.2, twin-stripe 0.2.2** — dependency-only bumps pinning sdk 0.3.1; their direct better-sqlite3 dependency (still in the published manifests) leaves the closure.

shared-types (0.6.0) and adapter-claude-sdk (0.1.0) are unchanged; `publish_one` skips already-published versions.

## Verification (Node 24, npm 11.16)

- Workspace build green; twin + sdk test suites green (25 files/212 tests slack, 28/143 stripe, plus github + sdk earlier in the same run)
- `npm run test:contract` — 61/61 pass
- `pack-publishable` manifests: no `workspace:`/`file:` specs
- Clean-room tarball install: **zero native modules** (no better-sqlite3, no `binding.gyp`, no `.node` artifacts), all six package imports + `sdk/server` resolve

## After merge

Create a GitHub Release tagged `packages-v3` to trigger the OIDC publish workflow. This unblocks F-704 (the CLI drops better-sqlite3 — it can only regenerate its lockfile once these versions exist on npm).