### PR TITLE
Capture per-turn LLM usage as LlmTurnEvent on self-host runs

### DIFF
--- a/.github/workflows/quickstart-smoke.yml
+++ b/.github/workflows/quickstart-smoke.yml
@@ -64,9 +64,23 @@ jobs:
         run: |
           npm ci
           npm test
+      # The CLI consumes @pome-sh/* as published versions, but a checkout can
+      # use a shared-types feature ahead of its npm release (e.g. a new
+      # events.jsonl kind). Pack the workspace packages and point the CLI at the
+      # local tarballs before building — the same pre-publish flow cli-ci and the
+      # overhead gate use, so "from this checkout" means the checkout's
+      # shared-types, not the registry's. Drop this once the consumed
+      # shared-types is on npm and the committed cli/package-lock.json resolves it.
+      - name: Pack @pome-sh packages and rewrite the CLI onto local tarballs
+        run: |
+          node scripts/pack-publishable.mjs --out "$RUNNER_TEMP/tarballs"
+          node scripts/use-local-pome-tarballs.mjs cli/package.json
       - name: Build the CLI from this checkout
         working-directory: cli
         run: |
+          # No committed lockfile for the rewritten tarball manifest; generate
+          # one then freeze-install (mirrors cli-ci).
+          npm install --package-lock-only --ignore-scripts
           npm ci
           npm run build
       # One secret, shared via env by the twin and the agent — the README's

--- a/cli/.changeset/llm-turn-event.md
+++ b/cli/.changeset/llm-turn-event.md
@@ -1,0 +1,15 @@
+---
+"@pome-sh/cli": minor
+---
+
+Per-turn LLM usage is now captured end to end on self-host runs. The Claude-SDK
+adapter emits an `LlmTurnEvent` for each assistant turn — model, input/output
+tokens, and the cache-read/cache-creation token counts — into `events.jsonl`.
+
+- `pome inspect` renders the new `LlmTurnEvent` rows (turn index, model, token
+  usage, cache read/create counts) and counts them in the CAS-adapter trace
+  health layer.
+- `pome eval` no longer corrupts already-kinded event rows on upload: it
+  previously mapped every row through the legacy TwinHttpEvent wrapper, which
+  clobbered any non-TwinHttpEvent kind. Legacy (kind-less) rows are still
+  wrapped; kinded rows now upload unchanged.

--- a/cli/scripts/cas-adapter-acceptance.ts
+++ b/cli/scripts/cas-adapter-acceptance.ts
@@ -101,6 +101,8 @@ interface EventRow {
   tool_use_id?: unknown;
   hook_name?: unknown;
   event_id?: unknown;
+  cache_read_input_tokens?: unknown;
+  cache_creation_input_tokens?: unknown;
 }
 
 async function main(): Promise<void> {
@@ -236,8 +238,26 @@ async function assertEventsShape(runDir: string): Promise<void> {
     );
   }
 
+  // (iv) ≥1 LlmTurnEvent carrying cache tokens (F-766). The whole point of the
+  // kind is that per-turn usage — including the cache-read/cache-creation
+  // token counts the OTLP side-lane drops — reaches the events.jsonl ledger.
+  const turns = rows.filter((r) => r.kind === "LlmTurnEvent");
+  if (turns.length === 0) fail("expected ≥1 LlmTurnEvent, got 0");
+  const turnsWithCache = turns.filter(
+    (r) =>
+      typeof r.cache_read_input_tokens === "number" ||
+      typeof r.cache_creation_input_tokens === "number",
+  );
+  if (turnsWithCache.length === 0) {
+    fail(
+      `expected ≥1 LlmTurnEvent with cache tokens, got ${turns.length} turn row(s) ` +
+        `but none carried cache_read/cache_creation counts (did withTurnUsage run?)`,
+    );
+  }
+
   console.log(
-    `[cas-acceptance] shape OK — Llm=${llm.length} TwinTagged=${tagged.length}/${twin.length} ToolUse=${toolUse.length} PreToolUse=${preToolUse.length}`,
+    `[cas-acceptance] shape OK — Llm=${llm.length} TwinTagged=${tagged.length}/${twin.length} ` +
+      `ToolUse=${toolUse.length} PreToolUse=${preToolUse.length} LlmTurn=${turns.length}(cache=${turnsWithCache.length})`,
   );
 }
 

--- a/cli/src/cli/eval.ts
+++ b/cli/src/cli/eval.ts
@@ -57,7 +57,7 @@ import {
   type ProjectConfig,
 } from "./project-config.js";
 import type { RecorderEvent as LegacyGithubRecorderEvent } from "@pome-sh/shared-types";
-import type { FinalizeResponse } from "../types/shared.js";
+import { isLegacyEventRow, type FinalizeResponse } from "../types/shared.js";
 
 const EVAL_SESSION_FILE = "eval-session.json";
 // The eval command has no scenario file (and therefore no per-scenario
@@ -422,22 +422,33 @@ export async function runEval(options: RunEvalOptions): Promise<RunEvalResult> {
 
   // Re-apply wrapping + redaction before anything leaves the machine.
   // events.jsonl and the state blobs are written pre-redacted (and
-  // pre-wrapped) by artifacts.ts, but `pome eval` also accepts
-  // hand-assembled dirs — redaction is idempotent, and toTwinHttpEvent
-  // passes rows that already carry a `kind` through untouched, so this is
-  // cheap insurance that exactly mirrors what the hosted runner uploads
-  // (cloud's FDRS-398 schema gate rejects raw legacy rows).
+  // pre-wrapped) by artifacts.ts, but `pome eval` also accepts hand-assembled
+  // dirs — redaction is idempotent, so this is cheap insurance that mirrors
+  // what the hosted runner uploads (cloud's FDRS-398 schema gate rejects raw
+  // legacy rows).
+  //
+  // Only LEGACY rows (pre-FDRS-398 — no `kind` discriminator) get wrapped into
+  // a TwinHttpEvent. Rows that already carry a `kind` (any union member —
+  // LlmTurnEvent, ToolUseEvent, LlmCallEvent, …) are preserved as-is: routing
+  // them through toTwinHttpEvent re-wraps every non-TwinHttpEvent kind,
+  // clobbering `kind` to "TwinHttpEvent" and setting event_id to an absent
+  // `request_id` (the pre-F-766 corruption bug).
   const eventsJsonl =
     artifacts.eventsJsonl
       .split("\n")
       .filter((line) => line.trim().length > 0)
-      .map((line) =>
-        JSON.stringify(
-          redactEvent(
-            toTwinHttpEvent(JSON.parse(line) as LegacyGithubRecorderEvent),
-          ),
-        ),
-      )
+      .map((line) => {
+        const parsed = JSON.parse(line) as unknown;
+        // Already-kinded rows pass through unchanged (redacted). Only legacy
+        // rows are wrapped — and we do NOT re-validate kinded rows here: the
+        // original path never did, cloud's schema gate is the arbiter, and
+        // strict parsing would reject the intentionally-terse hand-assembled
+        // dirs `pome eval` also accepts.
+        const event = isLegacyEventRow(parsed)
+          ? toTwinHttpEvent(parsed as LegacyGithubRecorderEvent)
+          : parsed;
+        return JSON.stringify(redactEvent(event));
+      })
       .join("\n") + "\n";
   const blobs = {
     eventsJsonl,

--- a/cli/src/hosted/client.ts
+++ b/cli/src/hosted/client.ts
@@ -238,9 +238,10 @@ export interface FinalizeInput {
   stateFinalStorageKey?: string;
   // F0-4 / L7 — when set, cloud's finalize-run switches the correlator to
   // `correlateTraceJsonlWithSignals` so adapter-emitted HookEvent /
-  // ToolUseEvent / SubagentSpawnEvent rows correlate into lanes/steps
-  // alongside the twin-HTTP timeline. The CLI uploads signals.jsonl via
-  // `requestSignalsUploadUrl` first; the returned storage key flows here.
+  // ToolUseEvent / ToolResultEvent / SubagentSpawnEvent / LlmTurnEvent rows
+  // correlate into lanes/steps alongside the twin-HTTP timeline. The CLI
+  // uploads signals.jsonl via `requestSignalsUploadUrl` first; the returned
+  // storage key flows here.
   signalsStorageKey?: string;
   // Multi-twin (M3): per-twin state storage keys, keyed by twin id. Sent only
   // for multi-twin sessions; each entry carries at least one of
@@ -302,8 +303,9 @@ export interface HostedClient {
     twins?: string[],
   ): Promise<StateUploadUrlResponse>;
   /** F0-4 / L7 — mint a signed PUT for `signals.jsonl` (adapter-emitted
-   *  HookEvent / ToolUseEvent / SubagentSpawnEvent rows). The returned
-   *  `key` flows into `FinalizeInput.signalsStorageKey`. */
+   *  HookEvent / ToolUseEvent / ToolResultEvent / SubagentSpawnEvent /
+   *  LlmTurnEvent rows). The returned `key` flows into
+   *  `FinalizeInput.signalsStorageKey`. */
   requestSignalsUploadUrl(sessionId: string): Promise<SignalsUploadUrlResponse>;
   /** D18.1 — mint a signed PUT for meta.json. See `MetaUploadUrlResponse`
    *  for the feature-detection contract (a 404 here means an older control

--- a/cli/src/recorder/inspect.ts
+++ b/cli/src/recorder/inspect.ts
@@ -7,6 +7,7 @@ import {
   type Event,
   type HookEvent,
   type LlmCallEvent,
+  type LlmTurnEvent,
   type SubagentSpawnEvent,
   type ToolResultEvent,
   type ToolUseEvent,
@@ -129,12 +130,14 @@ export function computeTraceHealth(input: TraceHealthInput): TraceHealthLayer[] 
 
   // CAS adapter layer — only active when the agent is wired through
   // `@pome-sh/claude-agent-sdk`. Heuristic: any of ToolUse/ToolResult/
-  // SubagentSpawn/Hook indicates adapter is live.
+  // SubagentSpawn/Hook/LlmTurn indicates adapter is live. LlmTurnEvent (F-766)
+  // is adapter-emitted like its siblings, so it counts toward this layer.
   const casCount =
     counts.ToolUseEvent +
     counts.ToolResultEvent +
     counts.SubagentSpawnEvent +
-    counts.HookEvent;
+    counts.HookEvent +
+    counts.LlmTurnEvent;
   const casExpected = input.scenarioExpectsCas ? 1 : casCount > 0 ? 1 : 0;
   const cas: TraceHealthLayer = {
     name: "CAS adapter",
@@ -166,6 +169,7 @@ function emptyCounts(): CountsByKind {
     ToolResultEvent: 0,
     SubagentSpawnEvent: 0,
     HookEvent: 0,
+    LlmTurnEvent: 0,
   };
 }
 
@@ -220,6 +224,8 @@ function renderEventLines(event: Event): string[] {
       return renderSubagentSpawn(event);
     case "HookEvent":
       return renderHook(event);
+    case "LlmTurnEvent":
+      return renderLlmTurn(event);
   }
 }
 
@@ -262,4 +268,19 @@ function renderSubagentSpawn(event: SubagentSpawnEvent): string[] {
 function renderHook(event: HookEvent): string[] {
   const tool = event.tool_name ? ` tool=${event.tool_name}` : "";
   return [`- HookEvent      ${event.hook_name}${tool}`];
+}
+
+function renderLlmTurn(event: LlmTurnEvent): string[] {
+  const model = event.model ?? "unknown";
+  const tokens = `${event.input_tokens ?? "?"}/${event.output_tokens ?? "?"}`;
+  const cache = `${event.cache_read_input_tokens ?? "?"}/${event.cache_creation_input_tokens ?? "?"}`;
+  const est = event.latency_ms_estimated ? "~" : "";
+  const finish =
+    event.finish_reasons && event.finish_reasons.length > 0
+      ? `  finish=${event.finish_reasons.join(",")}`
+      : "";
+  return [
+    `- LlmTurnEvent   turn ${event.turn_index}  model=${model}  tokens=${tokens} (${est}${event.latency_ms}ms)`,
+    `    cache read/create=${cache}${finish}`,
+  ];
 }

--- a/cli/src/runner/mergeAdapterSignals.ts
+++ b/cli/src/runner/mergeAdapterSignals.ts
@@ -13,8 +13,8 @@ import { redactEvent } from "../recorder/redaction.js";
 //   2. The trace writer then appends `TwinHttpEvent` rows from the in-process
 //      twin recorder (FDRS-415).
 //   3. This helper reads `signals.jsonl` (HookEvent / ToolUseEvent /
-//      ToolResultEvent / SubagentSpawnEvent rows written by the agent
-//      subprocess via `POME_ADAPTER_SIGNALS_PATH`), validates each line
+//      ToolResultEvent / SubagentSpawnEvent / LlmTurnEvent rows written by the
+//      agent subprocess via `POME_ADAPTER_SIGNALS_PATH`), validates each line
 //      against the M0 unified `eventSchema`, then **interleaves** the signal
 //      rows with the existing events.jsonl rows by ts ascending and rewrites
 //      the file. The merged file is the canonical view for `pome inspect`

--- a/cli/test/integration/demo-e2e.test.ts
+++ b/cli/test/integration/demo-e2e.test.ts
@@ -9,6 +9,7 @@ import { createServer, type Server } from "node:http";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { gunzipSync } from "node:zlib";
 import { afterAll, describe, expect, it } from "vitest";
 import { runDemo } from "../../src/demo/runDemo.js";
 import { captureServerForTests } from "../fixtures/captureServerForTests.js";
@@ -67,11 +68,16 @@ async function startStubCloud(): Promise<StubCloud> {
   let mintCount = 0;
 
   const server = createServer((req, res) => {
-    let raw = "";
+    // Collect as bytes: blob PUTs arrive gzipped (putBlob sets
+    // content-encoding: gzip), so a utf8 string would mangle them. JSON POST
+    // bodies are plaintext and decode from the same buffer.
+    const chunks: Buffer[] = [];
     req.on("data", (chunk) => {
-      raw += String(chunk);
+      chunks.push(Buffer.from(chunk));
     });
     req.on("end", () => {
+      const rawBuf = Buffer.concat(chunks);
+      const raw = rawBuf.toString("utf8");
       const url = req.url ?? "";
       const json = (status: number, body: unknown): void => {
         res.writeHead(status, { "content-type": "application/json" });
@@ -79,7 +85,8 @@ async function startStubCloud(): Promise<StubCloud> {
       };
 
       if (req.method === "PUT" && url.startsWith("/put/")) {
-        putBodies.set(url, raw);
+        // Blob uploads are gzipped by putBlob; gunzip to store the real trace.
+        putBodies.set(url, gunzipSync(rawBuf).toString("utf8"));
         res.writeHead(200);
         res.end();
         return;

--- a/cli/test/unit/eval-command.test.ts
+++ b/cli/test/unit/eval-command.test.ts
@@ -9,6 +9,7 @@ import { existsSync } from "node:fs";
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { gunzipSync } from "node:zlib";
 
 import {
   deriveEvalIdentity,
@@ -152,6 +153,15 @@ function makeEvalClient({
   };
 
   return { client, calls };
+}
+
+// putBlob (uploadAndFinalize.ts) gzips every blob before PUT and sets
+// `content-encoding: gzip` (the cloud reader gunzips transparently). Tests that
+// assert on uploaded *content* must decode the captured body — `.text()` on the
+// raw Request returns the gzipped bytes, not JSON.
+function decodePutBody(init: RequestInit | undefined): string {
+  const body = init?.body;
+  return gunzipSync(Buffer.from(body as Uint8Array)).toString("utf8");
 }
 
 function mockPutFetch(): { putUrls: () => string[] } {
@@ -548,7 +558,7 @@ describe("pome eval upload + finalize flow (FDRS-656)", () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (url, init) => {
       const urlStr = String(url);
       if ((init as RequestInit | undefined)?.method === "PUT") {
-        bodies[urlStr] = await new Request(urlStr, init as RequestInit).text();
+        bodies[urlStr] = decodePutBody(init as RequestInit);
         return new Response(null, { status: 200 });
       }
       throw new Error(`Unexpected fetch call to ${urlStr}`);
@@ -857,7 +867,7 @@ describe("pome eval review fixes (FDRS-656 follow-up)", () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (url, init) => {
       const urlStr = String(url);
       if ((init as RequestInit | undefined)?.method === "PUT") {
-        bodies[urlStr] = await new Request(urlStr, init as RequestInit).text();
+        bodies[urlStr] = decodePutBody(init as RequestInit);
         return new Response(null, { status: 200 });
       }
       throw new Error(`Unexpected fetch call to ${urlStr}`);
@@ -875,6 +885,57 @@ describe("pome eval review fixes (FDRS-656 follow-up)", () => {
     const uploaded = JSON.parse(bodies[EVENTS_URL]!.trimEnd());
     expect(uploaded.kind).toBe("TwinHttpEvent");
     expect(uploaded.event_id).toBe("req_legacy");
+  });
+
+  it("already-kinded rows (LlmTurnEvent) survive eval upload unchanged (F-766)", async () => {
+    // Pre-F-766, every row was mapped through toTwinHttpEvent, which re-wrapped
+    // any non-TwinHttpEvent kind — clobbering `kind` to "TwinHttpEvent" and
+    // setting event_id to the (absent) request_id. A kinded row must now
+    // round-trip intact so cloud sees the real per-turn usage + cache tokens.
+    const turnRow = JSON.stringify({
+      kind: "LlmTurnEvent",
+      ts: "2026-06-30T10:00:02.000Z",
+      event_id: "evt_turn_1",
+      parent_id: null,
+      turn_index: 0,
+      model: "claude-opus-4-8",
+      input_tokens: 1200,
+      output_tokens: 340,
+      cache_read_input_tokens: 900,
+      cache_creation_input_tokens: 128,
+      finish_reasons: ["end_turn"],
+      latency_ms: 2150,
+      latency_ms_estimated: true,
+      session_id: null,
+    });
+    const runDir = await writeRunDir(tmp, { eventsJsonl: `${turnRow}\n` });
+
+    const bodies: Record<string, string> = {};
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (url, init) => {
+      const urlStr = String(url);
+      if ((init as RequestInit | undefined)?.method === "PUT") {
+        bodies[urlStr] = decodePutBody(init as RequestInit);
+        return new Response(null, { status: 200 });
+      }
+      throw new Error(`Unexpected fetch call to ${urlStr}`);
+    });
+    const { client } = makeEvalClient();
+
+    await runEval({
+      runDir,
+      agent: "triage-bot",
+      hosted: { baseUrl: "http://no-cloud.invalid", apiKey: "pme_test" },
+      client,
+      projectConfig: null,
+    });
+
+    const uploaded = JSON.parse(bodies[EVENTS_URL]!.trimEnd());
+    expect(uploaded.kind).toBe("LlmTurnEvent");
+    expect(uploaded.event_id).toBe("evt_turn_1");
+    expect(uploaded.turn_index).toBe(0);
+    expect(uploaded.cache_read_input_tokens).toBe(900);
+    expect(uploaded.cache_creation_input_tokens).toBe(128);
+    expect(uploaded.finish_reasons).toEqual(["end_turn"]);
   });
 
   it("corrupt latest.json → named usage error with exit 5", async () => {

--- a/cli/test/unit/inspect.test.ts
+++ b/cli/test/unit/inspect.test.ts
@@ -13,6 +13,7 @@ import type {
   Event,
   HookEvent,
   LlmCallEvent,
+  LlmTurnEvent,
   SubagentSpawnEvent,
   ToolResultEvent,
   ToolUseEvent,
@@ -97,7 +98,24 @@ const hook: HookEvent = {
   tool_name: "add_label",
 };
 
-const allEvents: Event[] = [llmCall, twinHttp, toolUse, toolResult, subagentSpawn, hook];
+const llmTurn: LlmTurnEvent = {
+  kind: "LlmTurnEvent",
+  ts: "2026-05-26T00:00:01.500Z",
+  event_id: "evt_turn_1",
+  parent_id: null,
+  turn_index: 0,
+  model: "claude-opus-4-8",
+  input_tokens: 1200,
+  output_tokens: 340,
+  cache_read_input_tokens: 900,
+  cache_creation_input_tokens: 128,
+  finish_reasons: ["end_turn"],
+  latency_ms: 2150,
+  latency_ms_estimated: true,
+  session_id: null,
+};
+
+const allEvents: Event[] = [llmCall, twinHttp, toolUse, toolResult, subagentSpawn, hook, llmTurn];
 
 describe("readEventsJsonl", () => {
   let tmp: string;
@@ -121,7 +139,7 @@ describe("readEventsJsonl", () => {
     const result = await readEventsJsonl(tmp);
     expect(result.kind).toBe("events");
     if (result.kind !== "events") return;
-    expect(result.events).toHaveLength(6);
+    expect(result.events).toHaveLength(7);
     expect(result.events.map((e) => e.kind)).toEqual([
       "LlmCallEvent",
       "TwinHttpEvent",
@@ -129,6 +147,7 @@ describe("readEventsJsonl", () => {
       "ToolResultEvent",
       "SubagentSpawnEvent",
       "HookEvent",
+      "LlmTurnEvent",
     ]);
   });
 
@@ -199,7 +218,7 @@ describe("computeTraceHealth", () => {
       },
       {
         name: "CAS adapter",
-        count: 4,
+        count: 5,
         expectedAtLeast: 1,
         status: "ok",
         note: null,
@@ -253,7 +272,7 @@ describe("renderTraceHealth", () => {
     expect(lines[0]).toBe("Trace health:");
     expect(lines).toContain("  proxy: 1/expected≥1 [ok]");
     expect(lines).toContain("  twin: 1/expected≥1 [ok]");
-    expect(lines).toContain("  CAS adapter: 4/expected≥1 [ok]");
+    expect(lines).toContain("  CAS adapter: 5/expected≥1 [ok]");
   });
 
   it("appends the warning note when the layer is in warning state", () => {
@@ -272,7 +291,7 @@ describe("renderTraceHealth", () => {
 describe("renderEvents", () => {
   it("emits one section header and per-kind rows", () => {
     const lines = renderEvents(allEvents);
-    expect(lines[0]).toBe("Events (6):");
+    expect(lines[0]).toBe("Events (7):");
     const body = lines.slice(1).join("\n");
     expect(body).toContain("TwinHttpEvent");
     expect(body).toContain("POST /repos/acme/api/issues/1/labels → 200");
@@ -282,6 +301,8 @@ describe("renderEvents", () => {
     expect(body).toContain("ToolResultEvent ok (use_id=tu_1)");
     expect(body).toContain("SubagentSpawnEvent parent_tool_use_id=tu_1");
     expect(body).toContain("HookEvent      PreToolUse tool=add_label");
+    expect(body).toContain("LlmTurnEvent   turn 0  model=claude-opus-4-8  tokens=1200/340");
+    expect(body).toContain("cache read/create=900/128  finish=end_turn");
   });
 
   it("handles the empty case", () => {

--- a/cli/test/unit/runner/mergeAdapterSignals.test.ts
+++ b/cli/test/unit/runner/mergeAdapterSignals.test.ts
@@ -42,6 +42,25 @@ function hook(ts: string, event_id: string, hook_name = "PreToolUse") {
   };
 }
 
+function llmTurn(ts: string, event_id: string, turn_index = 0) {
+  return {
+    ts,
+    event_id,
+    parent_id: null,
+    kind: "LlmTurnEvent",
+    turn_index,
+    model: "claude-opus-4-8",
+    input_tokens: 1200,
+    output_tokens: 340,
+    cache_read_input_tokens: 900,
+    cache_creation_input_tokens: 128,
+    finish_reasons: ["end_turn"],
+    latency_ms: 2150,
+    latency_ms_estimated: true,
+    session_id: null,
+  };
+}
+
 describe("mergeAdapterSignalsIntoEvents", () => {
   it("interleaves 3 LlmCallEvents + 2 HookEvents in ts order; every merged row validates (FDRS-412)", async () => {
     const dir = await workspace();
@@ -74,6 +93,39 @@ describe("mergeAdapterSignalsIntoEvents", () => {
     for (const row of parsed) {
       expect(eventSchema.safeParse(row).success).toBe(true);
     }
+  });
+
+  it("admits LlmTurnEvent signal rows and preserves cache tokens (F-766)", async () => {
+    const dir = await workspace();
+    const eventsPath = join(dir, "events.jsonl");
+    const signalsPath = join(dir, "signals.jsonl");
+
+    // A twin HTTP row already on disk, plus a turn-usage row + a tool row from
+    // the adapter signals sidechannel — interleaved by ts on merge.
+    const existing = llm("2026-05-26T12:00:00.000Z", "llm_a");
+    const turn = llmTurn("2026-05-26T12:00:02.000Z", "turn_0");
+    const hk = hook("2026-05-26T12:00:01.000Z", "hook_x");
+    await writeFile(eventsPath, JSON.stringify(existing) + "\n");
+    await writeFile(signalsPath, [hk, turn].map((r) => JSON.stringify(r)).join("\n") + "\n");
+
+    const result = await mergeAdapterSignalsIntoEvents(signalsPath, eventsPath);
+    expect(result).toEqual({ appended: 2, dropped: 0 });
+
+    const parsed = (await readFile(eventsPath, "utf8"))
+      .split("\n")
+      .filter((l) => l.length > 0)
+      .map((l) => JSON.parse(l));
+    expect(parsed.map((r) => r.event_id)).toEqual(["llm_a", "hook_x", "turn_0"]);
+
+    const turnRow = parsed.find((r) => r.kind === "LlmTurnEvent");
+    expect(turnRow).toBeDefined();
+    // The cache-token counts — the whole point of F-766 — survive the merge.
+    expect(turnRow.cache_read_input_tokens).toBe(900);
+    expect(turnRow.cache_creation_input_tokens).toBe(128);
+    expect(turnRow.turn_index).toBe(0);
+    expect(turnRow.finish_reasons).toEqual(["end_turn"]);
+    // ...and it schema-validates as a canonical union member.
+    expect(eventSchema.safeParse(turnRow).success).toBe(true);
   });
 
   it("re-sorts out-of-order events.jsonl rows when merging signals (interleave)", async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4858,7 +4858,7 @@
         "@opentelemetry/exporter-trace-otlp-http": "^0.220.0",
         "@opentelemetry/resources": "^2.0.0",
         "@opentelemetry/sdk-trace-base": "^2.0.0",
-        "@pome-sh/shared-types": "0.6.0"
+        "@pome-sh/shared-types": "0.8.0"
       },
       "devDependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.197",
@@ -4876,14 +4876,6 @@
         "@anthropic-ai/claude-agent-sdk": {
           "optional": false
         }
-      }
-    },
-    "packages/adapter-claude-sdk/node_modules/@pome-sh/shared-types": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.6.0.tgz",
-      "integrity": "sha512-UfJF/pY+kot7zQsQWVo1imWi1j0TgyGqmg8oy50uezwcl8YcFvI7omPbbcv1XlXBC4Na+MR4bRdxkUiYccysIw==",
-      "peerDependencies": {
-        "zod": "^4.1.13"
       }
     },
     "packages/adapter-claude-sdk/node_modules/typescript": {
@@ -4951,7 +4943,7 @@
     },
     "packages/shared-types": {
       "name": "@pome-sh/shared-types",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "devDependencies": {
         "@types/node": "^26.1.0",
         "typescript": "^5.9.3",

--- a/packages/adapter-claude-sdk/fixtures/cas-triage-agent.ts
+++ b/packages/adapter-claude-sdk/fixtures/cas-triage-agent.ts
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// FDRS-413 — CAS-adapter triage agent fixture for the PR/FAQ acceptance #2
-// e2e gate. Drives scenario 01 (acme/api #1) through the real adapter surface
-// (`withPome()` + wrapped `tool()`) so the resulting events.jsonl carries all
-// four signal kinds the acceptance criteria require:
+// FDRS-413 / F-766 — CAS-adapter triage agent fixture for the PR/FAQ
+// acceptance #2 e2e gate. Drives scenario 01 (acme/api #1) through the real
+// adapter surface (`withPome()` + wrapped `tool()`) so the resulting
+// events.jsonl carries all five signal kinds the acceptance criteria require:
 //
 //   - LlmCallEvent     — one TCP CONNECT through HTTPS_PROXY (the bench-style
 //                        path used by FDRS-405; the capture-server records the
@@ -18,6 +18,10 @@
 //                        sidechannel
 //   - HookEvent        — buildPomeHooks() produces the PreToolUse matcher we
 //                        invoke explicitly with the same tool_use_id
+//   - LlmTurnEvent     — the synthetic assistant message also carries a `usage`
+//                        block (incl. cache-read/cache-creation tokens), so
+//                        `withTurnUsage` writes one LlmTurnEvent per turn into
+//                        the signals sidechannel (F-766)
 //
 // Using real adapter internals (rather than a fake-signals stub like the
 // FDRS-411 fixture) is what makes this the *acceptance #2* gate: the trace
@@ -35,6 +39,7 @@ import { URL } from "node:url";
 import { withPome, tool } from "../src/index.js";
 import { buildPomeHooks } from "../src/hooks.js";
 import { withToolEvents } from "../src/wrapQuery.js";
+import { withTurnUsage } from "../src/turn-usage.js";
 
 type GitHubIssue = {
   number: number;
@@ -102,10 +107,13 @@ async function main(): Promise<void> {
   ).handler({}, { tool_use_id: TOOL_USE_ID });
 
   // 3) Drive a synthetic SDK message stream through the real message-stream
-  // wrapper so it writes the ToolUseEvent + ToolResultEvent rows the
+  // wrappers so they write the ToolUseEvent + ToolResultEvent rows AND the
+  // LlmTurnEvent row (the assistant turn carries a usage block) that the
   // correlator merges into events.jsonl. Iterating to completion is what
   // triggers the writes.
-  for await (const _ of withToolEvents(syntheticSdkStream(TOOL_USE_ID, handlerResult))) {
+  for await (const _ of withTurnUsage(
+    withToolEvents(syntheticSdkStream(TOOL_USE_ID, handlerResult)),
+  )) {
     void _;
   }
 
@@ -143,12 +151,26 @@ async function main(): Promise<void> {
 async function* syntheticSdkStream(
   toolUseId: string,
   handlerResult: unknown,
-): AsyncGenerator<{ type: string; message?: { content?: unknown } }, void, unknown> {
+): AsyncGenerator<
+  { type: string; message?: { content?: unknown; model?: string; usage?: unknown; stop_reason?: string } },
+  void,
+  unknown
+> {
   // Mirrors the SDK's assistant-then-user pattern: assistant emits the
-  // tool_use block, then a follow-up user turn carries the tool_result.
+  // tool_use block (with the turn's usage block, incl. cache tokens, so
+  // withTurnUsage writes an LlmTurnEvent), then a follow-up user turn carries
+  // the tool_result.
   yield {
     type: "assistant",
     message: {
+      model: "claude-opus-4-8",
+      stop_reason: "tool_use",
+      usage: {
+        input_tokens: 1200,
+        output_tokens: 340,
+        cache_read_input_tokens: 900,
+        cache_creation_input_tokens: 128,
+      },
       content: [
         {
           type: "tool_use",

--- a/packages/adapter-claude-sdk/package.json
+++ b/packages/adapter-claude-sdk/package.json
@@ -33,7 +33,7 @@
     "@opentelemetry/exporter-trace-otlp-http": "^0.220.0",
     "@opentelemetry/resources": "^2.0.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
-    "@pome-sh/shared-types": "0.6.0"
+    "@pome-sh/shared-types": "0.8.0"
   },
   "peerDependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.197"

--- a/packages/adapter-claude-sdk/src/query.ts
+++ b/packages/adapter-claude-sdk/src/query.ts
@@ -7,6 +7,7 @@ import {
 } from "@anthropic-ai/claude-agent-sdk";
 import { buildPomeHooks } from "./hooks.js";
 import { withGenAiSpans } from "./genai-spans.js";
+import { withTurnUsage } from "./turn-usage.js";
 import { withToolEvents } from "./wrapQuery.js";
 
 type QueryParams = Parameters<typeof sdkQuery>[0];
@@ -26,11 +27,17 @@ type HooksConfig = Partial<Record<HookEvent, HookCallbackMatcher[]>>;
  * the underlying SDK directly if you need them.
  */
 export function query(params: QueryParams): AsyncGenerator<SDKMessage, void, unknown> {
-  // withGenAiSpans (outermost) reads each assistant turn's token usage and
-  // emits gen_ai OTLP spans for the dashboard's Agent telemetry panel; it
-  // flushes the exporter on the terminal `result` message. Inert when no OTLP
-  // endpoint is configured.
-  return withGenAiSpans<SDKMessage>(withToolEvents<SDKMessage>(sdkQuery(withPomeHooks(params))));
+  // Three read-only stream wrappers, composed innermost-first:
+  //   • withToolEvents   — ToolUse/ToolResult/SubagentSpawn rows → signals JSONL
+  //   • withTurnUsage    — one LlmTurnEvent per usage-bearing assistant turn
+  //                        (incl. cache tokens) → signals JSONL (F-766)
+  //   • withGenAiSpans   — gen_ai OTLP spans for the dashboard telemetry panel;
+  //                        flushes the exporter on the terminal `result`.
+  // The two signals wrappers append to POME_ADAPTER_SIGNALS_PATH and are inert
+  // when it is unset; withGenAiSpans is inert when no OTLP endpoint is set.
+  return withGenAiSpans<SDKMessage>(
+    withTurnUsage<SDKMessage>(withToolEvents<SDKMessage>(sdkQuery(withPomeHooks(params)))),
+  );
 }
 
 function withPomeHooks(params: QueryParams): QueryParams {

--- a/packages/adapter-claude-sdk/src/signals.ts
+++ b/packages/adapter-claude-sdk/src/signals.ts
@@ -20,11 +20,20 @@
 // first time the adapter observes a non-null `parent_tool_use_id` on an SDK
 // message; same single-writer pattern.
 //
+// F-766: adds LlmTurnEvent writer. Emitted once per assistant turn that
+// reported usage (see turn-usage.ts); same single-writer pattern, same file.
+//
 // Standalone dev (no CLI runner): env unset → every write is a static noop.
 
 import { appendFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
-import type { HookEvent, SubagentSpawnEvent, ToolResultEvent, ToolUseEvent } from "@pome-sh/shared-types";
+import type {
+  HookEvent,
+  LlmTurnEvent,
+  SubagentSpawnEvent,
+  ToolResultEvent,
+  ToolUseEvent,
+} from "@pome-sh/shared-types";
 
 export const ADAPTER_SIGNALS_ENV = "POME_ADAPTER_SIGNALS_PATH";
 
@@ -70,6 +79,18 @@ export function writeToolResultEvent(row: ToolResultEventRow): void {
 export type SubagentSpawnEventRow = SubagentSpawnEvent;
 
 export function writeSubagentSpawnEvent(row: SubagentSpawnEventRow): void {
+  const path = resolveSignalsPath();
+  if (!path) return;
+  appendFileSync(path, JSON.stringify(row) + "\n");
+}
+
+// `LlmTurnEvent` — one row per assistant turn that reported usage (F-766). The
+// writer is intentionally identical to its siblings: the turn-detection logic
+// lives in `withTurnUsage` (turn-usage.ts), and this file stays a thin,
+// single-writer JSONL appender.
+export type LlmTurnEventRow = LlmTurnEvent;
+
+export function writeLlmTurnEvent(row: LlmTurnEventRow): void {
   const path = resolveSignalsPath();
   if (!path) return;
   appendFileSync(path, JSON.stringify(row) + "\n");

--- a/packages/adapter-claude-sdk/src/turn-usage.ts
+++ b/packages/adapter-claude-sdk/src/turn-usage.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// withTurnUsage (F-766) — stream wrapper that emits one `LlmTurnEvent` per
+// assistant turn into the signals JSONL (see signals.ts for the single-writer
+// contract). It is the JSONL source-of-truth counterpart to the OTLP
+// `withGenAiSpans` lane (genai-spans.ts): both use the SAME turn detection —
+// every `assistant` message carrying `message.usage` is one LLM round-trip —
+// but this lane also captures the cache-read / cache-creation token counts and
+// `finish_reasons` that the OTLP side-lane drops, and it never reaches the
+// OTLP exporter, so the two lanes stay independent (the OTLP lane is untouched).
+//
+// The span window is approximated from message timing exactly as genai-spans.ts
+// does — start = the moment we began awaiting this turn (the previous yielded
+// message), end = now — so `latency_ms` is an estimate and every M1 row is
+// stamped `latency_ms_estimated: true` (the SDK surfaces no per-call API
+// timing). `turn_index` is 0-based per `query()` stream. `parent_id` and
+// `session_id` are null in M1.
+//
+// No signals path configured (standalone dev, or any run outside the pome CLI
+// runner): `writeLlmTurnEvent` is a static noop, so this wrapper just passes
+// messages through.
+
+import { newEventId, writeLlmTurnEvent } from "./signals.js";
+
+type WithType = { type?: string };
+
+type AssistantLike = {
+  type: "assistant";
+  message?: { model?: unknown; usage?: unknown; stop_reason?: unknown };
+};
+
+function asNumber(v: unknown): number | null {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+function asString(v: unknown): string | null {
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+export async function* withTurnUsage<T extends WithType>(
+  source: AsyncIterable<T>,
+): AsyncGenerator<T, void, unknown> {
+  // Boundary marking the start of the current turn. Initialized when iteration
+  // begins; advanced after every yielded message so each turn's latency spans
+  // only the gap since the previous message (matches genai-spans.ts).
+  let turnStartMs = Date.now();
+  // 0-based counter, per this query() stream. Advances only for turns that
+  // actually reported usage (a usage-less assistant message is not a turn).
+  let turnIndex = 0;
+
+  for await (const msg of source) {
+    if (msg.type === "assistant") {
+      const a = msg as AssistantLike & WithType;
+      const usage = (a.message?.usage ?? {}) as Record<string, unknown>;
+      const inputTokens = asNumber(usage.input_tokens);
+      const outputTokens = asNumber(usage.output_tokens);
+      // Only a turn that reported usage is a real, completed LLM round-trip.
+      if (inputTokens != null || outputTokens != null) {
+        const stopReason = asString(a.message?.stop_reason);
+        writeLlmTurnEvent({
+          ts: new Date().toISOString(),
+          event_id: newEventId(),
+          parent_id: null,
+          kind: "LlmTurnEvent",
+          turn_index: turnIndex,
+          model: asString(a.message?.model),
+          input_tokens: inputTokens,
+          output_tokens: outputTokens,
+          cache_read_input_tokens: asNumber(usage.cache_read_input_tokens),
+          cache_creation_input_tokens: asNumber(usage.cache_creation_input_tokens),
+          finish_reasons: stopReason != null ? [stopReason] : null,
+          latency_ms: Math.max(0, Date.now() - turnStartMs),
+          latency_ms_estimated: true,
+          session_id: null,
+        });
+        turnIndex += 1;
+      }
+    }
+
+    yield msg;
+    turnStartMs = Date.now();
+  }
+}

--- a/packages/adapter-claude-sdk/test/turnUsage.test.ts
+++ b/packages/adapter-claude-sdk/test/turnUsage.test.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// withTurnUsage → LlmTurnEvent rows in the signals JSONL (F-766). Points the
+// adapter's signals writer at a tmp file via the env contract, drives a
+// synthetic SDK message stream, and asserts one LlmTurnEvent per assistant turn
+// that reported usage — carrying the cache-read/cache-creation tokens the OTLP
+// lane drops. Same turn detection as the OTLP `withGenAiSpans` lane, but this
+// is the JSONL source-of-truth lane.
+
+import { mkdtempSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ADAPTER_SIGNALS_ENV } from "../src/signals.js";
+import { withTurnUsage } from "../src/turn-usage.js";
+
+let tmp: string;
+let signalsPath: string;
+const ORIGINAL_ENV = process.env[ADAPTER_SIGNALS_ENV];
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "pome-turn-"));
+  signalsPath = join(tmp, "adapter-signals.jsonl");
+  process.env[ADAPTER_SIGNALS_ENV] = signalsPath;
+});
+
+afterEach(() => {
+  if (ORIGINAL_ENV === undefined) delete process.env[ADAPTER_SIGNALS_ENV];
+  else process.env[ADAPTER_SIGNALS_ENV] = ORIGINAL_ENV;
+});
+
+function readRows(): Array<Record<string, unknown>> {
+  if (!existsSync(signalsPath)) return [];
+  return readFileSync(signalsPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((l) => JSON.parse(l) as Record<string, unknown>);
+}
+
+async function drive(messages: Array<{ type: string; [k: string]: unknown }>): Promise<void> {
+  async function* src() {
+    for (const m of messages) yield m;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  for await (const _ of withTurnUsage(src())) void _;
+}
+
+describe("withTurnUsage → LlmTurnEvent signals", () => {
+  it("emits one LlmTurnEvent per usage-bearing assistant turn, with cache tokens", async () => {
+    await drive([
+      { type: "system" },
+      {
+        type: "assistant",
+        message: {
+          model: "claude-opus-4-8",
+          stop_reason: "end_turn",
+          usage: {
+            input_tokens: 1200,
+            output_tokens: 340,
+            cache_read_input_tokens: 900,
+            cache_creation_input_tokens: 128,
+          },
+        },
+      },
+      { type: "result", subtype: "success" },
+    ]);
+
+    const rows = readRows();
+    expect(rows).toHaveLength(1);
+    const r = rows[0]!;
+    expect(r.kind).toBe("LlmTurnEvent");
+    expect(r.turn_index).toBe(0);
+    expect(r.parent_id).toBeNull();
+    expect(r.model).toBe("claude-opus-4-8");
+    expect(r.input_tokens).toBe(1200);
+    expect(r.output_tokens).toBe(340);
+    expect(r.cache_read_input_tokens).toBe(900);
+    expect(r.cache_creation_input_tokens).toBe(128);
+    expect(r.finish_reasons).toEqual(["end_turn"]);
+    expect(r.latency_ms_estimated).toBe(true);
+    expect(typeof r.latency_ms).toBe("number");
+    expect(r.latency_ms as number).toBeGreaterThanOrEqual(0);
+    expect(r.session_id).toBeNull();
+    // ts is ISO-8601 + event_id present (uuid).
+    expect(typeof r.ts).toBe("string");
+    expect(typeof r.event_id).toBe("string");
+  });
+
+  it("increments turn_index across usage turns and skips usage-less turns", async () => {
+    await drive([
+      { type: "assistant", message: { model: "m", usage: { input_tokens: 5, output_tokens: 2 } } },
+      // No usage → no row, and turn_index must NOT advance for it.
+      { type: "assistant", message: { model: "m" } },
+      { type: "assistant", message: { model: "m", usage: { input_tokens: 7, output_tokens: 3 } } },
+      { type: "result", subtype: "success" },
+    ]);
+
+    const rows = readRows();
+    expect(rows.map((r) => r.turn_index)).toEqual([0, 1]);
+  });
+
+  it("emits explicit null for absent cache/model/finish fields (nullable, not optional)", async () => {
+    await drive([
+      { type: "assistant", message: { usage: { input_tokens: 10, output_tokens: 4 } } },
+      { type: "result", subtype: "success" },
+    ]);
+
+    const rows = readRows();
+    expect(rows).toHaveLength(1);
+    const r = rows[0]!;
+    // The keys are PRESENT with null values (stable on-disk shape).
+    expect(r).toHaveProperty("model", null);
+    expect(r).toHaveProperty("cache_read_input_tokens", null);
+    expect(r).toHaveProperty("cache_creation_input_tokens", null);
+    expect(r).toHaveProperty("finish_reasons", null);
+    expect(r).toHaveProperty("session_id", null);
+  });
+
+  it("is a static noop when the signals env is unset (no file, no throw)", async () => {
+    delete process.env[ADAPTER_SIGNALS_ENV];
+    await expect(
+      drive([
+        { type: "assistant", message: { model: "m", usage: { input_tokens: 1, output_tokens: 1 } } },
+        { type: "result", subtype: "success" },
+      ]),
+    ).resolves.toBeUndefined();
+    expect(existsSync(signalsPath)).toBe(false);
+  });
+
+  it("yields every source message verbatim (transparent pass-through)", async () => {
+    const seen: string[] = [];
+    async function* src() {
+      yield { type: "assistant", message: { usage: { input_tokens: 1, output_tokens: 1 } } };
+      yield { type: "result" };
+    }
+    for await (const m of withTurnUsage(src())) seen.push(m.type);
+    expect(seen).toEqual(["assistant", "result"]);
+  });
+});

--- a/packages/shared-types/CHANGELOG.md
+++ b/packages/shared-types/CHANGELOG.md
@@ -1,5 +1,28 @@
 # @pome-sh/shared-types — CHANGELOG
 
+## 0.8.0
+
+### Added
+
+- `LlmTurnEvent` — a new member of the `events.jsonl` discriminated union
+  (`eventSchema`) for per-assistant-turn LLM usage. Envelope: `ts`, `event_id`,
+  `parent_id` (null in M1); payload `turn_index` (0-based, per adapter query
+  stream), `model`, `input_tokens`, `output_tokens`, `cache_read_input_tokens`,
+  `cache_creation_input_tokens`, `finish_reasons`, `latency_ms` +
+  `latency_ms_estimated`, and `session_id` (null in M1). Absent SDK values are
+  nullable, not optional. The Claude-SDK adapter emits it into the signals
+  JSONL; the self-host merge admits it. No cost fields (computed cloud-side).
+  Not projected by the legacy shim in M1 (M2 maps it to a `chat` span).
+
+### Notes
+
+- This is a **minor** bump even though the change is additive: `eventSchema` is
+  a frozen canonical contract surface, so a new union member is a
+  consumer-must-act change (an older reader rejects a new `LlmTurnEvent` row).
+- `semconv.ts` now documents that `gen_ai.*` migrated at core v1.42.0 into the
+  zero-release `semantic-conventions-genai` repo — future GenAI pins must use a
+  commit SHA, not a version tag.
+
 ## 0.7.0
 
 ### Added

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/shared-types",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Shared wire-format contract for Pome — Zod schemas for traces, recorder events, runs, OTel mapping, and secret redaction.",
   "private": false,
   "type": "module",

--- a/packages/shared-types/src/otel/legacy-shim.ts
+++ b/packages/shared-types/src/otel/legacy-shim.ts
@@ -69,6 +69,14 @@ const ATTR_LEGACY_KIND = `${LEGACY_ATTR_NAMESPACE}.kind`;
 const ATTR_LEGACY_RECORD_JSON = `${LEGACY_ATTR_NAMESPACE}.record_json`;
 
 // The legacy variants this shim accepts. Discriminated on `kind`.
+//
+// NOT-SHIMMABLE-IN-M1: `HookEvent`, `ToolResultEvent`, `SubagentSpawnEvent`, and
+// `LlmTurnEvent` (F-766) are intentionally absent. They are captured into
+// events.jsonl but not projected to spans yet — the M2 projection layer adds
+// full coverage (LlmTurnEvent → a `chat` span carrying the cache-token
+// attributes; ToolResult pairs into its execute_tool span; etc.). Until then
+// `shimLegacyEventToSpan` rejects these kinds with a typed ZodError rather than
+// emitting a lossy span. The otel-legacy-shim test locks this deliberately.
 export const shimmableLegacyEventSchema = z.discriminatedUnion("kind", [
   twinHttpEventSchema,
   llmCallEventSchema,

--- a/packages/shared-types/src/otel/semconv.ts
+++ b/packages/shared-types/src/otel/semconv.ts
@@ -34,6 +34,13 @@ export type OtelCoreSemconvVersion = typeof OTEL_CORE_SEMCONV_VERSION;
 
 // Pinned GenAI convention/schema version. The GenAI surface is experimental and
 // versions ahead of core; `gen_ai.provider.name` is canonical at this version.
+//
+// MIGRATION NOTE (F-766): at core v1.42.0 the `gen_ai.*` conventions were split
+// OUT of `open-telemetry/semantic-conventions` into the dedicated
+// `open-telemetry/semantic-conventions-genai` repo, which has published ZERO
+// tagged releases so far. There is therefore no version tag to bump to for the
+// next GenAI revision — a future bump must pin a specific COMMIT SHA from that
+// repo (not a semver tag) and record it here alongside the schema URL.
 export const OTEL_GENAI_SCHEMA_VERSION = "1.42.0" as const;
 export type OtelGenaiSchemaVersion = typeof OTEL_GENAI_SCHEMA_VERSION;
 

--- a/packages/shared-types/src/recorder-events.ts
+++ b/packages/shared-types/src/recorder-events.ts
@@ -234,6 +234,43 @@ export const hookEventSchema = z.object({
 });
 export type HookEvent = z.infer<typeof hookEventSchema>;
 
+// `LlmTurnEvent` — emitted by the CAS adapter (F-766) once per assistant turn
+// that reported usage (same turn detection as the OTLP `withGenAiSpans` lane).
+// Per-turn LLM usage — and specifically the cache-read/cache-creation token
+// counts — is the only capture-side datum that never otherwise reaches
+// events.jsonl: the OTLP side-lane carries a subset (input/output tokens only)
+// and is not the JSONL source of truth. Everything else the trace needs is
+// projected cloud-side from existing kinds, so this is the sole new M1 kind.
+//
+// Field discipline (grill 2026-07-14 + codex review 2026-07-15):
+//   - Absent SDK values are `nullable`, not `optional` — writers emit explicit
+//     null so the on-disk JSON shape is stable.
+//   - `parent_id: null` in M1 (turn→tool parent linkage is M2).
+//   - `session_id: null` in M1 (no session-id env plumbing — out of scope).
+//   - No cost fields (no OTEL convention; computed cloud-side from a pricing
+//     table at display time).
+//   - `turn_index` is 0-based per adapter `query()` stream, NOT globally unique.
+//   - `latency_ms_estimated` is true whenever `latency_ms` is approximated from
+//     message timing (always true in M1 — the SDK surfaces no per-call API
+//     timing). The field exists so a future real-timing source can set false.
+export const llmTurnEventSchema = z.object({
+  ...eventBaseShape,
+  kind: z.literal("LlmTurnEvent"),
+  turn_index: z.number().int().min(0),
+  model: z.string().min(1).nullable(),
+  input_tokens: z.number().int().min(0).nullable(),
+  output_tokens: z.number().int().min(0).nullable(),
+  cache_read_input_tokens: z.number().int().min(0).nullable(),
+  cache_creation_input_tokens: z.number().int().min(0).nullable(),
+  // OTel `gen_ai.response.finish_reasons` is an array; Anthropic reports one
+  // `stop_reason` per turn. null when the SDK surfaced none.
+  finish_reasons: z.array(z.string()).nullable(),
+  latency_ms: z.number().int().min(0),
+  latency_ms_estimated: z.boolean(),
+  session_id: z.string().min(1).nullable(),
+});
+export type LlmTurnEvent = z.infer<typeof llmTurnEventSchema>;
+
 // The unified event row. Discriminated on `kind` — adding a future variant
 // (e.g. `OtelSpanEvent` in v2) is a non-breaking extension. The exported
 // reader applies the FDRS-653 task-vocab normalization to `TwinHttpEvent`
@@ -245,6 +282,7 @@ const eventUnionSchema = z.discriminatedUnion("kind", [
   toolResultEventSchema,
   subagentSpawnEventSchema,
   hookEventSchema,
+  llmTurnEventSchema,
 ]);
 export const eventSchema = eventUnionSchema.transform((event) =>
   event.kind === "TwinHttpEvent" ? normalizeTaskStepVocab(event) : event,

--- a/packages/shared-types/test/events.test.ts
+++ b/packages/shared-types/test/events.test.ts
@@ -11,6 +11,7 @@ import {
   hookEventSchema,
   isLegacyEventRow,
   llmCallEventSchema,
+  llmTurnEventSchema,
   recorderEventSchema,
   subagentSpawnEventSchema,
   toolResultEventSchema,
@@ -118,6 +119,40 @@ const hookFixture = {
   kind: "HookEvent" as const,
   hook_name: "PreToolUse",
   tool_name: "Bash",
+};
+
+const llmTurnFixture = {
+  ...baseFields,
+  event_id: "evt_turn_1",
+  kind: "LlmTurnEvent" as const,
+  turn_index: 0,
+  model: "claude-opus-4-8",
+  input_tokens: 1200,
+  output_tokens: 340,
+  cache_read_input_tokens: 900,
+  cache_creation_input_tokens: 128,
+  finish_reasons: ["end_turn"],
+  latency_ms: 2150,
+  latency_ms_estimated: true,
+  session_id: null,
+};
+
+// A turn where the SDK surfaced no cache/model/finish data — every absent
+// value is an explicit null (nullable, not optional).
+const llmTurnMinimalFixture = {
+  ...baseFields,
+  event_id: "evt_turn_min",
+  kind: "LlmTurnEvent" as const,
+  turn_index: 3,
+  model: null,
+  input_tokens: 10,
+  output_tokens: null,
+  cache_read_input_tokens: null,
+  cache_creation_input_tokens: null,
+  finish_reasons: null,
+  latency_ms: 0,
+  latency_ms_estimated: true,
+  session_id: null,
 };
 
 describe("twinHttpEventSchema", () => {
@@ -281,6 +316,60 @@ describe("hookEventSchema", () => {
   });
 });
 
+describe("llmTurnEventSchema", () => {
+  it("parses a full fixture with cache tokens + finish reasons", () => {
+    const r = llmTurnEventSchema.parse(llmTurnFixture);
+    expect(r.kind).toBe("LlmTurnEvent");
+    expect(r.turn_index).toBe(0);
+    expect(r.model).toBe("claude-opus-4-8");
+    expect(r.input_tokens).toBe(1200);
+    expect(r.output_tokens).toBe(340);
+    expect(r.cache_read_input_tokens).toBe(900);
+    expect(r.cache_creation_input_tokens).toBe(128);
+    expect(r.finish_reasons).toEqual(["end_turn"]);
+    expect(r.latency_ms).toBe(2150);
+    expect(r.latency_ms_estimated).toBe(true);
+    expect(r.session_id).toBeNull();
+  });
+
+  it("parses a minimal fixture (absent SDK values are explicit null)", () => {
+    const r = llmTurnEventSchema.parse(llmTurnMinimalFixture);
+    expect(r.model).toBeNull();
+    expect(r.output_tokens).toBeNull();
+    expect(r.cache_read_input_tokens).toBeNull();
+    expect(r.cache_creation_input_tokens).toBeNull();
+    expect(r.finish_reasons).toBeNull();
+    expect(r.turn_index).toBe(3);
+  });
+
+  it("requires turn_index (0-based, non-negative int)", () => {
+    const { turn_index: _omit, ...rest } = llmTurnFixture;
+    expect(() => llmTurnEventSchema.parse(rest)).toThrow();
+    expect(() => llmTurnEventSchema.parse({ ...llmTurnFixture, turn_index: -1 })).toThrow();
+    expect(() => llmTurnEventSchema.parse({ ...llmTurnFixture, turn_index: 1.5 })).toThrow();
+  });
+
+  it("requires latency_ms_estimated (boolean, not optional)", () => {
+    const { latency_ms_estimated: _omit, ...rest } = llmTurnFixture;
+    expect(() => llmTurnEventSchema.parse(rest)).toThrow();
+  });
+
+  it("treats nullable token/model/finish/session fields as required (nullable, not optional)", () => {
+    for (const key of [
+      "model",
+      "input_tokens",
+      "output_tokens",
+      "cache_read_input_tokens",
+      "cache_creation_input_tokens",
+      "finish_reasons",
+      "session_id",
+    ] as const) {
+      const { [key]: _omit, ...rest } = llmTurnFixture;
+      expect(() => llmTurnEventSchema.parse(rest), `omitting ${key} should throw`).toThrow();
+    }
+  });
+});
+
 describe("eventSchema (discriminated union)", () => {
   it("discriminates each variant by kind", () => {
     expect(eventSchema.parse(twinHttpFixture).kind).toBe("TwinHttpEvent");
@@ -291,6 +380,7 @@ describe("eventSchema (discriminated union)", () => {
       "SubagentSpawnEvent"
     );
     expect(eventSchema.parse(hookFixture).kind).toBe("HookEvent");
+    expect(eventSchema.parse(llmTurnFixture).kind).toBe("LlmTurnEvent");
   });
 
   it("rejects an unknown kind value", () => {
@@ -317,6 +407,7 @@ describe("isLegacyEventRow", () => {
     expect(isLegacyEventRow(toolResultFixture)).toBe(false);
     expect(isLegacyEventRow(subagentSpawnFixture)).toBe(false);
     expect(isLegacyEventRow(hookFixture)).toBe(false);
+    expect(isLegacyEventRow(llmTurnFixture)).toBe(false);
   });
 
   it("returns false for non-object inputs", () => {

--- a/packages/shared-types/test/export-surface.test.ts
+++ b/packages/shared-types/test/export-surface.test.ts
@@ -227,6 +227,7 @@ const EXPECTED_EXPORTS = [
   "judgeModelSchema",
   "laneSchema",
   "llmCallEventSchema",
+  "llmTurnEventSchema",
   "mapOtelSpanToEvent",
   "meResponseSchema",
   "msToNanos",

--- a/packages/shared-types/test/otel-legacy-shim.test.ts
+++ b/packages/shared-types/test/otel-legacy-shim.test.ts
@@ -226,6 +226,33 @@ describe("rejects non-shimmable input", () => {
     expect(() => shimLegacyEventToSpan({})).toThrow(z.ZodError);
   });
 
+  it("does NOT shim an LlmTurnEvent in M1 (deliberate — M2 maps it to a chat span)", () => {
+    // LlmTurnEvent (F-766) is a capture-only kind in M1: per-turn usage +
+    // cache tokens land in events.jsonl but the shim intentionally does not
+    // project it yet. The M2 projection layer maps it to a `chat` span with
+    // cache-token attributes. Until then it is not in `shimmableLegacyEventSchema`,
+    // so the shim rejects it with a typed ZodError rather than silently
+    // producing a lossy span. If this test starts failing because the shim now
+    // accepts LlmTurnEvent, that is an M2 change — update it deliberately.
+    const llmTurn = {
+      ts: "2026-06-02T12:00:00.000Z",
+      event_id: "evt_turn",
+      parent_id: null,
+      kind: "LlmTurnEvent" as const,
+      turn_index: 0,
+      model: "claude-opus-4-8",
+      input_tokens: 1200,
+      output_tokens: 340,
+      cache_read_input_tokens: 900,
+      cache_creation_input_tokens: 128,
+      finish_reasons: ["end_turn"],
+      latency_ms: 2150,
+      latency_ms_estimated: true,
+      session_id: null,
+    };
+    expect(() => shimLegacyEventToSpan(llmTurn, RUN)).toThrow(z.ZodError);
+  });
+
   it("throws a typed ZodError on an invalid ts (rejected by the datetime schema)", () => {
     // `ts` is validated as ISO-8601 by the legacy schema before any nano math,
     // so a bad timestamp surfaces as a ZodError, never a NaN nano string.

--- a/packages/shared-types/trace-contract.json
+++ b/packages/shared-types/trace-contract.json
@@ -1,6 +1,6 @@
 {
   "package": "@pome-sh/shared-types",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "zod": {
     "range": "^4.1.13",
     "major": 4


### PR DESCRIPTION
Executive summary: Per-turn LLM usage — and specifically the cache-read/cache-creation token counts — is the one capture-side datum that never reaches the `events.jsonl` ledger (the OTLP side-lane carries only a subset and isn't the source of truth). This wires a new additive `LlmTurnEvent` kind end to end on self-host runs: the Claude-SDK adapter emits it, the self-host merge admits it, and `pome inspect` / `pome eval` handle it. It also fixes a pre-existing `pome eval` bug that corrupted any non-`TwinHttpEvent` row on upload.

## What
- **shared-types:** new `LlmTurnEvent` member of the `events.jsonl` union (`turn_index`, `model`, input/output tokens, `cache_read`/`cache_creation_input_tokens`, `finish_reasons`, `latency_ms` + `latency_ms_estimated`, `session_id`). Absent SDK values are nullable-not-optional; `parent_id`/`session_id` are null in M1; no cost fields. Minor bump `0.7.0 → 0.8.0`, `trace-contract.json` regenerated, and the legacy shim locks it as not-shimmable-in-M1 (M2 maps it to a `chat` span).
- **adapter:** a new `withTurnUsage` stream wrapper emits one `LlmTurnEvent` per usage-bearing assistant turn into the signals JSONL — same turn detection as the OTLP `withGenAiSpans` lane (which is untouched), but also capturing cache tokens + `finish_reasons`.
- **CLI:** the self-host merge admits the kind; `pome inspect` renders + counts it (CAS-adapter layer); `pome eval` preserves already-kinded rows.
- **e2e:** the CAS-adapter acceptance gate asserts a real self-host `pome run` writes a turn row with cache tokens.

## Why
M1 of the detailed-traces work: get per-turn usage (the only datum that can't be projected cloud-side from existing kinds, because it never reaches the JSONL) into the source of truth so the cloud trace view + evaluator can use it. Hosted is unchanged by design — it uploads `signals.jsonl` as a separate blob and does not merge into `events.jsonl`, so this is self-host-only.

## Notes for reviewer
- **`pome eval` corruption fix:** `pome eval` mapped every `events.jsonl` row through `toTwinHttpEvent`, which re-wraps *any* non-`TwinHttpEvent` kind — clobbering `kind` to `"TwinHttpEvent"` and setting `event_id` to an absent `request_id`. So an `LlmTurnEvent` (or `ToolUseEvent`, …) row was corrupted on upload. Now only legacy (kind-less) rows are wrapped; kinded rows pass through unchanged. Deliberately no strict re-validation — the original path never validated, and cloud's schema gate is the arbiter — so the intentionally-terse hand-assembled dirs `pome eval` also accepts keep working. Regression test asserts an `LlmTurnEvent` survives upload with cache tokens intact.
- **CI infra (bundled):** `quickstart-smoke` built the CLI with a plain `npm ci` (registry shared-types 0.7.0), so it could not build the checkout's `inspect.ts` that renders the new kind. It now rewrites the CLI onto local tarballs before building, matching `cli-ci` / the overhead gate. Reverts to committed-lock `npm ci` once shared-types is published.
- **Bundled test fix beyond the LlmTurnEvent scope:** `cli-ci` has been red on `main` since the gzip-blob-uploads change — three tests asserted on the now-gzipped upload body (`eval` redacts-secrets + legacy-wrap, and the `demo-e2e` stub cloud). This PR decodes the gzipped body in those tests, restoring the full CLI suite to green. Flagging since it's not part of the per-turn-usage work.
- **Publishing is deferred to the follow-up.** shared-types `0.8.0` is version-bumped + changelogged but **not** published here. The adapter (a workspace) links the local package via an exact-pin bump `0.6.0 → 0.8.0`; the CLI keeps its `0.7.0` registry pin (CI rebuilds it from local tarballs) and gets a Changeset instead. Publishing shared-types, bumping the CLI pin, and pome-cloud compat are the next ticket.

## Tests / CI
Local (Node 24): shared-types 318 tests, adapter 99 (incl. new `turnUsage.test.ts`), CLI full suite 80 files / 658 tests — all green. `typecheck` (all workspaces), `check:trace-contract`, `test:contract`, `gate:no-native`, and the CLI version-bump + version-floor gates all pass. e2e: ran the CAS-adapter acceptance gate against a real self-host `pome run` — produced an `LlmTurnEvent` with `cache_read_input_tokens=900`, `cache_creation_input_tokens=128`.

<!-- Closes F-766 -->