### PR TITLE
shared-types: canonical pome.json/pome.yaml manifest model, slug authority, zod-generated JSON Schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       # was folded in here).
       - run: npm run gate:no-eval
       - run: npm run check:trace-contract -w @pome-sh/shared-types
+      # F-818 — the committed manifest JSON Schema (served at
+      # pome.sh/schemas/v1/pome.json) must match the zod source.
+      - run: npm run check:manifest-schema -w @pome-sh/shared-types
       # Consumers import sibling packages through their published `exports`
       # (e.g. `@pome-sh/sdk/server` → dist/server.d.ts). Build the workspace in
       # dependency order so those subpaths resolve before typecheck/test.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5859,13 +5859,13 @@
     },
     "packages/adapter-claude-sdk": {
       "name": "@pome-sh/adapter-claude-sdk",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.220.0",
         "@opentelemetry/resources": "^2.0.0",
         "@opentelemetry/sdk-trace-base": "^2.0.0",
-        "@pome-sh/shared-types": "0.11.0"
+        "@pome-sh/shared-types": "0.12.0"
       },
       "devDependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.215",
@@ -5887,9 +5887,9 @@
     },
     "packages/sdk": {
       "name": "@pome-sh/sdk",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
-        "@pome-sh/shared-types": "0.11.0",
+        "@pome-sh/shared-types": "0.12.0",
         "hono": "^4.12.27",
         "zod": "^4.1.13"
       },
@@ -5914,11 +5914,12 @@
     },
     "packages/shared-types": {
       "name": "@pome-sh/shared-types",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "devDependencies": {
         "@types/node": "^26.1.0",
         "typescript": "^5.9.3",
         "vitest": "^4.1.10",
+        "yaml": "^2.9.0",
         "zod": "^4.1.13"
       },
       "peerDependencies": {
@@ -5927,12 +5928,12 @@
     },
     "packages/twin-github": {
       "name": "@pome-sh/twin-github",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.10",
-        "@pome-sh/sdk": "0.5.0",
-        "@pome-sh/shared-types": "0.11.0",
+        "@pome-sh/sdk": "0.5.1",
+        "@pome-sh/shared-types": "0.12.0",
         "hono": "^4.12.27",
         "zod": "^4.1.13"
       },
@@ -5954,10 +5955,10 @@
     },
     "packages/twin-gmail": {
       "name": "@pome-sh/twin-gmail",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@pome-sh/sdk": "0.5.0",
+        "@pome-sh/sdk": "0.5.1",
         "hono": "^4.12.27",
         "zod": "^4.1.13"
       },
@@ -5977,12 +5978,12 @@
     },
     "packages/twin-slack": {
       "name": "@pome-sh/twin-slack",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.10",
-        "@pome-sh/sdk": "0.5.0",
-        "@pome-sh/shared-types": "0.11.0",
+        "@pome-sh/sdk": "0.5.1",
+        "@pome-sh/shared-types": "0.12.0",
         "hono": "^4.12.27",
         "zod": "^4.1.13"
       },
@@ -6004,12 +6005,12 @@
     },
     "packages/twin-stripe": {
       "name": "@pome-sh/twin-stripe",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.10",
-        "@pome-sh/sdk": "0.5.0",
-        "@pome-sh/shared-types": "0.11.0",
+        "@pome-sh/sdk": "0.5.1",
+        "@pome-sh/shared-types": "0.12.0",
         "hono": "^4.12.27",
         "zod": "^4.1.13"
       },

--- a/packages/adapter-claude-sdk/CHANGELOG.md
+++ b/packages/adapter-claude-sdk/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @pome-sh/adapter-claude-sdk — CHANGELOG
 
+## 0.2.3 — 2026-07-21
+
+Dependency-only patch: repin `@pome-sh/shared-types` to 0.12.0 (F-818). No
+adapter surface change.
+
 ## Unreleased
 
 ## 0.2.2 — 2026-07-20

--- a/packages/adapter-claude-sdk/package.json
+++ b/packages/adapter-claude-sdk/package.json
@@ -1,13 +1,20 @@
 {
   "name": "@pome-sh/adapter-claude-sdk",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Pome adapter for Anthropic's Claude Agent SDK — wraps query() and tools so agent traces land in the Pome trace format.",
   "private": false,
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "exports": { ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" } },
-  "publishConfig": { "access": "public" },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/pome-sh/digital-twins.git",
@@ -33,13 +40,15 @@
     "@opentelemetry/exporter-trace-otlp-http": "^0.220.0",
     "@opentelemetry/resources": "^2.0.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
-    "@pome-sh/shared-types": "0.11.0"
+    "@pome-sh/shared-types": "0.12.0"
   },
   "peerDependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.215"
   },
   "peerDependenciesMeta": {
-    "@anthropic-ai/claude-agent-sdk": { "optional": false }
+    "@anthropic-ai/claude-agent-sdk": {
+      "optional": false
+    }
   },
   "devDependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.215",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @pome-sh/sdk
 
+## 0.5.1 — 2026-07-21
+
+Dependency-only patch: repin `@pome-sh/shared-types` to 0.12.0 (manifest data
+model + slug authority, F-818). No SDK surface change.
+
 ## 0.5.0 — 2026-07-20
 
 Additive MCP / recorder contract for the upcoming Gmail twin. Existing

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,17 +1,28 @@
 {
   "name": "@pome-sh/sdk",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Twin engine for Pome digital twins — defineTwin() + serve(): HTTP mounting, bearer auth, trace recorder, MCP dispatch, SQLite-backed state.",
   "private": false,
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" },
-    "./server": { "types": "./dist/server.d.ts", "default": "./dist/server.js" },
-    "./parity": { "types": "./dist/parity.d.ts", "default": "./dist/parity.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./server": {
+      "types": "./dist/server.d.ts",
+      "default": "./dist/server.js"
+    },
+    "./parity": {
+      "types": "./dist/parity.d.ts",
+      "default": "./dist/parity.js"
+    }
   },
-  "publishConfig": { "access": "public" },
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/pome-sh/digital-twins.git",
@@ -33,7 +44,7 @@
     "emit-fidelity": "tsx scripts/emit-fidelity.ts"
   },
   "dependencies": {
-    "@pome-sh/shared-types": "0.11.0",
+    "@pome-sh/shared-types": "0.12.0",
     "hono": "^4.12.27",
     "zod": "^4.1.13"
   },
@@ -41,7 +52,9 @@
     "@hono/node-server": "^2.0.8"
   },
   "peerDependenciesMeta": {
-    "@hono/node-server": { "optional": true }
+    "@hono/node-server": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@hono/node-server": "^2.0.10",

--- a/packages/shared-types/CHANGELOG.md
+++ b/packages/shared-types/CHANGELOG.md
@@ -10,8 +10,11 @@
   `ManifestInput` types. Only `agent.slug` is required; `artifacts_dir` /
   `pass_threshold` default to `runs` / `100` on parse.
 - `SLUG_RE`, `SLUG_MAX_LENGTH`, `agentSlugSchema`, and `deriveAgentSlug` —
-  the agent-slug authority, ported byte-identically from the pome-cloud
-  control-plane so local and server validation can never drift.
+  the agent-slug authority. `SLUG_RE` is byte-identical to the pome-cloud
+  control-plane's regex; `deriveAgentSlug` is a behavior-identical port
+  (equivalence-tested against the upstream body, with the edge-strip regex
+  rewritten to linear form to clear CodeQL's js/polynomial-redos) so local and
+  server validation can never drift.
   **Consumer note (pome-cloud):** as of F-820 the control-plane and dashboard
   must import these instead of their private copies
   (`apps/control-plane/src/routes/agents.ts`, `packages/db/src/agent-slug.ts`).

--- a/packages/shared-types/CHANGELOG.md
+++ b/packages/shared-types/CHANGELOG.md
@@ -1,5 +1,30 @@
 # @pome-sh/shared-types — CHANGELOG
 
+## 0.12.0
+
+### Added
+
+- Canonical `pome.json` / `pome.yaml` manifest data model (F-818, spec F-804):
+  `manifestSchema` + `manifestAgentSchema` (agent identity block + snake_case
+  CLI run-config keys, carrier-agnostic), with `Manifest` / `ManifestAgent` /
+  `ManifestInput` types. Only `agent.slug` is required; `artifacts_dir` /
+  `pass_threshold` default to `runs` / `100` on parse.
+- `SLUG_RE`, `SLUG_MAX_LENGTH`, `agentSlugSchema`, and `deriveAgentSlug` —
+  the agent-slug authority, ported byte-identically from the pome-cloud
+  control-plane so local and server validation can never drift.
+  **Consumer note (pome-cloud):** as of F-820 the control-plane and dashboard
+  must import these instead of their private copies
+  (`apps/control-plane/src/routes/agents.ts`, `packages/db/src/agent-slug.ts`).
+- `manifest-schema.json` — JSON Schema generated from the zod manifest schema
+  at build time (`emit:manifest-schema`, snapshot-tested, shipped in the
+  tarball). This is the document pome.sh/schemas/v1/pome.json serves (F-821);
+  `buildManifestJsonSchema()` is exported for that route.
+- Additive `/v1` agent-identity fields, all optional (tolerant reader both
+  directions): `createAgentRequestSchema` gains `slug` / `description` /
+  `version` / `framework`; `createSessionRequestSchema` gains `agent_version`
+  (per-run override); `agentResponseSchema` gains `framework` / `description` /
+  `version` / `created` (resolver auto-register flag).
+
 ## 0.11.0
 
 ### Added

--- a/packages/shared-types/manifest-schema.json
+++ b/packages/shared-types/manifest-schema.json
@@ -1,0 +1,68 @@
+{
+  "$id": "https://pome.sh/schemas/v1/pome.json",
+  "title": "Pome agent manifest (pome.json / pome.yaml)",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "agent": {
+      "type": "object",
+      "properties": {
+        "slug": {
+          "type": "string",
+          "maxLength": 64,
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "framework": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "slug"
+      ]
+    },
+    "command": {
+      "type": "string",
+      "minLength": 1
+    },
+    "twins": {
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "tasks": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifacts_dir": {
+      "default": "runs",
+      "type": "string",
+      "minLength": 1
+    },
+    "pass_threshold": {
+      "default": 100,
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 100
+    }
+  },
+  "required": [
+    "agent"
+  ]
+}

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/shared-types",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Shared wire-format contract for Pome — Zod schemas for traces, recorder events, runs, OTel mapping, and secret redaction.",
   "private": false,
   "type": "module",
@@ -14,7 +14,13 @@
     "./otel/fixtures": "./src/otel/fixtures/index.ts",
     "./redaction": "./src/redaction.ts"
   },
-  "files": ["dist", "src", "package.json", "trace-contract.json"],
+  "files": [
+    "dist",
+    "src",
+    "package.json",
+    "trace-contract.json",
+    "manifest-schema.json"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/pome-sh/digital-twins.git",
@@ -28,17 +34,24 @@
     "build:runtime": "tsc -p tsconfig.runtime.json",
     "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "build": "rm -rf dist && tsc -p tsconfig.build.json",
+    "build": "rm -rf dist && tsc -p tsconfig.build.json && node scripts/emit-manifest-schema.mjs",
     "prepublishOnly": "npm run build",
     "emit:trace-contract": "node scripts/emit-trace-contract.mjs",
-    "check:trace-contract": "node scripts/emit-trace-contract.mjs --check"
+    "check:trace-contract": "node scripts/emit-trace-contract.mjs --check",
+    "emit:manifest-schema": "node scripts/emit-manifest-schema.mjs",
+    "check:manifest-schema": "node scripts/emit-manifest-schema.mjs --check"
   },
-  "peerDependencies": { "zod": "^4.1.13" },
+  "peerDependencies": {
+    "zod": "^4.1.13"
+  },
   "devDependencies": {
     "@types/node": "^26.1.0",
     "typescript": "^5.9.3",
     "vitest": "^4.1.10",
+    "yaml": "^2.9.0",
     "zod": "^4.1.13"
   },
-  "publishConfig": { "access": "public" }
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/shared-types/scripts/emit-manifest-schema.mjs
+++ b/packages/shared-types/scripts/emit-manifest-schema.mjs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Emits manifest-schema.json from the zod manifest schema (F-818), following
+// the emit-trace-contract.mjs pattern: default mode writes the file, --check
+// fails if the committed file is missing or stale. Imports the TS source
+// directly — node >= 23.6 strips types natively, and src/manifest.ts
+// deliberately has no relative imports (only "zod"), so no build is required.
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const args = process.argv.slice(2);
+const outIdx = args.indexOf("--out");
+const check = args.includes("--check");
+const outPath = resolve(outIdx >= 0 ? args[outIdx + 1] : join(packageRoot, "manifest-schema.json"));
+
+const { buildManifestJsonSchema } = await import("../src/manifest.ts");
+
+const body = `${JSON.stringify(buildManifestJsonSchema(), null, 2)}\n`;
+
+if (check) {
+  if (!existsSync(outPath)) {
+    throw new Error(`${relative(packageRoot, outPath)} does not exist. Run emit:manifest-schema.`);
+  }
+  const existing = readFileSync(outPath, "utf8");
+  if (existing !== body) {
+    throw new Error(`${relative(packageRoot, outPath)} is stale. Run emit:manifest-schema.`);
+  }
+} else {
+  writeFileSync(outPath, body);
+}
+
+console.log(relative(packageRoot, outPath));

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -33,3 +33,4 @@ export * from "./task.js";              // §3 TASKS — task config / task / pe
 export * from "./rest.js";              // §4 PUBLIC REST API (minus finalize family)
 export * from "./finalize-shapes.js";   // §4 PUBLIC REST API — /finalize response family
 export * from "./errors.js";            // §5 ERROR ENVELOPE
+export * from "./manifest.js";          // §6 MANIFEST — pome.json/pome.yaml + slug authority (F-818)

--- a/packages/shared-types/src/manifest.ts
+++ b/packages/shared-types/src/manifest.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// shared-types §6 — the pome.json / pome.yaml MANIFEST (F-818, format spec
+// F-804). One canonical zod schema; JSON and YAML are interchangeable carriers
+// of the same snake_case keys (both files present is a hard error at the CLI
+// loader, not here). The `agent` block is the stable cross-carrier identity
+// contract; top-level keys are CLI run-config and may evolve faster.
+//
+// SLUG_RE and deriveAgentSlug are THE slug authority for every consumer (CLI,
+// control-plane /v1/agents, dashboard, MCP). They were ported byte-identically
+// from pome-cloud (apps/control-plane/src/routes/agents.ts and
+// packages/db/src/agent-slug.ts), which import them from here as of F-820 —
+// local and server validation must never drift again.
+
+import { z } from "zod";
+
+// Canonical agent-slug shape: kebab-case, lowercase alphanumerics, no edge or
+// doubled dashes. Length is capped separately (the regex is anchored on shape).
+export const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+export const SLUG_MAX_LENGTH = 64;
+
+// Shared agent slug derivation for REST, dashboard, and CLI registration
+// paths. Keep this pure: validation and reserved-slug checks live at each API
+// edge. Returns "" when nothing sluggable remains — callers must check.
+export function deriveAgentSlug(input: string): string {
+  return input
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export const agentSlugSchema = z
+  .string()
+  .max(SLUG_MAX_LENGTH)
+  .regex(SLUG_RE, "Agent slug must be kebab-case: lowercase letters, digits, single dashes");
+
+// The `agent` identity block. `slug` is the only required field in the whole
+// manifest — portable and non-sensitive. The registered `agt_` id is
+// deliberately NOT here: committed opaque ids are the fork-404 bug class; the
+// platform resolver (POST /v1/agents) maps slug → id under the caller's team.
+export const manifestAgentSchema = z.object({
+  slug: agentSlugSchema,
+  name: z.string().min(1).optional(),          // display name (server display_name)
+  description: z.string().optional(),          // shown on dashboard
+  version: z.string().optional(),              // user-declared label; never auto-bumped
+  // Open enum by design: unknown frameworks get a did-you-mean warning at the
+  // consuming edge, never a validation error.
+  framework: z.string().min(1).optional(),     // langgraph | claude-agent-sdk | openai-agents | …
+});
+export type ManifestAgent = z.infer<typeof manifestAgentSchema>;
+
+export const manifestSchema = z.object({
+  // pome.json carries the editor pointer; pome.yaml uses a comment instead.
+  $schema: z.string().optional(),
+  agent: manifestAgentSchema,
+  command: z.string().min(1).optional(),       // how the CLI launches the agent
+  twins: z.array(z.string().min(1)).min(1).optional(), // default twin set for runs
+  tasks: z.string().min(1).optional(),         // task files directory (legacy name: scenarios)
+  artifacts_dir: z.string().min(1).default("runs"),
+  pass_threshold: z.number().int().min(0).max(100).default(100),
+});
+export type Manifest = z.infer<typeof manifestSchema>;
+// Writer-side shape: what an author may put in pome.json / pome.yaml before
+// the run-config defaults are injected (z.input trick, F-778).
+export type ManifestInput = z.input<typeof manifestSchema>;
+
+// The JSON Schema served at pome.sh/schemas/v1/pome.json (F-821) and resolved
+// by editors via the manifest's `$schema` pointer. `io: "input"` emits the
+// AUTHOR-side shape — run-config keys with defaults stay optional instead of
+// being promoted to required by the parsed (output) view. Shared by the
+// build-time emitter (scripts/emit-manifest-schema.mjs) and the snapshot test
+// so the two can never disagree.
+export function buildManifestJsonSchema(): Record<string, unknown> {
+  return {
+    $id: "https://pome.sh/schemas/v1/pome.json",
+    title: "Pome agent manifest (pome.json / pome.yaml)",
+    ...z.toJSONSchema(manifestSchema, { io: "input" }),
+  };
+}

--- a/packages/shared-types/src/manifest.ts
+++ b/packages/shared-types/src/manifest.ts
@@ -7,9 +7,10 @@
 // contract; top-level keys are CLI run-config and may evolve faster.
 //
 // SLUG_RE and deriveAgentSlug are THE slug authority for every consumer (CLI,
-// control-plane /v1/agents, dashboard, MCP). They were ported byte-identically
-// from pome-cloud (apps/control-plane/src/routes/agents.ts and
-// packages/db/src/agent-slug.ts), which import them from here as of F-820 —
+// control-plane /v1/agents, dashboard, MCP). SLUG_RE is byte-identical to the
+// pome-cloud control-plane's regex; deriveAgentSlug is a behavior-identical
+// port of packages/db/src/agent-slug.ts (equivalence pinned in
+// test/manifest.test.ts). pome-cloud imports both from here as of F-820 —
 // local and server validation must never drift again.
 
 import { z } from "zod";
@@ -22,13 +23,18 @@ export const SLUG_MAX_LENGTH = 64;
 // Shared agent slug derivation for REST, dashboard, and CLI registration
 // paths. Keep this pure: validation and reserved-slug checks live at each API
 // edge. Returns "" when nothing sluggable remains — callers must check.
+//
+// The first replace collapses every non-alphanumeric run (dashes included) to
+// a single dash, so afterwards each edge carries at most one dash — the
+// anchored single-char strips are exhaustive and stay linear (the upstream
+// `/^-+|-+$/g` form is a CodeQL js/polynomial-redos finding).
 export function deriveAgentSlug(input: string): string {
   return input
     .toLowerCase()
     .trim()
     .replace(/[^a-z0-9]+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-+|-+$/g, "");
+    .replace(/^-/, "")
+    .replace(/-$/, "");
 }
 
 export const agentSlugSchema = z

--- a/packages/shared-types/src/rest.ts
+++ b/packages/shared-types/src/rest.ts
@@ -72,6 +72,11 @@ const createSessionRequestObjectSchema = z
     // runs.group_id at finalize; the demo/eval mints already accept the same
     // field. Format mirrors the cloud's GROUP_ID_RE. Legacy clients omit it.
     group_id: z.string().regex(/^[A-Za-z0-9_-]{6,64}$/).optional(),
+    // F-818 (spec F-804): per-run override of the manifest's agent.version —
+    // an opaque user-declared label stamped onto the session/run rows (F-820).
+    // Absent = the agent's registered version. Additive; older clients omit it
+    // and an older cloud strips it.
+    agent_version: z.string().optional(),
   })
   .refine(
     (v) => Boolean(v.task_source) !== Boolean(v.task_id),
@@ -297,6 +302,18 @@ export type CriterionDefInput = z.input<typeof criterionDefSchema>;
 // canonical for the slug; the CLI persists whatever id/slug it returns.
 export const createAgentRequestSchema = z.object({
   name: z.string().min(1),
+  // Manifest identity (F-818, spec F-804): human-ish slug input — the server
+  // derives the canonical kebab slug with the same deriveAgentSlug exported
+  // from `./manifest.js`, then validates it against SLUG_RE. Cap mirrors the
+  // control-plane edge; shape is deliberately NOT enforced here.
+  slug: z.string().min(1).max(64).optional(),
+  description: z.string().optional(),
+  // User-declared version label from the manifest's agent.version — an opaque
+  // string, never auto-bumped, never semver-interpreted.
+  version: z.string().optional(),
+  // Open enum by design (F-804): unknown frameworks get a did-you-mean warning
+  // server-side, never a validation error.
+  framework: z.string().min(1).optional(),
   // Multi-twin (M3): the twins this agent is allowed to exercise. Absent = the
   // server's default enablement. The cloud intersects a session's requested
   // twins with the agent's enabled services. Additive; older clients omit it.
@@ -311,6 +328,16 @@ export const agentResponseSchema = z.object({
   slug: z.string(),
   display_name: z.string(),
   judge_model: z.string(),
+  // Manifest identity (F-818): registered agent.framework / agent.description /
+  // agent.version, nullable where the server has nothing stored. Optional for
+  // the pre-F-820 cloud, which omits them.
+  framework: z.string().optional(),
+  description: z.string().nullable().optional(),
+  version: z.string().nullable().optional(),
+  // F-818 resolver semantics: true when POST /v1/agents auto-registered a new
+  // agent for this slug, false when it resolved an existing one. Optional for
+  // the pre-F-820 cloud; absence means "unknown", not "resolved".
+  created: z.boolean().optional(),
   // Multi-twin (M3): the services (twins) this agent may exercise. Absent on an
   // older cloud; new CLIs treat absence as "unconstrained / server default".
   enabled_services: z.array(z.string()).optional(),

--- a/packages/shared-types/test/agent-contract.test.ts
+++ b/packages/shared-types/test/agent-contract.test.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-818 — additive agent-identity fields on the /v1 wire (spec: F-804).
+// POST /v1/agents request gains slug/description/version/framework;
+// POST /v1/sessions gains agent_version (per-run override of the manifest's
+// agent.version); the agent response gains framework/description/version and
+// the resolver's created flag. Every addition is optional so (old CLI × new
+// cloud) and (new CLI × old cloud) both keep working — these tests pin the
+// tolerant-reader property alongside the new shapes.
+
+import { describe, expect, it } from "vitest";
+import {
+  agentResponseSchema,
+  createAgentRequestSchema,
+  createSessionRequestSchema,
+} from "../src/index.js";
+
+describe("createAgentRequestSchema — manifest identity fields (F-818)", () => {
+  it("still accepts the pre-F-818 minimal payload", () => {
+    expect(createAgentRequestSchema.safeParse({ name: "PR Review Agent" }).success).toBe(true);
+  });
+
+  it("accepts the full manifest-shaped registration payload", () => {
+    const parsed = createAgentRequestSchema.parse({
+      name: "PR Review Agent",
+      slug: "pr-review-agent",
+      description: "Reviews PRs against team conventions",
+      version: "0.2.0",
+      framework: "langgraph",
+      twins: ["github"],
+    });
+    expect(parsed.slug).toBe("pr-review-agent");
+    expect(parsed.version).toBe("0.2.0");
+    expect(parsed.framework).toBe("langgraph");
+  });
+
+  it("caps the human-ish slug input at 64 chars (server derives the canonical slug)", () => {
+    expect(
+      createAgentRequestSchema.safeParse({ name: "A", slug: "a".repeat(65) }).success,
+    ).toBe(false);
+    // Human-ish input is allowed — derivation to SLUG_RE happens server-side.
+    expect(
+      createAgentRequestSchema.safeParse({ name: "A", slug: "My Agent" }).success,
+    ).toBe(true);
+  });
+});
+
+describe("createSessionRequestSchema.agent_version (F-818)", () => {
+  it("accepts an agent_version per-run override", () => {
+    const parsed = createSessionRequestSchema.parse({
+      twins: ["github"],
+      task_id: "task-1",
+      agent_version: "0.2.0",
+    }) as { agent_version?: string };
+    expect(parsed.agent_version).toBe("0.2.0");
+  });
+
+  it("stays optional — legacy session mints are unchanged", () => {
+    const parsed = createSessionRequestSchema.parse({
+      task_id: "task-1",
+    }) as { agent_version?: string };
+    expect(parsed.agent_version).toBeUndefined();
+  });
+});
+
+describe("agentResponseSchema — resolver fields (F-818)", () => {
+  const base = {
+    id: "agt_YRZsOPRGSaxiSKCNcXfaB",
+    slug: "pr-review-agent",
+    display_name: "PR Review Agent",
+    judge_model: "google/gemini-2.5-flash",
+  };
+
+  it("still accepts the pre-F-818 response (old cloud)", () => {
+    const parsed = agentResponseSchema.parse(base);
+    expect(parsed.created).toBeUndefined();
+  });
+
+  it("accepts the resolver response with created + identity fields", () => {
+    const parsed = agentResponseSchema.parse({
+      ...base,
+      framework: "langgraph",
+      description: "Reviews PRs against team conventions",
+      version: "0.2.0",
+      created: true,
+      enabled_services: ["github"],
+    });
+    expect(parsed.created).toBe(true);
+    expect(parsed.framework).toBe("langgraph");
+  });
+
+  it("accepts null description/version (unset on the server)", () => {
+    const parsed = agentResponseSchema.parse({
+      ...base,
+      description: null,
+      version: null,
+      created: false,
+    });
+    expect(parsed.description).toBeNull();
+    expect(parsed.created).toBe(false);
+  });
+});

--- a/packages/shared-types/test/export-surface.test.ts
+++ b/packages/shared-types/test/export-surface.test.ts
@@ -50,6 +50,9 @@ import type {
   FinalizeStatusUrl,
   GmailSeedState,
   GithubSeedState,
+  Manifest,
+  ManifestAgent,
+  ManifestInput,
   MeResponse,
   PerTwinStateKeys,
   PersistedScenario,
@@ -109,6 +112,9 @@ type _TypeSurfaceAssert = [
   FinalizeStatusUrl,
   GmailSeedState,
   GithubSeedState,
+  Manifest,
+  ManifestAgent,
+  ManifestInput,
   MeResponse,
   PerTwinStateKeys,
   PersistedScenario,
@@ -139,7 +145,7 @@ type _TypeSurfaceAssert = [
 // Compile-time anchor: exactly one tuple entry per guarded type. The literal
 // type on the left fails to compile if an entry is added or removed above
 // without updating the count.
-const TYPE_SURFACE_SIZE: _TypeSurfaceAssert["length"] = 54;
+const TYPE_SURFACE_SIZE: _TypeSurfaceAssert["length"] = 57;
 
 // Runtime value exports (types are erased and cannot appear on `Object.keys`).
 const EXPECTED_EXPORTS = [
@@ -182,16 +188,20 @@ const EXPECTED_EXPORTS = [
   "OTEL_STATUS_CODES",
   "SERVER_ADDRESS",
   "SERVER_PORT",
+  "SLUG_MAX_LENGTH",
+  "SLUG_RE",
   "UINT64_MAX",
   "URL_FULL",
   "URL_PATH",
   "acceptInviteRequestSchema",
   "acceptInviteResponseSchema",
   "agentResponseSchema",
+  "agentSlugSchema",
   "apiErrorSchema",
   "apiErrorTypeSchema",
   "apiKeyCreatedSchema",
   "apiKeySchema",
+  "buildManifestJsonSchema",
   "canonicalSpanIdSchema",
   "canonicalTraceIdSchema",
   "compareUint64",
@@ -206,6 +216,7 @@ const EXPECTED_EXPORTS = [
   "criterionKindSchema",
   "criterionResultSchema",
   "criterionSchema",
+  "deriveAgentSlug",
   "deterministicCriterionResultSchema",
   "eventSchema",
   "finalizeAcceptedResponseSchema",
@@ -236,6 +247,8 @@ const EXPECTED_EXPORTS = [
   "laneSchema",
   "llmCallEventSchema",
   "llmTurnEventSchema",
+  "manifestAgentSchema",
+  "manifestSchema",
   "mapOtelSpanToEvent",
   "meResponseSchema",
   "msToNanos",
@@ -300,10 +313,10 @@ describe("@pome-sh/shared-types barrel export surface (F-754)", () => {
     expect(Object.keys(api).sort()).toEqual([...EXPECTED_EXPORTS]);
   });
 
-  it("guards the TYPE surface (54 types/interfaces)", () => {
+  it("guards the TYPE surface (57 types/interfaces)", () => {
     // The real guard is the type-only import + _TypeSurfaceAssert tuple above,
     // enforced at typecheck time. This assertion just anchors the count at
     // runtime so the guard's scope is visible in test output.
-    expect(TYPE_SURFACE_SIZE).toBe(54);
+    expect(TYPE_SURFACE_SIZE).toBe(57);
   });
 });

--- a/packages/shared-types/test/manifest-json-schema.test.ts
+++ b/packages/shared-types/test/manifest-json-schema.test.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-818 — snapshot guard for the zod-generated manifest JSON Schema. The
+// committed manifest-schema.json is what pome.sh/schemas/v1/pome.json serves
+// (F-821) and what editors resolve via the manifest's `$schema` pointer; this
+// test pins its bytes to `buildManifestJsonSchema()` so the emitted output
+// stays stable across builds — any zod upgrade or schema edit that changes the
+// generated document must re-emit the file in the same PR
+// (`npm run emit:manifest-schema`).
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { SLUG_RE, buildManifestJsonSchema } from "../src/index.js";
+
+const COMMITTED_PATH = new URL("../manifest-schema.json", import.meta.url);
+
+describe("manifest JSON Schema emission (F-818)", () => {
+  it("matches the committed manifest-schema.json byte-for-byte", () => {
+    const committed = readFileSync(COMMITTED_PATH, "utf8");
+    expect(committed).toBe(`${JSON.stringify(buildManifestJsonSchema(), null, 2)}\n`);
+  });
+
+  it("is deterministic across calls", () => {
+    expect(buildManifestJsonSchema()).toEqual(buildManifestJsonSchema());
+  });
+
+  it("carries the served $id and requires only the agent block", () => {
+    const schema = buildManifestJsonSchema() as {
+      $id: string;
+      required: string[];
+      properties: { agent: { required: string[]; properties: { slug: { pattern: string } } } };
+    };
+    expect(schema.$id).toBe("https://pome.sh/schemas/v1/pome.json");
+    // Author-side (input) shape: run-config keys with defaults stay optional.
+    expect(schema.required).toEqual(["agent"]);
+    expect(schema.properties.agent.required).toEqual(["slug"]);
+    // The one regex, everywhere — the emitted pattern is SLUG_RE itself.
+    expect(schema.properties.agent.properties.slug.pattern).toBe(SLUG_RE.source);
+  });
+});

--- a/packages/shared-types/test/manifest.test.ts
+++ b/packages/shared-types/test/manifest.test.ts
@@ -89,6 +89,37 @@ describe("deriveAgentSlug (F-818)", () => {
       expect(slug === "" || SLUG_RE.test(slug), input).toBe(true);
     }
   });
+
+  it("is behavior-identical to the pome-cloud reference implementation", () => {
+    // The upstream packages/db/src/agent-slug.ts body, verbatim. Our export
+    // rewrites the edge-strip to linear regexes (CodeQL js/polynomial-redos);
+    // this corpus pins that the observable mapping never diverged.
+    const reference = (input: string): string =>
+      input
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/-+/g, "-")
+        .replace(/^-+|-+$/g, "");
+    const corpus = [
+      "PR Review Agent",
+      "  My --- Agent!  ",
+      "Émile's Agent",
+      "---",
+      "--a--b--",
+      "-a-",
+      "!!!",
+      "",
+      "a",
+      "9 Lives",
+      "x_y.z",
+      `${"-".repeat(500)}a${"-".repeat(500)}`,
+      "UPPER_case  mixed\t123",
+    ];
+    for (const input of corpus) {
+      expect(deriveAgentSlug(input), JSON.stringify(input)).toBe(reference(input));
+    }
+  });
 });
 
 describe("manifestSchema — carrier-agnostic (F-818)", () => {

--- a/packages/shared-types/test/manifest.test.ts
+++ b/packages/shared-types/test/manifest.test.ts
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-818 — the canonical pome.json / pome.yaml manifest data model. The manifest
+// zod schema, SLUG_RE, and deriveAgentSlug live here as the single source of
+// truth consumed by CLI, control-plane, and MCP; the control-plane's private
+// copies (apps/control-plane/src/routes/agents.ts SLUG_RE and
+// packages/db/src/agent-slug.ts deriveAgentSlug in pome-cloud) are retired in
+// favor of these exports (F-820), so local and server validation stay
+// byte-identical. Full format spec: Linear F-804.
+
+import { describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+import {
+  SLUG_RE,
+  deriveAgentSlug,
+  manifestAgentSchema,
+  manifestSchema,
+} from "../src/index.js";
+
+// The F-804 canonical pome.json example, verbatim.
+const POME_JSON_EXAMPLE = `{
+  "$schema": "https://pome.sh/schemas/v1/pome.json",
+  "agent": {
+    "slug": "pr-review-agent",
+    "name": "PR Review Agent",
+    "description": "Reviews PRs against team conventions",
+    "version": "0.2.0",
+    "framework": "langgraph"
+  },
+  "command": "npm start",
+  "twins": ["github"],
+  "tasks": "tasks/",
+  "artifacts_dir": "runs",
+  "pass_threshold": 100
+}`;
+
+// The F-804 pome.yaml alias, verbatim — same keys, different carrier.
+const POME_YAML_EXAMPLE = `# yaml-language-server: $schema=https://pome.sh/schemas/v1/pome.json
+agent:
+  slug: pr-review-agent
+  name: PR Review Agent
+  description: Reviews PRs against team conventions
+  version: 0.2.0
+  framework: langgraph
+command: npm start
+twins: [github]
+tasks: tasks/
+artifacts_dir: runs
+pass_threshold: 100
+`;
+
+describe("SLUG_RE (F-818)", () => {
+  it("is byte-identical to the control-plane's slug regex", () => {
+    // The whole point of the move: local and server validation share one
+    // regex. This pins the source so a 'harmless' edit here is loud.
+    expect(SLUG_RE.source).toBe("^[a-z0-9]+(?:-[a-z0-9]+)*$");
+    expect(SLUG_RE.flags).toBe("");
+  });
+
+  it("accepts kebab slugs and rejects everything else", () => {
+    for (const good of ["a", "pr-review-agent", "a1-b2", "0agent"]) {
+      expect(SLUG_RE.test(good), good).toBe(true);
+    }
+    for (const bad of ["", "-a", "a-", "a--b", "A", "a_b", "a b", "émile"]) {
+      expect(SLUG_RE.test(bad), bad).toBe(false);
+    }
+  });
+});
+
+describe("deriveAgentSlug (F-818)", () => {
+  it("derives the canonical kebab slug from a display name", () => {
+    expect(deriveAgentSlug("PR Review Agent")).toBe("pr-review-agent");
+  });
+
+  it("trims, collapses separator runs, and strips edge dashes", () => {
+    expect(deriveAgentSlug("  My --- Agent!  ")).toBe("my-agent");
+    expect(deriveAgentSlug("Émile's Agent")).toBe("mile-s-agent");
+  });
+
+  it("returns the empty string when nothing sluggable remains", () => {
+    expect(deriveAgentSlug("")).toBe("");
+    expect(deriveAgentSlug("---")).toBe("");
+    expect(deriveAgentSlug("!!!")).toBe("");
+  });
+
+  it("passes SLUG_RE for any non-empty derivation", () => {
+    for (const input of ["PR Review Agent", "a", "9 Lives", "x_y.z"]) {
+      const slug = deriveAgentSlug(input);
+      expect(slug === "" || SLUG_RE.test(slug), input).toBe(true);
+    }
+  });
+});
+
+describe("manifestSchema — carrier-agnostic (F-818)", () => {
+  it("validates the F-804 pome.json example verbatim", () => {
+    const parsed = manifestSchema.parse(JSON.parse(POME_JSON_EXAMPLE));
+    expect(parsed.agent.slug).toBe("pr-review-agent");
+    expect(parsed.agent.framework).toBe("langgraph");
+    expect(parsed.command).toBe("npm start");
+    expect(parsed.twins).toEqual(["github"]);
+    expect(parsed.tasks).toBe("tasks/");
+  });
+
+  it("validates the F-804 pome.yaml example and yields the same manifest", () => {
+    const fromYaml = manifestSchema.parse(parseYaml(POME_YAML_EXAMPLE));
+    const fromJson = manifestSchema.parse(JSON.parse(POME_JSON_EXAMPLE));
+    // Carriers share keys: apart from the JSON-only "$schema" pointer the two
+    // parses are the same manifest.
+    const { $schema: _ignored, ...jsonRest } = fromJson;
+    expect(fromYaml).toEqual(jsonRest);
+  });
+
+  it("requires only agent.slug — a minimal manifest parses", () => {
+    const parsed = manifestSchema.parse({ agent: { slug: "my-agent" } });
+    expect(parsed.agent.slug).toBe("my-agent");
+  });
+
+  it("applies the documented CLI run-config defaults (runs / 100)", () => {
+    const parsed = manifestSchema.parse({ agent: { slug: "my-agent" } });
+    expect(parsed.artifacts_dir).toBe("runs");
+    expect(parsed.pass_threshold).toBe(100);
+  });
+
+  it("rejects a manifest without an agent block", () => {
+    expect(manifestSchema.safeParse({ command: "npm start" }).success).toBe(false);
+  });
+
+  it("rejects invalid slugs (case, separators, length > 64)", () => {
+    for (const slug of ["My-Agent", "a_b", "-lead", "trail-", "a".repeat(65)]) {
+      expect(manifestSchema.safeParse({ agent: { slug } }).success, slug).toBe(false);
+    }
+    expect(manifestSchema.safeParse({ agent: { slug: "a".repeat(64) } }).success).toBe(true);
+  });
+
+  it("rejects an out-of-range pass_threshold", () => {
+    for (const pass_threshold of [-1, 101, 99.5]) {
+      expect(
+        manifestSchema.safeParse({ agent: { slug: "a" }, pass_threshold }).success,
+        String(pass_threshold),
+      ).toBe(false);
+    }
+  });
+
+  it("accepts unknown framework values (open enum — warn, never block)", () => {
+    const parsed = manifestAgentSchema.parse({ slug: "a", framework: "my-bespoke-framework" });
+    expect(parsed.framework).toBe("my-bespoke-framework");
+  });
+});

--- a/packages/shared-types/trace-contract.json
+++ b/packages/shared-types/trace-contract.json
@@ -1,6 +1,6 @@
 {
   "package": "@pome-sh/shared-types",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "zod": {
     "range": "^4.1.13",
     "major": 4

--- a/packages/twin-github/CHANGELOG.md
+++ b/packages/twin-github/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the GitHub twin are documented here. The format is
 loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 the package follows [Semantic Versioning](https://semver.org/).
 
+## 0.2.2 — 2026-07-21
+
+Dependency-only patch: repin `@pome-sh/sdk` to 0.5.1 and
+`@pome-sh/shared-types` to 0.12.0 (F-818). No twin surface change.
+
 ## 0.2.1 — 2026-07-20
 
 Dependency-only release: repins the shared first-party contract to

--- a/packages/twin-github/package.json
+++ b/packages/twin-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-github",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Deterministic GitHub-shaped twin for agent testing — REST + MCP, SQLite-backed state.",
   "private": false,
   "type": "module",
@@ -47,8 +47,8 @@
   },
   "dependencies": {
     "@hono/node-server": "^2.0.10",
-    "@pome-sh/sdk": "0.5.0",
-    "@pome-sh/shared-types": "0.11.0",
+    "@pome-sh/sdk": "0.5.1",
+    "@pome-sh/shared-types": "0.12.0",
     "hono": "^4.12.27",
     "zod": "^4.1.13"
   },

--- a/packages/twin-gmail/CHANGELOG.md
+++ b/packages/twin-gmail/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @pome-sh/twin-gmail — CHANGELOG
 
+## 0.1.1 — 2026-07-21
+
+Dependency-only patch: repin `@pome-sh/sdk` to 0.5.1 (F-818 batch). No twin
+surface change.
+
 ## 0.1.0 — 2026-07-20
 
 First public release of the deterministic Gmail twin:

--- a/packages/twin-gmail/package.json
+++ b/packages/twin-gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-gmail",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Deterministic Gmail-shaped twin for agent testing — SQLite-backed domain core.",
   "private": false,
   "type": "module",
@@ -44,7 +44,7 @@
     "preview:drift": "tsx scripts/preview-drift.ts"
   },
   "dependencies": {
-    "@pome-sh/sdk": "0.5.0",
+    "@pome-sh/sdk": "0.5.1",
     "hono": "^4.12.27",
     "zod": "^4.1.13"
   },

--- a/packages/twin-slack/CHANGELOG.md
+++ b/packages/twin-slack/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the Slack twin are documented here. The format is
 loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 the package follows [Semantic Versioning](https://semver.org/).
 
+## 0.2.2 — 2026-07-21
+
+Dependency-only patch: repin `@pome-sh/sdk` to 0.5.1 and
+`@pome-sh/shared-types` to 0.12.0 (F-818). No twin surface change.
+
 ## 0.2.1 — 2026-07-20
 
 Dependency-only release: repins the shared first-party contract to

--- a/packages/twin-slack/package.json
+++ b/packages/twin-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-slack",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Deterministic Slack Web API twin for agent testing — REST + MCP, SQLite-backed state.",
   "private": false,
   "type": "module",
@@ -46,8 +46,8 @@
   },
   "dependencies": {
     "@hono/node-server": "^2.0.10",
-    "@pome-sh/sdk": "0.5.0",
-    "@pome-sh/shared-types": "0.11.0",
+    "@pome-sh/sdk": "0.5.1",
+    "@pome-sh/shared-types": "0.12.0",
     "hono": "^4.12.27",
     "zod": "^4.1.13"
   },

--- a/packages/twin-stripe/CHANGELOG.md
+++ b/packages/twin-stripe/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the Stripe twin are documented here. The format is
 loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 the package follows [Semantic Versioning](https://semver.org/).
 
+## 0.2.5 — 2026-07-21
+
+Dependency-only patch: repin `@pome-sh/sdk` to 0.5.1 and
+`@pome-sh/shared-types` to 0.12.0 (F-818). No twin surface change.
+
 ## 0.2.4 — 2026-07-20
 
 Dependency-only release: repins the shared first-party contract to

--- a/packages/twin-stripe/package.json
+++ b/packages/twin-stripe/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pome-sh/twin-stripe",
-  "version": "0.2.4",
-  "description": "Deterministic test double for Stripe x402 machine payments \u2014 stateful clone agents can drive without burning sandbox quota or real chain gas.",
+  "version": "0.2.5",
+  "description": "Deterministic test double for Stripe x402 machine payments — stateful clone agents can drive without burning sandbox quota or real chain gas.",
   "private": false,
   "type": "module",
   "main": "./dist/src/index.js",
@@ -61,8 +61,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@hono/node-server": "^2.0.10",
-    "@pome-sh/sdk": "0.5.0",
-    "@pome-sh/shared-types": "0.11.0",
+    "@pome-sh/sdk": "0.5.1",
+    "@pome-sh/shared-types": "0.12.0",
     "hono": "^4.12.27",
     "zod": "^4.1.13"
   },


### PR DESCRIPTION
Executive summary: Moves the agent-manifest contract into `@pome-sh/shared-types` as the single source of truth for CLI, control-plane, and MCP. The new `manifestSchema` validates both `pome.json` and `pome.yaml` (same snake_case keys, carrier-agnostic), the slug rules (`SLUG_RE`, `deriveAgentSlug`) are ported byte-identically from the server so local and server validation can never drift, and a JSON Schema is generated from zod at build time for editors and the future `pome.sh/schemas/v1/pome.json` route. Ships as shared-types **0.12.0** plus dependency-only repins of the sibling packages.

## What
- New `src/manifest.ts`: `manifestSchema` / `manifestAgentSchema` (only `agent.slug` required; `artifacts_dir`/`pass_threshold` default to `runs`/`100`), `SLUG_RE`, `SLUG_MAX_LENGTH`, `agentSlugSchema`, `deriveAgentSlug`, and `buildManifestJsonSchema()`.
- `manifest-schema.json` emitted from zod (`scripts/emit-manifest-schema.mjs`, same pattern as `emit-trace-contract.mjs`), wired into `build`, snapshot-tested byte-for-byte, checked in CI, and shipped in the tarball.
- Additive `/v1` wire fields (all optional, tolerant both directions): `createAgentRequestSchema` + `slug`/`description`/`version`/`framework`; `createSessionRequestSchema` + `agent_version`; `agentResponseSchema` + `framework`/`description`/`version`/`created`.
- Release batch: shared-types 0.11.0 → **0.12.0** (0.x "minor plays major"); sdk 0.5.1, adapter-claude-sdk 0.2.3, twin-github 0.2.2, twin-slack 0.2.2, twin-stripe 0.2.5, twin-gmail 0.1.1 are dependency-only patch repins per PACKAGE_RELEASE.md.

## Why
Agents need a stable identity linking repo code to the platform. Today the slug regex and derivation live privately in the server while clients reimplement them — the local/server slug-mismatch class of bug. One canonical zod schema kills the three-way contract drift and gives editors a real JSON Schema for `pome.json`/`pome.yaml`.

## Notes for reviewer
- **Contract audit:** every wire change is additive and optional — a pre-existing request/response parses unchanged (pinned by tests in `test/agent-contract.test.ts`). No persisted data migration needed; no renames, no tightening of existing fields.
- `SLUG_RE` is a verbatim port from the server; `deriveAgentSlug` is a behavior-identical port — its edge-strip regex is rewritten to linear form to clear CodeQL's `js/polynomial-redos`, with a corpus test pinning equivalence to the upstream body. `test/manifest.test.ts` also pins `SLUG_RE.source` so a "harmless" edit is loud. The server switches to importing these in the follow-up server-side work.
- The emit script imports `src/manifest.ts` directly (Node ≥ 23.6 type stripping); this works because `manifest.ts` deliberately has no relative imports. The snapshot test guards the committed bytes either way.
- The JSON Schema is emitted with `io: "input"` so defaulted run-config keys stay optional for authors instead of being promoted to required.
- Export-surface counters updated: +7 runtime exports, type surface 54 → 57.

## Tests / CI
- `npm test` across all workspaces: 1,483 tests green (shared-types 354, incl. 25 new manifest/agent-contract tests; TDD red→green).
- `npm run typecheck`, `lint:dead-code`, `gate:no-native`, `gate:no-eval`, `check:trace-contract`, `check:manifest-schema`, no-cloud-imports, legacy-marker gates all pass locally.
- `node scripts/pack-publishable.mjs` clean; `manifest-schema.json` verified present in the 0.12.0 tarball.

<!-- Closes F-818 -->
