### PR TITLE
feat(shared-types): multi-twin session contract

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4951,7 +4951,7 @@
     },
     "packages/shared-types": {
       "name": "@pome-sh/shared-types",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "devDependencies": {
         "@types/node": "^26.1.0",
         "typescript": "^5.9.3",

--- a/packages/shared-types/CHANGELOG.md
+++ b/packages/shared-types/CHANGELOG.md
@@ -8,8 +8,11 @@
   - `criterionSchema.twin` (run.ts) and `criterionDefSchema.twin` (rest.ts) —
     optional per-criterion twin attribution; absent = the session's primary
     twin (`twins[0]`). Rides the D/P→code/model transform untouched.
+  - `finalizeRequestSchema` (finalize-shapes.ts) — the LIVE `POST
+    /v1/sessions/:id/finalize` request body the CLI sends (criterion defs plus
+    trace/state/signals storage keys).
   - `perTwinStateKeysSchema` plus an optional `per_twin_state_keys` on the
-    submit-result request — per-twin initial/final state storage keys.
+    finalize request — per-twin initial/final state storage keys.
   - `createAgentRequestSchema` (with optional `twins`) and `agentResponseSchema`
     (with optional `enabled_services`) for the `POST /v1/agents` surface.
   - `stateUploadUrlResponseSchema` with an optional per-twin URL+key map.

--- a/packages/shared-types/CHANGELOG.md
+++ b/packages/shared-types/CHANGELOG.md
@@ -1,5 +1,27 @@
 # @pome-sh/shared-types — CHANGELOG
 
+## 0.7.0
+
+### Added
+
+- Multi-twin (M3) session wire contract — purely additive, zero-breaking:
+  - `criterionSchema.twin` (run.ts) and `criterionDefSchema.twin` (rest.ts) —
+    optional per-criterion twin attribution; absent = the session's primary
+    twin (`twins[0]`). Rides the D/P→code/model transform untouched.
+  - `perTwinStateKeysSchema` plus an optional `per_twin_state_keys` on the
+    submit-result request — per-twin initial/final state storage keys.
+  - `createAgentRequestSchema` (with optional `twins`) and `agentResponseSchema`
+    (with optional `enabled_services`) for the `POST /v1/agents` surface.
+  - `stateUploadUrlResponseSchema` with an optional per-twin URL+key map.
+  - `seedEnvelopeSchema` and `isMultiTwinSeedEnvelope(twins)` — the seed is a
+    per-twin envelope `{ <twin>: <flat seed> }` iff a session has more than one
+    twin; single-twin sessions always use the flat seed shape. No shape-sniffing.
+
+### Changed
+
+- `createSessionRequestSchema.twins` doc: multi-twin arrays are now honored (max
+  3 twins per session, cap enforced cloud-side; one isolated sandbox per twin).
+
 ## 0.6.1
 
 ### Added

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/shared-types",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Shared wire-format contract for Pome — Zod schemas for traces, recorder events, runs, OTel mapping, and secret redaction.",
   "private": false,
   "type": "module",

--- a/packages/shared-types/src/finalize-shapes.ts
+++ b/packages/shared-types/src/finalize-shapes.ts
@@ -7,6 +7,47 @@
 
 import { z } from "zod";
 import { criterionResultSchema } from "./run.js";
+import { criterionDefSchema, perTwinStateKeysSchema } from "./rest.js";
+
+// POST /v1/sessions/:id/finalize — ADR-013 managed-judge REQUEST. This is the
+// LIVE scoring wire: the CLI (cli/src/hosted/client.ts `finalize`) uploads trace
+// / state / signals blobs via the presigned upload-url routes, then POSTs the
+// criterion *definitions* plus the storage KEYS here; the cloud runs the managed
+// judge and returns `finalizeInitialResponseSchema`. (The sibling
+// `submitResultRequestSchema` in rest.ts is the DEPRECATED BYOK shim that scores
+// CLI-side and uploads inline state_*_json_b64.)
+//
+// Not `.strict()`: a tolerant reader that strips unknown additive keys, matching
+// the rest of the §4 request/response family. Field set mirrors the CLI body
+// exactly — `scenario_*` vocab (finalize does not take the W3 `task_*` aliases),
+// storage keys optional (cloud falls back to conventional paths when omitted).
+export const finalizeRequestSchema = z.object({
+  stop_reason: z.string(),                       // "completed" | "timeout" | "preflight_failed" | …
+  exit_code: z.number().int(),
+  duration_ms: z.number().int(),
+  agent_model: z.string(),
+  agent_sdk: z.string().nullable(),              // normalizeAgentSdk() output: trimmed string or null
+  // Criterion DEFINITIONS (not results): cloud judges these against the recorded
+  // trace/state and returns the authoritative score. Carries optional per-criterion
+  // twin attribution (multi-twin M3).
+  criteria: z.array(criterionDefSchema),
+  scenario_name: z.string(),
+  scenario_hash: z.string(),
+  scenario_prompt: z.string(),
+  expected_behavior: z.string(),
+  // Optional storage-key overrides; omitted keys fall back to the conventional
+  // team-<>/session-<>/<filename> paths written by the *-upload-url routes.
+  trace_storage_key: z.string().optional(),
+  state_initial_storage_key: z.string().optional(),
+  state_final_storage_key: z.string().optional(),
+  signals_storage_key: z.string().optional(),
+  // Multi-twin (M3): additive per-twin state storage keys, keyed by twin id.
+  // Absent on single-twin sessions, which use the flat state_*_storage_key fields
+  // above. Unknown to an older cloud, which strips it and scores the primary twin
+  // unchanged (new CLI × old cloud degrades gracefully).
+  per_twin_state_keys: perTwinStateKeysSchema.optional(),
+});
+export type FinalizeRequest = z.infer<typeof finalizeRequestSchema>;
 
 // /v1/sessions/:id/finalize — ADR-013 managed-judge response.
 // Not `.strict()`: cloud may emit additive M7 keys (`evaluator_version`,

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -28,6 +28,7 @@ export * from "./otel/index.js";
 export * from "./identity.js";          // §1 IDENTITY
 export * from "./sessions.js";          // §2 SESSIONS
 export * from "./seed-state.js";        // §3 TASKS — provider seed-state schemas
+export * from "./seed-envelope.js";     // §3 TASKS — multi-twin seed envelope (M3)
 export * from "./task.js";              // §3 TASKS — task config / task / persisted-task
 export * from "./rest.js";              // §4 PUBLIC REST API (minus finalize family)
 export * from "./finalize-shapes.js";   // §4 PUBLIC REST API — /finalize response family

--- a/packages/shared-types/src/rest.ts
+++ b/packages/shared-types/src/rest.ts
@@ -199,10 +199,20 @@ export type CreateSessionResponse = z.infer<typeof createSessionResponseSchema>;
 // alongside the other §4 state-storage-key shapes.
 export const perTwinStateKeysSchema = z.record(
   z.string(),
-  z.object({
-    state_initial_key: z.string().min(1).optional(),
-    state_final_key: z.string().min(1).optional(),
-  }),
+  z
+    .object({
+      state_initial_key: z.string().min(1).optional(),
+      state_final_key: z.string().min(1).optional(),
+    })
+    // A twin entry must carry AT LEAST ONE storage key — an empty `{}` conveys
+    // nothing and is almost always a serialization bug. Both keys stay
+    // individually optional: final-only is legal (initial state is optional in
+    // the single-twin contract too — `state_initial_json_b64` can be an empty
+    // snapshot), and initial-only is legal symmetrically.
+    .refine(
+      (v) => v.state_initial_key !== undefined || v.state_final_key !== undefined,
+      { message: "Each twin entry must carry at least one of state_initial_key or state_final_key" },
+    ),
 );
 export type PerTwinStateKeys = z.infer<typeof perTwinStateKeysSchema>;
 

--- a/packages/shared-types/src/rest.ts
+++ b/packages/shared-types/src/rest.ts
@@ -194,7 +194,9 @@ export type CreateSessionResponse = z.infer<typeof createSessionResponseSchema>;
 // final state blobs to. One entry per twin the session provisioned. Single-twin
 // sessions omit this and keep using the flat top-level state fields. Additive:
 // an older cloud that does not read this field strips it and scores the primary
-// twin unchanged.
+// twin unchanged. Consumed by `finalizeRequestSchema` (finalize-shapes.ts) — the
+// LIVE scoring wire — as the optional `per_twin_state_keys` field; defined here
+// alongside the other §4 state-storage-key shapes.
 export const perTwinStateKeysSchema = z.record(
   z.string(),
   z.object({
@@ -234,11 +236,6 @@ const submitResultRequestObjectSchema = z.object({
   trace_jsonl_b64: z.string(),
   state_initial_json_b64: z.string(),
   state_final_json_b64: z.string(),
-  // Multi-twin (M3): additive per-twin state storage keys. Absent on single-twin
-  // sessions, which keep uploading a single twin's state via the flat
-  // state_*_json_b64 blobs above. Unknown to an older cloud, which strips it and
-  // scores the primary twin unchanged (new CLI × old cloud degrades gracefully).
-  per_twin_state_keys: perTwinStateKeysSchema.optional(),
   // NOTE: agent_stdout is intentionally NOT in this request. Cloud never
   // receives the agent's prompts or completions. The CLI uses agent_stdout
   // locally for the [model] judge then discards it.

--- a/packages/shared-types/src/rest.ts
+++ b/packages/shared-types/src/rest.ts
@@ -37,6 +37,19 @@ export type MeResponse = z.infer<typeof meResponseSchema>;
 // sending `scenario_source` / `scenario_id` keep working unchanged.
 const createSessionRequestObjectSchema = z
   .object({
+    // Multi-twin (M3): multi-twin arrays are now honored — the cloud provisions
+    // one isolated sandbox per twin. Max 3 twins per session; the cap is
+    // enforced cloud-side, so we deliberately do NOT add a `.max()` here (the
+    // boundary stays permissive and the cloud owns the quota rule). `twins[0]`
+    // is the session's primary twin — the default attribution for criteria and
+    // state that omit an explicit twin.
+    //
+    // Back-compat (the whole M3 contract): a single-twin `twins` array plus none
+    // of the new optional fields below is byte-identical to pre-M3 behavior, so
+    // (old CLI × new cloud) is unchanged. (new CLI × old cloud) with >1 twin is
+    // rejected by the cloud with 422 `multi_twin_unsupported`; a single-twin
+    // request degrades gracefully because every new field is optional and
+    // non-strict readers strip unknown keys rather than erroring.
     twins: z.array(z.string()).min(1).default(["github"]),
     task_source: z.string().optional(),        // base64-encoded UTF-8 markdown; 0.3.0 alias: scenario_source
     task_id: z.string().optional(),            // alternative: stored task; 0.3.0 alias: scenario_id
@@ -176,6 +189,21 @@ export type CreateSessionResponse = z.infer<typeof createSessionResponseSchema>;
 // blobs via presigned URLs and call /finalize with ADR-013's managed judge.
 // The shape below stays the wire contract either way.)
 //
+// Multi-twin (M3): per-twin state storage keys, keyed by twin id. Each entry
+// carries the storage KEYS (not URLs) the CLI uploaded that twin's initial /
+// final state blobs to. One entry per twin the session provisioned. Single-twin
+// sessions omit this and keep using the flat top-level state fields. Additive:
+// an older cloud that does not read this field strips it and scores the primary
+// twin unchanged.
+export const perTwinStateKeysSchema = z.record(
+  z.string(),
+  z.object({
+    state_initial_key: z.string().min(1).optional(),
+    state_final_key: z.string().min(1).optional(),
+  }),
+);
+export type PerTwinStateKeys = z.infer<typeof perTwinStateKeysSchema>;
+
 // W3 vocab (FDRS-653): `task_name` / `task_hash` canonical; the exported
 // schema accepts 0.3.0 CLIs' `scenario_name` / `scenario_hash` and criterion
 // kinds D/P inside `criteria_results`, normalizing both.
@@ -206,6 +234,11 @@ const submitResultRequestObjectSchema = z.object({
   trace_jsonl_b64: z.string(),
   state_initial_json_b64: z.string(),
   state_final_json_b64: z.string(),
+  // Multi-twin (M3): additive per-twin state storage keys. Absent on single-twin
+  // sessions, which keep uploading a single twin's state via the flat
+  // state_*_json_b64 blobs above. Unknown to an older cloud, which strips it and
+  // scores the primary twin unchanged (new CLI × old cloud degrades gracefully).
+  per_twin_state_keys: perTwinStateKeysSchema.optional(),
   // NOTE: agent_stdout is intentionally NOT in this request. Cloud never
   // receives the agent's prompts or completions. The CLI uses agent_stdout
   // locally for the [model] judge then discards it.
@@ -235,8 +268,65 @@ export const criterionDefSchema = z.object({
   id: z.string().min(1),
   text: z.string().min(1),
   kind: z.enum(["D", "P"]),
+  // Multi-twin (M3): the twin a [D:<twin>]/[P:<twin>] scenario criterion
+  // attributes to. Absent = the session's primary twin (twins[0]). Additive —
+  // single-twin scenarios omit it and score against the sole twin as before.
+  twin: z.string().min(1).optional(),
 });
 export type CriterionDef = z.infer<typeof criterionDefSchema>;
+
+// POST /v1/agents — register an agent (vercel-link shape). The server is
+// canonical for the slug; the CLI persists whatever id/slug it returns.
+export const createAgentRequestSchema = z.object({
+  name: z.string().min(1),
+  // Multi-twin (M3): the twins this agent is allowed to exercise. Absent = the
+  // server's default enablement. The cloud intersects a session's requested
+  // twins with the agent's enabled services. Additive; older clients omit it.
+  twins: z.array(z.string()).min(1).optional(),
+});
+export type CreateAgentRequest = z.infer<typeof createAgentRequestSchema>;
+
+// POST /v1/agents response. Not `.strict()`: the cloud may emit additive fields
+// that older/newer CLIs strip rather than reject (tolerant reader).
+export const agentResponseSchema = z.object({
+  id: z.string(),                              // agt_<nanoid>
+  slug: z.string(),
+  display_name: z.string(),
+  judge_model: z.string(),
+  // Multi-twin (M3): the services (twins) this agent may exercise. Absent on an
+  // older cloud; new CLIs treat absence as "unconstrained / server default".
+  enabled_services: z.array(z.string()).optional(),
+});
+export type AgentResponse = z.infer<typeof agentResponseSchema>;
+
+// POST /v1/sessions/:id/state-upload-url response — a presigned PUT URL + the
+// storage KEY (not a URL) for each of the initial and final state blobs. Mirrors
+// the sibling *-upload-url routes' `{ url, key }` entry, but returns the
+// initial/final pair in a single call.
+export const stateUploadUrlEntrySchema = z.object({
+  url: z.string().url(),
+  key: z.string().min(1),
+});
+export type StateUploadUrlEntry = z.infer<typeof stateUploadUrlEntrySchema>;
+
+export const stateUploadUrlResponseSchema = z.object({
+  state_initial: stateUploadUrlEntrySchema,
+  state_final: stateUploadUrlEntrySchema,
+  // Multi-twin (M3): one initial/final URL+key pair per twin, keyed by twin id,
+  // so each twin's state blobs land under its own storage prefix. Absent on
+  // single-twin sessions and on an older cloud, where the top-level pair is
+  // authoritative (new CLI × old cloud degrades gracefully).
+  per_twin: z
+    .record(
+      z.string(),
+      z.object({
+        state_initial: stateUploadUrlEntrySchema,
+        state_final: stateUploadUrlEntrySchema,
+      }),
+    )
+    .optional(),
+});
+export type StateUploadUrlResponse = z.infer<typeof stateUploadUrlResponseSchema>;
 
 // GET /v1/usage — live concurrent-session quota snapshot.
 // FDRS-613: `sessions_remaining` tightened to `.int().min(0)` to match the

--- a/packages/shared-types/src/run.ts
+++ b/packages/shared-types/src/run.ts
@@ -55,6 +55,10 @@ export const criterionSchema = z.object({
   // Accepts D | P | code | model; parsed output is always code | model.
   type: criterionKindInputSchema,
   text: z.string().min(1),
+  // Multi-twin (M3): the twin this criterion attributes to. Rides through the
+  // D/P→code/model transform above untouched. Absent = the run's primary twin
+  // (the session's twins[0]). Additive — single-twin runs omit it.
+  twin: z.string().min(1).optional(),
 });
 export type Criterion = z.infer<typeof criterionSchema>;
 

--- a/packages/shared-types/src/seed-envelope.ts
+++ b/packages/shared-types/src/seed-envelope.ts
@@ -20,6 +20,17 @@ import { z } from "zod";
 // its domain shape. The envelope keeps only the two invariants that are the
 // boundary's business: the envelope is a JSON object, and each value is a JSON
 // object.
+//
+// WHERE THE ENVELOPE-IFF-MULTI-TWIN RULE IS ENFORCED (not here): this schema and
+// createSessionRequestSchema.seed are deliberately shape-blind — the request
+// boundary accepts any JSON-object `seed` for both single- and multi-twin
+// sessions and forwards it verbatim. The correlation between the `seed` shape and
+// `twins.length` is validated at the EDGES, where the `twins` array is known:
+//   - the cloud validates envelope-iff-multi-twin at session create; and
+//   - the CLI validates it at scenario parse time
+// (both landing in follow-up PRs). Do NOT add that cross-field check to the
+// request schema — the twin owns its seed shape, and sniffing here would be the
+// ambiguous, brittle coupling THE RULE exists to avoid.
 export const seedEnvelopeSchema = z.record(
   z.string(),
   z.record(z.string(), z.unknown()),
@@ -30,6 +41,11 @@ export type SeedEnvelope = z.infer<typeof seedEnvelopeSchema>;
  * THE RULE, in code: a session's `seed` is a per-twin envelope iff the session
  * has more than one twin. Decide from the `twins` array alone — never by
  * sniffing the seed's shape.
+ *
+ * This is the shared PREDICATE, not the enforcement point. The actual
+ * envelope-iff-multi-twin check runs at the edges that know `twins`: the cloud
+ * at session create and the CLI at scenario parse time (follow-up PRs). The
+ * create-session request schema stays a shape-blind pass-through by design.
  */
 export function isMultiTwinSeedEnvelope(twins: string[]): boolean {
   return twins.length > 1;

--- a/packages/shared-types/src/seed-envelope.ts
+++ b/packages/shared-types/src/seed-envelope.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// shared-types §3 — multi-twin seed envelope. Re-exported through the
+// `@pome-sh/shared-types` barrel (index.ts).
+//
+// THE RULE (no shape-sniffing anywhere): the create-session `seed` override is a
+// per-twin envelope `{ <twin>: <flat seed> }` IF AND ONLY IF the session has
+// more than one twin. Single-twin sessions ALWAYS use the flat single-twin seed
+// shape (the domain seed object the twin's own `parseSeed` owns — see
+// createSessionRequestSchema.seed). Callers decide which shape to send from the
+// session's `twins` array alone (`isMultiTwinSeedEnvelope`), never by inspecting
+// the seed's contents. This keeps the boundary shape-blind: a flat seed and an
+// envelope are both JSON objects, so sniffing would be ambiguous and brittle.
+
+import { z } from "zod";
+
+// Multi-twin (M3) seed envelope: twin id → that twin's flat domain seed. Like
+// createSessionRequestSchema.seed, each per-twin seed is a permissive,
+// shape-blind JSON object — the twin pod's `parseSeed` is the sole authority on
+// its domain shape. The envelope keeps only the two invariants that are the
+// boundary's business: the envelope is a JSON object, and each value is a JSON
+// object.
+export const seedEnvelopeSchema = z.record(
+  z.string(),
+  z.record(z.string(), z.unknown()),
+);
+export type SeedEnvelope = z.infer<typeof seedEnvelopeSchema>;
+
+/**
+ * THE RULE, in code: a session's `seed` is a per-twin envelope iff the session
+ * has more than one twin. Decide from the `twins` array alone — never by
+ * sniffing the seed's shape.
+ */
+export function isMultiTwinSeedEnvelope(twins: string[]): boolean {
+  return twins.length > 1;
+}

--- a/packages/shared-types/test/export-surface.test.ts
+++ b/packages/shared-types/test/export-surface.test.ts
@@ -42,6 +42,7 @@ import type {
   FinalizeFailureError,
   FinalizeInitialResponse,
   FinalizeQueuedStatusResponse,
+  FinalizeRequest,
   FinalizeResponse,
   FinalizeRunningStatusResponse,
   FinalizeStatusResponse,
@@ -100,6 +101,7 @@ type _TypeSurfaceAssert = [
   FinalizeFailureError,
   FinalizeInitialResponse,
   FinalizeQueuedStatusResponse,
+  FinalizeRequest,
   FinalizeResponse,
   FinalizeRunningStatusResponse,
   FinalizeStatusResponse,
@@ -136,7 +138,7 @@ type _TypeSurfaceAssert = [
 // Compile-time anchor: exactly one tuple entry per guarded type. The literal
 // type on the left fails to compile if an entry is added or removed above
 // without updating the count.
-const TYPE_SURFACE_SIZE: _TypeSurfaceAssert["length"] = 53;
+const TYPE_SURFACE_SIZE: _TypeSurfaceAssert["length"] = 54;
 
 // Runtime value exports (types are erased and cannot appear on `Object.keys`).
 const EXPECTED_EXPORTS = [
@@ -205,6 +207,7 @@ const EXPECTED_EXPORTS = [
   "finalizeFailureErrorSchema",
   "finalizeInitialResponseSchema",
   "finalizeQueuedStatusResponseSchema",
+  "finalizeRequestSchema",
   "finalizeResponseSchema",
   "finalizeRunningStatusResponseSchema",
   "finalizeStatusResponseSchema",
@@ -288,10 +291,10 @@ describe("@pome-sh/shared-types barrel export surface (F-754)", () => {
     expect(Object.keys(api).sort()).toEqual([...EXPECTED_EXPORTS]);
   });
 
-  it("guards the TYPE surface (53 types/interfaces)", () => {
+  it("guards the TYPE surface (54 types/interfaces)", () => {
     // The real guard is the type-only import + _TypeSurfaceAssert tuple above,
     // enforced at typecheck time. This assertion just anchors the count at
     // runtime so the guard's scope is visible in test output.
-    expect(TYPE_SURFACE_SIZE).toBe(53);
+    expect(TYPE_SURFACE_SIZE).toBe(54);
   });
 });

--- a/packages/shared-types/test/export-surface.test.ts
+++ b/packages/shared-types/test/export-surface.test.ts
@@ -23,10 +23,12 @@ import * as api from "../src/index.js";
 import type {
   AcceptInviteRequest,
   AcceptInviteResponse,
+  AgentResponse,
   ApiError,
   ApiErrorType,
   ApiKey,
   ApiKeyCreated,
+  CreateAgentRequest,
   CreateEvalSessionResponse,
   CreateInviteRequest,
   CreateInviteResponse,
@@ -46,16 +48,20 @@ import type {
   FinalizeStatusUrl,
   GithubSeedState,
   MeResponse,
+  PerTwinStateKeys,
   PersistedScenario,
   PersistedTask,
   PlanTier,
   Scenario,
   ScenarioConfig,
+  SeedEnvelope,
   SeedState,
   Session,
   SessionPublic,
   SessionState,
   SlackSeedState,
+  StateUploadUrlEntry,
+  StateUploadUrlResponse,
   StripeSeedState,
   SubmitResultRequest,
   SubmitResultResponse,
@@ -75,10 +81,12 @@ import type {
 type _TypeSurfaceAssert = [
   AcceptInviteRequest,
   AcceptInviteResponse,
+  AgentResponse,
   ApiError,
   ApiErrorType,
   ApiKey,
   ApiKeyCreated,
+  CreateAgentRequest,
   CreateEvalSessionResponse,
   CreateInviteRequest,
   CreateInviteResponse,
@@ -98,16 +106,20 @@ type _TypeSurfaceAssert = [
   FinalizeStatusUrl,
   GithubSeedState,
   MeResponse,
+  PerTwinStateKeys,
   PersistedScenario,
   PersistedTask,
   PlanTier,
   Scenario,
   ScenarioConfig,
+  SeedEnvelope,
   SeedState,
   Session,
   SessionPublic,
   SessionState,
   SlackSeedState,
+  StateUploadUrlEntry,
+  StateUploadUrlResponse,
   StripeSeedState,
   SubmitResultRequest,
   SubmitResultResponse,
@@ -124,7 +136,7 @@ type _TypeSurfaceAssert = [
 // Compile-time anchor: exactly one tuple entry per guarded type. The literal
 // type on the left fails to compile if an entry is added or removed above
 // without updating the count.
-const TYPE_SURFACE_SIZE: _TypeSurfaceAssert["length"] = 47;
+const TYPE_SURFACE_SIZE: _TypeSurfaceAssert["length"] = 53;
 
 // Runtime value exports (types are erased and cannot appear on `Object.keys`).
 const EXPECTED_EXPORTS = [
@@ -166,6 +178,7 @@ const EXPECTED_EXPORTS = [
   "URL_PATH",
   "acceptInviteRequestSchema",
   "acceptInviteResponseSchema",
+  "agentResponseSchema",
   "apiErrorSchema",
   "apiErrorTypeSchema",
   "apiKeyCreatedSchema",
@@ -174,6 +187,7 @@ const EXPECTED_EXPORTS = [
   "canonicalTraceIdSchema",
   "compareUint64",
   "correlatorKindSchema",
+  "createAgentRequestSchema",
   "createEvalSessionResponseSchema",
   "createInviteRequestSchema",
   "createInviteResponseSchema",
@@ -205,6 +219,7 @@ const EXPECTED_EXPORTS = [
   "groupGitHubAccessControlByCategory",
   "hookEventSchema",
   "isLegacyEventRow",
+  "isMultiTwinSeedEnvelope",
   "isUint64",
   "judgeModelSchema",
   "laneSchema",
@@ -220,6 +235,7 @@ const EXPECTED_EXPORTS = [
   "otelSpanInputSchema",
   "otelSpanKindSchema",
   "otelStatusCodeSchema",
+  "perTwinStateKeysSchema",
   "persistedScenarioSchema",
   "persistedTaskSchema",
   "planTierSchema",
@@ -233,6 +249,7 @@ const EXPECTED_EXPORTS = [
   "runSchema",
   "scenarioConfigSchema",
   "scenarioSchema",
+  "seedEnvelopeSchema",
   "seedStateSchema",
   "sessionPublicSchema",
   "sessionSchema",
@@ -241,6 +258,8 @@ const EXPECTED_EXPORTS = [
   "shimmableLegacyEventSchema",
   "slackSeedStateSchema",
   "stateDeltaSchema",
+  "stateUploadUrlEntrySchema",
+  "stateUploadUrlResponseSchema",
   "stepSchema",
   "stripeSeedStateSchema",
   "subagentSpawnEventSchema",
@@ -269,10 +288,10 @@ describe("@pome-sh/shared-types barrel export surface (F-754)", () => {
     expect(Object.keys(api).sort()).toEqual([...EXPECTED_EXPORTS]);
   });
 
-  it("guards the pre-refactor TYPE surface (47 inline types/interfaces)", () => {
+  it("guards the TYPE surface (53 types/interfaces)", () => {
     // The real guard is the type-only import + _TypeSurfaceAssert tuple above,
     // enforced at typecheck time. This assertion just anchors the count at
     // runtime so the guard's scope is visible in test output.
-    expect(TYPE_SURFACE_SIZE).toBe(47);
+    expect(TYPE_SURFACE_SIZE).toBe(53);
   });
 });

--- a/packages/shared-types/test/multi-twin-contract.test.ts
+++ b/packages/shared-types/test/multi-twin-contract.test.ts
@@ -64,6 +64,20 @@ describe("perTwinStateKeysSchema", () => {
   it("accepts an empty map", () => {
     expect(perTwinStateKeysSchema.parse({})).toEqual({});
   });
+
+  it("accepts a final-only twin entry (initial state is optional)", () => {
+    const value = { stripe: { state_final_key: "k/st/final" } };
+    expect(perTwinStateKeysSchema.parse(value)).toEqual(value);
+  });
+
+  it("accepts an initial-only twin entry", () => {
+    const value = { github: { state_initial_key: "k/gh/init" } };
+    expect(perTwinStateKeysSchema.parse(value)).toEqual(value);
+  });
+
+  it("rejects an empty twin entry with neither key", () => {
+    expect(perTwinStateKeysSchema.safeParse({ github: {} }).success).toBe(false);
+  });
 });
 
 describe("seedEnvelopeSchema + isMultiTwinSeedEnvelope — THE RULE", () => {

--- a/packages/shared-types/test/multi-twin-contract.test.ts
+++ b/packages/shared-types/test/multi-twin-contract.test.ts
@@ -12,11 +12,11 @@ import {
   createAgentRequestSchema,
   createSessionResponseSchema,
   criterionDefSchema,
+  finalizeRequestSchema,
   isMultiTwinSeedEnvelope,
   perTwinStateKeysSchema,
   seedEnvelopeSchema,
   stateUploadUrlResponseSchema,
-  submitResultRequestSchema,
 } from "../src/index.js";
 
 describe("criterionSchema.twin (run.ts) — rides the D/P→code/model transform", () => {
@@ -95,6 +95,10 @@ describe("createAgentRequestSchema", () => {
   it("parses a name-only request unchanged (older clients)", () => {
     expect(createAgentRequestSchema.parse({ name: "viktor" })).toEqual({ name: "viktor" });
   });
+
+  it("rejects an empty twins allowlist (min(1))", () => {
+    expect(createAgentRequestSchema.safeParse({ name: "viktor", twins: [] }).success).toBe(false);
+  });
 });
 
 describe("agentResponseSchema", () => {
@@ -143,36 +147,36 @@ describe("stateUploadUrlResponseSchema", () => {
   });
 });
 
-describe("submitResultRequestSchema.per_twin_state_keys (rest.ts)", () => {
+describe("finalizeRequestSchema.per_twin_state_keys (finalize-shapes.ts) — LIVE scoring wire", () => {
   const base = {
-    task_name: "viktor/mvp",
-    task_hash: "abc123",
+    stop_reason: "completed",
+    exit_code: 0,
     duration_ms: 1200,
     agent_model: "sonnet",
-    satisfaction_score: 90,
-    criteria_results: [],
-    judge_model: "google/gemini-2.5-flash",
-    judge_tokens_in: 10,
-    judge_tokens_out: 20,
-    trace_jsonl_b64: "",
-    state_initial_json_b64: "",
-    state_final_json_b64: "",
+    agent_sdk: null,
+    criteria: [{ id: "c1", text: "PR merged", kind: "D" as const, twin: "github" }],
+    scenario_name: "viktor/mvp",
+    scenario_hash: "abc123",
+    scenario_prompt: "ship the MVP",
+    expected_behavior: "opens and merges a PR",
   };
 
   it("parses without per_twin_state_keys (single-twin / older CLI)", () => {
-    const parsed = submitResultRequestSchema.parse(base);
+    const parsed = finalizeRequestSchema.parse(base);
     expect(parsed.per_twin_state_keys).toBeUndefined();
   });
 
   it("parses with an additive per_twin_state_keys map (multi-twin / new CLI)", () => {
-    const parsed = submitResultRequestSchema.parse({
+    const parsed = finalizeRequestSchema.parse({
       ...base,
+      state_initial_storage_key: "k/init",
+      state_final_storage_key: "k/final",
       per_twin_state_keys: {
         github: { state_initial_key: "k/gh/init", state_final_key: "k/gh/final" },
         stripe: { state_final_key: "k/st/final" },
       },
     });
-    expect(parsed.task_name).toBe("viktor/mvp");
+    expect(parsed.scenario_name).toBe("viktor/mvp");
     expect(parsed.per_twin_state_keys).toEqual({
       github: { state_initial_key: "k/gh/init", state_final_key: "k/gh/final" },
       stripe: { state_final_key: "k/st/final" },

--- a/packages/shared-types/test/multi-twin-contract.test.ts
+++ b/packages/shared-types/test/multi-twin-contract.test.ts
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// M3 multi-twin wire contract — additive, zero-breaking schema changes across
+// rest.ts / run.ts / seed-envelope.ts. Every field added here is optional, so
+// the assertions below double as back-compat proof: the same payloads parse
+// with and without the new keys.
+
+import { describe, expect, it } from "vitest";
+import { criterionSchema } from "../src/run.js";
+import {
+  agentResponseSchema,
+  createAgentRequestSchema,
+  createSessionResponseSchema,
+  criterionDefSchema,
+  isMultiTwinSeedEnvelope,
+  perTwinStateKeysSchema,
+  seedEnvelopeSchema,
+  stateUploadUrlResponseSchema,
+  submitResultRequestSchema,
+} from "../src/index.js";
+
+describe("criterionSchema.twin (run.ts) — rides the D/P→code/model transform", () => {
+  it("parses code/model criteria with an explicit twin", () => {
+    expect(criterionSchema.parse({ type: "code", text: "refund exists", twin: "stripe" }))
+      .toEqual({ type: "code", text: "refund exists", twin: "stripe" });
+    expect(criterionSchema.parse({ type: "model", text: "polite reply", twin: "slack" }))
+      .toEqual({ type: "model", text: "polite reply", twin: "slack" });
+  });
+
+  it("normalizes 0.3.0 D/P spellings while carrying twin through untouched", () => {
+    expect(criterionSchema.parse({ type: "D", text: "PR merged", twin: "github" }))
+      .toEqual({ type: "code", text: "PR merged", twin: "github" });
+    expect(criterionSchema.parse({ type: "P", text: "summary reads well", twin: "github" }))
+      .toEqual({ type: "model", text: "summary reads well", twin: "github" });
+  });
+
+  it("still parses without twin (single-twin default = primary twin)", () => {
+    expect(criterionSchema.parse({ type: "D", text: "x" }))
+      .toEqual({ type: "code", text: "x" });
+  });
+});
+
+describe("criterionDefSchema.twin (rest.ts)", () => {
+  it("accepts an optional twin on a scenario criterion def", () => {
+    expect(criterionDefSchema.parse({ id: "c1", text: "t", kind: "D", twin: "stripe" }))
+      .toEqual({ id: "c1", text: "t", kind: "D", twin: "stripe" });
+  });
+
+  it("parses without twin unchanged", () => {
+    expect(criterionDefSchema.parse({ id: "c1", text: "t", kind: "P" }))
+      .toEqual({ id: "c1", text: "t", kind: "P" });
+  });
+});
+
+describe("perTwinStateKeysSchema", () => {
+  it("parses a per-twin map of optional initial/final storage keys", () => {
+    const value = {
+      github: { state_initial_key: "k/gh/init", state_final_key: "k/gh/final" },
+      stripe: { state_final_key: "k/st/final" },
+    };
+    expect(perTwinStateKeysSchema.parse(value)).toEqual(value);
+  });
+
+  it("accepts an empty map", () => {
+    expect(perTwinStateKeysSchema.parse({})).toEqual({});
+  });
+});
+
+describe("seedEnvelopeSchema + isMultiTwinSeedEnvelope — THE RULE", () => {
+  it("parses a per-twin envelope of flat, shape-blind seeds", () => {
+    const envelope = {
+      github: { repositories: [{ owner: "acme", name: "server" }] },
+      stripe: { customers: [{ id: "cus_1" }], unknown_future: { a: 1 } },
+    };
+    expect(seedEnvelopeSchema.parse(envelope)).toEqual(envelope);
+  });
+
+  it("rejects a non-object per-twin value", () => {
+    expect(seedEnvelopeSchema.safeParse({ github: [1, 2, 3] }).success).toBe(false);
+  });
+
+  it("decides envelope-vs-flat from twins.length alone (no shape-sniffing)", () => {
+    expect(isMultiTwinSeedEnvelope(["github"])).toBe(false);
+    expect(isMultiTwinSeedEnvelope(["github", "stripe"])).toBe(true);
+    expect(isMultiTwinSeedEnvelope(["github", "stripe", "slack"])).toBe(true);
+  });
+});
+
+describe("createAgentRequestSchema", () => {
+  it("accepts a name plus an optional twins allowlist", () => {
+    expect(createAgentRequestSchema.parse({ name: "viktor", twins: ["github", "stripe"] }))
+      .toEqual({ name: "viktor", twins: ["github", "stripe"] });
+  });
+
+  it("parses a name-only request unchanged (older clients)", () => {
+    expect(createAgentRequestSchema.parse({ name: "viktor" })).toEqual({ name: "viktor" });
+  });
+});
+
+describe("agentResponseSchema", () => {
+  it("carries an optional enabled_services list and strips unknown keys", () => {
+    const parsed = agentResponseSchema.parse({
+      id: "agt_1",
+      slug: "viktor",
+      display_name: "Viktor",
+      judge_model: "google/gemini-2.5-flash",
+      enabled_services: ["github", "stripe"],
+      unknown_future: true,
+    });
+    expect(parsed).toEqual({
+      id: "agt_1",
+      slug: "viktor",
+      display_name: "Viktor",
+      judge_model: "google/gemini-2.5-flash",
+      enabled_services: ["github", "stripe"],
+    });
+  });
+
+  it("parses without enabled_services (older cloud)", () => {
+    const parsed = agentResponseSchema.parse({
+      id: "agt_1",
+      slug: "viktor",
+      display_name: "Viktor",
+      judge_model: "m",
+    });
+    expect(parsed.enabled_services).toBeUndefined();
+  });
+});
+
+describe("stateUploadUrlResponseSchema", () => {
+  const pair = {
+    state_initial: { url: "https://s3.example.com/put/init", key: "k/init" },
+    state_final: { url: "https://s3.example.com/put/final", key: "k/final" },
+  };
+
+  it("parses the flat single-twin pair (legacy / older cloud)", () => {
+    expect(stateUploadUrlResponseSchema.parse(pair)).toEqual(pair);
+  });
+
+  it("parses an additive per_twin map of pairs", () => {
+    const value = { ...pair, per_twin: { github: pair, stripe: pair } };
+    expect(stateUploadUrlResponseSchema.parse(value)).toEqual(value);
+  });
+});
+
+describe("submitResultRequestSchema.per_twin_state_keys (rest.ts)", () => {
+  const base = {
+    task_name: "viktor/mvp",
+    task_hash: "abc123",
+    duration_ms: 1200,
+    agent_model: "sonnet",
+    satisfaction_score: 90,
+    criteria_results: [],
+    judge_model: "google/gemini-2.5-flash",
+    judge_tokens_in: 10,
+    judge_tokens_out: 20,
+    trace_jsonl_b64: "",
+    state_initial_json_b64: "",
+    state_final_json_b64: "",
+  };
+
+  it("parses without per_twin_state_keys (single-twin / older CLI)", () => {
+    const parsed = submitResultRequestSchema.parse(base);
+    expect(parsed.per_twin_state_keys).toBeUndefined();
+  });
+
+  it("parses with an additive per_twin_state_keys map (multi-twin / new CLI)", () => {
+    const parsed = submitResultRequestSchema.parse({
+      ...base,
+      per_twin_state_keys: {
+        github: { state_initial_key: "k/gh/init", state_final_key: "k/gh/final" },
+        stripe: { state_final_key: "k/st/final" },
+      },
+    });
+    expect(parsed.task_name).toBe("viktor/mvp");
+    expect(parsed.per_twin_state_keys).toEqual({
+      github: { state_initial_key: "k/gh/init", state_final_key: "k/gh/final" },
+      stripe: { state_final_key: "k/st/final" },
+    });
+  });
+});
+
+describe("createSessionResponseSchema — legacy (no per_twin) still normalizes", () => {
+  it("synthesizes per_twin + session_token from single-twin fields", () => {
+    const parsed = createSessionResponseSchema.parse({
+      session_id: "ses_1",
+      twin_url: "https://api.pome.sh/github/ses_1",
+      openapi_url: "https://api.pome.sh/github/ses_1/openapi.json",
+      agent_token: "edt_tok",
+      expires_at: "2026-07-13T12:00:00.000Z",
+    });
+    expect(parsed.session_token).toBe("ses_1");
+    expect(parsed.per_twin.github).toEqual({
+      api_url: "https://api.pome.sh/github/ses_1",
+      mcp_url: "https://mcp.pome.sh/github/ses_1",
+      openapi_url: "https://api.pome.sh/github/ses_1/openapi.json",
+    });
+    expect(parsed.provider_credentials).toEqual({});
+  });
+});

--- a/packages/shared-types/trace-contract.json
+++ b/packages/shared-types/trace-contract.json
@@ -1,6 +1,6 @@
 {
   "package": "@pome-sh/shared-types",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "zod": {
     "range": "^4.1.13",
     "major": 4


### PR DESCRIPTION
## What

Additive, zero-breaking Zod schema changes to `@pome-sh/shared-types` that let the wire contract express a single session spanning multiple twins. This PR is the contract only; cloud provisioning and CLI wiring land in follow-up PRs.

## What the contract now expresses

- **Per-twin criteria** — `criterionSchema.twin` (run.ts) and `criterionDefSchema.twin` (rest.ts). A `[D:<twin>]`/`[P:<twin>]` criterion attributes to that twin; absent = the session's primary twin (`twins[0]`). Rides the existing D/P→code/model transform untouched.
- **Per-twin state** — `perTwinStateKeysSchema` + optional `per_twin_state_keys` on the finalize request (`finalizeRequestSchema`, the LIVE scoring wire); `stateUploadUrlResponseSchema` gains an optional per-twin URL+key map.
- **Agents API** — `createAgentRequestSchema` (optional `twins`) and `agentResponseSchema` (optional `enabled_services`) for `POST /v1/agents`.
- **Multi-twin sessions** — `createSessionRequestSchema.twins` doc now states multi-twin arrays are honored, max 3 twins per session (cap enforced cloud-side), one isolated sandbox per twin.

## The iff-envelope rule

`seedEnvelopeSchema` + `isMultiTwinSeedEnvelope(twins)`: the create-session `seed` is a per-twin envelope `{ <twin>: <flat seed> }` **if and only if** the session has more than one twin. Single-twin sessions always use the flat seed shape. Callers decide from the `twins` array alone — no shape-sniffing anywhere.

## Back-compat guarantees

Every new field is optional. Old CLI x new cloud is byte-identical single-twin behavior (no new fields sent). New CLI x old cloud: a multi-twin create is rejected `422 multi_twin_unsupported`, and unknown fields are stripped by non-strict readers so single-twin requests degrade gracefully.

## Housekeeping

Minor bump to `0.7.0`; export-surface guard, CHANGELOG, and `trace-contract.json` updated. shared-types tests, typecheck, and build are green.

Cloud and CLI implementations land in follow-up PRs.
