### PR TITLE
feat(twin-stripe): add semantic customers + card-on-file payment methods

### DIFF
--- a/packages/twin-stripe/FIDELITY.md
+++ b/packages/twin-stripe/FIDELITY.md
@@ -5,7 +5,7 @@
 page documents exactly which surfaces are faithful to real Stripe today,
 at what tier, and how fidelity is verified.
 
-Last verified: 2026-05-09.
+Last verified: 2026-07-11.
 Stripe API version pinned: `2026-03-04.preview`.
 
 ## What "fidelity" means here
@@ -41,7 +41,7 @@ build depends on (port `:3333`, `/healthz`, `STRIPE_CLONE_HOST`,
 in the package README. Changing any of those is a breaking change for
 `pome-cloud` and requires a matching cloud consumer PR.
 
-## REST routes (v1 = 12 semantic + everything else loud 501)
+## REST routes (v1 = 22 semantic + everything else loud 501)
 
 | Route | Tier | Tests | Notes |
 | --- | --- | --- | --- |
@@ -57,11 +57,21 @@ in the package README. Changing any of those is a breaking change for
 | `GET /s/:sid/v1/balance_transactions` | semantic | `balance.test.ts` | Ledger entries. |
 | `GET /s/:sid/v1/events/:id` | semantic | `events.test.ts` | |
 | `GET /s/:sid/v1/events` | semantic | `events.test.ts` | Filter by `type`, `created`. **No webhook delivery in v1** — agents poll this. |
+| `POST /s/:sid/v1/customers` | semantic | `customers.test.ts` | F-732 (heat: hot, ruled F-729). Every field optional, like real Stripe. Emits `customer.created`. |
+| `GET /s/:sid/v1/customers/:id` | semantic | `customers.test.ts` | Deleted customers serve the `{deleted: true}` stub, like real Stripe. |
+| `GET /s/:sid/v1/customers` | semantic | `customers.test.ts` | Cursor pagination on `(created, id)`; `email` filter; deleted rows excluded. |
+| `POST /s/:sid/v1/customers/:id` | semantic | `customers.test.ts` | Update. Metadata merges per-key; an empty value unsets the key (Stripe's metadata contract). |
+| `DELETE /s/:sid/v1/customers/:id` | semantic | `customers.test.ts` | Soft delete; detaches the customer's payment methods in the same transaction. Idempotent. |
+| `GET /s/:sid/v1/customers/:id/payment_methods` | semantic | `payment-methods.test.ts` | The hot card-on-file read. `type` filter. 404 for deleted customers. |
+| `POST /s/:sid/v1/payment_methods` | semantic | `payment-methods.test.ts` | Card only (F-731 adds card PIs). Test card numbers → brand/last4; Luhn + expiry `card_error`s; PAN never stored. |
+| `GET /s/:sid/v1/payment_methods/:id` | semantic | `payment-methods.test.ts` | Top-level `GET /v1/payment_methods` (list) stays loud 501 per the F-729 ruling. |
+| `POST /s/:sid/v1/payment_methods/:id/attach` | semantic | `payment-methods.test.ts` | One customer per PM; a previously-detached PM can never be reattached. Emits `payment_method.attached`. |
+| `POST /s/:sid/v1/payment_methods/:id/detach` | semantic | `payment-methods.test.ts` | Emits `payment_method.detached`. |
 
-Anything else under `/v1/*` (`/v1/customers`,
-`/v1/setup_intents`, `/v1/checkout/*`, `/v1/products`, `/v1/prices`,
-`/v1/webhook_endpoints`, `/v1/payment_methods`, `/v1/shared_payment/*`,
-`/v1/profiles`, etc.) returns:
+Anything else under `/v1/*` (`/v1/setup_intents`, `/v1/checkout/*`,
+`/v1/products`, `/v1/prices`, `/v1/webhook_endpoints`,
+`/v1/shared_payment/*`, `/v1/profiles`, the top-level
+`GET /v1/payment_methods` list, etc.) returns:
 
 ```json
 {
@@ -82,7 +92,7 @@ Anything else under `/v1/*` (`/v1/customers`,
 
 HTTP status: 501.
 
-## MCP tools (12 — names match `stripe-node` method names)
+## MCP tools (25 live; 22 documented — names match `stripe-node` method names)
 
 | Tool | Backing route | Tier |
 | --- | --- | --- |
@@ -98,6 +108,16 @@ HTTP status: 501.
 | `list_balance_transactions` | GET /v1/balance_transactions | semantic |
 | `retrieve_event` | GET /v1/events/:id | semantic |
 | `list_events` | GET /v1/events | semantic |
+| `create_customer` | POST /v1/customers | semantic |
+| `retrieve_customer` | GET /v1/customers/:id | semantic |
+| `update_customer` | POST /v1/customers/:id | semantic |
+| `delete_customer` | DELETE /v1/customers/:id | semantic |
+| `list_customers` | GET /v1/customers | semantic |
+| `list_customer_payment_methods` | GET /v1/customers/:id/payment_methods | semantic |
+| `create_payment_method` | POST /v1/payment_methods | semantic |
+| `retrieve_payment_method` | GET /v1/payment_methods/:id | semantic |
+| `attach_payment_method` | POST /v1/payment_methods/:id/attach | semantic |
+| `detach_payment_method` | POST /v1/payment_methods/:id/detach | semantic |
 
 Every MCP tool is callable via both `POST /s/:sid/mcp/call` (with
 `{tool, arguments}` body) and `POST /s/:sid/mcp/tools/:name` (with the

--- a/packages/twin-stripe/fidelity.inventory.json
+++ b/packages/twin-stripe/fidelity.inventory.json
@@ -2,7 +2,7 @@
   "twin": "stripe",
   "package": "@pome-sh/twin-stripe",
   "updated": "2026-07-11",
-  "notes": "Both tables lint 1:1 against FIDELITY.md; FIDELITY_MATRIX.md stays a legacy pinned matrix. The refunds chain is implemented but undocumented — declared in doc_drift until F-733 reconciles the docs. Heat tiers await the F-729 rubric ruling.",
+  "notes": "Both tables lint 1:1 against FIDELITY.md; FIDELITY_MATRIX.md stays a legacy pinned matrix. The refunds chain is implemented but undocumented — declared in doc_drift until F-733 reconciles the docs. The customer-management chain (F-732) carries its ruled heat (hot, F-729); the remaining pre-M5 surfaces stay unclassified until their owning tickets (F-731 payments, F-733 refunds docs, F-734 warm set) land.",
   "tools": [
     {
       "name": "create_payment_intent",
@@ -93,6 +93,66 @@
       "heat": "unclassified",
       "fidelity": "semantic",
       "justification": "Implemented and tested in code but absent from the FIDELITY.md tables; doc reconciliation owned by F-733."
+    },
+    {
+      "name": "create_customer",
+      "heat": "hot",
+      "fidelity": "semantic",
+      "justification": "TC:customer-mgmt (ruled F-729): customer management is the precondition of nearly every collection chain. Vendor MCP has meta-tools only; task chain wins per rubric."
+    },
+    {
+      "name": "retrieve_customer",
+      "heat": "hot",
+      "fidelity": "semantic",
+      "justification": "TC:customer-mgmt (ruled F-729)."
+    },
+    {
+      "name": "update_customer",
+      "heat": "hot",
+      "fidelity": "semantic",
+      "justification": "TC:customer-mgmt (ruled F-729); Stripe per-key metadata merge modeled semantically."
+    },
+    {
+      "name": "delete_customer",
+      "heat": "hot",
+      "fidelity": "semantic",
+      "justification": "TC:customer-mgmt (ruled F-729); soft delete serves the {deleted: true} stub and detaches PMs like real Stripe."
+    },
+    {
+      "name": "list_customers",
+      "heat": "hot",
+      "fidelity": "semantic",
+      "justification": "TC:customer-mgmt (ruled F-729); cursor pagination + email filter."
+    },
+    {
+      "name": "list_customer_payment_methods",
+      "heat": "hot",
+      "fidelity": "semantic",
+      "justification": "TC:card-on-file (ruled F-729): the customer-scoped PM list is the hot read; the top-level PM list stays cold."
+    },
+    {
+      "name": "create_payment_method",
+      "heat": "hot",
+      "fidelity": "semantic",
+      "justification": "TC:card-on-file (ruled F-729): card PMs from test card numbers; PAN never stored. Card-mode PI confirm lands in F-731."
+    },
+    {
+      "name": "retrieve_payment_method",
+      "heat": "hot",
+      "fidelity": "semantic",
+      "justification": "TC:card-on-file (ruled F-729)."
+    },
+    {
+      "name": "attach_payment_method",
+      "heat": "hot",
+      "fidelity": "semantic",
+      "justification": "TC:card-on-file (ruled F-729): one customer per PM; a detached PM can never be reattached (Stripe lifecycle rule)."
+    },
+    {
+      "name": "detach_payment_method",
+      "heat": "hot",
+      "fidelity": "semantic",
+      "justification": "TC:card-on-file (ruled F-729)."
     }
   ],
   "rest": [
@@ -185,6 +245,66 @@
       "heat": "unclassified",
       "fidelity": "semantic",
       "justification": "Implemented and tested in code but absent from the FIDELITY.md tables; doc reconciliation owned by F-733."
+    },
+    {
+      "name": "POST /s/:sid/v1/customers",
+      "heat": "hot",
+      "fidelity": "semantic",
+      "justification": "TC:customer-mgmt (ruled F-729): customer management is the precondition of nearly every collection chain."
+    },
+    {
+      "name": "GET /s/:sid/v1/customers/:id",
+      "heat": "hot",
+      "fidelity": "semantic",
+      "justification": "TC:customer-mgmt (ruled F-729); deleted customers serve the {deleted: true} stub like real Stripe."
+    },
+    {
+      "name": "GET /s/:sid/v1/customers",
+      "heat": "hot",
+      "fidelity": "semantic",
+      "justification": "TC:customer-mgmt (ruled F-729); cursor pagination + email filter, deleted rows excluded."
+    },
+    {
+      "name": "POST /s/:sid/v1/customers/:id",
+      "heat": "hot",
+      "fidelity": "semantic",
+      "justification": "TC:customer-mgmt (ruled F-729); Stripe per-key metadata merge (empty value unsets)."
+    },
+    {
+      "name": "DELETE /s/:sid/v1/customers/:id",
+      "heat": "hot",
+      "fidelity": "semantic",
+      "justification": "TC:customer-mgmt (ruled F-729); soft delete detaches the customer's PMs in the same transaction."
+    },
+    {
+      "name": "GET /s/:sid/v1/customers/:id/payment_methods",
+      "heat": "hot",
+      "fidelity": "semantic",
+      "justification": "TC:card-on-file (ruled F-729): the customer-scoped PM list is the hot read; the top-level GET /v1/payment_methods stays cold (loud 501)."
+    },
+    {
+      "name": "POST /s/:sid/v1/payment_methods",
+      "heat": "hot",
+      "fidelity": "semantic",
+      "justification": "TC:card-on-file (ruled F-729): card PMs from test card numbers (Luhn + expiry card_errors); PAN never stored."
+    },
+    {
+      "name": "GET /s/:sid/v1/payment_methods/:id",
+      "heat": "hot",
+      "fidelity": "semantic",
+      "justification": "TC:card-on-file (ruled F-729)."
+    },
+    {
+      "name": "POST /s/:sid/v1/payment_methods/:id/attach",
+      "heat": "hot",
+      "fidelity": "semantic",
+      "justification": "TC:card-on-file (ruled F-729): one customer per PM; a detached PM can never be reattached."
+    },
+    {
+      "name": "POST /s/:sid/v1/payment_methods/:id/detach",
+      "heat": "hot",
+      "fidelity": "semantic",
+      "justification": "TC:card-on-file (ruled F-729)."
     }
   ],
   "doc_drift": [

--- a/packages/twin-stripe/scripts/fidelity-parity.ts
+++ b/packages/twin-stripe/scripts/fidelity-parity.ts
@@ -3,11 +3,14 @@
 // fidelity:parity — declarative parity scenario for twin-stripe (F-730).
 // The runner lives in @pome-sh/sdk/parity; this file is scenario data only:
 // the crypto-deposit money chain (create PI → confirm → settle → charge →
-// refund → ledger → events) plus a second PI for the cancel path, covering
-// every MCP tool in fidelity.inventory.json — including the refunds chain
-// that is live in code but still absent from FIDELITY.md (declared as
-// doc_drift, reconciliation owned by F-733). The loud-501 probe pins the
-// Stripe-shaped unsupported envelope on /v1/customers.
+// refund → ledger → events), a second PI for the cancel path, and the
+// customer-management chain (F-732: customer CRUD + card-on-file
+// attach/detach), covering every MCP tool in fidelity.inventory.json —
+// including the refunds chain that is live in code but still absent from
+// FIDELITY.md (declared as doc_drift, reconciliation owned by F-733). The
+// loud-501 probe pins the Stripe-shaped unsupported envelope on
+// /v1/checkout/sessions (it moved off /v1/customers when F-732 made
+// customers a supported surface).
 
 import { join } from "node:path";
 import { loadFidelityInventory, runParityCli, type ParityStep } from "@pome-sh/sdk/parity";
@@ -69,6 +72,55 @@ const steps: ParityStep[] = [
     },
   },
   { tool: "cancel_payment_intent", arguments: (state) => ({ id: state.pi2 }) },
+  // Customer-management chain (F-732): CRUD + card-on-file attach/detach.
+  {
+    tool: "create_customer",
+    arguments: { name: "Parity Customer", email: "parity@example.com", metadata: { a: "1" } },
+    capture: (body, state) => {
+      state.customer = (body as { id?: string }).id;
+    },
+  },
+  { tool: "retrieve_customer", arguments: (state) => ({ id: state.customer }) },
+  {
+    tool: "update_customer",
+    arguments: (state) => ({ id: state.customer, name: "Parity Customer II", metadata: { a: "", b: "2" } }),
+    verify: (body) => {
+      const metadata = (body as { metadata?: Record<string, string> }).metadata ?? {};
+      if (metadata.a !== undefined) return "metadata key 'a' should have been unset by the empty value";
+      if (metadata.b !== "2") return "metadata key 'b' should have been merged in";
+      return undefined;
+    },
+  },
+  { tool: "list_customers", arguments: { limit: 10 } },
+  {
+    tool: "create_payment_method",
+    arguments: { type: "card", card: { number: "4242424242424242", exp_month: 12, exp_year: 2032 } },
+    capture: (body, state) => {
+      state.pm = (body as { id?: string }).id;
+    },
+  },
+  { tool: "retrieve_payment_method", arguments: (state) => ({ id: state.pm }) },
+  {
+    tool: "attach_payment_method",
+    arguments: (state) => ({ id: state.pm, customer: state.customer }),
+    verify: (body) =>
+      (body as { customer?: string | null }).customer ? undefined : "attach should set customer",
+  },
+  {
+    tool: "list_customer_payment_methods",
+    arguments: (state) => ({ customer: state.customer }),
+    verify: (body) =>
+      ((body as { data?: unknown[] }).data?.length ?? 0) === 1
+        ? undefined
+        : "customer should list exactly the attached PM",
+  },
+  {
+    tool: "detach_payment_method",
+    arguments: (state) => ({ id: state.pm }),
+    verify: (body) =>
+      (body as { customer?: string | null }).customer === null ? undefined : "detach should clear customer",
+  },
+  { tool: "delete_customer", arguments: (state) => ({ id: state.customer }) },
 ];
 
 await runParityCli({
@@ -78,6 +130,6 @@ await runParityCli({
   liveToolNames: listTools().map((tool) => tool.name),
   steps,
   restProbes: [
-    { surface: "unsupported-rest", path: "/v1/customers", status: 501, expectUnsupportedEnvelope: true },
+    { surface: "unsupported-rest", path: "/v1/checkout/sessions", status: 501, expectUnsupportedEnvelope: true },
   ],
 });

--- a/packages/twin-stripe/scripts/smoke.ts
+++ b/packages/twin-stripe/scripts/smoke.ts
@@ -196,10 +196,11 @@ async function main() {
       log("ok", `5 events emitted: ${types.join(", ")}`);
     }
 
-    // 6. unsupported route → loud 501
+    // 6. unsupported route → loud 501. (/v1/customers became a supported
+    // surface in F-732; probe a path still on the catch-all.)
     {
-      const r = await fetch(`${baseUrl}/s/${sid}/v1/customers`, { headers });
-      assertOk(r.status === 501, `6. /v1/customers returned ${r.status}, expected 501`);
+      const r = await fetch(`${baseUrl}/s/${sid}/v1/checkout/sessions`, { headers });
+      assertOk(r.status === 501, `6. /v1/checkout/sessions returned ${r.status}, expected 501`);
       const env = await r.json() as { error: { code: string; fidelity: string } };
       assertOk(env.error.code === "endpoint_not_supported", `6. error.code=${env.error.code}`);
       assertOk(env.error.fidelity === "unsupported", `6. error.fidelity=${env.error.fidelity}`);

--- a/packages/twin-stripe/src/domain/customers.ts
+++ b/packages/twin-stripe/src/domain/customers.ts
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Customers domain — F-732 (M5 customer-management hot path).
+//
+// Stripe semantics carried here: metadata updates merge per-key (an empty
+// or null value unsets the key), DELETE is a soft delete that keeps the row
+// so retrieve can serve the `{deleted: true}` stub exactly like real
+// Stripe, and deleting a customer detaches its payment methods in the same
+// better-sqlite3 transaction.
+
+import type { CustomerRow, TwinStripeDatabase } from "../types.js";
+import { TwinError } from "../errors.js";
+import { newId } from "../ids.js";
+import { nowUnix } from "../util.js";
+import { ensureStripeTables } from "./schema.js";
+import { listPaginated } from "./payment-intents.js";
+
+export type CustomerFieldsInput = {
+  name?: string | null;
+  email?: string | null;
+  description?: string | null;
+  phone?: string | null;
+  metadata?: Record<string, string | null>;
+};
+
+export type ListCustomersInput = {
+  limit?: number;
+  starting_after?: string;
+  ending_before?: string;
+  email?: string;
+  created_gt?: number;
+  created_gte?: number;
+  created_lt?: number;
+  created_lte?: number;
+};
+
+export class CustomersDomain {
+  constructor(readonly db: TwinStripeDatabase) {
+    ensureStripeTables(db);
+  }
+
+  create(accountId: string, input: CustomerFieldsInput): CustomerRow {
+    const id = newId("customer");
+    const metadata: Record<string, string> = {};
+    for (const [key, value] of Object.entries(input.metadata ?? {})) {
+      if (value !== null && value !== "") metadata[key] = value;
+    }
+    this.db
+      .prepare(
+        `INSERT INTO customers (
+          id, account_id, name, email, description, phone, metadata_json, deleted, created
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?)`
+      )
+      .run(
+        id,
+        accountId,
+        input.name ?? null,
+        input.email ?? null,
+        input.description ?? null,
+        input.phone ?? null,
+        JSON.stringify(metadata),
+        nowUnix()
+      );
+    return this.requireById(accountId, id);
+  }
+
+  getById(accountId: string, id: string): CustomerRow | null {
+    return (
+      (this.db
+        .prepare("SELECT * FROM customers WHERE id = ? AND account_id = ?")
+        .get(id, accountId) as CustomerRow | undefined) ?? null
+    );
+  }
+
+  /** Any row, deleted or live. Missing id → Stripe's 404 resource_missing. */
+  requireById(accountId: string, id: string): CustomerRow {
+    const row = this.getById(accountId, id);
+    if (!row) throw noSuchCustomer(id);
+    return row;
+  }
+
+  /** Live row only. Deleted customers 404 for writes and sub-resources. */
+  requireLive(accountId: string, id: string): CustomerRow {
+    const row = this.requireById(accountId, id);
+    if (row.deleted) throw noSuchCustomer(id);
+    return row;
+  }
+
+  /**
+   * Update fields; metadata merges per-key, an empty/null value unsets the
+   * key (real Stripe's metadata contract).
+   */
+  update(accountId: string, id: string, input: CustomerFieldsInput): CustomerRow {
+    const existing = this.requireLive(accountId, id);
+    const metadata = JSON.parse(existing.metadata_json) as Record<string, string>;
+    for (const [key, value] of Object.entries(input.metadata ?? {})) {
+      if (value === null || value === "") delete metadata[key];
+      else metadata[key] = value;
+    }
+    this.db
+      .prepare(
+        `UPDATE customers SET name = ?, email = ?, description = ?, phone = ?, metadata_json = ?
+          WHERE id = ? AND account_id = ?`
+      )
+      .run(
+        input.name !== undefined ? input.name : existing.name,
+        input.email !== undefined ? input.email : existing.email,
+        input.description !== undefined ? input.description : existing.description,
+        input.phone !== undefined ? input.phone : existing.phone,
+        JSON.stringify(metadata),
+        id,
+        accountId
+      );
+    return this.requireById(accountId, id);
+  }
+
+  /**
+   * Soft-delete. Detaches the customer's payment methods in the same
+   * transaction (real Stripe invalidates them on customer deletion).
+   * Idempotent: deleting an already-deleted customer returns the row.
+   */
+  delete(accountId: string, id: string): { row: CustomerRow; alreadyDeleted: boolean } {
+    const tx = this.db.transaction((): { row: CustomerRow; alreadyDeleted: boolean } => {
+      const existing = this.requireById(accountId, id);
+      if (existing.deleted) return { row: existing, alreadyDeleted: true };
+      this.db
+        .prepare("UPDATE customers SET deleted = 1 WHERE id = ? AND account_id = ?")
+        .run(id, accountId);
+      this.db
+        .prepare(
+          "UPDATE payment_methods SET customer_id = NULL, detached = 1 WHERE customer_id = ? AND account_id = ?"
+        )
+        .run(id, accountId);
+      return { row: this.requireById(accountId, id), alreadyDeleted: false };
+    });
+    return tx();
+  }
+
+  list(
+    accountId: string,
+    input: ListCustomersInput
+  ): { rows: CustomerRow[]; hasMore: boolean; limit: number } {
+    const extra: Array<{ sql: string; args: unknown[] }> = [{ sql: "deleted = 0", args: [] }];
+    if (input.email) extra.push({ sql: "email = ?", args: [input.email] });
+    return listPaginated<CustomerRow>(this.db, "customers", accountId, input, extra);
+  }
+}
+
+function noSuchCustomer(id: string): TwinError {
+  return new TwinError(
+    "invalid_request_error",
+    "resource_missing",
+    `No such customer: '${id}'.`,
+    { param: "customer", statusCode: 404 }
+  );
+}

--- a/packages/twin-stripe/src/domain/events.ts
+++ b/packages/twin-stripe/src/domain/events.ts
@@ -19,7 +19,12 @@ export type EventType =
   | "payment_intent.succeeded"
   | "payment_intent.canceled"
   | "charge.succeeded"
-  | "charge.refunded";
+  | "charge.refunded"
+  | "customer.created"
+  | "customer.updated"
+  | "customer.deleted"
+  | "payment_method.attached"
+  | "payment_method.detached";
 
 export type CreateEventInput = {
   type: EventType;

--- a/packages/twin-stripe/src/domain/index.ts
+++ b/packages/twin-stripe/src/domain/index.ts
@@ -14,4 +14,11 @@ export { EventsDomain } from "./events.js";
 export type { ListEventsInput } from "./events.js";
 export { RefundsDomain } from "./refunds.js";
 export type { CreateRefundInput, ListRefundsInput } from "./refunds.js";
+export { CustomersDomain } from "./customers.js";
+export type { CustomerFieldsInput, ListCustomersInput } from "./customers.js";
+export { PaymentMethodsDomain } from "./payment-methods.js";
+export type {
+  CreatePaymentMethodInput,
+  ListCustomerPaymentMethodsInput,
+} from "./payment-methods.js";
 export { ensureStripeTables, resetStripeTables } from "./schema.js";

--- a/packages/twin-stripe/src/domain/payment-intents.ts
+++ b/packages/twin-stripe/src/domain/payment-intents.ts
@@ -357,12 +357,17 @@ export function depositAddressFromId(id: string): string {
  *
  * `accountId` scopes results to the calling session's account so two
  * sessions sharing a DB file cannot see each other's rows.
+ *
+ * `extraWheres` lets a caller inject table-specific predicates (e.g. the
+ * customers table's `deleted = 0`, payment_methods' `customer_id = ?`)
+ * without teaching this generic helper every column name.
  */
 export function listPaginated<T extends { id: string; created: number }>(
   db: TwinStripeDatabase,
   table: string,
   accountId: string,
-  input: ListPIsInput & { type?: string; payment_intent?: string; customer?: string }
+  input: ListPIsInput & { type?: string; payment_intent?: string; customer?: string },
+  extraWheres: Array<{ sql: string; args: unknown[] }> = []
 ): { rows: T[]; hasMore: boolean; limit: number } {
   const limitRaw = input.limit ?? 10;
   const limit = Math.min(100, Math.max(1, Math.floor(limitRaw)));
@@ -407,6 +412,10 @@ export function listPaginated<T extends { id: string; created: number }>(
   if (input.payment_intent) {
     wheres.push("payment_intent_id = ?");
     args.push(input.payment_intent);
+  }
+  for (const extra of extraWheres) {
+    wheres.push(extra.sql);
+    args.push(...extra.args);
   }
 
   const where = `WHERE ${wheres.join(" AND ")}`;

--- a/packages/twin-stripe/src/domain/payment-methods.ts
+++ b/packages/twin-stripe/src/domain/payment-methods.ts
@@ -80,13 +80,24 @@ export class PaymentMethodsDomain {
       );
     }
     const expYear = Number(card.exp_year);
-    const currentYear = new Date(nowUnix() * 1000).getUTCFullYear();
+    const now = new Date(nowUnix() * 1000);
+    const currentYear = now.getUTCFullYear();
     if (!Number.isInteger(expYear) || expYear < currentYear) {
       throw new TwinError(
         "card_error",
         "invalid_expiry_year",
         "Your card's expiration year is invalid.",
         { param: "card[exp_year]", statusCode: 402 }
+      );
+    }
+    // Cards expire at end-of-month: the current month is still valid, a past
+    // month of the current year is not.
+    if (expYear === currentYear && expMonth < now.getUTCMonth() + 1) {
+      throw new TwinError(
+        "card_error",
+        "invalid_expiry_month",
+        "Your card's expiration month is invalid.",
+        { param: "card[exp_month]", statusCode: 402 }
       );
     }
 
@@ -179,6 +190,14 @@ export class PaymentMethodsDomain {
       )
       .run(id, accountId);
     return this.requireById(accountId, id);
+  }
+
+  /** All PMs currently attached to a customer (no pagination — used by
+   *  customer deletion to emit one detached event per PM). */
+  allAttachedToCustomer(accountId: string, customerId: string): PaymentMethodRow[] {
+    return this.db
+      .prepare("SELECT * FROM payment_methods WHERE customer_id = ? AND account_id = ?")
+      .all(customerId, accountId) as PaymentMethodRow[];
   }
 
   listForCustomer(

--- a/packages/twin-stripe/src/domain/payment-methods.ts
+++ b/packages/twin-stripe/src/domain/payment-methods.ts
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Payment methods domain — F-732 (M5 card-on-file chain).
+//
+// Card-only in this milestone (card PIs land in F-731). The PAN is never
+// stored: creation derives brand/last4/fingerprint and drops the number.
+// Attach/detach carries Stripe's lifecycle rules — one customer per PM,
+// and a detached PM can never be reattached.
+
+import { createHash } from "node:crypto";
+import type { PaymentMethodRow, TwinStripeDatabase } from "../types.js";
+import { TwinError } from "../errors.js";
+import { newId } from "../ids.js";
+import { nowUnix } from "../util.js";
+import { ensureStripeTables } from "./schema.js";
+import { listPaginated } from "./payment-intents.js";
+
+export type CreatePaymentMethodInput = {
+  type?: unknown;
+  card?: {
+    number?: unknown;
+    exp_month?: unknown;
+    exp_year?: unknown;
+    cvc?: unknown;
+  } | null;
+};
+
+export type ListCustomerPaymentMethodsInput = {
+  limit?: number;
+  starting_after?: string;
+  ending_before?: string;
+  type?: string;
+};
+
+export class PaymentMethodsDomain {
+  constructor(readonly db: TwinStripeDatabase) {
+    ensureStripeTables(db);
+  }
+
+  create(accountId: string, input: CreatePaymentMethodInput): PaymentMethodRow {
+    if (typeof input.type !== "string" || input.type.length === 0) {
+      throw new TwinError(
+        "invalid_request_error",
+        "parameter_missing",
+        "Missing required param: type.",
+        { param: "type", statusCode: 400 }
+      );
+    }
+    if (input.type !== "card") {
+      throw new TwinError(
+        "invalid_request_error",
+        "parameter_invalid_string",
+        `payment method type must be "card" for v1 of this twin (got '${input.type}').`,
+        { param: "type", statusCode: 400 }
+      );
+    }
+    const card = input.card;
+    if (!card || typeof card !== "object") {
+      throw new TwinError(
+        "invalid_request_error",
+        "parameter_missing",
+        "Missing required param: card.",
+        { param: "card", statusCode: 400 }
+      );
+    }
+    const number = typeof card.number === "string" ? card.number.replace(/[\s-]/g, "") : "";
+    if (!/^\d{12,19}$/.test(number) || !passesLuhn(number)) {
+      throw new TwinError("card_error", "incorrect_number", "Your card number is incorrect.", {
+        param: "card[number]",
+        statusCode: 402,
+      });
+    }
+    const expMonth = Number(card.exp_month);
+    if (!Number.isInteger(expMonth) || expMonth < 1 || expMonth > 12) {
+      throw new TwinError(
+        "card_error",
+        "invalid_expiry_month",
+        "Your card's expiration month is invalid.",
+        { param: "card[exp_month]", statusCode: 402 }
+      );
+    }
+    const expYear = Number(card.exp_year);
+    const currentYear = new Date(nowUnix() * 1000).getUTCFullYear();
+    if (!Number.isInteger(expYear) || expYear < currentYear) {
+      throw new TwinError(
+        "card_error",
+        "invalid_expiry_year",
+        "Your card's expiration year is invalid.",
+        { param: "card[exp_year]", statusCode: 402 }
+      );
+    }
+
+    const id = newId("payment_method");
+    this.db
+      .prepare(
+        `INSERT INTO payment_methods (
+          id, account_id, type, card_brand, card_last4, card_exp_month,
+          card_exp_year, card_fingerprint, customer_id, detached, created
+        ) VALUES (?, ?, 'card', ?, ?, ?, ?, ?, NULL, 0, ?)`
+      )
+      .run(
+        id,
+        accountId,
+        brandFromNumber(number),
+        number.slice(-4),
+        expMonth,
+        expYear,
+        // Stable per PAN, like Stripe's card fingerprint — but derived, so
+        // the PAN itself is never persisted anywhere.
+        createHash("sha256").update(number).digest("hex").slice(0, 16),
+        nowUnix()
+      );
+    return this.requireById(accountId, id);
+  }
+
+  getById(accountId: string, id: string): PaymentMethodRow | null {
+    return (
+      (this.db
+        .prepare("SELECT * FROM payment_methods WHERE id = ? AND account_id = ?")
+        .get(id, accountId) as PaymentMethodRow | undefined) ?? null
+    );
+  }
+
+  requireById(accountId: string, id: string): PaymentMethodRow {
+    const row = this.getById(accountId, id);
+    if (!row) {
+      throw new TwinError(
+        "invalid_request_error",
+        "resource_missing",
+        `No such payment_method: '${id}'.`,
+        { param: "payment_method", statusCode: 404 }
+      );
+    }
+    return row;
+  }
+
+  /**
+   * Attach to a customer. Caller has already resolved the customer as live.
+   * Stripe rules: one customer per PM, and a previously-detached PM may
+   * never be reattached.
+   */
+  attach(accountId: string, id: string, customerId: string): PaymentMethodRow {
+    const pm = this.requireById(accountId, id);
+    if (pm.customer_id) {
+      throw new TwinError(
+        "invalid_request_error",
+        "payment_method_already_attached",
+        "This PaymentMethod has already been attached to a customer.",
+        { param: "payment_method", statusCode: 400 }
+      );
+    }
+    if (pm.detached) {
+      throw new TwinError(
+        "invalid_request_error",
+        "payment_method_previously_detached",
+        "A payment method that has been previously detached from a customer may not be reattached.",
+        { param: "payment_method", statusCode: 400 }
+      );
+    }
+    this.db
+      .prepare("UPDATE payment_methods SET customer_id = ? WHERE id = ? AND account_id = ?")
+      .run(customerId, id, accountId);
+    return this.requireById(accountId, id);
+  }
+
+  detach(accountId: string, id: string): PaymentMethodRow {
+    const pm = this.requireById(accountId, id);
+    if (!pm.customer_id) {
+      throw new TwinError(
+        "invalid_request_error",
+        "payment_method_not_attached",
+        "The payment method you provided is not attached to a customer.",
+        { param: "payment_method", statusCode: 400 }
+      );
+    }
+    this.db
+      .prepare(
+        "UPDATE payment_methods SET customer_id = NULL, detached = 1 WHERE id = ? AND account_id = ?"
+      )
+      .run(id, accountId);
+    return this.requireById(accountId, id);
+  }
+
+  listForCustomer(
+    accountId: string,
+    customerId: string,
+    input: ListCustomerPaymentMethodsInput
+  ): { rows: PaymentMethodRow[]; hasMore: boolean; limit: number } {
+    return listPaginated<PaymentMethodRow>(this.db, "payment_methods", accountId, input, [
+      { sql: "customer_id = ?", args: [customerId] },
+    ]);
+  }
+}
+
+function passesLuhn(number: string): boolean {
+  let sum = 0;
+  let double = false;
+  for (let i = number.length - 1; i >= 0; i--) {
+    let digit = number.charCodeAt(i) - 48;
+    if (double) {
+      digit *= 2;
+      if (digit > 9) digit -= 9;
+    }
+    sum += digit;
+    double = !double;
+  }
+  return sum % 10 === 0;
+}
+
+function brandFromNumber(number: string): string {
+  if (/^4/.test(number)) return "visa";
+  if (/^(5[1-5]|2[2-7])/.test(number)) return "mastercard";
+  if (/^3[47]/.test(number)) return "amex";
+  if (/^6(011|5)/.test(number)) return "discover";
+  return "unknown";
+}

--- a/packages/twin-stripe/src/domain/schema.ts
+++ b/packages/twin-stripe/src/domain/schema.ts
@@ -107,15 +107,54 @@ CREATE INDEX IF NOT EXISTS idx_refunds_charge ON refunds(charge_id);
 CREATE INDEX IF NOT EXISTS idx_refunds_payment_intent ON refunds(payment_intent_id);
 CREATE INDEX IF NOT EXISTS idx_refunds_created ON refunds(created);
 CREATE INDEX IF NOT EXISTS idx_refunds_account_id ON refunds(account_id);
+
+CREATE TABLE IF NOT EXISTS customers (
+  id TEXT PRIMARY KEY,
+  account_id TEXT NOT NULL,
+  name TEXT,
+  email TEXT,
+  description TEXT,
+  phone TEXT,
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  deleted INTEGER NOT NULL DEFAULT 0,
+  created INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_customers_created ON customers(created);
+CREATE INDEX IF NOT EXISTS idx_customers_email ON customers(email);
+CREATE INDEX IF NOT EXISTS idx_customers_account_id ON customers(account_id);
+
+CREATE TABLE IF NOT EXISTS payment_methods (
+  id TEXT PRIMARY KEY,
+  account_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  card_brand TEXT NOT NULL,
+  card_last4 TEXT NOT NULL,
+  card_exp_month INTEGER NOT NULL,
+  card_exp_year INTEGER NOT NULL,
+  card_fingerprint TEXT NOT NULL,
+  customer_id TEXT,
+  detached INTEGER NOT NULL DEFAULT 0,
+  created INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_payment_methods_customer ON payment_methods(customer_id);
+CREATE INDEX IF NOT EXISTS idx_payment_methods_created ON payment_methods(created);
+CREATE INDEX IF NOT EXISTS idx_payment_methods_account_id ON payment_methods(account_id);
 `;
 
 // Delete order matters for foreign-key cascades: refunds → charges → PIs.
+// payment_methods reference customers by plain column (no FK), but clear
+// them before customers anyway so a mid-reset read never sees an attached
+// PM whose customer row is gone.
 const STRIPE_TABLES = [
   "refunds",
   "events",
   "balance_transactions",
   "charges",
   "payment_intents",
+  "payment_methods",
+  "customers",
 ];
 
 /**

--- a/packages/twin-stripe/src/domain/stripe-domain.ts
+++ b/packages/twin-stripe/src/domain/stripe-domain.ts
@@ -288,9 +288,19 @@ export class StripeDomain {
 
   deleteCustomer(accountId: string, id: string): { body: unknown; delta: StateDelta } {
     const before = this.customers.requireById(accountId, id);
+    const attached = this.paymentMethods.allAttachedToCustomer(accountId, id);
     const { row, alreadyDeleted } = this.customers.delete(accountId, id);
     if (!alreadyDeleted) {
       this.events.create(accountId, { type: "customer.deleted", object: deletedCustomerJson(row) });
+      // Deletion detached every attached PM (inside customers.delete's
+      // transaction); event-polling consumers see one detached event per PM,
+      // carrying the post-detach shape.
+      for (const pm of attached) {
+        this.events.create(accountId, {
+          type: "payment_method.detached",
+          object: paymentMethodJson(this.paymentMethods.requireById(accountId, pm.id)),
+        });
+      }
     }
     return {
       body: deletedCustomerJson(row),

--- a/packages/twin-stripe/src/domain/stripe-domain.ts
+++ b/packages/twin-stripe/src/domain/stripe-domain.ts
@@ -21,7 +21,9 @@ import type {
   PIRow,
   ChargeRow,
   BalanceTxRow,
+  CustomerRow,
   EventRow,
+  PaymentMethodRow,
   RefundRow,
   StateDelta,
 } from "../types.js";
@@ -38,13 +40,26 @@ import {
   type CreateRefundInput,
   type ListRefundsInput,
 } from "./refunds.js";
+import {
+  CustomersDomain,
+  type CustomerFieldsInput,
+  type ListCustomersInput,
+} from "./customers.js";
+import {
+  PaymentMethodsDomain,
+  type CreatePaymentMethodInput,
+  type ListCustomerPaymentMethodsInput,
+} from "./payment-methods.js";
 import { ensureStripeTables, resetStripeTables } from "./schema.js";
 import {
   paymentIntentJson,
   chargeJson,
   balanceTransactionJson,
   balanceJson,
+  customerJson,
+  deletedCustomerJson,
   eventJson,
+  paymentMethodJson,
   refundJson,
   serializedList,
 } from "../serializers.js";
@@ -55,6 +70,8 @@ export class StripeDomain {
   readonly balance: BalanceDomain;
   readonly events: EventsDomain;
   readonly refunds: RefundsDomain;
+  readonly customers: CustomersDomain;
+  readonly paymentMethods: PaymentMethodsDomain;
 
   constructor(readonly db: TwinStripeDatabase) {
     ensureStripeTables(db);
@@ -63,6 +80,8 @@ export class StripeDomain {
     this.balance = new BalanceDomain(db);
     this.events = new EventsDomain(db);
     this.refunds = new RefundsDomain(db);
+    this.customers = new CustomersDomain(db);
+    this.paymentMethods = new PaymentMethodsDomain(db);
   }
 
   /** Reset Stripe-domain state. Used by `/admin/reset`. */
@@ -233,6 +252,128 @@ export class StripeDomain {
     return serializedList(rows.map(refundJson), hasMore, limit, "/v1/refunds");
   }
 
+  // ---------- Customers ----------
+
+  createCustomer(
+    accountId: string,
+    input: CustomerFieldsInput
+  ): { body: unknown; delta: StateDelta } {
+    const row = this.customers.create(accountId, input);
+    this.events.create(accountId, { type: "customer.created", object: customerJson(row) });
+    return {
+      body: customerJson(row),
+      delta: { before: null, after: rowToRecord(row) },
+    };
+  }
+
+  /** Deleted customers serve the `{deleted: true}` stub, like real Stripe. */
+  retrieveCustomer(accountId: string, id: string) {
+    const row = this.customers.requireById(accountId, id);
+    return row.deleted ? deletedCustomerJson(row) : customerJson(row);
+  }
+
+  updateCustomer(
+    accountId: string,
+    id: string,
+    input: CustomerFieldsInput
+  ): { body: unknown; delta: StateDelta } {
+    const before = this.customers.requireLive(accountId, id);
+    const row = this.customers.update(accountId, id, input);
+    this.events.create(accountId, { type: "customer.updated", object: customerJson(row) });
+    return {
+      body: customerJson(row),
+      delta: { before: rowToRecord(before), after: rowToRecord(row) },
+    };
+  }
+
+  deleteCustomer(accountId: string, id: string): { body: unknown; delta: StateDelta } {
+    const before = this.customers.requireById(accountId, id);
+    const { row, alreadyDeleted } = this.customers.delete(accountId, id);
+    if (!alreadyDeleted) {
+      this.events.create(accountId, { type: "customer.deleted", object: deletedCustomerJson(row) });
+    }
+    return {
+      body: deletedCustomerJson(row),
+      delta: { before: rowToRecord(before), after: rowToRecord(row) },
+    };
+  }
+
+  listCustomers(accountId: string, input: ListCustomersInput) {
+    const { rows, hasMore, limit } = this.customers.list(accountId, input);
+    return serializedList(rows.map(customerJson), hasMore, limit, "/v1/customers");
+  }
+
+  listCustomerPaymentMethods(
+    accountId: string,
+    customerId: string,
+    input: ListCustomerPaymentMethodsInput
+  ) {
+    // 404 for unknown AND deleted customers — a deleted customer has no
+    // payment-method sub-resource anymore.
+    this.customers.requireLive(accountId, customerId);
+    const { rows, hasMore, limit } = this.paymentMethods.listForCustomer(
+      accountId,
+      customerId,
+      input
+    );
+    return serializedList(
+      rows.map(paymentMethodJson),
+      hasMore,
+      limit,
+      `/v1/customers/${customerId}/payment_methods`
+    );
+  }
+
+  // ---------- Payment methods ----------
+
+  createPaymentMethod(
+    accountId: string,
+    input: CreatePaymentMethodInput
+  ): { body: unknown; delta: StateDelta } {
+    const row = this.paymentMethods.create(accountId, input);
+    return {
+      body: paymentMethodJson(row),
+      delta: { before: null, after: rowToRecord(row) },
+    };
+  }
+
+  retrievePaymentMethod(accountId: string, id: string) {
+    return paymentMethodJson(this.paymentMethods.requireById(accountId, id));
+  }
+
+  attachPaymentMethod(
+    accountId: string,
+    id: string,
+    customerId: string
+  ): { body: unknown; delta: StateDelta } {
+    // Resolve the customer first so a missing/deleted customer 404s before
+    // any PM lifecycle error fires.
+    this.customers.requireLive(accountId, customerId);
+    const before = this.paymentMethods.requireById(accountId, id);
+    const row = this.paymentMethods.attach(accountId, id, customerId);
+    this.events.create(accountId, {
+      type: "payment_method.attached",
+      object: paymentMethodJson(row),
+    });
+    return {
+      body: paymentMethodJson(row),
+      delta: { before: rowToRecord(before), after: rowToRecord(row) },
+    };
+  }
+
+  detachPaymentMethod(accountId: string, id: string): { body: unknown; delta: StateDelta } {
+    const before = this.paymentMethods.requireById(accountId, id);
+    const row = this.paymentMethods.detach(accountId, id);
+    this.events.create(accountId, {
+      type: "payment_method.detached",
+      object: paymentMethodJson(row),
+    });
+    return {
+      body: paymentMethodJson(row),
+      delta: { before: rowToRecord(before), after: rowToRecord(row) },
+    };
+  }
+
   // ---------- Charges ----------
 
   retrieveCharge(accountId: string, id: string) {
@@ -305,12 +446,22 @@ export class StripeDomain {
     const refunds = this.db
       .prepare("SELECT * FROM refunds WHERE account_id = ? ORDER BY created DESC, rowid DESC")
       .all(accountId) as RefundRow[];
+    const customers = this.db
+      .prepare("SELECT * FROM customers WHERE account_id = ? ORDER BY created DESC, rowid DESC")
+      .all(accountId) as CustomerRow[];
+    const paymentMethods = this.db
+      .prepare(
+        "SELECT * FROM payment_methods WHERE account_id = ? ORDER BY created DESC, rowid DESC"
+      )
+      .all(accountId) as PaymentMethodRow[];
     return {
       payment_intents: pis.map(paymentIntentJson),
       charges: charges.map(chargeJson),
       balance_transactions: balanceTxs.map(balanceTransactionJson),
       events: events.map(eventJson),
       refunds: refunds.map(refundJson),
+      customers: customers.map((row) => (row.deleted ? deletedCustomerJson(row) : customerJson(row))),
+      payment_methods: paymentMethods.map(paymentMethodJson),
     };
   }
 }

--- a/packages/twin-stripe/src/routes/_helpers.ts
+++ b/packages/twin-stripe/src/routes/_helpers.ts
@@ -247,6 +247,104 @@ export function parseListQuery(c: Context) {
   } as Record<string, unknown>;
 }
 
+/**
+ * Stripe accepts both JSON and form-urlencoded bodies. Real Stripe bills
+ * itself as form-only on POST; the SDKs tend to send form. For agent-friendly
+ * v1 we accept JSON too. Return whichever parses; empty-body POSTs return
+ * `{}`. (Moved here from routes/payment-intents.ts when F-732 gave it a
+ * second and third consumer.)
+ */
+export async function readBodyForm(c: Context): Promise<unknown> {
+  const contentType = c.req.header("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    try {
+      return await c.req.json();
+    } catch {
+      return {};
+    }
+  }
+  if (contentType.includes("application/x-www-form-urlencoded") || contentType.includes("multipart/form-data")) {
+    try {
+      const form = await c.req.parseBody({ all: true });
+      return formToObject(form as Record<string, unknown>);
+    } catch {
+      return {};
+    }
+  }
+  // No content-type or unknown: try JSON, fall back to form, fall back to {}.
+  try {
+    return await c.req.json();
+  } catch {
+    try {
+      const form = await c.req.parseBody({ all: true });
+      return formToObject(form as Record<string, unknown>);
+    } catch {
+      return {};
+    }
+  }
+}
+
+/**
+ * Stripe's bracket-form encoding: `payment_method_types[0]=crypto&
+ * payment_method_options[crypto][mode]=deposit`. Convert to nested object.
+ */
+function formToObject(form: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [rawKey, value] of Object.entries(form)) {
+    const path = parseBracketPath(rawKey);
+    setDeep(out, path, value);
+  }
+  return out;
+}
+
+/** Keys that walk Object.prototype and would let a request pollute every
+ *  other object in the same JS process. Real Stripe form-encoding never
+ *  uses these names; rejecting them costs nothing and closes the
+ *  prototype-pollution primitive. */
+const POLLUTION_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+function parseBracketPath(key: string): Array<string | number> {
+  const parts: Array<string | number> = [];
+  const regex = /([^\[\]]+)|\[([^\[\]]*)\]/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(key)) !== null) {
+    const piece = match[1] ?? match[2] ?? "";
+    if (/^\d+$/.test(piece)) parts.push(Number(piece));
+    else parts.push(piece);
+  }
+  return parts;
+}
+
+function setDeep(target: Record<string, unknown>, path: Array<string | number>, value: unknown) {
+  // Reject any path that walks through __proto__, constructor, or
+  // prototype. A malicious form body with `__proto__[polluted]=pwned`
+  // would otherwise mutate Object.prototype and corrupt every other
+  // object in this process for the rest of the sandbox's lifetime.
+  for (const key of path) {
+    if (typeof key === "string" && POLLUTION_KEYS.has(key)) {
+      // Drop the assignment silently — the field would not be a real
+      // Stripe parameter anyway. Real Stripe returns 400 for unknown
+      // params; v1 deliberately accepts unknowns to keep the agent
+      // surface flexible, so silent drop is the closest fidelity.
+      return;
+    }
+  }
+  let cursor: Record<string | number, unknown> = target;
+  for (let i = 0; i < path.length; i++) {
+    const key = path[i]!;
+    const isLast = i === path.length - 1;
+    if (isLast) {
+      cursor[key] = value;
+    } else {
+      const nextKey = path[i + 1]!;
+      if (cursor[key] === undefined) {
+        cursor[key] = typeof nextKey === "number" ? [] : {};
+      }
+      cursor = cursor[key] as Record<string | number, unknown>;
+    }
+  }
+}
+
 function createdRangeFromQuery(c: Context) {
   const out: Record<string, number> = {};
   const flat = c.req.query("created");

--- a/packages/twin-stripe/src/routes/customers.ts
+++ b/packages/twin-stripe/src/routes/customers.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Customers REST — F-732 (M5 customer-management hot path).
+//
+// POST /v1/customers · GET /v1/customers(/:id) · POST /v1/customers/:id ·
+// DELETE /v1/customers/:id · GET /v1/customers/:id/payment_methods.
+// Idempotency is handled upstream by idempotencyMiddleware; every mutation
+// carries the canonical state_delta through to respond().
+
+import type { Hono } from "hono";
+import { z } from "zod";
+import type { StripeDomain } from "../domain/index.js";
+import type { Recorder } from "../types.js";
+import { accountId, created, handle, ok, parseListQuery, readBodyForm } from "./_helpers.js";
+
+// Every field optional, like real Stripe. Metadata values keep "" and null
+// so the domain can apply Stripe's per-key unset semantics on update.
+const customerFieldsSchema = z.object({
+  name: z.string().nullish(),
+  email: z.string().nullish(),
+  description: z.string().nullish(),
+  phone: z.string().nullish(),
+  metadata: z.record(z.string(), z.string().nullable()).optional(),
+});
+
+export function registerCustomersRoutes(
+  router: Hono,
+  domain: StripeDomain,
+  recorder: Recorder | undefined,
+  runId: string
+) {
+  router.post("/v1/customers", (c) =>
+    handle(c, recorder, runId, async () => {
+      const input = customerFieldsSchema.parse(await readBodyForm(c));
+      const { body, delta } = domain.createCustomer(accountId(c), input);
+      return created(body, delta);
+    })
+  );
+
+  router.get("/v1/customers/:id/payment_methods", (c) =>
+    handle(c, recorder, runId, () => {
+      const list = parseListQuery(c);
+      return ok(
+        domain.listCustomerPaymentMethods(accountId(c), c.req.param("id")!, {
+          ...list,
+          type: c.req.query("type"),
+        })
+      );
+    })
+  );
+
+  router.get("/v1/customers/:id", (c) =>
+    handle(c, recorder, runId, () =>
+      ok(domain.retrieveCustomer(accountId(c), c.req.param("id")!))
+    )
+  );
+
+  router.post("/v1/customers/:id", (c) =>
+    handle(c, recorder, runId, async () => {
+      const input = customerFieldsSchema.parse(await readBodyForm(c));
+      const { body, delta } = domain.updateCustomer(accountId(c), c.req.param("id")!, input);
+      return ok(body, true, delta);
+    })
+  );
+
+  router.delete("/v1/customers/:id", (c) =>
+    handle(c, recorder, runId, () => {
+      const { body, delta } = domain.deleteCustomer(accountId(c), c.req.param("id")!);
+      return ok(body, true, delta);
+    })
+  );
+
+  router.get("/v1/customers", (c) =>
+    handle(c, recorder, runId, () => {
+      const list = parseListQuery(c);
+      return ok(
+        domain.listCustomers(accountId(c), { ...list, email: c.req.query("email") })
+      );
+    })
+  );
+}

--- a/packages/twin-stripe/src/routes/index.ts
+++ b/packages/twin-stripe/src/routes/index.ts
@@ -17,6 +17,8 @@ import { registerChargesRoutes } from "./charges.js";
 import { registerBalanceRoutes } from "./balance.js";
 import { registerEventsRoutes } from "./events.js";
 import { registerRefundsRoutes } from "./refunds.js";
+import { registerCustomersRoutes } from "./customers.js";
+import { registerPaymentMethodsRoutes } from "./payment-methods.js";
 
 export function registerStripeRoutes(
   router: Hono,
@@ -28,6 +30,8 @@ export function registerStripeRoutes(
   registerPaymentIntentRoutes(router, domain, recorder, runId);
   registerChargesRoutes(router, domain, recorder, runId);
   registerRefundsRoutes(router, domain, recorder, runId);
+  registerCustomersRoutes(router, domain, recorder, runId);
+  registerPaymentMethodsRoutes(router, domain, recorder, runId);
   registerBalanceRoutes(router, domain, recorder, runId);
   registerEventsRoutes(router, domain, recorder, runId);
 

--- a/packages/twin-stripe/src/routes/payment-intents.ts
+++ b/packages/twin-stripe/src/routes/payment-intents.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // REST routes #1-6 from FDRS-270.
 
-import type { Hono, Context } from "hono";
+import type { Hono } from "hono";
 import { z } from "zod";
 import type { StripeDomain } from "../domain/index.js";
 import type { Recorder } from "../types.js";
-import { handle, ok, created, parseListQuery, accountId } from "./_helpers.js";
+import { handle, ok, created, parseListQuery, accountId, readBodyForm } from "./_helpers.js";
 
 const createPISchema = z.object({
   amount: z.coerce.number().int().positive(),
@@ -87,101 +87,4 @@ export function registerPaymentIntentRoutes(
         return ok(body, true, delta);
       })
   );
-}
-
-/**
- * Stripe accepts both JSON and form-urlencoded bodies. Real Stripe bills
- * itself as form-only on POST; the SDKs tend to send form. For agent-friendly
- * v1 we accept JSON too. Return whichever parses; empty-body POSTs return
- * `{}`.
- */
-async function readBodyForm(c: Context): Promise<unknown> {
-  const contentType = c.req.header("content-type") ?? "";
-  if (contentType.includes("application/json")) {
-    try {
-      return await c.req.json();
-    } catch {
-      return {};
-    }
-  }
-  if (contentType.includes("application/x-www-form-urlencoded") || contentType.includes("multipart/form-data")) {
-    try {
-      const form = await c.req.parseBody({ all: true });
-      return formToObject(form as Record<string, unknown>);
-    } catch {
-      return {};
-    }
-  }
-  // No content-type or unknown: try JSON, fall back to form, fall back to {}.
-  try {
-    return await c.req.json();
-  } catch {
-    try {
-      const form = await c.req.parseBody({ all: true });
-      return formToObject(form as Record<string, unknown>);
-    } catch {
-      return {};
-    }
-  }
-}
-
-/**
- * Stripe's bracket-form encoding: `payment_method_types[0]=crypto&
- * payment_method_options[crypto][mode]=deposit`. Convert to nested object.
- */
-function formToObject(form: Record<string, unknown>): Record<string, unknown> {
-  const out: Record<string, unknown> = {};
-  for (const [rawKey, value] of Object.entries(form)) {
-    const path = parseBracketPath(rawKey);
-    setDeep(out, path, value);
-  }
-  return out;
-}
-
-/** Keys that walk Object.prototype and would let a request pollute every
- *  other object in the same JS process. Real Stripe form-encoding never
- *  uses these names; rejecting them costs nothing and closes the
- *  prototype-pollution primitive. */
-const POLLUTION_KEYS = new Set(["__proto__", "constructor", "prototype"]);
-
-function parseBracketPath(key: string): Array<string | number> {
-  const parts: Array<string | number> = [];
-  const regex = /([^\[\]]+)|\[([^\[\]]*)\]/g;
-  let match: RegExpExecArray | null;
-  while ((match = regex.exec(key)) !== null) {
-    const piece = match[1] ?? match[2] ?? "";
-    if (/^\d+$/.test(piece)) parts.push(Number(piece));
-    else parts.push(piece);
-  }
-  return parts;
-}
-
-function setDeep(target: Record<string, unknown>, path: Array<string | number>, value: unknown) {
-  // Reject any path that walks through __proto__, constructor, or
-  // prototype. A malicious form body with `__proto__[polluted]=pwned`
-  // would otherwise mutate Object.prototype and corrupt every other
-  // object in this process for the rest of the sandbox's lifetime.
-  for (const key of path) {
-    if (typeof key === "string" && POLLUTION_KEYS.has(key)) {
-      // Drop the assignment silently — the field would not be a real
-      // Stripe parameter anyway. Real Stripe returns 400 for unknown
-      // params; v1 deliberately accepts unknowns to keep the agent
-      // surface flexible, so silent drop is the closest fidelity.
-      return;
-    }
-  }
-  let cursor: Record<string | number, unknown> = target;
-  for (let i = 0; i < path.length; i++) {
-    const key = path[i]!;
-    const isLast = i === path.length - 1;
-    if (isLast) {
-      cursor[key] = value;
-    } else {
-      const nextKey = path[i + 1]!;
-      if (cursor[key] === undefined) {
-        cursor[key] = typeof nextKey === "number" ? [] : {};
-      }
-      cursor = cursor[key] as Record<string | number, unknown>;
-    }
-  }
 }

--- a/packages/twin-stripe/src/routes/payment-methods.ts
+++ b/packages/twin-stripe/src/routes/payment-methods.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Payment methods REST — F-732 (M5 card-on-file chain).
+//
+// POST /v1/payment_methods · GET /v1/payment_methods/:id ·
+// POST /v1/payment_methods/:id/attach|detach. The top-level list
+// (GET /v1/payment_methods) stays on the loud-501 surface per the F-729
+// ruling — the customer-scoped list is the hot read.
+
+import type { Hono } from "hono";
+import type { StripeDomain } from "../domain/index.js";
+import type { CreatePaymentMethodInput } from "../domain/index.js";
+import type { Recorder } from "../types.js";
+import { TwinError } from "../errors.js";
+import { accountId, created, handle, ok, readBodyForm } from "./_helpers.js";
+
+export function registerPaymentMethodsRoutes(
+  router: Hono,
+  domain: StripeDomain,
+  recorder: Recorder | undefined,
+  runId: string
+) {
+  router.post("/v1/payment_methods", (c) =>
+    handle(c, recorder, runId, async () => {
+      // Validation (with Stripe's parameter_missing / card_error codes)
+      // lives in the domain, so the raw body passes through untyped.
+      const body = (await readBodyForm(c)) as CreatePaymentMethodInput;
+      const { body: response, delta } = domain.createPaymentMethod(accountId(c), body);
+      return created(response, delta);
+    })
+  );
+
+  router.get("/v1/payment_methods/:id", (c) =>
+    handle(c, recorder, runId, () =>
+      ok(domain.retrievePaymentMethod(accountId(c), c.req.param("id")!))
+    )
+  );
+
+  router.post("/v1/payment_methods/:id/attach", (c) =>
+    handle(c, recorder, runId, async () => {
+      const body = (await readBodyForm(c)) as { customer?: unknown };
+      const customer = typeof body.customer === "string" ? body.customer : "";
+      if (!customer) {
+        throw new TwinError(
+          "invalid_request_error",
+          "parameter_missing",
+          "Missing required param: customer.",
+          { param: "customer", statusCode: 400 }
+        );
+      }
+      const { body: response, delta } = domain.attachPaymentMethod(
+        accountId(c),
+        c.req.param("id")!,
+        customer
+      );
+      return ok(response, true, delta);
+    })
+  );
+
+  router.post("/v1/payment_methods/:id/detach", (c) =>
+    handle(c, recorder, runId, () => {
+      const { body, delta } = domain.detachPaymentMethod(accountId(c), c.req.param("id")!);
+      return ok(body, true, delta);
+    })
+  );
+}

--- a/packages/twin-stripe/src/serializers.ts
+++ b/packages/twin-stripe/src/serializers.ts
@@ -4,14 +4,25 @@
 // Mirrors twin-github/src/serializers.ts in spirit — pure functions,
 // row in / object out.
 
-import type { PIRow, ChargeRow, BalanceTxRow, EventRow, RefundRow } from "./types.js";
+import type {
+  PIRow,
+  ChargeRow,
+  BalanceTxRow,
+  CustomerRow,
+  EventRow,
+  PaymentMethodRow,
+  RefundRow,
+} from "./types.js";
 import type {
   ApiList,
   BalanceTransaction,
   Balance,
   Charge,
+  Customer,
   DeepPartial,
+  DeletedCustomer,
   PaymentIntent,
+  PaymentMethod,
   Refund,
   StripeEvent,
 } from "./upstream-types.js";
@@ -181,6 +192,77 @@ export function refundJson(row: RefundRow) {
     status: row.status,
     transfer_reversal: null,
   } satisfies DeepPartial<Refund>;
+}
+
+export function customerJson(row: CustomerRow) {
+  return {
+    id: row.id,
+    object: "customer",
+    address: null,
+    balance: 0,
+    created: row.created,
+    currency: null,
+    default_source: null,
+    delinquent: false,
+    description: row.description,
+    discount: null,
+    email: row.email,
+    invoice_settings: {
+      custom_fields: null,
+      default_payment_method: null,
+      footer: null,
+      rendering_options: null,
+    },
+    livemode: false,
+    metadata: parseJson(row.metadata_json, {}),
+    name: row.name,
+    phone: row.phone,
+    preferred_locales: [],
+    shipping: null,
+    tax_exempt: "none",
+    test_clock: null,
+  } satisfies DeepPartial<Customer>;
+}
+
+/**
+ * Real Stripe serves this stub for DELETE and for every retrieve of a
+ * deleted customer — three fields, nothing else.
+ */
+export function deletedCustomerJson(row: CustomerRow) {
+  return {
+    id: row.id,
+    object: "customer",
+    deleted: true,
+  } satisfies DeepPartial<DeletedCustomer>;
+}
+
+export function paymentMethodJson(row: PaymentMethodRow) {
+  return {
+    id: row.id,
+    object: "payment_method",
+    billing_details: {
+      address: { city: null, country: null, line1: null, line2: null, postal_code: null, state: null },
+      email: null,
+      name: null,
+      phone: null,
+    },
+    card: {
+      brand: row.card_brand,
+      exp_month: row.card_exp_month,
+      exp_year: row.card_exp_year,
+      fingerprint: row.card_fingerprint,
+      funding: "credit",
+      last4: row.card_last4,
+    },
+    created: row.created,
+    customer: row.customer_id,
+    livemode: false,
+    metadata: {},
+    // Twin row `type` is a free `string`; upstream `PaymentMethod.type` is a
+    // literal union. Narrow for the type anchor only (FDRS-454), runtime
+    // value ("card") unchanged.
+    type: row.type as PaymentMethod["type"],
+  } satisfies DeepPartial<PaymentMethod>;
 }
 
 export function balanceTransactionJson(row: BalanceTxRow) {

--- a/packages/twin-stripe/src/tools.ts
+++ b/packages/twin-stripe/src/tools.ts
@@ -166,14 +166,15 @@ export const toolDefinitions = [
   {
     name: "update_customer",
     description:
-      "Update a customer's fields. Metadata merges per-key; an empty value unsets the key.",
+      "Update a customer's fields. Metadata merges per-key; a null or empty value unsets the key.",
     schema: z.object({
       id: z.string().min(1),
       name: z.string().optional(),
       email: z.string().optional(),
       description: z.string().optional(),
       phone: z.string().optional(),
-      metadata: z.record(z.string(), z.string()).optional(),
+      // Nullable values mirror the REST surface: null (or "") unsets the key.
+      metadata: z.record(z.string(), z.string().nullable()).optional(),
     }),
   },
   {

--- a/packages/twin-stripe/src/tools.ts
+++ b/packages/twin-stripe/src/tools.ts
@@ -148,6 +148,88 @@ export const toolDefinitions = [
     }),
   },
   {
+    name: "create_customer",
+    description: "Create a customer. All fields optional, like real Stripe.",
+    schema: z.object({
+      name: z.string().optional(),
+      email: z.string().optional(),
+      description: z.string().optional(),
+      phone: z.string().optional(),
+      metadata: z.record(z.string(), z.string()).optional(),
+    }),
+  },
+  {
+    name: "retrieve_customer",
+    description: "Retrieve a Customer by id. Deleted customers return the {deleted: true} stub.",
+    schema: z.object({ id: z.string().min(1) }),
+  },
+  {
+    name: "update_customer",
+    description:
+      "Update a customer's fields. Metadata merges per-key; an empty value unsets the key.",
+    schema: z.object({
+      id: z.string().min(1),
+      name: z.string().optional(),
+      email: z.string().optional(),
+      description: z.string().optional(),
+      phone: z.string().optional(),
+      metadata: z.record(z.string(), z.string()).optional(),
+    }),
+  },
+  {
+    name: "delete_customer",
+    description: "Delete a customer (soft delete; its payment methods are detached).",
+    schema: z.object({ id: z.string().min(1) }),
+  },
+  {
+    name: "list_customers",
+    description: "List customers with optional email / created filters.",
+    schema: z.object({
+      ...limitShape,
+      ...createdRange,
+      email: z.string().optional(),
+    }),
+  },
+  {
+    name: "list_customer_payment_methods",
+    description: "List the payment methods attached to a customer.",
+    schema: z.object({
+      customer: z.string().min(1),
+      type: z.string().optional(),
+      ...limitShape,
+    }),
+  },
+  {
+    name: "create_payment_method",
+    description:
+      "Create a card payment method from test card details (e.g. number 4242424242424242).",
+    schema: z.object({
+      type: z.literal("card"),
+      card: z.object({
+        number: z.string().min(1),
+        exp_month: z.coerce.number().int(),
+        exp_year: z.coerce.number().int(),
+        cvc: z.string().optional(),
+      }),
+    }),
+  },
+  {
+    name: "retrieve_payment_method",
+    description: "Retrieve a PaymentMethod by id.",
+    schema: z.object({ id: z.string().min(1) }),
+  },
+  {
+    name: "attach_payment_method",
+    description:
+      "Attach a payment method to a customer. One customer per PM; a detached PM cannot be reattached.",
+    schema: z.object({ id: z.string().min(1), customer: z.string().min(1) }),
+  },
+  {
+    name: "detach_payment_method",
+    description: "Detach a payment method from its customer.",
+    schema: z.object({ id: z.string().min(1) }),
+  },
+  {
     name: "retrieve_balance",
     description: "Retrieve the current balance (available + pending per currency).",
     schema: z.object({}).optional(),
@@ -195,6 +277,12 @@ export function isMutatingTool(name: string): boolean {
     "cancel_payment_intent",
     "simulate_crypto_deposit",
     "create_refund",
+    "create_customer",
+    "update_customer",
+    "delete_customer",
+    "create_payment_method",
+    "attach_payment_method",
+    "detach_payment_method",
   ].includes(name);
 }
 
@@ -244,6 +332,36 @@ export function executeTool(
       const flat = flattenCreated(parsed);
       return domain.listRefunds(accountId, { ...parsed, ...flat } as never);
     }
+    case "create_customer":
+      return domain.createCustomer(accountId, parsed as never).body;
+    case "retrieve_customer":
+      return domain.retrieveCustomer(accountId, parsed.id as string);
+    case "update_customer": {
+      const { id, ...fields } = parsed as { id: string } & Record<string, unknown>;
+      return domain.updateCustomer(accountId, id, fields as never).body;
+    }
+    case "delete_customer":
+      return domain.deleteCustomer(accountId, parsed.id as string).body;
+    case "list_customers": {
+      const flat = flattenCreated(parsed);
+      return domain.listCustomers(accountId, { ...parsed, ...flat } as never);
+    }
+    case "list_customer_payment_methods": {
+      const { customer, ...rest } = parsed as { customer: string } & Record<string, unknown>;
+      return domain.listCustomerPaymentMethods(accountId, customer, rest as never);
+    }
+    case "create_payment_method":
+      return domain.createPaymentMethod(accountId, parsed as never).body;
+    case "retrieve_payment_method":
+      return domain.retrievePaymentMethod(accountId, parsed.id as string);
+    case "attach_payment_method":
+      return domain.attachPaymentMethod(
+        accountId,
+        parsed.id as string,
+        parsed.customer as string
+      ).body;
+    case "detach_payment_method":
+      return domain.detachPaymentMethod(accountId, parsed.id as string).body;
     case "retrieve_balance":
       return domain.retrieveBalance(accountId);
     case "list_balance_transactions": {

--- a/packages/twin-stripe/src/types.ts
+++ b/packages/twin-stripe/src/types.ts
@@ -213,6 +213,32 @@ export type EventRow = {
   api_version: string;
 };
 
+export type CustomerRow = {
+  id: string;
+  account_id: string;
+  name: string | null;
+  email: string | null;
+  description: string | null;
+  phone: string | null;
+  metadata_json: string;
+  deleted: 0 | 1;
+  created: number;
+};
+
+export type PaymentMethodRow = {
+  id: string;
+  account_id: string;
+  type: string;
+  card_brand: string;
+  card_last4: string;
+  card_exp_month: number;
+  card_exp_year: number;
+  card_fingerprint: string;
+  customer_id: string | null;
+  detached: 0 | 1;
+  created: number;
+};
+
 export type RefundStatus = "succeeded" | "pending" | "failed" | "canceled";
 
 export type RefundRow = {

--- a/packages/twin-stripe/src/upstream-types.ts
+++ b/packages/twin-stripe/src/upstream-types.ts
@@ -25,6 +25,9 @@ export type Charge = Stripe.Charge;
 export type Refund = Stripe.Refund;
 export type BalanceTransaction = Stripe.BalanceTransaction;
 export type Balance = Stripe.Balance;
+export type Customer = Stripe.Customer;
+export type DeletedCustomer = Stripe.DeletedCustomer;
+export type PaymentMethod = Stripe.PaymentMethod;
 
 // Stripe's paginated list envelope (object: "list", data, has_more, url). Generic
 // over the element type so the twin's `serializedList<T>` anchors against it.

--- a/packages/twin-stripe/test/customers.test.ts
+++ b/packages/twin-stripe/test/customers.test.ts
@@ -6,7 +6,7 @@
 // events, and F1 account scoping.
 
 import { describe, expect, it } from "vitest";
-import { createStripeApp, rest } from "./_appHelper.js";
+import { callTool, createStripeApp, rest } from "./_appHelper.js";
 import { createTwinStripeApp } from "../src/twin.js";
 import { openTwinStripeDatabase } from "../src/db.js";
 
@@ -130,6 +130,17 @@ describe("Customers — POST/GET/DELETE /v1/customers", () => {
     expect(types).toContain("customer.created");
     expect(types).toContain("customer.updated");
     expect(types).toContain("customer.deleted");
+  });
+
+  it("MCP update_customer accepts metadata nulls to unset keys, like the REST surface", async () => {
+    const app = await createStripeApp();
+    const c = await callTool(app, "create_customer", { metadata: { a: "1", b: "2" } });
+    const u = await callTool(app, "update_customer", {
+      id: c.body.id,
+      metadata: { a: null, c: "3" },
+    });
+    expect(u.status).toBe(200);
+    expect(u.body.metadata).toEqual({ b: "2", c: "3" });
   });
 
   it("honors Idempotency-Key on POST /v1/customers", async () => {

--- a/packages/twin-stripe/test/customers.test.ts
+++ b/packages/twin-stripe/test/customers.test.ts
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Customers — F-732 (M5 customer-management hot path, ruled F-729).
+// Customer CRUD at semantic tier: create/retrieve/update/list/delete,
+// Stripe metadata merge semantics, the deleted-customer stub, lifecycle
+// events, and F1 account scoping.
+
+import { describe, expect, it } from "vitest";
+import { createStripeApp, rest } from "./_appHelper.js";
+import { createTwinStripeApp } from "../src/twin.js";
+import { openTwinStripeDatabase } from "../src/db.js";
+
+describe("Customers — POST/GET/DELETE /v1/customers", () => {
+  it("creates a customer with name/email/metadata", async () => {
+    const app = await createStripeApp();
+    const r = await rest(app, "POST", "/v1/customers", {
+      name: "Ada Lovelace",
+      email: "ada@example.com",
+      description: "first customer",
+      metadata: { plan: "pro" },
+    });
+    expect(r.status).toBe(200);
+    expect(r.body).toMatchObject({
+      object: "customer",
+      name: "Ada Lovelace",
+      email: "ada@example.com",
+      description: "first customer",
+      metadata: { plan: "pro" },
+      livemode: false,
+    });
+    expect(r.body.id).toMatch(/^cus_/);
+    expect(typeof r.body.created).toBe("number");
+  });
+
+  it("creates an empty customer (every field optional, like real Stripe)", async () => {
+    const app = await createStripeApp();
+    const r = await rest(app, "POST", "/v1/customers", {});
+    expect(r.status).toBe(200);
+    expect(r.body).toMatchObject({
+      object: "customer",
+      name: null,
+      email: null,
+      description: null,
+      metadata: {},
+    });
+  });
+
+  it("retrieves a customer by id; 404 resource_missing for unknown", async () => {
+    const app = await createStripeApp();
+    const c = await rest(app, "POST", "/v1/customers", { name: "Ada" });
+    const get = await rest(app, "GET", `/v1/customers/${c.body.id}`);
+    expect(get.status).toBe(200);
+    expect(get.body).toMatchObject({ id: c.body.id, name: "Ada" });
+
+    const missing = await rest(app, "GET", "/v1/customers/cus_doesnotexist");
+    expect(missing.status).toBe(404);
+    expect(missing.body.error.code).toBe("resource_missing");
+  });
+
+  it("updates fields and merges metadata per-key (empty value unsets)", async () => {
+    const app = await createStripeApp();
+    const c = await rest(app, "POST", "/v1/customers", {
+      name: "Ada",
+      metadata: { a: "1", b: "2" },
+    });
+    const u = await rest(app, "POST", `/v1/customers/${c.body.id}`, {
+      email: "ada@example.com",
+      metadata: { b: "", c: "3" },
+    });
+    expect(u.status).toBe(200);
+    expect(u.body).toMatchObject({
+      id: c.body.id,
+      name: "Ada",
+      email: "ada@example.com",
+      metadata: { a: "1", c: "3" },
+    });
+    expect(u.body.metadata.b).toBeUndefined();
+
+    const missing = await rest(app, "POST", "/v1/customers/cus_doesnotexist", { name: "x" });
+    expect(missing.status).toBe(404);
+  });
+
+  it("lists customers with pagination and email filter, excluding deleted", async () => {
+    const app = await createStripeApp();
+    const a = await rest(app, "POST", "/v1/customers", { email: "a@example.com" });
+    await rest(app, "POST", "/v1/customers", { email: "b@example.com" });
+    const gone = await rest(app, "POST", "/v1/customers", { email: "c@example.com" });
+    await rest(app, "DELETE", `/v1/customers/${gone.body.id}`);
+
+    const all = await rest(app, "GET", "/v1/customers");
+    expect(all.status).toBe(200);
+    expect(all.body).toMatchObject({ object: "list", url: "/v1/customers" });
+    expect(all.body.data).toHaveLength(2);
+
+    const filtered = await rest(app, "GET", "/v1/customers?email=a@example.com");
+    expect(filtered.body.data).toHaveLength(1);
+    expect(filtered.body.data[0].id).toBe(a.body.id);
+
+    const limited = await rest(app, "GET", "/v1/customers?limit=1");
+    expect(limited.body.data).toHaveLength(1);
+    expect(limited.body.has_more).toBe(true);
+  });
+
+  it("deletes a customer: returns the deleted stub, then GET serves the stub", async () => {
+    const app = await createStripeApp();
+    const c = await rest(app, "POST", "/v1/customers", { name: "Ada" });
+    const del = await rest(app, "DELETE", `/v1/customers/${c.body.id}`);
+    expect(del.status).toBe(200);
+    expect(del.body).toEqual({ id: c.body.id, object: "customer", deleted: true });
+
+    // Real Stripe serves the deleted stub on retrieve, not a 404.
+    const get = await rest(app, "GET", `/v1/customers/${c.body.id}`);
+    expect(get.status).toBe(200);
+    expect(get.body).toEqual({ id: c.body.id, object: "customer", deleted: true });
+
+    // Updates against a deleted customer fail loudly.
+    const upd = await rest(app, "POST", `/v1/customers/${c.body.id}`, { name: "Ghost" });
+    expect(upd.status).toBe(404);
+    expect(upd.body.error.code).toBe("resource_missing");
+  });
+
+  it("emits customer.created / customer.updated / customer.deleted events", async () => {
+    const app = await createStripeApp();
+    const c = await rest(app, "POST", "/v1/customers", { name: "Ada" });
+    await rest(app, "POST", `/v1/customers/${c.body.id}`, { name: "Ada L" });
+    await rest(app, "DELETE", `/v1/customers/${c.body.id}`);
+
+    const events = await rest(app, "GET", "/v1/events");
+    const types = (events.body.data as Array<{ type: string }>).map((e) => e.type);
+    expect(types).toContain("customer.created");
+    expect(types).toContain("customer.updated");
+    expect(types).toContain("customer.deleted");
+  });
+
+  it("honors Idempotency-Key on POST /v1/customers", async () => {
+    const app = await createStripeApp();
+    const headers = { "Idempotency-Key": "customer-create-once" };
+    const r1 = await rest(app, "POST", "/v1/customers", { name: "Ada" }, headers);
+    const r2 = await rest(app, "POST", "/v1/customers", { name: "Ada" }, headers);
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    expect(r2.body.id).toBe(r1.body.id);
+    const list = await rest(app, "GET", "/v1/customers");
+    expect(list.body.data).toHaveLength(1);
+  });
+
+  it("exportState includes customers[] and payment_methods[]", async () => {
+    const app = await createStripeApp();
+    const c = await rest(app, "POST", "/v1/customers", { name: "Ada" });
+    const state = await rest(app, "GET", "/_pome/state");
+    expect(state.status).toBe(200);
+    expect(state.body.customers).toHaveLength(1);
+    expect(state.body.customers[0]).toMatchObject({ id: c.body.id, object: "customer" });
+    expect(state.body.payment_methods).toEqual([]);
+  });
+});
+
+describe("F1 — customers are account-scoped", () => {
+  it("session B cannot read or list session A's customers", async () => {
+    const db = openTwinStripeDatabase(":memory:");
+    const app = createTwinStripeApp({
+      db,
+      runId: "scope-test",
+      seed: {
+        api_keys: [
+          { key: "sk_test_pome_a", sid: "a", account_id: "acct_a" },
+          { key: "sk_test_pome_b", sid: "b", account_id: "acct_b" },
+        ],
+      },
+    });
+    const call = async (sid: string, key: string, method: string, path: string, body?: unknown) => {
+      const init: RequestInit = { method, headers: { Authorization: `Bearer ${key}` } };
+      if (body !== undefined) {
+        init.headers = { Authorization: `Bearer ${key}`, "content-type": "application/json" };
+        init.body = JSON.stringify(body);
+      }
+      const r = await app.request(`/s/${sid}${path}`, init);
+      return { status: r.status, body: (await r.json().catch(() => null)) as any };
+    };
+
+    const created = await call("a", "sk_test_pome_a", "POST", "/v1/customers", { name: "Ada" });
+    expect(created.status).toBe(200);
+
+    const cross = await call("b", "sk_test_pome_b", "GET", `/v1/customers/${created.body.id}`);
+    expect(cross.status).toBe(404);
+
+    const list = await call("b", "sk_test_pome_b", "GET", "/v1/customers");
+    expect(list.body.data).toEqual([]);
+  });
+});

--- a/packages/twin-stripe/test/payment-methods.test.ts
+++ b/packages/twin-stripe/test/payment-methods.test.ts
@@ -6,7 +6,7 @@
 // rule, no reattach after detach, loud errors), the customer PM listing, and
 // attach/detach events.
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createStripeApp, rest, type StripeTestApp } from "./_appHelper.js";
 
 const VISA = "4242424242424242";
@@ -101,6 +101,38 @@ describe("Payment methods — POST/GET /v1/payment_methods", () => {
     });
     expect(pastYear.status).toBe(402);
     expect(pastYear.body.error.code).toBe("invalid_expiry_year");
+  });
+
+  describe("current-year expiry", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("rejects a past month of the current year; accepts a future month", async () => {
+      // Fake Date only — faking timers wholesale would stall the app's async plumbing.
+      vi.useFakeTimers({ toFake: ["Date"], now: new Date("2026-07-15T12:00:00Z") });
+      const app = await createStripeApp();
+
+      const past = await rest(app, "POST", "/v1/payment_methods", {
+        type: "card",
+        card: { number: VISA, exp_month: 3, exp_year: 2026 },
+      });
+      expect(past.status).toBe(402);
+      expect(past.body.error.code).toBe("invalid_expiry_month");
+
+      const future = await rest(app, "POST", "/v1/payment_methods", {
+        type: "card",
+        card: { number: VISA, exp_month: 12, exp_year: 2026 },
+      });
+      expect(future.status).toBe(200);
+
+      // The current month itself is still valid (cards expire end-of-month).
+      const thisMonth = await rest(app, "POST", "/v1/payment_methods", {
+        type: "card",
+        card: { number: VISA, exp_month: 7, exp_year: 2026 },
+      });
+      expect(thisMonth.status).toBe(200);
+    });
   });
 
   it("retrieves a payment method by id; 404 for unknown", async () => {
@@ -207,6 +239,25 @@ describe("Attach / detach — POST /v1/payment_methods/:id/attach|detach", () =>
     // The PM list of a deleted customer 404s like the customer itself.
     const list = await rest(app, "GET", `/v1/customers/${customer}/payment_methods`);
     expect(list.status).toBe(404);
+  });
+
+  it("deleting a customer emits payment_method.detached per attached PM", async () => {
+    const app = await createStripeApp();
+    const customer = await createCustomer(app);
+    const pm1 = await createCardPM(app);
+    const pm2 = await createCardPM(app, "5555555555554444");
+    await rest(app, "POST", `/v1/payment_methods/${pm1}/attach`, { customer });
+    await rest(app, "POST", `/v1/payment_methods/${pm2}/attach`, { customer });
+
+    await rest(app, "DELETE", `/v1/customers/${customer}`);
+
+    const events = await rest(app, "GET", "/v1/events?limit=100");
+    const detached = (events.body.data as Array<{ type: string; data: { object: { id: string; customer: string | null } } }>)
+      .filter((e) => e.type === "payment_method.detached");
+    expect(detached.map((e) => e.data.object.id).sort()).toEqual([pm1, pm2].sort());
+    for (const event of detached) {
+      expect(event.data.object.customer).toBeNull();
+    }
   });
 
   it("emits payment_method.attached / payment_method.detached events", async () => {

--- a/packages/twin-stripe/test/payment-methods.test.ts
+++ b/packages/twin-stripe/test/payment-methods.test.ts
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Payment methods — F-732 (M5 card-on-file chain, ruled F-729).
+// Semantic tier: create card PMs (test card numbers → brand/last4, PAN never
+// stored), retrieve, attach/detach lifecycle against customers (one-customer
+// rule, no reattach after detach, loud errors), the customer PM listing, and
+// attach/detach events.
+
+import { describe, expect, it } from "vitest";
+import { createStripeApp, rest, type StripeTestApp } from "./_appHelper.js";
+
+const VISA = "4242424242424242";
+
+async function createCustomer(app: StripeTestApp, body: Record<string, unknown> = {}) {
+  const r = await rest(app, "POST", "/v1/customers", body);
+  expect(r.status).toBe(200);
+  return r.body.id as string;
+}
+
+async function createCardPM(app: StripeTestApp, number = VISA) {
+  const r = await rest(app, "POST", "/v1/payment_methods", {
+    type: "card",
+    card: { number, exp_month: 12, exp_year: 2032, cvc: "123" },
+  });
+  expect(r.status).toBe(200);
+  return r.body.id as string;
+}
+
+describe("Payment methods — POST/GET /v1/payment_methods", () => {
+  it("creates a card payment method: brand/last4 derived, PAN never echoed", async () => {
+    const app = await createStripeApp();
+    const r = await rest(app, "POST", "/v1/payment_methods", {
+      type: "card",
+      card: { number: VISA, exp_month: 12, exp_year: 2032, cvc: "123" },
+    });
+    expect(r.status).toBe(200);
+    expect(r.body).toMatchObject({
+      object: "payment_method",
+      type: "card",
+      customer: null,
+      livemode: false,
+      card: { brand: "visa", last4: "4242", exp_month: 12, exp_year: 2032 },
+    });
+    expect(r.body.id).toMatch(/^pm_/);
+    // The PAN must not appear anywhere in the response.
+    expect(JSON.stringify(r.body)).not.toContain(VISA);
+  });
+
+  it("derives the brand from the test card number", async () => {
+    const app = await createStripeApp();
+    const mc = await rest(app, "POST", "/v1/payment_methods", {
+      type: "card",
+      card: { number: "5555555555554444", exp_month: 1, exp_year: 2031 },
+    });
+    expect(mc.body.card).toMatchObject({ brand: "mastercard", last4: "4444" });
+
+    const amex = await rest(app, "POST", "/v1/payment_methods", {
+      type: "card",
+      card: { number: "378282246310005", exp_month: 1, exp_year: 2031 },
+    });
+    expect(amex.body.card).toMatchObject({ brand: "amex", last4: "0005" });
+  });
+
+  it("rejects missing type, non-card type, and missing card details", async () => {
+    const app = await createStripeApp();
+    const noType = await rest(app, "POST", "/v1/payment_methods", {});
+    expect(noType.status).toBe(400);
+    expect(noType.body.error.code).toBe("parameter_missing");
+    expect(noType.body.error.param).toBe("type");
+
+    const sepa = await rest(app, "POST", "/v1/payment_methods", {
+      type: "sepa_debit",
+    });
+    expect(sepa.status).toBe(400);
+    expect(sepa.body.error.type).toBe("invalid_request_error");
+
+    const noCard = await rest(app, "POST", "/v1/payment_methods", { type: "card" });
+    expect(noCard.status).toBe(400);
+    expect(noCard.body.error.param).toBe("card");
+  });
+
+  it("rejects a bad card number / expiry with a card_error (Stripe 402)", async () => {
+    const app = await createStripeApp();
+    const badNumber = await rest(app, "POST", "/v1/payment_methods", {
+      type: "card",
+      card: { number: "4242424242424241", exp_month: 12, exp_year: 2032 },
+    });
+    expect(badNumber.status).toBe(402);
+    expect(badNumber.body.error).toMatchObject({ type: "card_error", code: "incorrect_number" });
+
+    const badMonth = await rest(app, "POST", "/v1/payment_methods", {
+      type: "card",
+      card: { number: VISA, exp_month: 13, exp_year: 2032 },
+    });
+    expect(badMonth.status).toBe(402);
+    expect(badMonth.body.error.code).toBe("invalid_expiry_month");
+
+    const pastYear = await rest(app, "POST", "/v1/payment_methods", {
+      type: "card",
+      card: { number: VISA, exp_month: 12, exp_year: 2020 },
+    });
+    expect(pastYear.status).toBe(402);
+    expect(pastYear.body.error.code).toBe("invalid_expiry_year");
+  });
+
+  it("retrieves a payment method by id; 404 for unknown", async () => {
+    const app = await createStripeApp();
+    const pm = await createCardPM(app);
+    const get = await rest(app, "GET", `/v1/payment_methods/${pm}`);
+    expect(get.status).toBe(200);
+    expect(get.body).toMatchObject({ id: pm, type: "card" });
+
+    const missing = await rest(app, "GET", "/v1/payment_methods/pm_doesnotexist");
+    expect(missing.status).toBe(404);
+    expect(missing.body.error.code).toBe("resource_missing");
+  });
+});
+
+describe("Attach / detach — POST /v1/payment_methods/:id/attach|detach", () => {
+  it("attaches a PM to a customer and lists it via GET /v1/customers/:id/payment_methods", async () => {
+    const app = await createStripeApp();
+    const customer = await createCustomer(app, { name: "Ada" });
+    const pm = await createCardPM(app);
+
+    const attach = await rest(app, "POST", `/v1/payment_methods/${pm}/attach`, { customer });
+    expect(attach.status).toBe(200);
+    expect(attach.body).toMatchObject({ id: pm, customer });
+
+    const list = await rest(app, "GET", `/v1/customers/${customer}/payment_methods`);
+    expect(list.status).toBe(200);
+    expect(list.body).toMatchObject({ object: "list", url: `/v1/customers/${customer}/payment_methods` });
+    expect(list.body.data).toHaveLength(1);
+    expect(list.body.data[0].id).toBe(pm);
+
+    const typed = await rest(app, "GET", `/v1/customers/${customer}/payment_methods?type=card`);
+    expect(typed.body.data).toHaveLength(1);
+    const wrongType = await rest(app, "GET", `/v1/customers/${customer}/payment_methods?type=sepa_debit`);
+    expect(wrongType.body.data).toHaveLength(0);
+  });
+
+  it("attach requires a customer param and an existing customer", async () => {
+    const app = await createStripeApp();
+    const pm = await createCardPM(app);
+
+    const missingParam = await rest(app, "POST", `/v1/payment_methods/${pm}/attach`, {});
+    expect(missingParam.status).toBe(400);
+    expect(missingParam.body.error).toMatchObject({ code: "parameter_missing", param: "customer" });
+
+    const missingCustomer = await rest(app, "POST", `/v1/payment_methods/${pm}/attach`, {
+      customer: "cus_doesnotexist",
+    });
+    expect(missingCustomer.status).toBe(404);
+    expect(missingCustomer.body.error.code).toBe("resource_missing");
+  });
+
+  it("refuses to attach an already-attached PM (one customer per PM)", async () => {
+    const app = await createStripeApp();
+    const c1 = await createCustomer(app);
+    const c2 = await createCustomer(app);
+    const pm = await createCardPM(app);
+    await rest(app, "POST", `/v1/payment_methods/${pm}/attach`, { customer: c1 });
+
+    const again = await rest(app, "POST", `/v1/payment_methods/${pm}/attach`, { customer: c2 });
+    expect(again.status).toBe(400);
+    expect(again.body.error.type).toBe("invalid_request_error");
+    expect(again.body.error.message).toMatch(/already been attached/i);
+  });
+
+  it("detaches a PM; a detached PM can never be reattached (Stripe rule)", async () => {
+    const app = await createStripeApp();
+    const customer = await createCustomer(app);
+    const pm = await createCardPM(app);
+    await rest(app, "POST", `/v1/payment_methods/${pm}/attach`, { customer });
+
+    const detach = await rest(app, "POST", `/v1/payment_methods/${pm}/detach`);
+    expect(detach.status).toBe(200);
+    expect(detach.body).toMatchObject({ id: pm, customer: null });
+
+    const list = await rest(app, "GET", `/v1/customers/${customer}/payment_methods`);
+    expect(list.body.data).toHaveLength(0);
+
+    const reattach = await rest(app, "POST", `/v1/payment_methods/${pm}/attach`, { customer });
+    expect(reattach.status).toBe(400);
+    expect(reattach.body.error.message).toMatch(/previously (used|detached)/i);
+  });
+
+  it("refuses to detach a PM that is not attached", async () => {
+    const app = await createStripeApp();
+    const pm = await createCardPM(app);
+    const detach = await rest(app, "POST", `/v1/payment_methods/${pm}/detach`);
+    expect(detach.status).toBe(400);
+    expect(detach.body.error.type).toBe("invalid_request_error");
+  });
+
+  it("deleting a customer detaches its payment methods", async () => {
+    const app = await createStripeApp();
+    const customer = await createCustomer(app);
+    const pm = await createCardPM(app);
+    await rest(app, "POST", `/v1/payment_methods/${pm}/attach`, { customer });
+
+    await rest(app, "DELETE", `/v1/customers/${customer}`);
+
+    const get = await rest(app, "GET", `/v1/payment_methods/${pm}`);
+    expect(get.status).toBe(200);
+    expect(get.body.customer).toBeNull();
+
+    // The PM list of a deleted customer 404s like the customer itself.
+    const list = await rest(app, "GET", `/v1/customers/${customer}/payment_methods`);
+    expect(list.status).toBe(404);
+  });
+
+  it("emits payment_method.attached / payment_method.detached events", async () => {
+    const app = await createStripeApp();
+    const customer = await createCustomer(app);
+    const pm = await createCardPM(app);
+    await rest(app, "POST", `/v1/payment_methods/${pm}/attach`, { customer });
+    await rest(app, "POST", `/v1/payment_methods/${pm}/detach`);
+
+    const events = await rest(app, "GET", "/v1/events");
+    const types = (events.body.data as Array<{ type: string }>).map((e) => e.type);
+    expect(types).toContain("payment_method.attached");
+    expect(types).toContain("payment_method.detached");
+  });
+
+  it("records canonical state_delta on attach (before: unattached, after: attached)", async () => {
+    const app = await createStripeApp();
+    const customer = await createCustomer(app);
+    const pm = await createCardPM(app);
+    await rest(app, "POST", `/v1/payment_methods/${pm}/attach`, { customer });
+
+    const events = await rest(app, "GET", "/_pome/events");
+    const attachPost = (events.body as Array<Record<string, unknown>>).find(
+      (e) => typeof e.path === "string" && (e.path as string).endsWith(`/v1/payment_methods/${pm}/attach`)
+    );
+    expect(attachPost).toBeDefined();
+    expect(attachPost!.state_mutation).toBe(true);
+    const delta = attachPost!.state_delta as { before: Record<string, unknown>; after: Record<string, unknown> };
+    expect(delta.before).toMatchObject({ id: pm, customer_id: null });
+    expect(delta.after).toMatchObject({ id: pm, customer_id: customer });
+  });
+});

--- a/packages/twin-stripe/test/socket-boundary.test.ts
+++ b/packages/twin-stripe/test/socket-boundary.test.ts
@@ -133,7 +133,7 @@ describe("socket boundary — real MCP SDK client over @hono/node-server", () =>
       // Pin the catalog size independently of listTools() so a silent catalog
       // shrink cannot self-verify (both sides derive from the same array
       // otherwise).
-      expect(catalog.length).toBe(15);
+      expect(catalog.length).toBe(25);
       expect(listResult.tools).toHaveLength(catalog.length);
       expect(listResult.tools.map((t) => t.name)).toEqual(catalog.map((t) => t.name));
       for (const tool of listResult.tools) {

--- a/packages/twin-stripe/test/state-export.test.ts
+++ b/packages/twin-stripe/test/state-export.test.ts
@@ -98,6 +98,8 @@ describe("state export determinism (F-684)", () => {
       balance_transactions: [],
       events: [],
       refunds: [],
+      customers: [],
+      payment_methods: [],
     });
   });
 });

--- a/packages/twin-stripe/test/tools.test.ts
+++ b/packages/twin-stripe/test/tools.test.ts
@@ -10,35 +10,45 @@ import { toolDefinitions } from "../src/tools.js";
 const TOOL_NAMES = toolDefinitions.map((t) => t.name);
 
 describe("MCP tools", () => {
-  it("listTools returns 15 tools", async () => {
+  it("listTools returns 25 tools", async () => {
     const app = await createStripeApp();
     const tools = await rest(app, "GET", "/mcp/tools");
     expect(tools.status).toBe(200);
-    expect(tools.body.tools).toHaveLength(15);
+    expect(tools.body.tools).toHaveLength(25);
     const names = tools.body.tools.map((t: any) => t.name).sort();
     expect(names).toEqual(
       [
+        "attach_payment_method",
         "cancel_payment_intent",
         "confirm_payment_intent",
+        "create_customer",
         "create_payment_intent",
+        "create_payment_method",
         "create_refund",
+        "delete_customer",
+        "detach_payment_method",
         "list_balance_transactions",
         "list_charges",
+        "list_customer_payment_methods",
+        "list_customers",
         "list_events",
         "list_payment_intents",
         "list_refunds",
         "retrieve_balance",
         "retrieve_charge",
+        "retrieve_customer",
         "retrieve_event",
         "retrieve_payment_intent",
+        "retrieve_payment_method",
         "retrieve_refund",
         "simulate_crypto_deposit",
+        "update_customer",
       ].sort()
     );
   });
 
   it("every tool is callable through /mcp/call", async () => {
-    expect(TOOL_NAMES).toHaveLength(15);
+    expect(TOOL_NAMES).toHaveLength(25);
     for (const name of TOOL_NAMES) {
       const app = await createStripeApp();
       const args = await argsFor(app, name);
@@ -93,8 +103,39 @@ async function argsFor(
     case "list_balance_transactions":
     case "list_events":
     case "list_refunds":
+    case "list_customers":
     case "retrieve_balance":
       return {};
+    case "create_customer":
+      return { name: "Ada Lovelace", email: "ada@example.com" };
+    case "retrieve_customer":
+    case "update_customer":
+    case "delete_customer":
+    case "list_customer_payment_methods": {
+      const customer = await callTool(app, "create_customer", { name: "Ada" });
+      if (name === "update_customer") return { id: customer.body.id, name: "Ada L" };
+      if (name === "list_customer_payment_methods") return { customer: customer.body.id };
+      return { id: customer.body.id };
+    }
+    case "create_payment_method":
+      return {
+        type: "card",
+        card: { number: "4242424242424242", exp_month: 12, exp_year: 2032, cvc: "123" },
+      };
+    case "retrieve_payment_method":
+    case "detach_payment_method":
+    case "attach_payment_method": {
+      const pm = await callTool(app, "create_payment_method", {
+        type: "card",
+        card: { number: "4242424242424242", exp_month: 12, exp_year: 2032 },
+      });
+      if (name === "retrieve_payment_method") return { id: pm.body.id };
+      const customer = await callTool(app, "create_customer", { name: "Ada" });
+      if (name === "attach_payment_method") return { id: pm.body.id, customer: customer.body.id };
+      // detach: attach first so the detach succeeds.
+      await callTool(app, "attach_payment_method", { id: pm.body.id, customer: customer.body.id });
+      return { id: pm.body.id };
+    }
     case "create_refund": {
       const charge = await settleCharge(app);
       return { charge };

--- a/packages/twin-stripe/test/unsupported.test.ts
+++ b/packages/twin-stripe/test/unsupported.test.ts
@@ -7,10 +7,11 @@ import { describe, expect, it } from "vitest";
 import { createStripeApp, rest } from "./_appHelper.js";
 
 // /v1/refunds moved off this list when M3a Lane B (FDRS-338) landed the
-// refunds resource. Anything still on the list returns the loud 501.
+// refunds resource; /v1/customers moved off when F-732 landed the customer
+// chain. GET /v1/payment_methods (the top-level list) stays 501 per the
+// F-729 ruling — only the customer-scoped list is implemented. Anything
+// still on the list returns the loud 501.
 const UNSUPPORTED_PATHS: Array<[string, string]> = [
-  ["GET", "/v1/customers"],
-  ["POST", "/v1/customers"],
   ["POST", "/v1/setup_intents"],
   ["GET", "/v1/products"],
   ["GET", "/v1/checkout/sessions"],


### PR DESCRIPTION
## Executive summary
Makes the customer-management task chain — Customer CRUD + attaching payment methods — a **semantic-tier** surface in twin-stripe. These endpoints were on the loud-501 list until now (genuine greenfield); after this PR an agent can create/update/list/delete customers and create/attach/detach card payment methods against the twin exactly the way it would against real Stripe, with lifecycle events, canonical state_deltas, and account scoping. The MCP tool surface grows 15 → 25; the structured fidelity inventory records the whole chain at `heat: hot` per the ruled per-twin list.

## What
- **Customers (REST + MCP)**: `POST/GET /v1/customers(/:id)`, `POST /v1/customers/:id` (update), `DELETE /v1/customers/:id`, `GET /v1/customers` — with real-Stripe semantics: every create field optional, per-key metadata merge (empty value unsets), soft delete serving the `{deleted: true}` stub on subsequent retrieves, deleted rows excluded from lists, `email` filter, cursor pagination on `(created, id)`.
- **Payment methods (REST + MCP)**: `POST /v1/payment_methods` (card only; test card numbers → brand/last4/fingerprint, Luhn + expiry `card_error`s at Stripe's 402, **PAN never stored or echoed**), `GET /v1/payment_methods/:id`, `POST /v1/payment_methods/:id/attach|detach` (one customer per PM; a previously-detached PM can never be reattached), `GET /v1/customers/:id/payment_methods` (`type` filter). Deleting a customer detaches its PMs in the same transaction. Top-level `GET /v1/payment_methods` stays loud-501 per the ruling.
- **10 new MCP tools** mirroring the routes (`create_customer` … `detach_payment_method`), wired through the same domain layer.
- **Events**: `customer.created/updated/deleted`, `payment_method.attached/detached` — pollable via `GET /v1/events` (no-webhooks-v1 model unchanged).
- **Fidelity contract**: inventory +10 tools / +10 REST rows at `heat: hot`, `fidelity: semantic` with `TC:customer-mgmt` / `TC:card-on-file` justifications (ruled F-729); FIDELITY.md tables updated 1:1; parity scenario extended to drive the full chain (`fidelity:parity` green, 25/25); the loud-501 probes in parity + smoke moved off `/v1/customers` to `/v1/checkout/sessions`.
- **State surface**: `/_pome/state` export gains `customers[]` + `payment_methods[]`; admin reset covers the new tables.
- Shared `readBodyForm` (bracket-form parsing + prototype-pollution guard) moved from the PI route to `routes/_helpers.ts` now that three route modules need it; `listPaginated` gains an `extraWheres` hook instead of per-table pagination copies.

## Why
Per the project ruling, customer management is hot — it is the precondition of nearly every collection chain — and F-731's card/payment-method PI flows are blocked on these resources existing. This is the first stripe endpoint-depth ticket built against the F-729 ruled list and the F-730 parity harness.

## Notes for reviewer
- `/healthz` shape is untouched (`tools` remains the MCP tool-list length, now 25 by construction; the contract test pins shape, not count). Surface counts live in the structured inventory.
- Heat values are set only for the new chain's rows; the pre-M5 rows stay `unclassified` until their owning tickets (F-731 payments, F-733 refunds docs, F-734 warm set) land — additive-only, no collisions with the parallel M5 lanes.
- TDD: both new test files were written first and watched fail 501 across all 23 cases before any implementation landed (`tdd-required` label).
- `npm run smoke` fails on a clean checkout of `main` in a fresh workspace (workspace-linked `@pome-sh/shared-types` exports `.ts` sources that plain `node dist/src/server.js` can't load) — pre-existing, unrelated, and reproduced without this diff; not addressed here.

## Greptile review
- [x] Applied P1 — same-year past expiry month now rejected with `card_error` / `invalid_expiry_month` (end-of-month rule: the current month stays valid). Regression-tested under a faked Date (`9c3c426`).
- [x] Applied P1 — deleting a customer now emits one `payment_method.detached` event per attached PM (post-detach shape), so event pollers see the transition the delete transaction performed (`9c3c426`).
- [x] Applied P2 — MCP `update_customer` metadata values accept `null` to unset a key, mirroring the REST surface (`9c3c426`).
- [ ] Declined P2 (cursors on `list_customer_payment_methods`) — every MCP list tool in this twin (`list_payment_intents`, `list_charges`, …) uniformly exposes `limit` only; adding cursor params to a single tool would break that convention. Cursor pagination remains available on the REST surface.

## Tests / CI
- twin-stripe: 169 tests / 30 files green (26 new); `npm run typecheck` clean
- `npm test` all workspaces (94/247/280/231/213/166) — green
- `npm run test:contract` — 69 pass / 0 fail
- `npm run fidelity:parity` (twin-stripe) — exit 0, 25 tools / 25 REST surfaces, zero failures
- gates: code-health, copy-markers, no-eval, no-cloud-imports, no-native (via CI), knip dead-code — pass

## Review required
Yes — expands the published twin-stripe surface (REST + MCP) and its fidelity contract.

<!-- Closes F-732 -->
