### PR TITLE
Ship twins in the CLI: pome twin start github|slack|stripe

### DIFF
--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -99,6 +99,13 @@ jobs:
       - run: npm run typecheck
       - run: npm run build
       - run: npm test
+      # F-709 — the frozen M1 runtime-contract assertions, asserted against
+      # twins started via the CLI front door (`pome twin start <twin>`).
+      # Reuses the build above; the CLI resolves the twins from the local
+      # @pome-sh tarballs installed earlier in this job.
+      - name: Contract suite vs pome twin start
+        working-directory: ${{ github.workspace }}
+        run: node --test contract/cli-start.test.mjs
       # Former cli-publish-smoke.yml — same tarball install, so pack/clean-room
       # checks reuse this job instead of a second npm ci + pack cycle.
       - name: npm publish --dry-run (packs the real tarball)

--- a/cli/.changeset/tidy-donuts-serve.md
+++ b/cli/.changeset/tidy-donuts-serve.md
@@ -1,0 +1,5 @@
+---
+"@pome-sh/cli": minor
+---
+
+`pome twin start <twin>` now starts any of the three twins (github, slack, stripe) as a long-lived foreground server (Ctrl-C to stop) on the same in-process boot path `pome run --local` uses, and prints a ready-to-use JWT. The command reuses a secret persisted at `.pome-data/<twin>/secret` (`POME_TWIN_DATA_DIR` overrides the directory); an env-injected `TWIN_AUTH_SECRET` always wins.

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -1,13 +1,10 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
-import { serve } from "@hono/node-server";
 import { Command } from "commander";
-import { randomBytes } from "node:crypto";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { cp, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { sign } from "hono/jwt";
 import {
   readLatestRun,
   readMetaSummary,
@@ -67,7 +64,7 @@ import {
   writeProjectConfig,
   type ProjectConfig,
 } from "./project-config.js";
-import { createGitHubCloneApp, openGitHubCloneDatabase, seedGitHubCloneDatabase } from "../twin/githubCloneAdapter.js";
+import { createGitHubCloneApp } from "../twin/githubCloneAdapter.js";
 import {
   buildFixPrompt,
   buildGroupFixPrompt,
@@ -1095,42 +1092,14 @@ export function createProgram() {
   const twin = program.command("twin").description("Manage local twins");
   twin
     .command("start")
-    .argument("<name>", "Twin name")
-    .option("--port <port>", "Port to bind", "3333")
-    .description("Start a standalone twin")
-    .action(async (name: string, options: { port: string }) => {
-      if (name !== "github") throw new Error("Only the github twin exists in the MSP.");
-      await mkdir(".pome", { recursive: true });
-      const db = await openGitHubCloneDatabase(".pome/github.db");
-      await seedGitHubCloneDatabase(db);
-      const port = Number(options.port);
-      const app = (await createGitHubCloneApp({ db, runId: "standalone" })) as any;
-      const baseUrl = `http://127.0.0.1:${port}`;
-      const restUrl = `${baseUrl}/s/standalone`;
-      const mcpUrl = `${restUrl}/mcp`;
-      const authSecret = process.env.TWIN_AUTH_SECRET ?? randomBytes(32).toString("hex");
-      process.env.TWIN_AUTH_SECRET = authSecret;
-      const token = await sign(
-        { sid: "standalone", team_id: "tm_local", exp: Math.floor(Date.now() / 1000) + 60 * 60 * 24 },
-        // The secret was just pinned into the env above; the ported twin no
-        // longer exports resolveAuthSecret (engine-owned, F-682).
-        authSecret
-      );
-      serve({ fetch: app.fetch, port, hostname: "127.0.0.1" });
-      await writeFile(
-        ".pome/twin-status.json",
-        JSON.stringify({ name, url: restUrl, rest_url: restUrl, mcp_url: mcpUrl, auth_token: token }, null, 2)
-      );
-      console.log(`Pome ${name} twin listening at ${restUrl}`);
-      console.log(`POME_GITHUB_REST_URL=${restUrl}`);
-      console.log(`POME_GITHUB_MCP_URL=${mcpUrl}`);
-      console.log(`POME_AUTH_TOKEN=${token}`);
-      // F28 — every `/s/<sid>/*` endpoint requires a Bearer JWT, including
-      // /s/standalone/healthz. New users curling the printed `${restUrl}`
-      // get HTTP 401 and assume the twin is broken. The unauth liveness
-      // probe lives at the root `/healthz`. Print the curl command so
-      // copy-paste debugging works without a JWT.
-      console.log(`Health check (no auth): curl ${baseUrl}/healthz`);
+    .argument("<name>", "Twin name (github | slack | stripe)")
+    .option("--port <port>", "Port to bind (default: $PORT or 3333)")
+    .description(
+      "Start a standalone twin as a long-lived foreground server (Ctrl-C to stop)",
+    )
+    .action(async (name: string, options: { port?: string }) => {
+      const { runTwinStartCommand } = await import("../twin/twinStart.js");
+      await runTwinStartCommand(name, options);
     });
 
   twin

--- a/cli/src/twin/twinStart.ts
+++ b/cli/src/twin/twinStart.ts
@@ -100,7 +100,9 @@ export async function runTwinStartCommand(
   // suite injects PORT, same as the packaged twin entries).
   const portRaw = options.port ?? process.env.PORT ?? "3333";
   const port = Number(portRaw);
-  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+  // Port 0 (ephemeral) is rejected: every printed URL and the status-file
+  // token would name a port nobody can discover from outside the process.
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
     throw new Error(`pome twin start: invalid --port "${portRaw}"`);
   }
 

--- a/cli/src/twin/twinStart.ts
+++ b/cli/src/twin/twinStart.ts
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// `pome twin start <twin>` (F-709) — the docker-free front door. Boots any
+// of the three twins as a long-lived foreground server (Ctrl-C to stop) on
+// the same in-process boot path `pome run --local` uses (`bootTwin`), so
+// `npx @pome-sh/cli twin start github` serves the identical control plane
+// the packaged twin entries serve, with zero installs beyond Node ≥ 24.
+//
+// Auth: the twin's bearer middleware reads `TWIN_AUTH_SECRET` from the env
+// (engine contract). The CLI resolves the secret the same way an operator
+// would — an env-injected `TWIN_AUTH_SECRET` always wins, else the secret a
+// prior twin boot persisted at `.pome-data/<twin>/secret` (F-708 write side;
+// `POME_TWIN_DATA_DIR` overrides the directory) is reused, else a per-boot
+// ephemeral secret is generated. Loopback binds deliberately do NOT persist
+// a new secret file — that mirrors F-708's loopback carve-out, and the
+// ready-to-use JWT is reprinted on every boot anyway.
+
+import { randomBytes } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { serve } from "@hono/node-server";
+import { sign } from "hono/jwt";
+import { defaultSeedState as defaultSlackSeedState } from "@pome-sh/twin-slack";
+import { defaultSeed as defaultStripeSeed } from "@pome-sh/twin-stripe";
+import { bootTwin } from "./twinHarness.js";
+
+export const SUPPORTED_STANDALONE_TWINS = ["github", "slack", "stripe"] as const;
+
+/** The fixed session id a standalone twin serves under (`/s/standalone`). */
+const STANDALONE_SID = "standalone";
+
+export type StandaloneAuthSecret = {
+  secret: string;
+  source: "env" | "persisted" | "ephemeral";
+  /** Set when `source` is "persisted": the file the secret was read from. */
+  path?: string;
+};
+
+/**
+ * Read side of the F-708 secret contract. Resolution order:
+ *   1. env `TWIN_AUTH_SECRET` (always wins — same rule as the twin boots)
+ *   2. the persisted `.pome-data/<twin>/secret` (`POME_TWIN_DATA_DIR`
+ *      overrides the directory); blank file = absent, < 32 chars = loud
+ *      error (never mint against a weak HS256 key, never guess)
+ *   3. a fresh per-boot secret, NOT persisted (loopback dev path)
+ */
+export function resolveStandaloneAuthSecret(
+  twin: string,
+  env: NodeJS.ProcessEnv = process.env,
+): StandaloneAuthSecret {
+  const injected = env.TWIN_AUTH_SECRET;
+  if (injected) return { secret: injected, source: "env" };
+
+  const dataDir = env.POME_TWIN_DATA_DIR || join(".pome-data", twin);
+  const secretPath = join(dataDir, "secret");
+  let raw: string | undefined;
+  try {
+    raw = readFileSync(secretPath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
+  const persisted = raw?.trim() ?? "";
+  if (persisted.length >= 32) {
+    return { secret: persisted, source: "persisted", path: secretPath };
+  }
+  if (persisted.length > 0) {
+    // Same rule as the engine's readSecretFile (F-708): a short secret is
+    // operator content we must not silently serve or regenerate over.
+    throw new Error(
+      `The persisted secret at ${secretPath} is shorter than 32 chars — fix or delete the file, or inject TWIN_AUTH_SECRET.`,
+    );
+  }
+  return { secret: randomBytes(32).toString("hex"), source: "ephemeral" };
+}
+
+function defaultSeedFor(twin: string): unknown {
+  switch (twin) {
+    case "slack":
+      return defaultSlackSeedState();
+    case "stripe":
+      return defaultStripeSeed();
+    default:
+      // github: bootTwin's adapter seeds the default world when the seed is
+      // undefined (pre-existing standalone behavior).
+      return undefined;
+  }
+}
+
+export async function runTwinStartCommand(
+  name: string,
+  options: { port?: string },
+): Promise<void> {
+  if (!(SUPPORTED_STANDALONE_TWINS as readonly string[]).includes(name)) {
+    throw new Error(
+      `Unknown twin '${name}'. Supported: ${SUPPORTED_STANDALONE_TWINS.join(", ")}.`,
+    );
+  }
+  // `PORT` fallback keeps the spawn surface env-drivable (the contract
+  // suite injects PORT, same as the packaged twin entries).
+  const portRaw = options.port ?? process.env.PORT ?? "3333";
+  const port = Number(portRaw);
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    throw new Error(`pome twin start: invalid --port "${portRaw}"`);
+  }
+
+  const resolved = resolveStandaloneAuthSecret(name);
+  // The in-process twin's auth middleware (resolveAuthSecret) reads the env;
+  // pinning the resolved secret here is what makes the minted JWT and the
+  // running twin agree.
+  process.env.TWIN_AUTH_SECRET = resolved.secret;
+
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const harness = await bootTwin({
+    twin: name,
+    seedState: defaultSeedFor(name),
+    runId: STANDALONE_SID,
+    twinBaseUrl: baseUrl,
+  });
+  const token = await sign(
+    {
+      sid: STANDALONE_SID,
+      team_id: "tm_local",
+      // Same claims `pome run --local` mints: `login` so the GitHub REST
+      // merge gate resolves the agent user; twin-supplied extras (stripe's
+      // `account_id`) so the token lands on the seeded account.
+      login: "pome-agent",
+      ...(harness.extraClaims ?? {}),
+      exp: Math.floor(Date.now() / 1000) + 60 * 60 * 24,
+    },
+    resolved.secret,
+  );
+
+  const restUrl = `${baseUrl}/s/${STANDALONE_SID}`;
+  const mcpUrl = `${restUrl}/mcp`;
+  const server = serve({ fetch: harness.app.fetch, port, hostname: "127.0.0.1" });
+
+  await mkdir(".pome", { recursive: true });
+  await writeFile(
+    ".pome/twin-status.json",
+    JSON.stringify(
+      { name, url: restUrl, rest_url: restUrl, mcp_url: mcpUrl, auth_token: token },
+      null,
+      2,
+    ),
+  );
+
+  console.log(`Pome ${name} twin listening at ${restUrl}`);
+  if (resolved.source === "persisted") {
+    console.log(
+      `Auth: using the persisted secret from ${resolved.path} (an env-injected TWIN_AUTH_SECRET overrides it).`,
+    );
+  }
+  console.log(`POME_${harness.envName}_REST_URL=${restUrl}`);
+  console.log(`POME_${harness.envName}_MCP_URL=${mcpUrl}`);
+  console.log(`POME_AUTH_TOKEN=${token}`);
+  // F28 — every `/s/<sid>/*` endpoint requires a Bearer JWT, including
+  // /s/standalone/healthz. New users curling the printed `${restUrl}` get
+  // HTTP 401 and assume the twin is broken. The unauth liveness probe lives
+  // at the root `/healthz`. Print the curl command so copy-paste debugging
+  // works without a JWT.
+  console.log(`Health check (no auth): curl ${baseUrl}/healthz`);
+  console.log("Ctrl-C to stop.");
+
+  // Foreground server: the bound socket keeps the event loop alive until a
+  // signal lands. Graceful path closes the listener, then flushes the
+  // recorder and releases the SQLite handle via the harness.
+  const shutdown = () => {
+    void (async () => {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      await harness.close();
+      process.exit(0);
+    })();
+  };
+  process.once("SIGINT", shutdown);
+  process.once("SIGTERM", shutdown);
+}

--- a/cli/src/twin/twinStart.ts
+++ b/cli/src/twin/twinStart.ts
@@ -137,15 +137,23 @@ export async function runTwinStartCommand(
   const mcpUrl = `${restUrl}/mcp`;
   const server = serve({ fetch: harness.app.fetch, port, hostname: "127.0.0.1" });
 
-  await mkdir(".pome", { recursive: true });
-  await writeFile(
-    ".pome/twin-status.json",
-    JSON.stringify(
-      { name, url: restUrl, rest_url: restUrl, mcp_url: mcpUrl, auth_token: token },
-      null,
-      2,
-    ),
-  );
+  try {
+    await mkdir(".pome", { recursive: true });
+    await writeFile(
+      ".pome/twin-status.json",
+      JSON.stringify(
+        { name, url: restUrl, rest_url: restUrl, mcp_url: mcpUrl, auth_token: token },
+        null,
+        2,
+      ),
+    );
+  } catch (err) {
+    // Boot fails loudly or not at all: without this, the rejection leaves a
+    // bound listener keeping the process alive behind the error message.
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await harness.close();
+    throw err;
+  }
 
   console.log(`Pome ${name} twin listening at ${restUrl}`);
   if (resolved.source === "persisted") {
@@ -169,6 +177,13 @@ export async function runTwinStartCommand(
   // recorder and releases the SQLite handle via the harness.
   const shutdown = () => {
     void (async () => {
+      // `close()` alone waits for in-flight keep-alive connections, so a
+      // stuck client would turn Ctrl-C into a hang: sever connections first,
+      // and keep an unref'd hard deadline in case a close callback never
+      // resolves anyway.
+      const hardExit = setTimeout(() => process.exit(1), 10_000);
+      hardExit.unref();
+      (server as { closeAllConnections?: () => void }).closeAllConnections?.();
       await new Promise<void>((resolve) => server.close(() => resolve()));
       await harness.close();
       process.exit(0);

--- a/cli/test/e2e/twinStart.test.ts
+++ b/cli/test/e2e/twinStart.test.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// F-709 acceptance — `pome twin start` as a real child process: boots the
+// twin as a foreground server, reuses the secret persisted at the F-708
+// contract location (POME_TWIN_DATA_DIR override), and both the JWT it
+// prints AND a JWT minted from the persisted secret authenticate against
+// the running twin. Ctrl-C (SIGINT) stops it cleanly. The frozen control
+// plane itself is asserted by contract/cli-start.test.mjs; this test owns
+// the secret read path + the printed-token journey.
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { once } from "node:events";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { sign } from "hono/jwt";
+import { afterEach, describe, expect, it } from "vitest";
+
+const CLI_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+const TSX_BIN = join(CLI_ROOT, "node_modules", ".bin", "tsx");
+const MAIN_TS = join(CLI_ROOT, "src", "cli", "main.ts");
+const PERSISTED_SECRET = "e2e-persisted-secret-0123456789abcdef";
+
+async function freePort(): Promise<number> {
+  const srv = createServer();
+  srv.listen(0, "127.0.0.1");
+  await once(srv, "listening");
+  const { port } = srv.address() as { port: number };
+  await new Promise((resolve) => srv.close(resolve));
+  return port;
+}
+
+let child: ChildProcess | undefined;
+
+afterEach(() => {
+  child?.kill("SIGKILL");
+  child = undefined;
+});
+
+describe("pome twin start (e2e)", () => {
+  it(
+    "serves /healthz, honors the persisted secret, and stops on SIGINT",
+    async () => {
+      const cwd = await mkdtemp(join(tmpdir(), "pome-twin-start-e2e-"));
+      const dataDir = join(cwd, "twin-data");
+      await mkdir(dataDir, { recursive: true });
+      await writeFile(join(dataDir, "secret"), `${PERSISTED_SECRET}\n`);
+
+      const port = await freePort();
+      const env = { ...process.env, POME_TWIN_DATA_DIR: dataDir };
+      delete env.TWIN_AUTH_SECRET; // the persisted-file branch under test
+      child = spawn(TSX_BIN, [MAIN_TS, "twin", "start", "github", "--port", String(port)], {
+        cwd,
+        env,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      let output = "";
+      child.stdout?.on("data", (chunk) => { output += chunk; });
+      child.stderr?.on("data", (chunk) => { output += chunk; });
+      const exited = new Promise<number | null>((resolve) => child?.once("exit", (code) => resolve(code)));
+
+      const base = `http://127.0.0.1:${port}`;
+      const deadline = Date.now() + 60_000;
+      for (;;) {
+        try {
+          const res = await fetch(`${base}/healthz`);
+          if (res.status === 200) break;
+        } catch {
+          // not listening yet
+        }
+        if (Date.now() > deadline) {
+          throw new Error(`twin start never answered /healthz 200\n--- output ---\n${output}`);
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+
+      expect(output).toContain(`using the persisted secret from ${join(dataDir, "secret")}`);
+
+      // A JWT minted from the persisted secret authenticates (the CLI and
+      // the running twin resolved the same secret).
+      const minted = await sign(
+        { sid: "standalone", team_id: "tm_local", exp: Math.floor(Date.now() / 1000) + 3600 },
+        PERSISTED_SECRET,
+      );
+      const viaFileSecret = await fetch(`${base}/s/standalone/_pome/health`, {
+        headers: { Authorization: `Bearer ${minted}` },
+      });
+      expect(viaFileSecret.status).toBe(200);
+
+      // The ready-to-use token the command prints works as printed.
+      const printed = output.match(/POME_AUTH_TOKEN=(\S+)/)?.[1];
+      expect(printed).toBeTruthy();
+      const viaPrintedToken = await fetch(`${base}/s/standalone/_pome/health`, {
+        headers: { Authorization: `Bearer ${printed}` },
+      });
+      expect(viaPrintedToken.status).toBe(200);
+
+      // Foreground contract: Ctrl-C stops the server and exits 0.
+      child.kill("SIGINT");
+      await expect(exited).resolves.toBe(0);
+    },
+    90_000,
+  );
+});

--- a/cli/test/e2e/twinStart.test.ts
+++ b/cli/test/e2e/twinStart.test.ts
@@ -48,7 +48,7 @@ describe("pome twin start (e2e)", () => {
       await writeFile(join(dataDir, "secret"), `${PERSISTED_SECRET}\n`);
 
       const port = await freePort();
-      const env = { ...process.env, POME_TWIN_DATA_DIR: dataDir };
+      const env: NodeJS.ProcessEnv = { ...process.env, POME_TWIN_DATA_DIR: dataDir };
       delete env.TWIN_AUTH_SECRET; // the persisted-file branch under test
       child = spawn(TSX_BIN, [MAIN_TS, "twin", "start", "github", "--port", String(port)], {
         cwd,

--- a/cli/test/unit/twinStartSecret.test.ts
+++ b/cli/test/unit/twinStartSecret.test.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// F-709 — read side of the F-708 secret contract in `pome twin start`:
+// env-injected TWIN_AUTH_SECRET always wins, else the persisted
+// `.pome-data/<twin>/secret` (POME_TWIN_DATA_DIR overrides the directory)
+// is reused, else a per-boot ephemeral secret. Blank file = absent; a
+// present-but-short secret fails loudly (mirrors the engine's
+// readSecretFile rule — never mint against a weak HS256 key).
+
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveStandaloneAuthSecret } from "../../src/twin/twinStart.js";
+
+const PERSISTED = "0123456789abcdef0123456789abcdef";
+
+async function dataDirWithSecret(contents?: string) {
+  const dir = await mkdtemp(join(tmpdir(), "pome-twin-start-secret-"));
+  if (contents !== undefined) await writeFile(join(dir, "secret"), contents);
+  return dir;
+}
+
+describe("resolveStandaloneAuthSecret", () => {
+  it("an env-injected TWIN_AUTH_SECRET wins over a persisted secret", async () => {
+    const dir = await dataDirWithSecret(`${PERSISTED}\n`);
+    const resolved = resolveStandaloneAuthSecret("github", {
+      TWIN_AUTH_SECRET: "env-injected-secret",
+      POME_TWIN_DATA_DIR: dir,
+    });
+    expect(resolved).toEqual({ secret: "env-injected-secret", source: "env" });
+  });
+
+  it("reads the persisted secret (trimmed) when the env is unset", async () => {
+    const dir = await dataDirWithSecret(`${PERSISTED}\n`);
+    const resolved = resolveStandaloneAuthSecret("github", { POME_TWIN_DATA_DIR: dir });
+    expect(resolved).toEqual({
+      secret: PERSISTED,
+      source: "persisted",
+      path: join(dir, "secret"),
+    });
+  });
+
+  it("generates an ephemeral 32-byte hex secret when nothing is persisted", async () => {
+    const dir = await dataDirWithSecret();
+    const first = resolveStandaloneAuthSecret("github", { POME_TWIN_DATA_DIR: dir });
+    const second = resolveStandaloneAuthSecret("github", { POME_TWIN_DATA_DIR: dir });
+    expect(first.source).toBe("ephemeral");
+    expect(first.secret).toMatch(/^[0-9a-f]{64}$/);
+    // Per-boot, never persisted: two resolutions never agree.
+    expect(second.secret).not.toBe(first.secret);
+  });
+
+  it("treats a blank persisted file as absent", async () => {
+    const dir = await dataDirWithSecret("\n");
+    const resolved = resolveStandaloneAuthSecret("github", { POME_TWIN_DATA_DIR: dir });
+    expect(resolved.source).toBe("ephemeral");
+  });
+
+  it("refuses a persisted secret shorter than 32 chars", async () => {
+    const dir = await dataDirWithSecret("too-short\n");
+    expect(() =>
+      resolveStandaloneAuthSecret("github", { POME_TWIN_DATA_DIR: dir }),
+    ).toThrow(/shorter than 32 chars/);
+  });
+
+  it("defaults the data dir to .pome-data/<twin> (cwd-relative contract location)", () => {
+    // No file exists at the contract location in the test cwd — the resolver
+    // must fall through to ephemeral rather than throw on ENOENT.
+    const resolved = resolveStandaloneAuthSecret("definitely-not-a-twin", {});
+    expect(resolved.source).toBe("ephemeral");
+  });
+});

--- a/contract/cli-start.test.mjs
+++ b/contract/cli-start.test.mjs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// CLI front-door contract suite (F-709). Runs the same frozen FDRS-711
+// assertions against twins started via `pome twin start <twin>` — the
+// docker-free quickstart path — instead of the packaged boot entries. The
+// CLI boots the twins in-process (cli/src/twin/twinHarness.ts) from its
+// @pome-sh/* dependencies, so this suite is the proof that the front door
+// serves the identical control plane + admin surface CONTRACT.md freezes.
+//
+// Prerequisite: a built CLI (`cd cli && npm ci && npm run build`) — chained
+// by cli-ci.yml, NOT by the root `test:contract` script (the CLI is not a
+// root workspace). Run locally with `node --test contract/cli-start.test.mjs`.
+//
+// bootGuardCase is deliberately absent: `pome twin start` binds loopback
+// only, so the F-708 non-loopback self-generation guard lives with the
+// packaged entries (contract.test.mjs). The CLI's read side of the secret
+// contract (env wins → persisted `.pome-data/<twin>/secret` → ephemeral)
+// is covered by the CLI's own unit + e2e suites.
+
+import { describe } from "node:test";
+import { PER_TWIN, adminGateCase, contractSuite } from "./suite.mjs";
+
+// `PORT` env drives the bind (twin start falls back to $PORT before 3333),
+// TWIN_AUTH_SECRET env-injection wins over any persisted secret, and the
+// db env vars keep the github twin on :memory: (slack/stripe already are).
+// The 3s healthz bound is the packaged-entry contract; the CLI front door
+// loads the full CLI import graph first, so it gets a looser 15s bound.
+const cliStart = (name, dbEnv) => ({
+  name,
+  pkg: "cli",
+  dbEnv,
+  entry: "cli/dist/src/cli/main.js",
+  args: ["twin", "start", name],
+  healthzDeadlineMs: 15_000,
+});
+
+const TWINS = [
+  cliStart("github", "GITHUB_CLONE_DB"),
+  cliStart("slack", "SLACK_CLONE_DB"),
+  cliStart("stripe", "STRIPE_CLONE_DB"),
+];
+
+for (const twin of TWINS) {
+  contractSuite(twin, PER_TWIN[twin.name], `${twin.name} (pome twin start)`);
+}
+
+describe("contract: pome twin start — admin gate token mode", () => {
+  for (const twin of TWINS) {
+    adminGateCase(twin, `${twin.name} (pome twin start)`);
+  }
+});

--- a/contract/helpers.mjs
+++ b/contract/helpers.mjs
@@ -65,15 +65,16 @@ export async function freePort() {
 }
 
 // A twin descriptor may carry an `entry` (repo-root-relative) to boot an
-// alternate server entry — used by the sdk-boot proof suite (FDRS-681).
-// Default is the contract's own `dist/src/server.js`.
+// alternate server entry — used by the sdk-boot proof suite (FDRS-681) and
+// the CLI front-door suite (F-709), which also appends `args` (e.g.
+// `twin start github`). Default is the contract's own `dist/src/server.js`.
 function entryArgs(twin) {
   if (twin.entry && TWIN_PKG_ROOT_OVERRIDE) {
     // Alternate entries (the sdk-boot proof suite) resolve inside this repo;
     // they cannot be rerouted through an external package root.
     throw new Error("CONTRACT_TWIN_PKG_ROOT cannot be combined with an alternate twin entry");
   }
-  return [twin.entry ? path.join(REPO_ROOT, twin.entry) : "dist/src/server.js"];
+  return [twin.entry ? path.join(REPO_ROOT, twin.entry) : "dist/src/server.js", ...(twin.args ?? [])];
 }
 
 // Package root the twin is spawned from: the repo-relative workspace dist by
@@ -88,7 +89,7 @@ function twinCwd(twin) {
  * with cwd = the package root. Resolves once GET /healthz answers 200, which
  * the contract requires within 3 seconds of spawn.
  */
-export async function spawnTwin(twin, { env = {}, port: portIn, healthzDeadlineMs = 3_000 } = {}) {
+export async function spawnTwin(twin, { env = {}, port: portIn, healthzDeadlineMs = twin.healthzDeadlineMs ?? 3_000 } = {}) {
   const port = portIn ?? (await freePort());
   const cwd = twinCwd(twin);
   // Plain `node` from PATH, never process.execPath: the contract is the cloud's


### PR DESCRIPTION
<!-- Closes F-709 -->

Executive summary: `pome twin start <twin>` now boots any of the three twins (github, slack, stripe) as a long-lived foreground server on the same in-process boot path `pome run --local` uses, so `npx @pome-sh/cli twin start github` is a zero-install quickstart on any machine with Node ≥ 24. The command resolves the twin auth secret operator-style — env-injected `TWIN_AUTH_SECRET` always wins, else the secret persisted at `.pome-data/<twin>/secret` is reused — and prints a ready-to-use JWT. The frozen M1 runtime-contract suite now also runs against twins started this way, proving the front door serves the identical control plane.

## What
The github-only MSP `twin start` scaffolding in `cli/main.ts` is replaced by `cli/src/twin/twinStart.ts`: validates the twin name, resolves the auth secret (env → persisted `.pome-data/<twin>/secret` with `POME_TWIN_DATA_DIR` override → per-boot ephemeral), boots via the existing `bootTwin` harness with each twin's default seed, serves foreground on 127.0.0.1 (`--port`, falling back to `$PORT` then 3333), prints REST/MCP URLs + a 24h JWT + the unauth healthz curl line, and shuts down cleanly on SIGINT/SIGTERM (recorder flush + SQLite close). New `contract/cli-start.test.mjs` runs the frozen contract assertions + admin-gate case against `pome twin start` for all three twins (wired into cli-ci); `contract/helpers.mjs` learns arg-carrying entries and per-descriptor healthz deadlines to support it.

## Why
M4 (docker-free front door): the emulate move is `npx <cli>` as the zero-install quickstart, and this ticket owns the CLI front-door command. It is the read side of the F-708 secret contract — the write side (self-generation on non-loopback twin boots) landed in #109.

## Notes for reviewer
- **Loopback binds do not persist a new secret file** — that mirrors #109's deliberate loopback carve-out. When no env and no file exist, the secret is per-boot ephemeral and the printed JWT is reprinted on every boot. A short (<32 chars) persisted file fails loudly, same rule as the engine's `readSecretFile`.
- Behavior change vs the old MSP command: the github twin's standalone db moves from `.pome/github.db` (persisted across restarts) to the harness default (`GITHUB_CLONE_DB` env or `:memory:`), matching slack/stripe and `pome run --local` semantics. `twin reset` / `twin status` are untouched.
- The CLI-start contract suite gets a 15s healthz bound (vs the packaged entries' frozen 3s) because the CLI loads its full import graph first; the packaged-entry bound is unchanged.
- No wire/contract change: CONTRACT.md untouched; the point of `cli-start.test.mjs` is asserting exactly that.

## Tests / CI
- New: `cli/test/unit/twinStartSecret.test.ts` (env wins / persisted read / blank-file = absent / short-file error / ephemeral fallback), `cli/test/e2e/twinStart.test.ts` (spawned CLI serves /healthz, persisted-secret JWT + printed token both authenticate, SIGINT exits 0), `contract/cli-start.test.mjs` (43 pass, 0 fail locally).
- Local: cli `npm run typecheck`, `npm run build`, `npm test` (593 tests / 77 files); root `npm run test:contract` (69 pass — helpers.mjs change is regression-free); code-health / dead-code / no-eval / copy-marker / no-cloud-imports gates green.
- Changeset: minor (`cli/.changeset/tidy-donuts-serve.md`) — satisfies the CLI version-bump gate.

## Review required
Yes — touches self-host packaging (the published CLI's quickstart surface) and the auth-secret read path.