### PR TITLE
test(cli): assert LlmTurnEvent rows survive the hosted upload lane

### DIFF
--- a/cli/test/e2e/runScenarioHosted.test.ts
+++ b/cli/test/e2e/runScenarioHosted.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { spawn } from "node:child_process";
+import { gunzipSync } from "node:zlib";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
@@ -18,6 +19,14 @@ const TWIN_AUTH_SECRET = "test-secret-32-chars-minimum-length";
 let cloudServer: ServerType | undefined;
 let receivedResult: unknown = null;
 let finalizeResponseOverrides: Record<string, unknown> = {};
+// F-768 — what `GET /_pome/events` serves. Default empty (the trivially-passing
+// tests); the hosted-signals-lane test seeds a real twin event so the
+// "not merged into events.jsonl" assertion has real content to exclude against.
+let eventsResponse: unknown[] = [];
+// F-768 — decompressed bodies the CLI PUT to the signed upload URLs, keyed by
+// blob kind ("events" / "signals"). The fake cloud gunzips on receipt (uploads
+// carry `content-encoding: gzip`).
+let uploadedBlobs: Record<string, string> = {};
 
 async function startFakeCloud(): Promise<number> {
   const app = new Hono();
@@ -51,7 +60,29 @@ async function startFakeCloud(): Promise<number> {
       ],
     })
   );
-  app.get("/s/:sid/_pome/events", (c) => c.json([]));
+  app.get("/s/:sid/_pome/events", (c) => c.json(eventsResponse));
+  // F-768 — mint signed upload URLs that point back at this fake cloud's PUT
+  // sink so the runner's real upload lane (redact → gzip → PUT → thread key
+  // onto /finalize) executes end to end. events.jsonl and signals.jsonl are
+  // deliberately separate blobs under separate keys — the runner never merges
+  // adapter signals into the trace on the hosted path.
+  app.post("/v1/sessions/:id/result-upload-url", (c) =>
+    c.json({
+      url: `http://127.0.0.1:${port}/_upload/events`,
+      key: `team-tm_test/session-${c.req.param("id")}/events.jsonl`,
+    }),
+  );
+  app.post("/v1/sessions/:id/signals-upload-url", (c) =>
+    c.json({
+      url: `http://127.0.0.1:${port}/_upload/signals`,
+      key: `team-tm_test/session-${c.req.param("id")}/signals.jsonl`,
+    }),
+  );
+  app.put("/_upload/:kind", async (c) => {
+    const gz = Buffer.from(await c.req.arrayBuffer());
+    uploadedBlobs[c.req.param("kind")] = gunzipSync(gz).toString("utf8");
+    return c.body(null, 200);
+  });
   app.post("/v1/sessions/:id/finalize", async (c) => {
     receivedResult = await c.req.json();
     return c.json(
@@ -84,6 +115,8 @@ describe("pome run --hosted (e2e via spawn)", () => {
   beforeEach(async () => {
     receivedResult = null;
     finalizeResponseOverrides = {};
+    eventsResponse = [];
+    uploadedBlobs = {};
     tmp = await mkdtemp(join(tmpdir(), "pome-e2e-"));
     // FDRS-641 — `pome run` gates on the doctor preflight (config present,
     // routing wired, egress floor; local twin boot is skipped on hosted
@@ -239,5 +272,189 @@ describe("pome run --hosted (e2e via spawn)", () => {
     expect(stderr).toMatch(/UNEVAL Trivial/);
     expect(stderr).toContain("score: un-evaluated (cannot pass)");
     expect(stderr).toContain("cloud score: 100/100");
+  }, 90_000);
+
+  // F-768 (M1 "Turn-usage into the main ledger") — the whole point of the
+  // LlmTurnEvent contract is that per-turn LLM usage, and specifically the
+  // cache-read/cache-creation token counts, reaches cloud. On the HOSTED lane
+  // that means the adapter's signals JSONL survives the runner's redact → gzip
+  // → PUT pipeline as its own `signals.jsonl` blob and its key is threaded onto
+  // /finalize — the runner never merges signals into the trace's events.jsonl.
+  // This drives one real `pome run --hosted` command and inspects the bytes the
+  // fake cloud actually received.
+  it("uploads LlmTurnEvent rows (cache tokens intact) as a separate signals.jsonl blob, threads signalsStorageKey to finalize, and never merges them into events.jsonl", async () => {
+    // A real twin HTTP event so the uploaded events.jsonl has genuine content
+    // to prove the turn rows are NOT merged into it.
+    eventsResponse = [
+      {
+        ts: "2026-07-15T18:00:01.000Z",
+        run_id: "run_fixture",
+        twin: "github",
+        request_id: "req_1",
+        step_id: null,
+        tool_call_id: "tc_1",
+        method: "GET",
+        path: "/repos/acme/api",
+        request_body: null,
+        status: 200,
+        response_body: { full_name: "acme/api" },
+        latency_ms: 5,
+        fidelity: "semantic",
+        state_mutation: false,
+        state_delta: null,
+        error: null,
+      },
+    ];
+
+    // Two per-turn usage rows the CAS adapter emits into the signals JSONL —
+    // one 0-based turn each, carrying the cache-read/cache-creation counts that
+    // no other event kind reaches cloud with.
+    const turnRows = [
+      {
+        kind: "LlmTurnEvent",
+        ts: "2026-07-15T18:00:00.000Z",
+        event_id: "turn_0",
+        parent_id: null,
+        turn_index: 0,
+        model: "claude-opus-4-8",
+        input_tokens: 1200,
+        output_tokens: 350,
+        cache_read_input_tokens: 8192,
+        cache_creation_input_tokens: 4096,
+        finish_reasons: ["end_turn"],
+        latency_ms: 4200,
+        latency_ms_estimated: true,
+        session_id: null,
+      },
+      {
+        kind: "LlmTurnEvent",
+        ts: "2026-07-15T18:00:05.000Z",
+        event_id: "turn_1",
+        parent_id: null,
+        turn_index: 1,
+        model: "claude-opus-4-8",
+        input_tokens: 640,
+        output_tokens: 120,
+        cache_read_input_tokens: 12288,
+        cache_creation_input_tokens: 0,
+        finish_reasons: ["end_turn"],
+        latency_ms: 900,
+        latency_ms_estimated: true,
+        session_id: null,
+      },
+    ];
+
+    // Stub agent: append the turn rows to the signals file the runner injects
+    // via POME_ADAPTER_SIGNALS_PATH — exactly where the real adapter writes.
+    const agentScript = join(tmp, "emit-turns.mjs");
+    await writeFile(
+      agentScript,
+      [
+        'import { appendFileSync } from "node:fs";',
+        `const rows = ${JSON.stringify(turnRows)};`,
+        "const path = process.env.POME_ADAPTER_SIGNALS_PATH;",
+        'for (const r of rows) appendFileSync(path, JSON.stringify(r) + "\\n");',
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const scenarioPath = join(tmp, "scn.md");
+    await writeFile(
+      scenarioPath,
+      [
+        "# Trivial",
+        "",
+        "## Prompt",
+        "Pretend prompt.",
+        "",
+        "## Success Criteria",
+        "- [D] No unsupported endpoint was called",
+        "- [D] No new labels were created",
+        "",
+        "## Config",
+        "```yaml",
+        "twins: [github]",
+        "timeout: 30",
+        "passThreshold: 100",
+        "```",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const child = spawn(
+      process.execPath,
+      [
+        "--import",
+        TSX_LOADER,
+        CLI_ENTRY,
+        "run",
+        scenarioPath,
+        "--hosted",
+        "--api-url",
+        `http://127.0.0.1:${port}`,
+        "--agent",
+        `node "${agentScript}"`,
+        "--artifacts-dir",
+        join(tmp, "runs"),
+      ],
+      {
+        cwd: tmp,
+        env: { ...process.env, POME_API_KEY: "pme_e2e_test" },
+      },
+    );
+
+    let stderr = "";
+    let stdout = "";
+    child.stderr.on("data", (d) => (stderr += d.toString()));
+    child.stdout.on("data", (d) => (stdout += d.toString()));
+    const code = await new Promise<number>((res) => child.on("close", res));
+
+    // The run was accepted end to end: cloud finalized it and the CLI passed.
+    expect(code, `stderr was:\n${stderr}\nstdout was:\n${stdout}`).toBe(0);
+    expect(stderr).toMatch(/PASS/);
+
+    // finalize received the signals storage key (no rejection).
+    expect(receivedResult).not.toBeNull();
+    expect(
+      (receivedResult as Record<string, unknown>).signals_storage_key,
+    ).toBe("team-tm_test/session-ses_e2e/signals.jsonl");
+
+    // The uploaded signals blob carries the turn rows, cache token counts
+    // intact after the redact + gzip round trip. Every row must parse (the
+    // redactJsonl line filter must not have corrupted the JSONL) and be an
+    // LlmTurnEvent. NOTE: runScenarioHosted runs the agent command twice — a
+    // ≤10s preflight probe then the real run — against the same signals file,
+    // so the fixture's two turns appear once per invocation; assert on the
+    // distinct turns present, not an exact count.
+    expect(uploadedBlobs.signals, "signals.jsonl was not uploaded").toBeDefined();
+    const signalRows = uploadedBlobs.signals
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(signalRows.every((row) => row.kind === "LlmTurnEvent")).toBe(true);
+    const turn0 = signalRows.find((row) => row.turn_index === 0);
+    const turn1 = signalRows.find((row) => row.turn_index === 1);
+    expect(turn0, "turn_index 0 row missing from signals blob").toMatchObject({
+      kind: "LlmTurnEvent",
+      input_tokens: 1200,
+      output_tokens: 350,
+      cache_read_input_tokens: 8192,
+      cache_creation_input_tokens: 4096,
+    });
+    expect(turn1, "turn_index 1 row missing from signals blob").toMatchObject({
+      kind: "LlmTurnEvent",
+      cache_read_input_tokens: 12288,
+      cache_creation_input_tokens: 0,
+    });
+
+    // The turn rows live ONLY in signals.jsonl. The hosted lane uploads adapter
+    // signals as a separate blob and never merges them into the trace, so
+    // events.jsonl carries the twin HTTP event but no LlmTurnEvent.
+    expect(uploadedBlobs.events, "events.jsonl was not uploaded").toBeDefined();
+    expect(uploadedBlobs.events).toContain("TwinHttpEvent");
+    expect(uploadedBlobs.events).toContain("/repos/acme/api");
+    expect(uploadedBlobs.events).not.toContain("LlmTurnEvent");
   }, 90_000);
 });


### PR DESCRIPTION
<!-- Closes F-768 -->

## What

Adds a hosted-lane e2e assertion (M1 "Turn-usage into the main ledger", F-768). One real `pome run --hosted` drives the full lane against the fake cloud, which now mints the signed events/signals upload URLs and gunzips the PUT bodies it receives. The test asserts the adapter's per-turn `LlmTurnEvent` rows — with the cache-read/creation token counts — land in the uploaded `signals.jsonl` blob intact after the runner's redact + gzip pipeline, that `signals_storage_key` is threaded onto `/finalize` and the run is accepted, and that the turn rows are **never** merged into the separate `events.jsonl` trace blob.

Test-only. The `@pome-sh/shared-types` 0.9.0 pin the checkout needs to build already landed on `main` via #155.

## Why

F-768 is the hosted sibling of F-766 (self-host `events.jsonl` turn rows) and F-767 (published shared-types + cloud compat, which resolved as "cloud already tolerates the kind, stays pinned 0.7.0 by design"). Per-turn LLM usage — specifically the cache token counts — is the datum M1 exists to carry into the ledger; on the hosted path that means proving the adapter's signals JSONL survives the runner's redact→gzip→PUT pipeline as its own blob and reaches finalize, without being merged into the trace.

## Notes for reviewer

- The runner runs the agent command twice (≤10s preflight probe + real run) against the same signals file, so the fixture's two turns appear once per invocation; the test asserts on the distinct turns present (integrity + cache tokens), not an exact row count. Documented inline.
- Verified the "not merged" assertion has teeth: temporarily merging `signalsJsonl` into `eventsJsonl` fails the test on the `events.jsonl` exclusion.
- Full CLI suite green (659/659) after rebase onto #155 (which also bumped twin-github to the 65-tool 0.2.0 surface).