### PR TITLE
Define @pome-sh/* versioning policy; point maintainers at the cloud promotion runbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,10 @@ Twin images publish only after the `ci` workflow succeeds for that SHA
 (`scripts/ci/wait-for-workflow.sh`) and Trivy scans pass. Published GHCR
 digests are cosign-signed with GitHub OIDC, and each digest receives an SPDX
 SBOM attestation. Downstream cloud snapshot promotion must pin and verify those
-signed digests before rebuilding runtime snapshots.
+signed digests before rebuilding runtime snapshots. That promotion is operated
+from the private `pome-sh/pome-cloud` repo — maintainers: see
+`docs/runbooks/twin-release-and-promotion.md` there. Version-bump rules for
+`@pome-sh/*` packages live in [`PACKAGE_RELEASE.md`](PACKAGE_RELEASE.md).
 
 Everything else — architecture, per-package details, and the CI gotchas
 (changeset gate, no-cloud-imports, twin Docker build) — is documented at

--- a/PACKAGE_RELEASE.md
+++ b/PACKAGE_RELEASE.md
@@ -15,6 +15,33 @@ The CLI package (`@pome-sh/cli`) keeps using the existing Changesets flow in
 4. Publish the CLI only after the exact package versions in `cli/package.json`
    exist on npm.
 
+## Versioning
+
+Every `@pome-sh/*` package is pre-1.0, so npm's 0.x caret semantics apply
+(`^0.N.x` never crosses into 0.N+1): **minor plays the major role**.
+
+- **Minor (0.N+1.0)** — anything a consumer must act on: a change to the
+  frozen runtime contract (`CONTRACT.md`, `/_pome/state` payloads), a
+  published API signature change or removal, an `engines` floor bump, or a
+  seed/state-schema change that invalidates existing recorded runs.
+- **Patch (0.N.x)** — everything else: additive exports, internal
+  implementation swaps behind an unchanged surface (e.g. the better-sqlite3 →
+  node:sqlite driver swap, packages-v3), dependency-only bumps, bug fixes.
+
+Judge by observable surface, not diff size. Internal `@pome-sh/*` consumers
+pin exact versions, so the question is always the *external* surface — and
+`npm run test:contract` is the arbiter: green means the contract surface did
+not change and no minor is required.
+
+A package goes 1.0 when its `CONTRACT.md` surface is frozen and pome-cloud
+serves real customer sessions on it; from then on standard semver applies
+(major = breaking).
+
+`@pome-sh/cli` versions via Changesets (see `AGENTS.md`): patch = fixes and
+internal changes, minor = new commands or flags, and any release whose
+changelog entry leads with `BREAKING:` (e.g. an engines floor bump) is at
+least a minor.
+
 Twin image workflows publish GHCR digests only after tests and Trivy pass. Each
 published digest is cosign-signed with GitHub OIDC and receives an SPDX SBOM
 attestation; the pome-cloud snapshot promotion PR must pin and verify one of


### PR DESCRIPTION
Executive summary: `PACKAGE_RELEASE.md` said *how* to release but nothing decided *when* a bump is minor vs patch — the packages-v3 batch surfaced the gap. This writes the policy down where releases live.

## What

**PACKAGE_RELEASE.md — new Versioning section:**

- 0.x era (all `@pome-sh/*` today): **minor** = anything a consumer must act on (frozen `CONTRACT.md` surface / `/_pome/state` payloads, published API signature change or removal, `engines` floor bump, seed/state-schema breaks); **patch** = everything else (additive exports, internal swaps behind an unchanged surface, dependency-only bumps, fixes). This encodes what npm's `^0.N.x` caret resolution already does — minor plays the major role pre-1.0.
- Judge by observable surface, not diff size; `npm run test:contract` green is the arbiter that no minor is required (internal consumers pin exact versions, so external surface is the only question).
- 1.0 trigger: `CONTRACT.md` frozen + pome-cloud serving real customer sessions on it; standard semver after.
- `@pome-sh/cli` stays on Changesets; `BREAKING:`-led changelog entries are at least a minor.

**AGENTS.md:** the guardrails section now names where cloud promotion actually runs — the private `pome-sh/pome-cloud` repo's `docs/runbooks/twin-release-and-promotion.md` — as a plain-text pointer (no URL: the repo is private and a link would 404 for OSS readers), plus a cross-reference to `PACKAGE_RELEASE.md` for version rules.

## Why now

Decided with Ao while shipping packages-v3 (sdk 0.3.1 as a patch: driver swap with zero API change, contract suite green — the worked example the policy text cites).

## Review required

Docs only; no code paths touched.