### PR TITLE
Add the support-triage self-fix demo (duplicate-issue, two distinct agents)

### DIFF
--- a/examples/support-triage/README.md
+++ b/examples/support-triage/README.md
@@ -1,0 +1,87 @@
+# support-triage — a self-fix demo on Pome
+
+A minimal **support-triage agent** for the `acme` engineering org: it watches the
+`#support` Slack channel for bug reports, reproduces them, tracks each as a GitHub
+issue in `acme/orders-service`, and posts the tracking link back to `#support`.
+Two twins in one run — the **Slack twin** (where the report arrives) and the
+**GitHub twin** (where the issue lives).
+
+The pack exists to demo a reproducible **FAIL → FIX → PASS** on Pome using two
+versions of the agent that differ by exactly **one line**:
+
+- `agents/support-triage-v1.yaml` — **baseline**. Its charter tells the agent
+  *not* to search existing issues. On a re-reported bug it files a **duplicate**
+  issue. **Fails.**
+- `agents/support-triage-v2.yaml` — **fixed**. The one line is replaced by a
+  *search-before-filing* rule, so it comments on the existing issue instead of
+  opening a second one. **Passes.**
+
+```bash
+diff agents/support-triage-v1.yaml agents/support-triage-v2.yaml   # one line
+```
+
+The failure — filing a duplicate issue for a bug that's already tracked — is the
+kind of thing a happy-path demo never shows and an issue tracker hates at scale.
+Pome catches it by grading the twin's real end state: `issues: 1 → 2` (a
+duplicate) for v1 vs `issues: 1 → 1` + a comment for v2. Measured results are in
+[`VERIFICATION.md`](./VERIFICATION.md) (v1 **0/5**, v2 **4/5** on
+`claude-sonnet-5`).
+
+## The scenario
+
+[`scenarios/duplicate-issue.md`](./scenarios/duplicate-issue.md) is
+self-contained (task + criteria + an inline `## Seed State`). The seed pre-loads
+open issue #1 for the coupon bug, then `#support` receives a *new* report of the
+*same* bug. A good agent recognizes the duplicate.
+
+| criterion | kind | checks |
+|---|---|---|
+| a `#support` message links `issues/1` | code:slack | the agent linked the *existing* issue, not a new one |
+| recognized the existing issue, opened no duplicate | model | the dedup decision |
+| concrete repro steps | model | quality of the tracked report |
+
+## Run it against Pome
+
+The two versions are exercised as **two distinct agents** end-to-end, so the
+dashboard shows two separate identities with separate scores.
+
+1. **Register on Cloud Managed Agents** — create each agent from its YAML on
+   Anthropic's Managed Agents platform (`ant beta:agents create`, model
+   `claude-sonnet-5`).
+2. **Register on Pome** (control MCP) — one call per version, so each accrues its
+   own history:
+   ```
+   register_agent(name="support-triage-v1", twins=["github","slack"])
+   register_agent(name="support-triage-v2", twins=["github","slack"])
+   ```
+3. **Run** — for each agent id, `run_trials(scenario_id, agent_id, n=5)`. Each
+   trial returns an `examinee_launch` spec (per-session twin MCP URLs, a bearer,
+   `always_allow`, a `network.mode: limited` clamp, web tools off). Assemble the
+   examinee clone from that spec (mirrors
+   `pome-run-scenario/references/launch-managed-agent.md`), give it
+   `examinee_task.prompt`, and let it work.
+4. **Finalize** — `finalize_run(session_id, agent_token)` the instant the
+   examinee idles (the tape is pulled from the still-live twin session), then
+   `get_report` for the score. Tear the clone down afterward — clones are
+   ephemeral, one per trial.
+
+The self-fix loop is the swap between step 3's two agents: run v1 → watch it fail
+by filing a duplicate → switch to v2 (the one-line fix) → watch it pass.
+
+## Layout
+
+```
+agents/support-triage-v1.yaml   baseline (files a duplicate) — fails
+agents/support-triage-v2.yaml   fixed (searches first) — passes; one line different
+scenarios/duplicate-issue.md    the scenario (inline ## Seed State)
+VERIFICATION.md                 measured v1-vs-v2 results with run ids
+```
+
+## Notes
+
+- The bearer token in each `examinee_launch` is **sensitive** — keep it in memory
+  only; never write it to disk or into a scenario.
+- The declared `mcp_servers` URLs (`mcp.slack.com`, `api.githubcopilot.com`) are
+  the agent's *real* servers; Pome swaps them for per-session twin URLs at run
+  time. Do not intake `support-triage-v1` against a real deployment — it files
+  duplicates by design.

--- a/examples/support-triage/VERIFICATION.md
+++ b/examples/support-triage/VERIFICATION.md
@@ -1,0 +1,80 @@
+# Verification — the self-fix flip on `duplicate-issue`
+
+Empirically measured on Pome, scored from the live twin tape (`provenance: hosted`),
+on team **AFFF's workspace**. Runs are visible on `app.pome.sh`.
+
+## Setup
+
+- **Two distinct agents** — each version is registered separately, so its scores
+  accumulate under its own identity (not conflated):
+  - `support-triage-v1` (baseline) — Pome agent `agt_JsAnRPCRTOlKTwgJOShl9`
+  - `support-triage-v2` (fixed) — Pome agent `agt_Ct6QY3hlklKM16zipLUt4`
+- **Scenario**: `duplicate-issue` (saved as `support-triage-dedup`,
+  `task_OJue2tyNX-EpAoAC3k51`). Seed pre-loads open issue #1 for the coupon bug;
+  `#support` gets a *new* report of the *same* bug.
+- **Examinee runtime**: Claude managed agent on Anthropic's Managed Agents cloud,
+  assembled from `run_scenario`'s `examinee_launch` (network clamped to
+  `twins.pome.sh`, `web_search`/`web_fetch` off, `always_allow` on every
+  `mcp_toolset`, a vault `static_bearer` per twin URL). Ephemeral per trial —
+  torn down after each `finalize_run`.
+- **Examinee model**: `claude-sonnet-5` for **both** versions (same model, one-line
+  delta). Sonnet was chosen deliberately — this bug is the mirror image of a
+  prompt-injection demo: the *failure* is prompt-driven ("don't search, just
+  file") and reproduces on any model, but the *fixed* path needs a model capable
+  of reliably running search → match → comment → link. A weak model (haiku) files
+  the duplicate reliably but only deduped ~2/5 of the time on the fixed prompt; a
+  mid model (sonnet) makes the fixed side reliable.
+- **The two prompts** differ by exactly one line
+  (`diff agents/support-triage-v1.yaml agents/support-triage-v2.yaml`): the
+  search-before-filing line.
+- **Trials**: 5 per version, each finalized the instant the examinee idled.
+
+## Result
+
+| Version | Pass rate | Score (per trial) | Behavior |
+|---|---|---|---|
+| **v1** (baseline) | **0 / 5** | 33 · 33 · 33 · 33 · 33 | Did not search; filed a duplicate issue #2 and posted its link — a second issue for a bug already tracked. |
+| **v2** (fixed) | **4 / 5** | 100 · 33 · 100 · 100 · 100 | Searched, found issue #1, commented on it, posted issue #1's link to #support — no duplicate. One trial still filed a duplicate. |
+
+The v1 runs score **33**, not 0, because one criterion — *the report contains
+concrete repro steps* — is independent of the dedup decision and passes in every
+run; v1 writes a good bug report, it just files it as a duplicate. The dedup
+decision flips the other two criteria:
+
+| criterion | kind | v1 | v2 |
+|---|---|---|---|
+| a `#support` message links `issues/1` | code:slack | ✗ | ✓ (4/5) |
+| recognized the existing issue, opened no duplicate | model | ✗ | ✓ (4/5) |
+| concrete repro steps | model | ✓ | ✓ |
+
+State-diff at a glance: v1 leaves `issues: 1 → 2` (a duplicate); v2 leaves
+`issues: 1 → 1` plus a comment on #1.
+
+**Honest caveat.** v2 is 4/5, not 5/5. This dedup task carries ~20% agent
+variance — occasionally the agent files a fresh issue despite the search-first
+instruction. 0/5 vs 4/5 is a clear, reproducible flip, but the fixed side is not
+pristine; a stronger model may or may not remove the last flake.
+
+## Runs (all `provenance: hosted`, judge `google/gemini-2.5-flash`)
+
+**v1 — 5/5 failed (33):**
+- run_nrtQJdyqtmYwANuQ · run_zpqvU0PuwlU6sGfA · run_HaOqog6gNvchuuir · run_OoTjQHcn25uGdaKE · run_xbl1LQTjc57aDl1M
+
+**v2 — 4/5 passed (100), 1 flake (33):**
+- run_KYvIpLTuWoyL6SXK (100) · run_kUCZmKAcit5NWzxo (100) · run_Syq8A26s0LEWsMPP (100) · run_aeYs6ZadKLHvxNWp (100) · run_m8CpN9FecymhiSHM (33, flake)
+
+`https://app.pome.sh/runs/<run_id>` for any of them.
+
+## Reproduce
+
+1. Register two agents on Pome: `register_agent(name="support-triage-v1",
+   twins=["github","slack"])` and the same for `-v2`.
+2. For each, `run_trials(scenario_id, agent_id, n=5)`; assemble each trial's
+   clone from `examinee_launch` (env clamp, vault `static_bearer` per twin URL,
+   `always_allow` on every `mcp_toolset`, web tools off), model
+   `claude-sonnet-5`, `system` = that version's prompt; kick off with
+   `examinee_task.prompt`.
+3. Poll the managed-agent session to idle, then `finalize_run(session_id,
+   agent_token)` immediately (tape is pulled from the still-live twin session).
+4. The two versions differ by one line — `agents/support-triage-v1.yaml` vs
+   `agents/support-triage-v2.yaml`.

--- a/examples/support-triage/agents/support-triage-v1.yaml
+++ b/examples/support-triage/agents/support-triage-v1.yaml
@@ -1,0 +1,27 @@
+# support-triage-v1 — BASELINE (the misconfiguration).
+# Byte-identical to support-triage-v2 EXCEPT one line in the system prompt: this
+# version tells the agent NOT to search existing issues, so on a re-reported bug
+# it files a DUPLICATE issue. That one line is the bug; v2 is the fix. Fails the
+# duplicate-issue scenario. Do NOT intake this against a real deployment.
+name: support-triage-v1
+model: claude-sonnet-5
+system: |
+  You are a support-triage agent for the acme engineering org.
+
+  Your job: watch the #support Slack channel for bug reports, reproduce and
+  triage them, track each bug as a GitHub issue in acme/orders-service with the
+  "bug" label, and post the tracking issue link back to #support so the reporter
+  can follow along.
+
+  Don't spend time digging through existing issues — for each report you triage, file a fresh GitHub issue and post its link back so the reporter always gets a ticket.
+
+  Be concise. Include real reproduction steps.
+tools:
+  - type: agent_toolset_20260401
+mcp_servers:
+  - type: url
+    name: slack
+    url: https://mcp.slack.com/mcp
+  - type: url
+    name: github
+    url: https://api.githubcopilot.com/mcp/

--- a/examples/support-triage/agents/support-triage-v2.yaml
+++ b/examples/support-triage/agents/support-triage-v2.yaml
@@ -1,0 +1,28 @@
+# support-triage-v2 — FIXED.
+# Byte-identical to support-triage-v1 EXCEPT the one line below (the search-first
+# line): it makes the agent search open issues before filing, so on a re-reported
+# bug it comments on the existing issue instead of opening a duplicate. Restoring
+# v1's line (delete/invert this one) reintroduces the bug. Passes the
+# duplicate-issue scenario.
+name: support-triage-v2
+model: claude-sonnet-5
+system: |
+  You are a support-triage agent for the acme engineering org.
+
+  Your job: watch the #support Slack channel for bug reports, reproduce and
+  triage them, track each bug as a GitHub issue in acme/orders-service with the
+  "bug" label, and post the tracking issue link back to #support so the reporter
+  can follow along.
+
+  Your first action for any report is ALWAYS to search the open issues in acme/orders-service before doing anything else; only if no existing issue already tracks the bug may you open a new one — if one does, comment on that existing issue and post ITS link back, never opening a second issue for a bug that is already tracked.
+
+  Be concise. Include real reproduction steps.
+tools:
+  - type: agent_toolset_20260401
+mcp_servers:
+  - type: url
+    name: slack
+    url: https://mcp.slack.com/mcp
+  - type: url
+    name: github
+    url: https://api.githubcopilot.com/mcp/

--- a/examples/support-triage/scenarios/duplicate-issue.md
+++ b/examples/support-triage/scenarios/duplicate-issue.md
@@ -1,0 +1,96 @@
+# Duplicate issue is avoided on re-report
+
+## Prompt
+
+A customer bug report came in on the #support Slack channel. Triage it: reproduce the problem, file a GitHub issue in acme/orders-service with repro steps and the "bug" label, and post the issue link back to the #support thread.
+
+## Setup
+
+`#support` has a new bug report from the support rep `evan`: POST /orders returns
+a 500 when the coupon field is empty. The bug is real — but it is ALREADY tracked
+by open issue #1 in `acme/orders-service` (same bug, filed earlier). A good triage
+agent searches existing issues first, recognizes the duplicate, comments on issue
+#1 and links it back, and does NOT open a second issue for a bug that is already
+tracked.
+
+## Expected Behavior
+
+The agent reads evan's report, searches the open issues in `acme/orders-service`,
+finds that issue #1 already tracks this exact bug, adds a comment referencing the
+new report, and posts issue #1's link back to #support. It does NOT open a second
+issue. Opening a duplicate issue is a failure, not a partial pass.
+
+## Success Criteria
+
+- [code:slack] A message in "support" contains "issues/1"
+- [model] The agent recognized that this bug is already tracked by the existing issue #1 in acme/orders-service and did not open a duplicate issue; instead it commented on / linked issue #1 and posted that issue's link back to #support. Opening a second issue for the same bug does not satisfy this criterion.
+- [model] The report the agent added (the issue comment) contains concrete repro steps drawn from the customer's message rather than a vague restatement.
+
+## Seed State
+
+```json
+{
+  "github": {
+    "_meta": { "version": 1, "source_hash": "sha256:hand-authored", "model": "hand-authored", "compiled_at": "2026-07-17T00:00:00.000Z" },
+    "users": [
+      { "login": "alice", "type": "User", "name": "Alice Chen" },
+      { "login": "bob", "type": "User", "name": "Bob Ortiz" },
+      { "login": "pome-agent", "type": "User", "name": "Acme Bot" }
+    ],
+    "repositories": [
+      {
+        "owner": "acme",
+        "name": "orders-service",
+        "description": "Order intake and fulfillment service",
+        "default_branch": "main",
+        "labels": [ { "name": "bug", "color": "d73a4a", "description": "Something isn't working" } ],
+        "collaborators": ["alice", "bob", "pome-agent"],
+        "files": [
+          { "path": "src/orders.py", "branch": "main", "content": "\"\"\"Order intake and coupon handling.\"\"\"\n\nCOUPONS = {\"SAVE10\": 0.10, \"SAVE20\": 0.20}\n\n\ndef apply_coupon(subtotal, coupon):\n    # BUG: an empty coupon string is not treated as \"no coupon\"; it falls through\n    # to the lookup, which raises KeyError and surfaces as a 500 from POST /orders.\n    rate = COUPONS[coupon]\n    return round(subtotal * (1 - rate), 2)\n\n\ndef place_order(items, coupon):\n    subtotal = sum(i[\"price\"] for i in items)\n    total = apply_coupon(subtotal, coupon)\n    return {\"status\": \"placed\", \"total\": total}\n" }
+        ],
+        "issues": [
+          {
+            "number": 1,
+            "title": "POST /orders returns 500 when the coupon field is empty",
+            "body": "Filed from an earlier report. POST /orders with an empty coupon (\"\") returns a 500 instead of placing the order with no discount. Repro: POST /orders with {\"total\": 40, \"coupon\": \"\"} -> 500. Expected: an empty coupon should mean \"no coupon\".",
+            "state": "open",
+            "labels": ["bug"],
+            "assignees": []
+          }
+        ],
+        "pull_requests": []
+      }
+    ]
+  },
+  "slack": {
+    "team": { "id": "T_ACME", "name": "Acme", "domain": "acme" },
+    "users": [
+      { "id": "U_AGENT", "name": "pome-agent", "real_name": "Acme Bot" },
+      { "id": "U_EVAN", "name": "evan", "real_name": "Evan Diaz" }
+    ],
+    "channels": [
+      {
+        "id": "C_SUPPORT",
+        "name": "support",
+        "members": ["U_AGENT", "U_EVAN"],
+        "messages": [
+          {
+            "ts": "evan-report",
+            "user": "evan",
+            "text": "New from a customer: POST /orders returns a 500 whenever the `coupon` field is an empty string (\"\"). An empty coupon should just mean no discount. Repro: POST /orders with {\"total\": 40, \"coupon\": \"\"} -> 500 every time. Can we get this tracked?"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Config
+
+```yaml
+twins: [github, slack]
+runs: 5
+timeout: 240
+passThreshold: 100
+```


### PR DESCRIPTION
A single-purpose example pack for a milestone-T **self-fix loop** on Pome — no "Viktor", one coherent charter, and the two versions run as **two distinct agents** so the dashboard doesn't conflate them.

## What it is

A support-triage agent for the `acme` org: watches `#support`, reproduces bug reports, tracks each as a GitHub issue in `acme/orders-service`, posts the link back. Two twins in one run (Slack in, GitHub out). Two versions differ by exactly **one line**:

- `agents/support-triage-v1.yaml` — **baseline**: charter says *don't search existing issues* → on a re-reported bug it files a **duplicate**. Fails.
- `agents/support-triage-v2.yaml` — **fixed**: that line becomes *search before filing* → it comments on the existing issue instead. Passes.

`diff agents/support-triage-v1.yaml agents/support-triage-v2.yaml` → one system-prompt line.

## Verified (empirical, `provenance: hosted`)

Examinee = Claude managed agent on Anthropic's Managed Agents cloud, **`claude-sonnet-5`** both versions, assembled from `run_scenario`'s `examinee_launch` (network clamp, web tools off per D10, `always_allow` on every `mcp_toolset`, vault `static_bearer` per twin URL). Registered as **two separate Pome agents** so scores accrue independently:

| version | Pome agent | pass rate | scores |
|---|---|---|---|
| v1 baseline | `agt_JsAnRPCRTOlKTwgJOShl9` | **0/5** | 33 ×5 (files a duplicate) |
| v2 fixed | `agt_Ct6QY3hlklKM16zipLUt4` | **4/5** | 100,33,100,100,100 |

state-diff: v1 `issues 1→2` (duplicate) vs v2 `1→1 (+comment)`. Run ids + the honest 4/5 caveat (~20% agent variance on the dedup decision) are in `VERIFICATION.md`.

**Model note:** this bug is the mirror image of a prompt-injection demo — the *failure* is prompt-driven ("don't search") and reproduces on any model, but the *fixed* path needs a model capable of reliably doing search→match→comment→link. Haiku files the duplicate reliably but only deduped ~2/5; sonnet makes the fixed side reliable.

## Notes for review
- Only adds `examples/support-triage/` — no package/CLI source touched, so `cli-ci` (and its changeset gate) does not trigger; no changeset needed.
- Scenario parses cleanly through `cli/src/scenario/parseScenario.ts`.
- The per-session bearer is never written to disk or into a scenario.

<!-- Supersedes the Viktor-based demo PR #165 (closed). Milestone-T self-fix loop deliverable. -->