### PR TITLE
feat(twin-stripe): reconcile refunds hot path with ledger, events, and FIDELITY sync

### DIFF
--- a/packages/twin-stripe/FIDELITY.md
+++ b/packages/twin-stripe/FIDELITY.md
@@ -5,7 +5,7 @@
 page documents exactly which surfaces are faithful to real Stripe today,
 at what tier, and how fidelity is verified.
 
-Last verified: 2026-07-11.
+Last verified: 2026-07-12.
 Stripe API version pinned: `2026-03-04.preview`.
 
 ## What "fidelity" means here
@@ -41,7 +41,7 @@ build depends on (port `:3333`, `/healthz`, `STRIPE_CLONE_HOST`,
 in the package README. Changing any of those is a breaking change for
 `pome-cloud` and requires a matching cloud consumer PR.
 
-## REST routes (v1 = 23 semantic + everything else loud 501)
+## REST routes (v1 = 26 semantic + everything else loud 501)
 
 | Route | Tier | Tests | Notes |
 | --- | --- | --- | --- |
@@ -54,6 +54,9 @@ in the package README. Changing any of those is a breaking change for
 | `POST /s/:sid/v1/test_helpers/payment_intents/:id/simulate_crypto_deposit` | semantic | `pi.test.ts`, `pi-concurrency.test.ts`, `events.test.ts` | The x402 settlement entry point. CAS `requires_action → processing → succeeded`; mints charge + balance txn + 5 events synchronously. |
 | `GET /s/:sid/v1/charges/:id` | semantic | `charges.test.ts` | Latest charge of a settled PI. |
 | `GET /s/:sid/v1/charges` | semantic | `charges.test.ts` | Filter by `payment_intent`, `customer`. |
+| `POST /s/:sid/v1/refunds` | semantic | `refunds.test.ts`, `refund-abuse-trap.test.ts` | F-733 (heat: hot, ruled F-729). Full or partial; `amount` defaults to the remaining refundable. Refuses over-refunds (`charge_already_refunded`) and failed charges (`charge_not_refundable`). Mints a negative `refund`-type balance transaction and emits `charge.refunded` + `refund.created` in the same transaction. |
+| `GET /s/:sid/v1/refunds/:id` | semantic | `refunds.test.ts` | |
+| `GET /s/:sid/v1/refunds` | semantic | `refunds.test.ts` | Filter by `charge`, `payment_intent`. Omits the legacy `count` field (divergence #9). |
 | `GET /s/:sid/v1/balance` | semantic | `balance.test.ts` | Available + pending; updated as PIs settle. |
 | `GET /s/:sid/v1/balance_transactions` | semantic | `balance.test.ts` | Ledger entries. |
 | `GET /s/:sid/v1/events/:id` | semantic | `events.test.ts` | |
@@ -93,7 +96,7 @@ Anything else under `/v1/*` (`/v1/setup_intents`, `/v1/checkout/*`,
 
 HTTP status: 501.
 
-## MCP tools (26 live; 23 documented — names match `stripe-node` method names)
+## MCP tools (26, 1:1 with the live tool list — names match `stripe-node` method names)
 
 | Tool | Backing route | Tier |
 | --- | --- | --- |
@@ -106,6 +109,9 @@ HTTP status: 501.
 | `simulate_crypto_deposit` | POST /v1/test_helpers/.../simulate_crypto_deposit | semantic |
 | `retrieve_charge` | GET /v1/charges/:id | semantic |
 | `list_charges` | GET /v1/charges | semantic |
+| `create_refund` | POST /v1/refunds | semantic |
+| `retrieve_refund` | GET /v1/refunds/:id | semantic |
+| `list_refunds` | GET /v1/refunds | semantic |
 | `retrieve_balance` | GET /v1/balance | semantic |
 | `list_balance_transactions` | GET /v1/balance_transactions | semantic |
 | `retrieve_event` | GET /v1/events/:id | semantic |
@@ -130,9 +136,9 @@ The tables above are 1:1-linted against the structured inventory
 hot/warm/cold heat tier per F-729) by `test/fidelity-contract.test.ts`, and
 `npm run fidelity:parity` (shared runner in `@pome-sh/sdk/parity`, F-730)
 exercises every inventoried tool end-to-end. Known gaps between code and
-these tables — today, the implemented refunds chain — are declared in the
-inventory's `doc_drift` with their owning ticket (F-733) and fail the lint
-the moment the docs catch up.
+these tables must be declared in the inventory's `doc_drift` with their
+owning ticket, and the lint fails the moment the docs catch up. None are
+declared today — F-733 reconciled the refunds chain, the last such gap.
 
 ## x402 middleware (`src/x402.ts`)
 
@@ -319,7 +325,7 @@ not exposed at the root mount — those remain at `/s/:sid/_pome/*` and
 ## Verification commands
 
 ```bash
-npm run test            # 31 files / 194 tests, all green
+npm run test            # 31 files / 214 tests, all green
 npm run smoke           # full x402 flow against built server
 npm run fidelity:parity # every inventoried MCP tool end-to-end
 npm run typecheck

--- a/packages/twin-stripe/fidelity.inventory.json
+++ b/packages/twin-stripe/fidelity.inventory.json
@@ -1,8 +1,8 @@
 {
   "twin": "stripe",
   "package": "@pome-sh/twin-stripe",
-  "updated": "2026-07-11",
-  "notes": "Both tables lint 1:1 against FIDELITY.md; FIDELITY_MATRIX.md stays a legacy pinned matrix. The refunds chain is implemented but undocumented — declared in doc_drift until F-733 reconciles the docs (its heat stays unclassified until that ticket lands). The customer-management chain (F-732) and the payment-collection chain (F-731: PI lifecycle incl. card decline/retry + settlement/ledger/event reads) carry their ruled heat (hot, F-729); the warm set lands with F-734.",
+  "updated": "2026-07-12",
+  "notes": "Both tables lint 1:1 against FIDELITY.md; FIDELITY_MATRIX.md stays a legacy pinned matrix. The payment-collection chain (F-731: PI lifecycle incl. card decline/retry + settlement/ledger/event reads), the customer-management chain (F-732), and the refunds chain (F-733 reconciliation: ledger + events closed, docs synced) carry their ruled heat (hot, F-729); the warm set lands with F-734. Disputes are unlisted cold per the F-729 ruled list (catch-all 501), not warm — see the F-733 [DECISION].",
   "tools": [
     {
       "name": "create_payment_intent",
@@ -84,21 +84,21 @@
     },
     {
       "name": "create_refund",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Implemented and tested in code but absent from the FIDELITY.md tables; doc reconciliation owned by F-733."
+      "justification": "TC:refund (ruled F-729); MCP:create_refund — the only resource keeping a dedicated tool on Stripe's official MCP server. F-733: mints the negative refund-type ledger entry and emits charge.refunded + refund.created in one transaction."
     },
     {
       "name": "retrieve_refund",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Implemented and tested in code but absent from the FIDELITY.md tables; doc reconciliation owned by F-733."
+      "justification": "TC:refund (ruled F-729): the post-refund verify read."
     },
     {
       "name": "list_refunds",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Implemented and tested in code but absent from the FIDELITY.md tables; doc reconciliation owned by F-733."
+      "justification": "TC:refund (ruled F-729); charge + payment_intent filters."
     },
     {
       "name": "create_customer",
@@ -242,21 +242,21 @@
     },
     {
       "name": "POST /s/:sid/v1/refunds",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Implemented and tested in code but absent from the FIDELITY.md tables; doc reconciliation owned by F-733."
+      "justification": "TC:refund (ruled F-729); MCP:create_refund corroborates. F-733: full/partial refunds, over-refund + failed-charge refusals, negative refund-type ledger entry, charge.refunded + refund.created events — all in one transaction. Refund partial ops (POST /v1/refunds/:id, /cancel) stay unlisted per F-729 ruling point 4."
     },
     {
       "name": "GET /s/:sid/v1/refunds/:id",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Implemented and tested in code but absent from the FIDELITY.md tables; doc reconciliation owned by F-733."
+      "justification": "TC:refund (ruled F-729): the post-refund verify read."
     },
     {
       "name": "GET /s/:sid/v1/refunds",
-      "heat": "unclassified",
+      "heat": "hot",
       "fidelity": "semantic",
-      "justification": "Implemented and tested in code but absent from the FIDELITY.md tables; doc reconciliation owned by F-733."
+      "justification": "TC:refund (ruled F-729); charge + payment_intent filters. Omits the legacy count field (FIDELITY.md divergence #9)."
     },
     {
       "name": "POST /s/:sid/v1/customers",
@@ -319,42 +319,5 @@
       "justification": "TC:card-on-file (ruled F-729)."
     }
   ],
-  "doc_drift": [
-    {
-      "kind": "tool",
-      "name": "create_refund",
-      "reason": "refunds chain shipped without FIDELITY.md rows",
-      "ticket": "F-733"
-    },
-    {
-      "kind": "tool",
-      "name": "retrieve_refund",
-      "reason": "refunds chain shipped without FIDELITY.md rows",
-      "ticket": "F-733"
-    },
-    {
-      "kind": "tool",
-      "name": "list_refunds",
-      "reason": "refunds chain shipped without FIDELITY.md rows",
-      "ticket": "F-733"
-    },
-    {
-      "kind": "rest",
-      "name": "POST /s/:sid/v1/refunds",
-      "reason": "refunds chain shipped without FIDELITY.md rows",
-      "ticket": "F-733"
-    },
-    {
-      "kind": "rest",
-      "name": "GET /s/:sid/v1/refunds/:id",
-      "reason": "refunds chain shipped without FIDELITY.md rows",
-      "ticket": "F-733"
-    },
-    {
-      "kind": "rest",
-      "name": "GET /s/:sid/v1/refunds",
-      "reason": "refunds chain shipped without FIDELITY.md rows",
-      "ticket": "F-733"
-    }
-  ]
+  "doc_drift": []
 }

--- a/packages/twin-stripe/scripts/fidelity-parity.ts
+++ b/packages/twin-stripe/scripts/fidelity-parity.ts
@@ -7,9 +7,9 @@
 // customer-management chain (F-732: customer CRUD + card-on-file
 // attach/detach), and the card collect-payment chain (F-731: card PI →
 // update-with-PM → confirm → succeeded), covering every MCP tool in
-// fidelity.inventory.json — including the refunds chain that is live in
-// code but still absent from FIDELITY.md (declared as doc_drift,
-// reconciliation owned by F-733). The loud-501 probe pins the
+// fidelity.inventory.json. The refund steps assert the F-733 semantics:
+// the ledger link on the refund body and the post-refund available
+// balance. The loud-501 probe pins the
 // Stripe-shaped unsupported envelope on /v1/checkout/sessions (it moved
 // off /v1/customers when F-732 made customers a supported surface).
 
@@ -51,11 +51,35 @@ const steps: ParityStep[] = [
     capture: (body, state) => {
       state.refund = (body as { id?: string }).id;
     },
+    verify: (body) =>
+      typeof (body as { balance_transaction?: string | null }).balance_transaction === "string"
+        ? undefined
+        : "a refund should link its negative refund-type balance transaction (F-733)",
   },
   { tool: "retrieve_refund", arguments: (state) => ({ id: state.refund }) },
   { tool: "list_refunds", arguments: (state) => ({ charge: state.charge }) },
-  { tool: "retrieve_balance" },
-  { tool: "list_balance_transactions", arguments: { limit: 10 } },
+  {
+    tool: "retrieve_balance",
+    verify: (body) => {
+      const usd = (body as { available?: Array<{ currency: string; amount: number }> }).available?.find(
+        (b) => b.currency === "usd"
+      );
+      // 20000 settled minus the 7500 refund above.
+      return usd?.amount === 12500
+        ? undefined
+        : `available balance should reflect the refund (expected 12500, got ${usd?.amount})`;
+    },
+  },
+  {
+    tool: "list_balance_transactions",
+    arguments: { limit: 10 },
+    verify: (body) => {
+      const data = (body as { data?: Array<{ type: string; amount: number }> }).data ?? [];
+      return data.some((t) => t.type === "refund" && t.amount === -7500)
+        ? undefined
+        : "the ledger should carry the negative refund-type entry (F-733)";
+    },
+  },
   {
     tool: "list_events",
     arguments: { limit: 10 },

--- a/packages/twin-stripe/scripts/smoke.ts
+++ b/packages/twin-stripe/scripts/smoke.ts
@@ -115,7 +115,9 @@ async function main() {
       const body = await r.json() as Record<string, unknown>;
       assertOk(body.twin === "stripe", `1. healthz twin=${body.twin}, expected "stripe"`);
       assertOk(body.implementation === "stripe_clone", `1. implementation=${body.implementation}`);
-      assertOk(body.tools === 15, `1. tools=${body.tools}, expected 15`);
+      // Deliberate magic-number pin (same tripwire as tools.test.ts): bump it
+      // when a ticket adds tools. 26 since F-731/F-732 (F-733 added none).
+      assertOk(body.tools === 26, `1. tools=${body.tools}, expected 26`);
       log("ok", `healthz: tools=${body.tools}, fidelity=${body.fidelity}, tthw=${(body.tthw_seconds as number).toFixed(2)}s`);
     }
 

--- a/packages/twin-stripe/src/db.ts
+++ b/packages/twin-stripe/src/db.ts
@@ -10,7 +10,7 @@
 // prices, checkout_sessions, SPT, webhook_endpoints) are deferred to v2.
 import { openTwinDatabase } from "@pome-sh/sdk";
 import type { TwinStripeDatabase } from "./types.js";
-import { ensureF731Columns } from "./domain/schema.js";
+import { ensureMigratedColumns } from "./domain/schema.js";
 
 const MIGRATION_SQL = `
 -- ----- chassis tables -------------------------------------------------------
@@ -153,9 +153,9 @@ export function openTwinStripeDatabase(
 
 export function migrate(db: TwinStripeDatabase) {
   db.exec(MIGRATION_SQL);
-  // CREATE IF NOT EXISTS can't add columns to a pre-F-731 DB file; patch
+  // CREATE IF NOT EXISTS can't add columns to an older DB file; patch
   // them in place so external migrate() callers get the full schema.
-  ensureF731Columns(db);
+  ensureMigratedColumns(db);
 }
 
 export function resetDatabase(db: TwinStripeDatabase) {

--- a/packages/twin-stripe/src/domain/events.ts
+++ b/packages/twin-stripe/src/domain/events.ts
@@ -22,6 +22,7 @@ export type EventType =
   | "charge.succeeded"
   | "charge.failed"
   | "charge.refunded"
+  | "refund.created"
   | "customer.created"
   | "customer.updated"
   | "customer.deleted"

--- a/packages/twin-stripe/src/domain/refunds.ts
+++ b/packages/twin-stripe/src/domain/refunds.ts
@@ -128,6 +128,24 @@ export class RefundsDomain {
     return tx();
   }
 
+  /**
+   * Backfill the ledger link after StripeDomain mints the refund's balance
+   * transaction (the txn needs the refund row's id/amount first, so the two
+   * inserts can't be reordered). Runs inside the coordinator's transaction.
+   */
+  linkBalanceTransaction(
+    accountId: string,
+    id: string,
+    balanceTransactionId: string
+  ): RefundRow {
+    this.db
+      .prepare(
+        "UPDATE refunds SET balance_transaction_id = ? WHERE id = ? AND account_id = ?"
+      )
+      .run(balanceTransactionId, id, accountId);
+    return this.requireById(accountId, id);
+  }
+
   getById(accountId: string, id: string): RefundRow | null {
     return (
       (this.db

--- a/packages/twin-stripe/src/domain/schema.ts
+++ b/packages/twin-stripe/src/domain/schema.ts
@@ -107,6 +107,7 @@ CREATE TABLE IF NOT EXISTS refunds (
   currency TEXT NOT NULL,
   status TEXT NOT NULL,
   reason TEXT,
+  balance_transaction_id TEXT,
   idempotency_key TEXT,
   created INTEGER NOT NULL,
   FOREIGN KEY (charge_id) REFERENCES charges(id) ON DELETE CASCADE
@@ -175,14 +176,16 @@ export function ensureStripeTables(db: TwinStripeDatabase) {
   db.pragma("journal_mode = WAL");
   db.pragma("foreign_keys = ON");
   db.exec(STRIPE_TABLES_SQL);
-  ensureF731Columns(db);
+  ensureMigratedColumns(db);
 }
 
-// F-731 card-mode columns. CREATE IF NOT EXISTS never alters an existing
-// table, so a DB file minted before F-731 (STRIPE_CLONE_DB pointing at an
-// old snapshot) needs the columns added in place. Idempotent; exported so
-// db.ts's migrate() patches old files even without a domain constructor.
-const F731_COLUMNS: Record<string, ReadonlyArray<[column: string, ddl: string]>> = {
+// Columns added after a table first shipped. CREATE IF NOT EXISTS never
+// alters an existing table, so a DB file minted earlier (STRIPE_CLONE_DB
+// pointing at an old snapshot) needs the columns added in place.
+// Idempotent; exported so db.ts's migrate() patches old files even without
+// a domain constructor. F-731 added the card-mode columns; F-733 links
+// refunds to their ledger entry.
+const MIGRATED_COLUMNS: Record<string, ReadonlyArray<[column: string, ddl: string]>> = {
   payment_intents: [
     ["payment_method_id", "payment_method_id TEXT"],
     ["customer_id", "customer_id TEXT"],
@@ -196,15 +199,20 @@ const F731_COLUMNS: Record<string, ReadonlyArray<[column: string, ddl: string]>>
     ["failure_message", "failure_message TEXT"],
     ["customer_id", "customer_id TEXT"],
   ],
+  refunds: [["balance_transaction_id", "balance_transaction_id TEXT"]],
 };
 
-export function ensureF731Columns(db: TwinStripeDatabase) {
-  for (const [table, columns] of Object.entries(F731_COLUMNS)) {
+export function ensureMigratedColumns(db: TwinStripeDatabase) {
+  for (const [table, columns] of Object.entries(MIGRATED_COLUMNS)) {
     const existing = new Set(
       (db.prepare(`SELECT name FROM pragma_table_info(?)`).all(table) as Array<{ name: string }>).map(
         (row) => row.name
       )
     );
+    // A table this migration knows about but the DB doesn't have yet is
+    // created later (db.ts's chassis migrate() runs before the domain DDL);
+    // its CREATE TABLE already carries the column.
+    if (existing.size === 0) continue;
     for (const [column, ddl] of columns) {
       if (!existing.has(column)) db.exec(`ALTER TABLE ${table} ADD COLUMN ${ddl};`);
     }

--- a/packages/twin-stripe/src/domain/stripe-domain.ts
+++ b/packages/twin-stripe/src/domain/stripe-domain.ts
@@ -441,15 +441,36 @@ export class StripeDomain {
 
   /**
    * Create a refund. Returns the serialized API shape plus a canonical
-   * `state_delta` so the route can hand both to `respond()`. The INSERT
-   * + charges.amount_refunded UPDATE happen in one better-sqlite3
-   * transaction inside `refunds.create()`.
+   * `state_delta` so the route can hand both to `respond()`.
+   *
+   * F-733: the whole flow — refund INSERT + charges.amount_refunded UPDATE
+   * (inside `refunds.create()`, nested as a savepoint), the negative
+   * refund-type balance transaction, the ledger link backfill, and the
+   * charge.refunded / refund.created events — commits in one better-sqlite3
+   * transaction, mirroring the settle flows.
    */
   createRefund(
     accountId: string,
     input: CreateRefundInput
   ): { body: unknown; delta: StateDelta } {
-    const { row } = this.refunds.create(accountId, input);
+    const tx = this.db.transaction((): RefundRow => {
+      const { row, charge } = this.refunds.create(accountId, input);
+      const balanceTx = this.balance.create(accountId, {
+        type: "refund",
+        amount: -row.amount,
+        fee: 0,
+        currency: row.currency,
+        source_id: row.id,
+        source_type: "refund",
+      });
+      const linked = this.refunds.linkBalanceTransaction(accountId, row.id, balanceTx.id);
+      // v1 has no webhook delivery; these are the poll-chain signals agents
+      // read after a refund (charge carries the post-refund amount_refunded).
+      this.events.create(accountId, { type: "charge.refunded", object: chargeJson(charge) });
+      this.events.create(accountId, { type: "refund.created", object: refundJson(linked) });
+      return linked;
+    });
+    const row = tx();
     return {
       body: refundJson(row),
       delta: { before: null, after: rowToRecord(row) },

--- a/packages/twin-stripe/src/seed.ts
+++ b/packages/twin-stripe/src/seed.ts
@@ -80,6 +80,7 @@ const refundSeedSchema = z.object({
   currency: z.string().min(1),
   status: z.enum(REFUND_STATUSES),
   reason: z.string().nullable().optional(),
+  balance_transaction_id: z.string().nullable().optional(),
   idempotency_key: z.string().nullable().optional(),
   created: z.number().int(),
 });
@@ -286,8 +287,8 @@ function insertSeedRefund(db: TwinStripeDatabase, row: RefundSeed): void {
   db.prepare(
     `INSERT INTO refunds (
       id, account_id, charge_id, payment_intent_id, amount, currency,
-      status, reason, idempotency_key, created
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      status, reason, balance_transaction_id, idempotency_key, created
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   ).run(
     row.id,
     row.account_id,
@@ -297,6 +298,7 @@ function insertSeedRefund(db: TwinStripeDatabase, row: RefundSeed): void {
     row.currency,
     row.status,
     row.reason ?? null,
+    row.balance_transaction_id ?? null,
     row.idempotency_key ?? null,
     row.created
   );

--- a/packages/twin-stripe/src/serializers.ts
+++ b/packages/twin-stripe/src/serializers.ts
@@ -213,7 +213,7 @@ export function refundJson(row: RefundRow) {
     id: row.id,
     object: "refund",
     amount: row.amount,
-    balance_transaction: null,
+    balance_transaction: row.balance_transaction_id,
     charge: row.charge_id,
     created: row.created,
     currency: row.currency,

--- a/packages/twin-stripe/src/types.ts
+++ b/packages/twin-stripe/src/types.ts
@@ -83,6 +83,7 @@ export type SeedRefund = {
   currency: string;
   status: RefundStatus;
   reason?: string | null;
+  balance_transaction_id?: string | null;
   idempotency_key?: string | null;
   created: number;
 };
@@ -259,6 +260,7 @@ export type RefundRow = {
   currency: string;
   status: RefundStatus;
   reason: string | null;
+  balance_transaction_id: string | null;
   idempotency_key: string | null;
   created: number;
 };

--- a/packages/twin-stripe/test/refunds.test.ts
+++ b/packages/twin-stripe/test/refunds.test.ts
@@ -174,6 +174,181 @@ describe("Refunds — POST/GET /v1/refunds", () => {
   });
 });
 
+describe("Refunds — ledger + events (F-733 semantic reconciliation)", () => {
+  it("mints a negative refund-type balance transaction and links it from the refund", async () => {
+    const app = await createStripeApp();
+    const { chargeId } = await createAndSettle(app, 20000);
+
+    const r = await rest(app, "POST", "/v1/refunds", { charge: chargeId, amount: 7500 });
+    expect(r.status).toBe(200);
+    expect(r.body.balance_transaction).toMatch(/^txn_/);
+
+    const txs = await rest(app, "GET", "/v1/balance_transactions");
+    const refundTx = txs.body.data.find(
+      (t: Record<string, unknown>) => t.id === r.body.balance_transaction
+    );
+    expect(refundTx).toMatchObject({
+      type: "refund",
+      amount: -7500,
+      net: -7500,
+      currency: "usd",
+    });
+  });
+
+  it("decrements the available balance by the refunded amount", async () => {
+    const app = await createStripeApp();
+    const { chargeId } = await createAndSettle(app, 20000);
+
+    await rest(app, "POST", "/v1/refunds", { charge: chargeId, amount: 7500 });
+    const balance = await rest(app, "GET", "/v1/balance");
+    const usd = balance.body.available.find(
+      (b: { currency: string }) => b.currency === "usd"
+    );
+    expect(usd.amount).toBe(12500);
+  });
+
+  it("defaults to the full remaining refundable amount when `amount` is omitted", async () => {
+    const app = await createStripeApp();
+    const { chargeId } = await createAndSettle(app, 20000);
+
+    await rest(app, "POST", "/v1/refunds", { charge: chargeId, amount: 7500 });
+    const rest2 = await rest(app, "POST", "/v1/refunds", { charge: chargeId });
+    expect(rest2.status).toBe(200);
+    expect(rest2.body.amount).toBe(12500);
+
+    const charge = await rest(app, "GET", `/v1/charges/${chargeId}`);
+    expect(charge.body.refunded).toBe(true);
+    expect(charge.body.amount_refunded).toBe(20000);
+  });
+
+  it("emits charge.refunded and refund.created events on the poll chain", async () => {
+    const app = await createStripeApp();
+    const { chargeId } = await createAndSettle(app, 20000);
+    const r = await rest(app, "POST", "/v1/refunds", { charge: chargeId, amount: 7500 });
+
+    const chargeRefunded = await rest(app, "GET", "/v1/events?type=charge.refunded");
+    expect(chargeRefunded.body.data).toHaveLength(1);
+    expect(chargeRefunded.body.data[0].data.object).toMatchObject({
+      id: chargeId,
+      object: "charge",
+      amount_refunded: 7500,
+      refunded: false,
+    });
+
+    const refundCreated = await rest(app, "GET", "/v1/events?type=refund.created");
+    expect(refundCreated.body.data).toHaveLength(1);
+    expect(refundCreated.body.data[0].data.object).toMatchObject({
+      id: r.body.id,
+      object: "refund",
+      amount: 7500,
+      status: "succeeded",
+    });
+  });
+
+  it("refunds a card-rail charge end-to-end", async () => {
+    const app = await createStripeApp();
+    const pm = await rest(app, "POST", "/v1/payment_methods", {
+      type: "card",
+      card: { number: "4242424242424242", exp_month: 12, exp_year: 2033, cvc: "123" },
+    });
+    const pi = await rest(app, "POST", "/v1/payment_intents", {
+      amount: 12000,
+      currency: "usd",
+      payment_method_types: ["card"],
+      payment_method: pm.body.id,
+      confirm: true,
+    });
+    expect(pi.body.status).toBe("succeeded");
+
+    const r = await rest(app, "POST", "/v1/refunds", { charge: pi.body.latest_charge });
+    expect(r.status).toBe(200);
+    expect(r.body.amount).toBe(12000);
+    expect(r.body.balance_transaction).toMatch(/^txn_/);
+
+    const balance = await rest(app, "GET", "/v1/balance");
+    const usd = balance.body.available.find(
+      (b: { currency: string }) => b.currency === "usd"
+    );
+    expect(usd.amount).toBe(0);
+  });
+});
+
+describe("Refunds — error paths", () => {
+  it("400 parameter_missing when charge is omitted", async () => {
+    const app = await createStripeApp();
+    const r = await rest(app, "POST", "/v1/refunds", { amount: 100 });
+    expect(r.status).toBe(400);
+    expect(r.body.error.code).toBe("parameter_missing");
+    expect(r.body.error.param).toBe("charge");
+  });
+
+  it("404 resource_missing for an unknown charge", async () => {
+    const app = await createStripeApp();
+    const r = await rest(app, "POST", "/v1/refunds", { charge: "ch_doesnotexist" });
+    expect(r.status).toBe(404);
+    expect(r.body.error.code).toBe("resource_missing");
+  });
+
+  it("400 charge_already_refunded when amount exceeds the remaining refundable balance", async () => {
+    const app = await createStripeApp();
+    const { chargeId } = await createAndSettle(app, 20000);
+    await rest(app, "POST", "/v1/refunds", { charge: chargeId, amount: 15000 });
+
+    const over = await rest(app, "POST", "/v1/refunds", { charge: chargeId, amount: 6000 });
+    expect(over.status).toBe(400);
+    expect(over.body.error.code).toBe("charge_already_refunded");
+
+    // The refused attempt must not leak ledger or event side effects.
+    const txs = await rest(app, "GET", "/v1/balance_transactions?type=refund");
+    expect(txs.body.data).toHaveLength(1);
+    const refundEvents = await rest(app, "GET", "/v1/events?type=refund.created");
+    expect(refundEvents.body.data).toHaveLength(1);
+  });
+
+  it("400 parameter_invalid_integer for a zero or non-integer amount", async () => {
+    const app = await createStripeApp();
+    const { chargeId } = await createAndSettle(app, 20000);
+    for (const amount of [0, -100, 12.5]) {
+      const r = await rest(app, "POST", "/v1/refunds", { charge: chargeId, amount });
+      expect(r.status).toBe(400);
+      expect(r.body.error.code).toBe("parameter_invalid_integer");
+    }
+  });
+
+  it("400 charge_not_refundable for a declined (failed) card charge", async () => {
+    const app = await createStripeApp();
+    const pm = await rest(app, "POST", "/v1/payment_methods", {
+      type: "card",
+      card: { number: "4000000000000002", exp_month: 12, exp_year: 2033, cvc: "123" },
+    });
+    const pi = await rest(app, "POST", "/v1/payment_intents", {
+      amount: 2500,
+      currency: "usd",
+      payment_method_types: ["card"],
+      payment_method: pm.body.id,
+    });
+    const confirm = await rest(app, "POST", `/v1/payment_intents/${pi.body.id}/confirm`);
+    expect(confirm.status).toBe(402);
+    const after = await rest(app, "GET", `/v1/payment_intents/${pi.body.id}`);
+
+    const r = await rest(app, "POST", "/v1/refunds", { charge: after.body.latest_charge });
+    expect(r.status).toBe(400);
+    expect(r.body.error.code).toBe("charge_not_refundable");
+  });
+
+  it("filters the refund list by payment_intent", async () => {
+    const app = await createStripeApp();
+    const a = await createAndSettle(app, 20000);
+    const b = await createAndSettle(app, 30000);
+    await rest(app, "POST", "/v1/refunds", { charge: a.chargeId, amount: 1000 });
+    await rest(app, "POST", "/v1/refunds", { charge: b.chargeId, amount: 3000 });
+
+    const onlyA = await rest(app, "GET", `/v1/refunds?payment_intent=${a.piId}`);
+    expect(onlyA.body.data).toHaveLength(1);
+    expect(onlyA.body.data[0].payment_intent).toBe(a.piId);
+  });
+});
+
 async function createAndSettle(
   app: StripeTestApp,
   amount: number


### PR DESCRIPTION
## Executive summary
Reconciles twin-stripe's **already-implemented refunds chain** against the F-729 ruled hot set. The chain shipped semantic-ish but silently incomplete: a refund minted no ledger entry and emitted no events (so `GET /v1/balance` never decreased and the poll-confirm chain saw nothing), and the whole chain was absent from FIDELITY.md — the exact drift the structured inventory declared as `doc_drift`. This PR closes the semantic gaps, extends the thin tests (9 → 20 cases, red-first), and syncs the docs: refunds rows land in both FIDELITY.md tables at `heat: hot`, and the drift declarations self-expire. No new tools; the MCP surface stays 26.

## What
- **Refund ledger (semantic gap)**: `createRefund` now mints a negative `refund`-type balance transaction (`amount: -refund.amount`) and backfills the link onto the refund row (`refunds.balance_transaction_id`, new column added to the CREATE block and patched into older DB files via the existing pragma-guarded ALTER helper, generalized from `ensureF731Columns` to `ensureMigratedColumns`). `Refund.balance_transaction` serializes the real txn id instead of hardcoded `null`; available balance now decreases on refund.
- **Refund events (semantic gap)**: `charge.refunded` (declared in the twin's `EventType` union since v1 but never emitted) + `refund.created` are emitted on the poll chain — v1 has no webhooks, so these are the signals agents actually read after a refund.
- **One transaction**: refund INSERT + `charges.amount_refunded` UPDATE (nested as a savepoint) + balance txn + ledger link + both events commit atomically, mirroring the settle flows. A refused refund leaks no ledger or event side effects (tested).
- **Thin tests extended** (`refunds.test.ts` 9 → 20): ledger + balance + events assertions, full-refund default amount, card-rail refund end-to-end, `payment_intent` list filter, and the error paths (`parameter_missing`, `resource_missing`, `charge_already_refunded` incl. no-side-effect check, `parameter_invalid_integer`, `charge_not_refundable` on a declined card charge).
- **FIDELITY sync**: +3 REST rows and +3 tool rows (tables now 26/26, matching the live surface); REST header 23 → 26 semantic; the six inventory refund entries move `unclassified` → `hot` (`TC:refund`, ruled F-729; `MCP:create_refund` — the only resource keeping a dedicated tool on Stripe's official MCP server); all six `doc_drift` declarations removed (the lint fails if they outlive the drift). Refund partial ops (`POST /v1/refunds/:id`, `/cancel`) stay unlisted per ruling point 4.
- **Parity strengthened**: the refund steps now verify the ledger link on the refund body, the post-refund available balance (12500 after 20000 settle − 7500 refund), and the negative refund-type ledger entry.
- **Stale smoke pin fixed**: `scripts/smoke.ts` still pinned `tools=15` (pre-F-731/732; unnoticed because fresh-workspace smoke was broken) — bumped to 26 with a comment marking it as the deliberate tripwire it is.

## Why
F-733 (M5 endpoint-depth): the refunds chain was re-scoped after the 2026-07-11 codex review from greenfield "add refunds" to reconciliation — refunds already existed in code but were undocumented and semantically shallow at the ledger/event layer, exactly the drift class the old soft doc-checks missed. The F-729 ruling puts refunds in the hot set (target: semantic), and the inventory's `list_balance_transactions` justification already promised "ledger entries minted by settles and refunds" — this makes that true.

## Notes for reviewer
- `/healthz` shape untouched: `tools` remains the MCP tool-list length (26, unchanged — this ticket adds no tools). Contract suite green (69/0).
- Disputes: the F-729 ruled twin-stripe list does not name disputes anywhere (unlisted catch-all cold), so no dispute rows are added — the ticket's "otherwise recorded warm" clause predates the ruling; recorded as a [DECISION] on the ticket.
- TDD (`tdd-required`): the 5 ledger/event cases were written first and watched fail; the error-path cases pinned already-correct behavior.
- `refund.created`'s `data.object` is the refund; `charge.refunded`'s is the post-refund charge (carries updated `amount_refunded`/`refunded`), matching real Stripe's poll shapes.
- The migration helper now skips tables the DB doesn't have yet (db.ts's chassis `migrate()` runs before the domain DDL creates `refunds`; the CREATE already carries the column).

## Greptile review
- [x] Answered P1 "Refund Event Order Is Random" — ordering observation accurate (`created DESC, id DESC` with random ids), but no state-visibility harm: both events + charge/refund/ledger rows commit in one transaction. Same-second event-order nondeterminism is pre-existing twin-wide and faithful to real Stripe (no delivery-order guarantee); a deterministic within-second order would change the pinned `(created, id)` cursor model, deferred to a follow-up ruling. No code change.

## Tests / CI
- twin-stripe: 214 tests / 31 files green (11 new); `npm run typecheck` + `npm run build` clean
- `npm test` all workspaces (94/247/280/231/213/214) — green
- `npm run test:contract` — 69 pass / 0 fail
- `npm run fidelity:parity` (twin-stripe) — exit 0, 26 tools / 26 REST surfaces, zero failures, new refund/balance verifies green
- `npm run smoke` (twin-stripe) — passes end-to-end (after regenerating the workspace-linked shared-types runtime; clean-checkout smoke breakage is pre-existing and unrelated)
- gates: code-health, copy-markers, no-eval, no-cloud-imports — pass

## Review required
Yes — touches the published twin-stripe fidelity contract (FIDELITY.md + structured inventory) and refund wire behavior.

<!-- Closes F-733 -->
