### PR TITLE
fix(ci): pin setup-node@v6.4.0 for Trusted Publishing

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -98,14 +98,14 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      # No registry-url: setup-node's registry-url writes
-      # `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into .npmrc, and
-      # an empty expansion silently disables Trusted Publishing OIDC (E404 on
-      # PUT). packages-v10 failed after the Dependabot setup-node@v7 bump for
-      # this reason — see actions/setup-node#1551.
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      # Pin setup-node@v6.4.0 for the publish job. Dependabot's bump to v7
+      # broke Trusted Publishing (packages-v10 E404, packages-v11 ENEEDAUTH
+      # after removing registry-url). packages-v9 succeeded with this pin +
+      # registry-url; keep that known-good combo until OIDC+v7 is re-proven.
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
+          registry-url: https://registry.npmjs.org
           cache: npm
           cache-dependency-path: package-lock.json
       # Keep npm pinned to the GA Trusted Publishing release used by this path.
@@ -116,11 +116,6 @@ jobs:
       - name: Publish packages with provenance
         run: |
           set -euo pipefail
-          # Drop any classic-token auth that would shadow OIDC.
-          unset NODE_AUTH_TOKEN || true
-          if [ -n "${NPM_CONFIG_USERCONFIG:-}" ] && [ -f "$NPM_CONFIG_USERCONFIG" ]; then
-            sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG" || true
-          fi
           publish_one() {
             local pattern="$1"
             local tgz name_ver


### PR DESCRIPTION
## Summary
- packages-v10 failed with E404 after Dependabot bumped setup-node to v7.
- #169 removed `registry-url`; packages-v11 then failed with ENEEDAUTH.
- Restore the known-good packages-v9 combo: setup-node@v6.4.0 + registry-url + npm@11.5.1.

Unblocks publishing `@pome-sh/shared-types@0.11.0` for pome-cloud#324.

## Test plan
- [ ] Merge, cut `packages-v12`, confirm shared-types 0.11.0 on npm