### PR TITLE
feat(twin-slack): re-cut FIDELITY.md by heat rubric; add the 3 ruled MCP read tools

### DIFF
--- a/packages/sdk/src/fidelity-inventory.ts
+++ b/packages/sdk/src/fidelity-inventory.ts
@@ -60,6 +60,8 @@ export function loadFidelityInventory(path: string): FidelityInventory {
 export interface FidelityDocRow {
   name: string;
   fidelity: string;
+  /** Present only when the table carries the optional Heat column. */
+  heat?: string;
 }
 
 export interface FidelityDocSource {
@@ -108,19 +110,25 @@ export function expandSurfaceCell(cell: string): string[] {
   ];
 }
 
-/** Parse every markdown table whose header names surfaces of `kind` + Tier. */
+/**
+ * Parse every markdown table whose header names surfaces of `kind` + Tier.
+ * The Heat column (ENDPOINT-TIERS.md) is optional: parsed when the header
+ * names it, omitted otherwise, so pre-heat tables stay legal.
+ */
 export function parseFidelityDocRows(markdown: string, kind: "tool" | "rest"): FidelityDocRow[] {
   const nameHeaders = kind === "tool" ? TOOL_NAME_HEADERS : REST_NAME_HEADERS;
   const rows: FidelityDocRow[] = [];
   const lines = markdown.split("\n");
   let nameIdx = -1;
   let tierIdx = -1;
+  let heatIdx = -1;
   let inTable = false;
   for (const line of lines) {
     if (!line.trimStart().startsWith("|")) {
       inTable = false;
       nameIdx = -1;
       tierIdx = -1;
+      heatIdx = -1;
       continue;
     }
     const cells = splitTableRow(line);
@@ -128,13 +136,15 @@ export function parseFidelityDocRows(markdown: string, kind: "tool" | "rest"): F
       const headers = cells.map((cell) => cell.toLowerCase());
       nameIdx = headers.findIndex((header) => nameHeaders.has(header));
       tierIdx = headers.findIndex((header) => header === "tier");
+      heatIdx = headers.findIndex((header) => header === "heat");
       inTable = true;
       continue;
     }
     if (isSeparatorRow(cells) || nameIdx < 0 || tierIdx < 0) continue;
     const fidelity = cells[tierIdx] ?? "";
+    const heat = heatIdx >= 0 ? { heat: cells[heatIdx] ?? "" } : {};
     for (const name of expandSurfaceCell(cells[nameIdx] ?? "")) {
-      rows.push({ name, fidelity });
+      rows.push({ name, fidelity, ...heat });
     }
   }
   return rows;
@@ -182,6 +192,17 @@ export function lintFidelityInventory(
           );
           continue;
         }
+        if (
+          existing &&
+          existing.heat !== undefined &&
+          row.heat !== undefined &&
+          existing.heat !== row.heat
+        ) {
+          problems.push(
+            `${labels}: ${kind} '${row.name}' is documented twice with conflicting heat ('${existing.heat}' vs '${row.heat}')`
+          );
+          continue;
+        }
         documented.set(row.name, row);
       }
     }
@@ -195,6 +216,11 @@ export function lintFidelityInventory(
       if (entry.fidelity !== row.fidelity) {
         problems.push(
           `${kind} '${name}': inventory says fidelity '${entry.fidelity}' but ${labels} says '${row.fidelity}'`
+        );
+      }
+      if (row.heat !== undefined && entry.heat !== row.heat) {
+        problems.push(
+          `${kind} '${name}': inventory says heat '${entry.heat}' but ${labels} says '${row.heat}'`
         );
       }
     }

--- a/packages/sdk/test/fidelity-parity.test.ts
+++ b/packages/sdk/test/fidelity-parity.test.ts
@@ -256,3 +256,76 @@ describe("parseFidelityDocRows / lintFidelityInventory", () => {
     );
   });
 });
+
+// ENDPOINT-TIERS.md lint rule 5: when a FIDELITY table carries the optional
+// Heat column, its values must equal the inventory's — heat and fidelity are
+// lintable independently. Tables without a Heat column stay legal (pre-M5
+// twins), so the column is parsed only when the header names it.
+const HEAT_DOC = `
+## MCP Tools
+
+| Tool | Backing surface | Heat | Tier | Tests |
+| --- | --- | --- | --- | --- |
+| \`add_item\` | in-memory list | hot | semantic | \`x.test.ts\` |
+| \`count_items\` | in-memory list | warm | semantic | \`x.test.ts\` |
+
+## REST routes
+
+| Endpoint | Heat | Tier | Notes |
+| --- | --- | --- | --- |
+| \`GET /items\` | hot | semantic | — |
+`;
+
+describe("heat column lint (ENDPOINT-TIERS.md rule 5)", () => {
+  function ruledInventory(): FidelityInventory {
+    const inventory = toyInventory();
+    inventory.tools[0].heat = "hot";
+    inventory.tools[1].heat = "warm";
+    inventory.rest[0].heat = "hot";
+    return inventory;
+  }
+
+  it("parses the Heat column when the header names it, omits it otherwise", () => {
+    expect(parseFidelityDocRows(HEAT_DOC, "tool")).toEqual([
+      { name: "add_item", fidelity: "semantic", heat: "hot" },
+      { name: "count_items", fidelity: "semantic", heat: "warm" },
+    ]);
+    expect(parseFidelityDocRows(DOC, "tool")).toEqual([
+      { name: "add_item", fidelity: "semantic" },
+      { name: "count_items", fidelity: "semantic" },
+    ]);
+  });
+
+  it("passes when documented heat matches the inventory", () => {
+    const docs = [
+      { label: "FIDELITY.md", kind: "tool" as const, markdown: HEAT_DOC },
+      { label: "FIDELITY.md", kind: "rest" as const, markdown: HEAT_DOC },
+    ];
+    expect(lintFidelityInventory(ruledInventory(), docs)).toEqual([]);
+  });
+
+  it("reports heat mismatches between inventory and docs", () => {
+    const docs = [{ label: "FIDELITY.md", kind: "tool" as const, markdown: HEAT_DOC }];
+    const inventory = ruledInventory();
+    inventory.tools[0].heat = "warm";
+    expect(lintFidelityInventory(inventory, docs).join("\n")).toContain(
+      "inventory says heat 'warm' but FIDELITY.md says 'hot'"
+    );
+  });
+
+  it("does not lint heat when the doc table has no Heat column", () => {
+    const docs = [{ label: "FIDELITY.md", kind: "tool" as const, markdown: DOC }];
+    expect(lintFidelityInventory(ruledInventory(), docs)).toEqual([]);
+  });
+
+  it("reports duplicate doc rows with conflicting heat", () => {
+    const conflicting = HEAT_DOC.replace(
+      "| `count_items` | in-memory list | warm | semantic | `x.test.ts` |",
+      "| `count_items` | in-memory list | warm | semantic | `x.test.ts` |\n| `count_items` | in-memory list | cold | semantic | `x.test.ts` |"
+    );
+    const docs = [{ label: "FIDELITY.md", kind: "tool" as const, markdown: conflicting }];
+    expect(lintFidelityInventory(ruledInventory(), docs).join("\n")).toContain(
+      "documented twice with conflicting heat ('warm' vs 'cold')"
+    );
+  });
+});

--- a/packages/twin-slack/FIDELITY.md
+++ b/packages/twin-slack/FIDELITY.md
@@ -4,7 +4,7 @@
 not a universal clone. This page documents exactly which surfaces are
 faithful to real Slack today, at what tier, and how fidelity is verified.
 
-Last verified: 2026-05-28.
+Last verified: 2026-07-12.
 
 ## What "fidelity" means here
 
@@ -26,7 +26,12 @@ other is **heat** ("how deep it *should* be", `hot`/`warm`/`cold`, ruled per
 milestone). The engine-level rubric — tier criteria, target mapping, gap and
 tier-mismatch semantics — lives at
 [`packages/sdk/ENDPOINT-TIERS.md`](../sdk/ENDPOINT-TIERS.md). The `Tier`
-column below means fidelity.
+column below means fidelity; the `Heat` column carries the twin-slack ruling
+(F-729 `[DECISION]`, 2026-07-11, implemented by F-736). Where ruled heat is
+below current fidelity, the surface is listed in the
+[tier-mismatch ledger](#tier-mismatch-ledger); ruled-but-unimplemented warm
+surfaces and named cold surfaces live in
+[their own table](#ruled-gaps-and-named-cold-surfaces).
 
 The bar is: **agents written against real Slack run unchanged against the
 local twin for the surfaces below**, and trip a loud failure for anything
@@ -41,53 +46,117 @@ in the package README. Changing any of those is a breaking change for
 
 ## MCP Tools
 
-| Tool | Backing surface | Tier | Tests | Known deviations |
-| --- | --- | --- | --- | --- |
-| `slack_post_message` | SQLite messages | semantic | `mcp-contract.test.ts`, `domain-chat.test.ts`, `recorder-state-delta.test.ts` | Block-kit rendering is not validated; emoji shortcodes are preserved literally. |
-| `slack_reply_to_thread` | SQLite messages (thread_ts FK) | semantic | `mcp-contract.test.ts`, `domain.test.ts` | Routes via `chat.postMessage({thread_ts})`; `reply_broadcast` is recorded but not re-fanned out. |
-| `slack_add_reaction` | SQLite reactions | semantic | `mcp-contract.test.ts`, `domain.test.ts`, `concurrency.test.ts` | Reactions are unique per `(channel, ts, name, user)`; skin-tone modifier suffixes are preserved as-is. |
-| `slack_get_channel_history` | SQLite messages | semantic | `mcp-contract.test.ts`, `domain.test.ts`, `performance.test.ts` | `oldest`/`latest`/`inclusive` filters supported; per-message metadata follows real Slack envelope. |
-| `slack_get_thread_replies` | SQLite messages | semantic | `mcp-contract.test.ts`, `domain.test.ts`, `domain-chat.test.ts` | Parent decorated with `thread_ts === ts`, `subscribed: false`, `is_locked: false` per real Slack invariant. |
-| `slack_list_channels` | SQLite channels | semantic | `mcp-contract.test.ts`, `domain.test.ts`, `performance.test.ts` | `types` filter supports `public_channel,private_channel,mpim,im`; cursor pagination via base64url offsets. |
-| `slack_get_users` | SQLite users | semantic | `mcp-contract.test.ts`, `domain.test.ts` | Deleted users are included with `deleted: true`; profile pagination matches real Slack envelope. |
-| `slack_get_user_profile` | SQLite users.profile_json | semantic | `mcp-contract.test.ts`, `domain.test.ts` | Returns the full profile JSON; custom fields preserved verbatim through the round-trip. |
+| Tool | Backing surface | Heat | Tier | Tests | Known deviations |
+| --- | --- | --- | --- | --- | --- |
+| `slack_post_message` | SQLite messages | hot | semantic | `mcp-contract.test.ts`, `domain-chat.test.ts`, `recorder-state-delta.test.ts` | Block-kit rendering is not validated; emoji shortcodes are preserved literally. |
+| `slack_reply_to_thread` | SQLite messages (thread_ts FK) | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | Routes via `chat.postMessage({thread_ts})`; `reply_broadcast` is recorded but not re-fanned out. |
+| `slack_add_reaction` | SQLite reactions | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts`, `concurrency.test.ts` | Reactions are unique per `(channel, ts, name, user)`; skin-tone modifier suffixes are preserved as-is. |
+| `slack_get_channel_history` | SQLite messages | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts`, `performance.test.ts` | `oldest`/`latest`/`inclusive` filters supported; per-message metadata follows real Slack envelope. |
+| `slack_get_thread_replies` | SQLite messages | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts`, `domain-chat.test.ts` | Parent decorated with `thread_ts === ts`, `subscribed: false`, `is_locked: false` per real Slack invariant. |
+| `slack_list_channels` | SQLite channels | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts`, `performance.test.ts` | `types` filter supports `public_channel,private_channel,mpim,im`; cursor pagination via base64url offsets. |
+| `slack_get_users` | SQLite users | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | Deleted users are included with `deleted: true`; profile pagination matches real Slack envelope. |
+| `slack_get_user_profile` | SQLite users.profile_json | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | Returns the full profile JSON; custom fields preserved verbatim through the round-trip. |
+| `slack_search_messages` | SQLite messages (LIKE search) | hot | semantic | `mcp-contract.test.ts`, `tools-execute.test.ts` | F-736 hot-gap fill over `search.messages`: substring match, not Slack's query grammar (divergence #8). |
+| `slack_get_reactions` | SQLite reactions | hot | semantic | `mcp-contract.test.ts`, `tools-execute.test.ts` | F-736 hot-gap fill over `reactions.get`; returns the message with its grouped reactions. |
+| `slack_list_channel_members` | SQLite channel_members | hot | semantic | `mcp-contract.test.ts`, `tools-execute.test.ts` | F-736 hot-gap fill over `conversations.members`; returns user IDs with cursor pagination. |
 
-The visible MCP tool count is pinned at 8 in `test/mcp-contract.test.ts`;
+The visible MCP tool count is pinned at 11 in `test/mcp-contract.test.ts`
+(8 pre-M5 tools + the 3 F-736 hot-gap read tools ruled in F-729/SL2);
 descriptions, required fields, mutating set, and `additionalProperties:false`
 are all locked. Any drift breaks the contract test loudly.
 
 ## REST routes
 
-| Endpoint | Tier | Tests | Notes |
-| --- | --- | --- | --- |
-| `auth.test` | semantic | `app.test.ts`, `auth.test.ts` | Returns `{ok, url, team, user, team_id, user_id, bot_id?}`. |
-| `chat.postMessage` | semantic | `app.test.ts`, `domain-chat.test.ts`, `recorder-state-delta.test.ts` | Form-encoded + JSON body; persists `username`, `icon_emoji`, `icon_url`; emits `bot_id`, `bot_profile`, `app_id` for bot authors. |
-| `chat.update` | semantic | `domain-chat.test.ts`, `app-routes.test.ts` | `edited_ts` allocated via the workspace-unique ts counter — no collisions. |
-| `chat.delete` | semantic | `app.test.ts`, `actor-session.test.ts`, `domain.test.ts` | Hard delete (matches real Slack); thread parent `reply_count` decrements transactionally. No admin override. |
-| `chat.scheduleMessage` / `chat.deleteScheduledMessage` | semantic | `domain.test.ts`, `app-routes.test.ts` | No fire path — scheduled messages persist until explicit delete. |
-| `conversations.list` | semantic | `app.test.ts`, `recorder-state-delta.test.ts` | Cursor pagination, `types` filter, `exclude_archived`. |
-| `conversations.info` | semantic | `app-routes.test.ts` | `include_num_members` supported. |
-| `conversations.create` | semantic | `app.test.ts`, `domain-conversations.test.ts` | Granular error codes: `invalid_name_required` / `_maxlength` / `_specials` / `_punctuation`. |
-| `conversations.history` | semantic | `app.test.ts`, `performance.test.ts` | Newest-first ordering; `pin_count` included. |
-| `conversations.replies` | semantic | `domain-chat.test.ts`, `domain.test.ts` | Parent decorated with `thread_ts === ts`, `subscribed:false`, `is_locked:false`. |
-| `conversations.invite` / `join` / `leave` / `kick` / `archive` / `members` | semantic | `app-routes.test.ts`, `domain.test.ts`, `domain-conversations.test.ts` | `cant_kick_self`, `cant_kick_from_general`, `cant_leave_general`, `cant_archive_general` matched. |
-| `conversations.open` | semantic | `domain-conversations.test.ts`, `concurrency.test.ts` | Deterministic DM channel id by sorted member-id signature with a partial UNIQUE index. |
-| `reactions.add` / `remove` / `get` | semantic | `app.test.ts`, `domain.test.ts`, `concurrency.test.ts` | `already_reacted` / `no_reaction` error codes. |
-| `users.list` / `users.info` / `users.lookupByEmail` / `users.profile.get` / `users.profile.set` | semantic | `domain.test.ts`, `app-routes.test.ts` | `users_not_found` error code on email miss. |
-| `pins.add` / `remove` / `list` | semantic | `domain.test.ts`, `app-routes.test.ts` | `already_pinned` / `no_pin` codes; SQL constraint-mapped on race. |
-| `search.messages` | semantic | `domain.test.ts`, `performance.test.ts` | Substring (LIKE-based) match; query syntax is intentionally smaller than real Slack search. |
-| `files.upload` / `info` / `list` / `delete` | shape | `domain.test.ts`, `app-routes.test.ts` | Metadata-only; no binary storage. URL fields point to deterministic `pome-twin-files.slack.com` hosts. |
-| `bookmarks.add` / `remove` / `list` | semantic | `domain.test.ts`, `app-routes.test.ts` | `link` type accepted; other bookmark types are unsupported per real Slack 2024 changelog. |
-| `team.info` | semantic | `app-routes.test.ts` | Returns workspace metadata; enterprise fields are NULL for non-Enterprise twins. |
+| Endpoint | Heat | Tier | Tests | Notes |
+| --- | --- | --- | --- | --- |
+| `auth.test` | hot | semantic | `app.test.ts`, `auth.test.ts` | Returns `{ok, url, team, user, team_id, user_id, bot_id?}`. |
+| `chat.postMessage` | hot | semantic | `app.test.ts`, `domain-chat.test.ts`, `recorder-state-delta.test.ts` | Form-encoded + JSON body; persists `username`, `icon_emoji`, `icon_url`; emits `bot_id`, `bot_profile`, `app_id` for bot authors. |
+| `chat.update` | hot | semantic | `domain-chat.test.ts`, `app-routes.test.ts` | `edited_ts` allocated via the workspace-unique ts counter — no collisions. Hot per SL1: agents edit their own progress messages. |
+| `chat.delete` | hot | semantic | `app.test.ts`, `actor-session.test.ts`, `domain.test.ts` | Hard delete (matches real Slack); thread parent `reply_count` decrements transactionally. No admin override. Hot per SL1. |
+| `chat.scheduleMessage` / `chat.deleteScheduledMessage` | hot | semantic | `domain.test.ts`, `app-routes.test.ts` | No fire path — scheduled messages persist until explicit delete. |
+| `conversations.list` | hot | semantic | `app.test.ts`, `recorder-state-delta.test.ts` | Cursor pagination, `types` filter, `exclude_archived`. |
+| `conversations.info` | hot | semantic | `app-routes.test.ts` | `include_num_members` supported. |
+| `conversations.create` | hot | semantic | `app.test.ts`, `domain-conversations.test.ts` | Granular error codes: `invalid_name_required` / `_maxlength` / `_specials` / `_punctuation`. |
+| `conversations.history` | hot | semantic | `app.test.ts`, `performance.test.ts` | Newest-first ordering; `pin_count` included. |
+| `conversations.replies` | hot | semantic | `domain-chat.test.ts`, `domain.test.ts` | Parent decorated with `thread_ts === ts`, `subscribed:false`, `is_locked:false`. |
+| `conversations.invite` / `join` / `members` | hot | semantic | `app-routes.test.ts`, `domain.test.ts`, `domain-conversations.test.ts` | Membership setup + the member read behind `slack_list_channel_members`. |
+| `conversations.leave` / `kick` / `archive` | warm | semantic | `app-routes.test.ts`, `domain.test.ts`, `domain-conversations.test.ts` | `cant_kick_self`, `cant_kick_from_general`, `cant_leave_general`, `cant_archive_general` matched. Warm-ruled: see the tier-mismatch ledger. |
+| `conversations.open` | hot | semantic | `domain-conversations.test.ts`, `concurrency.test.ts` | Deterministic DM channel id by sorted member-id signature with a partial UNIQUE index. |
+| `reactions.add` / `get` | hot | semantic | `app.test.ts`, `domain.test.ts`, `concurrency.test.ts` | `already_reacted` error code; `get` backs `slack_get_reactions`. |
+| `reactions.remove` | warm | semantic | `app.test.ts`, `domain.test.ts` | `no_reaction` error code. Warm-ruled undo step: see the tier-mismatch ledger. |
+| `users.list` / `users.info` / `users.lookupByEmail` / `users.profile.get` | hot | semantic | `domain.test.ts`, `app-routes.test.ts` | `users_not_found` error code on email miss. |
+| `users.profile.set` | warm | semantic | `domain.test.ts`, `app-routes.test.ts` | Warm-ruled (no vendor MCP write): see the tier-mismatch ledger. |
+| `pins.add` / `remove` / `list` | warm | semantic | `domain.test.ts`, `app-routes.test.ts` | `already_pinned` / `no_pin` codes; SQL constraint-mapped on race. Warm-ruled: see the tier-mismatch ledger. |
+| `search.messages` | hot | semantic | `domain.test.ts`, `performance.test.ts` | Substring (LIKE-based) match; query syntax is intentionally smaller than real Slack search. |
+| `files.upload` / `info` / `list` / `delete` | warm | shape | `domain.test.ts`, `app-routes.test.ts` | Metadata-only; no binary storage. URL fields point to deterministic `pome-twin-files.slack.com` hosts. Shape is at the warm target (SL5). |
+| `bookmarks.add` / `remove` / `list` | warm | semantic | `domain.test.ts`, `app-routes.test.ts` | `link` type accepted; other bookmark types are unsupported per real Slack 2024 changelog. Warm-ruled: see the tier-mismatch ledger. |
+| `team.info` | warm | semantic | `app-routes.test.ts` | Returns workspace metadata; enterprise fields are NULL for non-Enterprise twins. Warm-ruled context read: see the tier-mismatch ledger. |
 
 Routes not listed return **501 + `_twin.fidelity:"unsupported"`** so agents
-fail loudly rather than silently no-op.
+fail loudly rather than silently no-op. Cold surfaces agents plausibly probe
+carry named rows below, so the loud 501 is documented and test-backed; the
+rest of the upstream API is implicitly cold via the catch-all.
+
+## Ruled gaps and named cold surfaces
+
+Per the F-729 twin-slack ruling, the hot and warm sets are exhaustive: warm
+surfaces the twin does not implement yet appear here as explicit gaps
+(fidelity below the `shape` target) with their defer rationale — F-736 filled
+hot gaps only (SL2); warm gaps were ruled defer (SL3/SL4). Named cold rows
+document the loud 501 for surfaces agents plausibly probe. Message drafts are
+deliberately absent: a client-UI concept with no Web API analog to name a row
+for (PS).
+
+| Endpoint | Heat | Tier | Notes |
+| --- | --- | --- | --- |
+| `canvases.create` / `canvases.edit` / `canvases.delete` | warm | unsupported | Deferred post-M5 (SL3). Strongest promotion candidate: Slack's first-party MCP server ships 3 canvas tools. |
+| `conversations.setTopic` / `conversations.setPurpose` | warm | unsupported | Deferred post-M5 (SL4). "Set the channel topic" is a classic agent task; no vendor MCP tool. |
+| `emoji.list` | warm | unsupported | Deferred post-M5 (SL4). Vendor ships an emoji-search tool; trivial read when filled. |
+| `chat.postEphemeral` | cold | unsupported | The twin has no per-viewer visibility model (PS). 501 test-backed. |
+| `files.getUploadURLExternal` / `files.completeUploadExternal` | cold | unsupported | Modern upload flow; the twin serves legacy v1 upload (divergence #7). Promotion candidate when v1 sunsets. 501 test-backed. |
+| `admin.*` | cold | unsupported | No admin scopes modeled (divergence #6) (PS). Representative 501 probes test-backed. |
+| `usergroups.*` | cold | unsupported | Outside the single-workspace twin scope (PS). 501 test-backed. |
+| `views.*` | cold | unsupported | Client-UI modal surface, not on an agent chain (PS). 501 test-backed. |
+
+## Tier-mismatch ledger
+
+Surfaces whose ruled heat is **warm** but whose measured fidelity is
+`semantic` — implementation deeper than the ruling demands. Per the M5
+additive-only project `[DECISION]` (2026-07-11), nothing here is demoted in
+code this milestone (the Twin Fidelity Watch launch gate F-440 is counting
+consecutive green runs); each entry becomes a demotion-review follow-up
+ticket after that gate closes. The ledger makes over-investment visible; it
+does not trigger removals.
+
+| Surface | Heat | Fidelity today | Target | Why it stays for now |
+| --- | --- | --- | --- | --- |
+| `reactions.remove` | warm | semantic | shape | Undo step; F-440 additive-only window. |
+| `conversations.leave` | warm | semantic | shape | Rare cleanup chain; F-440 additive-only window. |
+| `conversations.kick` | warm | semantic | shape | Rare moderation chain; F-440 additive-only window. |
+| `conversations.archive` | warm | semantic | shape | Rare cleanup chain; F-440 additive-only window. |
+| `users.profile.set` | warm | semantic | shape | Plausible set-own-status chain, no vendor write tool; F-440 additive-only window. |
+| `pins.add` | warm | semantic | shape | Occasional chain, absent from the vendor server; F-440 additive-only window. |
+| `pins.remove` | warm | semantic | shape | Occasional chain, absent from the vendor server; F-440 additive-only window. |
+| `pins.list` | warm | semantic | shape | Occasional chain, absent from the vendor server; F-440 additive-only window. |
+| `bookmarks.add` | warm | semantic | shape | Occasional chain, absent from the vendor server; F-440 additive-only window. |
+| `bookmarks.remove` | warm | semantic | shape | Occasional chain, absent from the vendor server; F-440 additive-only window. |
+| `bookmarks.list` | warm | semantic | shape | Occasional chain, absent from the vendor server; F-440 additive-only window. |
+| `team.info` | warm | semantic | shape | Context read adjacent to hot chains; F-440 additive-only window. |
 
 ## Fidelity-watch coverage (status.pome.sh)
 
 The daily watchdog reports twin-slack at **19 of 45 semantic surfaces**, 26 rolling
 out. The number is built from source, never hand-typed
 (the Twin Fidelity Watch in pome-cloud); here is exactly what it counts.
+
+> **Denominator reconcile deferred (SL5).** The 45 predates the F-736 re-cut:
+> it counts `files.info` / `files.list` / `files.delete` as semantic (the
+> table above rules them shape ×4 — the table wins) and does not yet include
+> the three F-736 MCP read tools (`slack_search_messages`,
+> `slack_get_reactions`, `slack_list_channel_members`). Reconciling
+> pome-cloud's `sandboxes/slack/surfaces.ts` is deliberately deferred until
+> the F-440 launch gate finishes its consecutive-green count (additive-only
+> collision), tracked by F-737.
 
 - **Denominator (45)** — the full semantic surface inventory: 8 MCP tools + 37
   semantic REST methods (`files.upload` is shape-tier, excluded). MCP tools and
@@ -269,6 +338,8 @@ npm run verify:cloud-token              # cloud xoxb-pome-* token validates
 The tables above are 1:1-linted against the structured inventory
 [`fidelity.inventory.json`](fidelity.inventory.json) (which also carries the
 hot/warm/cold heat tier per F-729) by `test/fidelity-contract.test.ts`; the
-shared parity runner (`@pome-sh/sdk/parity`) asserts the same inventory
-matches the live tool list and that a declarative scenario exercises every
-tool.
+same test enforces the heat discipline (no unclassified surfaces, hot ⇒
+semantic, cold ⇒ unsupported, and the tier-mismatch ledger exactly matching
+the warm-above-target set). The shared parity runner (`@pome-sh/sdk/parity`)
+asserts the same inventory matches the live tool list and that a declarative
+scenario exercises every tool.

--- a/packages/twin-slack/README.md
+++ b/packages/twin-slack/README.md
@@ -2,7 +2,7 @@
 
 > One of three twins in this repository (GitHub, Stripe x402, Slack).
 
-`@pome-sh/twin-slack` is a local, stateful Slack twin for agent testing. It exposes Slack Web API–shaped REST routes plus an 8-tool MCP-style API backed by the same SQLite domain services. The 8 visible MCP tools mirror the canonical Slack agent toolset (post message, reply to thread, add reaction, get channel history, get thread replies, list channels, list users, get user profile).
+`@pome-sh/twin-slack` is a local, stateful Slack twin for agent testing. It exposes Slack Web API–shaped REST routes plus an 11-tool MCP-style API backed by the same SQLite domain services. The 11 visible MCP tools mirror the canonical Slack agent toolset (post message, reply to thread, add reaction, get channel history, get thread replies, list channels, list users, get user profile, search messages, get reactions, list channel members).
 
 ## Quickstart
 
@@ -57,7 +57,7 @@ The default seed creates:
 - **Real MCP (JSON-RPC, Streamable HTTP, stateless):** `POST /s/:sid/mcp`
   — speaks the protocol the `@modelcontextprotocol/sdk` `Client` +
   `StreamableHTTPClientTransport` expect (`initialize`, `tools/list`,
-  `tools/call`, `ping`, `notifications/*`). 8 visible tools returned via
+  `tools/call`, `ping`, `notifications/*`). 11 visible tools returned via
   `tools/list` with camelCase `inputSchema`.
 - Legacy custom MCP routes:
   - `GET  /s/:sid/mcp/tools` — returns `{ tools: [{ name, description, input_schema }, ...] }`

--- a/packages/twin-slack/fidelity.inventory.json
+++ b/packages/twin-slack/fidelity.inventory.json
@@ -1,286 +1,376 @@
 {
   "twin": "slack",
   "package": "@pome-sh/twin-slack",
-  "updated": "2026-07-11",
-  "notes": "Both tables lint 1:1 against FIDELITY.md. REST names are Slack Web API method names. Heat tiers await the F-729 rubric ruling.",
+  "updated": "2026-07-12",
+  "notes": "Re-cut against packages/sdk/ENDPOINT-TIERS.md per the F-729 twin-slack ruling (SL1-SL5), implemented by F-736. Heat is ruled, fidelity is measured; both tables lint 1:1 against FIDELITY.md. The hot and warm sets are exhaustive (ruled-but-unimplemented warm gaps carry fidelity 'unsupported' plus a defer note); cold rows are named-only — the remaining upstream tail stays implicitly cold via the 501 catch-all. Warm surfaces above their shape target are mirrored in FIDELITY.md's tier-mismatch ledger (M5 additive-only ruling: no code demotions this milestone). Message drafts have no Web API analog to name a row for (PS, client-UI concept) — recorded here, not as a surface.",
   "tools": [
     {
       "name": "slack_post_message",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): TC:post-and-read — the core agent messaging chain; MCP: vendor first-party server ships the message write."
     },
     {
       "name": "slack_reply_to_thread",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): TC:post-and-read — threaded follow-up on the messaging chain; MCP: vendor thread read/write tools."
     },
     {
       "name": "slack_add_reaction",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): MCP:add_reaction (vendor first-party tool); TC:post-and-read — ack/verify step on the messaging chain."
     },
     {
       "name": "slack_get_channel_history",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): TC:post-and-read — the channel read agents poll after posting; MCP: vendor channel-read tool."
     },
     {
       "name": "slack_get_thread_replies",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): TC:post-and-read — thread read on the messaging chain; MCP: vendor thread-read tool."
     },
     {
       "name": "slack_list_channels",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): TC:discovery — channel lookup precedes nearly every chain; MCP: vendor channel search/read tools."
     },
     {
       "name": "slack_get_users",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): TC:discovery — user lookup precedes DMs, invites, and mentions; MCP: vendor user-search tool."
     },
     {
       "name": "slack_get_user_profile",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): TC:discovery; MCP:read_user_profile (vendor first-party tool)."
+    },
+    {
+      "name": "slack_search_messages",
+      "heat": "hot",
+      "fidelity": "semantic",
+      "justification": "Ruled hot (F-729, SL2): TC:discovery; MCP: vendor search suite (5 search tools). F-736 hot-gap fill — an MCP-only agent could not search before this tool; backed by the existing semantic search.messages domain."
+    },
+    {
+      "name": "slack_get_reactions",
+      "heat": "hot",
+      "fidelity": "semantic",
+      "justification": "Ruled hot (F-729, SL2): MCP:get_reactions (vendor first-party tool); TC:post-and-read verify step. F-736 hot-gap fill backed by the existing semantic reactions.get domain."
+    },
+    {
+      "name": "slack_list_channel_members",
+      "heat": "hot",
+      "fidelity": "semantic",
+      "justification": "Ruled hot (F-729, SL2): MCP:list_channel_members (vendor first-party tool); TC:discovery. F-736 hot-gap fill backed by the existing semantic conversations.members domain."
     }
   ],
   "rest": [
     {
       "name": "auth.test",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): TC:sdk-bootstrap — every @slack/web-api client calls it first."
     },
     {
       "name": "chat.postMessage",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): TC:post-and-read — the core agent messaging chain; MCP: mirrored by the message-write tool."
     },
     {
       "name": "chat.update",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729, SL1): TC:agents-edit-own-updates — agents editing their own progress/status messages is a real chain; no vendor MCP tool, task chain wins per the rubric."
     },
     {
       "name": "chat.delete",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729, SL1): TC:agents-edit-own-updates — retract/replace step of the same chain; no vendor MCP tool, task chain wins per the rubric."
     },
     {
       "name": "chat.scheduleMessage",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): TC:schedule-then-adjust; MCP:schedule_message (vendor first-party tool)."
     },
     {
       "name": "chat.deleteScheduledMessage",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): TC:schedule-then-adjust — one chain with chat.scheduleMessage (schedule, then adjust)."
     },
     {
       "name": "conversations.list",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): TC:discovery; MCP: vendor channel search/read tools."
     },
     {
       "name": "conversations.info",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): TC:discovery; MCP: vendor channel-read tools."
     },
     {
       "name": "conversations.create",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): TC:channel-setup; MCP:create_conversation (covers channel/group-DM/IM)."
     },
     {
       "name": "conversations.history",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): TC:post-and-read; MCP: vendor channel-read tool."
     },
     {
       "name": "conversations.replies",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): TC:post-and-read; MCP: vendor thread-read tool."
     },
     {
       "name": "conversations.invite",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): TC:channel-setup; MCP:create_conversation covers membership setup."
     },
     {
       "name": "conversations.join",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): TC:channel-setup — the agent joins before posting."
     },
     {
       "name": "conversations.leave",
-      "heat": "unclassified",
+      "heat": "warm",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled warm (F-729): TC: rare cleanup chain; no vendor MCP tool. Fidelity semantic > shape target → tier-mismatch ledger (M5 additive-only)."
     },
     {
       "name": "conversations.kick",
-      "heat": "unclassified",
+      "heat": "warm",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled warm (F-729): TC: rare moderation chain; no vendor MCP tool. Fidelity semantic > shape target → tier-mismatch ledger (M5 additive-only)."
     },
     {
       "name": "conversations.archive",
-      "heat": "unclassified",
+      "heat": "warm",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled warm (F-729): TC: rare cleanup chain; no vendor MCP tool. Fidelity semantic > shape target → tier-mismatch ledger (M5 additive-only)."
     },
     {
       "name": "conversations.members",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): TC:discovery; MCP:list_channel_members (vendor first-party tool)."
     },
     {
       "name": "conversations.open",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): TC:channel-setup — DM open precedes direct-message chains; MCP:create_conversation covers IM/group-DM."
     },
     {
       "name": "reactions.add",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): MCP:add_reaction (vendor first-party tool); TC:post-and-read ack step."
     },
     {
       "name": "reactions.remove",
-      "heat": "unclassified",
+      "heat": "warm",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled warm (F-729): TC: undo chain, rare; no vendor MCP tool. Fidelity semantic > shape target → tier-mismatch ledger (M5 additive-only)."
     },
     {
       "name": "reactions.get",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): MCP:get_reactions (vendor first-party tool); TC:post-and-read verify step."
     },
     {
       "name": "users.list",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): TC:discovery; MCP: vendor user-search tool."
     },
     {
       "name": "users.info",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): TC:discovery; MCP: vendor profile-read tool."
     },
     {
       "name": "users.lookupByEmail",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): TC:discovery — email is the id agents usually start from."
     },
     {
       "name": "users.profile.get",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): TC:discovery; MCP:read_user_profile (vendor first-party tool)."
     },
     {
       "name": "users.profile.set",
-      "heat": "unclassified",
+      "heat": "warm",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled warm (F-729): TC:set-own-status is plausible but no vendor MCP write exists. Fidelity semantic > shape target → tier-mismatch ledger (M5 additive-only)."
     },
     {
       "name": "pins.add",
-      "heat": "unclassified",
+      "heat": "warm",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled warm (F-729): TC: occasional chain; MCP: conspicuously absent from the vendor's first-party server. Fidelity semantic > shape target → tier-mismatch ledger (M5 additive-only)."
     },
     {
       "name": "pins.remove",
-      "heat": "unclassified",
+      "heat": "warm",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled warm (F-729): TC: occasional chain; MCP: absent from the vendor's first-party server. Fidelity semantic > shape target → tier-mismatch ledger (M5 additive-only)."
     },
     {
       "name": "pins.list",
-      "heat": "unclassified",
+      "heat": "warm",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled warm (F-729): TC: occasional chain; MCP: absent from the vendor's first-party server. Fidelity semantic > shape target → tier-mismatch ledger (M5 additive-only)."
     },
     {
       "name": "search.messages",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled hot (F-729): TC:discovery; MCP: vendor search suite (5 search tools)."
     },
     {
       "name": "files.upload",
-      "heat": "unclassified",
+      "heat": "warm",
       "fidelity": "shape",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled warm (F-729, SL5): metadata-only legacy v1 upload (divergence #7), no binary storage — fidelity shape, at target; MCP: vendor ships only the read side (read_file)."
     },
     {
       "name": "files.info",
-      "heat": "unclassified",
+      "heat": "warm",
       "fidelity": "shape",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled warm (F-729, SL5): metadata-only, no binary storage — fidelity shape, at target; MCP:read_file (vendor first-party tool)."
     },
     {
       "name": "files.list",
-      "heat": "unclassified",
+      "heat": "warm",
       "fidelity": "shape",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled warm (F-729, SL5): TC: occasional file-context read; metadata-only, no binary storage — fidelity shape, at target."
     },
     {
       "name": "files.delete",
-      "heat": "unclassified",
+      "heat": "warm",
       "fidelity": "shape",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled warm (F-729, SL5): TC: rare cleanup step on the file chain; metadata-only, no binary storage — fidelity shape, at target."
     },
     {
       "name": "bookmarks.add",
-      "heat": "unclassified",
+      "heat": "warm",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled warm (F-729): TC: occasional chain; MCP: absent from the vendor's first-party server. Fidelity semantic > shape target → tier-mismatch ledger (M5 additive-only)."
     },
     {
       "name": "bookmarks.remove",
-      "heat": "unclassified",
+      "heat": "warm",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled warm (F-729): TC: occasional chain; MCP: absent from the vendor's first-party server. Fidelity semantic > shape target → tier-mismatch ledger (M5 additive-only)."
     },
     {
       "name": "bookmarks.list",
-      "heat": "unclassified",
+      "heat": "warm",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled warm (F-729): TC: occasional chain; MCP: absent from the vendor's first-party server. Fidelity semantic > shape target → tier-mismatch ledger (M5 additive-only)."
     },
     {
       "name": "team.info",
-      "heat": "unclassified",
+      "heat": "warm",
       "fidelity": "semantic",
-      "justification": "Pre-M5 baseline (F-730): fidelity mirrors the documented tier; heat awaits the F-729 rubric ruling."
+      "justification": "Ruled warm (F-729): TC: context read adjacent to hot chains; no vendor MCP tool. Fidelity semantic > shape target → tier-mismatch ledger (M5 additive-only)."
+    },
+    {
+      "name": "canvases.create",
+      "heat": "warm",
+      "fidelity": "unsupported",
+      "justification": "Ruled warm (F-729, SL3): MCP: vendor first-party server ships 3 canvas tools; growing agent chain. Gap (unsupported < shape target) deferred — F-736 fills hot gaps only; strongest post-M5 promotion candidate."
+    },
+    {
+      "name": "canvases.edit",
+      "heat": "warm",
+      "fidelity": "unsupported",
+      "justification": "Ruled warm (F-729, SL3): MCP: vendor first-party server ships 3 canvas tools. Gap (unsupported < shape target) deferred — F-736 fills hot gaps only; strongest post-M5 promotion candidate."
+    },
+    {
+      "name": "canvases.delete",
+      "heat": "warm",
+      "fidelity": "unsupported",
+      "justification": "Ruled warm (F-729, SL3): MCP: vendor canvas toolset implies lifecycle cleanup. Gap (unsupported < shape target) deferred — F-736 fills hot gaps only."
+    },
+    {
+      "name": "conversations.setTopic",
+      "heat": "warm",
+      "fidelity": "unsupported",
+      "justification": "Ruled warm (F-729, SL4): TC:set-channel-topic — a classic agent task; no vendor MCP tool. Gap (unsupported < shape target) deferred post-M5."
+    },
+    {
+      "name": "conversations.setPurpose",
+      "heat": "warm",
+      "fidelity": "unsupported",
+      "justification": "Ruled warm (F-729, SL4): TC:set-channel-topic sibling; no vendor MCP tool. Gap (unsupported < shape target) deferred post-M5."
+    },
+    {
+      "name": "emoji.list",
+      "heat": "warm",
+      "fidelity": "unsupported",
+      "justification": "Ruled warm (F-729, SL4): MCP:search_emojis (vendor first-party tool); trivial read. Gap (unsupported < shape target) deferred post-M5."
+    },
+    {
+      "name": "chat.postEphemeral",
+      "heat": "cold",
+      "fidelity": "unsupported",
+      "justification": "Ruled cold (F-729): PS — the twin has no per-viewer visibility model. Loud 501 envelope test-backed (app.test.ts)."
+    },
+    {
+      "name": "files.getUploadURLExternal",
+      "heat": "cold",
+      "fidelity": "unsupported",
+      "justification": "Ruled cold (F-729): PS — the twin serves the legacy v1 upload (divergence #7); promotion candidate when v1 sunsets. Loud 501 envelope test-backed (app.test.ts)."
+    },
+    {
+      "name": "files.completeUploadExternal",
+      "heat": "cold",
+      "fidelity": "unsupported",
+      "justification": "Ruled cold (F-729): PS — second half of the modern upload flow the twin does not model (divergence #7). Loud 501 envelope test-backed (app.test.ts)."
+    },
+    {
+      "name": "admin.*",
+      "heat": "cold",
+      "fidelity": "unsupported",
+      "justification": "Ruled cold (F-729): PS — no admin scopes modeled (divergence #6); vendor first-party server ships no admin tools. Representative loud-501 probes test-backed (app.test.ts, fidelity-parity)."
+    },
+    {
+      "name": "usergroups.*",
+      "heat": "cold",
+      "fidelity": "unsupported",
+      "justification": "Ruled cold (F-729): PS — outside the single-workspace twin scope; vendor first-party server ships no usergroup tools. Representative loud-501 probe test-backed (app.test.ts)."
+    },
+    {
+      "name": "views.*",
+      "heat": "cold",
+      "fidelity": "unsupported",
+      "justification": "Ruled cold (F-729): PS — client-UI modal surface, not on an autonomous agent chain. Representative loud-501 probe test-backed (app.test.ts)."
     }
   ],
   "doc_drift": []

--- a/packages/twin-slack/scripts/fidelity-parity.ts
+++ b/packages/twin-slack/scripts/fidelity-parity.ts
@@ -44,6 +44,34 @@ const steps: ParityStep[] = [
     },
   },
   { tool: "slack_get_user_profile", arguments: (state) => ({ user_id: state.aliceId }) },
+  // F-736 hot-gap read tools: search the posted message, read back the
+  // reaction added above, list the members of the channel we posted into.
+  {
+    tool: "slack_search_messages",
+    arguments: { query: "Parity" },
+    verify: (body) => {
+      const matches = (body as { messages?: { matches?: unknown[] } }).messages?.matches ?? [];
+      return matches.length > 0 ? undefined : "search returned no match for the posted message";
+    },
+  },
+  {
+    tool: "slack_get_reactions",
+    arguments: (state) => ({ channel_id: state.channelId, timestamp: state.ts }),
+    verify: (body) => {
+      const reactions = (body as { message?: { reactions?: Array<{ name?: string }> } }).message?.reactions ?? [];
+      return reactions.some((r) => r.name === "thumbsup")
+        ? undefined
+        : "reactions read did not include the thumbsup added earlier";
+    },
+  },
+  {
+    tool: "slack_list_channel_members",
+    arguments: (state) => ({ channel_id: state.channelId }),
+    verify: (body) => {
+      const members = (body as { members?: string[] }).members ?? [];
+      return members.length > 0 ? undefined : "channel member list came back empty";
+    },
+  },
 ];
 
 await runParityCli({
@@ -59,5 +87,10 @@ await runParityCli({
   },
   restProbes: [
     { surface: "unsupported-rest", method: "POST", path: "/admin.conversations.search", status: 501, expectUnsupportedEnvelope: true },
+    // Named cold rows (F-729 ruling / F-736): the loud 501 is part of the contract.
+    { surface: "cold:chat.postEphemeral", method: "POST", path: "/chat.postEphemeral", status: 501, expectUnsupportedEnvelope: true },
+    { surface: "cold:files.getUploadURLExternal", method: "GET", path: "/files.getUploadURLExternal", status: 501, expectUnsupportedEnvelope: true },
+    { surface: "cold:usergroups.list", method: "GET", path: "/usergroups.list", status: 501, expectUnsupportedEnvelope: true },
+    { surface: "cold:views.publish", method: "POST", path: "/views.publish", status: 501, expectUnsupportedEnvelope: true },
   ],
 });

--- a/packages/twin-slack/scripts/smoke.ts
+++ b/packages/twin-slack/scripts/smoke.ts
@@ -48,7 +48,7 @@ function assert(condition: unknown, message: string) {
   const body = (await res.json()) as Record<string, unknown>;
   assert(res.status === 200, "GET /healthz returns 200");
   assert(body.twin === "slack", "healthz reports twin=slack");
-  assert(body.tools === 8, "healthz reports 8 tools");
+  assert(body.tools === 11, "healthz reports 11 tools");
 }
 
 // 2. auth.test
@@ -140,7 +140,7 @@ let threadParentTs = "";
   const { status, body } = await call("/mcp/tools");
   assert(status === 200, "GET /mcp/tools 200");
   const tools = (body as { tools: Array<{ name: string }> }).tools;
-  assert(tools.length === 8, `8 tools listed (got ${tools.length})`);
+  assert(tools.length === 11, `11 tools listed (got ${tools.length})`);
   assert(tools.every((t) => t.name.startsWith("slack_")), "all tools prefixed slack_");
 }
 
@@ -153,7 +153,7 @@ let threadParentTs = "";
   });
   const body = (await res.json()) as { result: { tools: Array<{ name: string; inputSchema: { additionalProperties: false } }> } };
   assert(res.status === 200, "MCP tools/list 200");
-  assert(body.result.tools.length === 8, "MCP lists 8 tools");
+  assert(body.result.tools.length === 11, "MCP lists 11 tools");
   assert(body.result.tools.every((t) => t.inputSchema?.additionalProperties === false), "all tools have additionalProperties:false");
 }
 

--- a/packages/twin-slack/scripts/validate-mcp.output.txt
+++ b/packages/twin-slack/scripts/validate-mcp.output.txt
@@ -1,8 +1,8 @@
-Server: http://127.0.0.1:57347
-MCP   : http://127.0.0.1:57347/s/validate-mcp-session/mcp
+Server: http://127.0.0.1:49180
+MCP   : http://127.0.0.1:49180/s/validate-mcp-session/mcp
 
 ━━━ 1. JSON-RPC tools/list ━━━
-tools/list returned 8 tools (expected 8)
+tools/list returned 11 tools (expected 11)
   - slack_post_message: Post a new message to a Slack channel
   - slack_reply_to_thread: Reply to a specific message thread in Slack
   - slack_add_reaction: Add a reaction emoji to a message
@@ -11,13 +11,16 @@ tools/list returned 8 tools (expected 8)
   - slack_list_channels: List public or pre-defined channels in the workspace with pagination
   - slack_get_users: Get a list of all users in the workspace with their basic profile information
   - slack_get_user_profile: Get detailed profile information for a specific user
+  - slack_search_messages: Search messages in the workspace by text query
+  - slack_get_reactions: Get all reactions on a specific message
+  - slack_list_channel_members: List the member user IDs of a channel with pagination
 
 ━━━ 2. tools/call slack_list_channels via JSON-RPC ━━━
 {
   "content": [
     {
       "type": "text",
-      "text": "{\"ok\":true,\"channels\":[{\"id\":\"C_GENERAL\",\"name\":\"general\",\"name_normalized\":\"general\",\"is_channel\":true,\"is_group\":false,\"is_im\":false,\"is_mpim\":false,\"is_private\":false,\"is_archived\":false,\"is_general\":true,\"is_shared\":false,\"is_org_shared\":false,\"is_pending_ext_shared\":false,\"pending_shared\":[],\"context_team_id\":\"T_POME\",\"creator\":\"U_PRIMARY\",\"created\":1779912654,\"unlinked\":0,\"parent_conversation\":null,\"topic\":{\"value\":\"Company-wide announcements and chatter.\",\"creator\":\"U_PRIMARY\",\"last_set\":1779912654},\"purpose\":{\"value\":\"This channel is for company-wide communication.\",\"creator\":\"U_PRIMARY\",\"last_set\":1779912654},\"previous_names\":[],\"num_members\":3},{\"id\":\"C_RANDOM\",\"name\":\"random\",\"name_normalized\":\"random\",\"is_channel\":true,\"is_group\":false,\"is_im\":false,\"is_mpim\":false,\"is_private\":false,\"is_archived\":false,\"is_general\":false,\"is_shared\":false,\"is_org_shared\":false,\"is_pending_ext_shared\":false,\"pending_shared\":[],\"context_team_id\":\"T_POME\",\"creator\":\"U_PRIMARY\",\"created\":1779912654,\"unlinked\":0,\"parent_conversation\":null,\"topic\":{\"value\":\"Non-work chatter and water cooler talk.\",\"creator\":\"U_PRIMARY\",\"last_set\":1779912654},\"purpose\":{\"value\":\"A place for non-work-related flimflam.\",\"creator\":\"U_PRIMARY\",\"last_set\":1779912654},\"previous_names\":[],\"num_members\":0}],\"response_metadata\":{\"next_cursor\":\"\"}}"
+      "text": "{\"ok\":true,\"channels\":[{\"id\":\"C_GENERAL\",\"name\":\"general\",\"name_normalized\":\"general\",\"is_channel\":true,\"is_group\":false,\"is_im\":false,\"is_mpim\":false,\"is_private\":false,\"is_archived\":false,\"is_general\":true,\"is_shared\":false,\"is_org_shared\":false,\"is_pending_ext_shared\":false,\"pending_shared\":[],\"context_team_id\":\"T_POME\",\"creator\":\"U_PRIMARY\",\"created\":1783811863,\"unlinked\":0,\"topic\":{\"value\":\"Company-wide announcements and chatter.\",\"creator\":\"U_PRIMARY\",\"last_set\":1783811863},\"purpose\":{\"value\":\"This channel is for company-wide communication.\",\"creator\":\"U_PRIMARY\",\"last_set\":1783811863},\"parent_conversation\":null,\"num_members\":3},{\"id\":\"C_RANDOM\",\"name\":\"random\",\"name_normalized\":\"random\",\"is_channel\":true,\"is_group\":false,\"is_im\":false,\"is_mpim\":false,\"is_private\":false,\"is_archived\":false,\"is_general\":false,\"is_shared\":false,\"is_org_shared\":false,\"is_pending_ext_shared\":false,\"pending_shared\":[],\"context_team_id\":\"T_POME\",\"creator\":\"U_PRIMARY\",\"created\":1783811863,\"unlinked\":0,\"topic\":{\"value\":\"Non-work chatter and water cooler talk.\",\"creator\":\"U_PRIMARY\",\"last_set\":1783811863},\"purpose\":{\"value\":\"A place for non-work-related flimflam.\",\"creator\":\"U_PRIMARY\",\"last_set\":1783811863},\"parent_conversation\":null,\"num_members\":0}],\"response_metadata\":{\"next_cursor\":\"\"}}"
     }
   ]
 }
@@ -54,20 +57,19 @@ legacy /mcp/call status=200
       "pending_shared": [],
       "context_team_id": "T_POME",
       "creator": "U_PRIMARY",
-      "created": 1779912654,
+      "created": 1783811863,
       "unlinked": 0,
-      "parent_conversation": null,
       "topic": {
         "value": "Company-wide announcements and chatter.",
         "creator": "U_PRIMARY",
-        "last_set": 1779912654
+        "last_set": 1783811863
       },
       "purpose": {
         "value": "This channel is for company-wide communication.",
         "creator": "U_PRIMARY",
-        "last_set": 1779912654
+        "last_set": 1783811863
       },
-      "previous_names": [],
+      "parent_conversation": null,
       "num_members": 3
     },
     {
@@ -87,20 +89,19 @@ legacy /mcp/call status=200
       "pending_shared": [],
       "context_team_id": "T_POME",
       "creator": "U_PRIMARY",
-      "created": 1779912654,
+      "created": 1783811863,
       "unlinked": 0,
-      "parent_conversation": null,
       "topic": {
         "value": "Non-work chatter and water cooler talk.",
         "creator": "U_PRIMARY",
-        "last_set": 1779912654
+        "last_set": 1783811863
       },
       "purpose": {
         "value": "A place for non-work-related flimflam.",
         "creator": "U_PRIMARY",
-        "last_set": 1779912654
+        "last_set": 1783811863
       },
-      "previous_names": [],
+      "parent_conversation": null,
       "num_members": 0
     }
   ],
@@ -110,6 +111,7 @@ legacy /mcp/call status=200
 }
 
 ━━━ 5. Recorder events (twin emits one event per tools/call regardless of MCP vs legacy) ━━━
-recorder captured 2 tool events
+recorder captured 3 tool events
   - /s/validate-mcp-session/mcp → tool=slack_list_channels status=200 state_mutation=false
   - /s/validate-mcp-session/mcp → tool=slack_post_message status=200 state_mutation=true
+  - /s/validate-mcp-session/mcp/call → tool=slack_list_channels status=200 state_mutation=false

--- a/packages/twin-slack/scripts/validate-mcp.ts
+++ b/packages/twin-slack/scripts/validate-mcp.ts
@@ -6,7 +6,7 @@
 // `@modelcontextprotocol/sdk` `Client` over `StreamableHTTPClientTransport`
 // with a Bearer header, and:
 //
-//   1. Verifies tools/list returns the 8 visible Slack-agent tools via
+//   1. Verifies tools/list returns the 11 visible Slack-agent tools via
 //      real JSON-RPC framing.
 //   2. Calls slack_list_channels and slack_post_message end-to-end.
 //   3. Calls the same tools via the legacy `/mcp/call` REST shim and diffs

--- a/packages/twin-slack/src/tools.ts
+++ b/packages/twin-slack/src/tools.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import type { StateDelta } from "@pome-sh/shared-types";
 import type { SlackDomain } from "./domain.js";
 
-// Slack MCP tools — the 8 visible Slack-agent tools exposed by tools/list.
+// Slack MCP tools — the 11 visible Slack-agent tools exposed by tools/list.
 // Schemas use z.strictObject so toJSONSchema emits `additionalProperties:false`.
 
 export const toolDefinitions = [
@@ -93,6 +93,41 @@ export const toolDefinitions = [
     schema: z
       .strictObject({
         user_id: z.string(),
+      })
+      .strict(),
+  },
+  {
+    name: "slack_search_messages",
+    description: "Search messages in the workspace by text query",
+    readOnly: true,
+    schema: z
+      .strictObject({
+        query: z.string(),
+        count: z.number().optional(),
+        page: z.number().optional(),
+      })
+      .strict(),
+  },
+  {
+    name: "slack_get_reactions",
+    description: "Get all reactions on a specific message",
+    readOnly: true,
+    schema: z
+      .strictObject({
+        channel_id: z.string(),
+        timestamp: z.string(),
+      })
+      .strict(),
+  },
+  {
+    name: "slack_list_channel_members",
+    description: "List the member user IDs of a channel with pagination",
+    readOnly: true,
+    schema: z
+      .strictObject({
+        channel_id: z.string(),
+        limit: z.number().optional(),
+        cursor: z.string().optional(),
       })
       .strict(),
   },
@@ -194,6 +229,21 @@ export function executeTool(
     case "slack_get_user_profile": {
       const p = parsed as { user_id: string };
       return domain.usersProfileGet({ user: p.user_id }, actor);
+    }
+    case "slack_search_messages": {
+      const p = parsed as { query: string; count?: number; page?: number };
+      return domain.searchMessages({ query: p.query, count: p.count, page: p.page }, actor);
+    }
+    case "slack_get_reactions": {
+      const p = parsed as { channel_id: string; timestamp: string };
+      return domain.reactionsGet({ channel: p.channel_id, timestamp: p.timestamp }, actor);
+    }
+    case "slack_list_channel_members": {
+      const p = parsed as { channel_id: string; limit?: number; cursor?: string };
+      return domain.conversationsMembers(
+        { channel: p.channel_id, limit: p.limit, cursor: p.cursor },
+        actor
+      );
     }
     default:
       throw new Error(`Unknown tool: ${name}`);

--- a/packages/twin-slack/test/app.test.ts
+++ b/packages/twin-slack/test/app.test.ts
@@ -36,7 +36,7 @@ describe("twin-slack HTTP contract", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as Record<string, unknown>;
     expect(body.twin).toBe("slack");
-    expect(body.tools).toBe(8);
+    expect(body.tools).toBe(11);
     expect(body.ok).toBe(true);
   });
 
@@ -156,6 +156,29 @@ describe("twin-slack HTTP contract", () => {
     expect(body.ok).toBe(false);
     expect(body.error).toBe("unsupported_endpoint");
     expect(body._twin.fidelity).toBe("unsupported");
+  });
+
+  it("named cold surfaces (F-736 ruling) return the loud 501 unsupported envelope", async () => {
+    const { app } = freshApp();
+    const coldProbes: Array<{ path: string; method: string }> = [
+      { path: "chat.postEphemeral", method: "POST" },
+      { path: "files.getUploadURLExternal", method: "GET" },
+      { path: "files.completeUploadExternal", method: "POST" },
+      { path: "admin.users.list", method: "GET" },
+      { path: "usergroups.list", method: "GET" },
+      { path: "views.publish", method: "POST" },
+    ];
+    for (const probe of coldProbes) {
+      const res = await app.request(
+        `/s/${TEST_SID}/${probe.path}`,
+        withAuth(token, { method: probe.method })
+      );
+      expect(res.status, `${probe.path} should 501`).toBe(501);
+      const body = (await res.json()) as { ok: boolean; error: string; _twin: { fidelity: string } };
+      expect(body.ok).toBe(false);
+      expect(body.error).toBe("unsupported_endpoint");
+      expect(body._twin.fidelity).toBe("unsupported");
+    }
   });
 
   it("admin/reset only allowed from localhost (no remoteAddress in app.request)", async () => {

--- a/packages/twin-slack/test/fidelity-contract.test.ts
+++ b/packages/twin-slack/test/fidelity-contract.test.ts
@@ -87,3 +87,70 @@ describe("FIDELITY.md contract", () => {
     }
   });
 });
+
+// Heat discipline (F-736): every surface carries its ruled heat tier and the
+// exact target mapping from packages/sdk/ENDPOINT-TIERS.md holds — hot must
+// be semantic (F-736 filled the last hot gaps), cold must be unsupported,
+// and warm surfaces sitting above their shape target must each appear in
+// FIDELITY.md's tier-mismatch ledger (M5 additive-only ruling: visible in
+// the ledger, never demoted in code).
+describe("heat tiers (F-729 ruling, F-736 re-cut)", () => {
+  const inventory = loadFidelityInventory(join(PKG_ROOT, "fidelity.inventory.json"));
+  const surfaces = [...inventory.tools, ...inventory.rest];
+
+  function ledgerSection(): string {
+    const body = readFileSync(FIDELITY_PATH, "utf8");
+    const start = body.indexOf("## Tier-mismatch ledger");
+    expect(start, "FIDELITY.md is missing the '## Tier-mismatch ledger' section").toBeGreaterThan(-1);
+    const rest = body.slice(start + 1);
+    const end = rest.indexOf("\n## ");
+    return end === -1 ? rest : rest.slice(0, end);
+  }
+
+  it("no surface is left unclassified", () => {
+    const unclassified = surfaces.filter((s) => s.heat === "unclassified").map((s) => s.name);
+    expect(unclassified).toEqual([]);
+  });
+
+  it("every justification cites a rubric evidence code", () => {
+    for (const surface of surfaces) {
+      expect(
+        /\b(TC|MCP|TR|SB|PS)\b/.test(surface.justification),
+        `'${surface.name}' justification cites no ENDPOINT-TIERS.md evidence code`
+      ).toBe(true);
+    }
+  });
+
+  it("hot surfaces are all semantic (no open hot gaps after F-736)", () => {
+    const gaps = surfaces.filter((s) => s.heat === "hot" && s.fidelity !== "semantic");
+    expect(gaps.map((s) => s.name)).toEqual([]);
+  });
+
+  it("named cold surfaces are all unsupported", () => {
+    const mismatches = surfaces.filter((s) => s.heat === "cold" && s.fidelity !== "unsupported");
+    expect(mismatches.map((s) => s.name)).toEqual([]);
+  });
+
+  it("warm surfaces above their shape target each appear in the tier-mismatch ledger", () => {
+    const ledger = ledgerSection();
+    const overTarget = surfaces.filter((s) => s.heat === "warm" && s.fidelity === "semantic");
+    expect(overTarget.length).toBeGreaterThan(0);
+    for (const surface of overTarget) {
+      expect(
+        ledger.includes("`" + surface.name + "`"),
+        `warm surface '${surface.name}' is above its shape target but missing from the ledger`
+      ).toBe(true);
+    }
+  });
+
+  it("the ledger names no surface that is actually at or below target", () => {
+    const ledger = ledgerSection();
+    const atTarget = surfaces.filter((s) => !(s.heat === "warm" && s.fidelity === "semantic"));
+    for (const surface of atTarget) {
+      expect(
+        ledger.includes("`" + surface.name + "`"),
+        `'${surface.name}' is at/below target but listed in the ledger`
+      ).toBe(false);
+    }
+  });
+});

--- a/packages/twin-slack/test/mcp-contract.test.ts
+++ b/packages/twin-slack/test/mcp-contract.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// MCP tools contract — pins the 8 visible Slack-agent tools' shapes so any
+// MCP tools contract — pins the 11 visible Slack-agent tools' shapes so any
 // drift (added/removed/renamed tool, changed description, changed required
 // fields, changed mutating set) breaks this test loudly. Constants are
 // declared in-test so the contract has no external dependency.
@@ -64,15 +64,33 @@ const EXPECTED_TOOLS: ExpectedTool[] = [
     required: ["user_id"],
     readOnly: true,
   },
+  {
+    name: "slack_search_messages",
+    description: "Search messages in the workspace by text query",
+    required: ["query"],
+    readOnly: true,
+  },
+  {
+    name: "slack_get_reactions",
+    description: "Get all reactions on a specific message",
+    required: ["channel_id", "timestamp"],
+    readOnly: true,
+  },
+  {
+    name: "slack_list_channel_members",
+    description: "List the member user IDs of a channel with pagination",
+    required: ["channel_id"],
+    readOnly: true,
+  },
 ];
 
 const EXPECTED_NAMES = EXPECTED_TOOLS.map((t) => t.name).sort();
 const EXPECTED_MUTATORS = new Set(EXPECTED_TOOLS.filter((t) => !t.readOnly).map((t) => t.name));
 
 describe("MCP tools contract", () => {
-  it("exposes exactly the 8 visible Slack-agent tools", () => {
+  it("exposes exactly the 11 visible Slack-agent tools", () => {
     expect(toolDefinitions.map((t) => t.name).sort()).toEqual(EXPECTED_NAMES);
-    expect(EXPECTED_TOOLS.length).toBe(8);
+    expect(EXPECTED_TOOLS.length).toBe(11);
   });
 
   it("MUTATING_TOOL_NAMES contains the 3 write tools (no readOnlyHint)", () => {
@@ -108,13 +126,13 @@ describe("MCP tools contract", () => {
 
   it("listTools() returns snake_case input_schema (legacy)", () => {
     const tools = listTools();
-    expect(tools.length).toBe(8);
+    expect(tools.length).toBe(11);
     expect(tools[0]).toHaveProperty("input_schema");
   });
 
   it("listToolsForMcp() returns camelCase inputSchema (MCP spec)", () => {
     const tools = listToolsForMcp();
-    expect(tools.length).toBe(8);
+    expect(tools.length).toBe(11);
     expect(tools[0]).toHaveProperty("inputSchema");
   });
 
@@ -123,6 +141,6 @@ describe("MCP tools contract", () => {
     const mutators = tools.filter((t) => !("annotations" in t));
     const readers = tools.filter((t) => t.annotations?.readOnlyHint === true);
     expect(mutators.length).toBe(3);
-    expect(readers.length).toBe(5);
+    expect(readers.length).toBe(8);
   });
 });

--- a/packages/twin-slack/test/mcp-jsonrpc.test.ts
+++ b/packages/twin-slack/test/mcp-jsonrpc.test.ts
@@ -60,10 +60,10 @@ describe("MCP JSON-RPC dispatch", () => {
     expect((body as { result: unknown }).result).toEqual({});
   });
 
-  it("tools/list returns 8 tools with inputSchema", async () => {
+  it("tools/list returns 11 tools with inputSchema", async () => {
     const { body } = await jsonRpc(token, { jsonrpc: "2.0", id: 1, method: "tools/list" });
     const tools = (body as { result: { tools: Array<{ name: string; inputSchema: unknown }> } }).result.tools;
-    expect(tools.length).toBe(8);
+    expect(tools.length).toBe(11);
     expect(tools.every((t) => Boolean(t.inputSchema))).toBe(true);
   });
 

--- a/packages/twin-slack/test/mcp-legacy.test.ts
+++ b/packages/twin-slack/test/mcp-legacy.test.ts
@@ -21,7 +21,7 @@ describe("legacy MCP routes", () => {
     token = await signTestToken();
   });
 
-  it("GET /mcp/tools lists 8 tools", async () => {
+  it("GET /mcp/tools lists 11 tools", async () => {
     const app = freshApp();
     const res = await app.request(`${base}/mcp/tools`, withAuth(token, {}));
     expect(res.status).toBe(200);

--- a/packages/twin-slack/test/socket-boundary.test.ts
+++ b/packages/twin-slack/test/socket-boundary.test.ts
@@ -73,7 +73,7 @@ function authHeaders(extra: Record<string, string> = {}) {
 }
 
 describe("socket boundary — real MCP SDK client over @hono/node-server", () => {
-  it("completes the initialize handshake and lists the 8 agent tools through JSON-RPC framing", async () => {
+  it("completes the initialize handshake and lists the 11 agent tools through JSON-RPC framing", async () => {
     const transport = new StreamableHTTPClientTransport(new URL(mcpUrl), {
       requestInit: { headers: authHeaders() }
     });
@@ -87,7 +87,7 @@ describe("socket boundary — real MCP SDK client over @hono/node-server", () =>
       // Pin the catalog size independently of toolDefinitions so a silent
       // catalog shrink cannot self-verify (both sides derive from the same
       // array otherwise).
-      expect(toolDefinitions.length).toBe(8);
+      expect(toolDefinitions.length).toBe(11);
       expect(listResult.tools).toHaveLength(toolDefinitions.length);
       expect(listResult.tools.map((t) => t.name)).toEqual(toolDefinitions.map((t) => t.name));
     } finally {

--- a/packages/twin-slack/test/tools-execute.test.ts
+++ b/packages/twin-slack/test/tools-execute.test.ts
@@ -14,7 +14,7 @@ function fresh() {
 describe("executeTool", () => {
   const actor = { login: "pome-agent" };
 
-  it("runs all 8 tools", () => {
+  it("runs all 11 tools", () => {
     const domain = fresh();
     const parent = executeTool(
       domain,
@@ -72,5 +72,34 @@ describe("executeTool", () => {
       actor
     ) as { profile: { real_name: string } };
     expect(profile.profile.real_name).toBe("Alice");
+
+    const search = executeTool(
+      domain,
+      "slack_search_messages",
+      { query: "parent" },
+      undefined,
+      actor
+    ) as { messages: { matches: Array<{ text: string }> } };
+    expect(search.messages.matches.some((m) => m.text === "parent")).toBe(true);
+
+    const reactions = executeTool(
+      domain,
+      "slack_get_reactions",
+      { channel_id: "C_GENERAL", timestamp: parent.ts },
+      undefined,
+      actor
+    ) as { message: { reactions: Array<{ name: string; count: number }> } };
+    expect(reactions.message.reactions).toEqual([
+      expect.objectContaining({ name: "eyes", count: 1 }),
+    ]);
+
+    const members = executeTool(
+      domain,
+      "slack_list_channel_members",
+      { channel_id: "C_GENERAL" },
+      undefined,
+      actor
+    ) as { members: string[] };
+    expect(members.members).toContain("U_ALICE");
   });
 });


### PR DESCRIPTION
## Executive summary
Re-cuts twin-slack's fidelity contract against the `packages/sdk/ENDPOINT-TIERS.md` rubric per the F-729 ruled list (SL1–SL5): all 50 REST surfaces + 11 MCP tools in `fidelity.inventory.json` now carry a ruled **heat** tier with an evidence-coded justification, orthogonal to measured fidelity. The three ruled hot gaps close — **`slack_search_messages`**, **`slack_get_reactions`**, **`slack_list_channel_members`** (SL2) — as pure wiring over existing semantic domains, moving the MCP surface **8 → 11**. Everything else is additive documentation: a 12-entry tier-mismatch ledger, a ruled-gaps table, and heat-discipline tests that keep all of it honest.

## What
- **3 new MCP read tools (SL2, the F-736 hot gaps)**: `slack_search_messages` → `searchMessages`, `slack_get_reactions` → `reactionsGet`, `slack_list_channel_members` → `conversationsMembers`. All `readOnly` (mutating set stays 3); schemas `additionalProperties:false` like the rest. An MCP-only agent could previously post and read but never search, read reactions back, or list members — the vendor's first-party server ships all three.
- **Tool count 8 → 11 across every pin**: mcp-contract (names/descriptions/required/mutators/readOnly), mcp-jsonrpc, mcp-legacy, socket-boundary, healthz assertion, smoke, validate-mcp, README. `/healthz` **shape** untouched — `tools` remains the tool-list length per CONTRACT.md (invariant is equality, not a literal), and twin-slack's healthz intentionally still carries no fidelity field.
- **Inventory re-cut (`fidelity.inventory.json`)**: every surface `unclassified` → ruled heat + justification citing rubric evidence codes (`TC:`/`MCP:`/`SB`/`PS`). Hot = 22 REST + 11 tools, all semantic (no open hot gaps). Warm set is exhaustive: 12 semantic-built (ledger), 4 `files.*` at shape target (SL5: table wins), 6 ruled-but-unimplemented gap rows with defer notes (SL3/SL4). Cold rows are named-only: `chat.postEphemeral`, modern upload pair, `admin.*`/`usergroups.*`/`views.*`; message drafts stay prose (no Web API analog to name).
- **FIDELITY.md**: `Heat` column in both tables; combined rows with mixed heat split (`conversations.invite/join/members` hot vs `leave/kick/archive` warm; `reactions.add/get` vs `remove`; `users.profile.set` out of the users row); new **Ruled gaps and named cold surfaces** table; new **Tier-mismatch ledger** (12 entries).
- **Tier-mismatch ledger (additive-only ruling)**: the 12 warm-ruled surfaces built semantic (`reactions.remove`, `conversations.leave/kick/archive`, `users.profile.set`, `pins.*` ×3, `bookmarks.*` ×3, `team.info`) are recorded, **not demoted** — demotion review is deferred until the F-440 launch gate finishes its consecutive-green count.
- **Heat-discipline tests** (new, in `fidelity-contract.test.ts`): no `unclassified` left; every justification cites an evidence code; hot ⇒ semantic; named cold ⇒ unsupported; ledger ⊇ warm-above-target and names nothing at/below target (both directions).
- **Parity scenario**: +3 steps with semantic verifies (search finds the posted message, reactions read returns the added thumbsup, member list non-empty) and +4 named-cold 501 envelope probes.
- **Fidelity-watch note (SL5)**: the 45-surface denominator predates this re-cut (counts `files.info/list/delete` as semantic; excludes the 3 new tools). Documented as deliberately deferred to pome-cloud (`sandboxes/slack/surfaces.ts`) post-F-440, tracked by F-737.

## Why
M5's milestone bullet: "GitHub + Slack lists re-cut against the rubric." The F-729 twin-slack `[DECISION]` (2026-07-11) ruled the hot/warm/cold cut and scoped F-736 to annotate everything, fill only the hot gaps, and record over-investment in a ledger instead of demoting — protecting the F-440 launch gate. This is the first twin to land the full re-cut shape (ledger + named-cold + gap rows); F-735 (github) and F-734 (stripe warm set) follow the same pattern.

## Notes for reviewer
- TDD (`tdd-required`): all contract/pin changes and the heat-discipline tests were written first and watched fail (10 red) before the tools/inventory/docs landed.
- The ledger table deliberately has no `Tier` header so the FIDELITY lint parses it as prose, not a surface table; the ruled-gaps table deliberately does (`Endpoint`+`Tier`) so its rows 1:1-lint against the inventory.
- Wildcard cold rows (`admin.*` etc.) are family rulings; each is backed by a representative 501 probe (app.test + parity).
- `npm run smoke` fails on a clean checkout of `main` ("conversations.replies non-existent returns 404") — pre-existing, reproduced with this diff stashed; same class as the fresh-workspace smoke issue noted on #118.
- `scripts/validate-mcp.output.txt` is regenerated (committed artifact of `npm run validate:mcp`).

## Tests / CI
- twin-slack: 220 tests / 25 files green; typecheck + build clean; coverage 95.27% lines / 96.28% funcs
- `npm test` all workspaces (94/247/280/231/220/203) — green
- `npm run test:contract` — 69 pass, 0 fail
- `npm run fidelity:parity` (twin-slack) — ok:true, 11 tools / 50 rest surfaces, zero failures
- `npm run validate:mcp` — clean; gates: code-health, copy-markers, no-eval, no-cloud-imports, no-native, dead-code — pass

## Greptile review
- [x] Applied P2 — the FIDELITY `Heat` column is now linted against the inventory at the sdk level (`8a012e9`): `parseFidelityDocRows` captures the optional column when a table header names it, `lintFidelityInventory` reports inventory-vs-doc heat mismatches and duplicate rows with conflicting heat (ENDPOINT-TIERS.md lint rule 5, red-first tested ×5 in `packages/sdk/test/fidelity-parity.test.ts`). Pre-heat tables (twin-github/twin-stripe today) stay legal; their re-cuts inherit the lint the moment they add the column.

## Review required
Yes — expands the published twin-slack surface (MCP 8 → 11) and re-cuts its fidelity contract.

<!-- Closes F-736 -->

