### PR TITLE
chore: purge last bun invocations from the repo toolchain

### DIFF
--- a/cli/scripts/make-unwired-fixture.mjs
+++ b/cli/scripts/make-unwired-fixture.mjs
@@ -49,7 +49,6 @@ await rm(join(dest, "README.md"), { force: true });
 // package-lock.json may pin the adapter at a relative file: path that breaks
 // outside the monorepo — drop it and let `npm install` regenerate.
 await rm(join(dest, "package-lock.json"), { force: true });
-await rm(join(dest, "bun.lock"), { force: true });
 
 // ---- src/index.ts: strip the wiring -----------------------------------
 

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -19,10 +19,10 @@ echo "pre-commit: open-core boundary lint"
 bash scripts/lint-no-cloud-imports.sh
 
 echo "pre-commit: no local eval gate"
-bun run gate:no-eval
+npm run gate:no-eval
 
 echo "pre-commit: copy-marker gate"
-bun run lint:copy-markers
+npm run lint:copy-markers
 
 staged_count="$(git diff --cached --name-only --diff-filter=ACMR | wc -l | tr -d ' ')"
 if [ "$staged_count" = "0" ]; then


### PR DESCRIPTION
<!-- Closes F-707 -->
Executive summary: The Bun→npm migration (#85) flipped every workflow, Dockerfile, manifest, and doc to npm, but left the versioned pre-commit hook calling `bun run` for two gates. A contributor following AGENTS.md's hook-install instruction (`bash scripts/hooks/install.sh`) on a Bun-less machine got a broken pre-commit. This closes out the last `bun` invocations in the repo's own toolchain.

## What
- `scripts/hooks/pre-commit`: `bun run gate:no-eval` / `bun run lint:copy-markers` → `npm run …`.
- `cli/scripts/make-unwired-fixture.mjs`: drop the `bun.lock` cleanup line, dead since #85 deleted all lockfiles.

## Why
The Bun-free milestone's acceptance requires no `bun` invocation anywhere in `.github/`, `scripts/`, or docs, and contributors needing only Node ≥ 24. A repo-wide token sweep found these as the only remaining hits in the repo's own toolchain (the CLI's package-manager detection for *user* projects is intentional and untouched).

## Tests / CI
- Ran the modified hook end-to-end (`bash scripts/hooks/pre-commit`): all three gates pass via npm, exit 0.
- Ran `node cli/scripts/make-unwired-fixture.mjs <tmp>`: fixture builds correctly.
- `cli/scripts/**` is outside the cli version-bump gate's watched paths (`cli/src/**`, `cli/vendor/**`), so no changeset needed.