### PR TITLE
fix(ci): revert twin signing to cosign v2 — restores attest + green CI

### DIFF
--- a/.github/workflows/twin-image.yml
+++ b/.github/workflows/twin-image.yml
@@ -123,20 +123,16 @@ jobs:
           format: spdx-json
           output-file: twin-${{ matrix.twin }}.spdx.json
           upload-artifact: true
-      # cosign v3 keyless sign/attest embeds an RFC3161 signed timestamp
-      # (Fulcio/Rekor/TSA URLs come from the TUF signing config,
-      # --use-signing-config default). The prior cosign v2.x line produced
-      # NO signed timestamp, so twin SPDX attestations became unverifiable
-      # ~10min after signing once the short-lived Fulcio cert expired: cosign
-      # accepts the hashedrekord signature's Rekor SET to anchor an expired
-      # cert but NOT the dsse attestation's, and asks for a signed timestamp.
-      # Pinned to match pome-cloud's control-plane deploy gate, which verifies
-      # with this installer's default cosign (v3.0.6) — sign and verify on the
-      # identical build.
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      # cosign v2. The v3.0.6 bump (attempted RFC3161-timestamped signatures)
+      # was reverted: it gave no benefit — the pome-cloud deploy gate hard-gates
+      # only the image SIGNATURE, which verifies on un-timestamped v2 signatures
+      # too because the hashedrekord Rekor SET anchors the expired Fulcio cert
+      # (the SPDX attestation is best-effort there, ADR-016 decision #4). And
+      # cosign v3 `attest --type spdx` rejected the anchore SBOM predicate
+      # ("invalid attestation: decoding json"), failing the sign step on every
+      # v3 run and producing NO attestation. v2 signs + attests cleanly.
+      - uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
         if: ${{ github.event_name != 'pull_request' }}
-        with:
-          cosign-release: 'v3.0.6'
       # Push the EXACT image built + scanned above (already loaded into the local
       # daemon under every steps.meta.outputs.tags) — no second build, so the
       # published artifact is byte-identical to the one Trivy scanned. PR builds

--- a/scripts/ci/sign-image-digests.sh
+++ b/scripts/ci/sign-image-digests.sh
@@ -31,30 +31,20 @@ while IFS= read -r tag || [ -n "$tag" ]; do
   ref="${tag}@${digest}"
 
   echo "signing $ref"
-  # cosign v3 keyless embeds an RFC3161 signed timestamp automatically (TSA URL
-  # from the TUF signing config). No --timestamp-server-url needed; that flag
-  # was removed in v3 in favour of --use-signing-config (default true).
   cosign sign --yes "$ref"
   cosign attest --yes --predicate "$sbom_file" --type spdx "$ref"
 
-  # Signature: enforce the RFC3161 timestamp (--use-signed-timestamps).
-  # cosign v3 `sign` embeds it via the TUF signing config, so this passes at
-  # build AND stays verifiable after the ~10min Fulcio cert expires — that
-  # durably-timestamped signature is what the pome-cloud control-plane deploy
-  # gate hard-requires (ADR-016 decision #4).
-  echo "verifying $ref signature (with signed timestamps)"
+  # Build-time self-check that the pushed digest is signed + carries the SPDX
+  # attestation, under the same keyless identity. No --use-signed-timestamps:
+  # the pome-cloud control-plane deploy gate owns timestamp/expiry handling and
+  # hard-gates only the signature (SPDX attestation best-effort, ADR-016
+  # decision #4); requiring a timestamp here just breaks the build (cosign
+  # emits none for attestations).
+  echo "verifying $ref"
   cosign verify \
-    --use-signed-timestamps \
     --certificate-identity-regexp "$identity_regexp" \
     --certificate-oidc-issuer "$issuer" \
     "$ref" >/dev/null
-  # Attestation: NO --use-signed-timestamps. cosign `attest` (v3.1.1, latest)
-  # emits no RFC3161 timestamp (no --new-bundle-format on attest), so requiring
-  # one here fails the sign step on every run. The deploy gate treats the SPDX
-  # attestation as best-effort for exactly this reason (ADR-016 decision #4);
-  # verify it here while the cert is fresh (surfaces a bad/mis-signed SBOM at
-  # build) without demanding a timestamp cosign cannot produce.
-  echo "verifying $ref SPDX attestation"
   cosign verify-attestation \
     --type spdx \
     --certificate-identity-regexp "$identity_regexp" \


### PR DESCRIPTION
## What

Revert the cosign v3.0.6 bump (#126) in `twin-image.yml` back to cosign-installer **v3.9.2 (cosign v2)** and restore the plain sign/verify block in `sign-image-digests.sh` (drop all `--use-signed-timestamps`).

## Why

#126 bumped cosign to v3.0.6 to attempt RFC3161-timestamped signatures. Two problems:

1. **It broke `twin-image.yml`.** cosign v3 `attest --type spdx` rejects the anchore SBOM predicate — `error signing bundle: ... invalid attestation: decoding json` — so the sign step failed on **every** v3 run and produced **no** SPDX attestation (only the signature got pushed before the failure). #129 fixed the verify guard but not this.
2. **The v3 bump gave no benefit.** The pome-cloud deploy gate hard-gates only the image **signature**, and cosign verifies un-timestamped **v2** signatures fine — the `hashedrekord` Rekor SET anchors the expired Fulcio cert. The SPDX attestation is best-effort there (ADR-016 decision #4). The **v0.3.0 release deployed cleanly on the old v2-signed digests**, proving timestamped signatures were never required.

Reverting to v2 restores working `attest` (SPDX attestations produced again) and green CI, with no loss.

## Notes for reviewer

- Currently-pinned pome-cloud manifests reference v3-signed digests (signature-only); they stay valid (gate passes on the signature). Future rebuilds produce v2 digests that also pass.
- Restores the exact pre-#126 signing config (proven green on the Jul-10 runs).