### PR TITLE
feat(fidelity): shared fidelity:parity runner + structured per-twin inventories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,5 +55,10 @@ jobs:
       # so `@pome-sh/sdk/server` (dist) resolves when the contract runner boots
       # the twins.
       - run: npm run test:contract
+      # F-730 — fidelity:parity in all three twins: the shared sdk runner
+      # asserts live tool list === fidelity.inventory.json === scenario
+      # coverage, and drives every tool through POST /s/:sid/mcp/call.
+      # Reuses the build above (`@pome-sh/sdk/parity` resolves from dist).
+      - run: npm run fidelity:parity -w @pome-sh/twin-github -w @pome-sh/twin-slack -w @pome-sh/twin-stripe
       # Twin Fidelity Watch (tools/fidelity) moved to pome-cloud
       # (packages/fidelity-watch) — it owns status.pome.sh now.

--- a/knip.json
+++ b/knip.json
@@ -36,6 +36,10 @@
       "entry": ["src/index.ts", "src/server.ts", "scripts/**/*.ts"],
       "project": ["src/**/*.ts", "test/**/*.ts", "scripts/**/*.ts"]
     },
+    "packages/sdk": {
+      "entry": ["src/index.ts", "src/server.ts", "src/parity.ts", "scripts/**/*.ts"],
+      "project": ["src/**/*.ts", "test/**/*.ts", "scripts/**/*.ts"]
+    },
     "cli": {
       "entry": [
         "src/cli/main.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -8,7 +8,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" },
-    "./server": { "types": "./dist/server.d.ts", "default": "./dist/server.js" }
+    "./server": { "types": "./dist/server.d.ts", "default": "./dist/server.js" },
+    "./parity": { "types": "./dist/parity.d.ts", "default": "./dist/parity.js" }
   },
   "publishConfig": { "access": "public" },
   "repository": {

--- a/packages/sdk/src/fidelity-inventory.ts
+++ b/packages/sdk/src/fidelity-inventory.ts
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Structured fidelity inventory (F-730). Each twin ships a machine-readable
+// surface list — `fidelity.inventory.json` — carrying, per MCP tool and REST
+// surface, the heat tier (how deep the endpoint SHOULD be, ruled by the
+// F-729 rubric) orthogonal to the fidelity tier (how deep it IS, per
+// `fidelityTierSchema`), plus a justification for the classification.
+//
+// The FIDELITY doc tables are 1:1-linted against this inventory instead of
+// the old soft "docs mention the tool name" checks (which let twin-stripe's
+// implemented-but-undocumented refunds drift by silently). Known, ticketed
+// doc gaps are declared in `doc_drift`: the lint accepts exactly those
+// gaps and fails loudly once the docs catch up, so a declaration can never
+// outlive the drift it describes.
+
+import { readFileSync } from "node:fs";
+import { z } from "zod";
+import { fidelityTierSchema } from "./index.js";
+
+export const heatTierSchema = z.enum(["hot", "warm", "cold", "unclassified"]);
+export type HeatTier = z.infer<typeof heatTierSchema>;
+
+export const fidelitySurfaceSchema = z.strictObject({
+  /** MCP tool name, or the REST surface string exactly as documented. */
+  name: z.string().min(1),
+  heat: heatTierSchema,
+  fidelity: fidelityTierSchema,
+  justification: z.string().min(1),
+});
+export type FidelitySurface = z.infer<typeof fidelitySurfaceSchema>;
+
+export const fidelityDocDriftSchema = z.strictObject({
+  kind: z.enum(["tool", "rest"]),
+  /** Must match an inventory entry of the same kind. */
+  name: z.string().min(1),
+  reason: z.string().min(1),
+  /** The Linear ticket that owns reconciling the docs. */
+  ticket: z.string().regex(/^F-\d+$/),
+});
+export type FidelityDocDrift = z.infer<typeof fidelityDocDriftSchema>;
+
+export const fidelityInventorySchema = z.strictObject({
+  twin: z.string().min(1),
+  package: z.string().min(1),
+  /** ISO date (YYYY-MM-DD) of the last human review of this inventory. */
+  updated: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  notes: z.string().optional(),
+  tools: z.array(fidelitySurfaceSchema).min(1),
+  rest: z.array(fidelitySurfaceSchema),
+  doc_drift: z.array(fidelityDocDriftSchema).default([]),
+});
+export type FidelityInventory = z.infer<typeof fidelityInventorySchema>;
+
+export function loadFidelityInventory(path: string): FidelityInventory {
+  return fidelityInventorySchema.parse(JSON.parse(readFileSync(path, "utf8")));
+}
+
+// ─── FIDELITY doc table parsing ──────────────────────────────────────────────
+
+export interface FidelityDocRow {
+  name: string;
+  fidelity: string;
+}
+
+export interface FidelityDocSource {
+  /** Shown in lint problems, e.g. "FIDELITY.md". */
+  label: string;
+  kind: "tool" | "rest";
+  markdown: string;
+}
+
+const TOOL_NAME_HEADERS = new Set(["tool"]);
+const REST_NAME_HEADERS = new Set(["route", "endpoint", "surface"]);
+
+function splitTableRow(line: string): string[] {
+  return line
+    .replace(/^\s*\|/, "")
+    .replace(/\|\s*$/, "")
+    .split("|")
+    .map((cell) => cell.trim());
+}
+
+function isSeparatorRow(cells: string[]): boolean {
+  return cells.every((cell) => /^:?-{3,}:?$/.test(cell));
+}
+
+/**
+ * Expand one name cell into surface names. Backticked spans are the names;
+ * a span with no `.`, `/`, or space is shorthand for a sibling of the first
+ * span (Slack-style `` `reactions.add` / `remove` / `get` ``) and inherits
+ * its dotted prefix. Cells with no backticks name the surface verbatim
+ * (e.g. "Any unsupported path").
+ */
+export function expandSurfaceCell(cell: string): string[] {
+  const spans = [...cell.matchAll(/`([^`]+)`/g)].map((match) => match[1].trim());
+  if (spans.length === 0) {
+    const text = cell.trim();
+    return text.length > 0 ? [text] : [];
+  }
+  const [first, ...rest] = spans;
+  const lastDot = first.lastIndexOf(".");
+  const prefix = lastDot >= 0 ? first.slice(0, lastDot + 1) : "";
+  return [
+    first,
+    ...rest.map((span) =>
+      /[./ ]/.test(span) || prefix === "" ? span : `${prefix}${span}`
+    ),
+  ];
+}
+
+/** Parse every markdown table whose header names surfaces of `kind` + Tier. */
+export function parseFidelityDocRows(markdown: string, kind: "tool" | "rest"): FidelityDocRow[] {
+  const nameHeaders = kind === "tool" ? TOOL_NAME_HEADERS : REST_NAME_HEADERS;
+  const rows: FidelityDocRow[] = [];
+  const lines = markdown.split("\n");
+  let nameIdx = -1;
+  let tierIdx = -1;
+  let inTable = false;
+  for (const line of lines) {
+    if (!line.trimStart().startsWith("|")) {
+      inTable = false;
+      nameIdx = -1;
+      tierIdx = -1;
+      continue;
+    }
+    const cells = splitTableRow(line);
+    if (!inTable) {
+      const headers = cells.map((cell) => cell.toLowerCase());
+      nameIdx = headers.findIndex((header) => nameHeaders.has(header));
+      tierIdx = headers.findIndex((header) => header === "tier");
+      inTable = true;
+      continue;
+    }
+    if (isSeparatorRow(cells) || nameIdx < 0 || tierIdx < 0) continue;
+    const fidelity = cells[tierIdx] ?? "";
+    for (const name of expandSurfaceCell(cells[nameIdx] ?? "")) {
+      rows.push({ name, fidelity });
+    }
+  }
+  return rows;
+}
+
+// ─── Lint: inventory ⇔ docs, both directions ─────────────────────────────────
+
+/**
+ * 1:1-lint the inventory against the FIDELITY doc tables. Returns human-
+ * readable problems (empty = clean). Directions checked per kind:
+ * every doc row must be in the inventory with the same fidelity tier, and
+ * every inventory entry must be documented unless a `doc_drift` entry
+ * (with its owning ticket) declares the gap. A drift declaration whose
+ * name IS documented is stale and reported, so drift entries self-expire.
+ */
+export function lintFidelityInventory(
+  inventory: FidelityInventory,
+  docs: FidelityDocSource[]
+): string[] {
+  const problems: string[] = [];
+  for (const kind of ["tool", "rest"] as const) {
+    const sources = docs.filter((doc) => doc.kind === kind);
+    if (sources.length === 0) continue;
+    const labels = sources.map((doc) => doc.label).join(", ");
+    const entries = kind === "tool" ? inventory.tools : inventory.rest;
+    const drift = new Map(
+      inventory.doc_drift.filter((d) => d.kind === kind).map((d) => [d.name, d])
+    );
+
+    const inventoryByName = new Map<string, FidelitySurface>();
+    for (const entry of entries) {
+      if (inventoryByName.has(entry.name)) {
+        problems.push(`inventory ${kind} '${entry.name}' is listed twice`);
+      }
+      inventoryByName.set(entry.name, entry);
+    }
+
+    const documented = new Map<string, FidelityDocRow>();
+    for (const source of sources) {
+      for (const row of parseFidelityDocRows(source.markdown, kind)) {
+        documented.set(row.name, row);
+      }
+    }
+
+    for (const [name, row] of documented) {
+      const entry = inventoryByName.get(name);
+      if (!entry) {
+        problems.push(`${labels}: ${kind} '${name}' documented but missing from fidelity.inventory.json`);
+        continue;
+      }
+      if (entry.fidelity !== row.fidelity) {
+        problems.push(
+          `${kind} '${name}': inventory says fidelity '${entry.fidelity}' but ${labels} says '${row.fidelity}'`
+        );
+      }
+    }
+
+    for (const entry of entries) {
+      if (documented.has(entry.name)) continue;
+      const declared = drift.get(entry.name);
+      if (!declared) {
+        problems.push(
+          `${kind} '${entry.name}' is in fidelity.inventory.json but undocumented in ${labels}; add the row or declare doc_drift`
+        );
+      }
+    }
+
+    for (const declared of drift.values()) {
+      if (!inventoryByName.has(declared.name)) {
+        problems.push(
+          `doc_drift ${kind} '${declared.name}' (${declared.ticket}) matches no inventory entry`
+        );
+      }
+      if (documented.has(declared.name)) {
+        problems.push(
+          `doc_drift ${kind} '${declared.name}' (${declared.ticket}) is stale — ${labels} now documents it; remove the declaration`
+        );
+      }
+    }
+  }
+  return problems;
+}
+
+/** Set-compare tool names: inventory vs the live `listTools()` surface. */
+export function compareToolNames(
+  inventoryNames: string[],
+  liveNames: string[]
+): { missing: string[]; extra: string[] } {
+  const inventory = new Set(inventoryNames);
+  const live = new Set(liveNames);
+  return {
+    missing: [...live].filter((name) => !inventory.has(name)).sort(),
+    extra: [...inventory].filter((name) => !live.has(name)).sort(),
+  };
+}

--- a/packages/sdk/src/fidelity-inventory.ts
+++ b/packages/sdk/src/fidelity-inventory.ts
@@ -175,6 +175,13 @@ export function lintFidelityInventory(
     const documented = new Map<string, FidelityDocRow>();
     for (const source of sources) {
       for (const row of parseFidelityDocRows(source.markdown, kind)) {
+        const existing = documented.get(row.name);
+        if (existing && existing.fidelity !== row.fidelity) {
+          problems.push(
+            `${labels}: ${kind} '${row.name}' is documented twice with conflicting tiers ('${existing.fidelity}' vs '${row.fidelity}')`
+          );
+          continue;
+        }
         documented.set(row.name, row);
       }
     }

--- a/packages/sdk/src/parity.ts
+++ b/packages/sdk/src/parity.ts
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Shared fidelity:parity runner (F-730). One engine-level runner; each twin
+// supplies declarative scenario data — an ordered, stateful chain of MCP
+// calls with cross-call captures (a PR number, a charge id, a message ts) —
+// plus its structured fidelity inventory. No per-twin runner copies (M1
+// "twin-infra copies: 0" gate).
+//
+// The runner asserts three rings agree before it reports green:
+//   1. live tool list (code truth from listTools())
+//   2. fidelity.inventory.json tools (the machine-readable inventory)
+//   3. scenario step coverage (every inventory tool exercised)
+// and that every step answers its expected status through the frozen
+// `POST /s/:sid/mcp/call` surface. Optional REST probes pin the loud-501
+// unsupported envelope; an optional `live` hook lets a twin compare
+// read-only shapes against the real upstream (e.g. `gh api`).
+
+import { sign } from "hono/jwt";
+import {
+  compareToolNames,
+  type FidelityInventory,
+} from "./fidelity-inventory.js";
+
+export type ParityState = Record<string, unknown>;
+
+export interface ParityStep {
+  tool: string;
+  arguments?: Record<string, unknown> | ((state: ParityState) => Record<string, unknown>);
+  /** Pull cross-call state (ids, numbers, shas) out of the response body. */
+  capture?: (body: unknown, state: ParityState) => void;
+  /** Expected HTTP status; default: any 2xx. */
+  status?: number;
+  /** Extra body assertion; return a problem string to fail the step. */
+  verify?: (body: unknown) => string | undefined;
+}
+
+export interface ParityRestProbe {
+  /** Label in the report, e.g. "unsupported-rest". */
+  surface: string;
+  method?: string;
+  /** Session-relative path, e.g. "/repos/acme/api/actions/runs". */
+  path: string;
+  /** Expected HTTP status. */
+  status: number;
+  /** Assert the body carries a `fidelity: "unsupported"` marker. */
+  expectUnsupportedEnvelope?: boolean;
+}
+
+export interface ParityAppLike {
+  request(path: string | Request, init?: RequestInit): Response | Promise<Response>;
+}
+
+export interface RunParityOptions {
+  app: ParityAppLike;
+  twin: string;
+  inventory: FidelityInventory;
+  /** `listTools()` names from the twin source — the code truth. */
+  liveToolNames: string[];
+  steps: ParityStep[];
+  restProbes?: ParityRestProbe[];
+  /** Session id; default "fidelity-parity". */
+  sid?: string;
+  /** JWT secret; default env TWIN_AUTH_SECRET or the engine dev secret. */
+  secret?: string;
+  /** Extra JWT claims (login, team_id, account_id, ...). */
+  claims?: Record<string, unknown>;
+  /** Applied to every step without its own `verify` (twin error envelopes). */
+  stepVerify?: (body: unknown) => string | undefined;
+  /** Optional live upstream probes; entries are appended to the report. */
+  live?: () => Promise<unknown[]>;
+}
+
+export interface ParityResult {
+  ok: boolean;
+  failures: string[];
+  report: unknown[];
+}
+
+function bodyKeys(body: unknown): string[] {
+  if (Array.isArray(body)) return ["array"];
+  if (body && typeof body === "object") {
+    return Object.keys(body as Record<string, unknown>).sort();
+  }
+  return [];
+}
+
+export async function runFidelityParity(options: RunParityOptions): Promise<ParityResult> {
+  const sid = options.sid ?? "fidelity-parity";
+  const secret = options.secret ?? process.env.TWIN_AUTH_SECRET ?? "dev-only-insecure-secret";
+  const token = await sign(
+    { sid, exp: Math.floor(Date.now() / 1000) + 3600, ...options.claims },
+    secret
+  );
+  const base = `/s/${sid}`;
+  const failures: string[] = [];
+  const report: unknown[] = [];
+
+  // Ring 1 ⇔ ring 2: inventory tools must equal the live tool list.
+  const inventoryNames = options.inventory.tools.map((entry) => entry.name);
+  const inventoryDiff = compareToolNames(inventoryNames, options.liveToolNames);
+  for (const name of inventoryDiff.missing) {
+    failures.push(`tool '${name}' is live in listTools() but missing from fidelity.inventory.json`);
+  }
+  for (const name of inventoryDiff.extra) {
+    failures.push(`tool '${name}' is in fidelity.inventory.json but not in listTools()`);
+  }
+
+  // Ring 2 ⇔ ring 3: every inventory tool needs at least one scenario step.
+  const covered = new Set(options.steps.map((step) => step.tool));
+  for (const name of inventoryNames) {
+    if (!covered.has(name)) failures.push(`no parity scenario step covers tool '${name}'`);
+  }
+  for (const tool of covered) {
+    if (!inventoryNames.includes(tool)) {
+      failures.push(`scenario step calls '${tool}' which is not in fidelity.inventory.json`);
+    }
+  }
+
+  const state: ParityState = {};
+  for (const step of options.steps) {
+    const args =
+      typeof step.arguments === "function" ? step.arguments(state) : step.arguments ?? {};
+    const response = await options.app.request(`${base}/mcp/call`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+      body: JSON.stringify({ tool: step.tool, arguments: args }),
+    });
+    const body: unknown = await response.json().catch(() => ({}));
+    const expected = step.status === undefined ? response.ok : response.status === step.status;
+    if (!expected) {
+      failures.push(
+        `${step.tool}: expected ${step.status ?? "2xx"}, got ${response.status} ${JSON.stringify(body).slice(0, 300)}`
+      );
+    } else {
+      const problem = (step.verify ?? options.stepVerify)?.(body);
+      if (problem) failures.push(`${step.tool}: ${problem}`);
+      step.capture?.(body, state);
+    }
+    report.push({ tool: step.tool, status: response.status, ok: response.ok, keys: bodyKeys(body) });
+  }
+
+  for (const probe of options.restProbes ?? []) {
+    const response = await options.app.request(`${base}${probe.path}`, {
+      method: probe.method ?? "GET",
+      headers: { authorization: `Bearer ${token}` },
+    });
+    const body: unknown = await response.json().catch(() => ({}));
+    if (response.status !== probe.status) {
+      failures.push(`${probe.surface}: expected ${probe.status}, got ${response.status}`);
+    }
+    if (probe.expectUnsupportedEnvelope && !JSON.stringify(body).includes('"fidelity":"unsupported"')) {
+      failures.push(`${probe.surface}: body does not carry the fidelity:"unsupported" envelope`);
+    }
+    report.push({ surface: probe.surface, status: response.status, body });
+  }
+
+  if (options.live) {
+    report.push(...(await options.live()));
+  }
+
+  return { ok: failures.length === 0, failures, report };
+}
+
+/** Script entrypoint: run, print the JSON report, set the exit code. */
+export async function runParityCli(options: RunParityOptions): Promise<ParityResult> {
+  const result = await runFidelityParity(options);
+  console.log(
+    JSON.stringify(
+      {
+        twin: options.twin,
+        tools: options.inventory.tools.length,
+        rest_surfaces: options.inventory.rest.length,
+        ok: result.ok,
+        failures: result.failures,
+        report: result.report,
+      },
+      null,
+      2
+    )
+  );
+  if (!result.ok) {
+    console.error(`fidelity:parity FAILED for ${options.twin} (${result.failures.length} problem(s))`);
+    process.exitCode = 1;
+  }
+  return result;
+}
+
+export {
+  compareToolNames,
+  expandSurfaceCell,
+  fidelityDocDriftSchema,
+  fidelityInventorySchema,
+  fidelitySurfaceSchema,
+  heatTierSchema,
+  lintFidelityInventory,
+  loadFidelityInventory,
+  parseFidelityDocRows,
+} from "./fidelity-inventory.js";
+export type {
+  FidelityDocDrift,
+  FidelityDocRow,
+  FidelityDocSource,
+  FidelityInventory,
+  FidelitySurface,
+  HeatTier,
+} from "./fidelity-inventory.js";

--- a/packages/sdk/test/fidelity-parity.test.ts
+++ b/packages/sdk/test/fidelity-parity.test.ts
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: Apache-2.0
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createApp } from "../src/server.js";
+import {
+  expandSurfaceCell,
+  fidelityInventorySchema,
+  lintFidelityInventory,
+  parseFidelityDocRows,
+  runFidelityParity,
+  type FidelityInventory,
+  type ParityStep,
+} from "../src/parity.js";
+import { TEST_AUTH_SECRET, TEST_SID } from "./_authHelper.js";
+import { toyTwin } from "./_toyTwin.js";
+
+const previousSecret = process.env.TWIN_AUTH_SECRET;
+beforeAll(() => {
+  process.env.TWIN_AUTH_SECRET = TEST_AUTH_SECRET;
+});
+afterAll(() => {
+  if (previousSecret === undefined) delete process.env.TWIN_AUTH_SECRET;
+  else process.env.TWIN_AUTH_SECRET = previousSecret;
+});
+
+const BASELINE = "pre-M5 baseline; heat awaits the F-729 rubric ruling";
+
+function toyInventory(): FidelityInventory {
+  return fidelityInventorySchema.parse({
+    twin: "toy",
+    package: "@pome-sh/toy",
+    updated: "2026-07-11",
+    tools: [
+      { name: "add_item", heat: "unclassified", fidelity: "semantic", justification: BASELINE },
+      { name: "count_items", heat: "unclassified", fidelity: "semantic", justification: BASELINE },
+    ],
+    rest: [
+      { name: "GET /items", heat: "unclassified", fidelity: "semantic", justification: BASELINE },
+    ],
+  });
+}
+
+const TOY_STEPS: ParityStep[] = [
+  {
+    tool: "add_item",
+    arguments: { item: "first" },
+    capture: (body, state) => {
+      state.total = (body as { total?: number }).total;
+    },
+  },
+  {
+    tool: "count_items",
+    verify: (body) =>
+      (body as { count?: number }).count === 1 ? undefined : "expected count 1",
+  },
+];
+
+describe("runFidelityParity", () => {
+  it("is green when live tools, inventory, and scenario coverage agree", async () => {
+    const app = createApp(toyTwin);
+    const result = await runFidelityParity({
+      app,
+      twin: "toy",
+      sid: TEST_SID,
+      secret: TEST_AUTH_SECRET,
+      inventory: toyInventory(),
+      liveToolNames: ["add_item", "count_items"],
+      steps: TOY_STEPS,
+      restProbes: [
+        { surface: "unsupported-rest", path: "/nope/not-a-route", status: 501, expectUnsupportedEnvelope: true },
+      ],
+    });
+    expect(result.failures).toEqual([]);
+    expect(result.ok).toBe(true);
+    expect(result.report).toHaveLength(3);
+  });
+
+  it("fails when the inventory misses a live tool", async () => {
+    const app = createApp(toyTwin);
+    const inventory = toyInventory();
+    inventory.tools = inventory.tools.filter((tool) => tool.name !== "count_items");
+    const result = await runFidelityParity({
+      app,
+      twin: "toy",
+      sid: TEST_SID,
+      secret: TEST_AUTH_SECRET,
+      inventory,
+      liveToolNames: ["add_item", "count_items"],
+      steps: TOY_STEPS,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.failures.join("\n")).toContain("missing from fidelity.inventory.json");
+  });
+
+  it("fails when a scenario leaves an inventory tool uncovered", async () => {
+    const app = createApp(toyTwin);
+    const result = await runFidelityParity({
+      app,
+      twin: "toy",
+      sid: TEST_SID,
+      secret: TEST_AUTH_SECRET,
+      inventory: toyInventory(),
+      liveToolNames: ["add_item", "count_items"],
+      steps: TOY_STEPS.filter((step) => step.tool !== "count_items"),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.failures.join("\n")).toContain("no parity scenario step covers tool 'count_items'");
+  });
+
+  it("fails a step whose response is not the expected status", async () => {
+    const app = createApp(toyTwin);
+    const steps: ParityStep[] = [
+      { tool: "add_item", arguments: {} }, // missing required `item` → 4xx
+      ...TOY_STEPS,
+    ];
+    const result = await runFidelityParity({
+      app,
+      twin: "toy",
+      sid: TEST_SID,
+      secret: TEST_AUTH_SECRET,
+      inventory: toyInventory(),
+      liveToolNames: ["add_item", "count_items"],
+      steps,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.failures.some((failure) => failure.startsWith("add_item: expected 2xx"))).toBe(true);
+  });
+});
+
+describe("expandSurfaceCell", () => {
+  it("expands slack-style shorthand groups against the first span's prefix", () => {
+    expect(expandSurfaceCell("`reactions.add` / `remove` / `get`")).toEqual([
+      "reactions.add",
+      "reactions.remove",
+      "reactions.get",
+    ]);
+  });
+
+  it("keeps fully-qualified spans verbatim", () => {
+    expect(
+      expandSurfaceCell("`users.list` / `users.info` / `users.profile.get`")
+    ).toEqual(["users.list", "users.info", "users.profile.get"]);
+  });
+
+  it("splits multi-route cells and drops prose annotations", () => {
+    expect(expandSurfaceCell("`POST /mcp/call` and `POST /mcp/tools/:name`")).toEqual([
+      "POST /mcp/call",
+      "POST /mcp/tools/:name",
+    ]);
+    expect(expandSurfaceCell("`GET /repos/:owner/:repo/contents/*` (READ)")).toEqual([
+      "GET /repos/:owner/:repo/contents/*",
+    ]);
+  });
+
+  it("returns plain cells verbatim", () => {
+    expect(expandSurfaceCell("Any unsupported path")).toEqual(["Any unsupported path"]);
+  });
+});
+
+const DOC = `
+## MCP Tools
+
+| Tool | Backing surface | Tier | Tests | Known deviations |
+| --- | --- | --- | --- | --- |
+| \`add_item\` | in-memory list | semantic | \`x.test.ts\` | — |
+| \`count_items\` | in-memory list | semantic | \`x.test.ts\` | — |
+
+## REST routes
+
+| Endpoint | Tier | Tests | Notes |
+| --- | --- | --- | --- |
+| \`GET /items\` | semantic | \`x.test.ts\` | — |
+`;
+
+describe("parseFidelityDocRows / lintFidelityInventory", () => {
+  it("parses tool and rest tables by header", () => {
+    expect(parseFidelityDocRows(DOC, "tool")).toEqual([
+      { name: "add_item", fidelity: "semantic" },
+      { name: "count_items", fidelity: "semantic" },
+    ]);
+    expect(parseFidelityDocRows(DOC, "rest")).toEqual([
+      { name: "GET /items", fidelity: "semantic" },
+    ]);
+  });
+
+  it("passes a clean inventory and reports drift in both directions", () => {
+    const docs = [
+      { label: "FIDELITY.md", kind: "tool" as const, markdown: DOC },
+      { label: "FIDELITY.md", kind: "rest" as const, markdown: DOC },
+    ];
+    expect(lintFidelityInventory(toyInventory(), docs)).toEqual([]);
+
+    const missingInInventory = toyInventory();
+    missingInInventory.tools = missingInInventory.tools.slice(0, 1);
+    expect(lintFidelityInventory(missingInInventory, docs).join("\n")).toContain(
+      "'count_items' documented but missing"
+    );
+
+    const undocumented = toyInventory();
+    undocumented.rest.push({
+      name: "POST /items",
+      heat: "unclassified",
+      fidelity: "semantic",
+      justification: BASELINE,
+    });
+    expect(lintFidelityInventory(undocumented, docs).join("\n")).toContain(
+      "'POST /items' is in fidelity.inventory.json but undocumented"
+    );
+  });
+
+  it("accepts declared doc drift and flags it once stale", () => {
+    const docs = [
+      { label: "FIDELITY.md", kind: "tool" as const, markdown: DOC },
+      { label: "FIDELITY.md", kind: "rest" as const, markdown: DOC },
+    ];
+    const inventory = toyInventory();
+    inventory.rest.push({
+      name: "POST /items",
+      heat: "unclassified",
+      fidelity: "semantic",
+      justification: "implemented but not yet documented",
+    });
+    inventory.doc_drift = [
+      { kind: "rest", name: "POST /items", reason: "docs lag the route", ticket: "F-733" },
+    ];
+    expect(lintFidelityInventory(inventory, docs)).toEqual([]);
+
+    // Once the docs cover the surface, the declaration must be removed.
+    const caughtUp = DOC.replace(
+      "| `GET /items` | semantic | `x.test.ts` | — |",
+      "| `GET /items` | semantic | `x.test.ts` | — |\n| `POST /items` | semantic | `x.test.ts` | — |"
+    );
+    const staleDocs = [
+      { label: "FIDELITY.md", kind: "tool" as const, markdown: caughtUp },
+      { label: "FIDELITY.md", kind: "rest" as const, markdown: caughtUp },
+    ];
+    expect(lintFidelityInventory(inventory, staleDocs).join("\n")).toContain("is stale");
+  });
+
+  it("reports fidelity tier mismatches between inventory and docs", () => {
+    const docs = [{ label: "FIDELITY.md", kind: "tool" as const, markdown: DOC }];
+    const inventory = toyInventory();
+    inventory.tools[0].fidelity = "shape";
+    expect(lintFidelityInventory(inventory, docs).join("\n")).toContain(
+      "inventory says fidelity 'shape' but FIDELITY.md says 'semantic'"
+    );
+  });
+});

--- a/packages/sdk/test/fidelity-parity.test.ts
+++ b/packages/sdk/test/fidelity-parity.test.ts
@@ -244,4 +244,15 @@ describe("parseFidelityDocRows / lintFidelityInventory", () => {
       "inventory says fidelity 'shape' but FIDELITY.md says 'semantic'"
     );
   });
+
+  it("reports duplicate doc rows with conflicting tiers instead of last-row-wins", () => {
+    const conflicting = DOC.replace(
+      "| `count_items` | in-memory list | semantic | `x.test.ts` | — |",
+      "| `count_items` | in-memory list | shape | `x.test.ts` | — |\n| `count_items` | in-memory list | semantic | `x.test.ts` | — |"
+    );
+    const docs = [{ label: "FIDELITY.md", kind: "tool" as const, markdown: conflicting }];
+    expect(lintFidelityInventory(toyInventory(), docs).join("\n")).toContain(
+      "documented twice with conflicting tiers ('shape' vs 'semantic')"
+    );
+  });
 });

--- a/packages/twin-github/FIDELITY.md
+++ b/packages/twin-github/FIDELITY.md
@@ -278,8 +278,17 @@ CLI auth available. The fixture set is the contract.
 
 ### 2. MCP parity (`scripts/fidelity-parity.ts`)
 
-`scripts/fidelity-parity.ts` exercises all 62 MCP tools end-to-end against
-a freshly seeded local twin. It runs in two modes:
+`scripts/fidelity-parity.ts` is declarative scenario data for the shared
+engine runner (`@pome-sh/sdk/parity`, F-730): an ordered, stateful call
+chain that exercises every MCP tool end-to-end against a freshly seeded
+local twin. The runner fails unless three rings agree — the live
+`listTools()` surface, the structured inventory
+([`fidelity.inventory.json`](fidelity.inventory.json), which also carries
+the hot/warm/cold heat tier per F-729), and the scenario's tool coverage —
+and every call must answer 2xx through `POST /s/:sid/mcp/call`. The tables
+above are 1:1-linted against the same inventory by
+`test/fidelity-contract.test.ts`, so an implemented-but-undocumented
+surface fails CI instead of drifting silently. It runs in two modes:
 
 - **Local-only** — every tool is invoked locally; success means the contract
   surface is reachable and produces a well-typed response.

--- a/packages/twin-github/fidelity.inventory.json
+++ b/packages/twin-github/fidelity.inventory.json
@@ -1,0 +1,641 @@
+{
+  "twin": "github",
+  "package": "@pome-sh/twin-github",
+  "updated": "2026-07-11",
+  "notes": "Tool surface lints 1:1 against FIDELITY.md; REST surface lints 1:1 against FIDELITY_MATRIX.md (FIDELITY.md documents REST as prose). Heat tiers await the F-729 rubric ruling.",
+  "tools": [
+    {
+      "name": "search_repositories",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "create_repository",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "fork_repository",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "get_repository",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "search_code",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "search_users",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "get_file_contents",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "list_commits",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "create_or_update_file",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "create_branch",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "push_files",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "get_issue",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "update_issue",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "search_issues",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "list_issues",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "add_issue_comment",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "list_issue_comments",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "create_issue",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "list_repository_labels",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "create_label",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "list_issue_labels",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "add_issue_labels",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "remove_issue_label",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "list_collaborators",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "add_assignees",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "get_pull_request",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "get_pull_request_reviews",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "create_pull_request_review",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "get_pull_request_comments",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "get_pull_request_files",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "get_pull_request_status",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "list_pull_requests",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "merge_pull_request",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "update_pull_request_branch",
+      "heat": "unclassified",
+      "fidelity": "shape",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "create_pull_request",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "list_branches",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "get_branch",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "delete_branch",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "delete_file",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "get_commit",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "compare_commits",
+      "heat": "unclassified",
+      "fidelity": "shape",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "get_pull_request_diff",
+      "heat": "unclassified",
+      "fidelity": "shape",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "update_pull_request",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "get_pull_request_commits",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "create_pull_request_review_comment",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "add_reply_to_pull_request_comment",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "update_issue_comment",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "delete_issue_comment",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "list_milestones",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "create_milestone",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "update_milestone",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "delete_milestone",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "create_commit_status",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "get_combined_status_for_ref",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "create_check_run",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "list_check_runs_for_ref",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "list_tags",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "list_releases",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "get_latest_release",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "create_release",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "get_me",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "add_collaborator",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    }
+  ],
+  "rest": [
+    {
+      "name": "GET /repos/:owner/:repo",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /repos/:owner/:repo/issues",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "POST /repos/:owner/:repo/issues",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /repos/:owner/:repo/issues/:number",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "PATCH /repos/:owner/:repo/issues/:number",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "PATCH /repos/:owner/:repo/issues/comments/:comment_id",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "DELETE /repos/:owner/:repo/issues/comments/:comment_id",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /repos/:owner/:repo/collaborators",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /repos/:owner/:repo/collaborators/:username",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "PUT /repos/:owner/:repo/collaborators/:username",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /repos/:owner/:repo/pulls",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "POST /repos/:owner/:repo/pulls",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "PATCH /repos/:owner/:repo/pulls/:number",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /repos/:owner/:repo/pulls/:number/*",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /repos/:owner/:repo/pulls/:number/commits",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /repos/:owner/:repo/pulls/:number/diff",
+      "heat": "unclassified",
+      "fidelity": "shape",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "POST /repos/:owner/:repo/pulls/:number/comments",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "POST /repos/:owner/:repo/pulls/:number/comments/:comment_id/replies",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /repos/:owner/:repo/branches",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /repos/:owner/:repo/branches/:branch",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "DELETE /repos/:owner/:repo/git/refs/heads/:branch",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /repos/:owner/:repo/contents/*",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "PUT /repos/:owner/:repo/contents/*",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "DELETE /repos/:owner/:repo/contents/*",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /repos/:owner/:repo/commits/:ref",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /repos/:owner/:repo/compare/:basehead",
+      "heat": "unclassified",
+      "fidelity": "shape",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "POST /repos/:owner/:repo/statuses/:sha",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /repos/:owner/:repo/commits/:ref/status",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "POST /repos/:owner/:repo/check-runs",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /repos/:owner/:repo/commits/:ref/check-runs",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /repos/:owner/:repo/milestones",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "POST /repos/:owner/:repo/milestones",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "PATCH /repos/:owner/:repo/milestones/:number",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "DELETE /repos/:owner/:repo/milestones/:number",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /repos/:owner/:repo/tags",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /repos/:owner/:repo/releases",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /repos/:owner/:repo/releases/latest",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "POST /repos/:owner/:repo/releases",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /user",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /search/*",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "POST /mcp/call",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "POST /mcp/tools/:name",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "Any unsupported path",
+      "heat": "unclassified",
+      "fidelity": "unsupported",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    }
+  ],
+  "doc_drift": []
+}

--- a/packages/twin-github/package.json
+++ b/packages/twin-github/package.json
@@ -23,7 +23,8 @@
   "files": [
     "dist",
     "README.md",
-    "FIDELITY.md"
+    "FIDELITY.md",
+    "fidelity.inventory.json"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/twin-github/scripts/fidelity-parity.ts
+++ b/packages/twin-github/scripts/fidelity-parity.ts
@@ -1,105 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// fidelity:parity — declarative parity scenario for twin-github (F-730).
+// The runner lives in @pome-sh/sdk/parity; this file is scenario data only:
+// an ordered, stateful chain that exercises every MCP tool in
+// fidelity.inventory.json against the seeded acme/api world, plus the
+// loud-501 REST probe and optional read-only live-shape probes via `gh api`
+// (set GITHUB_PARITY_REPO=owner/repo).
+
 import { spawnSync } from "node:child_process";
-import { sign } from "hono/jwt";
+import { join } from "node:path";
+import { loadFidelityInventory, runParityCli, type ParityStep } from "@pome-sh/sdk/parity";
 import { createGitHubCloneApp } from "../src/twin.js";
 import { listTools } from "../src/tools.js";
 
-type HarnessState = { pullNumber?: number };
-type ToolCase = { tool: string; arguments: Record<string, unknown> | ((state: HarnessState) => Record<string, unknown>); mutates?: boolean };
+const repo = { owner: "acme", repo: "api" };
 
-const sid = "fidelity-parity";
-const secret = process.env.TWIN_AUTH_SECRET ?? "dev-only-insecure-secret";
-const token = await sign({ sid, team_id: "tm_fidelity", exp: Math.floor(Date.now() / 1000) + 3600 }, secret);
-const app = createGitHubCloneApp();
-const base = `/s/${sid}`;
-
-const cases: ToolCase[] = [
+const steps: ParityStep[] = [
+  // Reads against the seeded world
   { tool: "search_repositories", arguments: { query: "acme" } },
-  { tool: "create_repository", arguments: { owner: "qa", name: "parity" }, mutates: true },
-  { tool: "fork_repository", arguments: { owner: "acme", repo: "api", organization: "forks" }, mutates: true },
-  { tool: "get_repository", arguments: { owner: "acme", repo: "api" } },
+  { tool: "get_repository", arguments: { ...repo } },
   { tool: "search_code", arguments: { query: "handler" } },
   { tool: "search_users", arguments: { query: "alice" } },
-  { tool: "get_file_contents", arguments: { owner: "acme", repo: "api", path: "README.md" } },
-  { tool: "list_commits", arguments: { owner: "acme", repo: "api" } },
-  { tool: "create_or_update_file", arguments: { owner: "acme", repo: "api", path: "parity.txt", message: "Add parity", content: "ok\n" }, mutates: true },
-  { tool: "create_branch", arguments: { owner: "acme", repo: "api", branch: "parity" }, mutates: true },
-  { tool: "push_files", arguments: { owner: "acme", repo: "api", branch: "parity", message: "Change parity", files: [{ path: "parity.txt", content: "changed\n" }] }, mutates: true },
-  { tool: "get_issue", arguments: { owner: "acme", repo: "api", issue_number: 1 } },
-  { tool: "update_issue", arguments: { owner: "acme", repo: "api", issue_number: 1, state: "open" }, mutates: true },
+  { tool: "get_file_contents", arguments: { ...repo, path: "README.md" } },
+  { tool: "list_commits", arguments: { ...repo } },
+  { tool: "list_branches", arguments: { ...repo } },
+  {
+    tool: "get_branch",
+    arguments: { ...repo, branch: "main" },
+    capture: (body, state) => {
+      state.mainSha = (body as { commit?: { sha?: string } }).commit?.sha;
+    },
+  },
+  // Repositories + branches + files
+  { tool: "create_repository", arguments: { owner: "qa", name: "parity" } },
+  { tool: "fork_repository", arguments: { ...repo, organization: "forks" } },
+  { tool: "create_or_update_file", arguments: { ...repo, path: "parity.txt", message: "Add parity", content: "ok\n" } },
+  { tool: "create_branch", arguments: { ...repo, branch: "parity" } },
+  { tool: "push_files", arguments: { ...repo, branch: "parity", message: "Change parity", files: [{ path: "parity.txt", content: "changed\n" }] } },
+  // Advance main past the branch point so update_pull_request_branch has work
+  {
+    tool: "create_or_update_file",
+    arguments: { ...repo, path: "delete-me.txt", message: "Add delete-me", content: "bye\n" },
+    capture: (body, state) => {
+      state.deleteMeSha = (body as { content?: { sha?: string } }).content?.sha;
+    },
+  },
+  { tool: "delete_file", arguments: (state) => ({ ...repo, path: "delete-me.txt", message: "Remove delete-me", sha: state.deleteMeSha }) },
+  { tool: "get_commit", arguments: { ...repo, ref: "main" } },
+  { tool: "compare_commits", arguments: { ...repo, base: "main", head: "parity" } },
+  // Issues + comments
+  { tool: "get_issue", arguments: { ...repo, issue_number: 1 } },
+  { tool: "update_issue", arguments: { ...repo, issue_number: 1, state: "open" } },
   { tool: "search_issues", arguments: { query: "500" } },
-  { tool: "list_issues", arguments: { owner: "acme", repo: "api", state: "all" } },
-  { tool: "add_issue_comment", arguments: { owner: "acme", repo: "api", issue_number: 1, body: "Parity comment" }, mutates: true },
-  { tool: "list_issue_comments", arguments: { owner: "acme", repo: "api", issue_number: 1 } },
-  { tool: "create_issue", arguments: { owner: "acme", repo: "api", title: "Parity issue" }, mutates: true },
-  { tool: "list_repository_labels", arguments: { owner: "acme", repo: "api" } },
-  { tool: "create_label", arguments: { owner: "acme", repo: "api", name: "parity-label", color: "ededed" }, mutates: true },
-  { tool: "list_issue_labels", arguments: { owner: "acme", repo: "api", issue_number: 1 } },
-  { tool: "add_issue_labels", arguments: { owner: "acme", repo: "api", issue_number: 1, labels: ["parity-label"] }, mutates: true },
-  { tool: "remove_issue_label", arguments: { owner: "acme", repo: "api", issue_number: 1, label: "parity-label" }, mutates: true },
-  { tool: "list_collaborators", arguments: { owner: "acme", repo: "api" } },
-  { tool: "add_assignees", arguments: { owner: "acme", repo: "api", issue_number: 1, assignees: ["alice"] }, mutates: true },
-  { tool: "create_pull_request", arguments: { owner: "acme", repo: "api", title: "Parity PR", head: "parity", base: "main" }, mutates: true },
-  { tool: "get_pull_request", arguments: (state) => ({ owner: "acme", repo: "api", pull_number: state.pullNumber }) },
-  { tool: "get_pull_request_reviews", arguments: (state) => ({ owner: "acme", repo: "api", pull_number: state.pullNumber }) },
-  { tool: "create_pull_request_review", arguments: (state) => ({ owner: "acme", repo: "api", pull_number: state.pullNumber, event: "APPROVE" }), mutates: true },
-  { tool: "get_pull_request_comments", arguments: (state) => ({ owner: "acme", repo: "api", pull_number: state.pullNumber }) },
-  { tool: "get_pull_request_files", arguments: (state) => ({ owner: "acme", repo: "api", pull_number: state.pullNumber }) },
-  { tool: "get_pull_request_status", arguments: (state) => ({ owner: "acme", repo: "api", pull_number: state.pullNumber }) },
-  { tool: "list_pull_requests", arguments: { owner: "acme", repo: "api", state: "all" } },
-  { tool: "update_pull_request_branch", arguments: (state) => ({ owner: "acme", repo: "api", pull_number: state.pullNumber }), mutates: true },
-  { tool: "merge_pull_request", arguments: (state) => ({ owner: "acme", repo: "api", pull_number: state.pullNumber }), mutates: true }
+  { tool: "list_issues", arguments: { ...repo, state: "all" } },
+  {
+    tool: "add_issue_comment",
+    arguments: { ...repo, issue_number: 1, body: "Parity comment" },
+    capture: (body, state) => {
+      state.issueCommentId = (body as { id?: number }).id;
+    },
+  },
+  { tool: "list_issue_comments", arguments: { ...repo, issue_number: 1 } },
+  { tool: "update_issue_comment", arguments: (state) => ({ ...repo, comment_id: state.issueCommentId, body: "Parity comment (edited)" }) },
+  { tool: "delete_issue_comment", arguments: (state) => ({ ...repo, comment_id: state.issueCommentId }) },
+  { tool: "create_issue", arguments: { ...repo, title: "Parity issue" } },
+  // Labels
+  { tool: "list_repository_labels", arguments: { ...repo } },
+  { tool: "create_label", arguments: { ...repo, name: "parity-label", color: "ededed" } },
+  { tool: "list_issue_labels", arguments: { ...repo, issue_number: 1 } },
+  { tool: "add_issue_labels", arguments: { ...repo, issue_number: 1, labels: ["parity-label"] } },
+  { tool: "remove_issue_label", arguments: { ...repo, issue_number: 1, label: "parity-label" } },
+  // Collaborators + identity
+  { tool: "list_collaborators", arguments: { ...repo } },
+  { tool: "add_assignees", arguments: { ...repo, issue_number: 1, assignees: ["alice"] } },
+  { tool: "add_collaborator", arguments: { ...repo, username: "bob" } },
+  { tool: "get_me" },
+  // Milestones
+  { tool: "list_milestones", arguments: { ...repo } },
+  {
+    tool: "create_milestone",
+    arguments: { ...repo, title: "Parity milestone" },
+    capture: (body, state) => {
+      state.milestoneNumber = (body as { number?: number }).number;
+    },
+  },
+  { tool: "update_milestone", arguments: (state) => ({ ...repo, milestone_number: state.milestoneNumber, description: "Parity milestone (updated)" }) },
+  { tool: "delete_milestone", arguments: (state) => ({ ...repo, milestone_number: state.milestoneNumber }) },
+  // Commit statuses + check runs (against the pre-branch main head)
+  { tool: "create_commit_status", arguments: (state) => ({ ...repo, sha: state.mainSha, state: "success", context: "parity" }) },
+  { tool: "get_combined_status_for_ref", arguments: { ...repo, ref: "main" } },
+  { tool: "create_check_run", arguments: (state) => ({ ...repo, name: "parity-check", head_sha: state.mainSha, status: "completed", conclusion: "success" }) },
+  { tool: "list_check_runs_for_ref", arguments: { ...repo, ref: "main" } },
+  // Pull request chain
+  {
+    tool: "create_pull_request",
+    arguments: { ...repo, title: "Parity PR", head: "parity", base: "main" },
+    capture: (body, state) => {
+      state.pullNumber = (body as { number?: number }).number;
+    },
+  },
+  { tool: "get_pull_request", arguments: (state) => ({ ...repo, pull_number: state.pullNumber }) },
+  { tool: "get_pull_request_reviews", arguments: (state) => ({ ...repo, pull_number: state.pullNumber }) },
+  { tool: "create_pull_request_review", arguments: (state) => ({ ...repo, pull_number: state.pullNumber, event: "APPROVE" }) },
+  {
+    tool: "create_pull_request_review_comment",
+    arguments: (state) => ({ ...repo, pull_number: state.pullNumber, body: "Inline parity", path: "parity.txt", line: 1 }),
+    capture: (body, state) => {
+      state.reviewCommentId = (body as { id?: number }).id;
+    },
+  },
+  { tool: "add_reply_to_pull_request_comment", arguments: (state) => ({ ...repo, pull_number: state.pullNumber, comment_id: state.reviewCommentId, body: "Parity reply" }) },
+  { tool: "get_pull_request_comments", arguments: (state) => ({ ...repo, pull_number: state.pullNumber }) },
+  { tool: "get_pull_request_files", arguments: (state) => ({ ...repo, pull_number: state.pullNumber }) },
+  { tool: "get_pull_request_status", arguments: (state) => ({ ...repo, pull_number: state.pullNumber }) },
+  { tool: "get_pull_request_diff", arguments: (state) => ({ ...repo, pull_number: state.pullNumber }) },
+  { tool: "get_pull_request_commits", arguments: (state) => ({ ...repo, pull_number: state.pullNumber }) },
+  { tool: "list_pull_requests", arguments: { ...repo, state: "all" } },
+  { tool: "update_pull_request", arguments: (state) => ({ ...repo, pull_number: state.pullNumber, title: "Parity PR (renamed)" }) },
+  { tool: "update_pull_request_branch", arguments: (state) => ({ ...repo, pull_number: state.pullNumber }) },
+  { tool: "merge_pull_request", arguments: (state) => ({ ...repo, pull_number: state.pullNumber }) },
+  { tool: "delete_branch", arguments: { ...repo, branch: "parity" } },
+  // Tags + releases
+  { tool: "create_release", arguments: { ...repo, tag_name: "v0.0.1-parity", name: "Parity release" } },
+  { tool: "list_tags", arguments: { ...repo } },
+  { tool: "list_releases", arguments: { ...repo } },
+  { tool: "get_latest_release", arguments: { ...repo } },
 ];
 
-const expected = listTools().map((tool) => tool.name).sort();
-const covered = cases.map((item) => item.tool).sort();
-if (JSON.stringify(expected) !== JSON.stringify(covered)) {
-  throw new Error(`fidelity harness case list does not match tool list.\nexpected=${expected.join(",")}\ncovered=${covered.join(",")}`);
-}
-
-const report: unknown[] = [];
-const state: HarnessState = {};
-for (const item of cases) {
-  const args = typeof item.arguments === "function" ? item.arguments(state) : item.arguments;
-  const response = await app.request(`${base}/mcp/call`, {
-    method: "POST",
-    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
-    body: JSON.stringify({ tool: item.tool, arguments: args })
-  });
-  const body = await response.json().catch(() => ({}));
-  if (item.tool === "create_pull_request" && response.ok && body && typeof body === "object" && typeof (body as { number?: unknown }).number === "number") {
-    state.pullNumber = (body as { number: number }).number;
+function liveGitHubProbes(): unknown[] {
+  const sandboxRepo = process.env.GITHUB_PARITY_REPO;
+  if (!sandboxRepo) {
+    return [{ real_github: "skipped", reason: "set GITHUB_PARITY_REPO=owner/repo to compare read-only live shapes with gh api" }];
   }
-  report.push({
-    tool: item.tool,
-    status: response.status,
-    ok: response.ok,
-    keys: body && typeof body === "object" && !Array.isArray(body) ? Object.keys(body as Record<string, unknown>).sort() : Array.isArray(body) ? ["array"] : []
-  });
-}
-
-const unsupported = await app.request(`${base}/repos/acme/api/actions/runs`, {
-  headers: { authorization: `Bearer ${token}` }
-});
-report.push({ surface: "unsupported-rest", status: unsupported.status, body: await unsupported.json() });
-
-const sandboxRepo = process.env.GITHUB_PARITY_REPO;
-if (sandboxRepo) {
   const endpoints = [
     `repos/${sandboxRepo}`,
     `repos/${sandboxRepo}/contents/README.md`,
     `repos/${sandboxRepo}/issues?state=open&per_page=1`,
-    `search/repositories?q=repo:${sandboxRepo}`
+    `search/repositories?q=repo:${sandboxRepo}`,
   ];
-  for (const endpoint of endpoints) {
+  return endpoints.map((endpoint) => {
     const result = spawnSync("gh", ["api", endpoint], { encoding: "utf8" });
-    report.push({
+    return {
       real_github_endpoint: endpoint,
       status: result.status === 0 ? 200 : "gh-error",
-      stderr: result.status === 0 ? undefined : result.stderr.trim().slice(0, 400)
-    });
-  }
-} else {
-  report.push({ real_github: "skipped", reason: "set GITHUB_PARITY_REPO=owner/repo to compare read-only live shapes with gh api" });
+      stderr: result.status === 0 ? undefined : result.stderr.trim().slice(0, 400),
+    };
+  });
 }
 
-console.log(JSON.stringify({ tools: expected.length, report }, null, 2));
+await runParityCli({
+  app: createGitHubCloneApp(),
+  twin: "github",
+  inventory: loadFidelityInventory(join(import.meta.dirname, "..", "fidelity.inventory.json")),
+  liveToolNames: listTools().map((tool) => tool.name),
+  steps,
+  claims: { team_id: "tm_fidelity", login: "pome-agent" },
+  restProbes: [
+    { surface: "unsupported-rest", path: "/repos/acme/api/actions/runs", status: 501, expectUnsupportedEnvelope: true },
+  ],
+  live: async () => liveGitHubProbes(),
+});

--- a/packages/twin-github/test/fidelity-contract.test.ts
+++ b/packages/twin-github/test/fidelity-contract.test.ts
@@ -1,14 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Fidelity contract (F-730): the structured inventory is the hub — it must
+// match the live tool list exactly, and the FIDELITY doc tables must match
+// the inventory 1:1 (tier included). This replaces the old soft "docs
+// mention the tool name" check, which could not see undocumented surfaces.
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+import {
+  compareToolNames,
+  lintFidelityInventory,
+  loadFidelityInventory,
+} from "@pome-sh/sdk/parity";
 import { listTools } from "../src/tools.js";
 
+const root = resolve(import.meta.dirname, "..");
+const inventory = loadFidelityInventory(resolve(root, "fidelity.inventory.json"));
+const fidelity = readFileSync(resolve(root, "FIDELITY.md"), "utf8");
+const matrix = readFileSync(resolve(root, "FIDELITY_MATRIX.md"), "utf8");
+
 describe("fidelity contract documentation", () => {
-  it("documents every MCP tool with a fidelity tier and backing surface", () => {
-    const fidelity = readFileSync(resolve(import.meta.dirname, "..", "FIDELITY.md"), "utf8");
-    for (const tool of listTools()) {
-      expect(fidelity).toContain(`\`${tool.name}\``);
-    }
+  it("keeps fidelity.inventory.json 1:1 with the live tool list", () => {
+    expect(
+      compareToolNames(
+        inventory.tools.map((tool) => tool.name),
+        listTools().map((tool) => tool.name)
+      )
+    ).toEqual({ missing: [], extra: [] });
+  });
+
+  it("keeps the FIDELITY doc tables 1:1 with fidelity.inventory.json", () => {
+    expect(
+      lintFidelityInventory(inventory, [
+        { label: "FIDELITY.md", kind: "tool", markdown: fidelity },
+        { label: "FIDELITY_MATRIX.md", kind: "rest", markdown: matrix },
+      ])
+    ).toEqual([]);
+  });
+
+  it("documents the fidelity tier vocabulary and a verification date", () => {
     expect(fidelity).toContain("semantic");
     expect(fidelity).toContain("shape");
     expect(fidelity).toContain("unsupported");
@@ -16,7 +46,6 @@ describe("fidelity contract documentation", () => {
   });
 
   it("keeps a route-level matrix for product-supported REST behavior", () => {
-    const matrix = readFileSync(resolve(import.meta.dirname, "..", "FIDELITY_MATRIX.md"), "utf8");
     for (const surface of [
       "`GET /repos/:owner/:repo`",
       "`POST /repos/:owner/:repo/issues`",

--- a/packages/twin-slack/FIDELITY.md
+++ b/packages/twin-slack/FIDELITY.md
@@ -254,6 +254,14 @@ npm run typecheck                       # zero TS errors
 npm run test                            # all tests pass
 npm run test:coverage                   # ≥ 90% lines, ≥ 90% funcs
 npm run validate:mcp                    # JSON-RPC SDK round-trip
+npm run fidelity:parity                 # every MCP tool through /mcp/call (F-730)
 TWIN_AUTH_SECRET=dev SLACK_DETERMINISTIC_TS=1 npm run smoke
 npm run verify:cloud-token              # cloud xoxb-pome-* token validates
 ```
+
+The tables above are 1:1-linted against the structured inventory
+[`fidelity.inventory.json`](fidelity.inventory.json) (which also carries the
+hot/warm/cold heat tier per F-729) by `test/fidelity-contract.test.ts`; the
+shared parity runner (`@pome-sh/sdk/parity`) asserts the same inventory
+matches the live tool list and that a declarative scenario exercises every
+tool.

--- a/packages/twin-slack/fidelity.inventory.json
+++ b/packages/twin-slack/fidelity.inventory.json
@@ -1,0 +1,287 @@
+{
+  "twin": "slack",
+  "package": "@pome-sh/twin-slack",
+  "updated": "2026-07-11",
+  "notes": "Both tables lint 1:1 against FIDELITY.md. REST names are Slack Web API method names. Heat tiers await the F-729 rubric ruling.",
+  "tools": [
+    {
+      "name": "slack_post_message",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "slack_reply_to_thread",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "slack_add_reaction",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "slack_get_channel_history",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "slack_get_thread_replies",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "slack_list_channels",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "slack_get_users",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "slack_get_user_profile",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    }
+  ],
+  "rest": [
+    {
+      "name": "auth.test",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "chat.postMessage",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "chat.update",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "chat.delete",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "chat.scheduleMessage",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "chat.deleteScheduledMessage",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "conversations.list",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "conversations.info",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "conversations.create",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "conversations.history",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "conversations.replies",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "conversations.invite",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "conversations.join",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "conversations.leave",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "conversations.kick",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "conversations.archive",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "conversations.members",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "conversations.open",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "reactions.add",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "reactions.remove",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "reactions.get",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "users.list",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "users.info",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "users.lookupByEmail",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "users.profile.get",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "users.profile.set",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "pins.add",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "pins.remove",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "pins.list",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "search.messages",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "files.upload",
+      "heat": "unclassified",
+      "fidelity": "shape",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "files.info",
+      "heat": "unclassified",
+      "fidelity": "shape",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "files.list",
+      "heat": "unclassified",
+      "fidelity": "shape",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "files.delete",
+      "heat": "unclassified",
+      "fidelity": "shape",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "bookmarks.add",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "bookmarks.remove",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "bookmarks.list",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "team.info",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    }
+  ],
+  "doc_drift": []
+}

--- a/packages/twin-slack/package.json
+++ b/packages/twin-slack/package.json
@@ -23,7 +23,8 @@
   "files": [
     "dist",
     "README.md",
-    "FIDELITY.md"
+    "FIDELITY.md",
+    "fidelity.inventory.json"
   ],
   "publishConfig": {
     "access": "public"
@@ -40,7 +41,8 @@
     "prepack": "npm run build",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "fidelity:parity": "tsx scripts/fidelity-parity.ts"
   },
   "dependencies": {
     "@hono/node-server": "^2.0.8",

--- a/packages/twin-slack/scripts/fidelity-parity.ts
+++ b/packages/twin-slack/scripts/fidelity-parity.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// fidelity:parity — declarative parity scenario for twin-slack (F-730).
+// The runner lives in @pome-sh/sdk/parity; this file is scenario data only:
+// an ordered, stateful chain (post → thread → reaction → reads) that
+// exercises every MCP tool in fidelity.inventory.json against the seeded
+// workspace, plus the loud-501 probe for an unsupported Web API method.
+//
+// Slack answers HTTP 200 with `{ok:false, error}` on API errors, so every
+// step also asserts the Slack envelope's own ok flag.
+
+import { join } from "node:path";
+import { loadFidelityInventory, runParityCli, type ParityStep } from "@pome-sh/sdk/parity";
+import { defaultSeedState } from "../src/seed.js";
+import { createSlackTwinApp } from "../src/twin.js";
+import { listTools } from "../src/tools.js";
+
+type SlackEnvelope = { ok?: boolean; error?: string };
+
+const steps: ParityStep[] = [
+  {
+    tool: "slack_list_channels",
+    capture: (body, state) => {
+      const channels = (body as { channels?: Array<{ id?: string; name?: string }> }).channels ?? [];
+      state.channelId = channels.find((channel) => channel.name === "general")?.id;
+    },
+  },
+  {
+    tool: "slack_post_message",
+    arguments: (state) => ({ channel_id: state.channelId, text: "Parity message" }),
+    capture: (body, state) => {
+      state.ts = (body as { ts?: string }).ts;
+    },
+  },
+  { tool: "slack_reply_to_thread", arguments: (state) => ({ channel_id: state.channelId, thread_ts: state.ts, text: "Parity reply" }) },
+  { tool: "slack_add_reaction", arguments: (state) => ({ channel_id: state.channelId, timestamp: state.ts, reaction: "thumbsup" }) },
+  { tool: "slack_get_channel_history", arguments: (state) => ({ channel_id: state.channelId }) },
+  { tool: "slack_get_thread_replies", arguments: (state) => ({ channel_id: state.channelId, thread_ts: state.ts }) },
+  {
+    tool: "slack_get_users",
+    capture: (body, state) => {
+      const members = (body as { members?: Array<{ id?: string; name?: string }> }).members ?? [];
+      state.aliceId = members.find((member) => member.name === "alice")?.id;
+    },
+  },
+  { tool: "slack_get_user_profile", arguments: (state) => ({ user_id: state.aliceId }) },
+];
+
+await runParityCli({
+  app: createSlackTwinApp({ seed: defaultSeedState() }),
+  twin: "slack",
+  inventory: loadFidelityInventory(join(import.meta.dirname, "..", "fidelity.inventory.json")),
+  liveToolNames: listTools().map((tool) => tool.name),
+  steps,
+  claims: { team_id: "T_POME", login: "pome-agent" },
+  stepVerify: (body) => {
+    const envelope = body as SlackEnvelope;
+    return envelope.ok === false ? `slack error envelope: ${envelope.error ?? "unknown"}` : undefined;
+  },
+  restProbes: [
+    { surface: "unsupported-rest", method: "POST", path: "/admin.conversations.search", status: 501, expectUnsupportedEnvelope: true },
+  ],
+});

--- a/packages/twin-slack/test/fidelity-contract.test.ts
+++ b/packages/twin-slack/test/fidelity-contract.test.ts
@@ -1,18 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Asserts FIDELITY.md exists and stays in sync with the actual code:
-//   - References every visible MCP tool
-//   - Lists every shipped REST surface area
-//   - Calls out the fidelity tiers
-//
-// If FIDELITY.md drifts from src/tools.ts the contract test fails loudly,
-// which forces a deliberate doc update on any tool surface change.
+// Fidelity contract (F-730): the structured inventory is the hub — it must
+// match the live tool list exactly, and the FIDELITY.md tables must match
+// the inventory 1:1 (tier included). This replaces the old soft "docs
+// mention the tool name" check, which could not see undocumented surfaces.
+// The slack-specific doc pins (tier vocabulary, required REST surfaces, ts
+// invariant, mutating tool set) stay.
 
 import { describe, expect, it } from "vitest";
 import { readFileSync, existsSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { toolDefinitions, MUTATING_TOOL_NAMES } from "../src/tools.js";
+import {
+  compareToolNames,
+  lintFidelityInventory,
+  loadFidelityInventory,
+} from "@pome-sh/sdk/parity";
+import { listTools, MUTATING_TOOL_NAMES } from "../src/tools.js";
 
 const PKG_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const FIDELITY_PATH = join(PKG_ROOT, "FIDELITY.md");
@@ -22,14 +26,25 @@ describe("FIDELITY.md contract", () => {
     expect(existsSync(FIDELITY_PATH)).toBe(true);
   });
 
-  it("FIDELITY.md mentions every visible MCP tool by name", () => {
+  it("keeps fidelity.inventory.json 1:1 with the live tool list", () => {
+    const inventory = loadFidelityInventory(join(PKG_ROOT, "fidelity.inventory.json"));
+    expect(
+      compareToolNames(
+        inventory.tools.map((tool) => tool.name),
+        listTools().map((tool) => tool.name)
+      )
+    ).toEqual({ missing: [], extra: [] });
+  });
+
+  it("keeps the FIDELITY.md tables 1:1 with fidelity.inventory.json", () => {
+    const inventory = loadFidelityInventory(join(PKG_ROOT, "fidelity.inventory.json"));
     const body = readFileSync(FIDELITY_PATH, "utf8");
-    for (const tool of toolDefinitions) {
-      expect(
-        body.includes("`" + tool.name + "`"),
-        `FIDELITY.md is missing the tool '${tool.name}'`
-      ).toBe(true);
-    }
+    expect(
+      lintFidelityInventory(inventory, [
+        { label: "FIDELITY.md", kind: "tool", markdown: body },
+        { label: "FIDELITY.md", kind: "rest", markdown: body },
+      ])
+    ).toEqual([]);
   });
 
   it("FIDELITY.md declares the three fidelity tiers", () => {

--- a/packages/twin-stripe/FIDELITY.md
+++ b/packages/twin-stripe/FIDELITY.md
@@ -96,6 +96,15 @@ Every MCP tool is callable via both `POST /s/:sid/mcp/call` (with
 `{tool, arguments}` body) and `POST /s/:sid/mcp/tools/:name` (with the
 arguments as the body). Coverage in `tools.test.ts`.
 
+The tables above are 1:1-linted against the structured inventory
+[`fidelity.inventory.json`](fidelity.inventory.json) (which also carries the
+hot/warm/cold heat tier per F-729) by `test/fidelity-contract.test.ts`, and
+`npm run fidelity:parity` (shared runner in `@pome-sh/sdk/parity`, F-730)
+exercises every inventoried tool end-to-end. Known gaps between code and
+these tables — today, the implemented refunds chain — are declared in the
+inventory's `doc_drift` with their owning ticket (F-733) and fail the lint
+the moment the docs catch up.
+
 ## x402 middleware (`src/x402.ts`)
 
 `paymentMiddleware(routeMap, twinOptions)` is a Hono helper that:

--- a/packages/twin-stripe/fidelity.inventory.json
+++ b/packages/twin-stripe/fidelity.inventory.json
@@ -1,0 +1,228 @@
+{
+  "twin": "stripe",
+  "package": "@pome-sh/twin-stripe",
+  "updated": "2026-07-11",
+  "notes": "Both tables lint 1:1 against FIDELITY.md; FIDELITY_MATRIX.md stays a legacy pinned matrix. The refunds chain is implemented but undocumented — declared in doc_drift until F-733 reconciles the docs. Heat tiers await the F-729 rubric ruling.",
+  "tools": [
+    {
+      "name": "create_payment_intent",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "retrieve_payment_intent",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "list_payment_intents",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "confirm_payment_intent",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "cancel_payment_intent",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "simulate_crypto_deposit",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "retrieve_charge",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "list_charges",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "retrieve_balance",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "list_balance_transactions",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "retrieve_event",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "list_events",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "create_refund",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Implemented and tested in code but absent from the FIDELITY.md tables; doc reconciliation owned by F-733."
+    },
+    {
+      "name": "retrieve_refund",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Implemented and tested in code but absent from the FIDELITY.md tables; doc reconciliation owned by F-733."
+    },
+    {
+      "name": "list_refunds",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Implemented and tested in code but absent from the FIDELITY.md tables; doc reconciliation owned by F-733."
+    }
+  ],
+  "rest": [
+    {
+      "name": "POST /s/:sid/v1/payment_intents",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /s/:sid/v1/payment_intents/:id",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /s/:sid/v1/payment_intents",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "POST /s/:sid/v1/payment_intents/:id/confirm",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "POST /s/:sid/v1/payment_intents/:id/cancel",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "POST /s/:sid/v1/test_helpers/payment_intents/:id/simulate_crypto_deposit",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /s/:sid/v1/charges/:id",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /s/:sid/v1/charges",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /s/:sid/v1/balance",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /s/:sid/v1/balance_transactions",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /s/:sid/v1/events/:id",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "GET /s/:sid/v1/events",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+    },
+    {
+      "name": "POST /s/:sid/v1/refunds",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Implemented and tested in code but absent from the FIDELITY.md tables; doc reconciliation owned by F-733."
+    },
+    {
+      "name": "GET /s/:sid/v1/refunds/:id",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Implemented and tested in code but absent from the FIDELITY.md tables; doc reconciliation owned by F-733."
+    },
+    {
+      "name": "GET /s/:sid/v1/refunds",
+      "heat": "unclassified",
+      "fidelity": "semantic",
+      "justification": "Implemented and tested in code but absent from the FIDELITY.md tables; doc reconciliation owned by F-733."
+    }
+  ],
+  "doc_drift": [
+    {
+      "kind": "tool",
+      "name": "create_refund",
+      "reason": "refunds chain shipped without FIDELITY.md rows",
+      "ticket": "F-733"
+    },
+    {
+      "kind": "tool",
+      "name": "retrieve_refund",
+      "reason": "refunds chain shipped without FIDELITY.md rows",
+      "ticket": "F-733"
+    },
+    {
+      "kind": "tool",
+      "name": "list_refunds",
+      "reason": "refunds chain shipped without FIDELITY.md rows",
+      "ticket": "F-733"
+    },
+    {
+      "kind": "rest",
+      "name": "POST /s/:sid/v1/refunds",
+      "reason": "refunds chain shipped without FIDELITY.md rows",
+      "ticket": "F-733"
+    },
+    {
+      "kind": "rest",
+      "name": "GET /s/:sid/v1/refunds/:id",
+      "reason": "refunds chain shipped without FIDELITY.md rows",
+      "ticket": "F-733"
+    },
+    {
+      "kind": "rest",
+      "name": "GET /s/:sid/v1/refunds",
+      "reason": "refunds chain shipped without FIDELITY.md rows",
+      "ticket": "F-733"
+    }
+  ]
+}

--- a/packages/twin-stripe/package.json
+++ b/packages/twin-stripe/package.json
@@ -23,7 +23,8 @@
   "files": [
     "dist",
     "README.md",
-    "FIDELITY.md"
+    "FIDELITY.md",
+    "fidelity.inventory.json"
   ],
   "publishConfig": {
     "access": "public"
@@ -36,7 +37,8 @@
     "start": "node dist/src/server.js",
     "prepack": "npm run build",
     "test": "vitest run",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "fidelity:parity": "tsx scripts/fidelity-parity.ts"
   },
   "keywords": [
     "stripe",

--- a/packages/twin-stripe/scripts/fidelity-parity.ts
+++ b/packages/twin-stripe/scripts/fidelity-parity.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// fidelity:parity — declarative parity scenario for twin-stripe (F-730).
+// The runner lives in @pome-sh/sdk/parity; this file is scenario data only:
+// the crypto-deposit money chain (create PI → confirm → settle → charge →
+// refund → ledger → events) plus a second PI for the cancel path, covering
+// every MCP tool in fidelity.inventory.json — including the refunds chain
+// that is live in code but still absent from FIDELITY.md (declared as
+// doc_drift, reconciliation owned by F-733). The loud-501 probe pins the
+// Stripe-shaped unsupported envelope on /v1/customers.
+
+import { join } from "node:path";
+import { loadFidelityInventory, runParityCli, type ParityStep } from "@pome-sh/sdk/parity";
+import { createTwinStripeApp } from "../src/twin.js";
+import { listTools } from "../src/tools.js";
+
+const createPi = {
+  amount: 20000,
+  currency: "usd",
+  payment_method_types: ["crypto"],
+  payment_method_options: { crypto: { mode: "deposit", deposit_options: { networks: ["base"] } } },
+};
+
+const steps: ParityStep[] = [
+  {
+    tool: "create_payment_intent",
+    arguments: createPi,
+    capture: (body, state) => {
+      state.pi = (body as { id?: string }).id;
+    },
+  },
+  { tool: "retrieve_payment_intent", arguments: (state) => ({ id: state.pi }) },
+  { tool: "confirm_payment_intent", arguments: (state) => ({ id: state.pi }) },
+  {
+    tool: "simulate_crypto_deposit",
+    arguments: (state) => ({ id: state.pi }),
+    capture: (body, state) => {
+      state.charge = (body as { latest_charge?: string }).latest_charge;
+    },
+  },
+  { tool: "list_payment_intents", arguments: { limit: 10 } },
+  { tool: "retrieve_charge", arguments: (state) => ({ id: state.charge }) },
+  { tool: "list_charges", arguments: (state) => ({ payment_intent: state.pi }) },
+  {
+    tool: "create_refund",
+    arguments: (state) => ({ charge: state.charge, amount: 7500 }),
+    capture: (body, state) => {
+      state.refund = (body as { id?: string }).id;
+    },
+  },
+  { tool: "retrieve_refund", arguments: (state) => ({ id: state.refund }) },
+  { tool: "list_refunds", arguments: (state) => ({ charge: state.charge }) },
+  { tool: "retrieve_balance" },
+  { tool: "list_balance_transactions", arguments: { limit: 10 } },
+  {
+    tool: "list_events",
+    arguments: { limit: 10 },
+    capture: (body, state) => {
+      state.event = (body as { data?: Array<{ id?: string }> }).data?.[0]?.id;
+    },
+  },
+  { tool: "retrieve_event", arguments: (state) => ({ id: state.event }) },
+  // Second PI: the cancel path (a settled PI refuses cancellation)
+  {
+    tool: "create_payment_intent",
+    arguments: createPi,
+    capture: (body, state) => {
+      state.pi2 = (body as { id?: string }).id;
+    },
+  },
+  { tool: "cancel_payment_intent", arguments: (state) => ({ id: state.pi2 }) },
+];
+
+await runParityCli({
+  app: createTwinStripeApp(),
+  twin: "stripe",
+  inventory: loadFidelityInventory(join(import.meta.dirname, "..", "fidelity.inventory.json")),
+  liveToolNames: listTools().map((tool) => tool.name),
+  steps,
+  restProbes: [
+    { surface: "unsupported-rest", path: "/v1/customers", status: 501, expectUnsupportedEnvelope: true },
+  ],
+});

--- a/packages/twin-stripe/test/fidelity-contract.test.ts
+++ b/packages/twin-stripe/test/fidelity-contract.test.ts
@@ -1,11 +1,46 @@
 // SPDX-License-Identifier: Apache-2.0
+//
+// Fidelity contract (F-730): the structured inventory is the hub — it must
+// match the live tool list exactly, and the FIDELITY.md tables must match
+// the inventory 1:1 (tier included). The old matrix-only check missed the
+// refunds chain shipping without docs; that gap is now declared as
+// doc_drift in fidelity.inventory.json (reconciliation owned by F-733) and
+// this test fails the moment the declaration goes stale.
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+import {
+  compareToolNames,
+  lintFidelityInventory,
+  loadFidelityInventory,
+} from "@pome-sh/sdk/parity";
+import { listTools } from "../src/tools.js";
 
-describe("Stripe fidelity matrix", () => {
+const root = resolve(import.meta.dirname, "..");
+const inventory = loadFidelityInventory(resolve(root, "fidelity.inventory.json"));
+const fidelity = readFileSync(resolve(root, "FIDELITY.md"), "utf8");
+
+describe("Stripe fidelity contract", () => {
+  it("keeps fidelity.inventory.json 1:1 with the live tool list", () => {
+    expect(
+      compareToolNames(
+        inventory.tools.map((tool) => tool.name),
+        listTools().map((tool) => tool.name)
+      )
+    ).toEqual({ missing: [], extra: [] });
+  });
+
+  it("keeps the FIDELITY.md tables 1:1 with fidelity.inventory.json", () => {
+    expect(
+      lintFidelityInventory(inventory, [
+        { label: "FIDELITY.md", kind: "tool", markdown: fidelity },
+        { label: "FIDELITY.md", kind: "rest", markdown: fidelity },
+      ])
+    ).toEqual([]);
+  });
+
   it("documents supported REST and x402 product surfaces", () => {
-    const matrix = readFileSync(resolve(import.meta.dirname, "..", "FIDELITY_MATRIX.md"), "utf8");
+    const matrix = readFileSync(resolve(root, "FIDELITY_MATRIX.md"), "utf8");
     for (const surface of [
       "`POST /v1/payment_intents`",
       "`GET /v1/payment_intents`",


### PR DESCRIPTION
## Executive summary
Generalizes the fidelity parity harness from a single stale twin-github script into a shared engine-level runner (`@pome-sh/sdk/parity`) driven by declarative per-twin scenarios, and introduces a machine-readable fidelity inventory per twin that the FIDELITY docs are 1:1-linted against. The old script hard-coded 35 cases against a 62-tool surface (and threw on the mismatch); the docs-vs-code check was a soft "mentions the tool name" scan that let twin-stripe's implemented refunds chain ship undocumented. Both failure modes are now structurally impossible to reintroduce silently.

## What
- **`@pome-sh/sdk/parity`** (new subpath export): a shared parity runner — ordered stateful MCP call chains with cross-call captures, loud-501 REST probes, optional live upstream probes — plus the `fidelity.inventory.json` zod schema, a FIDELITY-table parser (handles grouped Slack-style rows and multi-route cells), and a bidirectional inventory⇔docs lint with self-expiring `doc_drift` declarations.
- **`fidelity.inventory.json` ×3**: every MCP tool and documented REST surface, carrying `heat` (hot/warm/cold — `unclassified` until the endpoint-tier rubric ruling lands) orthogonal to `fidelity` (semantic/shape/unsupported), with per-entry justification. Ships in the npm tarball next to FIDELITY.md.
- **twin-github**: parity scenario restored to the full 62-tool surface; `scripts/fidelity-parity.ts` is now scenario data over the shared runner (runner asserts live tools === inventory === scenario coverage, every call 2xx).
- **twin-slack + twin-stripe**: new `npm run fidelity:parity`, green across their full surfaces (8 and 15 tools). The stripe scenario drives the whole money chain — create PI → confirm → simulate crypto deposit → charge → refund → ledger → events → cancel — including the refunds tools the docs still omit; that gap is declared as `doc_drift` and the lint fails the moment the docs catch up (or the declaration goes stale).
- **`fidelity-contract.test.ts` ×3**: rewritten to the hard 1:1 lint (tier equality included), keeping each twin's legacy doc pins.
- **ci.yml**: runs `fidelity:parity` for all three twins after the contract suite, so the harness can no longer rot outside CI.

## Why
The endpoint-depth milestone requires every new hot-path endpoint to ship with a parity check, but the tooling only existed in twin-github and was itself behind. This closes the tooling gap and unblocks the per-twin endpoint work. `/healthz` stays contract-frozen — surface counts live in the inventory, not the health endpoint.

## Notes for reviewer
- The runner lives in the sdk (no per-twin copies, per the twin-infra-copies:0 gate); twins contribute only data. `ParityAppLike` accepts Hono's `Response | Promise<Response>`.
- twin-github's REST axis lints against `FIDELITY_MATRIX.md` (FIDELITY.md documents REST as prose); slack/stripe lint both axes against `FIDELITY.md`. Stripe's `FIDELITY_MATRIX.md` stays a legacy pinned matrix.
- The three stripe refund doc rows are deliberately NOT added here — that reconciliation is owned by a follow-up; this PR makes the drift visible and machine-tracked instead of silent.
- New sdk files are additive exports (patch-level per PACKAGE_RELEASE.md); no version bumps in this PR — the batch release owns those.

## Greptile review
- [x] Applied Greptile P2: duplicate doc rows with conflicting tiers are now reported by the lint instead of last-row-wins (`1ce70b9`, regression-tested).

## Tests / CI
- `npm run build`, `npm run typecheck` — clean
- `npm test` all workspaces (280/246/94/213/145 tests) + `npm run test:coverage -w @pome-sh/twin-github` (231 tests, 96.5% lines) — green
- `npm run test:contract` — green
- `npm run fidelity:parity` in all three twins — exit 0, zero failures
- copy-markers, code-health, no-cloud-imports, no-eval, no-native, knip dead-code — all pass

## Review required
Yes — adds a published `@pome-sh/sdk` subpath export and a new required CI step on public `main`.

<!-- Closes F-730 -->
