### PR TITLE
fix(ci): strip setup-node authToken for Trusted Publishing

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -98,24 +98,33 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      # Pin setup-node@v6.4.0 for the publish job. Dependabot's bump to v7
-      # broke Trusted Publishing (packages-v10 E404, packages-v11 ENEEDAUTH
-      # after removing registry-url). packages-v9 succeeded with this pin +
-      # registry-url; keep that known-good combo until OIDC+v7 is re-proven.
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      # registry-url writes registry= into .npmrc (needed) and also
+      # `_authToken=${NODE_AUTH_TOKEN}` (harmful for OIDC when empty/dummy).
+      # Keep registry-url, then strip the authToken line before publish.
+      # See actions/setup-node#1551; packages-v10/v12 E404, packages-v11 ENEEDAUTH.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
           cache: npm
           cache-dependency-path: package-lock.json
-      # Keep npm pinned to the GA Trusted Publishing release used by this path.
       - name: Install npm with OIDC trusted publishing support
-        run: npm install -g npm@11.5.1
+        run: npm install -g npm@11.6.2
       - run: npm ci
       - run: node scripts/pack-publishable.mjs --out "$RUNNER_TEMP/tarballs"
       - name: Publish packages with provenance
         run: |
           set -euo pipefail
+          unset NODE_AUTH_TOKEN || true
+          if [ -n "${NPM_CONFIG_USERCONFIG:-}" ] && [ -f "$NPM_CONFIG_USERCONFIG" ]; then
+            sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG"
+            echo "npmrc after strip:"
+            cat "$NPM_CONFIG_USERCONFIG"
+          fi
+          if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
+            echo "ACTIONS_ID_TOKEN_REQUEST_URL missing — OIDC will not work" >&2
+            exit 1
+          fi
           publish_one() {
             local pattern="$1"
             local tgz name_ver

--- a/packages/adapter-claude-sdk/package.json
+++ b/packages/adapter-claude-sdk/package.json
@@ -10,12 +10,12 @@
   "publishConfig": { "access": "public" },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pome-sh/pome-twins.git",
+    "url": "git+https://github.com/pome-sh/digital-twins.git",
     "directory": "packages/adapter-claude-sdk"
   },
-  "homepage": "https://github.com/pome-sh/pome-twins/tree/main/packages/adapter-claude-sdk",
+  "homepage": "https://github.com/pome-sh/digital-twins/tree/main/packages/adapter-claude-sdk",
   "bugs": {
-    "url": "https://github.com/pome-sh/pome-twins/issues"
+    "url": "https://github.com/pome-sh/digital-twins/issues"
   },
   "files": [
     "dist",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -14,12 +14,12 @@
   "publishConfig": { "access": "public" },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pome-sh/pome-twins.git",
+    "url": "git+https://github.com/pome-sh/digital-twins.git",
     "directory": "packages/sdk"
   },
-  "homepage": "https://github.com/pome-sh/pome-twins/tree/main/packages/sdk",
+  "homepage": "https://github.com/pome-sh/digital-twins/tree/main/packages/sdk",
   "bugs": {
-    "url": "https://github.com/pome-sh/pome-twins/issues"
+    "url": "https://github.com/pome-sh/digital-twins/issues"
   },
   "files": [
     "dist",

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -17,12 +17,12 @@
   "files": ["dist", "src", "package.json", "trace-contract.json"],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pome-sh/pome-twins.git",
+    "url": "git+https://github.com/pome-sh/digital-twins.git",
     "directory": "packages/shared-types"
   },
-  "homepage": "https://github.com/pome-sh/pome-twins/tree/main/packages/shared-types",
+  "homepage": "https://github.com/pome-sh/digital-twins/tree/main/packages/shared-types",
   "bugs": {
-    "url": "https://github.com/pome-sh/pome-twins/issues"
+    "url": "https://github.com/pome-sh/digital-twins/issues"
   },
   "scripts": {
     "build:runtime": "tsc -p tsconfig.runtime.json",

--- a/packages/twin-github/package.json
+++ b/packages/twin-github/package.json
@@ -71,12 +71,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pome-sh/pome-twins.git",
+    "url": "git+https://github.com/pome-sh/digital-twins.git",
     "directory": "packages/twin-github"
   },
-  "homepage": "https://github.com/pome-sh/pome-twins/tree/main/packages/twin-github",
+  "homepage": "https://github.com/pome-sh/digital-twins/tree/main/packages/twin-github",
   "bugs": {
-    "url": "https://github.com/pome-sh/pome-twins/issues"
+    "url": "https://github.com/pome-sh/digital-twins/issues"
   },
   "license": "Apache-2.0",
   "engines": {

--- a/packages/twin-gmail/package.json
+++ b/packages/twin-gmail/package.json
@@ -65,12 +65,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pome-sh/pome-twins.git",
+    "url": "git+https://github.com/pome-sh/digital-twins.git",
     "directory": "packages/twin-gmail"
   },
-  "homepage": "https://github.com/pome-sh/pome-twins/tree/main/packages/twin-gmail",
+  "homepage": "https://github.com/pome-sh/digital-twins/tree/main/packages/twin-gmail",
   "bugs": {
-    "url": "https://github.com/pome-sh/pome-twins/issues"
+    "url": "https://github.com/pome-sh/digital-twins/issues"
   },
   "license": "Apache-2.0",
   "engines": {

--- a/packages/twin-slack/package.json
+++ b/packages/twin-slack/package.json
@@ -70,12 +70,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pome-sh/pome-twins.git",
+    "url": "git+https://github.com/pome-sh/digital-twins.git",
     "directory": "packages/twin-slack"
   },
-  "homepage": "https://github.com/pome-sh/pome-twins/tree/main/packages/twin-slack",
+  "homepage": "https://github.com/pome-sh/digital-twins/tree/main/packages/twin-slack",
   "bugs": {
-    "url": "https://github.com/pome-sh/pome-twins/issues"
+    "url": "https://github.com/pome-sh/digital-twins/issues"
   },
   "license": "Apache-2.0",
   "engines": {

--- a/packages/twin-stripe/package.json
+++ b/packages/twin-stripe/package.json
@@ -51,12 +51,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pome-sh/pome-twins.git",
+    "url": "git+https://github.com/pome-sh/digital-twins.git",
     "directory": "packages/twin-stripe"
   },
-  "homepage": "https://github.com/pome-sh/pome-twins/tree/main/packages/twin-stripe",
+  "homepage": "https://github.com/pome-sh/digital-twins/tree/main/packages/twin-stripe",
   "bugs": {
-    "url": "https://github.com/pome-sh/pome-twins/issues"
+    "url": "https://github.com/pome-sh/digital-twins/issues"
   },
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
## Summary
- packages-v10/v12: provenance signs (OIDC works) but PUT returns E404.
- packages-v11 (no registry-url): ENEEDAUTH.
- Root cause pattern: setup-node `registry-url` injects `_authToken=${NODE_AUTH_TOKEN}` / dummy token that shadows Trusted Publishing for the package PUT while provenance still succeeds.
- Fix: keep `registry-url`, strip `_authToken`, unset `NODE_AUTH_TOKEN`, bump npm to 11.6.2, align `repository.url` to `pome-sh/digital-twins`.

## Test plan
- [ ] Merge + `packages-v13` → `@pome-sh/shared-types@0.11.0` on npm