### PR TITLE
fix(cli): exclude preflight-probe signals from the hosted usage ledger

### DIFF
--- a/cli/.changeset/preflight-signals-ledger.md
+++ b/cli/.changeset/preflight-signals-ledger.md
@@ -1,0 +1,5 @@
+---
+"@pome-sh/cli": patch
+---
+
+Hosted runs no longer count the preflight probe's telemetry toward the uploaded usage ledger. The runner ran the agent command twice against one shared signals file (a ≤10s preflight probe, then the real run) and uploaded the file whole, so per-turn LLM usage (`LlmTurnEvent`) was double-counted. The shared signals file is now truncated after a successful preflight, before the real run, so the uploaded `signals.jsonl` reflects real-run telemetry only.

--- a/cli/src/runner/runScenarioHosted.ts
+++ b/cli/src/runner/runScenarioHosted.ts
@@ -331,6 +331,14 @@ export async function runScenarioHosted(
 
     let agentResult = preflight;
     if (preflight.exitCode === 0) {
+      // F-771 — the preflight probe appended its own signals (turns/steps/
+      // tool_calls) to the shared POME_ADAPTER_SIGNALS_PATH file. Those must
+      // NOT reach the uploaded signals.jsonl / usage ledger. Truncate before
+      // the real run so the blob counts real-run telemetry only. runAgentCommand
+      // awaits child exit, so the preflight's writes are already flushed here.
+      // Gated on preflight success: the preflight-failed → single-run path keeps
+      // its current behavior (it uploads the preflight's signals).
+      await writeFile(signalsPath, "");
       agentResult = await runAgentCommand({
         command: options.agentCommand,
         env,

--- a/cli/test/e2e/runScenarioHosted.test.ts
+++ b/cli/test/e2e/runScenarioHosted.test.ts
@@ -438,7 +438,7 @@ describe("pome run --hosted (e2e via spawn)", () => {
       signalRows,
       "signals blob must count the real run's turns only (preflight excluded)",
     ).toHaveLength(2);
-    expect(signalRows.map((row) => row.turn_index).sort()).toEqual([0, 1]);
+    expect(signalRows.map((row) => row.turn_index).sort((a, b) => a - b)).toEqual([0, 1]);
     const turn0 = signalRows.find((row) => row.turn_index === 0);
     const turn1 = signalRows.find((row) => row.turn_index === 1);
     expect(turn0, "turn_index 0 row missing from signals blob").toMatchObject({

--- a/cli/test/e2e/runScenarioHosted.test.ts
+++ b/cli/test/e2e/runScenarioHosted.test.ts
@@ -421,19 +421,24 @@ describe("pome run --hosted (e2e via spawn)", () => {
       (receivedResult as Record<string, unknown>).signals_storage_key,
     ).toBe("team-tm_test/session-ses_e2e/signals.jsonl");
 
-    // The uploaded signals blob carries the turn rows, cache token counts
-    // intact after the redact + gzip round trip. Every row must parse (the
-    // redactJsonl line filter must not have corrupted the JSONL) and be an
-    // LlmTurnEvent. NOTE: runScenarioHosted runs the agent command twice — a
-    // ≤10s preflight probe then the real run — against the same signals file,
-    // so the fixture's two turns appear once per invocation; assert on the
-    // distinct turns present, not an exact count.
+    // The uploaded signals blob carries the real run's turn rows, cache token
+    // counts intact after the redact + gzip round trip. Every row must parse
+    // (the redactJsonl line filter must not have corrupted the JSONL) and be an
+    // LlmTurnEvent. F-771 — the ≤10s preflight probe appends its own turns to
+    // the same signals file first; the runner truncates that file before the
+    // real run, so the uploaded blob contains the real run's 2 turns ONLY
+    // (turn_index 0 and 1), never the preflight's duplicate pair.
     expect(uploadedBlobs.signals, "signals.jsonl was not uploaded").toBeDefined();
     const signalRows = uploadedBlobs.signals
       .trim()
       .split("\n")
       .map((line) => JSON.parse(line));
     expect(signalRows.every((row) => row.kind === "LlmTurnEvent")).toBe(true);
+    expect(
+      signalRows,
+      "signals blob must count the real run's turns only (preflight excluded)",
+    ).toHaveLength(2);
+    expect(signalRows.map((row) => row.turn_index).sort()).toEqual([0, 1]);
     const turn0 = signalRows.find((row) => row.turn_index === 0);
     const turn1 = signalRows.find((row) => row.turn_index === 1);
     expect(turn0, "turn_index 0 row missing from signals blob").toMatchObject({


### PR DESCRIPTION
<!-- F-771 -->

## What
On the hosted lane, `runScenarioHosted` runs the agent command twice against one shared signals file — a ≤10s preflight probe, then the real run — and uploads the file whole. The preflight's `LlmTurnEvent` (and step/tool_call) signals were landing in the uploaded `signals.jsonl`, double-counting per-turn LLM usage. This truncates the shared signals file after a successful preflight, before the real run, so the uploaded blob counts real-run telemetry only.

## Why
The uploaded signals blob feeds the usage ledger. A real run emitting 2 turns produced 4 rows in the blob (2 preflight + 2 real). `POME_PREFLIGHT=1` is only honored by scaffolded/fixture agents, so any real adapter-wrapped agent inflates its turn usage. Fixing it capture-side (runner) protects every agent regardless of what it emits; cloud-side dedup isn't viable because preflight turns carry distinct `event_id`s. Surfaced by the F-768 hosted-upload assertion, which previously *tolerated* the double-write by asserting distinct-turn identity — this PR tightens that assertion to an exact count.

## Notes for reviewer
- The truncate is gated on `preflight.exitCode === 0` and sits before the real `runAgentCommand`: the preflight-failed → single-run path is intentionally unchanged (it still uploads the preflight's signals).
- `runAgentCommand` awaits child-process exit, so the preflight's writes are flushed before truncation — no race.
- Test-first: the tightened e2e assertion (`toHaveLength(2)`, `turn_index [0,1]`) goes red on the unpatched runner (blob has 4) and green after.

## Review required
Yes — touches the hosted usage/billing ledger (per-turn LLM usage counting).