### PR TITLE
fix(ci): sign twins with cosign v3 so attestations carry an RFC3161 timestamp

### DIFF
--- a/.github/workflows/twin-image.yml
+++ b/.github/workflows/twin-image.yml
@@ -123,8 +123,20 @@ jobs:
           format: spdx-json
           output-file: twin-${{ matrix.twin }}.spdx.json
           upload-artifact: true
-      - uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+      # cosign v3 keyless sign/attest embeds an RFC3161 signed timestamp
+      # (Fulcio/Rekor/TSA URLs come from the TUF signing config,
+      # --use-signing-config default). The prior cosign v2.x line produced
+      # NO signed timestamp, so twin SPDX attestations became unverifiable
+      # ~10min after signing once the short-lived Fulcio cert expired: cosign
+      # accepts the hashedrekord signature's Rekor SET to anchor an expired
+      # cert but NOT the dsse attestation's, and asks for a signed timestamp.
+      # Pinned to match pome-cloud's control-plane deploy gate, which verifies
+      # with this installer's default cosign (v3.0.6) — sign and verify on the
+      # identical build.
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         if: ${{ github.event_name != 'pull_request' }}
+        with:
+          cosign-release: 'v3.0.6'
       # Push the EXACT image built + scanned above (already loaded into the local
       # daemon under every steps.meta.outputs.tags) — no second build, so the
       # published artifact is byte-identical to the one Trivy scanned. PR builds

--- a/scripts/ci/sign-image-digests.sh
+++ b/scripts/ci/sign-image-digests.sh
@@ -31,15 +31,25 @@ while IFS= read -r tag || [ -n "$tag" ]; do
   ref="${tag}@${digest}"
 
   echo "signing $ref"
+  # cosign v3 keyless embeds an RFC3161 signed timestamp automatically (TSA URL
+  # from the TUF signing config). No --timestamp-server-url needed; that flag
+  # was removed in v3 in favour of --use-signing-config (default true).
   cosign sign --yes "$ref"
   cosign attest --yes --predicate "$sbom_file" --type spdx "$ref"
 
-  echo "verifying $ref"
+  # --use-signed-timestamps REQUIRES an RFC3161 timestamp to be present and
+  # valid. This is the load-bearing regression guard: without it, verification
+  # here passes on the still-fresh Fulcio cert and the missing-timestamp defect
+  # stays invisible until the cert expires (~10min) and a downstream consumer
+  # (pome-cloud control-plane deploy gate) fails. Fail the build instead.
+  echo "verifying $ref (with signed timestamps)"
   cosign verify \
+    --use-signed-timestamps \
     --certificate-identity-regexp "$identity_regexp" \
     --certificate-oidc-issuer "$issuer" \
     "$ref" >/dev/null
   cosign verify-attestation \
+    --use-signed-timestamps \
     --type spdx \
     --certificate-identity-regexp "$identity_regexp" \
     --certificate-oidc-issuer "$issuer" \


### PR DESCRIPTION
## What

Upgrade the twin image signing pipeline to **cosign v3.0.6** and enforce an RFC3161 signed timestamp on every twin signature/attestation.

- `twin-image.yml`: bump `cosign-installer` to v4.1.2 pinned to `cosign-release: v3.0.6` (matches pome-cloud's control-plane deploy gate).
- `scripts/ci/sign-image-digests.sh`: add `--use-signed-timestamps` to the post-sign `cosign verify` + `verify-attestation` (build-time regression guard).

## Why

Twin SPDX attestations became **unverifiable ~10 minutes after signing**. Images are signed keyless (short-lived Fulcio cert). Once the cert expires, cosign will anchor it with a Rekor SET for the `hashedrekord` image signature, but **not** for the `dsse` SPDX attestation — it requires an RFC3161 signed timestamp instead. The old cosign v2.x line produced none (and the script never passed `--timestamp-server-url`), so pome-cloud's control-plane deploy gate (`verify-twin-oci-artifact.ts --mode manifest`) failed closed on every release cut more than minutes after a twin rebuild, with the misleading `none of the attestations matched the predicate type: spdx, found: ,`.

cosign v3 keyless sign/attest embeds the RFC3161 timestamp automatically via the TUF signing config (`--use-signing-config`, default true); the v2 `--timestamp-server-url` flag no longer exists.

## Notes for reviewer

- The `--use-signed-timestamps` guard is load-bearing: without it, the in-script verify passes on the still-fresh cert and the missing-timestamp defect stays invisible until expiry. With it, a regression fails the build here.
- Pairs with pome-cloud PR adding `--use-signed-timestamps` to the verify gate. After this merges, twins must be rebuilt and the pome-cloud manifests re-pinned to the new digests.
- Diagnosis: expired Fulcio cert + dsse-entry not accepted for expiry anchoring, confirmed by inspecting the on-registry `.att` bundles. See ADR-016.