### PR TITLE
fix(ci): restore setup-node v6.4.0 for OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -98,33 +98,25 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      # registry-url writes registry= into .npmrc (needed) and also
-      # `_authToken=${NODE_AUTH_TOKEN}` (harmful for OIDC when empty/dummy).
-      # Keep registry-url, then strip the authToken line before publish.
-      # See actions/setup-node#1551; packages-v10/v12 E404, packages-v11 ENEEDAUTH.
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      # DO NOT bump this to setup-node v7 — v7 changed how registry-url writes
+      # the npmrc and breaks OIDC Trusted Publishing (ENEEDAUTH). v6.4.0 + npm
+      # 11.5.1 is the exact combo that published packages-v9 with no authToken
+      # hacks. See actions/setup-node#1551 and the packages-v10..v13 failures
+      # (2026-07-20). If Dependabot re-bumps this, revert it.
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
           cache: npm
           cache-dependency-path: package-lock.json
+      # Keep npm pinned to the GA Trusted Publishing release used by this path.
       - name: Install npm with OIDC trusted publishing support
-        run: npm install -g npm@11.6.2
+        run: npm install -g npm@11.5.1
       - run: npm ci
       - run: node scripts/pack-publishable.mjs --out "$RUNNER_TEMP/tarballs"
       - name: Publish packages with provenance
         run: |
           set -euo pipefail
-          unset NODE_AUTH_TOKEN || true
-          if [ -n "${NPM_CONFIG_USERCONFIG:-}" ] && [ -f "$NPM_CONFIG_USERCONFIG" ]; then
-            sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG"
-            echo "npmrc after strip:"
-            cat "$NPM_CONFIG_USERCONFIG"
-          fi
-          if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
-            echo "ACTIONS_ID_TOKEN_REQUEST_URL missing — OIDC will not work" >&2
-            exit 1
-          fi
           publish_one() {
             local pattern="$1"
             local tgz name_ver


### PR DESCRIPTION
## What
Revert the `publish` job's `actions/setup-node` from v7.0.0 back to the SHA-pinned **v6.4.0**, restore npm **11.5.1**, and remove the `unset NODE_AUTH_TOKEN` / `sed strip authToken` / OIDC-env-check hacks.

## Why
Dependabot bumped setup-node to v7, which changed how `registry-url` writes the npmrc and silently broke OIDC Trusted Publishing — `npm publish --provenance` returns `ENEEDAUTH`. Releases **packages-v10..v13 all failed** on 2026-07-20. The stripping hacks added afterward never recovered it.

v6.4.0 + npm 11.5.1 is the **exact combo that published packages-v9** cleanly, with zero authToken workarounds. This restores that path verbatim.

## Notes
- pack-smoke job stays on v7 (it does not publish; its runs are green).
- twin-gmail publish step + clean-room import checks are preserved.
- After merge: cut `packages-v14` to publish the stalled batch (shared-types 0.11.0, sdk 0.5.0, adapter 0.2.2, twin-github 0.2.1, twin-slack 0.2.1, twin-stripe 0.2.4, twin-gmail 0.1.0).

## Review
Diff of the publish job now equals packages-v9 apart from the twin-gmail additions.