### PR TITLE
Enforce zero native deps: no-native-modules CI gate + Dockerfile toolchain sweep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - run: bash scripts/lint-no-cloud-imports.sh
       - run: npm ci
       - run: npm run lint:dead-code
+      # F-705 — zero native deps is an invariant: no gyp-marked package in the
+      # production closure (prebuilt installers like esbuild/fsevents pass).
+      - run: npm run gate:no-native
       # F-692 / D9 — one repo-wide capture-only gate, scanning cli/src/**,
       # cli/scripts/**, and packages/** (cli-ci.yml's former duplicate step
       # was folded in here).

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -63,11 +63,9 @@ jobs:
       - name: CLI version not behind npm latest
         working-directory: ${{ github.workspace }}
         run: scripts/check-cli-version-floor.sh
-      # FDRS-652/658 — Node 24, not 20. `npm ci` builds better-sqlite3,
-      # whose install falls through to `node-gyp@latest`; that node-gyp bundles
-      # an undici needing `webidl.util.markAsUncloneable`, absent from Node 20's
-      # runtime (crashes with a TypeError). Node 24 has the API, so the native
-      # build succeeds.
+      # Node 24 — the repo's engines floor (node:sqlite twins, PR #85/F-719).
+      # The old reason (better-sqlite3's node-gyp needing Node 24 APIs) died
+      # with F-704; the floor itself stands.
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
@@ -95,6 +93,9 @@ jobs:
       - run: |
           npm install --package-lock-only --ignore-scripts
           npm ci
+      # F-705 — the CLI's production closure must stay free of gyp-marked
+      # packages (the published artifact bundles the twins).
+      - run: npm run gate:no-native
       - run: npm run typecheck
       - run: npm run build
       - run: npm test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ section in the same PR.
 | No cloud imports in OSS packages | [`scripts/lint-no-cloud-imports.sh`](scripts/lint-no-cloud-imports.sh) |
 | No cross-package file copies | [`scripts/check-copy-markers.mjs`](scripts/check-copy-markers.mjs) (empty allowlist) |
 | Dead code / orphan packages = 0 | [`knip.json`](knip.json) via `npm run lint:dead-code` in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) |
+| Zero native modules in the production dependency closure (gyp markers: `binding.gyp` / `"gypfile"`; prebuilt installers like esbuild/fsevents pass) | [`scripts/no-native-modules.mjs`](scripts/no-native-modules.mjs) via `npm run gate:no-native` in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) (root closure) and [`.github/workflows/cli-ci.yml`](.github/workflows/cli-ci.yml) (CLI closure) |
 | Package barrels + file-size hygiene | [`scripts/lint-code-health.mjs`](scripts/lint-code-health.mjs) |
 | `@pome-sh/cli` version never behind npm `latest` — a publish must not retag `latest` backwards (first publish exempt: an E404 baseline passes) | [`scripts/check-cli-version-floor.sh`](scripts/check-cli-version-floor.sh) in [`.github/workflows/cli-ci.yml`](.github/workflows/cli-ci.yml) (PRs) and [`.github/workflows/cli-release.yml`](.github/workflows/cli-release.yml) (pre-publish) |
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -52,6 +52,7 @@
     "test": "vitest run",
     "test:e2e": "vitest run test/e2e",
     "gate:no-eval": "node ../scripts/no-eval-in-oss.mjs",
+    "gate:no-native": "node ../scripts/no-native-modules.mjs --root .",
     "gate:recorder-overhead": "tsx scripts/recorder-overhead-gate.ts",
     "changeset": "changeset",
     "changeset:version": "changeset version",

--- a/cli/test/unit/no-native-modules.test.ts
+++ b/cli/test/unit/no-native-modules.test.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// F-705 — the no-native-modules gate keeps M2's "zero native deps" true by
+// failing CI when a gyp-marked package enters the production closure. The
+// decision table lives here: prod + gyp marker = offend; install-script
+// without markers (esbuild-shaped) = pass; dev/devOptional (fsevents-shaped)
+// = out of scope; platform-gated optional prod = skipped, missing prod = throw.
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+// @ts-expect-error — plain .mjs gate script, no type declarations.
+import { findNativeModules } from "../../../scripts/no-native-modules.mjs";
+
+interface FixturePkg {
+  path: string;
+  flags?: Record<string, boolean>;
+  bindingGyp?: boolean;
+  gypfileField?: boolean;
+  installScript?: boolean;
+  onDisk?: boolean; // default true
+}
+
+async function makeRoot(pkgs: FixturePkg[]): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "no-native-fixture-"));
+  const lockPackages: Record<string, object> = {
+    "": { name: "fixture-root", version: "0.0.0" },
+  };
+  for (const pkg of pkgs) {
+    lockPackages[pkg.path] = { version: "1.0.0", ...(pkg.flags ?? {}) };
+    if (pkg.onDisk === false) continue;
+    const dir = join(root, pkg.path);
+    await mkdir(dir, { recursive: true });
+    const manifest: Record<string, unknown> = { name: pkg.path.split("/").pop(), version: "1.0.0" };
+    if (pkg.gypfileField) manifest.gypfile = true;
+    if (pkg.installScript) manifest.scripts = { install: "node install.js" };
+    await writeFile(join(dir, "package.json"), JSON.stringify(manifest));
+    if (pkg.bindingGyp) await writeFile(join(dir, "binding.gyp"), "{}");
+  }
+  await writeFile(
+    join(root, "package-lock.json"),
+    JSON.stringify({ name: "fixture-root", lockfileVersion: 3, packages: lockPackages }),
+  );
+  return root;
+}
+
+describe("no-native-modules gate (F-705)", () => {
+  it("flags a production package with binding.gyp", async () => {
+    const root = await makeRoot([
+      { path: "node_modules/native-thing", bindingGyp: true },
+    ]);
+    const { offenders } = await findNativeModules(root);
+    expect(offenders).toEqual([
+      { path: "node_modules/native-thing", markers: ["binding.gyp"] },
+    ]);
+  });
+
+  it('flags a production package with "gypfile": true even without binding.gyp', async () => {
+    const root = await makeRoot([
+      { path: "node_modules/gypfield", gypfileField: true },
+    ]);
+    const { offenders } = await findNativeModules(root);
+    expect(offenders).toEqual([
+      { path: "node_modules/gypfield", markers: ['"gypfile": true'] },
+    ]);
+  });
+
+  it("passes an install-script-only prebuilt installer (esbuild-shaped)", async () => {
+    const root = await makeRoot([
+      { path: "node_modules/prebuilt", installScript: true, flags: { hasInstallScript: true } },
+    ]);
+    const { offenders, checked } = await findNativeModules(root);
+    expect(offenders).toEqual([]);
+    expect(checked).toBe(1);
+  });
+
+  it("ignores dev and devOptional packages even with gyp markers (fsevents-shaped)", async () => {
+    const root = await makeRoot([
+      { path: "node_modules/dev-native", bindingGyp: true, flags: { dev: true } },
+      { path: "node_modules/devopt-native", bindingGyp: true, flags: { devOptional: true } },
+    ]);
+    const { offenders, checked } = await findNativeModules(root);
+    expect(offenders).toEqual([]);
+    expect(checked).toBe(0);
+  });
+
+  it("skips a platform-gated optional prod package that is not installed", async () => {
+    const root = await makeRoot([
+      { path: "node_modules/other-os-binary", flags: { optional: true }, onDisk: false },
+    ]);
+    const { offenders, skippedOptional } = await findNativeModules(root);
+    expect(offenders).toEqual([]);
+    expect(skippedOptional).toEqual(["node_modules/other-os-binary"]);
+  });
+
+  it("throws (fail-closed) when a non-optional prod package is missing from disk", async () => {
+    const root = await makeRoot([
+      { path: "node_modules/not-installed", onDisk: false },
+    ]);
+    await expect(findNativeModules(root)).rejects.toThrow(/npm ci/);
+  });
+
+  it("ignores workspace link entries", async () => {
+    const root = await makeRoot([
+      { path: "node_modules/@pome-sh/sdk", flags: { link: true }, onDisk: false },
+    ]);
+    const { offenders, checked } = await findNativeModules(root);
+    expect(offenders).toEqual([]);
+    expect(checked).toBe(0);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "typecheck": "npm run typecheck --workspaces --if-present",
     "lint:no-cloud-imports": "bash scripts/lint-no-cloud-imports.sh",
     "gate:no-eval": "node scripts/no-eval-in-oss.mjs",
+    "gate:no-native": "node scripts/no-native-modules.mjs",
     "lint:copy-markers": "node scripts/check-copy-markers.mjs",
     "lint:code-health": "node scripts/lint-code-health.mjs",
     "lint:dead-code": "knip --no-config-hints"

--- a/packages/twin-github/Dockerfile
+++ b/packages/twin-github/Dockerfile
@@ -3,11 +3,6 @@
 # standalone package context.
 FROM node:24-bookworm@sha256:c35698d36238c69451c7e7a5951dd5c9b11c3e45884c918059c94c4a8be969b1 AS build
 WORKDIR /repo
-# better-sqlite3 is a native module that node-gyp must compile; the slim
-# runtime image lacks a C++ toolchain, so compile in this build stage.
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends python3 make g++ \
-  && rm -rf /var/lib/apt/lists/*
 COPY package.json package-lock.json ./
 COPY packages packages
 RUN npm ci

--- a/packages/twin-slack/Dockerfile
+++ b/packages/twin-slack/Dockerfile
@@ -3,11 +3,6 @@
 # standalone package context.
 FROM node:24-bookworm@sha256:c35698d36238c69451c7e7a5951dd5c9b11c3e45884c918059c94c4a8be969b1 AS build
 WORKDIR /repo
-# better-sqlite3 is a native module that node-gyp must compile; the slim
-# runtime image lacks a C++ toolchain, so compile in this build stage.
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends python3 make g++ \
-  && rm -rf /var/lib/apt/lists/*
 COPY package.json package-lock.json ./
 COPY packages packages
 RUN npm ci

--- a/packages/twin-stripe/Dockerfile
+++ b/packages/twin-stripe/Dockerfile
@@ -3,11 +3,6 @@
 # standalone package context.
 FROM node:24-bookworm@sha256:c35698d36238c69451c7e7a5951dd5c9b11c3e45884c918059c94c4a8be969b1 AS build
 WORKDIR /repo
-# better-sqlite3 is a native module that node-gyp must compile; the slim
-# runtime image lacks a C++ toolchain, so compile in this build stage.
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends python3 make g++ \
-  && rm -rf /var/lib/apt/lists/*
 COPY package.json package-lock.json ./
 COPY packages packages
 RUN npm ci

--- a/scripts/no-native-modules.mjs
+++ b/scripts/no-native-modules.mjs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-705 no-native-modules gate. "Zero native deps" (M2) is an invariant, not
+// an event: no package in the PRODUCTION dependency closure of the published
+// packages may carry a node-gyp build step. Detection is by gyp markers —
+// a `binding.gyp` file or a truthy `gypfile` manifest field — NOT by
+// `hasInstallScript`: prebuilt-binary installers (esbuild, fsevents) have
+// install scripts but need no compiler, and must pass.
+//
+// Scope is the lockfile's non-dev entries (workspace transitives included).
+// `dev` and `devOptional` entries are excluded: they never reach a
+// production install (`npm ci --omit=dev`) or a published artifact.
+// Run against a root whose `npm ci` has already populated node_modules —
+// marker inspection needs the unpacked package on disk.
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Intentional exceptions only; empty by design (same posture as the
+// copy-marker gate's allowlist). Keys are lockfile package paths, e.g.
+// "node_modules/some-package".
+const ALLOWLIST = new Set([]);
+
+export async function findNativeModules(root) {
+  const lockPath = join(root, "package-lock.json");
+  const lock = JSON.parse(await readFile(lockPath, "utf8"));
+  const offenders = [];
+  const skippedOptional = [];
+  let checked = 0;
+
+  for (const [path, entry] of Object.entries(lock.packages ?? {})) {
+    if (path === "") continue; // the root project itself
+    if (entry.link) continue; // workspace symlink; its deps have own entries
+    if (entry.dev || entry.devOptional) continue; // not in the prod closure
+    if (ALLOWLIST.has(path)) continue;
+
+    const pkgDir = join(root, path);
+    if (!existsSync(pkgDir)) {
+      if (entry.optional) {
+        // Platform-gated optional prod dep not installed here (e.g. another
+        // OS's prebuilt binary package). Nothing to inspect on this machine.
+        skippedOptional.push(path);
+        continue;
+      }
+      throw new Error(
+        `no-native-modules gate cannot inspect "${path}" — directory missing. ` +
+          `Run npm ci in ${root} first.`,
+      );
+    }
+
+    checked += 1;
+    const markers = [];
+    if (existsSync(join(pkgDir, "binding.gyp"))) markers.push("binding.gyp");
+    try {
+      const manifest = JSON.parse(await readFile(join(pkgDir, "package.json"), "utf8"));
+      if (manifest.gypfile) markers.push('"gypfile": true');
+    } catch {
+      // Unreadable manifest: binding.gyp check above still applies.
+    }
+    if (markers.length > 0) offenders.push({ path, markers });
+  }
+
+  return { offenders, checked, skippedOptional };
+}
+
+// Run as a script (not when imported by the test).
+const invokedDirectly =
+  process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (invokedDirectly) {
+  const rootArgIdx = process.argv.indexOf("--root");
+  const root =
+    rootArgIdx >= 0
+      ? resolve(process.argv[rootArgIdx + 1])
+      : resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+  const { offenders, checked, skippedOptional } = await findNativeModules(root);
+  if (offenders.length > 0) {
+    console.error(
+      "no-native-modules gate FAILED — native build step in the production closure:\n",
+    );
+    for (const { path, markers } of offenders) {
+      console.error(`  ✗ ${path} (${markers.join(", ")})`);
+    }
+    console.error(
+      "\nZero native deps is an M2 invariant: published packages must install " +
+        "with no compiler toolchain. Replace the dependency or move it out of " +
+        "the production closure.",
+    );
+    process.exit(1);
+  }
+  console.log(
+    `no-native-modules gate passed — ${checked} production packages clean` +
+      (skippedOptional.length > 0
+        ? ` (${skippedOptional.length} platform-gated optional packages not installed here, skipped)`
+        : ""),
+  );
+}


### PR DESCRIPTION
<!-- Closes F-705 -->

Executive summary: M2 made "zero native deps" true; this makes it **stay** true. A new gate fails any PR that introduces a gyp-marked package into the production dependency closure of the published packages — and the three twin Dockerfiles lose the now-dead `apt-get python3 make g++` build-stage toolchain #101 deferred here.

## What

- **`scripts/no-native-modules.mjs`** — scans a lockfile's production closure (workspace transitives included; `dev`/`devOptional` excluded — they never reach `npm ci --omit=dev` or a published artifact) for node-gyp markers: a `binding.gyp` file or a truthy `gypfile` manifest field. Deliberately **not** `hasInstallScript`: prebuilt installers (esbuild, fsevents) have install scripts but need no compiler, and pass. Fail-closed: a missing non-optional prod package aborts ("run npm ci first"); platform-gated optionals are skipped and counted. Empty allowlist, same posture as the copy-marker gate.
- **Wiring** (copy-markers pattern): `gate:no-native` at root → `ci.yml` after `npm ci`; in `cli/` → `cli-ci.yml` after its tarball-lock `npm ci`. Both closures enforced: workspace and published-CLI.
- **Unit test** `cli/test/unit/no-native-modules.test.ts` — 7 cases pinning the decision table (both markers offend; esbuild-shaped passes; fsevents-shaped dev/devOptional out of scope; optional-missing skipped; prod-missing throws; workspace links ignored).
- **Dockerfile sweep ×3** — the build-stage compiler toolchain existed only for better-sqlite3; `npm ci` in the image compiles nothing now (the lockfile carries no node-gyp/prebuild-install closure at all since #101). `twin-image.yml` validates the builds before any GHCR publish on merge.
- **cli-ci.yml** stale comment fixed (Node-24 rationale no longer cites better-sqlite3's node-gyp) and **AGENTS.md** invariants table gains the row (P8: invariant + enforcement in the same PR).

## Red/green evidence (Done-when bullet 3)

- **Green on main**: root closure 21 production packages clean; CLI closure 30 clean.
- **RED before the swap**: the same script run against `a81d424` (last pre-#101 commit, fresh `npm ci`) fails with exactly `✗ node_modules/better-sqlite3 (binding.gyp)`, exit 1.
- esbuild + fsevents: both `dev:true` in both lockfiles → excluded by prod-closure scoping; fsevents additionally ships prebuilt (`fsevents.node`, no binding.gyp in the tarball). Bullet 2 holds by both rules independently.

## Review required

Yes — public `main` requires review. CLI version-bump gate skips cleanly (no `cli/src/**` changes; verified locally).