### PR TITLE
Self-generate TWIN_AUTH_SECRET on first non-loopback twin boot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,9 @@ coverage/
 .env.*
 !.env.example
 
-# Local twin state (SQLite-backed runtime data)
-/.pome-data/
+# Local twin state (SQLite-backed runtime data). Unanchored: direct twin
+# boots (cwd = package root) self-generate .pome-data/<twin>/secret (F-708).
+.pome-data/
 .pome/
 .stripe_clone/
 *.db

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -1,6 +1,6 @@
 # Twin Runtime Contract
 
-**Version 1.0.0** — frozen 2026-07-07 (FDRS-711), verified by the black-box suite in [`contract/`](./contract/).
+**Version 1.1.0** — frozen 2026-07-07 (FDRS-711), boot-secret self-generation added 2026-07-10 (F-708). Verified by the black-box suite in [`contract/`](./contract/).
 
 This document enumerates everything pome-cloud (and the pome CLI) may rely on when booting and driving a twin. **Changing any item below is a breaking contract change**: update this document and the suite in the same PR, then open the matching pome-cloud consumer PR that pins and verifies the new signed twin artifact (rule of record: `packages/twin-github/README.md`, runtime-contract section).
 
@@ -8,7 +8,7 @@ This document enumerates everything pome-cloud (and the pome CLI) may rely on wh
 
 - Entry point: `node dist/src/server.js` with **cwd = the twin package root** (`packages/twin-<name>`).
 - `GET /healthz` answers **200 within 3 seconds** of spawn.
-- The twin **refuses to boot** on a non-loopback bind host without `TWIN_AUTH_SECRET` (exit code ≠ 0; the error names the variable).
+- Boot secret (F-708): an env-injected `TWIN_AUTH_SECRET` **always wins** — pome-cloud injects per-tenant secrets and the twin never self-generates when the variable is set (empty counts as unset). On a non-loopback bind host with no env secret, the twin **self-generates** a 32-byte hex secret, persists it at the compose-era location `.pome-data/<twin>/secret` (cwd-relative; `POME_TWIN_DATA_DIR` overrides the directory), prints it **once** to stdout, and reuses the persisted secret on subsequent boots. If the secret can be neither read nor generated, the twin still **refuses to boot** (exit code ≠ 0; the error names the variable). Loopback binds keep the dev-fallback path.
 - Runtime dependency arrangement: hoisted `node_modules` + `packages/shared-types` **with its compiled runtime JS** + `packages/sdk` **with its built `dist/`** (the twins are engine plugins since F-682/683/684; the runtime image ships the sdk so the hoisted workspace symlink resolves) (`npm run build:runtime -w @pome-sh/shared-types`). `@pome-sh/shared-types` exports `./src/index.ts`, so a plain-`node` boot relies on type stripping (**Node ≥ 22.18**) plus the built `src/*.js` files for its `.js` import specifiers. The GHCR runtime image ships `node:24`; the Dockerfiles are the reference implementation of this arrangement.
 
 ## Environment surface
@@ -20,7 +20,8 @@ This document enumerates everything pome-cloud (and the pome CLI) may rely on wh
 | `GITHUB_CLONE_DB` / `SLACK_CLONE_DB` / `STRIPE_CLONE_DB` | SQLite path or `:memory:` | `.<twin>_clone/<twin>.db` |
 | `<TWIN>_CLONE_NO_SEED=1` | skip the default seed at boot | seed applied |
 | `POME_SEED_JSON` | cloud-supplied seed applied at boot (FDRS-353) | default seed |
-| `TWIN_AUTH_SECRET` | HS256 secret for session JWTs + provider-shaped tokens | dev-only fallback; **required** in production / on non-loopback hosts |
+| `TWIN_AUTH_SECRET` | HS256 secret for session JWTs + provider-shaped tokens; env always wins | dev-only fallback on loopback; self-generated + persisted on non-loopback hosts (F-708); **required** in production |
+| `POME_TWIN_DATA_DIR` | directory for the twin's persisted boot secret (`<dir>/secret`) | `.pome-data/<twin>` relative to cwd |
 | `TWIN_ADMIN_TOKEN` | switches `/admin/*` to `X-Admin-Token` auth (timing-safe compare) | loopback-only socket check |
 | `POME_RUN_ID` | recorder run id stamped on events | `"spawn"` |
 | `POME_TWIN_VERSION` / `POME_TWIN_GIT_SHA` / `POME_TWIN_BUILD_TIME` | `/healthz` `runtime` block | `0.1.0` / `dev` / `dev` |

--- a/contract/suite.mjs
+++ b/contract/suite.mjs
@@ -9,7 +9,10 @@
 
 import { after, before, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { mintSessionJwt, req, spawnTwin, spawnTwinRaw } from "./helpers.mjs";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { AUTH_SECRET, mintSessionJwt, req, spawnTwin, spawnTwinRaw } from "./helpers.mjs";
 
 const SID = "contract-sid";
 const sPath = (p) => `/s/${SID}${p}`;
@@ -358,15 +361,91 @@ export function adminGateCase(twin, label = twin.name) {
   });
 }
 
-/** Refuses to boot on a non-loopback host without TWIN_AUTH_SECRET. */
+/**
+ * F-708 boot-secret contract: a non-loopback bind with no env-injected
+ * TWIN_AUTH_SECRET self-generates a 32-byte hex secret, persists it at the
+ * compose-era location (POME_TWIN_DATA_DIR overrides `.pome-data/<twin>`),
+ * prints it once to stdout, and reuses it on reboot. An env-injected secret
+ * always wins, and a failed generation still refuses to boot.
+ */
 export function bootGuardCase(twin, label = twin.name) {
-  it(`${label}: refuses to boot on a non-loopback host without TWIN_AUTH_SECRET`, async () => {
-    const { code, output } = await spawnTwinRaw(twin, {
+  const nonLoopback = (dataDir, extra = {}) => ({
+    env: {
       [twin.hostEnv]: "0.0.0.0",
-      PORT: "0",
       TWIN_AUTH_SECRET: "",
-    });
-    assert.notEqual(code, 0, "process exits non-zero");
-    assert.match(output, /TWIN_AUTH_SECRET/, "error names the missing secret");
+      POME_TWIN_DATA_DIR: dataDir,
+      ...extra,
+    },
+  });
+
+  it(`${label}: self-generates TWIN_AUTH_SECRET on a non-loopback bind and reuses it on reboot`, async () => {
+    const dataDir = await mkdtemp(path.join(tmpdir(), "pome-contract-secret-"));
+    try {
+      // First boot: generates, persists, prints once, and serves bearer
+      // traffic signed with the generated secret.
+      const t1 = await spawnTwin(twin, nonLoopback(dataDir));
+      let secret;
+      try {
+        secret = (await readFile(path.join(dataDir, "secret"), "utf8")).trim();
+        assert.match(secret, /^[0-9a-f]{64}$/, "persisted secret is 32-byte hex");
+        assert.ok(t1.output().includes(secret), "first boot prints the generated secret to stdout");
+        const health = await req(t1.base, sPath("/_pome/health"), { token: mintSessionJwt({ sid: SID, secret }) });
+        assert.equal(health.status, 200, "a JWT minted with the persisted secret authenticates");
+      } finally {
+        await t1.close();
+      }
+
+      // Second boot: reuses the persisted secret — no regeneration, no reprint.
+      const t2 = await spawnTwin(twin, nonLoopback(dataDir));
+      try {
+        const persisted = (await readFile(path.join(dataDir, "secret"), "utf8")).trim();
+        assert.equal(persisted, secret, "second boot does not regenerate the secret");
+        assert.ok(!t2.output().includes(secret), "second boot does not reprint the secret value");
+        const health = await req(t2.base, sPath("/_pome/health"), { token: mintSessionJwt({ sid: SID, secret }) });
+        assert.equal(health.status, 200, "the reused secret still authenticates");
+      } finally {
+        await t2.close();
+      }
+    } finally {
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it(`${label}: an env-injected TWIN_AUTH_SECRET always wins over a persisted one`, async () => {
+    const dataDir = await mkdtemp(path.join(tmpdir(), "pome-contract-secret-"));
+    try {
+      const persisted = "f".repeat(64);
+      await writeFile(path.join(dataDir, "secret"), `${persisted}\n`);
+      const t = await spawnTwin(twin, nonLoopback(dataDir, { TWIN_AUTH_SECRET: AUTH_SECRET }));
+      try {
+        const env = await req(t.base, sPath("/_pome/health"), { token: mintSessionJwt({ sid: SID }) });
+        assert.equal(env.status, 200, "the env-injected secret authenticates");
+        const file = await req(t.base, sPath("/_pome/health"), { token: mintSessionJwt({ sid: SID, secret: persisted }) });
+        assert.equal(file.status, 401, "the persisted secret is ignored when env is set");
+        const onDisk = (await readFile(path.join(dataDir, "secret"), "utf8")).trim();
+        assert.equal(onDisk, persisted, "the persisted file is left untouched");
+      } finally {
+        await t.close();
+      }
+    } finally {
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it(`${label}: still refuses to boot when the secret can be neither read nor generated`, async () => {
+    const blocker = await mkdtemp(path.join(tmpdir(), "pome-contract-secret-"));
+    try {
+      await writeFile(path.join(blocker, "not-a-dir"), "");
+      const { code, output } = await spawnTwinRaw(twin, {
+        [twin.hostEnv]: "0.0.0.0",
+        PORT: "0",
+        TWIN_AUTH_SECRET: "",
+        POME_TWIN_DATA_DIR: path.join(blocker, "not-a-dir", "nested"),
+      });
+      assert.notEqual(code, 0, "process exits non-zero");
+      assert.match(output, /TWIN_AUTH_SECRET/, "error names the missing secret");
+    } finally {
+      await rm(blocker, { recursive: true, force: true });
+    }
   });
 }

--- a/packages/sdk/src/server-helpers.ts
+++ b/packages/sdk/src/server-helpers.ts
@@ -6,7 +6,7 @@
 // which stays the only public entry.
 
 import { randomBytes } from "node:crypto";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { RESERVED_SESSION_PREFIXES, type ToolSpec, type TwinDefinition } from "./index.js";
 import { UnknownToolError } from "./errors.js";
@@ -46,6 +46,11 @@ export function isLoopbackHost(value: string): boolean {
  * `.pome-data/<twin>/secret` (cwd-relative; `POME_TWIN_DATA_DIR` overrides
  * the directory) is reused, or a fresh 32-byte hex secret is generated,
  * persisted there, and printed once to stdout so the operator can mint JWTs.
+ *
+ * The resolved secret lands in `process.env.TWIN_AUTH_SECRET`, which is
+ * process-global by design: the engine's auth (`resolveAuthSecret`) reads
+ * the env, so one process serves one secret — the frozen boot contract is
+ * one twin per process, and a multi-twin process shares the first secret.
  */
 export function ensureTwinAuthSecret(twin: string, host: string): void {
   if (process.env.TWIN_AUTH_SECRET) return;
@@ -76,8 +81,20 @@ export function ensureTwinAuthSecret(twin: string, host: string): void {
         console.log(`[twin-${twin}] TWIN_AUTH_SECRET not set — using the persisted secret from ${secretPath}`);
         return;
       }
-      // A blank file is an aborted earlier write — safe to clobber.
-      writeFileSync(secretPath, `${secret}\n`, { mode: 0o600 });
+      // A blank file is an aborted earlier write: remove it and retry the
+      // exclusive write, so a concurrent booter losing this second race
+      // adopts the winner's secret instead of overwriting it.
+      rmSync(secretPath, { force: true });
+      try {
+        writeFileSync(secretPath, `${secret}\n`, { mode: 0o600, flag: "wx" });
+      } catch (err2) {
+        if ((err2 as NodeJS.ErrnoException).code !== "EEXIST") throw err2;
+        const late = readSecretFile(secretPath);
+        if (!late) throw err2;
+        process.env.TWIN_AUTH_SECRET = late;
+        console.log(`[twin-${twin}] TWIN_AUTH_SECRET not set — using the persisted secret from ${secretPath}`);
+        return;
+      }
     }
     process.env.TWIN_AUTH_SECRET = secret;
     console.log(
@@ -101,7 +118,16 @@ function readSecretFile(secretPath: string): string | undefined {
     throw err;
   }
   const trimmed = raw.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
+  if (trimmed.length === 0) return undefined;
+  // The compose-era contract documents >= 32 chars. A shorter file (hand
+  // edit, truncation) must fail the boot loudly — never silently serve a
+  // weak HS256 key, and never silently regenerate over operator content.
+  if (trimmed.length < 32) {
+    throw new TwinBootError(
+      `TWIN_AUTH_SECRET is not set and the persisted secret at ${secretPath} is shorter than 32 chars — fix or delete the file, or inject TWIN_AUTH_SECRET.`
+    );
+  }
+  return trimmed;
 }
 
 export function shadowedPrefix(routePath: string): string | null {

--- a/packages/sdk/src/server-helpers.ts
+++ b/packages/sdk/src/server-helpers.ts
@@ -5,6 +5,9 @@
 // may import (TwinBootError, isLoopbackHost) is re-exported from server.ts,
 // which stays the only public entry.
 
+import { randomBytes } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { RESERVED_SESSION_PREFIXES, type ToolSpec, type TwinDefinition } from "./index.js";
 import { UnknownToolError } from "./errors.js";
 
@@ -33,6 +36,72 @@ export function makeDeltaSink() {
 /** Hostnames the boot guard treats as loopback binds. */
 export function isLoopbackHost(value: string): boolean {
   return value === "127.0.0.1" || value === "::1" || value === "localhost";
+}
+
+/**
+ * F-708: self-generate `TWIN_AUTH_SECRET` on first boot. An env-injected
+ * secret always wins (pome-cloud injects per-tenant secrets — that contract
+ * is untouched), and loopback binds keep the dev-fallback path. Otherwise
+ * the secret persisted at the compose-era contract location
+ * `.pome-data/<twin>/secret` (cwd-relative; `POME_TWIN_DATA_DIR` overrides
+ * the directory) is reused, or a fresh 32-byte hex secret is generated,
+ * persisted there, and printed once to stdout so the operator can mint JWTs.
+ */
+export function ensureTwinAuthSecret(twin: string, host: string): void {
+  if (process.env.TWIN_AUTH_SECRET) return;
+  if (isLoopbackHost(host)) return;
+
+  const dataDir = process.env.POME_TWIN_DATA_DIR || join(".pome-data", twin);
+  const secretPath = join(dataDir, "secret");
+
+  try {
+    const persisted = readSecretFile(secretPath);
+    if (persisted) {
+      process.env.TWIN_AUTH_SECRET = persisted;
+      console.log(`[twin-${twin}] TWIN_AUTH_SECRET not set — using the persisted secret from ${secretPath}`);
+      return;
+    }
+
+    const secret = randomBytes(32).toString("hex");
+    mkdirSync(dataDir, { recursive: true });
+    try {
+      // Compose-era file format: hex secret + trailing newline, owner-only.
+      // "wx" never clobbers a secret written by a concurrent first boot.
+      writeFileSync(secretPath, `${secret}\n`, { mode: 0o600, flag: "wx" });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+      const winner = readSecretFile(secretPath);
+      if (winner) {
+        process.env.TWIN_AUTH_SECRET = winner;
+        console.log(`[twin-${twin}] TWIN_AUTH_SECRET not set — using the persisted secret from ${secretPath}`);
+        return;
+      }
+      // A blank file is an aborted earlier write — safe to clobber.
+      writeFileSync(secretPath, `${secret}\n`, { mode: 0o600 });
+    }
+    process.env.TWIN_AUTH_SECRET = secret;
+    console.log(
+      `[twin-${twin}] TWIN_AUTH_SECRET not set — generated ${secret} (persisted to ${secretPath}; subsequent boots reuse it, an env-injected TWIN_AUTH_SECRET overrides it)`
+    );
+  } catch (err) {
+    if (err instanceof TwinBootError) throw err;
+    throw new TwinBootError(
+      `TWIN_AUTH_SECRET is not set and self-generating one at ${secretPath} failed: ${(err as Error).message}`
+    );
+  }
+}
+
+/** The persisted secret, trimmed; undefined when absent or blank. */
+function readSecretFile(secretPath: string): string | undefined {
+  let raw: string;
+  try {
+    raw = readFileSync(secretPath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw err;
+  }
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 export function shadowedPrefix(routePath: string): string | null {

--- a/packages/sdk/src/server.ts
+++ b/packages/sdk/src/server.ts
@@ -42,6 +42,7 @@ import {
   POME_CORE_ROUTE_NAMES,
   TwinBootError,
   assertUniqueToolNames,
+  ensureTwinAuthSecret,
   findTool,
   isLoopbackHost,
   makeDeltaSink,
@@ -50,8 +51,8 @@ import {
 } from "./server-helpers.js";
 
 // Public boot surface consumed by twin entrypoints
-// (`import { TwinBootError, isLoopbackHost, serve } from "@pome-sh/sdk/server"`).
-export { TwinBootError, isLoopbackHost, created, ok } from "./server-helpers.js";
+// (`import { ensureTwinAuthSecret, serve } from "@pome-sh/sdk/server"`).
+export { TwinBootError, ensureTwinAuthSecret, isLoopbackHost, created, ok } from "./server-helpers.js";
 
 export {
   createRecorderHandle,
@@ -461,13 +462,13 @@ export async function serve<TDb, TSeed, TDomain>(
   options: ServeOptions<TDb, TSeed> = {}
 ): Promise<ServeResult> {
   const hostname = options.hostname ?? "127.0.0.1";
-  // Contract boot guard: a twin must refuse to serve real traffic with the
-  // dev fallback secret. Checked before the app is built so the process
+  // Contract boot guard: a twin must never serve real traffic with the dev
+  // fallback secret. Since F-708 a non-loopback bind with no env-injected
+  // secret self-generates + persists one instead of refusing to boot; a
+  // failed generation still throws before the app is built, so the process
   // exits non-zero without ever listening.
-  if (options.port !== undefined && !isLoopbackHost(hostname) && !process.env.TWIN_AUTH_SECRET) {
-    throw new TwinBootError(
-      `TWIN_AUTH_SECRET is required when a twin listens on a non-loopback host (${hostname}).`
-    );
+  if (options.port !== undefined && !isLoopbackHost(hostname)) {
+    ensureTwinAuthSecret(definition.id, hostname);
   }
   // Resolve the store once so `close()` can flush the same instance the app
   // records into (durable when POME_RECORDER_EVENTS_PATH is set).

--- a/packages/sdk/test/auth-secret.test.ts
+++ b/packages/sdk/test/auth-secret.test.ts
@@ -122,6 +122,22 @@ describe("ensureTwinAuthSecret", () => {
     expect(readSecretFile()).toBe(`${composeSecret}\n`);
   });
 
+  it("refuses to boot on a persisted secret shorter than 32 chars instead of serving a weak key", () => {
+    writeFileSync(secretFile(), "x\n");
+    expect(() => ensureTwinAuthSecret("github", "0.0.0.0")).toThrow(TwinBootError);
+    expect(() => ensureTwinAuthSecret("github", "0.0.0.0")).toThrow(/TWIN_AUTH_SECRET/);
+    expect(process.env.TWIN_AUTH_SECRET).toBeUndefined();
+    // The operator's file is not silently regenerated either.
+    expect(readSecretFile()).toBe("x\n");
+  });
+
+  it("accepts a hand-placed persisted secret of at least 32 chars", () => {
+    const custom = "hand-placed-secret-32-chars-minimum!";
+    writeFileSync(secretFile(), `${custom}\n`);
+    ensureTwinAuthSecret("github", "0.0.0.0");
+    expect(process.env.TWIN_AUTH_SECRET).toBe(custom);
+  });
+
   it("treats a whitespace-only persisted file as absent and regenerates", () => {
     writeFileSync(secretFile(), " \n");
     ensureTwinAuthSecret("github", "0.0.0.0");

--- a/packages/sdk/test/auth-secret.test.ts
+++ b/packages/sdk/test/auth-secret.test.ts
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Moved from packages/twin-slack/test (F-683): the secret-resolution
 // mechanism is the engine's, so its unit coverage lives with the engine.
-import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveAuthSecret } from "../src/auth.js";
+import { TwinBootError, ensureTwinAuthSecret } from "../src/server.js";
 
 describe("resolveAuthSecret", () => {
   const prevNodeEnv = process.env.NODE_ENV;
@@ -25,5 +29,124 @@ describe("resolveAuthSecret", () => {
     delete process.env.TWIN_AUTH_SECRET;
     delete process.env.NODE_ENV;
     expect(resolveAuthSecret()).toBe("dev-only-insecure-secret");
+  });
+});
+
+// F-708: a twin bound to a non-loopback host with no env-injected secret
+// self-generates one, persists it at the compose-era contract location
+// (.pome-data/<twin>/secret; POME_TWIN_DATA_DIR overrides the directory),
+// prints it once to stdout, and reuses it on subsequent boots.
+describe("ensureTwinAuthSecret", () => {
+  const HEX_64 = /^[0-9a-f]{64}$/;
+  const prevSecret = process.env.TWIN_AUTH_SECRET;
+  const prevDataDir = process.env.POME_TWIN_DATA_DIR;
+  let dataDir: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  const secretFile = () => join(dataDir, "secret");
+  const logged = () => logSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+  const readSecretFile = () => readFileSync(secretFile(), "utf8");
+  const fileExists = () => {
+    try {
+      statSync(secretFile());
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "pome-sdk-secret-"));
+    process.env.POME_TWIN_DATA_DIR = dataDir;
+    delete process.env.TWIN_AUTH_SECRET;
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    rmSync(dataDir, { recursive: true, force: true });
+    if (prevSecret === undefined) delete process.env.TWIN_AUTH_SECRET;
+    else process.env.TWIN_AUTH_SECRET = prevSecret;
+    if (prevDataDir === undefined) delete process.env.POME_TWIN_DATA_DIR;
+    else process.env.POME_TWIN_DATA_DIR = prevDataDir;
+  });
+
+  it("env-injected secret always wins: no file is read or written", () => {
+    process.env.TWIN_AUTH_SECRET = "cloud-injected-per-tenant-secret-123456";
+    ensureTwinAuthSecret("github", "0.0.0.0");
+    expect(process.env.TWIN_AUTH_SECRET).toBe("cloud-injected-per-tenant-secret-123456");
+    expect(fileExists()).toBe(false);
+  });
+
+  it("loopback binds keep the dev-fallback path: no generation", () => {
+    ensureTwinAuthSecret("github", "127.0.0.1");
+    expect(process.env.TWIN_AUTH_SECRET).toBeUndefined();
+    expect(fileExists()).toBe(false);
+  });
+
+  it("non-loopback bind with no env: generates 32-byte hex, persists, sets env, prints once", () => {
+    ensureTwinAuthSecret("github", "0.0.0.0");
+    const secret = process.env.TWIN_AUTH_SECRET ?? "";
+    expect(secret).toMatch(HEX_64);
+    // Compose-era file format: the secret plus a trailing newline.
+    expect(readSecretFile()).toBe(`${secret}\n`);
+    // Owner-only: the CLI reads it as the same user; nobody else needs to.
+    expect(statSync(secretFile()).mode & 0o777).toBe(0o600);
+    expect(logged()).toContain(secret);
+    expect(logged()).toContain("TWIN_AUTH_SECRET");
+  });
+
+  it("empty env string counts as unset (compose entrypoint parity)", () => {
+    process.env.TWIN_AUTH_SECRET = "";
+    ensureTwinAuthSecret("slack", "0.0.0.0");
+    expect(process.env.TWIN_AUTH_SECRET).toMatch(HEX_64);
+  });
+
+  it("second boot reuses the persisted secret without regenerating or reprinting it", () => {
+    ensureTwinAuthSecret("github", "0.0.0.0");
+    const first = process.env.TWIN_AUTH_SECRET ?? "";
+    delete process.env.TWIN_AUTH_SECRET;
+    logSpy.mockClear();
+
+    ensureTwinAuthSecret("github", "0.0.0.0");
+    expect(process.env.TWIN_AUTH_SECRET).toBe(first);
+    expect(readSecretFile()).toBe(`${first}\n`);
+    expect(logged()).not.toContain(first);
+  });
+
+  it("reads a compose-era secret file (trailing newline) verbatim after trimming", () => {
+    const composeSecret = "a".repeat(64);
+    writeFileSync(secretFile(), `${composeSecret}\n`);
+    ensureTwinAuthSecret("stripe", "0.0.0.0");
+    expect(process.env.TWIN_AUTH_SECRET).toBe(composeSecret);
+    expect(readSecretFile()).toBe(`${composeSecret}\n`);
+  });
+
+  it("treats a whitespace-only persisted file as absent and regenerates", () => {
+    writeFileSync(secretFile(), " \n");
+    ensureTwinAuthSecret("github", "0.0.0.0");
+    expect(process.env.TWIN_AUTH_SECRET).toMatch(HEX_64);
+  });
+
+  it("defaults to .pome-data/<twin>/secret relative to cwd when POME_TWIN_DATA_DIR is unset", () => {
+    delete process.env.POME_TWIN_DATA_DIR;
+    const cwd = process.cwd();
+    try {
+      process.chdir(dataDir);
+      ensureTwinAuthSecret("github", "0.0.0.0");
+      const secret = process.env.TWIN_AUTH_SECRET ?? "";
+      expect(secret).toMatch(HEX_64);
+      expect(readFileSync(join(dataDir, ".pome-data", "github", "secret"), "utf8")).toBe(`${secret}\n`);
+    } finally {
+      process.chdir(cwd);
+    }
+  });
+
+  it("fails boot with TwinBootError naming TWIN_AUTH_SECRET when the data dir is unwritable", () => {
+    const blocker = join(dataDir, "blocker");
+    writeFileSync(blocker, "not a directory");
+    process.env.POME_TWIN_DATA_DIR = join(blocker, "nested");
+    expect(() => ensureTwinAuthSecret("github", "0.0.0.0")).toThrow(TwinBootError);
+    expect(() => ensureTwinAuthSecret("github", "0.0.0.0")).toThrow(/TWIN_AUTH_SECRET/);
   });
 });

--- a/packages/sdk/test/auth-secret.test.ts
+++ b/packages/sdk/test/auth-secret.test.ts
@@ -44,7 +44,7 @@ describe("ensureTwinAuthSecret", () => {
   let logSpy: ReturnType<typeof vi.spyOn>;
 
   const secretFile = () => join(dataDir, "secret");
-  const logged = () => logSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+  const logged = () => logSpy.mock.calls.map((call: unknown[]) => call.join(" ")).join("\n");
   const readSecretFile = () => readFileSync(secretFile(), "utf8");
   const fileExists = () => {
     try {

--- a/packages/sdk/test/serve-contract.test.ts
+++ b/packages/sdk/test/serve-contract.test.ts
@@ -4,6 +4,9 @@
 // healthz implementation+runtime block, per-twin healthz extras, the
 // definition-level auth options, JSON-RPC /s/:sid/mcp, the per-twin 501
 // unsupported envelope, state_delta plumbing, and the serve() boot guard.
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { defineTwin } from "../src/index.js";
@@ -244,17 +247,29 @@ describe("state_delta plumbing", () => {
 });
 
 describe("serve() boot guard", () => {
-  it("refuses a non-loopback bind without TWIN_AUTH_SECRET, naming the variable", async () => {
+  // F-708: a non-loopback bind with no env-injected secret no longer refuses
+  // to boot — the engine self-generates a secret and persists it.
+  it("self-generates and persists TWIN_AUTH_SECRET on a non-loopback bind", async () => {
     const saved = process.env.TWIN_AUTH_SECRET;
+    const savedDataDir = process.env.POME_TWIN_DATA_DIR;
     delete process.env.TWIN_AUTH_SECRET;
+    const dataDir = mkdtempSync(join(tmpdir(), "pome-serve-secret-"));
+    process.env.POME_TWIN_DATA_DIR = dataDir;
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
     try {
-      await expect(serve(toyTwin, { port: 0, hostname: "0.0.0.0" })).rejects.toThrow(
-        /TWIN_AUTH_SECRET/
-      );
+      const { close } = await serve(toyTwin, { port: 0, hostname: "0.0.0.0" });
+      await close();
+      const secret = process.env.TWIN_AUTH_SECRET ?? "";
+      expect(secret).toMatch(/^[0-9a-f]{64}$/);
+      expect(readFileSync(join(dataDir, "secret"), "utf8")).toBe(`${secret}\n`);
     } finally {
       process.env.TWIN_AUTH_SECRET = saved;
+      if (savedDataDir === undefined) delete process.env.POME_TWIN_DATA_DIR;
+      else process.env.POME_TWIN_DATA_DIR = savedDataDir;
+      rmSync(dataDir, { recursive: true, force: true });
       warnSpy.mockRestore();
+      logSpy.mockRestore();
     }
   });
 

--- a/packages/twin-github/src/server.ts
+++ b/packages/twin-github/src/server.ts
@@ -6,7 +6,7 @@
 // engine driver, load the boot seed, hand everything to the engine's
 // `serve()`.
 
-import { TwinBootError, isLoopbackHost, serve } from "@pome-sh/sdk/server";
+import { ensureTwinAuthSecret, serve } from "@pome-sh/sdk/server";
 import { openGitHubCloneDatabase } from "./db.js";
 import { loadSeedFromEnv } from "./seed.js";
 import { githubTwinDefinition } from "./twin.js";
@@ -15,13 +15,12 @@ const port = Number(process.env.PORT ?? process.env.GITHUB_CLONE_PORT ?? 3333);
 const host = process.env.GITHUB_CLONE_HOST ?? "127.0.0.1";
 const dbPath = process.env.GITHUB_CLONE_DB ?? ".github_clone/github.db";
 
-// The engine's serve() enforces the same guard; checking here first keeps
-// the refused boot from touching the filesystem (no db file is created).
-if (!isLoopbackHost(host) && !process.env.TWIN_AUTH_SECRET) {
-  throw new TwinBootError(
-    `TWIN_AUTH_SECRET is required when a twin listens on a non-loopback host (${host}).`
-  );
-}
+// F-708: an env-injected TWIN_AUTH_SECRET always wins; a non-loopback bind
+// with no env self-generates a secret and persists it at the compose-era
+// contract location (.pome-data/github/secret). The engine's serve() runs
+// the same guard; calling it here first keeps a failed boot from touching
+// the filesystem (no db file is created).
+ensureTwinAuthSecret("github", host);
 
 const db = openGitHubCloneDatabase(dbPath);
 // POME_SEED_JSON (FDRS-353) is strict-parsed: a malformed cloud seed fails

--- a/packages/twin-slack/src/server.ts
+++ b/packages/twin-slack/src/server.ts
@@ -6,7 +6,7 @@
 // engine driver, load the boot seed, hand everything to the engine's
 // `serve()`.
 
-import { TwinBootError, isLoopbackHost, serve } from "@pome-sh/sdk/server";
+import { ensureTwinAuthSecret, serve } from "@pome-sh/sdk/server";
 import { openSlackTwinDatabase } from "./db.js";
 import { loadSeedFromEnv } from "./seed.js";
 import { slackTwinDefinition } from "./twin.js";
@@ -15,13 +15,12 @@ const port = Number(process.env.PORT ?? process.env.SLACK_CLONE_PORT ?? 3333);
 const host = process.env.SLACK_CLONE_HOST ?? "127.0.0.1";
 const dbPath = process.env.SLACK_CLONE_DB ?? ".slack_clone/slack.db";
 
-// The engine's serve() enforces the same guard; checking here first keeps
-// the refused boot from touching the filesystem (no db file is created).
-if (!isLoopbackHost(host) && !process.env.TWIN_AUTH_SECRET) {
-  throw new TwinBootError(
-    `TWIN_AUTH_SECRET is required when a twin listens on a non-loopback host (${host}).`
-  );
-}
+// F-708: an env-injected TWIN_AUTH_SECRET always wins; a non-loopback bind
+// with no env self-generates a secret and persists it at the compose-era
+// contract location (.pome-data/slack/secret). The engine's serve() runs
+// the same guard; calling it here first keeps a failed boot from touching
+// the filesystem (no db file is created).
+ensureTwinAuthSecret("slack", host);
 
 const db = openSlackTwinDatabase(dbPath);
 // POME_SEED_JSON (FDRS-353) is strict-parsed: a malformed cloud seed fails

--- a/packages/twin-stripe/src/server.ts
+++ b/packages/twin-stripe/src/server.ts
@@ -7,7 +7,7 @@
 // `serve()`. Listens on :3333 (Vercel Sandbox port-forward target) and
 // honors STRIPE_CLONE_HOST=0.0.0.0 in containerized envs.
 
-import { TwinBootError, resolveRecorderStore, isLoopbackHost, serve } from "@pome-sh/sdk/server";
+import { ensureTwinAuthSecret, resolveRecorderStore, serve } from "@pome-sh/sdk/server";
 import { openTwinStripeDatabase } from "./db.js";
 import { loadSeedFromEnv } from "./seed.js";
 import { createStripeTwinDefinition } from "./twin.js";
@@ -16,13 +16,12 @@ const port = Number(process.env.PORT ?? process.env.STRIPE_CLONE_PORT ?? 3333);
 const host = process.env.STRIPE_CLONE_HOST ?? "127.0.0.1";
 const dbPath = process.env.STRIPE_CLONE_DB ?? ".stripe_clone/stripe.db";
 
-// The engine's serve() enforces the same guard; checking here first keeps
-// the refused boot from touching the filesystem (no db file is created).
-if (!isLoopbackHost(host) && !process.env.TWIN_AUTH_SECRET) {
-  throw new TwinBootError(
-    `TWIN_AUTH_SECRET is required when a twin listens on a non-loopback host (${host}).`
-  );
-}
+// F-708: an env-injected TWIN_AUTH_SECRET always wins; a non-loopback bind
+// with no env self-generates a secret and persists it at the compose-era
+// contract location (.pome-data/stripe/secret). The engine's serve() runs
+// the same guard; calling it here first keeps a failed boot from touching
+// the filesystem (no db file is created).
+ensureTwinAuthSecret("stripe", host);
 
 const startedAtMs = Date.now();
 const db = openTwinStripeDatabase(dbPath);


### PR DESCRIPTION
<!-- Closes F-708 -->

Executive summary: A twin bound to a non-loopback host with no env-injected secret no longer refuses to boot — the engine self-generates a 32-byte hex secret, persists it at the compose-era contract location `.pome-data/<twin>/secret`, prints it once to stdout, and reuses it on subsequent boots. An env-injected `TWIN_AUTH_SECRET` always wins, so the cloud's per-tenant injection contract is untouched. This moves the docker-compose entrypoint's secret bootstrap into the server itself, removing the last functional reason for the compose file.

## What
New engine helper `ensureTwinAuthSecret(twin, host)` in `@pome-sh/sdk/server` (implemented once, in twin-core): env-injected secret wins → loopback binds keep the dev-fallback path → otherwise read-or-generate `.pome-data/<twin>/secret` (`POME_TWIN_DATA_DIR` overrides the directory), set the env, and print the secret once on generation. `serve()` calls it instead of hard-failing, and the three twin entrypoints call it before opening the db so a failed boot still never touches the filesystem. CONTRACT.md (boot section + env table, v1.1.0) and the black-box contract suite are updated in the same PR.

## Why
Today the self-generation logic lives only in the docker-compose entrypoint (YAML anchor writing `/data/secret`); a direct `node dist/src/server.js` boot on a non-loopback host hard-fails without `TWIN_AUTH_SECRET`. The CLI-side read of the persisted secret (JWT minting) lands separately as the follow-up read-side ticket.

## Notes for reviewer
- **Contract change (deliberate):** the "refuses to boot" bullet in CONTRACT.md becomes "self-generates + persists"; a boot that can neither read nor generate a secret still exits non-zero naming the variable. Cloud is unaffected — it always injects the env, and env always wins (empty string counts as unset, matching the compose entrypoint's `-z` check).
- The persisted file keeps the compose-era format (hex + trailing newline) so compose-written secrets are picked up verbatim; new files are written `0o600` with a `wx` flag so a concurrent first boot never clobbers the winner's secret. A blank file is treated as an aborted write and regenerated.
- Second boot intentionally does **not** reprint the secret value, only the path.

## Tests / CI
- TDD: new unit coverage in `packages/sdk/test/auth-secret.test.ts` (env wins / loopback no-op / generate+persist+print / reuse without reprint / compose-file compat / blank-file regen / default cwd-relative location / TwinBootError on unwritable dir), watched red before implementing.
- `contract/suite.mjs` boot-guard cases now assert, per twin, black-box: first boot generates + persists + prints and serves JWTs signed with the persisted secret; second boot reuses without reprint; env-injected secret wins over a persisted one; unwritable data dir still refuses to boot.
- Local: `npm run build`, `npm test` (1190 tests across workspaces), `npm run test:contract` (72 tests, 0 fail), `npm run typecheck`, code-health / dead-code / no-eval / copy-marker / no-cloud-imports gates all green.

## Review required
Yes — touches the auth boot path and the frozen twin runtime contract (CONTRACT.md v1.0.0 → v1.1.0).