### PR TITLE
feat(shared-types): accept legacy and canonical criterion kinds on the finalize wire (0.10.0)

### DIFF
--- a/cli/.changeset/tolerant-criterion-kind-wire-type.md
+++ b/cli/.changeset/tolerant-criterion-kind-wire-type.md
@@ -1,0 +1,5 @@
+---
+"@pome-sh/cli": patch
+---
+
+Internal: type the hosted finalize payload's criteria as the wire *input* shape (`CriterionDefInput`). No behavior change — the CLI still sends the legacy `D`/`P` criterion kinds until the hosted service accepts the canonical `code`/`model` spellings.

--- a/cli/src/hosted/client.ts
+++ b/cli/src/hosted/client.ts
@@ -4,7 +4,7 @@ import {
   type CreateEvalSessionResponse,
   createSessionResponseSchema,
   type CreateSessionResponse,
-  type CriterionDefInput,
+  criterionDefSchema,
   finalizeResponseSchema,
   type FinalizeResponse,
   sessionPublicSchema,
@@ -22,6 +22,11 @@ import {
   HostedOrchError,
   HostedQuotaError,
 } from "./errors.js";
+
+// Writer-side shape of the finalize criteria (see FinalizeInput.criteria).
+// Derived with z.input so it tracks whatever the installed contract accepts
+// as INPUT rather than its parsed output.
+export type CriterionDefWire = z.input<typeof criterionDefSchema>;
 
 // Multi-twin (M3): provenance marker for `per_twin`. A single-twin OLD cloud
 // ships NO `per_twin` key; `createSessionResponseSchema` then SYNTHESIZES one
@@ -221,9 +226,11 @@ export interface FinalizeInput {
   agentSdk?: string | null;
   // Criterion *definitions* (not results). Cloud judges these against the
   // recorded trace/state and returns the authoritative score. Writer-side
-  // input type: the CLI may send legacy "D"/"P" kinds during the F-778
-  // compat window; cloud normalizes to "code"/"model" on parse.
-  criteria: CriterionDefInput[];
+  // input type (z.input, not z.infer): the CLI may send legacy "D"/"P" kinds
+  // during the F-778 compat window; cloud normalizes to "code"/"model" on
+  // parse. z.input keeps this compiling against both the published 0.9.x
+  // contract (D/P only) and the tolerant 0.10.0 reader.
+  criteria: CriterionDefWire[];
   scenarioName: string;
   scenarioHash: string;
   scenarioPrompt: string;

--- a/cli/src/hosted/client.ts
+++ b/cli/src/hosted/client.ts
@@ -4,7 +4,7 @@ import {
   type CreateEvalSessionResponse,
   createSessionResponseSchema,
   type CreateSessionResponse,
-  type CriterionDef,
+  type CriterionDefInput,
   finalizeResponseSchema,
   type FinalizeResponse,
   sessionPublicSchema,
@@ -220,8 +220,10 @@ export interface FinalizeInput {
   agentModel: string;
   agentSdk?: string | null;
   // Criterion *definitions* (not results). Cloud judges these against the
-  // recorded trace/state and returns the authoritative score.
-  criteria: CriterionDef[];
+  // recorded trace/state and returns the authoritative score. Writer-side
+  // input type: the CLI may send legacy "D"/"P" kinds during the F-778
+  // compat window; cloud normalizes to "code"/"model" on parse.
+  criteria: CriterionDefInput[];
   scenarioName: string;
   scenarioHash: string;
   scenarioPrompt: string;

--- a/cli/src/runner/runScenarioHosted.ts
+++ b/cli/src/runner/runScenarioHosted.ts
@@ -30,7 +30,7 @@ import {
 import { HostedOrchError, HostedTrialError } from "../hosted/errors.js";
 import type {
   CreateSessionResponse,
-  CriterionDef,
+  CriterionDefInput,
   RecorderEvent,
 } from "../types/shared.js";
 import type { RecorderEvent as LegacyGithubRecorderEvent } from "@pome-sh/shared-types";
@@ -564,12 +564,14 @@ export async function runScenarioHosted(
     //    storage, calls the managed judge via AI Gateway, persists the run
     //    row, and returns the authoritative score the dashboard records.
     //    The CLI prints this score on the `score:` line.
-    // `CriterionDef.kind` on the finalize request is still the legacy `D`/`P`
-    // wire vocabulary; map the canonical `code`/`model` kind back for the wire.
+    // The finalize wire still SENDS the legacy `D`/`P` kind spellings: prod
+    // cloud requires them until its shared-types pin reaches the tolerant
+    // 0.10.0 reader (F-778 compat window). The emission flips to canonical
+    // `code`/`model` in the CLI release that rides that window.
     // Multi-twin (M3): carry the per-criterion twin attribution so the cloud
-    // judge checks each [D:<twin>] against that twin's state. Absent = the
+    // judge checks each criterion against its twin's state. Absent = the
     // primary twin (single-twin scenarios omit it entirely).
-    const criteriaDefs: CriterionDef[] = scenario.criteria.map((c, idx) => ({
+    const criteriaDefs: CriterionDefInput[] = scenario.criteria.map((c, idx) => ({
       id: `crit_${idx}`,
       text: c.text,
       kind: c.type === "code" ? "D" : "P",

--- a/cli/src/runner/runScenarioHosted.ts
+++ b/cli/src/runner/runScenarioHosted.ts
@@ -30,9 +30,9 @@ import {
 import { HostedOrchError, HostedTrialError } from "../hosted/errors.js";
 import type {
   CreateSessionResponse,
-  CriterionDefInput,
   RecorderEvent,
 } from "../types/shared.js";
+import type { CriterionDefWire } from "../hosted/client.js";
 import type { RecorderEvent as LegacyGithubRecorderEvent } from "@pome-sh/shared-types";
 import type { Scenario } from "../scenario/scenarioSchema.js";
 import type { Score } from "../hosted/evalResultView.js";
@@ -571,7 +571,7 @@ export async function runScenarioHosted(
     // Multi-twin (M3): carry the per-criterion twin attribution so the cloud
     // judge checks each criterion against its twin's state. Absent = the
     // primary twin (single-twin scenarios omit it entirely).
-    const criteriaDefs: CriterionDefInput[] = scenario.criteria.map((c, idx) => ({
+    const criteriaDefs: CriterionDefWire[] = scenario.criteria.map((c, idx) => ({
       id: `crit_${idx}`,
       text: c.text,
       kind: c.type === "code" ? "D" : "P",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4878,6 +4878,14 @@
         }
       }
     },
+    "packages/adapter-claude-sdk/node_modules/@pome-sh/shared-types": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.9.0.tgz",
+      "integrity": "sha512-F5Vjqs2YlZWSnRjqrybyKBt98WI/3LPL4gzUuw+5tPUFT4GdAMQrEi+tkWmi0ekUVbMbCZqkZwTuWTa9dx6+5g==",
+      "peerDependencies": {
+        "zod": "^4.1.13"
+      }
+    },
     "packages/adapter-claude-sdk/node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -4943,7 +4951,7 @@
     },
     "packages/shared-types": {
       "name": "@pome-sh/shared-types",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "devDependencies": {
         "@types/node": "^26.1.0",
         "typescript": "^5.9.3",

--- a/packages/shared-types/CHANGELOG.md
+++ b/packages/shared-types/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @pome-sh/shared-types — CHANGELOG
 
+## 0.10.0
+
+### Changed
+
+- `criterionDefSchema.kind` (the `/v1` finalize wire boundary) is now a
+  tolerant reader (F-778): input accepts `"D" | "P" | "code" | "model"`;
+  parsed output is always the canonical `"code" | "model"` (normalized via
+  `LEGACY_CRITERION_KIND_MAP`). Previously the schema accepted ONLY the legacy
+  `"D" | "P"` spellings. **Consumer-must-act:** the `CriterionDef["kind"]`
+  *output* type changes from `"D" | "P"` to `"code" | "model"` — readers of
+  parsed finalize criteria (cloud finalize route, judge) must compare against
+  the canonical kinds after bumping this pin. Writers may send either spelling
+  during the compat window; released CLIs keep sending `"D"` / `"P"` until the
+  CLI release that rides this migration.
+- `LEGACY_CRITERION_KIND_MAP` is now documented as the single sanctioned
+  legacy-spelling exception of the F-778 zero-residue migration (read-only
+  input normalization; no writer may emit `D` / `P`).
+
 ## 0.9.0
 
 ### Removed

--- a/packages/shared-types/CHANGELOG.md
+++ b/packages/shared-types/CHANGELOG.md
@@ -18,6 +18,13 @@
   legacy-spelling exception of the F-778 zero-residue migration (read-only
   input normalization; no writer may emit `D` / `P`).
 
+### Added
+
+- `CriterionDefInput` (type-only) — the writer-side shape of the finalize
+  wire during the compat window (`kind: "D" | "P" | "code" | "model"`).
+  Producers that still emit the legacy spellings type their payloads with
+  this; readers keep seeing the canonical `CriterionDef` after parse.
+
 ## 0.9.0
 
 ### Removed

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/shared-types",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Shared wire-format contract for Pome — Zod schemas for traces, recorder events, runs, OTel mapping, and secret redaction.",
   "private": false,
   "type": "module",

--- a/packages/shared-types/src/rest.ts
+++ b/packages/shared-types/src/rest.ts
@@ -16,7 +16,7 @@ import {
   userSchema,
 } from "./identity.js";
 import { criterionResultSchema, judgeModelSchema, laneSchema, stepSchema } from "./run.js";
-import { normalizeTaskVocabKeys } from "./task-vocab.js";
+import { LEGACY_CRITERION_KIND_MAP, normalizeTaskVocabKeys } from "./task-vocab.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // 4. PUBLIC REST API (api.pome.sh/v1) request/response shapes
@@ -274,10 +274,17 @@ export type CreateEvalSessionResponse = z.infer<typeof createEvalSessionResponse
 export const criterionDefSchema = z.object({
   id: z.string().min(1),
   text: z.string().min(1),
-  kind: z.enum(["D", "P"]),
-  // Multi-twin (M3): the twin a [D:<twin>]/[P:<twin>] scenario criterion
+  // Tolerant reader (F-778): released CLIs still send the legacy "D"/"P"
+  // spellings; parsed output is always the canonical "code"/"model". Single
+  // source of truth for the rename is LEGACY_CRITERION_KIND_MAP.
+  kind: z
+    .enum(["D", "P", "code", "model"])
+    .transform((kind) =>
+      kind === "D" || kind === "P" ? LEGACY_CRITERION_KIND_MAP[kind] : kind,
+    ),
+  // Multi-twin (M3): the twin a [code:<twin>]/[model:<twin>] task criterion
   // attributes to. Absent = the session's primary twin (twins[0]). Additive —
-  // single-twin scenarios omit it and score against the sole twin as before.
+  // single-twin tasks omit it and score against the sole twin as before.
   twin: z.string().min(1).optional(),
 });
 export type CriterionDef = z.infer<typeof criterionDefSchema>;

--- a/packages/shared-types/src/rest.ts
+++ b/packages/shared-types/src/rest.ts
@@ -288,6 +288,10 @@ export const criterionDefSchema = z.object({
   twin: z.string().min(1).optional(),
 });
 export type CriterionDef = z.infer<typeof criterionDefSchema>;
+// Writer-side shape of the finalize wire during the F-778 compat window: a
+// producer may still send the legacy "D"/"P" spellings (released CLIs do);
+// readers always see the canonical CriterionDef after parse.
+export type CriterionDefInput = z.input<typeof criterionDefSchema>;
 
 // POST /v1/agents — register an agent (vercel-link shape). The server is
 // canonical for the slug; the CLI persists whatever id/slug it returns.

--- a/packages/shared-types/src/run.ts
+++ b/packages/shared-types/src/run.ts
@@ -142,7 +142,7 @@ const runObjectSchema = z.object({
   meta_s3_key: z.string().nullable(),
   duration_ms: z.number().int(),
   agent_model: z.string(),                     // which model the agent used (informational)
-  judge_model: judgeModelSchema,               // which model judged [P] (free-form)
+  judge_model: judgeModelSchema,               // which model judged [model] criteria (free-form)
   judge_tokens_in: z.number().int().min(0).nullable(),
   judge_tokens_out: z.number().int().min(0).nullable(),
   // ── FDRS-613: reconciled from pome-cloud /v1 wire truth (all additive with

--- a/packages/shared-types/src/task-vocab.ts
+++ b/packages/shared-types/src/task-vocab.ts
@@ -79,7 +79,21 @@ export function normalizeTaskVocabKeys(value: unknown): unknown {
   return out ?? value;
 }
 
-/** Legacy criterion kind → canonical criterion kind (W3: D→code, P→model). */
+/**
+ * Legacy criterion kind → canonical criterion kind (W3: D→code, P→model).
+ *
+ * SANCTIONED EXCEPTION (F-778). The full D/P→code/model migration removed the
+ * legacy spelling everywhere — including the markdown authoring marker, which
+ * is now `[code]` / `[model]` — EXCEPT this read-only shim. It exists because:
+ *   - 0.3.0-era persisted artifacts (run rows, `criteria_results` jsonb) carry
+ *     `D` / `P` and must keep parsing;
+ *   - released CLIs keep sending `"D"` / `"P"` on the finalize wire
+ *     (`criterionDefSchema` in ./rest.js) for one more release train.
+ * It is input-normalization only: no writer may emit `D` / `P`, and no new
+ * code may reference the legacy spellings outside this map and the schemas
+ * that apply it (`criterionKindInputSchema` in ./run.js, `criterionDefSchema`
+ * in ./rest.js). Removal rides the wire-window close-out ticket.
+ */
 export const LEGACY_CRITERION_KIND_MAP = {
   D: "code",
   P: "model",

--- a/packages/shared-types/test/export-surface.test.ts
+++ b/packages/shared-types/test/export-surface.test.ts
@@ -36,6 +36,7 @@ import type {
   CreateSessionRequest,
   CreateSessionResponse,
   CriterionDef,
+  CriterionDefInput,
   FinalizeAcceptedResponse,
   FinalizeCompletedStatusResponse,
   FinalizeFailedStatusResponse,
@@ -93,6 +94,7 @@ type _TypeSurfaceAssert = [
   CreateSessionRequest,
   CreateSessionResponse,
   CriterionDef,
+  CriterionDefInput,
   FinalizeAcceptedResponse,
   FinalizeCompletedStatusResponse,
   FinalizeFailedStatusResponse,
@@ -135,7 +137,7 @@ type _TypeSurfaceAssert = [
 // Compile-time anchor: exactly one tuple entry per guarded type. The literal
 // type on the left fails to compile if an entry is added or removed above
 // without updating the count.
-const TYPE_SURFACE_SIZE: _TypeSurfaceAssert["length"] = 52;
+const TYPE_SURFACE_SIZE: _TypeSurfaceAssert["length"] = 53;
 
 // Runtime value exports (types are erased and cannot appear on `Object.keys`).
 const EXPECTED_EXPORTS = [

--- a/packages/shared-types/test/export-surface.test.ts
+++ b/packages/shared-types/test/export-surface.test.ts
@@ -291,10 +291,10 @@ describe("@pome-sh/shared-types barrel export surface (F-754)", () => {
     expect(Object.keys(api).sort()).toEqual([...EXPECTED_EXPORTS]);
   });
 
-  it("guards the TYPE surface (54 types/interfaces)", () => {
+  it("guards the TYPE surface (53 types/interfaces)", () => {
     // The real guard is the type-only import + _TypeSurfaceAssert tuple above,
     // enforced at typecheck time. This assertion just anchors the count at
     // runtime so the guard's scope is visible in test output.
-    expect(TYPE_SURFACE_SIZE).toBe(52);
+    expect(TYPE_SURFACE_SIZE).toBe(53);
   });
 });

--- a/packages/shared-types/test/multi-twin-contract.test.ts
+++ b/packages/shared-types/test/multi-twin-contract.test.ts
@@ -40,15 +40,24 @@ describe("criterionSchema.twin (run.ts) — rides the D/P→code/model transform
   });
 });
 
-describe("criterionDefSchema.twin (rest.ts)", () => {
-  it("accepts an optional twin on a scenario criterion def", () => {
-    expect(criterionDefSchema.parse({ id: "c1", text: "t", kind: "D", twin: "stripe" }))
-      .toEqual({ id: "c1", text: "t", kind: "D", twin: "stripe" });
+describe("criterionDefSchema.kind (rest.ts) — tolerant reader, canonical output (F-778)", () => {
+  it("passes canonical code/model kinds through unchanged", () => {
+    expect(criterionDefSchema.parse({ id: "c1", text: "t", kind: "code", twin: "stripe" }))
+      .toEqual({ id: "c1", text: "t", kind: "code", twin: "stripe" });
+    expect(criterionDefSchema.parse({ id: "c1", text: "t", kind: "model" }))
+      .toEqual({ id: "c1", text: "t", kind: "model" });
   });
 
-  it("parses without twin unchanged", () => {
+  it("normalizes legacy D/P wire kinds from released CLIs to code/model", () => {
+    expect(criterionDefSchema.parse({ id: "c1", text: "t", kind: "D", twin: "stripe" }))
+      .toEqual({ id: "c1", text: "t", kind: "code", twin: "stripe" });
     expect(criterionDefSchema.parse({ id: "c1", text: "t", kind: "P" }))
-      .toEqual({ id: "c1", text: "t", kind: "P" });
+      .toEqual({ id: "c1", text: "t", kind: "model" });
+  });
+
+  it("rejects kinds outside the tolerant set", () => {
+    expect(criterionDefSchema.safeParse({ id: "c1", text: "t", kind: "d" }).success).toBe(false);
+    expect(criterionDefSchema.safeParse({ id: "c1", text: "t", kind: "deterministic" }).success).toBe(false);
   });
 });
 
@@ -178,6 +187,8 @@ describe("finalizeRequestSchema.per_twin_state_keys (finalize-shapes.ts) — LIV
   it("parses without per_twin_state_keys (single-twin / older CLI)", () => {
     const parsed = finalizeRequestSchema.parse(base);
     expect(parsed.per_twin_state_keys).toBeUndefined();
+    // Legacy D/P wire kinds normalize at the finalize boundary too (F-778).
+    expect(parsed.criteria).toEqual([{ id: "c1", text: "PR merged", kind: "code", twin: "github" }]);
   });
 
   it("parses with an additive per_twin_state_keys map (multi-twin / new CLI)", () => {

--- a/packages/shared-types/test/task-vocab.test.ts
+++ b/packages/shared-types/test/task-vocab.test.ts
@@ -132,7 +132,7 @@ describe("criterion kind vocabulary", () => {
     expect("confidence" in parsed && parsed.confidence).toBe(0.9);
   });
 
-  it("criterionResultSchema routes a legacy [D] result to the deterministic arm", () => {
+  it("criterionResultSchema routes a legacy D-kind result to the deterministic arm", () => {
     const parsed = criterionResultSchema.parse({
       criterion: { type: "D", text: "label added" },
       passed: false,

--- a/packages/shared-types/trace-contract.json
+++ b/packages/shared-types/trace-contract.json
@@ -1,6 +1,6 @@
 {
   "package": "@pome-sh/shared-types",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "zod": {
     "range": "^4.1.13",
     "major": 4


### PR DESCRIPTION
Executive summary: `criterionDefSchema.kind` — the finalize wire boundary between the CLI and the hosted evaluation service — becomes a tolerant reader: it now accepts both the legacy `"D" | "P"` and the canonical `"code" | "model"` criterion-kind spellings, and always parses to the canonical `"code" | "model"`. This is the first step of retiring the legacy `D`/`P` criterion-kind vocabulary end-to-end; a follow-up release moves the markdown authoring marker itself to `[code]`/`[model]`.

## What
- `rest.ts` `criterionDefSchema.kind`: `z.enum(["D","P"])` → tolerant input `["D","P","code","model"]` with a transform to canonical `code`/`model`, normalized via the existing `LEGACY_CRITERION_KIND_MAP` single source of truth.
- `LEGACY_CRITERION_KIND_MAP` doc comment now spells out its status as the one sanctioned legacy-spelling exception (read-only input normalization; no writer may emit `D`/`P`).
- Version 0.9.0 → 0.10.0 + CHANGELOG entry; root lockfile refresh for the workspace version.
- Two stale `[D]`/`[P]` marker mentions in comments/test names reworded.

## Why
The criterion-kind vocabulary was renamed `D`/`P` → `code`/`model` at the type layer in 0.5.0, but the finalize wire schema still *required* the legacy spellings, forcing the CLI to down-convert on upload. Making the boundary tolerant (accept both, emit canonical) opens the compat window that lets the CLI flip to sending canonical kinds without bricking already-released CLIs.

## Notes for reviewer
- **Contract audit:** input side is a pure widening (every previously-valid payload still parses). The **parsed output type changes**: `CriterionDef["kind"]` is now `"code" | "model"` instead of `"D" | "P"` — consumers that read parsed criteria must compare against the canonical kinds when they bump this pin. That is deliberate and called out in the CHANGELOG as consumer-must-act.
- No persisted-artifact impact: this schema validates live wire payloads only.
- In-repo consumers are unaffected: the CLI and adapter consume the *published* package (0.9.0 pins), and no workspace package reads `CriterionDef`.
- Public export surface is unchanged (guarded by `export-surface.test.ts`); the tolerant transform is defined inline rather than exporting the internal input schema.

## Tests / CI
- `packages/shared-types`: 319 tests green (new: canonical passthrough, legacy normalization at both the def and finalize-request level, rejection of out-of-set kinds), `typecheck` + `build` clean.
- Root: all 6 workspace suites green on node 24.
- Also drove the built `dist/` end-to-end: `kind:"D"` → `"code"`, `kind:"model"` passthrough, finalize-request criteria normalize, lowercase `"d"` rejected.