### PR TITLE
chore(twins): twin-github 0.2.0 + twin-slack 0.2.0 — cut stale npm surface (packages-v8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4970,7 +4970,7 @@
     },
     "packages/twin-github": {
       "name": "@pome-sh/twin-github",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.8",
@@ -5019,7 +5019,7 @@
     },
     "packages/twin-slack": {
       "name": "@pome-sh/twin-slack",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.8",

--- a/packages/twin-github/CHANGELOG.md
+++ b/packages/twin-github/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to the GitHub twin are documented here. The format is
 loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 the package follows [Semantic Versioning](https://semver.org/).
 
+## 0.2.0 — 2026-07-16
+
+Batches everything landed on main since 0.1.2 whose versions were never cut
+(the publish workflow skips already-published versions, so npm 0.1.2 had gone
+stale against the repo):
+
+- #122 — FIDELITY.md re-cut by the heat rubric and the M5 hot gaps filled; the
+  packaged MCP tool surface grows 62 → 65 (`pome twin start github` now serves
+  the consolidated FDRS-648 surface from npm, matching the repo).
+- #116 — structured fidelity inventory (`fidelity.inventory.json`) shipped as
+  the machine-readable seam source of truth.
+- #128 / #109 — `@pome-sh/sdk` pinned to 0.4.0: the twin self-generates
+  `TWIN_AUTH_SECRET` on first non-loopback boot (`ensureTwinAuthSecret`).
+
+Minor: the served REST/MCP fidelity surface changed shape.
+
 ## 0.1.2 — 2026-07-10
 
 Dependency-only release for the node:sqlite driver swap (F-703):

--- a/packages/twin-github/package.json
+++ b/packages/twin-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-github",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Deterministic GitHub-shaped twin for agent testing — REST + MCP, SQLite-backed state.",
   "private": false,
   "type": "module",

--- a/packages/twin-slack/CHANGELOG.md
+++ b/packages/twin-slack/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the Slack twin are documented here. The format is
 loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 the package follows [Semantic Versioning](https://semver.org/).
 
+## 0.2.0 — 2026-07-16
+
+Batches everything landed on main since 0.1.2 whose versions were never cut
+(the publish workflow skips already-published versions, so npm 0.1.2 had gone
+stale against the repo):
+
+- #119 — FIDELITY.md re-cut by the heat rubric; the 3 ruled MCP read tools
+  added to the packaged surface.
+- #116 — structured fidelity inventory (`fidelity.inventory.json`) shipped as
+  the machine-readable seam source of truth.
+- #128 / #109 — `@pome-sh/sdk` pinned to 0.4.0: the twin self-generates
+  `TWIN_AUTH_SECRET` on first non-loopback boot (`ensureTwinAuthSecret`).
+
+Minor: the served REST/MCP fidelity surface changed shape.
+
 ## 0.1.2 — 2026-07-10
 
 Dependency-only release for the node:sqlite driver swap (F-703):

--- a/packages/twin-slack/package.json
+++ b/packages/twin-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-slack",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Deterministic Slack Web API twin for agent testing — REST + MCP, SQLite-backed state.",
   "private": false,
   "type": "module",


### PR DESCRIPTION
<!-- Follow-up to F-767; pre-req for F-768 -->

## What

Version+changelog bumps only: `@pome-sh/twin-github` and `@pome-sh/twin-slack` 0.1.2 → 0.2.0, plus the root-lockfile update. Step 1 of the batch flow for a `packages-v8` release.

## Why

npm's 0.1.2 of both twins has gone stale against the repo: it predates the #122 FIDELITY re-cut + M5 hot-gap tools (registry twin-github serves **62** MCP tools, the repo serves **65** — `cli/test/integration/githubCloneAdapter.test.ts` fails against a registry install), the #119 ruled Slack read tools, the #116 structured fidelity inventories, and the sdk 0.4.0 pin (#128, self-generated `TWIN_AUTH_SECRET`). The publish workflow skips already-published versions, so packages-v6/v7 silently kept shipping nothing for the twins, and the local-tarball rewrite in cli-ci/quickstart-smoke masked the gap in CI.

Found while bumping the CLI's registry pins after packages-v7 (F-767 follow-up): the CLI test suite against a real `npm ci` from the registry redlines on the 62-vs-65 tool count.

## Notes for reviewer

- Minor per PACKAGE_RELEASE.md: the served REST/MCP fidelity surface changed shape between npm 0.1.2 and the repo.
- Smoked locally on Node 24: both twins pack; clean-room install resolves both bins; twin-github tests 254/254, twin-slack 220/220.
- After merge: GitHub Release `packages-v8` publishes both; shared-types/sdk/adapter/twin-stripe are current on npm and will be skipped.
- The CLI registry-pin PR (shared-types 0.9.0 + twins 0.2.0 + quickstart-smoke revert to committed-lock `npm ci`) follows once v8 is on npm.

## Review required

Yes — cuts the `packages-v8` publish batch; versions @gagan-pome's twin changes (#119/#122) — please sanity-check the changelog wording.