### PR TITLE
test(twin-github): assert seeded failing PR status surfaces on /pulls/:n/status

### DIFF
--- a/packages/twin-github/test/v2-hot-paths-rest.test.ts
+++ b/packages/twin-github/test/v2-hot-paths-rest.test.ts
@@ -306,6 +306,49 @@ describe("REST / cluster F — commit status + checks", () => {
     const response = await jsonReq(a, "POST", "/repos/acme/api/check-runs", { name: "lint", head_sha: sha, status: "completed" });
     expect(response.status).toBe(422);
   });
+
+  // Regression: a seeded PR `statuses[]` with state:"failure" must surface on
+  // GET /pulls/:n/status as combined state:"failure" (total_count > 0), not the
+  // empty-set default. Mirrors examples/minimal-viktor scenario 03 (failing-ci)
+  // exactly — an earlier (pre-consolidation) twin dropped seeded PR statuses and
+  // returned the zero-status default, which made that scenario unwinnable.
+  it("GET /pulls/:n/status surfaces a seeded failing PR status", async () => {
+    const a = createGitHubCloneApp({
+      seed: {
+        users: [{ login: "alice", type: "User", name: "Alice" }],
+        repositories: [
+          {
+            owner: "viktor-hq",
+            name: "orders-service",
+            default_branch: "main",
+            collaborators: ["alice"],
+            files: [
+              { path: "orders.py", content: "def total(items):\n    return 0\n", branch: "main" },
+              { path: "orders.py", content: "def total(items):\n    return 1\n", branch: "add-discounts" }
+            ],
+            pull_requests: [
+              {
+                number: 1,
+                title: "Add per-item discount support",
+                head: "add-discounts",
+                base: "main",
+                state: "open",
+                author: "alice",
+                reviews: [],
+                statuses: [{ context: "ci/test", state: "failure", description: "3 tests failing" }]
+              }
+            ]
+          }
+        ]
+      }
+    });
+    const status = await jsonReq(a, "GET", "/repos/viktor-hq/orders-service/pulls/1/status");
+    expect(status.status).toBe(200);
+    const body = status.body as { state: string; total_count: number; statuses: Array<{ context: string; state: string }> };
+    expect(body.state).toBe("failure");
+    expect(body.total_count).toBe(1);
+    expect(body.statuses[0]).toMatchObject({ context: "ci/test", state: "failure" });
+  });
 });
 
 // ----- Cluster G — tags & releases ------------------------------------


### PR DESCRIPTION
## Why

A hosted pome MCP run of `examples/minimal-viktor` scenario 03 (failing-ci) scored 0: the agent saw CI=success and correctly merged. Root cause was a **stale deployed twin image** (`@pome-sh/twin-github@0.1.0`, pre-consolidation) whose `combinedStatusJson` defaulted zero statuses to `"success"` and did not attach seeded PR statuses.

The current source (0.2.0 / infra-pinned `ed7b171`) is already correct — `combinedStatusJson` returns `"pending"` for zero statuses and rolls up worst-case (`failure` > `pending` > `success`), and `seed()` attaches `pull_requests[].statuses[]` to the PR head SHA. But existing coverage was domain-level only.

## Change

Adds a route-level regression test that boots the real Hono app with the scenario-03 seed slice and asserts `GET /repos/:o/:r/pulls/:n/status` returns `state:"failure", total_count:1, statuses[0]={context:"ci/test",state:"failure"}` — the exact HTTP surface a merge-gating agent reads.

No source change (the behavior is already correct on `main`); this locks it against a regression. Full suite: 255 tests pass.

Note: making scenario 03 pass on the hosted MCP is operational — the prod `TWIN_TEMPLATE_SNAPSHOT_ID` (51 days old) must be promoted to the current snapshot (`snap_lGZe1…`, ed7b171) in pome-cloud + control-plane redeploy.