### PR TITLE
fix(ci): don't require a signed timestamp on the SPDX attestation verify

### DIFF
--- a/scripts/ci/sign-image-digests.sh
+++ b/scripts/ci/sign-image-digests.sh
@@ -37,19 +37,25 @@ while IFS= read -r tag || [ -n "$tag" ]; do
   cosign sign --yes "$ref"
   cosign attest --yes --predicate "$sbom_file" --type spdx "$ref"
 
-  # --use-signed-timestamps REQUIRES an RFC3161 timestamp to be present and
-  # valid. This is the load-bearing regression guard: without it, verification
-  # here passes on the still-fresh Fulcio cert and the missing-timestamp defect
-  # stays invisible until the cert expires (~10min) and a downstream consumer
-  # (pome-cloud control-plane deploy gate) fails. Fail the build instead.
-  echo "verifying $ref (with signed timestamps)"
+  # Signature: enforce the RFC3161 timestamp (--use-signed-timestamps).
+  # cosign v3 `sign` embeds it via the TUF signing config, so this passes at
+  # build AND stays verifiable after the ~10min Fulcio cert expires — that
+  # durably-timestamped signature is what the pome-cloud control-plane deploy
+  # gate hard-requires (ADR-016 decision #4).
+  echo "verifying $ref signature (with signed timestamps)"
   cosign verify \
     --use-signed-timestamps \
     --certificate-identity-regexp "$identity_regexp" \
     --certificate-oidc-issuer "$issuer" \
     "$ref" >/dev/null
+  # Attestation: NO --use-signed-timestamps. cosign `attest` (v3.1.1, latest)
+  # emits no RFC3161 timestamp (no --new-bundle-format on attest), so requiring
+  # one here fails the sign step on every run. The deploy gate treats the SPDX
+  # attestation as best-effort for exactly this reason (ADR-016 decision #4);
+  # verify it here while the cert is fresh (surfaces a bad/mis-signed SBOM at
+  # build) without demanding a timestamp cosign cannot produce.
+  echo "verifying $ref SPDX attestation"
   cosign verify-attestation \
-    --use-signed-timestamps \
     --type spdx \
     --certificate-identity-regexp "$identity_regexp" \
     --certificate-oidc-issuer "$issuer" \


### PR DESCRIPTION
## What

Remove `--use-signed-timestamps` from the in-script `cosign verify-attestation` in `scripts/ci/sign-image-digests.sh`. Keep it on the image-signature `cosign verify`.

## Why

#126 added the flag to the attestation verify as a regression guard, but cosign `attest` (v3.1.1, latest) emits **no** RFC3161 timestamp (no `--new-bundle-format` on `attest`), so `verify-attestation --use-signed-timestamps` fails — and `twin-image.yml` has been **red on every run since** (images still push + sign before the failure, so publishing wasn't blocked, but CI is permanently failing).

The signature keeps the timestamp guard: cosign v3 `sign` embeds an RFC3161 timestamp, that durably-timestamped signature is what the pome-cloud control-plane deploy gate hard-requires, and the gate already treats the SPDX attestation as **best-effort** (ADR-016 decision #4). So requiring a timestamp on the attestation was both impossible to satisfy and inconsistent with the deploy policy.

## Notes for reviewer

- Attestation is still verified at build (identity + issuer) while the cert is fresh — surfaces a bad/mis-signed SBOM — just without the timestamp requirement.
- Restores `twin-image.yml` to green; no change to what gets published or signed.