### PR TITLE
chore(adapter-claude-sdk): 0.2.0 — version+changelog for the packages-v6 batch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4852,7 +4852,7 @@
     },
     "packages/adapter-claude-sdk": {
       "name": "@pome-sh/adapter-claude-sdk",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.220.0",

--- a/packages/adapter-claude-sdk/CHANGELOG.md
+++ b/packages/adapter-claude-sdk/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.2.0 — 2026-07-16
+
+F-766 — `query()` now emits one `LlmTurnEvent` per assistant turn reporting usage: a `withTurnUsage` stream wrapper (same turn detection as the OTLP `withGenAiSpans` lane) writes `turn_index`, `model`, `input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`, `finish_reasons`, and `latency_ms` (+ `latency_ms_estimated`) to the signals JSONL (`POME_ADAPTER_SIGNALS_PATH`; inert when unset). The OTLP lane is untouched. `@pome-sh/shared-types` pin bumped 0.6.0 → 0.8.0 for the `LlmTurnEvent` schema.
+
+Minor, not patch: the adapter's output surface (the signals JSONL) gains a new event kind. A pre-#152 `pome eval` corrupts kinded rows on hosted upload (mapped through `toTwinHttpEvent`), so consumers must pair this adapter with a CLI carrying the F-766 eval fix — consumer-must-act under the pre-1.0 rule in `PACKAGE_RELEASE.md`.
+
 ## 0.1.0 — 2026-07-09
 
 First npm-published release (F-714). Drop-in adapter for Anthropic's

--- a/packages/adapter-claude-sdk/package.json
+++ b/packages/adapter-claude-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/adapter-claude-sdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pome adapter for Anthropic's Claude Agent SDK — wraps query() and tools so agent traces land in the Pome trace format.",
   "private": false,
   "type": "module",


### PR DESCRIPTION
<!-- Part of F-767 (do not auto-close: publish + cloud verification follow) -->

## What

Bumps `@pome-sh/adapter-claude-sdk` 0.1.0 → 0.2.0 with a changelog entry, plus the matching root-lockfile update. This is step 1 of the batch release flow (`PACKAGE_RELEASE.md`) for the `packages-v6` release that ships shared-types 0.8.0 (`LlmTurnEvent`).

## Why

F-767. PR #152 landed the `withTurnUsage` wrapper (the adapter now emits `LlmTurnEvent` per assistant turn) and bumped its shared-types pin 0.6.0 → 0.8.0, but left the adapter's own version at 0.1.0. `sdk-publish.yml` skips already-published versions, so without this bump `packages-v6` would publish shared-types 0.8.0 but silently skip the adapter — the LlmTurnEvent-emitting adapter would never reach npm, and main's manifest (0.1.0 pinning shared-types 0.8.0) would misrepresent the npm artifact (0.1.0 pinning 0.6.0).

Minor, not patch: the adapter's output surface (signals JSONL) gains a new event kind, and hosted `pome eval` needs a CLI carrying the F-766 kinded-row pass-through fix — consumer-must-act under the pre-1.0 rule.

## Notes for reviewer

- shared-types was already bumped + changelogged to 0.8.0 in #152; sdk (0.4.0) and the three twins are unchanged this batch and will be skipped by the publish job's already-published guard.
- Smoked locally on Node 24 per the release checklist: `pack-publishable.mjs` builds all six tarballs; the workflow's manifest guard + clean-room import pass, and the packed 0.8.0 `eventSchema` parses an `LlmTurnEvent` row. Adapter tests 99/99, shared-types tests 318/318.
- After merge: GitHub Release tagged `packages-v6` fires the OIDC publish. Follow-up after npm has 0.8.0: revert the quickstart-smoke local-tarball workaround from #152 back to committed-lock `npm ci`.

## Review required

Yes — cuts the `packages-v6` publish batch (published `@pome-sh/*` surface).