### PR TITLE
feat(cli): native multi-twin scenarios

### DIFF
--- a/cli/.changeset/multi-twin-scenarios.md
+++ b/cli/.changeset/multi-twin-scenarios.md
@@ -1,0 +1,25 @@
+---
+"@pome-sh/cli": minor
+---
+
+Native multi-twin scenario support. Scenarios can now exercise more than one twin
+in a single session:
+
+- `## Success Criteria` markers accept an optional twin tag — `[D:<twin>]` /
+  `[P:<twin>]` — that attributes each criterion to a specific twin. In a
+  multi-twin scenario every `[D]` must carry a tag; single-twin scenarios are
+  unchanged (a bare marker attributes to the sole twin).
+- `## Seed State` for a multi-twin scenario is a per-twin envelope
+  `{ <twin>: <seed> }`; a twin with no envelope key gets its default seed.
+  Single-twin seeds stay flat and byte-identical.
+- Hosted runs fan the twin environment out per twin —
+  `POME_<TWIN>_REST_URL` / `POME_<TWIN>_MCP_URL` for each twin — capture and
+  upload each twin's state, and finalize with per-criterion twin attribution.
+- `pome session create` accepts repeated `--twin` flags for an ad-hoc
+  multi-twin session and can now target the Slack twin.
+- `pome register agent --twins github,slack` records the agent's enabled
+  services and prints them back.
+
+New CLI × older cloud degrades gracefully: an old control plane that rejects a
+multi-twin session is reported with a clear hint, and single-twin behavior is
+unchanged end to end.

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pome-sh/cli",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "bundleDependencies": [
         "@pome-sh/sdk",
         "@pome-sh/shared-types",
@@ -24,7 +24,7 @@
         "@hono/node-server": "^2.0.6",
         "@openrouter/ai-sdk-provider": "^3.0.0",
         "@pome-sh/sdk": "0.3.1",
-        "@pome-sh/shared-types": "0.6.0",
+        "@pome-sh/shared-types": "0.7.0",
         "@pome-sh/twin-github": "0.1.2",
         "@pome-sh/twin-slack": "0.1.2",
         "@pome-sh/twin-stripe": "0.2.2",
@@ -1131,10 +1131,19 @@
         }
       }
     },
-    "node_modules/@pome-sh/shared-types": {
+    "node_modules/@pome-sh/sdk/node_modules/@pome-sh/shared-types": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.6.0.tgz",
       "integrity": "sha512-UfJF/pY+kot7zQsQWVo1imWi1j0TgyGqmg8oy50uezwcl8YcFvI7omPbbcv1XlXBC4Na+MR4bRdxkUiYccysIw==",
+      "inBundle": true,
+      "peerDependencies": {
+        "zod": "^4.1.13"
+      }
+    },
+    "node_modules/@pome-sh/shared-types": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.7.0.tgz",
+      "integrity": "sha512-Dw9OtxyhTcFVTkg+dLjNH/ynW1mJ+JswStRHwTAbwl1KyFlk/en8uz6KqzxINdP9JiIjQI7diZxqJsweKWCf3Q==",
       "inBundle": true,
       "peerDependencies": {
         "zod": "^4.1.13"
@@ -1160,6 +1169,15 @@
         "node": ">=24"
       }
     },
+    "node_modules/@pome-sh/twin-github/node_modules/@pome-sh/shared-types": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.6.0.tgz",
+      "integrity": "sha512-UfJF/pY+kot7zQsQWVo1imWi1j0TgyGqmg8oy50uezwcl8YcFvI7omPbbcv1XlXBC4Na+MR4bRdxkUiYccysIw==",
+      "inBundle": true,
+      "peerDependencies": {
+        "zod": "^4.1.13"
+      }
+    },
     "node_modules/@pome-sh/twin-slack": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@pome-sh/twin-slack/-/twin-slack-0.1.2.tgz",
@@ -1180,6 +1198,15 @@
         "node": ">=24"
       }
     },
+    "node_modules/@pome-sh/twin-slack/node_modules/@pome-sh/shared-types": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.6.0.tgz",
+      "integrity": "sha512-UfJF/pY+kot7zQsQWVo1imWi1j0TgyGqmg8oy50uezwcl8YcFvI7omPbbcv1XlXBC4Na+MR4bRdxkUiYccysIw==",
+      "inBundle": true,
+      "peerDependencies": {
+        "zod": "^4.1.13"
+      }
+    },
     "node_modules/@pome-sh/twin-stripe": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@pome-sh/twin-stripe/-/twin-stripe-0.2.2.tgz",
@@ -1198,6 +1225,15 @@
       },
       "engines": {
         "node": ">=24"
+      }
+    },
+    "node_modules/@pome-sh/twin-stripe/node_modules/@pome-sh/shared-types": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.6.0.tgz",
+      "integrity": "sha512-UfJF/pY+kot7zQsQWVo1imWi1j0TgyGqmg8oy50uezwcl8YcFvI7omPbbcv1XlXBC4Na+MR4bRdxkUiYccysIw==",
+      "inBundle": true,
+      "peerDependencies": {
+        "zod": "^4.1.13"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -67,7 +67,7 @@
     "@hono/node-server": "^2.0.6",
     "@openrouter/ai-sdk-provider": "^3.0.0",
     "@pome-sh/sdk": "0.3.1",
-    "@pome-sh/shared-types": "0.6.0",
+    "@pome-sh/shared-types": "0.7.0",
     "@pome-sh/twin-github": "0.1.2",
     "@pome-sh/twin-slack": "0.1.2",
     "@pome-sh/twin-stripe": "0.2.2",

--- a/cli/src/cli/eval.ts
+++ b/cli/src/cli/eval.ts
@@ -41,11 +41,13 @@ import {
 import { readLatestRun, toTwinHttpEvent } from "../recorder/artifacts.js";
 import { redactEvent, redactSecrets } from "../recorder/redaction.js";
 import {
+  criterionMarkerLabel,
   markerFor,
   outcomeOf,
   runScoreLine,
   scoreCountsSummary,
   scoreStatus,
+  twinSkipSuffix,
   type Score,
 } from "../hosted/evalResultView.js";
 import { resolveCredentials } from "./credentials.js";
@@ -614,7 +616,7 @@ export async function runEvalCommand(
       console.error(`  criteria: ${scoreCountsSummary(result.score)}`);
       for (const criterionResult of result.score.results) {
         console.error(
-          `  ${markerFor(outcomeOf(criterionResult))} [${criterionResult.criterion.type}] ${criterionResult.criterion.text}`,
+          `  ${markerFor(outcomeOf(criterionResult))} ${criterionMarkerLabel(criterionResult.criterion)} ${criterionResult.criterion.text}${twinSkipSuffix(criterionResult)}`,
         );
       }
     }

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -46,7 +46,7 @@ import {
   runSessionStop,
   type SessionListStateFilter,
 } from "./session.js";
-import { runRegisterAgent } from "./register.js";
+import { normalizeRegisterTwins, runRegisterAgent } from "./register.js";
 import { resolvePackageRoot } from "./resolve-package-root.js";
 import {
   ClaudeManagedDeferredError,
@@ -411,21 +411,28 @@ export function createProgram() {
       "Overwrite an existing agentId in pome.config.json",
       false,
     )
+    .option(
+      "--twins <list>",
+      "Comma-separated services this agent may exercise (e.g. github,slack). Default: the cloud's default enablement.",
+    )
     .description(
       "Create a cloud agent under the current team and write agentId to pome.config.json",
     )
-    .action(async (name: string, opts: { apiUrl: string; force: boolean }) => {
-      try {
-        await runRegisterAgent({
-          apiBaseUrl: opts.apiUrl,
-          name,
-          force: opts.force,
-        });
-      } catch (err) {
-        console.error(friendlyHostedError(err));
-        process.exitCode = 2;
-      }
-    });
+    .action(
+      async (name: string, opts: { apiUrl: string; force: boolean; twins?: string }) => {
+        try {
+          await runRegisterAgent({
+            apiBaseUrl: opts.apiUrl,
+            name,
+            force: opts.force,
+            twins: normalizeRegisterTwins(opts.twins),
+          });
+        } catch (err) {
+          console.error(friendlyHostedError(err));
+          process.exitCode = 2;
+        }
+      },
+    );
 
   const session = program
     .command("session")
@@ -435,8 +442,12 @@ export function createProgram() {
 
   session
     .command("create")
-    .description("Create a hosted sandbox session for a twin and print its connection info")
-    .requiredOption("--twin <name>", "github | stripe")
+    .description("Create a hosted sandbox session for one or more twins and print its connection info")
+    .requiredOption(
+      "--twin <name>",
+      "github | stripe | slack. Repeat the flag for a multi-twin session (e.g. --twin github --twin slack).",
+      (value: string, previous: string[] = []) => [...previous, value],
+    )
     .option(
       "--api-url <url>",
       "Control-plane URL",
@@ -454,7 +465,7 @@ export function createProgram() {
     )
     .action(
       async (opts: {
-        twin: string;
+        twin: string[];
         apiUrl: string;
         showSecrets: boolean;
         secretsFile?: string;
@@ -469,7 +480,7 @@ export function createProgram() {
           }
           await runSessionCreate({
             apiBaseUrl: opts.apiUrl,
-            twin: opts.twin,
+            twins: opts.twin,
             showSecrets: opts.showSecrets,
             format: format as "text" | "json" | "env",
             secretsFile: opts.secretsFile,

--- a/cli/src/cli/register.ts
+++ b/cli/src/cli/register.ts
@@ -189,7 +189,11 @@ export async function runRegisterAgent(
     console.error(
       `Enabled services: ${agent.enabled_services.length > 0 ? agent.enabled_services.join(", ") : "(none)"}.`,
     );
-  } else {
+  } else if (opts.twins && opts.twins.length > 0) {
+    // Only warn when the user asked to scope twins (`--twins`). An older cloud
+    // that predates `enabled_services` omits it; without `--twins` there was no
+    // scoping request to warn about, so a default `pome register agent` stays
+    // quiet (matches origin/main's silence in that path).
     console.error(
       "Enabled services: not reported by this pome cloud (older control plane) — twin scoping may not have taken effect.",
     );

--- a/cli/src/cli/register.ts
+++ b/cli/src/cli/register.ts
@@ -5,15 +5,18 @@
 // `pome.config.json` so subsequent `pome run` is auto-scoped to it.
 //
 // Wire shape (see pome-cloud `docs/05-api-spec.md` and ADR-013):
-//   POST /v1/agents  { name }
-//     200 { id: "agt_…", slug, display_name, judge_model }
+//   POST /v1/agents  { name, twins? }
+//     200 { id: "agt_…", slug, display_name, judge_model, enabled_services? }
 //     401 invalid_auth | 409 conflict (slug exists) | 422 validation_failed
 //
 // The CLI does not invent a slug — server is canonical. We persist whatever
-// slug the server returns next to the id.
+// slug the server returns next to the id. Multi-twin (M3): `--twins` narrows
+// the services this agent may exercise; an older cloud that predates the field
+// omits `enabled_services` from its response (we warn but still succeed).
 
 import { basename, dirname } from "node:path";
 
+import { MOUNTED_TWINS } from "@pome-sh/shared-types";
 import {
   HostedAuthError,
   HostedOrchError,
@@ -33,6 +36,10 @@ interface RegisterAgentOptions {
   apiBaseUrl: string;
   name: string;
   force: boolean;
+  /** Multi-twin (M3): the services this agent is allowed to exercise. Absent =
+   *  the server's default enablement. Validated against MOUNTED_TWINS locally
+   *  for a friendly error before the round-trip. */
+  twins?: string[];
 }
 
 interface AgentResponse {
@@ -40,6 +47,9 @@ interface AgentResponse {
   slug: string;
   display_name: string;
   judge_model: string;
+  /** Multi-twin (M3): services the agent may exercise. Absent on an older
+   *  cloud that predates the field. */
+  enabled_services?: string[];
 }
 
 function parseAgentResponse(raw: unknown): AgentResponse {
@@ -51,9 +61,36 @@ function parseAgentResponse(raw: unknown): AgentResponse {
     typeof (raw as { display_name?: unknown }).display_name === "string" &&
     typeof (raw as { judge_model?: unknown }).judge_model === "string"
   ) {
-    return raw as AgentResponse;
+    const enabled = (raw as { enabled_services?: unknown }).enabled_services;
+    const enabledServices =
+      Array.isArray(enabled) && enabled.every((s) => typeof s === "string")
+        ? (enabled as string[])
+        : undefined;
+    return { ...(raw as AgentResponse), enabled_services: enabledServices };
   }
   throw new HostedOrchError("POST /v1/agents returned unexpected shape");
+}
+
+/** Normalize a `--twins github,slack` comma list to a validated twin array.
+ *  Validates against MOUNTED_TWINS locally so a typo fails with a friendly
+ *  error before the network round-trip. Returns undefined for an empty input
+ *  (the server picks its default enablement). */
+export function normalizeRegisterTwins(raw: string | undefined): string[] | undefined {
+  if (raw === undefined) return undefined;
+  const twins = raw
+    .split(",")
+    .map((t) => t.trim().toLowerCase())
+    .filter((t) => t.length > 0);
+  if (twins.length === 0) return undefined;
+  const allowed = new Set<string>(MOUNTED_TWINS);
+  const unknown = twins.filter((t) => !allowed.has(t));
+  if (unknown.length > 0) {
+    throw new Error(
+      `Unknown twin(s) ${unknown.map((t) => `"${t}"`).join(", ")}. Supported: ${MOUNTED_TWINS.join(", ")}.`,
+    );
+  }
+  // De-dupe while preserving order.
+  return [...new Set(twins)];
 }
 
 /** POST /v1/agents and persist the returned identity into the config read.
@@ -63,18 +100,26 @@ async function createAndPersistAgent(input: {
   name: string;
   configRead: ProjectConfigRead;
   credentialsPath?: string;
+  /** Multi-twin (M3): when set, POSTed as `twins` so the cloud records the
+   *  agent's enabled services. Omitted from the body when absent so an older
+   *  cloud (and the byte-identical `pome install` path) is unchanged. */
+  twins?: string[];
 }): Promise<AgentResponse> {
   const creds = await resolveCredentials({
     apiBaseUrl: input.apiBaseUrl,
     credentialsPath: input.credentialsPath,
   });
+  const body: Record<string, unknown> = { name: input.name };
+  if (input.twins && input.twins.length > 0) {
+    body.twins = input.twins;
+  }
   const res = await fetch(`${creds.apiBaseUrl}/v1/agents`, {
     method: "POST",
     headers: {
       "x-api-key": creds.apiKey,
       "content-type": "application/json",
     },
-    body: JSON.stringify({ name: input.name }),
+    body: JSON.stringify(body),
   }).catch((err: unknown) => {
     throw new HostedOrchError(
       err instanceof Error ? err.message : "network error",
@@ -128,6 +173,7 @@ export async function runRegisterAgent(
     apiBaseUrl: opts.apiBaseUrl,
     name: opts.name,
     configRead,
+    twins: opts.twins,
   });
 
   const displayName = stripControlCharacters(agent.display_name);
@@ -136,6 +182,18 @@ export async function runRegisterAgent(
   );
   console.error(`Wrote agentId to ${CONFIG_FILE}.`);
   console.error(`Judge model: ${agent.judge_model}.`);
+  // Multi-twin (M3): echo the services the cloud enabled. An older cloud that
+  // predates `enabled_services` omits it — warn so the user knows the twin
+  // scoping did not take effect on this control plane.
+  if (agent.enabled_services !== undefined) {
+    console.error(
+      `Enabled services: ${agent.enabled_services.length > 0 ? agent.enabled_services.join(", ") : "(none)"}.`,
+    );
+  } else {
+    console.error(
+      "Enabled services: not reported by this pome cloud (older control plane) — twin scoping may not have taken effect.",
+    );
+  }
 }
 
 // ── FDRS-669 — `pome install` registration ─────────────────────────────────

--- a/cli/src/cli/session.ts
+++ b/cli/src/cli/session.ts
@@ -4,7 +4,7 @@ import { chmod, mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
 import { MOUNTED_TWINS } from "@pome-sh/shared-types";
-import { createHostedClient } from "../hosted/client.js";
+import { createHostedClient, perTwinReturnedByCloud } from "../hosted/client.js";
 import type { CreateSessionResponse } from "../types/shared.js";
 import {
   HostedAuthError,
@@ -63,6 +63,10 @@ function formatEnvExport(res: CreateSessionResponse, twins: string[]): string {
     `export POME_TWIN_URL=${JSON.stringify(res.twin_url)}`,
     `export POME_TWIN_NAMES=${JSON.stringify(twins.join(","))}`,
   ];
+  // Only trust per_twin.mcp_url when the cloud actually returned per_twin —
+  // the schema synthesizes mcp.pome.sh entries for old-cloud bodies, and those
+  // hosts don't serve MCP. Otherwise derive <api_url>/mcp (the legacy shape).
+  const fromCloud = perTwinReturnedByCloud(res);
   // Multi-twin (M3): one POME_<TWIN>_{REST,MCP}_URL pair per twin, plus the
   // provider-specific credential line. Loops per_twin so a github+slack session
   // emits distinct endpoints for each.
@@ -70,9 +74,10 @@ function formatEnvExport(res: CreateSessionResponse, twins: string[]): string {
     const upper = twin.toUpperCase();
     const pt = res.per_twin?.[twin];
     if (pt?.api_url) {
+      const mcpUrl = fromCloud ? ensureMcpSuffix(pt.mcp_url) : ensureMcpSuffix(pt.api_url);
       lines.push(`export POME_${upper}_REST_URL=${JSON.stringify(pt.api_url)}`);
       lines.push(
-        `export POME_${upper}_MCP_URL=${JSON.stringify(ensureMcpSuffix(pt.mcp_url))}`,
+        `export POME_${upper}_MCP_URL=${JSON.stringify(mcpUrl)}`,
       );
     }
     if (twin === "github") {
@@ -175,12 +180,16 @@ export async function runSessionCreate(opts: {
   // shows both endpoints. Falls back to the legacy bare twin_url on an older
   // cloud that only ships it.
   let printedAny = false;
+  const mcpFromCloud = perTwinReturnedByCloud(session);
   for (const twin of twins) {
     const pt = session.per_twin?.[twin];
     if (pt) {
       const label = twins.length > 1 ? `${twin} ` : "";
+      // Synthesized per_twin entries carry an mcp.pome.sh host that doesn't
+      // serve MCP — derive <api_url>/mcp unless the cloud returned per_twin.
+      const mcpUrl = mcpFromCloud ? ensureMcpSuffix(pt.mcp_url) : ensureMcpSuffix(pt.api_url);
       console.error(`${label}API: ${pt.api_url}`);
-      console.error(`${label}MCP: ${ensureMcpSuffix(pt.mcp_url)}`);
+      console.error(`${label}MCP: ${mcpUrl}`);
       printedAny = true;
     }
   }

--- a/cli/src/cli/session.ts
+++ b/cli/src/cli/session.ts
@@ -20,7 +20,7 @@ import { normalizeConfigAgentId, readProjectConfig } from "./project-config.js";
 // standalone `pome twin start` path already appends `/mcp` in `cli/main.ts`;
 // mirror that here so agents reading the printed value get a working MCP URL
 // regardless of which side ships the fix first.
-function ensureMcpSuffix(url: string): string {
+export function ensureMcpSuffix(url: string): string {
   return /\/mcp\/?$/.test(url) ? url : `${url.replace(/\/$/, "")}/mcp`;
 }
 

--- a/cli/src/cli/session.ts
+++ b/cli/src/cli/session.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { chmod, mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
+import { MOUNTED_TWINS } from "@pome-sh/shared-types";
 import { createHostedClient } from "../hosted/client.js";
 import type { CreateSessionResponse } from "../types/shared.js";
 import {
@@ -23,7 +24,10 @@ function ensureMcpSuffix(url: string): string {
   return /\/mcp\/?$/.test(url) ? url : `${url.replace(/\/$/, "")}/mcp`;
 }
 
-const ALLOWED_TWINS = new Set(["github", "stripe"]);
+// Multi-twin (M3): the CLI's ad-hoc session allowlist is the shared mounted-twin
+// set (github, stripe, slack). Slack is now reachable; repeated `--twin` flags
+// stand up a multi-twin session in one call.
+const ALLOWED_TWINS = new Set<string>(MOUNTED_TWINS);
 
 function redactSession(res: CreateSessionResponse): Record<string, unknown> {
   const pcIn = res.provider_credentials;
@@ -33,6 +37,9 @@ function redactSession(res: CreateSessionResponse): Record<string, unknown> {
   }
   if (pcIn.stripe) {
     pcOut.stripe = { ...pcIn.stripe, api_key: "***redacted***" };
+  }
+  if (pcIn.slack) {
+    pcOut.slack = { ...pcIn.slack, token: "***redacted***" };
   }
   return {
     session_id: res.session_id,
@@ -46,47 +53,82 @@ function redactSession(res: CreateSessionResponse): Record<string, unknown> {
   };
 }
 
-function formatEnvExport(res: CreateSessionResponse, twin: string): string {
+function formatEnvExport(res: CreateSessionResponse, twins: string[]): string {
   const lines: string[] = [
-    `# Pome hosted session — treat as secret. Twin: ${twin}`,
+    `# Pome hosted session — treat as secret. Twins: ${twins.join(", ")}`,
     `export POME_AUTH_TOKEN=${JSON.stringify(res.agent_token)}`,
     `export POME_SESSION_ID=${JSON.stringify(res.session_id)}`,
+    // Legacy single-endpoint URL (= the primary twin's api_url). Kept for
+    // agents written against the pre-multi-twin contract.
     `export POME_TWIN_URL=${JSON.stringify(res.twin_url)}`,
+    `export POME_TWIN_NAMES=${JSON.stringify(twins.join(","))}`,
   ];
-  if (res.per_twin?.[twin]?.api_url) {
-    lines.push(
-      `export POME_${twin.toUpperCase()}_API_URL=${JSON.stringify(res.per_twin[twin].api_url)}`,
-    );
-  }
-  const gh = res.provider_credentials.github;
-  if (gh) {
-    lines.push(`export POME_GITHUB_TOKEN=${JSON.stringify(gh.token)}`);
-  }
-  const st = res.provider_credentials.stripe;
-  if (st) {
-    lines.push(`export POME_STRIPE_API_KEY=${JSON.stringify(st.api_key)}`);
-    if (res.per_twin?.[twin]?.api_url) {
+  // Multi-twin (M3): one POME_<TWIN>_{REST,MCP}_URL pair per twin, plus the
+  // provider-specific credential line. Loops per_twin so a github+slack session
+  // emits distinct endpoints for each.
+  for (const twin of twins) {
+    const upper = twin.toUpperCase();
+    const pt = res.per_twin?.[twin];
+    if (pt?.api_url) {
+      lines.push(`export POME_${upper}_REST_URL=${JSON.stringify(pt.api_url)}`);
       lines.push(
-        `export POME_STRIPE_API_BASE=${JSON.stringify(res.per_twin[twin].api_url)}`,
+        `export POME_${upper}_MCP_URL=${JSON.stringify(ensureMcpSuffix(pt.mcp_url))}`,
       );
+    }
+    if (twin === "github") {
+      const gh = res.provider_credentials.github;
+      if (gh) {
+        lines.push(`export POME_GITHUB_TOKEN=${JSON.stringify(gh.token)}`);
+      }
+    } else if (twin === "stripe") {
+      const st = res.provider_credentials.stripe;
+      if (st) {
+        lines.push(`export POME_STRIPE_API_KEY=${JSON.stringify(st.api_key)}`);
+      }
+      if (pt?.api_url) {
+        lines.push(`export POME_STRIPE_API_BASE=${JSON.stringify(pt.api_url)}`);
+      }
+    } else if (twin === "slack") {
+      // The twin proxy verifies only the session JWT (agent_token) as bearer —
+      // the provider-specific Slack credential is NOT accepted at the proxy
+      // (same rationale as the Stripe api-key line in the hosted runner). So
+      // the agent's Slack bearer is the JWT, not provider_credentials.slack.token.
+      lines.push(`export POME_SLACK_TOKEN=${JSON.stringify(res.agent_token)}`);
     }
   }
   return `${lines.join("\n")}\n`;
 }
 
+/** Normalize one-or-more `--twin` flags into a validated, de-duped twin list.
+ *  Repeated flags stand up an ad-hoc multi-twin session; each is validated
+ *  against MOUNTED_TWINS for a friendly error before the round-trip. */
+export function normalizeSessionTwins(raw: string[]): string[] {
+  const twins = raw.map((t) => t.trim().toLowerCase()).filter((t) => t.length > 0);
+  for (const twin of twins) {
+    if (!ALLOWED_TWINS.has(twin)) {
+      throw new Error(
+        `Unknown twin "${twin}". Supported: ${[...ALLOWED_TWINS].join(", ")}.`,
+      );
+    }
+  }
+  const deduped = [...new Set(twins)];
+  if (deduped.length === 0) {
+    throw new Error(
+      `No twin specified. Pass --twin <name> (repeat for multi-twin). Supported: ${[...ALLOWED_TWINS].join(", ")}.`,
+    );
+  }
+  return deduped;
+}
+
 export async function runSessionCreate(opts: {
   apiBaseUrl: string;
-  twin: string;
+  /** One-or-more twins. Repeated `--twin` flags stand up a multi-twin session. */
+  twins: string[];
   showSecrets: boolean;
   format: "text" | "json" | "env";
   secretsFile?: string;
 }): Promise<void> {
-  const twin = opts.twin.trim().toLowerCase();
-  if (!ALLOWED_TWINS.has(twin)) {
-    throw new Error(
-      `Unknown twin "${opts.twin}". V1 supports: ${[...ALLOWED_TWINS].join(", ")}.`,
-    );
-  }
+  const twins = normalizeSessionTwins(opts.twins);
 
   const creds = await resolveCredentials({ apiBaseUrl: opts.apiBaseUrl });
   const client = createHostedClient({
@@ -99,14 +141,14 @@ export async function runSessionCreate(opts: {
     : undefined;
 
   const session = await client.createSession({
-    twins: [twin],
+    twins,
     scenarioSource: "# ..\n",
     idempotencyKey: randomUUID(),
     agentId,
   });
 
   if (opts.secretsFile) {
-    await writeSecretsFile(opts.secretsFile, formatEnvExport(session, twin));
+    await writeSecretsFile(opts.secretsFile, formatEnvExport(session, twins));
     console.error(`Wrote session secrets to ${opts.secretsFile} (mode 0600).`);
   }
 
@@ -129,10 +171,20 @@ export async function runSessionCreate(opts: {
 
   console.error(`Session: ${session.session_id}`);
   console.error(`Expires: ${session.expires_at}`);
-  if (session.per_twin?.[twin]) {
-    console.error(`API: ${session.per_twin[twin].api_url}`);
-    console.error(`MCP: ${ensureMcpSuffix(session.per_twin[twin].mcp_url)}`);
-  } else {
+  // Multi-twin (M3): print one API/MCP line per twin so a github+slack session
+  // shows both endpoints. Falls back to the legacy bare twin_url on an older
+  // cloud that only ships it.
+  let printedAny = false;
+  for (const twin of twins) {
+    const pt = session.per_twin?.[twin];
+    if (pt) {
+      const label = twins.length > 1 ? `${twin} ` : "";
+      console.error(`${label}API: ${pt.api_url}`);
+      console.error(`${label}MCP: ${ensureMcpSuffix(pt.mcp_url)}`);
+      printedAny = true;
+    }
+  }
+  if (!printedAny) {
     // Fallback for older cloud responses that only ship twin_url. Drop the
     // "(legacy)" label that confused users into thinking the URL was
     // deprecated (F21) — it's just the un-disambiguated single endpoint.

--- a/cli/src/hosted/client.ts
+++ b/cli/src/hosted/client.ts
@@ -54,15 +54,15 @@ export function perTwinReturnedByCloud(session: CreateSessionResponse): boolean 
   );
 }
 
-/** Whether a raw create-session wire body carried a `per_twin` key at all
- *  (before schema synthesis). Exported so the runner's env unit test can model
- *  the exact provenance the client stamps. */
+/** Whether a raw create-session wire body carried a usable `per_twin` map
+ *  (before schema synthesis). A `per_twin: null` counts as absent — the schema
+ *  would synthesize entries for it, and synthesized URLs must not be trusted.
+ *  Exported so the runner's env unit test can model the exact provenance the
+ *  client stamps. */
 export function rawBodyHadPerTwin(raw: unknown): boolean {
-  return (
-    typeof raw === "object" &&
-    raw !== null &&
-    (raw as { per_twin?: unknown }).per_twin !== undefined
-  );
+  if (typeof raw !== "object" || raw === null) return false;
+  const pt = (raw as { per_twin?: unknown }).per_twin;
+  return typeof pt === "object" && pt !== null;
 }
 
 export interface HostedClientConfig {

--- a/cli/src/hosted/client.ts
+++ b/cli/src/hosted/client.ts
@@ -23,6 +23,48 @@ import {
   HostedQuotaError,
 } from "./errors.js";
 
+// Multi-twin (M3): provenance marker for `per_twin`. A single-twin OLD cloud
+// ships NO `per_twin` key; `createSessionResponseSchema` then SYNTHESIZES one
+// (host-rewrites api.pome.sh→mcp.pome.sh with no `/mcp` suffix). Consumers that
+// build agent env from `per_twin[twin].mcp_url` must NOT trust that synthesized
+// value — it would drift POME_*_MCP_URL off origin/main's `${twin_url}/mcp`. We
+// record, on the parsed object as a NON-ENUMERABLE symbol (never serialized,
+// never spread), whether the raw wire body actually carried a `per_twin` key.
+const PER_TWIN_PROVENANCE = Symbol("pome.perTwinFromCloud");
+
+function markPerTwinProvenance(
+  session: CreateSessionResponse,
+  fromCloud: boolean,
+): CreateSessionResponse {
+  Object.defineProperty(session, PER_TWIN_PROVENANCE, {
+    value: fromCloud,
+    enumerable: false,
+    configurable: true,
+  });
+  return session;
+}
+
+/** True when the cloud's create-session body actually returned a `per_twin`
+ *  key (empty `{}` counts) — i.e. `per_twin` was NOT synthesized by the schema
+ *  from a legacy `twin_url`-only response. Consumers use this to decide whether
+ *  `per_twin[twin].mcp_url` is trustworthy. */
+export function perTwinReturnedByCloud(session: CreateSessionResponse): boolean {
+  return (
+    (session as Record<PropertyKey, unknown>)[PER_TWIN_PROVENANCE] === true
+  );
+}
+
+/** Whether a raw create-session wire body carried a `per_twin` key at all
+ *  (before schema synthesis). Exported so the runner's env unit test can model
+ *  the exact provenance the client stamps. */
+export function rawBodyHadPerTwin(raw: unknown): boolean {
+  return (
+    typeof raw === "object" &&
+    raw !== null &&
+    (raw as { per_twin?: unknown }).per_twin !== undefined
+  );
+}
+
 export interface HostedClientConfig {
   baseUrl: string;
   /** Team API key (`pme_…`) — or, with `authScheme: "bearer"`, a
@@ -745,7 +787,10 @@ export function createHostedClient(config: HostedClientConfig): HostedClient {
         body.group_id = input.groupId;
       }
       return postJson("/v1/sessions", body, (raw) =>
-        createSessionResponseSchema.parse(raw),
+        markPerTwinProvenance(
+          createSessionResponseSchema.parse(raw),
+          rawBodyHadPerTwin(raw),
+        ),
       );
     },
 

--- a/cli/src/hosted/client.ts
+++ b/cli/src/hosted/client.ts
@@ -13,6 +13,7 @@ import {
   type SubmitResultResponse,
   type CriterionResult,
   type Lane,
+  type PerTwinStateKeys,
   type Step,
 } from "../types/shared.js";
 import { z } from "zod";
@@ -140,9 +141,18 @@ export interface StateUploadUrlEntry {
   key: string;
 }
 
+export interface StateUploadUrlPair {
+  state_initial: StateUploadUrlEntry;
+  state_final: StateUploadUrlEntry;
+}
+
 export interface StateUploadUrlResponse {
   state_initial: StateUploadUrlEntry;
   state_final: StateUploadUrlEntry;
+  /** Multi-twin (M3): one initial/final URL+key pair per twin, keyed by twin
+   *  id. Absent on single-twin sessions and on an older cloud, where the
+   *  top-level pair (= primary twin) is authoritative. */
+  per_twin?: Record<string, StateUploadUrlPair>;
 }
 
 export interface SignalsUploadUrlResponse {
@@ -190,6 +200,12 @@ export interface FinalizeInput {
   // alongside the twin-HTTP timeline. The CLI uploads signals.jsonl via
   // `requestSignalsUploadUrl` first; the returned storage key flows here.
   signalsStorageKey?: string;
+  // Multi-twin (M3): per-twin state storage keys, keyed by twin id. Sent only
+  // for multi-twin sessions; each entry carries at least one of
+  // state_initial_key / state_final_key. Omitted on single-twin runs, which
+  // use the flat state_*StorageKey fields above. An older cloud strips it and
+  // scores the primary twin unchanged.
+  perTwinStateKeys?: PerTwinStateKeys;
 }
 
 export interface FinalizeOptions {
@@ -235,7 +251,14 @@ export interface HostedClient {
     input?: { errorCode?: string },
   ): Promise<AbandonSessionResponse>;
   requestEventsUploadUrl(sessionId: string): Promise<EventsUploadUrlResponse>;
-  requestStateUploadUrl(sessionId: string): Promise<StateUploadUrlResponse>;
+  /** Multi-twin (M3): pass `twins` (>1) to receive a per-twin URL+key pair
+   *  under `per_twin` in addition to the top-level primary-twin pair. Omit for
+   *  single-twin sessions. An older cloud ignores the body and returns only
+   *  the top-level pair. */
+  requestStateUploadUrl(
+    sessionId: string,
+    twins?: string[],
+  ): Promise<StateUploadUrlResponse>;
   /** F0-4 / L7 — mint a signed PUT for `signals.jsonl` (adapter-emitted
    *  HookEvent / ToolUseEvent / SubagentSpawnEvent rows). The returned
    *  `key` flows into `FinalizeInput.signalsStorageKey`. */
@@ -373,7 +396,9 @@ export function createHostedClient(config: HostedClientConfig): HostedClient {
         // labeled at-capacity state instead of a generic quota message.
         throw new HostedQuotaError(msg, reqId, cloudDetails);
       }
-      throw new HostedOrchError(msg, reqId, res.status);
+      // Carry the envelope `error.type` (e.g. `multi_twin_unsupported`) so
+      // callers can map specific rejections to friendly hints.
+      throw new HostedOrchError(msg, reqId, res.status, cloudErr?.type);
     }
     try {
       return parse(json, res);
@@ -872,23 +897,41 @@ export function createHostedClient(config: HostedClientConfig): HostedClient {
       );
     },
 
-    async requestStateUploadUrl(sessionId) {
+    async requestStateUploadUrl(sessionId, twins) {
+      // Multi-twin (M3): a `{ twins }` body asks the cloud to sign a per-twin
+      // pair for each twin (returned under `per_twin`). Single-twin callers
+      // pass nothing and the body stays `{}` — byte-identical to pre-M3.
+      const body: Record<string, unknown> =
+        twins && twins.length > 0 ? { twins } : {};
       return postJson(
         `/v1/sessions/${encodeURIComponent(sessionId)}/state-upload-url`,
-        {},
+        body,
         (raw) => {
           const isEntry = (x: unknown): x is StateUploadUrlEntry =>
             typeof x === "object" &&
             x !== null &&
             typeof (x as { url?: unknown }).url === "string" &&
             typeof (x as { key?: unknown }).key === "string";
-          if (
-            typeof raw === "object" &&
-            raw !== null &&
-            isEntry((raw as { state_initial?: unknown }).state_initial) &&
-            isEntry((raw as { state_final?: unknown }).state_final)
-          ) {
-            return raw as StateUploadUrlResponse;
+          const isPair = (x: unknown): x is StateUploadUrlPair =>
+            typeof x === "object" &&
+            x !== null &&
+            isEntry((x as { state_initial?: unknown }).state_initial) &&
+            isEntry((x as { state_final?: unknown }).state_final);
+          if (isPair(raw)) {
+            // Validate `per_twin` when present; drop it silently if malformed
+            // rather than failing the whole request (best-effort, like the
+            // rest of the upload surface).
+            const perTwinRaw = (raw as { per_twin?: unknown }).per_twin;
+            let perTwin: Record<string, StateUploadUrlPair> | undefined;
+            if (
+              typeof perTwinRaw === "object" &&
+              perTwinRaw !== null &&
+              !Array.isArray(perTwinRaw) &&
+              Object.values(perTwinRaw as Record<string, unknown>).every(isPair)
+            ) {
+              perTwin = perTwinRaw as Record<string, StateUploadUrlPair>;
+            }
+            return { ...(raw as StateUploadUrlResponse), per_twin: perTwin };
           }
           throw new HostedOrchError(
             "POST /v1/sessions/:id/state-upload-url returned unexpected shape",
@@ -922,6 +965,12 @@ export function createHostedClient(config: HostedClientConfig): HostedClient {
       }
       if (input.signalsStorageKey !== undefined) {
         body.signals_storage_key = input.signalsStorageKey;
+      }
+      if (
+        input.perTwinStateKeys !== undefined &&
+        Object.keys(input.perTwinStateKeys).length > 0
+      ) {
+        body.per_twin_state_keys = input.perTwinStateKeys;
       }
       const initial = await postJson(
         `/v1/sessions/${encodeURIComponent(sessionId)}/finalize`,

--- a/cli/src/hosted/errors.ts
+++ b/cli/src/hosted/errors.ts
@@ -55,6 +55,11 @@ export class HostedOrchError extends Error {
     message: string,
     public readonly requestId?: string,
     public readonly status?: number,
+    /** Machine-readable `error.type` from the cloud envelope, when present
+     *  (e.g. `multi_twin_unsupported` so the CLI can map an old-cloud
+     *  multi-twin rejection to a friendly hint). Undefined for
+     *  network/parse failures and the twin-pod 401 shape. */
+    public readonly type?: string,
   ) {
     super(message);
     this.name = "HostedOrchError";

--- a/cli/src/hosted/evalResultView.ts
+++ b/cli/src/hosted/evalResultView.ts
@@ -121,6 +121,30 @@ export function markerFor(outcome: CriterionOutcome): string {
   }
 }
 
+// Multi-twin (M3): the per-criterion bracket for terminal display —
+// `[code]` / `[model]`, plus the `:<twin>` suffix when the criterion attributes
+// to a specific twin (so a `[D:slack]`/`[P:github]` marker survives into the
+// UNEVAL / criteria list). A bare (primary-twin) criterion renders `[code]`
+// unchanged.
+export function criterionMarkerLabel(criterion: WireCriterion): string {
+  return criterion.twin ? `[${criterion.type}:${criterion.twin}]` : `[${criterion.type}]`;
+}
+
+// Multi-twin (M3): when the cloud could not evaluate a criterion for a
+// twin-related reason (a twin-tagged criterion, or a `no_matching_predicate`
+// skip), name the twin inline so the UNEVAL line explains WHICH twin's timeline
+// came up empty. Returns "" when there's nothing twin-specific to add.
+export function twinSkipSuffix(result: CriterionResult): string {
+  const twin = result.criterion.twin;
+  if (!twin) return "";
+  const outcome = outcomeOf(result);
+  const twinRelated =
+    outcome === "skipped" ||
+    outcome === "errored" ||
+    /no_matching_predicate|no matching predicate/i.test(result.reason);
+  return twinRelated ? ` (twin: ${twin})` : "";
+}
+
 export function scoreCountsSummary(score: Score): string {
   return `${score.passed ?? 0} passed, ${score.failed ?? 0} failed, ${score.skipped ?? 0} skipped, ${score.errored ?? 0} errored`;
 }

--- a/cli/src/hosted/uploadAndFinalize.ts
+++ b/cli/src/hosted/uploadAndFinalize.ts
@@ -8,7 +8,7 @@
 // the pre-extraction runner.
 
 import type { HostedClient } from "./client.js";
-import type { FinalizeResponse } from "../types/shared.js";
+import type { FinalizeResponse, PerTwinStateKeys } from "../types/shared.js";
 import type { Score } from "./evalResultView.js";
 import { outcomeOf } from "./evalResultView.js";
 import { redactSecrets } from "../recorder/redaction.js";
@@ -33,6 +33,15 @@ export interface RunBlobs {
   /** D18.1 — the run's meta.json (spec_version + twin_versions + the rest of
    *  writeRunArtifactsCore's payload), as written to / read from disk. */
   metaJson: string;
+  /** Multi-twin (M3): the session's twins. When >1, per-twin state upload URLs
+   *  are requested and each twin's state blobs are uploaded under its own
+   *  storage prefix. Absent / length ≤1 keeps the single-twin path unchanged. */
+  twins?: string[];
+  /** Multi-twin (M3): per-twin initial/final state JSON, keyed by twin id.
+   *  Includes the primary twin (whose blobs also go to the legacy top-level
+   *  pair). Only consumed when `twins.length > 1` and the cloud returns a
+   *  `per_twin` upload block. */
+  perTwinState?: Record<string, { initialJson: string; finalJson: string }>;
 }
 
 export interface UploadedBlobKeys {
@@ -40,6 +49,11 @@ export interface UploadedBlobKeys {
   stateInitialKey: string | null;
   stateFinalKey: string | null;
   signalsKey: string | null;
+  /** Multi-twin (M3): per-twin state storage keys, keyed by twin id. Each entry
+   *  carries at least one uploaded key (empty entries are dropped so the
+   *  finalize contract's ">=1 key per entry" invariant holds). Undefined when
+   *  the session is single-twin or the cloud returned no `per_twin` block. */
+  perTwinStateKeys?: PerTwinStateKeys;
   /** D18.1 — the storage key the presigned PUT landed at, or null whenever
    *  the upload didn't happen, INCLUDING the feature-detection case (older
    *  control plane 404s meta-upload-url). Never distinguished from any other
@@ -147,9 +161,17 @@ export async function uploadRunBlobs(
   async function uploadStates(): Promise<{
     initialKey: string | null;
     finalKey: string | null;
+    perTwinStateKeys?: PerTwinStateKeys;
   }> {
+    const multiTwin = (blobs.twins?.length ?? 0) > 1;
     try {
-      const upload = await client.requestStateUploadUrl(sessionId);
+      // Multi-twin (M3): ask for a per-twin URL block; single-twin passes
+      // nothing so the request body stays `{}` (byte-identical to pre-M3).
+      const upload = await client.requestStateUploadUrl(
+        sessionId,
+        multiTwin ? blobs.twins : undefined,
+      );
+      // Top-level (primary-twin) pair — always uploaded, legacy state_*_storage_key.
       const [initialOk, finalOk] = await Promise.all([
         putBlob(
           upload.state_initial.url,
@@ -164,9 +186,47 @@ export async function uploadRunBlobs(
           "state_final.json",
         ),
       ]);
+
+      // Multi-twin: upload each twin's blobs to its own storage prefix and
+      // collect the keys. Only when the cloud actually returned a `per_twin`
+      // block (an older cloud omits it → we fall back to the primary-only
+      // top-level keys, degrading gracefully). Entries with no uploaded key are
+      // dropped so the finalize contract's ">=1 key per entry" holds.
+      let perTwinStateKeys: PerTwinStateKeys | undefined;
+      if (multiTwin && upload.per_twin) {
+        const collected: PerTwinStateKeys = {};
+        for (const twin of blobs.twins ?? []) {
+          const pair = upload.per_twin[twin];
+          const state = blobs.perTwinState?.[twin];
+          if (!pair || !state) continue;
+          const [iOk, fOk] = await Promise.all([
+            putBlob(
+              pair.state_initial.url,
+              state.initialJson,
+              "application/json",
+              `state_initial.${twin}.json`,
+            ),
+            putBlob(
+              pair.state_final.url,
+              state.finalJson,
+              "application/json",
+              `state_final.${twin}.json`,
+            ),
+          ]);
+          const entry: { state_initial_key?: string; state_final_key?: string } = {};
+          if (iOk) entry.state_initial_key = pair.state_initial.key;
+          if (fOk) entry.state_final_key = pair.state_final.key;
+          if (entry.state_initial_key !== undefined || entry.state_final_key !== undefined) {
+            collected[twin] = entry;
+          }
+        }
+        if (Object.keys(collected).length > 0) perTwinStateKeys = collected;
+      }
+
       return {
         initialKey: initialOk ? upload.state_initial.key : null,
         finalKey: finalOk ? upload.state_final.key : null,
+        perTwinStateKeys,
       };
     } catch (err) {
       console.warn(
@@ -224,6 +284,7 @@ export async function uploadRunBlobs(
     eventsKey,
     stateInitialKey: stateKeys.initialKey,
     stateFinalKey: stateKeys.finalKey,
+    perTwinStateKeys: stateKeys.perTwinStateKeys,
     metaKey,
     signalsKey,
   };

--- a/cli/src/runner/ports.ts
+++ b/cli/src/runner/ports.ts
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import { createServer } from "node:net";
 
+// NOTE: allocate-then-close hands back a port that is free at close time; a
+// caller that rebinds it races any other process that grabs it in the gap.
+// Pre-existing and acceptable for local dev twins (loopback, short-lived).
 export async function getAvailablePort() {
   return new Promise<number>((resolve, reject) => {
     const server = createServer();

--- a/cli/src/runner/runScenario.ts
+++ b/cli/src/runner/runScenario.ts
@@ -15,6 +15,14 @@ import { buildEgressAllowlist, readBlockedEgress, type BlockedEgress } from "../
 import { mergeAdapterSignalsIntoEvents } from "./mergeAdapterSignals.js";
 import { writeRunNoScore } from "./runScenarioCore.js";
 
+// Promisify a Hono/node server `close()` so teardown can await in-flight
+// handlers draining before the twin's DB handle is released.
+function closeServer(server: ReturnType<typeof serve>): Promise<void> {
+  return new Promise<void>((resolvePromise, reject) => {
+    server.close((err) => (err ? reject(err) : resolvePromise()));
+  });
+}
+
 // Override for how `pome capture-server` is invoked as a child. Production
 // re-invokes process.argv[1] (the same compiled `pome` binary). Tests pass
 // `{ execPath: process.execPath, prefixArgs: ["--import", "tsx", "src/cli/main.ts"] }` to run from source.
@@ -298,8 +306,15 @@ export async function runScenario(options: RunScenarioOptions) {
     // in events.jsonl before we move on; THEN close each twin (releasing its
     // DB handle) and finally the shared recorder (flush + close).
     if (captureServer) await captureServer.shutdown();
-    for (const { server } of booted) server.close();
-    for (const { harness } of booted) await harness.close();
+    // Await each twin's HTTP server close (letting in-flight handlers drain)
+    // BEFORE releasing that twin's DB handle, so a late handler can't run
+    // against a closed DB (teardown errors / lost final recorder writes).
+    await Promise.all(
+      booted.map(async ({ server, harness }) => {
+        await closeServer(server);
+        await harness.close();
+      })
+    );
     await recorder.close?.();
   }
 }

--- a/cli/src/runner/runScenario.ts
+++ b/cli/src/runner/runScenario.ts
@@ -4,8 +4,10 @@ import { randomBytes, randomUUID } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join, resolve as resolvePath, sep as pathSep } from "node:path";
 import { sign } from "hono/jwt";
-import { parseScenarioFile } from "../scenario/parseScenario.js";
-import { bootTwin } from "../twin/twinHarness.js";
+import { parseScenarioFile, seedStateForTwin } from "../scenario/parseScenario.js";
+import { bootTwin, type TwinHarness } from "../twin/twinHarness.js";
+import { createRecorder } from "../recorder/recorder.js";
+import { redactSecrets } from "../recorder/redaction.js";
 import { getAvailablePort } from "./ports.js";
 import { runAgentCommand } from "./agentRunner.js";
 import { egressArgs, spawnCaptureServerChild } from "./captureServerChild.js";
@@ -119,24 +121,53 @@ export async function runScenario(options: RunScenarioOptions) {
     return readBlockedEgress(egressJsonlPath);
   };
 
-  const twinName = scenario.config.twins[0] ?? "github";
-  const port = await getAvailablePort();
-  const baseUrl = `http://127.0.0.1:${port}`;
-  // F-698: stream twin HTTP events into the same events.jsonl the
-  // capture-server appends to. Durable store writes TwinHttpEvent rows;
-  // finalize dedupes against disk so upload shape stays one row per event.
-  const harness = await bootTwin({
-    twin: twinName,
-    seedState: scenario.seedState,
-    runId,
-    twinBaseUrl: baseUrl,
-    eventsPath: eventsJsonlPath,
-  });
-  const stateInitial = await harness.exportState();
-
+  const twins = scenario.config.twins.length ? scenario.config.twins : ["github"];
+  const primaryTwin = twins[0]!;
+  const isMultiTwin = twins.length > 1;
   const sid = runId;
   const authSecret = process.env.TWIN_AUTH_SECRET ?? randomBytes(32).toString("hex");
   process.env.TWIN_AUTH_SECRET = authSecret;
+
+  // Multi-twin (M3): all twins in one local run share ONE recorder so their
+  // HTTP events stream into a single events.jsonl (the same file the
+  // capture-server appends to). The runner owns the recorder's lifecycle here;
+  // each harness's `close()` releases only its own DB handle. For single-twin
+  // this is behaviorally identical to the old bootTwin-internal recorder.
+  // The durable store writes TwinHttpEvent rows; finalize dedupes against disk
+  // so upload shape stays one row per event.
+  const recorder = createRecorder({ eventsPath: eventsJsonlPath });
+
+  // Boot one twin harness per config twin, each on its own localhost port.
+  // Merge every twin's POME_<envName>_{REST,MCP}_URL and its extra JWT claims;
+  // one token carries the union of claims (e.g. Stripe's account_id).
+  const booted: { twin: string; harness: TwinHarness; server: ReturnType<typeof serve> }[] = [];
+  const twinEnv: Record<string, string> = {};
+  const stateInitialByTwin: Record<string, unknown> = {};
+  let mergedClaims: Record<string, unknown> = {};
+  for (const twin of twins) {
+    const port = await getAvailablePort();
+    const baseUrl = `http://127.0.0.1:${port}`;
+    const harness = await bootTwin({
+      twin,
+      seedState: seedStateForTwin(scenario, twin),
+      runId,
+      twinBaseUrl: baseUrl,
+      recorder,
+    });
+    stateInitialByTwin[twin] = await harness.exportState();
+    const sessionBase = `${baseUrl}/s/${sid}`;
+    // Twin-agnostic URL contract: the agent reads `POME_<TWIN>_{REST,MCP}_URL`.
+    // For github this resolves to the historical `POME_GITHUB_{REST,MCP}_URL`;
+    // slack/stripe get their own prefixes (the mcp-loop scaffold's
+    // `resolveMcpUrl` already keys off `POME_<TWIN>_MCP_URL`).
+    twinEnv[`POME_${harness.envName}_REST_URL`] = sessionBase;
+    twinEnv[`POME_${harness.envName}_MCP_URL`] = `${sessionBase}/mcp`;
+    mergedClaims = { ...mergedClaims, ...(harness.extraClaims ?? {}) };
+    const server = serve({ fetch: harness.app.fetch, port, hostname: "127.0.0.1" });
+    booted.push({ twin, harness, server });
+  }
+  const stateInitial = stateInitialByTwin[primaryTwin];
+
   const token = await sign(
     {
       sid,
@@ -148,15 +179,13 @@ export async function runScenario(options: RunScenarioOptions) {
       // was invisible until a scripted REST agent needed to merge.
       login: "pome-agent",
       // Twin-supplied claims (e.g. Stripe's `account_id`, so the token resolves
-      // to the account the seed data lives in). github/slack supply none.
-      ...(harness.extraClaims ?? {}),
+      // to the account the seed data lives in) — merged across all twins.
+      // github/slack supply none.
+      ...mergedClaims,
       exp: Math.floor(Date.now() / 1000) + Math.max(scenario.config.timeout * 2, 600),
     },
     authSecret
   );
-  const sessionBase = `${baseUrl}/s/${sid}`;
-
-  const server = serve({ fetch: harness.app.fetch, port, hostname: "127.0.0.1" });
 
   const proxyEnv: Record<string, string> = captureServer
     ? {
@@ -171,19 +200,38 @@ export async function runScenario(options: RunScenarioOptions) {
     : {};
   const env = {
     POME_TASK: scenario.prompt,
-    POME_TWIN_NAMES: scenario.config.twins.join(","),
-    // Twin-agnostic URL contract: the agent reads `POME_<TWIN>_{REST,MCP}_URL`.
-    // For github this resolves to the historical `POME_GITHUB_{REST,MCP}_URL`;
-    // slack/stripe get their own prefixes (the mcp-loop scaffold's
-    // `resolveMcpUrl` already keys off `POME_<TWIN>_MCP_URL`).
-    [`POME_${harness.envName}_REST_URL`]: sessionBase,
-    [`POME_${harness.envName}_MCP_URL`]: `${sessionBase}/mcp`,
+    POME_TWIN_NAMES: twins.join(","),
+    ...twinEnv,
     POME_AUTH_TOKEN: token,
     POME_RUN_ID: runId,
     POME_ARTIFACTS_DIR: runDir,
     POME_ADAPTER_SIGNALS_PATH: signalsPathForEnv,
     ...(options.extraAgentEnv ?? {}),
     ...proxyEnv,
+  };
+
+  // Capture each twin's final state: the primary is the legacy `stateFinal`
+  // (state_final.json); every other twin is written alongside as
+  // `state_final.<twin>.json`. Best-effort disk writes for the extras.
+  const captureFinalStates = async (): Promise<unknown> => {
+    const finals: Record<string, unknown> = {};
+    for (const { twin, harness } of booted) {
+      finals[twin] = await harness.exportState();
+    }
+    if (isMultiTwin) {
+      for (const { twin } of booted) {
+        if (twin === primaryTwin) continue;
+        try {
+          await writeFile(
+            join(runDir, `state_final.${twin}.json`),
+            `${JSON.stringify(redactSecrets(finals[twin]), null, 2)}\n`,
+          );
+        } catch {
+          // best-effort — the primary state_final.json is what writeRun persists
+        }
+      }
+    }
+    return finals[primaryTwin];
   };
 
   try {
@@ -198,8 +246,8 @@ export async function runScenario(options: RunScenarioOptions) {
     if (preflight.exitCode !== 0) {
       // Flush durable twin rows before finalize/merge so pending TwinHttpEvent
       // lines are on disk before events.jsonl is rewritten (not only in finally).
-      await harness.flush();
-      const stateFinal = await harness.exportState();
+      await recorder.flush?.();
+      const stateFinal = await captureFinalStates();
       const { artifacts, exitCode } = await writeRun({
         artifactsDir,
         runId,
@@ -210,7 +258,7 @@ export async function runScenario(options: RunScenarioOptions) {
         agentStderr: preflight.stderr,
         agentExitCode: preflight.exitCode,
         agentTimedOut: preflight.timedOut ?? false,
-        events: harness.events(),
+        events: recorder.events(),
         stateInitial,
         stateFinal
       });
@@ -226,8 +274,8 @@ export async function runScenario(options: RunScenarioOptions) {
       env,
       timeoutSeconds: scenario.config.timeout
     });
-    await harness.flush();
-    const stateFinal = await harness.exportState();
+    await recorder.flush?.();
+    const stateFinal = await captureFinalStates();
     const { artifacts, exitCode } = await writeRun({
       artifactsDir,
       runId,
@@ -238,7 +286,7 @@ export async function runScenario(options: RunScenarioOptions) {
       agentStderr: agent.stderr,
       agentExitCode: agent.exitCode,
       agentTimedOut: agent.timedOut ?? false,
-      events: harness.events(),
+      events: recorder.events(),
       stateInitial,
       stateFinal
     });
@@ -247,10 +295,11 @@ export async function runScenario(options: RunScenarioOptions) {
     return { scenario, runId, artifacts, agent, exitCode, blockedEgress };
   } finally {
     // Drain capture-server first so any in-flight LlmCallEvent rows land
-    // in events.jsonl before we move on; THEN close the twin (which flushes
-    // the durable recorder and resets twin-side sockets).
+    // in events.jsonl before we move on; THEN close each twin (releasing its
+    // DB handle) and finally the shared recorder (flush + close).
     if (captureServer) await captureServer.shutdown();
-    server.close();
-    await harness.close();
+    for (const { server } of booted) server.close();
+    for (const { harness } of booted) await harness.close();
+    await recorder.close?.();
   }
 }

--- a/cli/src/runner/runScenarioHosted.ts
+++ b/cli/src/runner/runScenarioHosted.ts
@@ -11,7 +11,12 @@ import {
 } from "../hosted/evalResultCache.js";
 import { redactEvent, redactSecrets } from "../recorder/redaction.js";
 import { parseScenarioFile } from "../scenario/parseScenario.js";
-import { createHostedClient, type HostedClient } from "../hosted/client.js";
+import {
+  createHostedClient,
+  perTwinReturnedByCloud,
+  type HostedClient,
+} from "../hosted/client.js";
+import { ensureMcpSuffix } from "../cli/session.js";
 import {
   redactJsonl,
   scoreFromFinalizeResponse,
@@ -74,6 +79,123 @@ export interface RunScenarioHostedResult {
    *  reported to /finalize as duration_ms. FDRS-636 renders it as the trial
    *  row's duration. */
   durationMs: number;
+}
+
+/** Build the agent subprocess env for a hosted run.
+ *
+ * Two layers, in this order:
+ *
+ *  1. The LEGACY block (origin/main parity). Every hosted run — regardless of
+ *     which twins the session mounts — ALWAYS injected github + stripe vars
+ *     pointing at the primary/bare `twin_url`, plus POME_TWIN_BASE_URL and the
+ *     OTEL/task/run scaffolding. Byte-identical single-twin env is the bar, so
+ *     this block reproduces main's exact keys, values, AND insertion order.
+ *
+ *  2. The per-twin fan-out OVERLAY (M3). For each twin actually in the session,
+ *     set POME_<T>_REST_URL / POME_<T>_MCP_URL from `per_twin[T]` (distinct URLs
+ *     per twin) plus its provider bearer. For github/stripe this overwrites the
+ *     legacy values IN PLACE (same key → insertion order preserved); other twins
+ *     append new keys.
+ *
+ * MCP URL rule (regression guard): only trust `per_twin[T].mcp_url` when the
+ * cloud ACTUALLY RETURNED `per_twin` (`perTwinFromCloud`). A single-twin OLD
+ * cloud returns no `per_twin`; the schema synthesizes one whose `mcp_url`
+ * host-rewrites api.pome.sh→mcp.pome.sh with NO `/mcp` suffix. Trusting it would
+ * drift POME_*_MCP_URL off main's `${twin_url}/mcp`. So for a synthesized entry
+ * we construct `${api_url}/mcp`; only a cloud-returned value gets ensureMcpSuffix
+ * (the same normalization `pome session create` applies). */
+export function buildAgentEnv(params: {
+  session: CreateSessionResponse;
+  twins: string[];
+  /** True iff the cloud's create-session body carried a `per_twin` key. */
+  perTwinFromCloud: boolean;
+  prompt: string;
+  otlpEndpoint: string;
+  apiKey: string;
+  agentId?: string;
+  runId: string;
+  artifactsDir: string;
+  slug: string;
+  signalsPath: string;
+}): Record<string, string> {
+  const {
+    session,
+    twins,
+    perTwinFromCloud,
+    prompt,
+    otlpEndpoint,
+    apiKey,
+    agentId,
+    runId,
+    artifactsDir,
+    slug,
+    signalsPath,
+  } = params;
+
+  const env: Record<string, string> = {
+    POME_TASK: prompt,
+    POME_TWIN_NAMES: twins.join(","),
+    POME_OTEL_EXPORTER_OTLP_ENDPOINT: otlpEndpoint,
+    POME_OTEL_EXPORTER_OTLP_HEADERS: `x-api-key=${apiKey}`,
+    OTEL_SERVICE_NAME: agentId ?? "pome-agent",
+    OTEL_RESOURCE_ATTRIBUTES: `pome.session_id=${session.session_id},pome.run_id=${runId}${
+      agentId ? `,pome.agent_id=${agentId}` : ""
+    }`,
+    // The twin base URL, same value the self-host docs teach agents to fall
+    // back on. Agent code written against the standalone docker twin
+    // reads POME_TWIN_BASE_URL with a 127.0.0.1:3333 fallback; without this
+    // injection that fallback fires on hosted runs and the agent probes a
+    // loopback port nothing listens on. Legacy = the primary twin's bare url.
+    POME_TWIN_BASE_URL: session.twin_url,
+    // Legacy unconditional block (origin/main parity). Injected on EVERY hosted
+    // run regardless of twin; the per-twin overlay below overwrites these in
+    // place for github/stripe when those twins are in the session.
+    POME_GITHUB_REST_URL: session.twin_url,
+    POME_GITHUB_MCP_URL: `${session.twin_url}/mcp`,
+    POME_GITHUB_TOKEN:
+      session.provider_credentials.github?.token ?? session.agent_token,
+    POME_STRIPE_API_BASE: session.twin_url,
+    // Always use the JWT agent_token as the Stripe SDK's Bearer in hosted mode.
+    // The cloud also returns `provider_credentials.stripe.api_key` (an
+    // HMAC-signed `sk_test_pome_*`), but the pome-cloud proxy only accepts
+    // JWTs — it routes by verifying the bearer against `agent_token`. A
+    // stripe-style key short-circuits to the proxy's opaque 404 before the
+    // request reaches the twin pod. The Stripe SDK sends any opaque string as
+    // `Authorization: Bearer …`, and twin-stripe's dual-auth accepts JWTs
+    // natively, so the JWT round-trips cleanly end-to-end.
+    POME_STRIPE_API_KEY: session.agent_token,
+    POME_AUTH_TOKEN: session.agent_token,
+    POME_RUN_ID: runId,
+    POME_ARTIFACTS_DIR: join(artifactsDir, slug, runId),
+    POME_ADAPTER_SIGNALS_PATH: signalsPath,
+  };
+
+  for (const twin of twins) {
+    const upper = twin.toUpperCase();
+    const pt = session.per_twin?.[twin];
+    const apiUrl = pt?.api_url ?? session.twin_url;
+    const mcpUrl =
+      perTwinFromCloud && pt?.mcp_url
+        ? ensureMcpSuffix(pt.mcp_url)
+        : `${apiUrl.replace(/\/$/, "")}/mcp`;
+    env[`POME_${upper}_REST_URL`] = apiUrl;
+    env[`POME_${upper}_MCP_URL`] = mcpUrl;
+    if (twin === "github") {
+      env.POME_GITHUB_TOKEN =
+        session.provider_credentials.github?.token ?? session.agent_token;
+    } else if (twin === "stripe") {
+      env.POME_STRIPE_API_BASE = apiUrl;
+      env.POME_STRIPE_API_KEY = session.agent_token;
+    } else if (twin === "slack") {
+      // Same rationale as the Stripe api-key line: the twin proxy verifies only
+      // the session JWT as bearer, so the agent's Slack bearer is the
+      // agent_token — NOT provider_credentials.slack.token, which the proxy
+      // would reject.
+      env.POME_SLACK_TOKEN = session.agent_token;
+    }
+  }
+
+  return env;
 }
 
 export async function runScenarioHosted(
@@ -183,64 +305,21 @@ export async function runScenarioHosted(
       ).toString();
 
     // 3. Run the agent. Env mirrors self-host so a customer's agent code
-    //    is twin-mode-agnostic.
-    //
-    // Multi-twin (M3): the twin-endpoint env is a fan-out over the session's
-    // twins. Each twin T gets its OWN POME_<T>_REST_URL / POME_<T>_MCP_URL from
-    // per_twin[T] (distinct URLs per twin), plus its provider bearer. The legacy
-    // single-endpoint vars (POME_TWIN_BASE_URL) keep the primary twin's value so
-    // agents written against the pre-multi-twin contract still work.
-    const env: Record<string, string> = {
-      POME_TASK: scenario.prompt,
-      POME_TWIN_NAMES: twins.join(","),
-      POME_OTEL_EXPORTER_OTLP_ENDPOINT: otlpEndpoint,
-      POME_OTEL_EXPORTER_OTLP_HEADERS: `x-api-key=${options.hosted.apiKey}`,
-      OTEL_SERVICE_NAME: agentId ?? "pome-agent",
-      OTEL_RESOURCE_ATTRIBUTES: `pome.session_id=${session.session_id},pome.run_id=${runId}${
-        agentId ? `,pome.agent_id=${agentId}` : ""
-      }`,
-      // FDRS-667 — the twin base URL, same value the self-host docs teach
-      // agents to fall back on. Agent code written against the standalone
-      // docker twin reads POME_TWIN_BASE_URL with a 127.0.0.1:3333 fallback;
-      // without this injection that fallback fires on hosted runs and the
-      // agent probes a loopback port nothing listens on. Legacy = the primary
-      // twin's bare url.
-      POME_TWIN_BASE_URL: session.twin_url,
-      POME_AUTH_TOKEN: session.agent_token,
-      POME_RUN_ID: runId,
-      POME_ARTIFACTS_DIR: join(artifactsDir, scenario.slug, runId),
-      POME_ADAPTER_SIGNALS_PATH: signalsPath,
-    };
-    for (const twin of twins) {
-      const upper = twin.toUpperCase();
-      const pt = session.per_twin?.[twin];
-      const apiUrl = pt?.api_url ?? session.twin_url;
-      const mcpUrl = pt?.mcp_url ?? `${session.twin_url}/mcp`;
-      env[`POME_${upper}_REST_URL`] = apiUrl;
-      env[`POME_${upper}_MCP_URL`] = mcpUrl;
-      if (twin === "github") {
-        env.POME_GITHUB_TOKEN =
-          session.provider_credentials.github?.token ?? session.agent_token;
-      } else if (twin === "stripe") {
-        env.POME_STRIPE_API_BASE = apiUrl;
-        // Always use the JWT agent_token as the Stripe SDK's Bearer in hosted
-        // mode. The cloud also returns
-        // `provider_credentials.stripe.api_key` (an HMAC-signed
-        // `sk_test_pome_*`), but the pome-cloud proxy only accepts JWTs — it
-        // routes by verifying the bearer against `agent_token`. A stripe-style
-        // key short-circuits to the proxy's opaque 404 before the request
-        // reaches the twin pod. The Stripe SDK sends any opaque string as
-        // `Authorization: Bearer …`, and twin-stripe's dual-auth accepts JWTs
-        // natively, so the JWT round-trips cleanly end-to-end.
-        env.POME_STRIPE_API_KEY = session.agent_token;
-      } else if (twin === "slack") {
-        // Same rationale as the Stripe api-key line: the twin proxy verifies
-        // only the session JWT as bearer, so the agent's Slack bearer is the
-        // agent_token — NOT provider_credentials.slack.token, which the proxy
-        // would reject.
-        env.POME_SLACK_TOKEN = session.agent_token;
-      }
-    }
+    //    is twin-mode-agnostic. See `buildAgentEnv` for the origin/main legacy
+    //    block + per-twin fan-out overlay.
+    const env = buildAgentEnv({
+      session,
+      twins,
+      perTwinFromCloud: perTwinReturnedByCloud(session),
+      prompt: scenario.prompt,
+      otlpEndpoint,
+      apiKey: options.hosted.apiKey,
+      agentId,
+      runId,
+      artifactsDir,
+      slug: scenario.slug,
+      signalsPath,
+    });
 
     const preflightTimeoutSeconds = Math.min(10, scenario.config.timeout);
     const preflight = await runAgentCommand({
@@ -334,7 +413,12 @@ export async function runScenarioHosted(
           client.fetchEvents({ twinUrl: twinApiUrl(twin), agentToken: session.agent_token }),
         ]);
         stateFinalByTwin[twin] = sf;
-        eventsByTwin[twin] = (ev as RecorderEvent[]).map((e) => tagEventTwin(e, twin));
+        // Single-twin keeps the twin's events byte-identical to origin/main —
+        // no `twin` field is stamped. Only the multi-twin merge needs each line
+        // tagged so the interleaved stream stays attributable.
+        eventsByTwin[twin] = isMultiTwin
+          ? (ev as RecorderEvent[]).map((e) => tagEventTwin(e, twin))
+          : (ev as RecorderEvent[]);
       }),
     );
     const stateFinal = stateFinalByTwin[primaryTwin];

--- a/cli/src/runner/runScenarioHosted.ts
+++ b/cli/src/runner/runScenarioHosted.ts
@@ -22,7 +22,7 @@ import {
   normalizeConfigAgentSdk,
   readProjectConfig,
 } from "../cli/project-config.js";
-import { HostedTrialError } from "../hosted/errors.js";
+import { HostedOrchError, HostedTrialError } from "../hosted/errors.js";
 import type {
   CreateSessionResponse,
   CriterionDef,
@@ -118,25 +118,44 @@ export async function runScenarioHosted(
   // precedence; see parseScenario.resolveSeedState) so the cloud doesn't need
   // to re-extract it from the markdown. Prose `## Seed State` sections have no
   // fenced JSON to extract — cloud would 422 with "no fenced code block".
-  const session =
-    options.premintedSession ??
-    (await client.createSession({
+  const session = await createSessionOrExplain(
+    client,
+    options.premintedSession,
+    {
       scenarioSource,
       twins: scenario.config.twins,
       agentId,
       seed: scenario.seedState,
-    }));
+    },
+  );
+
+  // Multi-twin (M3) locals. `twins[0]` is the primary twin: the source of the
+  // legacy top-level state blobs / URLs / criterion attribution.
+  const twins = scenario.config.twins;
+  const primaryTwin = twins[0]!;
+  const isMultiTwin = twins.length > 1;
+  // Each twin's own api base. Prefer the per-twin URL; fall back to the legacy
+  // bare `twin_url` (the primary) when the cloud didn't disambiguate per twin
+  // (older cloud, or the empty `per_twin` in tests). Keeps single-twin runs
+  // fetching from the same URL they always did.
+  const twinApiUrl = (twin: string): string =>
+    session.per_twin?.[twin]?.api_url ?? session.twin_url;
 
   // Use session_id as the local artifact-dir id. The cloud's run_id (assigned
   // at /result time) is reported separately to the caller.
   const runId = session.session_id;
 
   try {
-    // 2. Capture initial twin state via bearer-protected /_pome/state.
-    const stateInitial = await client.fetchState({
-      twinUrl: session.twin_url,
-      agentToken: session.agent_token,
-    });
+    // 2. Capture initial twin state via bearer-protected /_pome/state — one
+    //    fetch per twin (each from its own api base). The primary twin's state
+    //    stays the legacy `stateInitial`.
+    const stateInitialByTwin = await fetchStateForTwins(
+      client,
+      twins,
+      twinApiUrl,
+      session.agent_token,
+    );
+    const stateInitial = stateInitialByTwin[primaryTwin];
 
     // Agent telemetry → pome-cloud. The agent runs as a LOCAL subprocess even on
     // hosted runs, and its LLM calls happen inside the SDK (they never traverse
@@ -165,9 +184,15 @@ export async function runScenarioHosted(
 
     // 3. Run the agent. Env mirrors self-host so a customer's agent code
     //    is twin-mode-agnostic.
-    const env = {
+    //
+    // Multi-twin (M3): the twin-endpoint env is a fan-out over the session's
+    // twins. Each twin T gets its OWN POME_<T>_REST_URL / POME_<T>_MCP_URL from
+    // per_twin[T] (distinct URLs per twin), plus its provider bearer. The legacy
+    // single-endpoint vars (POME_TWIN_BASE_URL) keep the primary twin's value so
+    // agents written against the pre-multi-twin contract still work.
+    const env: Record<string, string> = {
       POME_TASK: scenario.prompt,
-      POME_TWIN_NAMES: scenario.config.twins.join(","),
+      POME_TWIN_NAMES: twins.join(","),
       POME_OTEL_EXPORTER_OTLP_ENDPOINT: otlpEndpoint,
       POME_OTEL_EXPORTER_OTLP_HEADERS: `x-api-key=${options.hosted.apiKey}`,
       OTEL_SERVICE_NAME: agentId ?? "pome-agent",
@@ -178,28 +203,44 @@ export async function runScenarioHosted(
       // agents to fall back on. Agent code written against the standalone
       // docker twin reads POME_TWIN_BASE_URL with a 127.0.0.1:3333 fallback;
       // without this injection that fallback fires on hosted runs and the
-      // agent probes a loopback port nothing listens on.
+      // agent probes a loopback port nothing listens on. Legacy = the primary
+      // twin's bare url.
       POME_TWIN_BASE_URL: session.twin_url,
-      POME_GITHUB_REST_URL: session.twin_url,
-      POME_GITHUB_MCP_URL: `${session.twin_url}/mcp`,
-      POME_GITHUB_TOKEN: session.provider_credentials.github?.token ?? session.agent_token,
-      POME_STRIPE_API_BASE: session.twin_url,
-      // Always use the JWT agent_token as the Stripe SDK's Bearer in
-      // hosted mode (FDRS-369). The cloud also returns
-      // `provider_credentials.stripe.api_key` (an HMAC-signed
-      // `sk_test_pome_*`), but the pome-cloud proxy at
-      // `/s/:sid/*` only accepts JWTs — it routes by verifying the
-      // bearer against `agent_token`. A stripe-style key short-circuits
-      // to the proxy's opaque 404 before the request ever reaches the
-      // twin pod. The Stripe SDK is happy to send any opaque string as
-      // `Authorization: Bearer …`, and twin-stripe's dual-auth accepts
-      // JWTs natively, so the JWT round-trips cleanly end-to-end.
-      POME_STRIPE_API_KEY: session.agent_token,
       POME_AUTH_TOKEN: session.agent_token,
       POME_RUN_ID: runId,
       POME_ARTIFACTS_DIR: join(artifactsDir, scenario.slug, runId),
       POME_ADAPTER_SIGNALS_PATH: signalsPath,
     };
+    for (const twin of twins) {
+      const upper = twin.toUpperCase();
+      const pt = session.per_twin?.[twin];
+      const apiUrl = pt?.api_url ?? session.twin_url;
+      const mcpUrl = pt?.mcp_url ?? `${session.twin_url}/mcp`;
+      env[`POME_${upper}_REST_URL`] = apiUrl;
+      env[`POME_${upper}_MCP_URL`] = mcpUrl;
+      if (twin === "github") {
+        env.POME_GITHUB_TOKEN =
+          session.provider_credentials.github?.token ?? session.agent_token;
+      } else if (twin === "stripe") {
+        env.POME_STRIPE_API_BASE = apiUrl;
+        // Always use the JWT agent_token as the Stripe SDK's Bearer in hosted
+        // mode. The cloud also returns
+        // `provider_credentials.stripe.api_key` (an HMAC-signed
+        // `sk_test_pome_*`), but the pome-cloud proxy only accepts JWTs — it
+        // routes by verifying the bearer against `agent_token`. A stripe-style
+        // key short-circuits to the proxy's opaque 404 before the request
+        // reaches the twin pod. The Stripe SDK sends any opaque string as
+        // `Authorization: Bearer …`, and twin-stripe's dual-auth accepts JWTs
+        // natively, so the JWT round-trips cleanly end-to-end.
+        env.POME_STRIPE_API_KEY = session.agent_token;
+      } else if (twin === "slack") {
+        // Same rationale as the Stripe api-key line: the twin proxy verifies
+        // only the session JWT as bearer, so the agent's Slack bearer is the
+        // agent_token — NOT provider_credentials.slack.token, which the proxy
+        // would reject.
+        env.POME_SLACK_TOKEN = session.agent_token;
+      }
+    }
 
     const preflightTimeoutSeconds = Math.min(10, scenario.config.timeout);
     const preflight = await runAgentCommand({
@@ -277,16 +318,31 @@ export async function runScenarioHosted(
       throw new HostedTrialError(failure.reason, failure.errorCode);
     }
 
-    // 4. Capture final state + recorder events. Run in parallel for
-    //    latency. If either rejects (e.g., twin pod restarted between
-    //    preflight and now), the run fails before finalize fires —
-    //    the cloud has no record. Recovery is "user reruns"; V1 doesn't
-    //    retry transient twin failures.
-    const [stateFinal, eventsRaw] = await Promise.all([
-      client.fetchState({ twinUrl: session.twin_url, agentToken: session.agent_token }),
-      client.fetchEvents({ twinUrl: session.twin_url, agentToken: session.agent_token }),
-    ]);
-    const events = eventsRaw as RecorderEvent[];
+    // 4. Capture final state + recorder events — one fetch per twin, all in
+    //    parallel for latency. If any rejects (e.g., a twin pod restarted
+    //    between preflight and now), the run fails before finalize fires — the
+    //    cloud has no record. Recovery is "user reruns"; V1 doesn't retry
+    //    transient twin failures. Events from every twin are merged into one
+    //    ts-ordered stream (each line already carries its twin id from the
+    //    recorder; we only stamp it when a line lacks one).
+    const stateFinalByTwin: Record<string, unknown> = {};
+    const eventsByTwin: Record<string, RecorderEvent[]> = {};
+    await Promise.all(
+      twins.map(async (twin) => {
+        const [sf, ev] = await Promise.all([
+          client.fetchState({ twinUrl: twinApiUrl(twin), agentToken: session.agent_token }),
+          client.fetchEvents({ twinUrl: twinApiUrl(twin), agentToken: session.agent_token }),
+        ]);
+        stateFinalByTwin[twin] = sf;
+        eventsByTwin[twin] = (ev as RecorderEvent[]).map((e) => tagEventTwin(e, twin));
+      }),
+    );
+    const stateFinal = stateFinalByTwin[primaryTwin];
+    // Single-twin keeps the twin's own event order untouched (byte-identical);
+    // multi-twin interleaves all twins' events by timestamp.
+    const events: RecorderEvent[] = isMultiTwin
+      ? mergeEventsByTimestamp(twins.flatMap((t) => eventsByTwin[t] ?? []))
+      : eventsByTwin[primaryTwin] ?? [];
     // artifacts.ts still types `events` as the legacy twin/github RecorderEvent
     // (no step_id / tool_call_id / state_delta fields). Runtime data is the
     // same shape — cast to keep writeRunArtifactsCore happy without churning
@@ -314,6 +370,29 @@ export async function runScenarioHosted(
       stateInitial,
       stateFinal,
     });
+
+    // Multi-twin (M3): writeRunArtifactsCore writes the primary twin's final
+    // state as the legacy `state_final.json`. Write each NON-primary twin's
+    // final state alongside it as `state_final.<twin>.json` so local inspection
+    // sees every twin's world. Best-effort — a disk failure here must not fail
+    // an otherwise-complete run.
+    if (isMultiTwin) {
+      for (const twin of twins) {
+        if (twin === primaryTwin) continue;
+        try {
+          await writeFile(
+            join(artifacts.runDir, `state_final.${twin}.json`),
+            `${JSON.stringify(redactSecrets(stateFinalByTwin[twin]), null, 2)}\n`,
+          );
+        } catch (err) {
+          console.warn(
+            `[pome] state_final.${twin}.json not written (${
+              err instanceof Error ? err.message : String(err)
+            })`,
+          );
+        }
+      }
+    }
 
     // 6. FDRS-657 — NO local correlation. Correlation (like scoring/judging)
     //    is a cloud responsibility; the OSS CLI only captures the raw trace.
@@ -367,12 +446,28 @@ export async function runScenarioHosted(
     const metaJson = await readFile(join(artifacts.runDir, "meta.json"), "utf8").catch(
       () => "{}",
     );
+    // Multi-twin (M3): per-twin state blobs, keyed by twin id (includes the
+    // primary, whose blobs also land at the legacy top-level path). Undefined
+    // for single-twin, which keeps the flat state upload path unchanged.
+    const perTwinState = isMultiTwin
+      ? Object.fromEntries(
+          twins.map((twin) => [
+            twin,
+            {
+              initialJson: JSON.stringify(redactSecrets(stateInitialByTwin[twin])),
+              finalJson: JSON.stringify(redactSecrets(stateFinalByTwin[twin])),
+            },
+          ]),
+        )
+      : undefined;
     const uploaded = await uploadRunBlobs(client, session.session_id, {
       eventsJsonl,
       stateInitialJson,
       stateFinalJson,
       signalsJsonl,
       metaJson,
+      twins: isMultiTwin ? twins : undefined,
+      perTwinState,
     });
     const eventsJsonlUrl = uploaded.eventsKey;
     const stateKeys = {
@@ -387,10 +482,14 @@ export async function runScenarioHosted(
     //    The CLI prints this score on the `score:` line.
     // `CriterionDef.kind` on the finalize request is still the legacy `D`/`P`
     // wire vocabulary; map the canonical `code`/`model` kind back for the wire.
+    // Multi-twin (M3): carry the per-criterion twin attribution so the cloud
+    // judge checks each [D:<twin>] against that twin's state. Absent = the
+    // primary twin (single-twin scenarios omit it entirely).
     const criteriaDefs: CriterionDef[] = scenario.criteria.map((c, idx) => ({
       id: `crit_${idx}`,
       text: c.text,
       kind: c.type === "code" ? "D" : "P",
+      ...(c.twin ? { twin: c.twin } : {}),
     }));
     const stopReason = agentResult.timedOut
       ? "agent_timeout"
@@ -418,6 +517,10 @@ export async function runScenarioHosted(
       stateInitialStorageKey: stateKeys.initialKey ?? undefined,
       stateFinalStorageKey: stateKeys.finalKey ?? undefined,
       signalsStorageKey: signalsKey ?? undefined,
+      // Multi-twin (M3): per-twin state storage keys (>=1 key per entry).
+      // Undefined for single-twin / an older cloud that returned no per_twin
+      // upload block — the cloud then scores the primary twin from the flat keys.
+      perTwinStateKeys: uploaded.perTwinStateKeys,
     });
 
     // 9. Synthesize the cloud verdict for terminal display + the exit code.
@@ -507,6 +610,94 @@ export async function runScenarioHosted(
     await client.deleteSession(session.session_id).catch(() => undefined);
     await rm(signalsDir, { recursive: true, force: true }).catch(() => undefined);
   }
+}
+
+/** Mint the session unless one was pre-minted, mapping an old-cloud multi-twin
+ *  rejection (422 `multi_twin_unsupported`) to a friendly hint. Every other
+ *  error propagates unchanged so the existing auth/quota/orch mapping stands. */
+async function createSessionOrExplain(
+  client: HostedClient,
+  preminted: CreateSessionResponse | undefined,
+  input: {
+    scenarioSource: string;
+    twins: string[];
+    agentId?: string;
+    seed: unknown;
+  },
+): Promise<CreateSessionResponse> {
+  if (preminted) return preminted;
+  try {
+    return await client.createSession(input);
+  } catch (err) {
+    if (
+      err instanceof HostedOrchError &&
+      err.status === 422 &&
+      (err.type === "multi_twin_unsupported" ||
+        /multi_twin_unsupported/i.test(err.message))
+    ) {
+      throw new HostedOrchError(
+        "this pome cloud does not support multi-twin sessions yet",
+        err.requestId,
+        err.status,
+        err.type,
+      );
+    }
+    throw err;
+  }
+}
+
+/** Fetch `/_pome/state` for every twin (each from its own api base), keyed by
+ *  twin id. */
+async function fetchStateForTwins(
+  client: HostedClient,
+  twins: string[],
+  twinApiUrl: (twin: string) => string,
+  agentToken: string,
+): Promise<Record<string, unknown>> {
+  const byTwin: Record<string, unknown> = {};
+  await Promise.all(
+    twins.map(async (twin) => {
+      byTwin[twin] = await client.fetchState({
+        twinUrl: twinApiUrl(twin),
+        agentToken,
+      });
+    }),
+  );
+  return byTwin;
+}
+
+/** Stamp a recorder event with its twin id ONLY when the line doesn't already
+ *  carry one (the twin recorders set `twin` themselves; this is the merge-time
+ *  backfill for any that don't). Returns the input untouched when it already
+ *  carries a non-empty twin. */
+function tagEventTwin(event: RecorderEvent, twin: string): RecorderEvent {
+  if (event && typeof event === "object") {
+    const existing = (event as { twin?: unknown }).twin;
+    if (existing === undefined || existing === null || existing === "") {
+      return { ...event, twin } as RecorderEvent;
+    }
+  }
+  return event;
+}
+
+/** Merge multiple twins' event streams into one timestamp-ordered stream.
+ *  Stable: events with equal (or unparseable) `ts` keep their concatenation
+ *  order, so per-twin ordering is preserved within a timestamp. */
+function mergeEventsByTimestamp(events: RecorderEvent[]): RecorderEvent[] {
+  const tsOf = (e: RecorderEvent): string => {
+    const ts = (e as { ts?: unknown }).ts;
+    return typeof ts === "string" ? ts : "";
+  };
+  return events
+    .map((event, index) => ({ event, index }))
+    .sort((a, b) => {
+      const ta = tsOf(a.event);
+      const tb = tsOf(b.event);
+      if (ta < tb) return -1;
+      if (ta > tb) return 1;
+      return a.index - b.index;
+    })
+    .map(({ event }) => event);
 }
 
 /** FDRS-667 — the last non-empty stderr line, flattened and bounded, as the

--- a/cli/src/scenario/parseScenario.ts
+++ b/cli/src/scenario/parseScenario.ts
@@ -15,6 +15,7 @@ import {
   type Criterion,
   type Scenario,
   type ScenarioConfig,
+  type SeedEnvelope,
   type SeedState
 } from "./scenarioSchema.js";
 
@@ -33,7 +34,7 @@ export function parseScenario(markdown: string, slug = "scenario", sidecarSeed?:
   const seedText = sections.get("seed state") ?? "";
 
   const config = configText.trim() ? scenarioConfigSchema.parse(parseFencedYaml(configText)) : scenarioConfigSchema.parse({});
-  const criteria = parseCriteria(criteriaText);
+  const criteria = parseCriteria(criteriaText, config.twins);
   const seedState = resolveSeedState({ sidecarSeed, seedText, config, scenarioPath });
 
   return scenarioSchema.parse({
@@ -48,7 +49,13 @@ export function parseScenario(markdown: string, slug = "scenario", sidecarSeed?:
   });
 }
 
-function resolveSeedState(args: { sidecarSeed: unknown; seedText: string; config: ScenarioConfig; scenarioPath?: string }): SeedState {
+function resolveSeedState(args: { sidecarSeed: unknown; seedText: string; config: ScenarioConfig; scenarioPath?: string }): SeedState | SeedEnvelope {
+  // Multi-twin (M3): the seed is a per-twin envelope, decided from `config.twins`
+  // alone (envelope-iff-multi-twin — never by sniffing the seed shape).
+  if (args.config.twins.length > 1) {
+    return resolveMultiTwinSeedState(args);
+  }
+  // ── Single-twin: unchanged (byte-identical flat path). ──
   // Sidecar wins when present — it's the compile-seeds output, already
   // validated against the in-memory twin. The `_meta` key (source hash,
   // model, etc.) is stripped before schema parsing.
@@ -74,6 +81,89 @@ function resolveSeedState(args: { sidecarSeed: unknown; seedText: string; config
     }
   }
   return defaultSeedStateForConfig(args.config.twins);
+}
+
+// Multi-twin (M3): the seed (sidecar OR inline) MUST be the per-twin envelope
+// `{ <twin>: <flat seed> }`. Envelope keys are a subset of the scenario's twins;
+// each present value is parsed with THAT twin's own flat schema, and a twin with
+// no envelope key falls back to its default seed. A key that is not one of the
+// scenario's twins is a loud error. When no seed is provided at all, every twin
+// gets its default.
+function resolveMultiTwinSeedState(args: {
+  sidecarSeed: unknown;
+  seedText: string;
+  config: ScenarioConfig;
+  scenarioPath?: string;
+}): SeedEnvelope {
+  const twins = args.config.twins;
+  let raw: unknown | undefined;
+  if (args.sidecarSeed !== undefined) {
+    raw = stripSidecarMeta(args.sidecarSeed);
+  } else if (args.seedText.trim()) {
+    const text = stripFence(args.seedText);
+    if (!/^[\[{]/.test(text)) {
+      throw new Error(missingSidecarMessage(args.scenarioPath));
+    }
+    try {
+      raw = JSON.parse(text);
+    } catch (err) {
+      if (err instanceof SyntaxError) {
+        throw new Error(`Inline JSON seed in ## Seed State is malformed: ${err.message}`);
+      }
+      throw err;
+    }
+  } else {
+    raw = undefined;
+  }
+  return buildSeedEnvelope(raw, twins);
+}
+
+function buildSeedEnvelope(raw: unknown | undefined, twins: string[]): SeedEnvelope {
+  const envelope: SeedEnvelope = {};
+  if (raw === undefined) {
+    for (const twin of twins) envelope[twin] = defaultSeedForTwin(twin);
+    return envelope;
+  }
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error(
+      `Multi-twin scenarios need a per-twin seed envelope { <twin>: <seed> } for twins [${twins.join(", ")}], not a bare seed object.`,
+    );
+  }
+  const allowed = new Set(twins);
+  const provided = raw as Record<string, unknown>;
+  for (const key of Object.keys(provided)) {
+    if (!allowed.has(key)) {
+      throw new Error(
+        `Seed envelope key "${key}" is not one of the scenario's twins [${twins.join(", ")}].`,
+      );
+    }
+  }
+  for (const twin of twins) {
+    envelope[twin] =
+      twin in provided ? parseSeedForTwin(twin, provided[twin]) : defaultSeedForTwin(twin);
+  }
+  return envelope;
+}
+
+// Parse one twin's flat seed with its own schema — the same schemas the
+// single-twin flat path uses, keyed by twin id. Unknown twins fall back to the
+// GitHub parse (mirrors the single-twin default).
+function parseSeedForTwin(twin: string, input: unknown): SeedState {
+  if (twin === "stripe") return stripeSeedStateSchema.parse(input);
+  if (twin === "slack") return slackSeedStateSchema.parse(input);
+  return parseGitHubSeedState(input);
+}
+
+function defaultSeedForTwin(twin: string): SeedState {
+  if (twin === "stripe") {
+    return stripeSeedStateSchema.parse({
+      api_keys: [{ key: "sk_test_pome_default", sid: "default", account_id: "acct_default" }]
+    });
+  }
+  if (twin === "slack") {
+    return slackSeedStateSchema.parse({});
+  }
+  return seedSchema.parse(defaultSeedState());
 }
 
 function missingSidecarMessage(scenarioPath: string | undefined): string {
@@ -128,15 +218,73 @@ function splitSections(markdown: string) {
   return sections;
 }
 
-function parseCriteria(input: string): Criterion[] {
-  return input
-    .split("\n")
-    .map((line) => line.trim())
-    .map((line) => line.match(/^[-*]\s+\[([DP])\]\s+(.+)$/))
-    .filter((match): match is RegExpMatchArray => Boolean(match))
+// Criterion marker grammar (M3): `[D]` / `[P]` optionally carrying a twin tag,
+// `[D:<twin>]` / `[P:<twin>]`, where <twin> is `[a-z][a-z0-9_-]*`. The tag lands
+// on `criterion.twin`; a bare marker leaves it undefined (attributes to the
+// session's primary twin, `twins[0]`).
+const CRITERION_LINE_RE = /^[-*]\s+\[([DP])(?::([a-z][a-z0-9_-]*))?\]\s+(.+)$/;
+
+function parseCriteria(input: string, twins: string[]): Criterion[] {
+  const multiTwin = twins.length > 1;
+  const allowed = new Set(twins);
+  const primary = twins[0]!;
+  const criteria: Criterion[] = [];
+
+  for (const rawLine of input.split("\n")) {
+    const line = rawLine.trim();
+    const match = line.match(CRITERION_LINE_RE);
+    if (!match) continue;
+    const kind = match[1]!; // "D" | "P"
+    const tag = match[2]; // twin tag or undefined
+    const text = match[3]!.trim();
+    // Reconstruct the human-facing marker for error messages.
+    const marker = `[${kind}${tag ? `:${tag}` : ""}]`;
+
+    if (tag !== undefined) {
+      if (!multiTwin) {
+        // Single-twin: an explicit tag is allowed but must equal the sole twin.
+        if (tag !== primary) {
+          throw new Error(
+            `Criterion "${marker} ${text}" tags twin "${tag}", but this single-twin scenario runs "${primary}". Drop the tag or set config.twins to include "${tag}".`,
+          );
+        }
+      } else if (!allowed.has(tag)) {
+        // Multi-twin: an explicit tag must name one of the scenario's twins.
+        throw new Error(
+          `Criterion "${marker} ${text}" tags twin "${tag}", which is not in the scenario's twins [${twins.join(", ")}].`,
+        );
+      }
+    } else if (multiTwin && kind === "D") {
+      // Multi-twin: every deterministic [D] criterion MUST carry a tag so the
+      // cloud knows which twin's state to check it against. [P] may stay bare
+      // (attributes to the primary twin).
+      throw new Error(
+        `Criterion "${marker} ${text}" needs a twin tag ([D:<twin>]) in a multi-twin scenario (twins [${twins.join(", ")}]).`,
+      );
+    }
+
     // Authors still write `[D]`/`[P]` in markdown; the published contract's
     // tolerant reader normalizes those to the canonical `code`/`model` kinds.
-    .map((match) => criterionSchema.parse({ type: match[1], text: match[2]!.trim() }));
+    // The optional `twin` rides through untouched.
+    criteria.push(
+      criterionSchema.parse(
+        tag !== undefined ? { type: kind, text, twin: tag } : { type: kind, text },
+      ),
+    );
+  }
+
+  return criteria;
+}
+
+/** The flat seed a single twin boots from. Single-twin scenarios return the
+ *  flat `seedState` as-is; multi-twin scenarios return that twin's slice of the
+ *  per-twin envelope (decided from `config.twins`, per the envelope-iff-multi-twin
+ *  rule). Used by the local runner to seed each twin harness. */
+export function seedStateForTwin(scenario: Scenario, twin: string): unknown {
+  if (scenario.config.twins.length > 1) {
+    return (scenario.seedState as SeedEnvelope)[twin];
+  }
+  return scenario.seedState;
 }
 
 function parseFencedYaml(input: string) {

--- a/cli/src/scenario/scenarioSchema.ts
+++ b/cli/src/scenario/scenarioSchema.ts
@@ -87,6 +87,15 @@ export const seedStateSchema = z.union([
   stripeSeedStateSchema
 ]);
 
+// Multi-twin (M3): a per-twin seed envelope `{ <twin>: <flat seed> }`, produced
+// ONLY for scenarios whose `config.twins` has >1 entry (the envelope-iff-multi-twin
+// rule, decided from `twins` alone — never by sniffing the seed shape). Each value
+// is one twin's flat seed, the same shapes `seedStateSchema` unions. Single-twin
+// scenarios keep the flat shape byte-identical. parseScenario builds and validates
+// the envelope value-by-value with each twin's own schema; this record is the outer
+// shape scenarioSchema re-validates against.
+export const seedEnvelopeSchema = z.record(z.string(), seedStateSchema);
+
 export const scenarioSchema = z.object({
   slug: z.string().min(1),
   title: z.string().min(1),
@@ -95,7 +104,10 @@ export const scenarioSchema = z.object({
   expectedBehavior: z.string().default(""),
   criteria: z.array(criterionSchema).min(1),
   config: scenarioConfigSchema,
-  seedState: seedStateSchema
+  // Flat single-twin seed OR the multi-twin per-twin envelope. Flat is tried
+  // first so single-twin seeds match their strict arms; the envelope only
+  // matches when the flat union can't (its keys are twin ids, not seed fields).
+  seedState: z.union([seedStateSchema, seedEnvelopeSchema])
 });
 
 export type Criterion = z.infer<typeof criterionSchema>;
@@ -105,4 +117,5 @@ export type StripeSeedState = z.infer<typeof stripeSeedStateSchema>;
 export type SlackSeedState = z.infer<typeof slackSeedStateSchema>;
 export type StripeFailureInjectionRule = z.infer<typeof stripeFailureInjectionRuleSchema>;
 export type SeedState = z.infer<typeof seedStateSchema>;
+export type SeedEnvelope = z.infer<typeof seedEnvelopeSchema>;
 export type Scenario = z.infer<typeof scenarioSchema>;

--- a/cli/src/twin/twinHarness.ts
+++ b/cli/src/twin/twinHarness.ts
@@ -17,7 +17,7 @@
 // any twin land in one buffer typed as the legacy github `RecorderEvent` (the
 // shape is structurally shared via `@pome-sh/shared-types`; the `twin` field is
 // just a string, see `recorderEventSchema`). New twins slot in by adding a case.
-import { createRecorder } from "../recorder/recorder.js";
+import { createRecorder, type Recorder } from "../recorder/recorder.js";
 import type { RecorderEvent } from "@pome-sh/shared-types";
 import {
   createGitHubCloneApp,
@@ -87,15 +87,27 @@ export async function bootTwin(opts: {
    * twin-core durable recorder (same file capture-server appends to).
    */
   eventsPath?: string;
+  /**
+   * Multi-twin (M3): a SHARED recorder so every twin harness in one local run
+   * buffers into a single events stream / events.jsonl. When provided, this
+   * harness does NOT own the recorder — `close()` releases only its DB handle
+   * and the caller is responsible for `flush()`/`close()` on the recorder. When
+   * omitted (single-twin), the harness creates and owns its own recorder, so
+   * `close()` flushes + closes it exactly as before.
+   */
+  recorder?: Recorder;
 }): Promise<TwinHarness> {
-  const recorder = createRecorder({ eventsPath: opts.eventsPath });
+  const ownsRecorder = opts.recorder === undefined;
+  const recorder = opts.recorder ?? createRecorder({ eventsPath: opts.eventsPath });
 
   const flushRecorder = async () => {
     await recorder.flush?.();
   };
   const closeRecorderAndDb = async (dbClose: () => void) => {
     await flushRecorder();
-    await recorder.close?.();
+    // A shared recorder is owned by the caller — only flush here, never close
+    // it out from under sibling harnesses still writing to it.
+    if (ownsRecorder) await recorder.close?.();
     dbClose();
   };
 

--- a/cli/test/integration/runScenarioHosted.test.ts
+++ b/cli/test/integration/runScenarioHosted.test.ts
@@ -840,3 +840,98 @@ describe("runScenarioHosted multi-twin (github + slack)", () => {
     ).rejects.toThrow(/does not support multi-twin sessions yet/i);
   });
 });
+
+// ── Regression (BLOCKER): single-twin run against an OLD cloud that returns
+//    NO `per_twin` — the agent env must stay byte-identical to origin/main.
+//    The schema synthesizes a per_twin entry; the runner must NOT leak its
+//    synthesized mcp_url and must keep injecting the github + stripe vars.
+describe("runScenarioHosted single-twin old-cloud (no per_twin) env parity", () => {
+  let ocServer: ServerType | undefined;
+  let ocPort = 0;
+  let ocTmp: string | undefined;
+
+  afterEach(async () => {
+    ocServer?.close();
+    ocServer = undefined;
+    ocPort = 0;
+    if (ocTmp) {
+      await rm(ocTmp, { recursive: true, force: true });
+      ocTmp = undefined;
+    }
+  });
+
+  const SINGLE_SCENARIO =
+    "# Trivial\n\n## Prompt\nPretend prompt.\n\n## Success Criteria\n- [D] No unsupported endpoint was called\n";
+
+  it("injects POME_GITHUB_MCP_URL=${twin_url}/mcp and the unconditional stripe vars", async () => {
+    const app = new Hono();
+    app.post("/v1/sessions", async (c) => {
+      const token = await signJwt(
+        { sid: FAKE_SESSION_ID, team_id: "tm_test", exp: Math.floor(Date.now() / 1000) + 600 },
+        TWIN_AUTH_SECRET,
+      );
+      // OLD cloud: twin_url only, NO per_twin key, NO session_token.
+      return c.json({
+        session_id: FAKE_SESSION_ID,
+        twin_url: `http://127.0.0.1:${ocPort}/s/${FAKE_SESSION_ID}`,
+        expires_at: new Date(Date.now() + 600_000).toISOString(),
+        agent_token: token,
+        openapi_url: `http://127.0.0.1:${ocPort}/openapi.json`,
+        provider_credentials: {
+          github: { token: "ght_provider", header: "Authorization", scheme: "Bearer" },
+        },
+      });
+    });
+    app.get("/s/:sid/_pome/state", (c) => c.json({ repositories: [] }));
+    app.get("/s/:sid/_pome/events", (c) => c.json([]));
+    app.post("/v1/sessions/:id/finalize", (c) =>
+      c.json(
+        {
+          run_id: FAKE_RUN_ID,
+          score: 100,
+          judge_model: "test-judge",
+          dashboard_url: `http://127.0.0.1:${ocPort}/runs/${FAKE_RUN_ID}`,
+        },
+        201,
+      ),
+    );
+    app.delete("/v1/sessions/:id", (c) => c.json({ id: c.req.param("id"), state: "expired" }));
+
+    ocPort = await new Promise<number>((res) => {
+      ocServer = serve({ fetch: app.fetch, port: 0, hostname: "127.0.0.1" }, (info) => res(info.port));
+    });
+
+    ocTmp = await mkdtemp(join(tmpdir(), "pome-hosted-oc-"));
+    const scenarioPath = join(ocTmp, "scn.md");
+    await writeFile(scenarioPath, SINGLE_SCENARIO, "utf8");
+    const envFile = join(ocTmp, "agent-env.json");
+    const agentScript = `require('fs').writeFileSync(${JSON.stringify(envFile)}, JSON.stringify({ghr:process.env.POME_GITHUB_REST_URL, ghm:process.env.POME_GITHUB_MCP_URL, ght:process.env.POME_GITHUB_TOKEN, sb:process.env.POME_STRIPE_API_BASE, sk:process.env.POME_STRIPE_API_KEY, base:process.env.POME_TWIN_BASE_URL, auth:process.env.POME_AUTH_TOKEN}))`;
+    const stubAgent = `node -e ${JSON.stringify(agentScript)}`;
+
+    const result = await runScenarioHosted({
+      scenarioPath,
+      agentCommand: stubAgent,
+      artifactsDir: join(ocTmp, "runs"),
+      hosted: { baseUrl: `http://127.0.0.1:${ocPort}`, apiKey: "pme_test" },
+    });
+
+    expect(result.exitCode).toBe(0);
+
+    const agentEnv = JSON.parse(
+      await (await import("node:fs/promises")).readFile(envFile, "utf8"),
+    ) as Record<string, string>;
+    const twinUrl = `http://127.0.0.1:${ocPort}/s/${FAKE_SESSION_ID}`;
+
+    // The BLOCKER: MCP url is `${twin_url}/mcp`, never the synthesized value
+    // (which for a non-api host has no /mcp suffix at all).
+    expect(agentEnv.ghm).toBe(`${twinUrl}/mcp`);
+    expect(agentEnv.ghr).toBe(twinUrl);
+    expect(agentEnv.base).toBe(twinUrl);
+    // Provider github token flows through (origin/main parity).
+    expect(agentEnv.ght).toBe("ght_provider");
+    // Stripe vars injected UNCONDITIONALLY even on a github-only run.
+    expect(agentEnv.sb).toBe(twinUrl);
+    expect(agentEnv.sk).toBe(agentEnv.auth);
+    expect(agentEnv.sk).toBeTruthy();
+  });
+});

--- a/cli/test/integration/runScenarioHosted.test.ts
+++ b/cli/test/integration/runScenarioHosted.test.ts
@@ -560,3 +560,283 @@ describe("runScenarioHosted failure paths", () => {
     expect(receivedFinalize!.stop_reason).toBe("agent_timeout");
   });
 });
+
+// ── Multi-twin (M3): env fan-out, per-twin state capture/upload, finalize ──
+describe("runScenarioHosted multi-twin (github + slack)", () => {
+  let mtServer: ServerType | undefined;
+  let mtPort = 0;
+  let mtTmp: string | undefined;
+
+  afterEach(async () => {
+    mtServer?.close();
+    mtServer = undefined;
+    mtPort = 0;
+    if (mtTmp) {
+      await rm(mtTmp, { recursive: true, force: true });
+      mtTmp = undefined;
+    }
+  });
+
+  const MULTI_SCENARIO = [
+    "# Multi",
+    "",
+    "## Prompt",
+    "Do a github+slack task.",
+    "",
+    "## Success Criteria",
+    "- [D:github] Issue #1 is labeled",
+    "- [D:slack] A message was posted",
+    "",
+    "## Seed State",
+    "```json",
+    JSON.stringify({
+      github: { repositories: [{ owner: "acme", name: "api" }] },
+      slack: { channels: [{ name: "general" }] },
+    }),
+    "```",
+    "",
+    "## Config",
+    "```yaml",
+    'twins: ["github", "slack"]',
+    "```",
+    "",
+  ].join("\n");
+
+  it("fans env out per twin, fetches+uploads two states, and finalizes with twins + per_twin_state_keys", async () => {
+    const stateGets: Record<string, number> = { github: 0, slack: 0 };
+    const statePuts: Record<string, string | null> = {
+      "github/final": null,
+      "slack/final": null,
+      "github/initial": null,
+      "slack/initial": null,
+      "top/final": null,
+    };
+    let receivedFinalize: Record<string, unknown> | null = null;
+    let stateUploadBody: unknown = null;
+
+    const app = new Hono();
+
+    app.post("/v1/sessions", async (c) => {
+      const token = await signJwt(
+        { sid: FAKE_SESSION_ID, team_id: "tm_test", exp: Math.floor(Date.now() / 1000) + 600 },
+        TWIN_AUTH_SECRET,
+      );
+      return c.json({
+        session_id: FAKE_SESSION_ID,
+        session_token: "pst_test_hosted",
+        // Legacy bare url (= primary twin, un-disambiguated).
+        twin_url: `http://127.0.0.1:${mtPort}/s/${FAKE_SESSION_ID}`,
+        expires_at: new Date(Date.now() + 600_000).toISOString(),
+        agent_token: token,
+        openapi_url: `http://127.0.0.1:${mtPort}/openapi.json`,
+        // Distinct per-twin URLs.
+        per_twin: {
+          github: {
+            api_url: `http://127.0.0.1:${mtPort}/github/s/${FAKE_SESSION_ID}`,
+            mcp_url: `http://127.0.0.1:${mtPort}/github/s/${FAKE_SESSION_ID}/mcp`,
+            openapi_url: `http://127.0.0.1:${mtPort}/github/openapi.json`,
+          },
+          slack: {
+            api_url: `http://127.0.0.1:${mtPort}/slack/s/${FAKE_SESSION_ID}`,
+            mcp_url: `http://127.0.0.1:${mtPort}/slack/s/${FAKE_SESSION_ID}/mcp`,
+            openapi_url: `http://127.0.0.1:${mtPort}/slack/openapi.json`,
+          },
+        },
+      });
+    });
+
+    // Per-twin twin-pod stand-ins (distinct state per twin).
+    app.get("/github/s/:sid/_pome/state", (c) => {
+      stateGets.github += 1;
+      return c.json({ repositories: [{ owner: "acme", name: "api", full_name: "acme/api" }] });
+    });
+    app.get("/slack/s/:sid/_pome/state", (c) => {
+      stateGets.slack += 1;
+      return c.json({ channels: [{ name: "general" }] });
+    });
+    app.get("/github/s/:sid/_pome/events", (c) =>
+      c.json([
+        {
+          ts: "2026-05-11T00:00:01.000Z",
+          run_id: "run_fixture",
+          twin: "github",
+          request_id: "req_gh",
+          method: "GET",
+          path: "/repos/acme/api",
+          status: 200,
+          response_body: {},
+          latency_ms: 5,
+          fidelity: "semantic",
+          state_mutation: false,
+        },
+      ]),
+    );
+    app.get("/slack/s/:sid/_pome/events", (c) =>
+      c.json([
+        {
+          ts: "2026-05-11T00:00:03.000Z",
+          run_id: "run_fixture",
+          twin: "slack",
+          request_id: "req_sl",
+          method: "POST",
+          path: "/api/chat.postMessage",
+          status: 200,
+          response_body: {},
+          latency_ms: 5,
+          fidelity: "semantic",
+          state_mutation: true,
+        },
+      ]),
+    );
+
+    app.post("/v1/sessions/:id/result-upload-url", (c) => {
+      const sid = c.req.param("id");
+      return c.json({
+        url: `http://127.0.0.1:${mtPort}/__put/events`,
+        key: `team-tm_test/session-${sid}/events.jsonl`,
+      });
+    });
+
+    app.post("/v1/sessions/:id/state-upload-url", async (c) => {
+      const sid = c.req.param("id");
+      stateUploadBody = await c.req.json().catch(() => null);
+      const pair = (twin: string) => ({
+        state_initial: {
+          url: `http://127.0.0.1:${mtPort}/__put/${twin}/initial`,
+          key: `team-tm_test/session-${sid}/${twin}/state_initial.json`,
+        },
+        state_final: {
+          url: `http://127.0.0.1:${mtPort}/__put/${twin}/final`,
+          key: `team-tm_test/session-${sid}/${twin}/state_final.json`,
+        },
+      });
+      return c.json({
+        // Top-level pair = primary twin (github).
+        state_initial: {
+          url: `http://127.0.0.1:${mtPort}/__put/top/initial`,
+          key: `team-tm_test/session-${sid}/state_initial.json`,
+        },
+        state_final: {
+          url: `http://127.0.0.1:${mtPort}/__put/top/final`,
+          key: `team-tm_test/session-${sid}/state_final.json`,
+        },
+        per_twin: { github: pair("github"), slack: pair("slack") },
+      });
+    });
+
+    app.put("/__put/events", async () => new Response(null, { status: 200 }));
+    for (const key of ["github", "slack", "top"]) {
+      app.put(`/__put/${key}/initial`, async (c) => {
+        statePuts[`${key}/initial`] = await c.req.text();
+        return new Response(null, { status: 200 });
+      });
+      app.put(`/__put/${key}/final`, async (c) => {
+        statePuts[`${key}/final`] = await c.req.text();
+        return new Response(null, { status: 200 });
+      });
+    }
+
+    app.post("/v1/sessions/:id/finalize", async (c) => {
+      receivedFinalize = (await c.req.json()) as Record<string, unknown>;
+      return c.json(
+        {
+          run_id: FAKE_RUN_ID,
+          score: 100,
+          judge_model: "test-judge",
+          dashboard_url: `http://127.0.0.1:${mtPort}/runs/${FAKE_RUN_ID}`,
+        },
+        201,
+      );
+    });
+    app.delete("/v1/sessions/:id", (c) => c.json({ id: c.req.param("id"), state: "expired" }));
+
+    mtPort = await new Promise<number>((res) => {
+      mtServer = serve({ fetch: app.fetch, port: 0, hostname: "127.0.0.1" }, (info) => res(info.port));
+    });
+
+    mtTmp = await mkdtemp(join(tmpdir(), "pome-hosted-mt-"));
+    const scenarioPath = join(mtTmp, "scn.md");
+    await writeFile(scenarioPath, MULTI_SCENARIO, "utf8");
+    const envFile = join(mtTmp, "agent-env.json");
+    const agentScript = `require('fs').writeFileSync(${JSON.stringify(envFile)}, JSON.stringify({gh:process.env.POME_GITHUB_REST_URL, ghm:process.env.POME_GITHUB_MCP_URL, ght:process.env.POME_GITHUB_TOKEN, sl:process.env.POME_SLACK_REST_URL, slm:process.env.POME_SLACK_MCP_URL, slt:process.env.POME_SLACK_TOKEN, names:process.env.POME_TWIN_NAMES}))`;
+    const stubAgent = `node -e ${JSON.stringify(agentScript)}`;
+
+    const artifactsDir = join(mtTmp, "runs");
+    const result = await runScenarioHosted({
+      scenarioPath,
+      agentCommand: stubAgent,
+      artifactsDir,
+      hosted: { baseUrl: `http://127.0.0.1:${mtPort}`, apiKey: "pme_test" },
+    });
+
+    expect(result.score.satisfaction).toBe(100);
+
+    // Env fan-out: distinct per-twin endpoints; slack bearer = the session JWT.
+    const agentEnv = JSON.parse(await (await import("node:fs/promises")).readFile(envFile, "utf8")) as Record<string, string>;
+    expect(agentEnv.gh).toContain("/github/s/");
+    expect(agentEnv.sl).toContain("/slack/s/");
+    expect(agentEnv.gh).not.toBe(agentEnv.sl);
+    expect(agentEnv.ghm).toContain("/github/s/");
+    expect(agentEnv.slm).toContain("/slack/s/");
+    expect(agentEnv.names).toBe("github,slack");
+    // Slack + github bearers both = agent_token (proxy only verifies the JWT).
+    expect(agentEnv.slt).toBe(agentEnv.ght);
+    expect(agentEnv.slt).toBeTruthy();
+
+    // Two state fetches (one per twin), each hit by initial + final captures.
+    expect(stateGets.github).toBeGreaterThanOrEqual(2);
+    expect(stateGets.slack).toBeGreaterThanOrEqual(2);
+
+    // Two per-twin state uploads with distinct bodies.
+    expect(statePuts["github/final"]).not.toBeNull();
+    expect(statePuts["slack/final"]).not.toBeNull();
+    expect(JSON.parse(statePuts["github/final"] as string)).toHaveProperty("repositories");
+    expect(JSON.parse(statePuts["slack/final"] as string)).toHaveProperty("channels");
+
+    // state-upload-url was asked for both twins.
+    expect((stateUploadBody as { twins?: string[] }).twins).toEqual(["github", "slack"]);
+
+    // Finalize carries per-criterion twin attribution and per_twin_state_keys.
+    expect(receivedFinalize).not.toBeNull();
+    const finalize = receivedFinalize!;
+    const criteria = finalize.criteria as Array<{ text: string; kind: string; twin?: string }>;
+    expect(criteria.map((c) => c.twin)).toEqual(["github", "slack"]);
+    const perTwinKeys = finalize.per_twin_state_keys as Record<string, unknown>;
+    expect(Object.keys(perTwinKeys).sort()).toEqual(["github", "slack"]);
+    expect(perTwinKeys.slack).toMatchObject({
+      state_final_key: `team-tm_test/session-${FAKE_SESSION_ID}/slack/state_final.json`,
+    });
+
+    // Non-primary twin state written to artifacts alongside the legacy file.
+    const fs = await import("node:fs/promises");
+    const slackArtifact = JSON.parse(
+      await fs.readFile(join(result.artifacts.runDir, "state_final.slack.json"), "utf8"),
+    );
+    expect(slackArtifact).toHaveProperty("channels");
+  });
+
+  it("maps an old-cloud 422 multi_twin_unsupported to a friendly message", async () => {
+    const app = new Hono();
+    app.post("/v1/sessions", (c) =>
+      c.json(
+        { error: { type: "multi_twin_unsupported", message: "multi-twin not supported" } },
+        422,
+      ),
+    );
+    mtPort = await new Promise<number>((res) => {
+      mtServer = serve({ fetch: app.fetch, port: 0, hostname: "127.0.0.1" }, (info) => res(info.port));
+    });
+    mtTmp = await mkdtemp(join(tmpdir(), "pome-hosted-mt-"));
+    const scenarioPath = join(mtTmp, "scn.md");
+    await writeFile(scenarioPath, MULTI_SCENARIO, "utf8");
+
+    await expect(
+      runScenarioHosted({
+        scenarioPath,
+        agentCommand: "true",
+        artifactsDir: join(mtTmp, "runs"),
+        hosted: { baseUrl: `http://127.0.0.1:${mtPort}`, apiKey: "pme_test" },
+      }),
+    ).rejects.toThrow(/does not support multi-twin sessions yet/i);
+  });
+});

--- a/cli/test/unit/parseScenario.test.ts
+++ b/cli/test/unit/parseScenario.test.ts
@@ -1,5 +1,26 @@
 import { describe, expect, it } from "vitest";
 import { parseScenario } from "../../src/scenario/parseScenario.js";
+import type {
+  GithubSeedState,
+  SeedEnvelope,
+  StripeSeedState,
+} from "../../src/scenario/scenarioSchema.js";
+
+// seedState is now a union (flat single-twin seed | multi-twin envelope), so
+// the historical `"key" in seedState` narrowing no longer selects a single arm.
+// These helpers assert + cast to the arm the test knows it produced.
+function asGithub(seed: unknown): GithubSeedState {
+  if (!seed || typeof seed !== "object" || !("repositories" in seed)) {
+    throw new Error("expected legacy GitHub seed");
+  }
+  return seed as GithubSeedState;
+}
+function asStripe(seed: unknown): StripeSeedState {
+  if (!seed || typeof seed !== "object" || !("api_keys" in seed)) {
+    throw new Error("expected stripe seed");
+  }
+  return seed as StripeSeedState;
+}
 
 describe("parseScenario", () => {
   it("parses Pome markdown with config, criteria, and seed state", () => {
@@ -39,8 +60,7 @@ passThreshold: 75
     expect(scenario.criteria).toHaveLength(2);
     expect(scenario.config.timeout).toBe(12);
     expect(scenario.config.passThreshold).toBe(75);
-    if (!("repositories" in scenario.seedState)) throw new Error("expected legacy GitHub seed");
-    expect(scenario.seedState.repositories[0]?.labels?.[0]?.name).toBe("bug");
+    expect(asGithub(scenario.seedState).repositories[0]?.labels?.[0]?.name).toBe("bug");
   });
 
   it("rejects scenarios without a prompt", () => {
@@ -77,8 +97,7 @@ twins: ["stripe"]
 `);
 
     expect(scenario.config.twins).toEqual(["stripe"]);
-    if (!("api_keys" in scenario.seedState)) throw new Error("expected stripe seed");
-    expect(scenario.seedState.api_keys[0]?.key).toBe("sk_test_pome_demo");
+    expect(asStripe(scenario.seedState).api_keys[0]?.key).toBe("sk_test_pome_demo");
   });
 
   it("rejects wrapped Stripe seed shape (FDRS-365)", () => {
@@ -142,8 +161,7 @@ twins: ["stripe"]
 \`\`\`
 `);
 
-    if (!("api_keys" in scenario.seedState)) throw new Error("expected stripe seed");
-    const rules = scenario.seedState.failure_injection;
+    const rules = asStripe(scenario.seedState).failure_injection;
     expect(rules).toHaveLength(1);
     expect(rules[0]).toMatchObject({
       method: "POST",
@@ -178,8 +196,7 @@ twins: ["stripe"]
 \`\`\`
 `);
 
-    if (!("api_keys" in scenario.seedState)) throw new Error("expected stripe seed");
-    expect(scenario.seedState.failure_injection[0]?.mode).toBe("after_handler");
+    expect(asStripe(scenario.seedState).failure_injection[0]?.mode).toBe("after_handler");
   });
 
   it("throws a friendly compile-seeds error when ## Seed State is prose and no sidecar is present", () => {
@@ -275,9 +292,139 @@ Review the open pull request and decide whether to merge.
 \`\`\`
 `);
 
-    if (!("repositories" in scenario.seedState)) throw new Error("expected legacy GitHub seed");
-    expect(scenario.seedState.users?.map((user) => user.login)).toEqual(["alice", "adam-spoofer"]);
-    expect(scenario.seedState.repositories[0]?.pull_requests?.[0]?.author).toBe("adam-spoofer");
-    expect(scenario.seedState.repositories[0]?.files?.[1]?.branch).toBe("spoof-attempt");
+    const seed = asGithub(scenario.seedState);
+    expect(seed.users?.map((user) => user.login)).toEqual(["alice", "adam-spoofer"]);
+    expect(seed.repositories[0]?.pull_requests?.[0]?.author).toBe("adam-spoofer");
+    expect(seed.repositories[0]?.files?.[1]?.branch).toBe("spoof-attempt");
+  });
+});
+
+// ── Multi-twin (M3): tagged criteria + per-twin seed envelope ──────────────
+describe("parseScenario multi-twin", () => {
+  const MULTI_HEADER = `# Multi
+
+## Prompt
+Do a github+slack task.
+`;
+  const MULTI_CONFIG = `
+## Config
+\`\`\`yaml
+twins: ["github", "slack"]
+\`\`\`
+`;
+
+  function multiScenario(criteria: string, seed?: string) {
+    return `${MULTI_HEADER}
+## Success Criteria
+${criteria}
+${seed ? `\n## Seed State\n\`\`\`json\n${seed}\n\`\`\`\n` : ""}${MULTI_CONFIG}`;
+  }
+
+  it("attaches the twin tag from [D:twin] / [P:twin] to criterion.twin", () => {
+    const scenario = parseScenario(
+      multiScenario(
+        "- [D:github] Issue #1 is labeled\n- [D:slack] A message was posted\n- [P:slack] The summary is clear\n- [P] Overall reasonable",
+      ),
+    );
+    expect(scenario.criteria).toHaveLength(4);
+    expect(scenario.criteria[0]).toMatchObject({ type: "code", twin: "github" });
+    expect(scenario.criteria[1]).toMatchObject({ type: "code", twin: "slack" });
+    expect(scenario.criteria[2]).toMatchObject({ type: "model", twin: "slack" });
+    // Bare [P] in a multi-twin scenario is allowed and leaves twin undefined.
+    expect(scenario.criteria[3]?.type).toBe("model");
+    expect(scenario.criteria[3]?.twin).toBeUndefined();
+  });
+
+  it("rejects a bare [D] in a multi-twin scenario (every [D] must be tagged)", () => {
+    expect(() =>
+      parseScenario(
+        multiScenario("- [D] Something deterministic\n- [D:slack] A message was posted"),
+      ),
+    ).toThrow(/needs a twin tag/i);
+  });
+
+  it("rejects a tag that is not one of the scenario's twins", () => {
+    expect(() =>
+      parseScenario(
+        multiScenario("- [D:stripe] A charge exists\n- [D:github] Issue labeled"),
+      ),
+    ).toThrow(/not in the scenario's twins/i);
+  });
+
+  it("parses a per-twin seed envelope, one arm per twin", () => {
+    const scenario = parseScenario(
+      multiScenario(
+        "- [D:github] x\n- [D:slack] y",
+        JSON.stringify({
+          github: { repositories: [{ owner: "acme", name: "api" }] },
+          slack: { channels: [{ name: "general" }] },
+        }),
+      ),
+    );
+    const envelope = scenario.seedState as SeedEnvelope;
+    expect(asGithub(envelope.github).repositories[0]?.owner).toBe("acme");
+    expect("channels" in envelope.slack).toBe(true);
+  });
+
+  it("fills a twin's default seed when its envelope key is missing", () => {
+    const scenario = parseScenario(
+      multiScenario(
+        "- [D:github] x\n- [D:slack] y",
+        JSON.stringify({ github: { repositories: [{ owner: "acme", name: "api" }] } }),
+      ),
+    );
+    const envelope = scenario.seedState as SeedEnvelope;
+    // slack key absent → default slack seed present (schema-valid floor).
+    expect(envelope.slack).toBeDefined();
+    expect(asGithub(envelope.github).repositories[0]?.owner).toBe("acme");
+  });
+
+  it("rejects an envelope key that is not one of the scenario's twins", () => {
+    expect(() =>
+      parseScenario(
+        multiScenario(
+          "- [D:github] x\n- [D:slack] y",
+          JSON.stringify({
+            github: { repositories: [{ owner: "acme", name: "api" }] },
+            stripe: { api_keys: [] },
+          }),
+        ),
+      ),
+    ).toThrow(/not one of the scenario's twins/i);
+  });
+
+  it("defaults every twin's seed when no ## Seed State is present", () => {
+    const scenario = parseScenario(multiScenario("- [D:github] x\n- [D:slack] y"));
+    const envelope = scenario.seedState as SeedEnvelope;
+    expect(envelope.github).toBeDefined();
+    expect(envelope.slack).toBeDefined();
+  });
+});
+
+// Single-twin explicit-tag rules.
+describe("parseScenario single-twin tags", () => {
+  it("accepts an explicit tag equal to the sole twin", () => {
+    const scenario = parseScenario(`# Tagged single
+
+## Prompt
+p
+
+## Success Criteria
+- [D:github] Issue labeled
+`);
+    expect(scenario.criteria[0]).toMatchObject({ type: "code", twin: "github" });
+  });
+
+  it("rejects an explicit tag that differs from the sole twin", () => {
+    expect(() =>
+      parseScenario(`# Wrong tag
+
+## Prompt
+p
+
+## Success Criteria
+- [D:slack] A message was posted
+`),
+    ).toThrow(/single-twin scenario runs "github"/i);
   });
 });

--- a/cli/test/unit/register.test.ts
+++ b/cli/test/unit/register.test.ts
@@ -255,6 +255,32 @@ describe("runRegisterAgent", () => {
     const body = JSON.parse(String((fetchMock.mock.calls[0]![1] as RequestInit).body));
     expect(body).toEqual({ name: "Triage Bot" });
   });
+
+  it("stays silent about enabled_services when no --twins was passed (older cloud)", async () => {
+    await writeConfig({ agent: { command: "node a.js" } });
+    const errors: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((msg?: unknown) => {
+      errors.push(String(msg));
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      response({
+        id: "agt_123",
+        slug: "triage-bot",
+        display_name: "Triage Bot",
+        judge_model: "google/gemini-2.5-flash",
+      }),
+    );
+
+    await runRegisterAgent({
+      apiBaseUrl: "https://api.example.com",
+      name: "Triage Bot",
+      force: false,
+    });
+
+    // No twin scoping was requested, so an absent enabled_services must not warn.
+    expect(errors.join("\n")).not.toMatch(/not reported by this pome cloud/i);
+    expect(errors.join("\n")).not.toMatch(/enabled services/i);
+  });
 });
 
 describe("normalizeRegisterTwins", () => {

--- a/cli/test/unit/register.test.ts
+++ b/cli/test/unit/register.test.ts
@@ -5,7 +5,11 @@ import { join } from "node:path";
 import { basename } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HostedOrchError } from "../../src/hosted/errors.js";
-import { ensureAgentRegistered, runRegisterAgent } from "../../src/cli/register.js";
+import {
+  ensureAgentRegistered,
+  normalizeRegisterTwins,
+  runRegisterAgent,
+} from "../../src/cli/register.js";
 
 const originalCwd = process.cwd();
 const tempDirs: string[] = [];
@@ -175,6 +179,94 @@ describe("runRegisterAgent", () => {
       }),
     ).rejects.toThrow(/malformed agentId/);
     expect(existsSync("pome.config.json")).toBe(true);
+  });
+
+  // ── Multi-twin (M3): --twins body + enabled_services print + old-cloud warn ──
+  it("POSTs {name, twins} and prints the cloud's enabled services", async () => {
+    await writeConfig({ agent: { command: "node a.js" } });
+    const errors: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((msg?: unknown) => {
+      errors.push(String(msg));
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      response({
+        id: "agt_123",
+        slug: "triage-bot",
+        display_name: "Triage Bot",
+        judge_model: "google/gemini-2.5-flash",
+        enabled_services: ["github", "slack"],
+      }),
+    );
+
+    await runRegisterAgent({
+      apiBaseUrl: "https://api.example.com",
+      name: "Triage Bot",
+      force: false,
+      twins: ["github", "slack"],
+    });
+
+    const body = JSON.parse(String((fetchMock.mock.calls[0]![1] as RequestInit).body));
+    expect(body).toEqual({ name: "Triage Bot", twins: ["github", "slack"] });
+    expect(errors.join("\n")).toContain("Enabled services: github, slack");
+  });
+
+  it("warns when an older cloud omits enabled_services", async () => {
+    await writeConfig({ agent: { command: "node a.js" } });
+    const errors: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((msg?: unknown) => {
+      errors.push(String(msg));
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      response({
+        id: "agt_123",
+        slug: "triage-bot",
+        display_name: "Triage Bot",
+        judge_model: "google/gemini-2.5-flash",
+      }),
+    );
+
+    await runRegisterAgent({
+      apiBaseUrl: "https://api.example.com",
+      name: "Triage Bot",
+      force: false,
+      twins: ["github", "slack"],
+    });
+
+    expect(errors.join("\n")).toMatch(/not reported by this pome cloud/i);
+  });
+
+  it("omits twins from the body when none are passed (byte-identical to pre-M3)", async () => {
+    await writeConfig({ agent: { command: "node a.js" } });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      response({
+        id: "agt_123",
+        slug: "triage-bot",
+        display_name: "Triage Bot",
+        judge_model: "google/gemini-2.5-flash",
+      }),
+    );
+
+    await runRegisterAgent({
+      apiBaseUrl: "https://api.example.com",
+      name: "Triage Bot",
+      force: false,
+    });
+
+    const body = JSON.parse(String((fetchMock.mock.calls[0]![1] as RequestInit).body));
+    expect(body).toEqual({ name: "Triage Bot" });
+  });
+});
+
+describe("normalizeRegisterTwins", () => {
+  it("parses and de-dupes a comma list", () => {
+    expect(normalizeRegisterTwins("github, slack ,github")).toEqual(["github", "slack"]);
+  });
+  it("returns undefined for absent / empty input", () => {
+    expect(normalizeRegisterTwins(undefined)).toBeUndefined();
+    expect(normalizeRegisterTwins("  , ")).toBeUndefined();
+  });
+  it("rejects an unknown twin against MOUNTED_TWINS", () => {
+    expect(() => normalizeRegisterTwins("github,linear")).toThrow(/Unknown twin/);
   });
 });
 

--- a/cli/test/unit/runner/buildAgentEnv.test.ts
+++ b/cli/test/unit/runner/buildAgentEnv.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from "vitest";
+import {
+  createSessionResponseSchema,
+  type CreateSessionResponse,
+} from "@pome-sh/shared-types";
+import { buildAgentEnv } from "../../../src/runner/runScenarioHosted.js";
+import { rawBodyHadPerTwin } from "../../../src/hosted/client.js";
+
+// Regression: single-twin runs against an OLD cloud (no `per_twin` in the wire
+// body) must stay BYTE-IDENTICAL to origin/main's hosted env. The schema
+// synthesizes a `per_twin` entry whose `mcp_url` host-rewrites
+// api.pome.sh→mcp.pome.sh with NO `/mcp` suffix; the fan-out must NOT trust
+// that synthesized value and must fall back to `${twin_url}/mcp`, exactly as
+// main did. It must also keep injecting the github + stripe vars unconditionally
+// (main set them on every hosted run regardless of twin).
+
+const AGENT_TOKEN = "edt_fake.jwt.token";
+const GITHUB_PROVIDER_TOKEN = "ght_provider_x";
+const EXPIRES_AT = "2026-05-11T00:10:00.000Z";
+const TWIN_URL = "https://api.pome.sh/github/s/ses_old";
+const OPENAPI_URL = "https://api.pome.sh/github/openapi.json";
+
+const ENV_SCAFFOLD = {
+  prompt: "Do the thing.",
+  otlpEndpoint: "http://127.0.0.1:9/v1/sessions/ses_old/traces",
+  apiKey: "pme_test",
+  agentId: "agt_test",
+  runId: "ses_old",
+  artifactsDir: "runs",
+  slug: "scn",
+  signalsPath: "/tmp/signals.jsonl",
+} as const;
+
+/** Reproduce the env origin/main produced for a single-twin github session —
+ *  the acceptance bar for byte-identity. Mirrors main's env object literal
+ *  (keys AND insertion order) exactly. */
+function originMainEnv(session: CreateSessionResponse): Record<string, string> {
+  const { agentId, runId } = ENV_SCAFFOLD;
+  return {
+    POME_TASK: ENV_SCAFFOLD.prompt,
+    POME_TWIN_NAMES: "github",
+    POME_OTEL_EXPORTER_OTLP_ENDPOINT: ENV_SCAFFOLD.otlpEndpoint,
+    POME_OTEL_EXPORTER_OTLP_HEADERS: `x-api-key=${ENV_SCAFFOLD.apiKey}`,
+    OTEL_SERVICE_NAME: agentId,
+    OTEL_RESOURCE_ATTRIBUTES: `pome.session_id=${session.session_id},pome.run_id=${runId},pome.agent_id=${agentId}`,
+    POME_TWIN_BASE_URL: session.twin_url,
+    POME_GITHUB_REST_URL: session.twin_url,
+    POME_GITHUB_MCP_URL: `${session.twin_url}/mcp`,
+    POME_GITHUB_TOKEN:
+      session.provider_credentials.github?.token ?? session.agent_token,
+    POME_STRIPE_API_BASE: session.twin_url,
+    POME_STRIPE_API_KEY: session.agent_token,
+    POME_AUTH_TOKEN: session.agent_token,
+    POME_RUN_ID: runId,
+    POME_ARTIFACTS_DIR: `runs/scn/${runId}`,
+    POME_ADAPTER_SIGNALS_PATH: ENV_SCAFFOLD.signalsPath,
+  };
+}
+
+function oldCloudBody(extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    session_id: "ses_old",
+    // NOTE: no session_token, no per_twin — the schema synthesizes both.
+    twin_url: TWIN_URL,
+    expires_at: EXPIRES_AT,
+    agent_token: AGENT_TOKEN,
+    openapi_url: OPENAPI_URL,
+    provider_credentials: {
+      github: {
+        token: GITHUB_PROVIDER_TOKEN,
+        header: "Authorization",
+        scheme: "Bearer",
+      },
+    },
+    ...extra,
+  };
+}
+
+describe("buildAgentEnv — single-twin old-cloud byte-identity", () => {
+  it("omitted per_twin: POME_GITHUB_MCP_URL === twin_url + '/mcp' (not the mcp.pome.sh synthesis)", () => {
+    const raw = oldCloudBody();
+    // The schema synthesizes per_twin.github.mcp_url as the mcp.pome.sh host
+    // rewrite — the value we must NOT leak into the agent env.
+    const session = createSessionResponseSchema.parse(raw);
+    expect(session.per_twin.github?.mcp_url).toBe(
+      "https://mcp.pome.sh/github/s/ses_old",
+    );
+    // Client stamps perTwinFromCloud=false for a body with no per_twin key.
+    expect(rawBodyHadPerTwin(raw)).toBe(false);
+
+    const env = buildAgentEnv({
+      session,
+      twins: ["github"],
+      perTwinFromCloud: rawBodyHadPerTwin(raw),
+      ...ENV_SCAFFOLD,
+    });
+
+    expect(env.POME_GITHUB_MCP_URL).toBe(`${TWIN_URL}/mcp`);
+    expect(env.POME_GITHUB_MCP_URL).not.toContain("mcp.pome.sh");
+  });
+
+  it("omitted per_twin: FULL env is byte-identical to origin/main (values + key order)", () => {
+    const raw = oldCloudBody();
+    const session = createSessionResponseSchema.parse(raw);
+    const env = buildAgentEnv({
+      session,
+      twins: ["github"],
+      perTwinFromCloud: rawBodyHadPerTwin(raw),
+      ...ENV_SCAFFOLD,
+    });
+
+    const expected = originMainEnv(session);
+    expect(env).toEqual(expected);
+    // Insertion order matters for byte-identity of any serialized env dump.
+    expect(Object.keys(env)).toEqual(Object.keys(expected));
+    // Stripe vars injected unconditionally even for a github-only session.
+    expect(env.POME_STRIPE_API_BASE).toBe(TWIN_URL);
+    expect(env.POME_STRIPE_API_KEY).toBe(AGENT_TOKEN);
+  });
+
+  it("empty per_twin ({}): FULL env is byte-identical to the omitted-per_twin case", () => {
+    const rawEmpty = oldCloudBody({ per_twin: {} });
+    const sessionEmpty = createSessionResponseSchema.parse(rawEmpty);
+    // Empty per_twin still counts as cloud-returned, but there is no github
+    // entry to trust — so the fan-out falls back to `${twin_url}/mcp` anyway.
+    expect(rawBodyHadPerTwin(rawEmpty)).toBe(true);
+    const envEmpty = buildAgentEnv({
+      session: sessionEmpty,
+      twins: ["github"],
+      perTwinFromCloud: rawBodyHadPerTwin(rawEmpty),
+      ...ENV_SCAFFOLD,
+    });
+
+    const rawOmitted = oldCloudBody();
+    const sessionOmitted = createSessionResponseSchema.parse(rawOmitted);
+    const envOmitted = buildAgentEnv({
+      session: sessionOmitted,
+      twins: ["github"],
+      perTwinFromCloud: rawBodyHadPerTwin(rawOmitted),
+      ...ENV_SCAFFOLD,
+    });
+
+    expect(envEmpty).toEqual(envOmitted);
+    expect(envEmpty).toEqual(originMainEnv(sessionEmpty));
+  });
+
+  it("new cloud with real per_twin: trusts mcp_url + applies ensureMcpSuffix", () => {
+    const raw = oldCloudBody({
+      per_twin: {
+        github: {
+          api_url: "https://api.pome.sh/github/s/ses_new",
+          // No /mcp suffix on the wire — ensureMcpSuffix must append it.
+          mcp_url: "https://mcp.pome.sh/github/s/ses_new",
+          openapi_url: "https://api.pome.sh/github/openapi.json",
+        },
+      },
+    });
+    const session = createSessionResponseSchema.parse(raw);
+    expect(rawBodyHadPerTwin(raw)).toBe(true);
+    const env = buildAgentEnv({
+      session,
+      twins: ["github"],
+      perTwinFromCloud: rawBodyHadPerTwin(raw),
+      ...ENV_SCAFFOLD,
+    });
+    expect(env.POME_GITHUB_REST_URL).toBe("https://api.pome.sh/github/s/ses_new");
+    expect(env.POME_GITHUB_MCP_URL).toBe(
+      "https://mcp.pome.sh/github/s/ses_new/mcp",
+    );
+  });
+});

--- a/cli/test/unit/session.test.ts
+++ b/cli/test/unit/session.test.ts
@@ -18,11 +18,15 @@ vi.mock("../../src/cli/project-config.js", () => ({
   readProjectConfig: vi.fn(async () => null),
 }));
 
-vi.mock("../../src/hosted/client.js", () => ({
-  createHostedClient: vi.fn(() => ({
-    createSession: mocks.createSession,
-  })),
-}));
+vi.mock("../../src/hosted/client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/hosted/client.js")>();
+  return {
+    ...actual,
+    createHostedClient: vi.fn(() => ({
+      createSession: mocks.createSession,
+    })),
+  };
+});
 
 import { runSessionCreate } from "../../src/cli/session.js";
 

--- a/cli/test/unit/session.test.ts
+++ b/cli/test/unit/session.test.ts
@@ -44,6 +44,11 @@ const session: CreateSessionResponse = {
       mcp_url: "https://twin.example.com/s/ses_test/stripe/mcp",
       openapi_url: "https://twin.example.com/s/ses_test/stripe/openapi.json",
     },
+    slack: {
+      api_url: "https://twin.example.com/s/ses_test/slack",
+      mcp_url: "https://twin.example.com/s/ses_test/slack/mcp",
+      openapi_url: "https://twin.example.com/s/ses_test/slack/openapi.json",
+    },
   },
   provider_credentials: {
     github: {
@@ -53,6 +58,11 @@ const session: CreateSessionResponse = {
     },
     stripe: {
       api_key: "stripe_secret_key",
+      header: "Authorization",
+      scheme: "Bearer",
+    },
+    slack: {
+      token: "slack_secret_token",
       header: "Authorization",
       scheme: "Bearer",
     },
@@ -91,7 +101,7 @@ describe("runSessionCreate secret output", () => {
   it("keeps JSON output redacted even when --show-secrets is set", async () => {
     await runSessionCreate({
       apiBaseUrl: "https://api.example.com",
-      twin: "github",
+      twins: ["github"],
       showSecrets: true,
       format: "json",
     });
@@ -110,7 +120,7 @@ describe("runSessionCreate secret output", () => {
     try {
       await runSessionCreate({
         apiBaseUrl: "https://api.example.com",
-        twin: "stripe",
+        twins: ["stripe"],
         showSecrets: false,
         format: "env",
         secretsFile,
@@ -135,7 +145,7 @@ describe("runSessionCreate secret output", () => {
   it("refuses env format without printing exports when no secrets file is provided", async () => {
     await runSessionCreate({
       apiBaseUrl: "https://api.example.com",
-      twin: "github",
+      twins: ["github"],
       showSecrets: true,
       format: "env",
     });
@@ -145,5 +155,94 @@ describe("runSessionCreate secret output", () => {
     expect(combinedOutput).not.toContain("agent_secret_token");
     expect(combinedOutput).not.toContain("github_secret_token");
     expect(process.exitCode).toBe(2);
+  });
+
+  // ── Multi-twin (M3): slack allowed, repeated --twin, slack redaction, env ──
+  it("allows the slack twin (MOUNTED_TWINS) and creates a session for it", async () => {
+    await runSessionCreate({
+      apiBaseUrl: "https://api.example.com",
+      twins: ["slack"],
+      showSecrets: false,
+      format: "json",
+    });
+    expect(mocks.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ twins: ["slack"] }),
+    );
+  });
+
+  it("stands up a multi-twin session from repeated --twin values", async () => {
+    await runSessionCreate({
+      apiBaseUrl: "https://api.example.com",
+      twins: ["github", "slack"],
+      showSecrets: false,
+      format: "json",
+    });
+    expect(mocks.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ twins: ["github", "slack"] }),
+    );
+  });
+
+  it("de-dupes repeated twins and rejects an unknown twin", async () => {
+    await runSessionCreate({
+      apiBaseUrl: "https://api.example.com",
+      twins: ["github", "github"],
+      showSecrets: false,
+      format: "json",
+    });
+    expect(mocks.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ twins: ["github"] }),
+    );
+
+    await expect(
+      runSessionCreate({
+        apiBaseUrl: "https://api.example.com",
+        twins: ["linear"],
+        showSecrets: false,
+        format: "json",
+      }),
+    ).rejects.toThrow(/Unknown twin "linear"/);
+  });
+
+  it("redacts provider_credentials.slack.token in JSON output", async () => {
+    await runSessionCreate({
+      apiBaseUrl: "https://api.example.com",
+      twins: ["slack"],
+      showSecrets: true,
+      format: "json",
+    });
+    const output = stdout.join("\n");
+    expect(output).toContain("***redacted***");
+    expect(output).not.toContain("slack_secret_token");
+  });
+
+  it("writes a slack env export with POME_SLACK_* and the JWT as the slack bearer", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pome-session-slack-"));
+    const secretsFile = join(dir, "session.env");
+    try {
+      await runSessionCreate({
+        apiBaseUrl: "https://api.example.com",
+        twins: ["github", "slack"],
+        showSecrets: false,
+        format: "env",
+        secretsFile,
+      });
+      const contents = await readFile(secretsFile, "utf8");
+      // Distinct per-twin endpoints, plus the slack bearer = the session JWT
+      // (the proxy only verifies the JWT — never provider_credentials.slack.token).
+      expect(contents).toContain(
+        'POME_GITHUB_REST_URL="https://twin.example.com/s/ses_test/github"',
+      );
+      expect(contents).toContain(
+        'POME_SLACK_REST_URL="https://twin.example.com/s/ses_test/slack"',
+      );
+      expect(contents).toContain(
+        'POME_SLACK_MCP_URL="https://twin.example.com/s/ses_test/slack/mcp"',
+      );
+      expect(contents).toContain('POME_SLACK_TOKEN="agent_secret_token"');
+      expect(contents).not.toContain("slack_secret_token");
+      expect(contents).toContain('POME_TWIN_NAMES="github,slack"');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/cli/test/unit/twin/multiTwinHarness.test.ts
+++ b/cli/test/unit/twin/multiTwinHarness.test.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Multi-twin (M3) local runner mechanism: `runScenario` boots one bootTwin
+// harness per config twin, all sharing ONE recorder so their events land in a
+// single stream, and the runner (not the harness) owns the recorder's
+// lifecycle. This covers the shared-recorder wiring in isolation without the
+// full self-host e2e (agent + capture-server).
+import { describe, expect, it } from "vitest";
+import { defaultSeedState, seedSchema } from "@pome-sh/twin-github";
+import { bootTwin } from "../../../src/twin/twinHarness.js";
+import { createRecorder } from "../../../src/recorder/recorder.js";
+
+describe("bootTwin shared recorder (multi-twin local runner)", () => {
+  it("boots github + slack on one shared recorder and lets the caller own its lifecycle", async () => {
+    const recorder = createRecorder(); // in-memory, runner-owned
+
+    const github = await bootTwin({
+      twin: "github",
+      runId: "cli-multi-twin-test",
+      seedState: seedSchema.parse(defaultSeedState()),
+      recorder,
+    });
+    const slack = await bootTwin({
+      twin: "slack",
+      runId: "cli-multi-twin-test",
+      seedState: {},
+      recorder,
+    });
+
+    try {
+      // Distinct env prefixes → distinct POME_<TWIN>_{REST,MCP}_URL fan-out.
+      expect(github.envName).toBe("GITHUB");
+      expect(slack.envName).toBe("SLACK");
+
+      // Both harnesses read from the SAME shared buffer.
+      expect(github.events()).toEqual(slack.events());
+
+      // Each twin exports its own world.
+      const githubState = (await github.exportState()) as { repositories?: unknown[] };
+      expect(Array.isArray(githubState.repositories)).toBe(true);
+      const slackState = await slack.exportState();
+      expect(slackState).toBeTruthy();
+    } finally {
+      // Closing a harness that does NOT own the recorder must only release its
+      // DB handle — the shared recorder stays usable for its siblings and is
+      // closed once, by the caller, at the end.
+      await github.close();
+      // slack still works after a sibling closed.
+      expect(await slack.exportState()).toBeTruthy();
+      await slack.close();
+      await recorder.close?.();
+    }
+  });
+});


### PR DESCRIPTION
Adds native multi-twin scenario support to the CLI, integrating the shared-types 0.7.0 multi-twin contract. Single-twin behavior is unchanged end to end.

## What changed
- **`[D:twin]` / `[P:twin]` criteria tags.** Success-criteria markers accept an optional twin tag that attributes each criterion to a twin. In a multi-twin scenario every `[D]` must carry a tag and every tag must name one of `config.twins`; single-twin scenarios keep bare markers (an explicit tag must equal the sole twin).
- **Per-twin seed envelope.** A multi-twin `## Seed State` is `{ <twin>: <flat seed> }` — each value parsed with that twin's own schema, a missing twin key defaults that twin's seed, an unknown key errors. Decided from `config.twins` (envelope-iff-multi-twin), never by sniffing the seed. Single-twin flat seeds are byte-identical.
- **Env fan-out contract.** Hosted runs emit `POME_<TWIN>_REST_URL` / `POME_<TWIN>_MCP_URL` per twin from `per_twin[t]` (distinct URLs), with per-provider bearers (`POME_GITHUB_TOKEN`, `POME_STRIPE_API_KEY = agent_token`, `POME_SLACK_TOKEN = agent_token`). Legacy `POME_TWIN_BASE_URL` keeps the primary twin's value.
- **Per-twin state capture/upload.** State/events fetched per twin from `per_twin[t].api_url`; `state_final.json` (primary) plus `state_final.<twin>.json` for the rest; events merged timestamp-ordered. Upload requests per-twin URLs when >1 twin and finalize sends `criteria[*].twin` + `per_twin_state_keys` (falls back to the primary-only flat keys on an older cloud).
- **Slack sessions from the CLI.** `pome session create` accepts repeated `--twin` (multi-twin) and the slack twin; `pome register agent --twins github,slack` records enabled services and prints them back.
- **Old-cloud degradation.** A 422 `multi_twin_unsupported` create-session rejection maps to a clear "this pome cloud does not support multi-twin sessions yet" message; every new field is additive so an old cloud strips it and scores the primary twin.

## Notes
- The cloud side (per-twin provisioning + evaluation) ships in separate PRs; end-to-end verification against a live multi-twin cloud follows once those deploy.
- Bumps `@pome-sh/shared-types` to the published 0.7.0.

## Tests
- Unit: tagged-criteria happy/error paths, per-twin seed envelope (parse/default/unknown-key), flat-path regression, session slack/repeated-twin/redaction/env-export, register `--twins` + `enabled_services`, shared-recorder two-harness boot.
- Integration: fake cloud returns two distinct `per_twin` entries + per-twin state/upload/finalize — asserts env fan-out, two state fetches, two uploads, and finalize carrying `criteria[].twin` + `per_twin_state_keys`; plus the old-cloud 422 mapping.