### PR TITLE
docs: refresh root + twin-stripe READMEs to the shipped surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,54 @@
 # Pome Digital Twins
 
-Open-source API emulations for GitHub, Stripe, and Slack, powered by the `pome` CLI to run, test, and evaluate your AI agents locally.
+[![CI](https://github.com/pome-sh/pome-twins/actions/workflows/ci.yml/badge.svg)](https://github.com/pome-sh/pome-twins/actions/workflows/ci.yml)
+[![Quickstart smoke](https://github.com/pome-sh/pome-twins/actions/workflows/quickstart-smoke.yml/badge.svg)](https://github.com/pome-sh/pome-twins/actions/workflows/quickstart-smoke.yml)
+[![npm: @pome-sh/cli](https://img.shields.io/npm/v/%40pome-sh%2Fcli?label=%40pome-sh%2Fcli)](https://www.npmjs.com/package/@pome-sh/cli)
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENSE)
 
-A digital twin is a local emulation of a production API. It intercepts and answers the exact same **REST and MCP calls** your agent makes in production, backed by a real **SQLite database** to ensure high-fidelity, stateful simulations for end-to-end testing.
+Open-source digital twins of GitHub, Stripe, and Slack: 102 MCP tools and 155
+REST routes across the three, plus the `pome` CLI to run your AI agents
+against them locally and capture every trace.
+
+A digital twin is a local emulation of a production API. It intercepts and
+answers the exact same **REST and MCP calls** your agent makes in production,
+backed by a real **SQLite database** (Node's built-in `node:sqlite`, so
+nothing native to compile). Every run is stateful, deterministic, and
+resettable.
 
 ---
 
 ### Why use Pome Digital Twins?
 
-* **Comprehensive Testing:** Build robust, end-to-end test suites that mimic production systems entirely without touching live infrastructure.
-* **Agent Evaluation & ML Training:** Run your AI agents against thousands of complex scenarios locally or train machine learning models in a controlled environment.
-* **Zero Friction:** Say goodbye to live rate limits, flaky networks, and messy, shared sandbox accounts. Need a fresh start? Just reset the twin to return to a known, clean state instantly.
+* **Comprehensive Testing:** Build robust, end-to-end test suites that mimic
+  production systems entirely without touching live infrastructure.
+* **Agent Evaluation & ML Training:** Run your AI agents against the bundled
+  scenario library, locally or in CI. Several scenarios are adversarial:
+  identity spoofing, prompt injection, and friends.
+* **Zero Friction:** Say goodbye to live rate limits, flaky networks, and
+  messy shared sandbox accounts. Need a fresh start? Reset the twin and
+  you're back to a known, clean state instantly.
+* **Honest Fidelity:** Every route and tool is tiered: `semantic` (stateful
+  behavior, tested), `shape` (faithful response shape), or a loud `501`. A
+  twin never silently fakes success on a surface it doesn't implement.
 
 ### Real-World Emulation
 
-* **GitHub:** Open, list, review, and merge pull requests—fully gated by the same push-access rules as the live API.
-* **Stripe:** Create a payment and watch the account balance move dynamically.
-* **Slack:** Post messages to channels and immediately verify them on the next read.
+* **GitHub:** Open, list, review, and merge pull requests — fully gated by the
+  same push-access rules as the live API.
+* **Stripe:** Confirm a card PaymentIntent (magic test cards decline exactly
+  like real Stripe), settle an x402 crypto deposit, refund a charge, and watch
+  the balance and event ledger move.
+* **Slack:** Post messages, reply in threads, search, react — and verify all
+  of it on the next read.
 
 ---
 
-This repository contains the core digital twins and the CLI. To supercharge your agent evaluations, simulations, and observability, visit [pome.sh](https://pome.sh).
+This repository contains the digital twins, the twin engine, and the CLI. To
+supercharge your agent evaluations, simulations, and observability, visit
+[pome.sh](https://pome.sh).
 
-⚠️ Pome is in Beta. It's dependencies and CLI shape might change in the future. For questions or suggestions, email: `founders@pome.sh`
+⚠️ Pome is in Beta. Its dependencies and CLI shape might change in the future.
+For questions or suggestions, email: `founders@pome.sh`
 
 ## Quickstart
 
@@ -75,14 +101,62 @@ pome --help
 ```
 
 Run `pome login` once to connect the CLI to your Pome account, then `pome init`
-in any project where you want scenarios and run artifacts.
+in any project where you want scenarios and run artifacts. The full command
+reference lives in the [CLI README](./cli/README.md) and at
+[docs.pome.sh](https://docs.pome.sh).
+
+## The twins
+
+| Twin | MCP tools | REST routes | Highlights |
+| --- | --- | --- | --- |
+| [`twin-github`](./packages/twin-github/) | **65** (63 semantic) | 62 | Repos, issues, PRs, reviews, merges, collaborators, checks — push-access gated ([FIDELITY](./packages/twin-github/FIDELITY.md)) |
+| [`twin-stripe`](./packages/twin-stripe/) | **26** (all semantic) | 43 | Card + x402 crypto PaymentIntents, customers, payment methods, refunds, charges, balance, events; billing surfaces at shape tier ([FIDELITY](./packages/twin-stripe/FIDELITY.md)) |
+| [`twin-slack`](./packages/twin-slack/) | **11** (all semantic) | 50 | Channels, messages, threads, reactions, search, users, pins, scheduled messages ([FIDELITY](./packages/twin-slack/FIDELITY.md)) |
+
+Each twin documents its surface, route by route, in its `FIDELITY.md`; the
+tier definitions live in the engine-level
+[endpoint-tier rubric](./packages/sdk/ENDPOINT-TIERS.md). All three honor the
+frozen v1.1.0 runtime contract in [`CONTRACT.md`](./CONTRACT.md), verified by
+a black-box suite (`npm run test:contract`) that both pome-cloud and the CLI
+rely on. Published twin images are cosign-signed and ship SBOM attestations.
+
+## Running an agent
+
+`pome run --local` boots a twin in-process, runs your agent against it, and
+records the run (the trace plus before/after state) for you to read back with
+`pome inspect`. The CLI is **capture-only**: it never scores or judges
+locally. Evaluation — scoring a run against a scenario's pass/fail criteria —
+is a hosted feature on the Pome platform. `pome eval` bridges the two:
+capture a trace anywhere, then upload it for a cloud verdict.
+
+```bash
+pome run --local scenarios/         # self-hosted: records a raw trace
+pome eval runs/<scenario>/<run-id>  # uploads it for a cloud verdict
+pome login && pome run scenarios/   # hosted: records + evaluates in one go
+```
+
+## The scenario library
+
+`pome init` ships 19 ready-made scenarios: GitHub issue triage and PR flows,
+Stripe x402 payment and refund flows, Slack messaging. Several are
+adversarial — they probe whether your agent can be talked into spoofing an
+identity, following an injected prompt, merging a backdoored PR, fabricating
+green CI, or re-refunding a charge because someone asked nicely. Browse them
+with `pome scenarios` or in [`cli/scenarios/`](./cli/scenarios/).
 
 ## The example agents
 
-[`examples/triage-agent`](./examples/triage-agent/) is the worked
-Claude Agent SDK example: with a twin running (see quickstart) and an
-[Anthropic API key](https://console.anthropic.com/), it triages the seeded
-issues on `acme/api` end-to-end:
+Four worked agents live under [`examples/`](./examples/):
+
+| Example | Stack | What it does |
+| --- | --- | --- |
+| [`triage-agent`](./examples/triage-agent/) | Claude Agent SDK + MCP | Triages the seeded issues on `acme/api` end-to-end |
+| [`merge-agent`](./examples/merge-agent/) | Vercel AI SDK + REST | A PR merge agent vs. an identity-spoof scenario |
+| [`pr-summary-agent`](./examples/pr-summary-agent/) | Claude Agent SDK + MCP | Summarizes PRs: what/why/risk/checklist |
+| [`pr-summary-review`](./examples/pr-summary-review/) | Claude Agent SDK + MCP | Summarizes **and** reviews PRs (approve / comment / request changes) |
+
+To run the worked Claude Agent SDK example against a live twin (needs an
+[Anthropic API key](https://console.anthropic.com/)):
 
 ```bash
 git clone https://github.com/pome-sh/pome-twins.git && cd pome-twins/examples/triage-agent
@@ -92,39 +166,58 @@ export ANTHROPIC_API_KEY=sk-ant-...
 npm start
 ```
 
-## The twins
+## Build your own twin
 
-| Twin | Surface | State |
-| --- | --- | --- |
-| [`twin-github`](./packages/twin-github/) | GitHub REST + 35 MCP tools (repos, issues, PRs, reviews, collaborators, checks) | SQLite, push-access gated |
-| [`twin-stripe`](./packages/twin-stripe/) | Stripe x402 REST + MCP (payment intents, refunds, balance) | SQLite, balance-consistent |
-| [`twin-slack`](./packages/twin-slack/) | Slack Web API + MCP (channels, messages, reactions, files) | SQLite |
+The three twins are thin domain plugins on [`@pome-sh/sdk`](./packages/sdk/).
+The engine supplies the mechanism — HTTP mounting, bearer auth, the trace
+recorder with secret redaction, MCP dispatch, SQLite state, and the admin
+reset/seed gate — so a twin is just its domain logic and tools:
 
-## Running an agent
+```ts
+import { defineTwin } from "@pome-sh/sdk";
+import { serve } from "@pome-sh/sdk/server";
 
-`pome run --local` boots a twin in-process, runs your agent against it, and
-records the run — the trace plus before/after state — for you to read back with
-`pome inspect`. Self-hosted runs capture traces only. **Evaluation — scoring a
-run against a scenario's pass/fail criteria — is a hosted feature** on the Pome
-platform; there is no local scoring.
+const twin = defineTwin({
+  id: "my-service",
+  version: "0.1.0",
+  domain: ({ db, seed }) => createMyDomain(db, seed),
+  tools: [/* ToolSpec[] — name, zod schema, handler */],
+});
 
-```bash
-pome run --local scenarios/         # self-hosted: records a trace
-pome login && pome run scenarios/   # hosted: records + evaluates
+await serve(twin, { port: 3333 });
 ```
+
+Every engine-booted twin gets `/healthz`, session mounts, and MCP surfaces
+for free and automatically honors [`CONTRACT.md`](./CONTRACT.md). Start from
+the [SDK README](./packages/sdk/README.md) and the
+[endpoint-tier rubric](./packages/sdk/ENDPOINT-TIERS.md).
+
+## Published packages
+
+Everything ships to npm with provenance (Trusted Publishing):
+
+| Package | Role |
+| --- | --- |
+| [`@pome-sh/cli`](https://www.npmjs.com/package/@pome-sh/cli) | The `pome` CLI |
+| [`@pome-sh/twin-github`](https://www.npmjs.com/package/@pome-sh/twin-github) [`/twin-stripe`](https://www.npmjs.com/package/@pome-sh/twin-stripe) [`/twin-slack`](https://www.npmjs.com/package/@pome-sh/twin-slack) | The three twins |
+| [`@pome-sh/sdk`](https://www.npmjs.com/package/@pome-sh/sdk) | The twin engine (`defineTwin()`) |
+| [`@pome-sh/shared-types`](https://www.npmjs.com/package/@pome-sh/shared-types) | Zod schemas and the trace contract |
+| [`@pome-sh/adapter-claude-sdk`](https://www.npmjs.com/package/@pome-sh/adapter-claude-sdk) | Wire a Claude Agent SDK agent to a Pome run |
 
 ## Repo layout
 
 | Path | Role |
 | --- | --- |
-| [`packages/twin-{github,stripe,slack}`](./packages/) | The three twins (REST + MCP, SQLite) |
+| [`packages/twin-{github,stripe,slack}`](./packages/) | The three twins (REST + MCP, SQLite) — each with `README` + `FIDELITY.md` |
+| [`packages/sdk`](./packages/sdk/) | The twin engine — build your own twin with `defineTwin()` |
 | [`packages/shared-types`](./packages/shared-types/) | Zod schemas and trace contracts |
-| [`packages/sdk`](./packages/sdk/) | Library for building your own twin |
 | [`packages/adapter-claude-sdk`](./packages/adapter-claude-sdk/) | Wire a Claude Agent SDK agent to a Pome run |
-| [`cli/`](./cli/) | The `pome` CLI (run scenarios, inspect traces, manage sessions) |
-| [`cli/scenarios/`](./cli/scenarios/) | The bundled scenario library |
-| [`examples/triage-agent`](./examples/triage-agent/) | Worked agent example (Claude Agent SDK + MCP) against the GitHub twin |
-| [`examples/merge-agent`](./examples/merge-agent/) | Worked agent example (Vercel AI SDK + REST) — a PR merge agent vs. an identity-spoof scenario |
+| [`cli/`](./cli/) | The `pome` CLI (run scenarios, inspect traces, upload for evaluation) |
+| [`cli/scenarios/`](./cli/scenarios/) | The bundled scenario library (19 scenarios) |
+| [`examples/`](./examples/) | Four worked example agents |
+| [`CONTRACT.md`](./CONTRACT.md) | The frozen twin runtime contract (v1.1.0) |
+| [`AGENTS.md`](./AGENTS.md) | Contributor and agent conventions for this repo |
+
+Full documentation lives at [docs.pome.sh](https://docs.pome.sh).
 
 [Apache-2.0](./LICENSE)
-

--- a/packages/twin-stripe/README.md
+++ b/packages/twin-stripe/README.md
@@ -7,9 +7,11 @@ x402 machine payments**. Real Stripe sandbox doesn't auto-settle crypto
 deposits, the CDP facilitator settles on real Base, and `stripe-mock`
 has no x402 support — so without this twin there is nowhere to run agent
 tests against the x402 protocol that aren't either flaky, slow, or
-expensive. v1 ships **12 REST endpoints + 12 MCP tools + the
-`paymentMiddleware()` Hono helper**, all stateful, all tested, all loud
-about what they don't do.
+expensive. Today it ships **26 semantic REST routes + 26 MCP tools + the
+`paymentMiddleware()` Hono helper** (card and crypto PaymentIntents,
+customers, payment methods, refunds, charges, balance, events), plus 13
+shape-tier billing routes — all stateful, all tested, all loud about what
+they don't do.
 
 ## Quickstart
 
@@ -20,17 +22,16 @@ twin URL. Skip ahead to [Auth](#auth--works-with-real-stripe-sdks) for
 how to wire your existing Stripe SDK.
 
 To run the twin yourself locally (e.g., in CI or against an offline
-agent), clone this repo and run:
+agent), the zero-install path needs only Node ≥ 24:
 
 ```bash
-git clone https://github.com/pome-sh/pome-twins.git
-cd pome-twins && npm install
-npm run -w @pome-sh/twin-stripe dev &   # starts on :3333
-sleep 2
+npx @pome-sh/cli twin start stripe      # starts on :3333
+curl http://127.0.0.1:3333/healthz
 
-# Or with zero installs (only Node ≥ 24 required):
-# npx @pome-sh/cli twin start stripe --port 3334
-# curl http://127.0.0.1:3334/healthz
+# Or, to develop the twin from source:
+# git clone https://github.com/pome-sh/pome-twins.git
+# cd pome-twins && npm install
+# npm run -w @pome-sh/twin-stripe dev
 
 # Real Stripe SDKs work via host override — they hit /v1/* directly
 # (no /s/:sid prefix) and the bearer alone resolves the session:
@@ -58,22 +59,17 @@ deployments (e.g., the pome-cloud per-session proxy, where the `:sid`
 in the URL must match the bearer). Pick whichever shape your client
 prefers — they share handlers and produce identical responses.
 
-> **npm publish status**: this package is currently `private: true` in
-> `package.json` pending OSS Stage 1 + legal review (see plan §22). After
-> Stage 1, `npx @pome-sh/twin-stripe` will be the one-line install path;
-> until then, the monorepo clone above or the hosted twin on
-> pome.sh is the supported route.
-
-## What ships in v1
+## What ships today
 
 | Surface | Count | Tier |
 | --- | --- | --- |
-| REST endpoints under `/s/:sid/v1/*` | 12 | semantic |
-| MCP tools (1:1 with stripe-node) | 12 | semantic |
+| REST routes under `/s/:sid/v1/*` (payments, customers, payment methods, refunds, charges, balance, events) | 26 | semantic |
+| Billing reads/writes (products, prices, subscriptions, invoice reads) | 13 | shape |
+| MCP tools (1:1 with stripe-node) | 26 | semantic |
 | `paymentMiddleware()` Hono helper | 1 | semantic |
 | Pome introspection (`_pome/{health,state,events}`) | 3 | n/a |
 | Admin (`/admin/{reset,seed}`, localhost-only) | 2 | n/a |
-| Anything else under `/v1/*` | many | **loud 501 with `fidelity:"unsupported"`** |
+| Named cold surfaces (checkout, payment links, setup intents, webhook endpoints) + anything else under `/v1/*` | many | **loud 501 with `fidelity:"unsupported"`** |
 
 See [FIDELITY.md](./FIDELITY.md) for the full route table and known
 deviations from real Stripe.
@@ -137,19 +133,20 @@ Either way, the resolved session id must match the `:sid` in the URL.
 
 ## MCP
 
-15 tools available at `GET /s/:sid/mcp/tools`. Tool names match
+26 tools available at `GET /s/:sid/mcp/tools`. Tool names match
 `stripe-node` method names so an agent's mental model translates 1:1:
 
 ```
-create_payment_intent
-retrieve_payment_intent
-list_payment_intents
-confirm_payment_intent
-cancel_payment_intent
-simulate_crypto_deposit
-retrieve_charge
-list_charges
-retrieve_balance
+create_payment_intent          create_customer
+retrieve_payment_intent        retrieve_customer
+list_payment_intents           update_customer
+update_payment_intent          delete_customer
+confirm_payment_intent         list_customers
+cancel_payment_intent          list_customer_payment_methods
+simulate_crypto_deposit        create_payment_method
+retrieve_charge                retrieve_payment_method
+list_charges                   attach_payment_method
+retrieve_balance               detach_payment_method
 list_balance_transactions
 retrieve_event
 list_events
@@ -205,14 +202,19 @@ that pins and verifies the new signed digest.
 - The snapshot manifest at `pome-cloud/infra/twin-stripe-snapshot.json`
   records the OSS git sha and signed OCI digest each snapshot was built from.
 
-## What v1 does NOT do
+## What it does NOT do
+
+Shape tier (faithful response shape, deliberately no billing semantics —
+no events emitted, no invoices minted, no billing-cycle arithmetic):
+
+- Products, prices, subscriptions, invoice reads (F-734).
 
 Loud 501 with `fidelity: "unsupported"`:
 
-- All `/v1/shared_payment/*` (SPT) — deferred to v2.
-- Customer / payment-method CRUD — not on the x402 path.
-- Setup intents, refunds, products, prices, checkout sessions — v2.
-- Webhook delivery loop — agents poll `GET /v1/events` in v1.
+- Checkout sessions, payment links, setup intents, webhook endpoints —
+  named cold surfaces, test-backed.
+- All `/v1/shared_payment/*` (SPT) — deferred.
+- Webhook delivery loop — agents poll `GET /v1/events`.
 - Profiles, Connect, Issuing, Treasury, Tax, Climate, Identity — out forever
   for this twin.
 
@@ -235,26 +237,21 @@ Other deviations from real Stripe:
 npm install
 npm run dev                        # boot on :3333 with default seed
 npm run typecheck                  # tsc --noEmit
-npm run test                       # vitest, 17 files / 87 tests
+npm run test                       # vitest, 32 files / 237 tests
 npm run build                      # tsc → dist/src/server.js
 node dist/src/server.js            # production-shape boot
 ```
 
 ## Use it as a Stripe test double in your tests
 
-Until the package is on npm (post-Stage-1), the cleanest way is to clone
-this monorepo and shell out to `npm run dev` from your test setup:
+The cleanest way is to boot the published twin from your test setup; all
+it needs is Node ≥ 24:
 
 ```ts
 // In your test setup
 import { spawn } from "node:child_process";
-import { join } from "node:path";
 
-// Path to where you cloned pome-sh/pome-twins on disk
-const POME_REPO = process.env.POME_REPO ?? "/path/to/pome-twins";
-
-const twin = spawn("npm", ["run", "dev"], {
-  cwd: join(POME_REPO, "packages/twin-stripe"),
+const twin = spawn("npx", ["@pome-sh/cli", "twin", "start", "stripe"], {
   env: { ...process.env, PORT: "3333", STRIPE_CLONE_DB: ":memory:" },
 });
 // wait for /healthz before running your suite


### PR DESCRIPTION
Executive summary: The root README undersold the repo by roughly 2x after the twin-engine and endpoint-depth work landed, and the twin-stripe README was two milestones stale. This PR is docs-only: it corrects every count against the fidelity inventories and surfaces the assets the READMEs never mentioned (FIDELITY.md, CONTRACT.md, defineTwin(), pome eval, the scenario library, two of the four example agents).

## What
Rewrites the root `README.md`: real per-twin numbers (GitHub 65 MCP tools / 62 REST routes, Stripe 26 / 43, Slack 11 / 50), CI + npm badges, fidelity-tier section, `CONTRACT.md` + contract-suite mention, a build-your-own-twin section with the `defineTwin()` snippet, the `pome eval` capture-to-verdict flow, the 19-scenario library, all four example agents, and a published-packages table. Updates `packages/twin-stripe/README.md` from its "12 REST + 12 MCP tools" era to today's 26 semantic routes + 13 shape billing routes + 26 tools, removes the stale "private: true pending Stage 1" publish note, and makes `npx @pome-sh/cli twin start stripe` the primary local path.

## Why
Both READMEs predate the shipped surface: the twins table contradicted the twins' own FIDELITY.md files, and the Stripe package README contradicted its own fidelity table in the same directory. All counts were verified against `fidelity.inventory.json` per twin; every command and relative link in the new text was checked to resolve.

## Notes for reviewer
Docs-only — no source, config, or CI changes. The quickstart section is intentionally untouched (it is exercised by `quickstart-smoke.yml`, which this PR triggers via its README path filter). Numbers to spot-check if desired: `jq '.tools|length' packages/twin-*/fidelity.inventory.json`.