### PR TITLE
cli: adopt pome.json/pome.yaml manifest + .pome/link.json resolver cache

### DIFF
--- a/cli/.changeset/manifest-loader-link-cache.md
+++ b/cli/.changeset/manifest-loader-link-cache.md
@@ -1,0 +1,5 @@
+---
+"@pome-sh/cli": minor
+---
+
+Adopt the `pome.json` / `pome.yaml` manifest for agent identity (replaces `pome.config.json`). `pome register` / `pome install` now write the portable `agent.slug` to the manifest and cache the resolved `agt_` id in gitignored `.pome/link.json` (team-gated, so forks and re-clones self-onboard by slug and never carry a foreign id). Runs resolve identity from the manifest, stamp `agent_version` (with a new `--agent-version` override), and near-miss slugs get an interactive did-you-mean confirmation.

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -10,6 +10,7 @@
       "bundleDependencies": [
         "@pome-sh/sdk",
         "@pome-sh/shared-types",
+        "@pome-sh/twin-gmail",
         "@pome-sh/twin-github",
         "@pome-sh/twin-slack",
         "@pome-sh/twin-stripe"
@@ -23,11 +24,12 @@
         "@anthropic-ai/sdk": "^0.110.0",
         "@hono/node-server": "^2.0.10",
         "@openrouter/ai-sdk-provider": "^3.0.0",
-        "@pome-sh/sdk": "0.4.0",
-        "@pome-sh/shared-types": "0.10.0",
-        "@pome-sh/twin-github": "0.2.0",
-        "@pome-sh/twin-slack": "0.2.0",
-        "@pome-sh/twin-stripe": "0.2.3",
+        "@pome-sh/sdk": "0.5.0",
+        "@pome-sh/shared-types": "0.12.0",
+        "@pome-sh/twin-github": "0.2.1",
+        "@pome-sh/twin-gmail": "0.1.0",
+        "@pome-sh/twin-slack": "0.2.1",
+        "@pome-sh/twin-stripe": "0.2.4",
         "ai": "^7.0.18",
         "commander": "^15.0.0",
         "hono": "^4.10.7",
@@ -1146,12 +1148,12 @@
       }
     },
     "node_modules/@pome-sh/sdk": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@pome-sh/sdk/-/sdk-0.4.0.tgz",
-      "integrity": "sha512-I7znWBWmeGhQ2Vhn1UhI4rbIKehZuNfINIfUKDopmY7b2H5n94XyZ63UQJKqRBkTujrjl9L8N6v8pgI5xTGNoQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/sdk/-/sdk-0.5.0.tgz",
+      "integrity": "sha512-tY9aEii2cUthCLMv2Em83jnfHuo2FtyxpY6D1ghWWwu/OPj7DiuSs+TkG2QaGRr3urwWkA+Vk/Wv6Ki5Sz5WHA==",
       "inBundle": true,
       "dependencies": {
-        "@pome-sh/shared-types": "0.6.1",
+        "@pome-sh/shared-types": "0.11.0",
         "hono": "^4.12.27",
         "zod": "^4.1.13"
       },
@@ -1168,33 +1170,33 @@
       }
     },
     "node_modules/@pome-sh/sdk/node_modules/@pome-sh/shared-types": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.6.1.tgz",
-      "integrity": "sha512-OFSZux+rLXtbmBnCWrWudH3RiF26E9n247JqfMfsIB8aPiDSeuP2LuUzzRtqFHX3+B0r9DYKVwVlaCBZxWGrpw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.11.0.tgz",
+      "integrity": "sha512-UY1wyInHK6I15UK8PchH1Hpt0Wbuu80/3H0mVEuFZzDUvnXG/Q6EU/xhUTnrX4hAEhNFdrXqanT9XMl+6EOOwA==",
       "inBundle": true,
       "peerDependencies": {
         "zod": "^4.1.13"
       }
     },
     "node_modules/@pome-sh/shared-types": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.10.0.tgz",
-      "integrity": "sha512-oCxA0sbECvchNJOxtzlsiuuidQtmx1bc4MCH4Pq0V+vu+LoX+wdkti/j2WN1/y6tRjl0mLvcsjyTKtIgGedEDA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.12.0.tgz",
+      "integrity": "sha512-6YTujcaSInyNB4ZQnLs/5k9J9/AS4pEl5njxEOV+U8QYiq+LF1LswTC7fGIe9XOuaM3+e6pWcMhuvihBhqDjtA==",
       "inBundle": true,
       "peerDependencies": {
         "zod": "^4.1.13"
       }
     },
     "node_modules/@pome-sh/twin-github": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@pome-sh/twin-github/-/twin-github-0.2.0.tgz",
-      "integrity": "sha512-H7ARyaSJjh+s1e+58RbGqO16YNFBfLjOc+HlqjVjDiZx4xKrIEgBYDamxhyxHJeDkYTM7JaSR6X8SYYz3eqtPg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@pome-sh/twin-github/-/twin-github-0.2.1.tgz",
+      "integrity": "sha512-yF09/KeVTK3K2NpNiK0ShVx94DL4CUFejf3a/kIW71Q6Thb2eYlKKGr0Wt1kws4iFrTeT4got8qq7P5zLWUGWQ==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@hono/node-server": "^2.0.8",
-        "@pome-sh/sdk": "0.4.0",
-        "@pome-sh/shared-types": "0.9.0",
+        "@hono/node-server": "^2.0.10",
+        "@pome-sh/sdk": "0.5.0",
+        "@pome-sh/shared-types": "0.11.0",
         "hono": "^4.12.27",
         "zod": "^4.1.13"
       },
@@ -1206,24 +1208,42 @@
       }
     },
     "node_modules/@pome-sh/twin-github/node_modules/@pome-sh/shared-types": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.9.0.tgz",
-      "integrity": "sha512-F5Vjqs2YlZWSnRjqrybyKBt98WI/3LPL4gzUuw+5tPUFT4GdAMQrEi+tkWmi0ekUVbMbCZqkZwTuWTa9dx6+5g==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.11.0.tgz",
+      "integrity": "sha512-UY1wyInHK6I15UK8PchH1Hpt0Wbuu80/3H0mVEuFZzDUvnXG/Q6EU/xhUTnrX4hAEhNFdrXqanT9XMl+6EOOwA==",
       "inBundle": true,
       "peerDependencies": {
         "zod": "^4.1.13"
       }
     },
-    "node_modules/@pome-sh/twin-slack": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@pome-sh/twin-slack/-/twin-slack-0.2.0.tgz",
-      "integrity": "sha512-Bnj2R1Gh4rsaBbv48LvfK2NduEx7YZQktmtwNJ2ThH9jvxkfYnen8JF7olv12Iq3FHeB9i7RQv4taXYbLc7WZw==",
+    "node_modules/@pome-sh/twin-gmail": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/twin-gmail/-/twin-gmail-0.1.0.tgz",
+      "integrity": "sha512-XHUsAwX3T8DsAQy60DKnP7mDiXTWMCYInzEdRDwgTWhnDTj1zANkDYmlT2u9Buo5YqhJR8w965xYpCOo7U6xhQ==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@hono/node-server": "^2.0.8",
-        "@pome-sh/sdk": "0.4.0",
-        "@pome-sh/shared-types": "0.9.0",
+        "@pome-sh/sdk": "0.5.0",
+        "hono": "^4.12.27",
+        "zod": "^4.1.13"
+      },
+      "bin": {
+        "twin-gmail": "dist/src/server.js"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@pome-sh/twin-slack": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@pome-sh/twin-slack/-/twin-slack-0.2.1.tgz",
+      "integrity": "sha512-PBFqxPALQgJNo0fTlAPnHn3Pp8j2z95WQBoEGXc0v58/t4XYyVTnhMxt14TpOFuvwJEi02slvUFOU4HOAJULfg==",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@hono/node-server": "^2.0.10",
+        "@pome-sh/sdk": "0.5.0",
+        "@pome-sh/shared-types": "0.11.0",
         "hono": "^4.12.27",
         "zod": "^4.1.13"
       },
@@ -1235,24 +1255,24 @@
       }
     },
     "node_modules/@pome-sh/twin-slack/node_modules/@pome-sh/shared-types": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.9.0.tgz",
-      "integrity": "sha512-F5Vjqs2YlZWSnRjqrybyKBt98WI/3LPL4gzUuw+5tPUFT4GdAMQrEi+tkWmi0ekUVbMbCZqkZwTuWTa9dx6+5g==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.11.0.tgz",
+      "integrity": "sha512-UY1wyInHK6I15UK8PchH1Hpt0Wbuu80/3H0mVEuFZzDUvnXG/Q6EU/xhUTnrX4hAEhNFdrXqanT9XMl+6EOOwA==",
       "inBundle": true,
       "peerDependencies": {
         "zod": "^4.1.13"
       }
     },
     "node_modules/@pome-sh/twin-stripe": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@pome-sh/twin-stripe/-/twin-stripe-0.2.3.tgz",
-      "integrity": "sha512-2Hrq3hAJwhdHgJ6W07VhszRTtobv/fAyYasOYyyehsNMLFBPCOkl/P8FIjrXdEXWsIFuHSFaHNdmxztnRZTbpA==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@pome-sh/twin-stripe/-/twin-stripe-0.2.4.tgz",
+      "integrity": "sha512-Fddyd2wJAzTOZALxbjZUnjJtT9lAOLbj1n7EnMbHPWWCZRbJmXUVEeCIbFnKGimhO7nO0kwVH8zSxhAHwYoYZQ==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@hono/node-server": "^2.0.8",
-        "@pome-sh/sdk": "0.4.0",
-        "@pome-sh/shared-types": "0.9.0",
+        "@hono/node-server": "^2.0.10",
+        "@pome-sh/sdk": "0.5.0",
+        "@pome-sh/shared-types": "0.11.0",
         "hono": "^4.12.27",
         "zod": "^4.1.13"
       },
@@ -1264,9 +1284,9 @@
       }
     },
     "node_modules/@pome-sh/twin-stripe/node_modules/@pome-sh/shared-types": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.9.0.tgz",
-      "integrity": "sha512-F5Vjqs2YlZWSnRjqrybyKBt98WI/3LPL4gzUuw+5tPUFT4GdAMQrEi+tkWmi0ekUVbMbCZqkZwTuWTa9dx6+5g==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.11.0.tgz",
+      "integrity": "sha512-UY1wyInHK6I15UK8PchH1Hpt0Wbuu80/3H0mVEuFZzDUvnXG/Q6EU/xhUTnrX4hAEhNFdrXqanT9XMl+6EOOwA==",
       "inBundle": true,
       "peerDependencies": {
         "zod": "^4.1.13"

--- a/cli/package.json
+++ b/cli/package.json
@@ -67,7 +67,7 @@
     "@hono/node-server": "^2.0.10",
     "@openrouter/ai-sdk-provider": "^3.0.0",
     "@pome-sh/sdk": "0.5.0",
-    "@pome-sh/shared-types": "0.11.0",
+    "@pome-sh/shared-types": "0.12.0",
     "@pome-sh/twin-gmail": "0.1.0",
     "@pome-sh/twin-github": "0.2.1",
     "@pome-sh/twin-slack": "0.2.1",

--- a/cli/scripts/cas-adapter-acceptance.ts
+++ b/cli/scripts/cas-adapter-acceptance.ts
@@ -60,17 +60,17 @@ const TSX_BIN = resolve(CLI_ROOT, "node_modules/.bin/tsx");
 
 // FDRS-641 — `pome run` hard-gates on the doctor wiring checks (config → twin
 // → routing → egress) with no --force. This synthetic gate used to run in a
-// bare `cli/` with no pome.config.json, so post-FDRS-641 it dies at the config
-// check before spawning the agent. Rather than bypass the gate, run `pome run`
-// from a throwaway directory holding a valid pome.config.json + a wiring-marker
-// source that reads POME_GITHUB_REST_URL — what doctor's routing scan wants,
-// with no hardcoded host to trip it. Twin/egress pass against the local github
-// twin + deny-by-default floor the run already uses.
+// bare `cli/` with no manifest, so post-FDRS-641 it dies at the config check
+// before spawning the agent. Rather than bypass the gate, run `pome run` from a
+// throwaway directory holding a valid pome.json manifest (F-819) + a
+// wiring-marker source that reads POME_GITHUB_REST_URL — what doctor's routing
+// scan wants, with no hardcoded host to trip it. Twin/egress pass against the
+// local github twin + deny-by-default floor the run already uses.
 async function makeDoctorScaffold(): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), "pome-cas-scaffold-"));
   await writeFile(
-    join(dir, "pome.config.json"),
-    `${JSON.stringify({ agent: { command: "npx tsx agent.ts" } }, null, 2)}\n`,
+    join(dir, "pome.json"),
+    `${JSON.stringify({ agent: { slug: "cas-acceptance-agent" }, command: "npx tsx agent.ts" }, null, 2)}\n`,
   );
   await writeFile(
     join(dir, "agent.ts"),
@@ -162,7 +162,7 @@ async function runPome(input: { target: string; scaffold: string }): Promise<str
   env.POME_AGENT_ENV_ALLOWLIST = appendAllowlist(process.env.POME_AGENT_ENV_ALLOWLIST, "POME_CAPTURE_TEST_TARGET");
 
   // cwd = scaffold dir so `pome run`'s FDRS-641 doctor preflight finds the
-  // scaffolded pome.config.json + wiring marker (and passes).
+  // scaffolded pome.json manifest + wiring marker (and passes).
   const { stdout, stderr, exitCode } = await runChild(pomeExec, args, env, input.scaffold);
   if (exitCode !== 0) {
     process.stdout.write(stdout);

--- a/cli/scripts/eval-roundtrip.sh
+++ b/cli/scripts/eval-roundtrip.sh
@@ -14,7 +14,7 @@
 #      scripted example agent (`pome run --local`) — capture-only, no
 #      network, no credentials needed for this half. `pome run` hard-gates
 #      on `pome doctor`'s wiring checks with no --force, so this spins up a
-#      disposable scaffold dir with a minimal pome.config.json + a wiring
+#      disposable scaffold dir with a minimal pome.json manifest + a wiring
 #      marker source (same technique as scripts/cas-adapter-acceptance.ts)
 #      rather than bypassing the gate.
 #   2. Uploads that trace with `pome eval <run-dir>` against POME_API_URL,
@@ -67,13 +67,14 @@ if [[ -z "$RUN_DIR" ]]; then
   # caller-owned artifacts dir is never removed.
   trap 'rm -rf "$SCAFFOLD_DIR" "$ARTIFACTS_DIR"' EXIT
 
-  # FDRS-641 — `pome run`'s doctor preflight requires a pome.config.json
-  # (agent.command is enough) plus a routing-scan-friendly source in the cwd.
-  # The REAL agent is passed via --agent below; this marker file only exists
-  # so the wiring check has something to scan.
-  cat > "$SCAFFOLD_DIR/pome.config.json" <<'EOF'
+  # FDRS-641 — `pome run`'s doctor preflight requires a pome.json manifest
+  # (F-819: agent.slug + a top-level command) plus a routing-scan-friendly
+  # source in the cwd. The REAL agent is passed via --agent below; this marker
+  # file only exists so the wiring check has something to scan.
+  cat > "$SCAFFOLD_DIR/pome.json" <<'EOF'
 {
-  "agent": { "command": "npx tsx agent.ts" }
+  "agent": { "slug": "eval-roundtrip-agent" },
+  "command": "npx tsx agent.ts"
 }
 EOF
   cat > "$SCAFFOLD_DIR/agent.ts" <<'EOF'

--- a/cli/scripts/make-unwired-fixture.mjs
+++ b/cli/scripts/make-unwired-fixture.mjs
@@ -7,7 +7,7 @@
 // and the twin base URL replaced by a hardcoded production host
 // (https://api.github.com) — exactly the finding doctor's routing scan
 // names with file:line. `pome install` + the pome-setup skill should take
-// this copy back to doctor-green. There is no pome.config.json either, so
+// this copy back to doctor-green. There is no pome.json manifest either, so
 // the first doctor red is "config missing" (the skill runs `pome init`),
 // then the hardcoded-host red.
 //
@@ -198,6 +198,6 @@ console.error("");
 console.error("unwired fixture ready. acceptance run:");
 console.error(`  cd ${dest}`);
 console.error("  npm install");
-console.error("  pome doctor     # red: no pome.config.json; after the skill runs pome init,");
+console.error("  pome doctor     # red: no pome.json manifest; after the skill runs pome init,");
 console.error("                  # red: hardcoded https://api.github.com in src/index.ts");
 console.error("  pome install    # hands off to your coding agent; approve its edits; ends green");

--- a/cli/scripts/overhead-gate.ts
+++ b/cli/scripts/overhead-gate.ts
@@ -60,18 +60,18 @@ const TSX_BIN = resolve(CLI_ROOT, "node_modules/.bin/tsx");
 
 // FDRS-641 — `pome run` now hard-gates on the doctor wiring checks (config →
 // twin → routing → egress) with no --force. This synthetic benchmark used to
-// run in a bare `cli/` with no pome.config.json, so post-FDRS-641 it dies at
-// the config check before spawning the agent. We can't (and shouldn't) bypass
-// the gate, so instead we run `pome run` from a throwaway directory that holds
-// a valid pome.config.json plus a wiring-marker source that reads
+// run in a bare `cli/` with no manifest, so post-FDRS-641 it dies at the config
+// check before spawning the agent. We can't (and shouldn't) bypass the gate, so
+// instead we run `pome run` from a throwaway directory that holds a valid
+// pome.json manifest (F-819) plus a wiring-marker source that reads
 // POME_GITHUB_REST_URL — exactly what doctor's routing scan wants and nothing
 // that trips its hardcoded-host detection. The twin/egress checks pass against
 // the local github twin + deny-by-default floor the run already uses.
 async function makeDoctorScaffold(): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), "pome-overhead-scaffold-"));
   await writeFile(
-    join(dir, "pome.config.json"),
-    `${JSON.stringify({ agent: { command: "npx tsx agent.ts" } }, null, 2)}\n`,
+    join(dir, "pome.json"),
+    `${JSON.stringify({ agent: { slug: "overhead-gate-agent" }, command: "npx tsx agent.ts" }, null, 2)}\n`,
   );
   await writeFile(
     join(dir, "agent.ts"),
@@ -261,7 +261,7 @@ async function runPome(input: { noCapture: boolean; target: string; scaffold: st
   env.POME_CLI_DISABLE_KEYCHAIN = "1";
 
   // cwd = scaffold dir so `pome run`'s FDRS-641 doctor preflight finds the
-  // scaffolded pome.config.json + wiring marker (and passes).
+  // scaffolded pome.json manifest + wiring marker (and passes).
   const { stdout, stderr, exitCode } = await runChild(pomeExec, args, env, input.scaffold);
   if (exitCode !== 0) {
     process.stderr.write(stderr);

--- a/cli/src/cli/agent-identity.ts
+++ b/cli/src/cli/agent-identity.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Run-path agent identity (F-819). Resolves the `agt_` id + version to stamp on
+// a hosted session from the committed manifest + gitignored `.pome/link.json`.
+//
+// The cached id is trusted only when its `team_id` matches the caller's team: a
+// re-clone under the same team short-circuits with no network (Champion TTHW);
+// a fork or team switch silently re-resolves the slug via `POST /v1/agents` so
+// a run never sends a foreign `agt_` id and self-onboards with zero extra
+// commands. A resolver hiccup degrades to "unattributed" rather than blocking a
+// local twin run.
+
+import { dirname } from "node:path";
+
+import {
+  postAgentResolver,
+  resolveSeams,
+} from "./agent-resolver.js";
+import { resolveCredentials } from "./credentials.js";
+import {
+  ensurePomeGitignored,
+  readLinkCache,
+  resolveCachedAgentId,
+  writeLinkCache,
+} from "./link-cache.js";
+import { readManifest } from "./project-config.js";
+
+export interface RunAgentIdentity {
+  /** The resolved agent id to send at session create; absent = unattributed. */
+  agentId?: string;
+  /** `--agent-version` override, else the manifest's `agent.version`. */
+  agentVersion?: string;
+  /** The manifest's `agent.framework` — the run's "SDK badge" on the dashboard. */
+  framework?: string;
+  /** The manifest's `agent.slug`, when a manifest is present. */
+  agentSlug?: string;
+}
+
+export interface ResolveRunAgentIdentityInput {
+  /** Directory to discover the manifest + link cache from (walks up). */
+  startDir: string;
+  apiBaseUrl: string;
+  /** `--agent-version` flag value; wins over the manifest's version. */
+  agentVersionOverride?: string;
+  /** Test seam — forwarded to resolveCredentials. */
+  credentialsPath?: string;
+}
+
+export async function resolveRunAgentIdentity(
+  input: ResolveRunAgentIdentityInput,
+): Promise<RunAgentIdentity> {
+  const manifestRead = await readManifest(input.startDir);
+  if (!manifestRead) {
+    return input.agentVersionOverride
+      ? { agentVersion: input.agentVersionOverride }
+      : {};
+  }
+
+  const { agent } = manifestRead.manifest;
+  const agentVersion = input.agentVersionOverride ?? agent.version;
+  const base: RunAgentIdentity = {
+    agentVersion,
+    framework: agent.framework,
+    agentSlug: agent.slug,
+  };
+  const projectDir = dirname(manifestRead.path);
+
+  try {
+    const creds = await resolveCredentials({
+      apiBaseUrl: input.apiBaseUrl,
+      credentialsPath: input.credentialsPath,
+    });
+    const cachedId = resolveCachedAgentId(await readLinkCache(projectDir), creds.teamId);
+    if (cachedId) {
+      return { ...base, agentId: cachedId };
+    }
+    // Silent re-resolution — a run never prompts for a near-miss.
+    const resolved = await postAgentResolver(
+      creds,
+      {
+        name: agent.name ?? agent.slug,
+        slug: agent.slug,
+        description: agent.description,
+        version: agent.version,
+        framework: agent.framework,
+      },
+      resolveSeams({ stdinIsTTY: false }),
+    );
+    if (creds.teamId) {
+      await writeLinkCache(projectDir, { agent_id: resolved.id, team_id: creds.teamId });
+      await ensurePomeGitignored(projectDir);
+    }
+    return { ...base, agentId: resolved.id };
+  } catch (err) {
+    console.error(
+      `pome: could not resolve agent identity (${
+        err instanceof Error ? err.message : String(err)
+      }); running unattributed.`,
+    );
+    return base;
+  }
+}

--- a/cli/src/cli/agent-resolver.ts
+++ b/cli/src/cli/agent-resolver.ts
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The `POST /v1/agents` resolver round-trip (F-820), shared by `pome register`
+// (interactive near-miss) and the run paths (silent re-resolution of a
+// committed slug under the caller's team). Kept import-neutral — no register/
+// session dependency — so both sides can consume it without a cycle.
+
+import { createInterface } from "node:readline";
+
+import { agentResponseSchema, type AgentResponse } from "@pome-sh/shared-types";
+
+import { HostedAuthError, HostedOrchError } from "../hosted/errors.js";
+import type { ResolvedCredentials } from "./credentials.js";
+
+/** Test seams — default to a live TTY [y/N] prompt (mirrors install.ts). */
+export interface InteractiveSeams {
+  stdinIsTTY?: boolean;
+  confirm?: (question: string) => Promise<boolean>;
+}
+
+/** The manifest identity fields POSTed to the resolver. */
+export interface AgentPostBody {
+  name: string;
+  slug?: string;
+  description?: string;
+  version?: string;
+  framework?: string;
+  twins?: string[];
+  confirm?: boolean;
+}
+
+export function resolveSeams(opts: InteractiveSeams): Required<InteractiveSeams> {
+  return {
+    stdinIsTTY: opts.stdinIsTTY ?? Boolean(process.stdin.isTTY),
+    confirm: opts.confirm ?? promptYesNo,
+  };
+}
+
+interface AgentHttpResult {
+  ok: boolean;
+  status: number;
+  json: unknown;
+}
+
+async function requestAgent(
+  creds: ResolvedCredentials,
+  body: AgentPostBody,
+): Promise<AgentHttpResult> {
+  const res = await fetch(`${creds.apiBaseUrl}/v1/agents`, {
+    method: "POST",
+    headers: { "x-api-key": creds.apiKey, "content-type": "application/json" },
+    body: JSON.stringify(prunePostBody(body)),
+  }).catch((err: unknown) => {
+    throw new HostedOrchError(err instanceof Error ? err.message : "network error");
+  });
+  const text = await res.text();
+  let json: unknown = {};
+  try {
+    json = text.length ? JSON.parse(text) : {};
+  } catch {
+    throw new HostedOrchError(`non-JSON response (status ${res.status})`);
+  }
+  return { ok: res.ok, status: res.status, json };
+}
+
+/** Drop undefined keys so the wire body stays byte-clean (older cloud, tests). */
+function prunePostBody(body: AgentPostBody): Record<string, unknown> {
+  const out: Record<string, unknown> = { name: body.name };
+  if (body.slug !== undefined) out.slug = body.slug;
+  if (body.description !== undefined) out.description = body.description;
+  if (body.version !== undefined) out.version = body.version;
+  if (body.framework !== undefined) out.framework = body.framework;
+  if (body.twins && body.twins.length > 0) out.twins = body.twins;
+  if (body.confirm !== undefined) out.confirm = body.confirm;
+  return out;
+}
+
+function parseOkAgent(json: unknown): AgentResponse {
+  const parsed = agentResponseSchema.safeParse(json);
+  if (!parsed.success) {
+    throw new HostedOrchError("POST /v1/agents returned an unexpected shape");
+  }
+  return parsed.data;
+}
+
+function mapHttpError(status: number, json: unknown): Error {
+  const err = (json as { error?: { message?: string; type?: string } }).error;
+  if (status === 401 || status === 403) {
+    return new HostedAuthError(err?.message ?? `HTTP ${status}`);
+  }
+  if (status === 404) {
+    return new HostedOrchError(
+      err?.message ??
+        "POST /v1/agents is not available at this API URL. Upgrade pome-cloud or check that --api-url/POME_API_URL points at a version that supports agent registration.",
+    );
+  }
+  return new HostedOrchError(err?.message ?? `POST /v1/agents → HTTP ${status}`);
+}
+
+/** Extract the near-miss suggested slug from a 409 conflict envelope. F-820
+ *  returns it under `error.details.suggestion`; we also tolerate `suggestions[]`
+ *  and `slug` as forward-compatible fallbacks. */
+export function nearMissSuggestion(json: unknown): string | undefined {
+  const error = (json as { error?: { type?: string; details?: Record<string, unknown> } }).error;
+  if (error?.type !== "conflict") return undefined;
+  const details = error.details;
+  if (!details) return undefined;
+  const candidate =
+    details.suggestion ??
+    details.slug ??
+    (Array.isArray(details.suggestions) ? details.suggestions[0] : undefined);
+  return typeof candidate === "string" && candidate.length > 0 ? candidate : undefined;
+}
+
+/** POST the manifest identity, resolving a 409 near-miss per the confirmation
+ *  UX: interactive → "did you mean X?" (yes re-resolves X, no force-creates the
+ *  typed slug); non-TTY/CI → warn + force-create (`confirm: true`). */
+export async function postAgentResolver(
+  creds: ResolvedCredentials,
+  body: AgentPostBody,
+  seams: Required<InteractiveSeams>,
+): Promise<AgentResponse> {
+  const first = await requestAgent(creds, body);
+  if (first.ok) return parseOkAgent(first.json);
+
+  if (first.status === 409) {
+    const suggestion = nearMissSuggestion(first.json);
+    if (suggestion) {
+      const interactive = seams.stdinIsTTY && !process.env.CI;
+      let retry: AgentPostBody;
+      if (interactive) {
+        const yes = await seams.confirm(
+          `An agent named "${suggestion}" already exists on your team. Did you mean "${suggestion}"? [y/N] `,
+        );
+        retry = yes ? { ...body, slug: suggestion } : { ...body, confirm: true };
+      } else {
+        console.error(
+          `Near-miss: this slug is close to your team's existing "${suggestion}". Registering the new agent anyway (run interactively to link the existing one instead).`,
+        );
+        retry = { ...body, confirm: true };
+      }
+      const second = await requestAgent(creds, retry);
+      if (second.ok) return parseOkAgent(second.json);
+      throw mapHttpError(second.status, second.json);
+    }
+  }
+  throw mapHttpError(first.status, first.json);
+}
+
+async function promptYesNo(question: string): Promise<boolean> {
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    const answer = await new Promise<string>((resolve) => rl.question(question, resolve));
+    return /^y(es)?$/i.test(answer.trim());
+  } finally {
+    rl.close();
+  }
+}

--- a/cli/src/cli/credentials.ts
+++ b/cli/src/cli/credentials.ts
@@ -43,6 +43,10 @@ export interface ResolveCredentialsInput {
 export interface ResolvedCredentials {
   apiKey: string;
   apiBaseUrl: string;
+  /** The team the api key belongs to, when known (stored at login). Powers the
+   *  `.pome/link.json` team gate (F-819). Undefined for a bare `POME_API_KEY`
+   *  env key, whose team is known only server-side. */
+  teamId?: string;
 }
 
 export interface CredentialsFile {
@@ -112,6 +116,7 @@ export async function resolveCredentials(
     return {
       apiKey: keychain.api_key.trim(),
       apiBaseUrl: resolveApiBaseUrl(input.apiBaseUrl, keychain.api_url),
+      teamId: normalizeTeamId(keychain.team_id),
     };
   }
 
@@ -152,7 +157,14 @@ export async function resolveCredentials(
   return {
     apiKey: parsed.api_key.trim(),
     apiBaseUrl: resolveApiBaseUrl(input.apiBaseUrl, parsed.api_url),
+    teamId: normalizeTeamId(parsed.team_id),
   };
+}
+
+function normalizeTeamId(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 function resolveApiBaseUrl(

--- a/cli/src/cli/docs-topics.ts
+++ b/cli/src/cli/docs-topics.ts
@@ -119,7 +119,7 @@ export const DOCS_TOPICS: DocsTopic[] = [
     id: "cli-init",
     title: "pome init",
     path: "/docs/cli/init",
-    keywords: ["init", "scaffold", "pome.config.json", "project"],
+    keywords: ["init", "scaffold", "pome.json", "manifest", "project"],
   },
   {
     id: "troubleshooting",

--- a/cli/src/cli/eval.ts
+++ b/cli/src/cli/eval.ts
@@ -51,11 +51,7 @@ import {
   type Score,
 } from "../hosted/evalResultView.js";
 import { resolveCredentials } from "./credentials.js";
-import {
-  normalizeConfigAgentSdk,
-  readProjectConfig,
-  type ProjectConfig,
-} from "./project-config.js";
+import { readManifest } from "./project-config.js";
 import type { RecorderEvent as LegacyGithubRecorderEvent } from "@pome-sh/shared-types";
 import { isLegacyEventRow, type FinalizeResponse } from "../types/shared.js";
 
@@ -233,13 +229,19 @@ export interface EvalIdentity {
   taskName: string;
 }
 
+/** The manifest fields `pome eval` reads: the agent slug (identity) and the
+ *  framework (the finalize "SDK badge"). */
+export interface EvalProjectIdentity {
+  agentSlug?: string;
+  framework?: string;
+}
+
 /** Precedence: explicit flags → meta.json (`scenario`, then `title`) for the
- *  task; explicit flag → pome.config.json (`agentSlug`, then `agentId`) for
- *  the agent. */
+ *  task; explicit flag → manifest `agent.slug` for the agent. */
 export function deriveEvalIdentity(
   meta: RunMeta,
   flags: { agent?: string; task?: string },
-  config: ProjectConfig | null,
+  identity: EvalProjectIdentity | null,
 ): EvalIdentity {
   const taskName = flags.task?.trim() || meta.scenario || meta.title;
   if (!taskName) {
@@ -247,44 +249,40 @@ export function deriveEvalIdentity(
       "pome eval: could not derive a task name — meta.json has no `scenario` or `title` field. Pass --task <name>.",
     );
   }
-  const agent = flags.agent?.trim() || configAgent(config);
+  const agent = flags.agent?.trim() || identity?.agentSlug?.trim() || "";
   if (!agent) {
     throw new HostedUsageError(
-      "pome eval: no agent identity found. Pass --agent <slug>, or run `pome register agent <name>` so pome.config.json carries agentSlug.",
+      "pome eval: no agent identity found. Pass --agent <slug>, or run `pome register agent <name>` so pome.json carries agent.slug.",
     );
   }
   return { agent, taskName };
 }
 
-function configAgent(config: ProjectConfig | null): string | null {
-  if (!config) return null;
-  const slug = typeof config.agentSlug === "string" ? config.agentSlug.trim() : "";
-  if (slug.length > 0) return slug;
-  const id = typeof config.agentId === "string" ? config.agentId.trim() : "";
-  if (id.length > 0) return id;
-  return null;
-}
-
 /** Walk up from the run dir first (in-project runs), then from the CWD
  *  (external run dirs like `pome eval /tmp/some-run` invoked from a
- *  configured project). Corrupt configs surface as named usage errors
- *  instead of raw JSON.parse throws (exit 2). */
+ *  configured project). Corrupt manifests surface as named usage errors
+ *  instead of raw parse throws (exit 2). */
 async function discoverProjectConfig(
   runDir: string,
-): Promise<ProjectConfig | null> {
-  const fromRunDir = await readConfigNamed(runDir);
+): Promise<EvalProjectIdentity | null> {
+  const fromRunDir = await readIdentityNamed(runDir);
   if (fromRunDir) return fromRunDir;
-  return readConfigNamed(process.cwd());
+  return readIdentityNamed(process.cwd());
 }
 
-async function readConfigNamed(startDir: string): Promise<ProjectConfig | null> {
+async function readIdentityNamed(
+  startDir: string,
+): Promise<EvalProjectIdentity | null> {
+  let read;
   try {
-    return (await readProjectConfig(startDir))?.config ?? null;
+    read = await readManifest(startDir);
   } catch (err) {
     throw new HostedUsageError(
-      `pome eval: pome.config.json is corrupt — ${err instanceof Error ? err.message : String(err)}`,
+      `pome eval: pome manifest is corrupt — ${err instanceof Error ? err.message : String(err)}`,
     );
   }
+  if (!read) return null;
+  return { agentSlug: read.manifest.agent.slug, framework: read.manifest.agent.framework };
 }
 
 // ---------------------------------------------------------------------------
@@ -380,8 +378,8 @@ export interface RunEvalOptions {
   hosted: { baseUrl: string; apiKey: string };
   /** For tests: inject a client. Otherwise constructed from `hosted`. */
   client?: EvalClient;
-  /** For tests: bypass pome.config.json discovery (pass null for "none"). */
-  projectConfig?: ProjectConfig | null;
+  /** For tests: bypass manifest discovery (pass null for "none"). */
+  projectConfig?: EvalProjectIdentity | null;
 }
 
 export interface RunEvalResult {
@@ -401,7 +399,7 @@ export async function runEval(options: RunEvalOptions): Promise<RunEvalResult> {
   const runDir = options.runDir;
   const artifacts = await readRunDirArtifacts(runDir);
 
-  const config =
+  const projectIdentity =
     options.projectConfig !== undefined
       ? options.projectConfig
       : await discoverProjectConfig(runDir);
@@ -409,7 +407,7 @@ export async function runEval(options: RunEvalOptions): Promise<RunEvalResult> {
   const identity = deriveEvalIdentity(
     artifacts.meta,
     { agent: options.agent, task: options.task },
-    config,
+    projectIdentity,
   );
   const { agent, taskName } = identity;
 
@@ -493,7 +491,7 @@ export async function runEval(options: RunEvalOptions): Promise<RunEvalResult> {
       exitCode: artifacts.meta.exitCode ?? -1,
       durationMs: durationMsFrom(artifacts.meta),
       agentModel: "unknown",
-      agentSdk: config ? normalizeConfigAgentSdk(config) : null,
+      agentSdk: projectIdentity?.framework ?? null,
       // Eval sessions carry no client-side criteria — the cloud eval judge
       // owns them (FDRS-655). Cloud's finalize schema defaults all scenario
       // fields, so empty strings are accepted.

--- a/cli/src/cli/frameworks.ts
+++ b/cli/src/cli/frameworks.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Client-side did-you-mean for the manifest's open-enum `agent.framework`
+// (F-804 / F-819). An unknown framework is NEVER a validation error — the
+// manifest schema keeps it a free string. We only surface a friendly warning
+// with the nearest known value so a typo like "langraph" is caught locally
+// before it reaches the dashboard badge.
+
+/** Known agent frameworks. Open enum by design — this list drives the warning
+ *  suggestion only, never a hard rejection. */
+export const KNOWN_FRAMEWORKS = [
+  "langgraph",
+  "claude-agent-sdk",
+  "openai-agents",
+  "crewai",
+  "autogen",
+  "llamaindex",
+  "google-adk",
+  "mastra",
+  "pydantic-ai",
+  "semantic-kernel",
+] as const;
+
+const MAX_SUGGEST_DISTANCE = 2;
+
+export interface FrameworkSuggestion {
+  known: boolean;
+  /** Present only when unknown AND a known framework is within edit distance. */
+  suggestion?: string;
+}
+
+/** Classify a framework value. Known → `{ known: true }`. Unknown → `{ known:
+ *  false }`, with `suggestion` set to the nearest known value within edit
+ *  distance 2 (else omitted). Comparison is case-insensitive. */
+export function suggestFramework(input: string): FrameworkSuggestion {
+  const value = input.trim().toLowerCase();
+  if ((KNOWN_FRAMEWORKS as readonly string[]).includes(value)) {
+    return { known: true };
+  }
+  let best: string | undefined;
+  let bestDistance = MAX_SUGGEST_DISTANCE + 1;
+  for (const known of KNOWN_FRAMEWORKS) {
+    const distance = levenshtein(value, known);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = known;
+    }
+  }
+  if (best !== undefined && bestDistance <= MAX_SUGGEST_DISTANCE) {
+    return { known: false, suggestion: best };
+  }
+  return { known: false };
+}
+
+function levenshtein(a: string, b: string): number {
+  const rows = a.length + 1;
+  const cols = b.length + 1;
+  const prev = new Array<number>(cols);
+  const curr = new Array<number>(cols);
+  for (let j = 0; j < cols; j += 1) prev[j] = j;
+  for (let i = 1; i < rows; i += 1) {
+    curr[0] = i;
+    for (let j = 1; j < cols; j += 1) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(prev[j]! + 1, curr[j - 1]! + 1, prev[j - 1]! + cost);
+    }
+    for (let j = 0; j < cols; j += 1) prev[j] = curr[j]!;
+  }
+  return prev[cols - 1]!;
+}

--- a/cli/src/cli/install.ts
+++ b/cli/src/cli/install.ts
@@ -62,7 +62,7 @@ export const KICKOFF_PROMPT =
  *  (their agent won't have the pome-setup skill installed). */
 export const PASTE_PROMPT = [
   "Wire this repository to pome (https://pome.sh) so its agent runs against a twin in test:",
-  "1. If pome.config.json is missing, run `pome init`; set agent.command to how this agent starts.",
+  "1. If pome.json is missing, run `pome init`; set the top-level command to how this agent starts.",
   "2. Claude Agent SDK repos: add @pome-sh/adapter-claude-sdk, import query/tool from it (drop-in replacements), and call withPome() once at startup.",
   "3. Replace every hardcoded production API host (e.g. https://api.github.com) with the env the pome runner injects: read POME_GITHUB_REST_URL / POME_GITHUB_MCP_URL and POME_AUTH_TOKEN from process.env. Never write secrets or URLs into source.",
   "4. Make minimal, targeted edits and show each diff for approval before applying.",
@@ -286,7 +286,7 @@ export async function runInstall(options: InstallOptions): Promise<void> {
   }
 
   // 6. FDRS-669 — register the agent (idempotent) now that the session has
-  // had its chance to create pome.config.json. Runs before the doctor verify
+  // had its chance to create pome.json. Runs before the doctor verify
   // so even a red-doctor install leaves the repo registered: the first bare
   // `pome run` submits under this agent, and "Default agent" stays a
   // migration-era state only (Reliability IA v1, decision 2).
@@ -507,8 +507,8 @@ function printManualFallback(): void {
   );
   console.error("");
   console.error("wire it manually:");
-  console.error("  1. config       pome init                  # if pome.config.json is missing;");
-  console.error("                                              # then set agent.command to your agent's start command");
+  console.error("  1. config       pome init                  # if pome.json is missing;");
+  console.error("                                              # then set the top-level command to your agent's start command");
   console.error("  2. adapter      npm install @pome-sh/adapter-claude-sdk");
   console.error('  3. hook + env   import { withPome } from "@pome-sh/adapter-claude-sdk"; withPome();');
   console.error("                  read the twin URL from env, never hardcode:");

--- a/cli/src/cli/link-cache.ts
+++ b/cli/src/cli/link-cache.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// `.pome/link.json` — the gitignored, machine-local resolver cache (F-819,
+// spec F-804). It maps the committed `agent.slug` to the `agt_` id the platform
+// resolved for it, scoped to the team that resolved it. The cache is TRUSTED
+// only when its `team_id` matches the caller's team: a re-clone under the same
+// team short-circuits (Champion TTHW), a fork or team switch silently
+// re-resolves by slug so we never send a foreign `agt_` id.
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export const POME_DIR = ".pome";
+export const LINK_FILE = "link.json";
+const GITIGNORE_ENTRY = `${POME_DIR}/`;
+
+export interface LinkCache {
+  agent_id: string;
+  team_id: string;
+  resolved_at: string;
+}
+
+function linkPath(projectDir: string): string {
+  return join(projectDir, POME_DIR, LINK_FILE);
+}
+
+/** Read the link cache next to a manifest. Missing or malformed → null: this
+ *  is a cache, never a hard failure (a bad file just forces re-resolution). */
+export async function readLinkCache(projectDir: string): Promise<LinkCache | null> {
+  let text: string;
+  try {
+    text = await readFile(linkPath(projectDir), "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    typeof (parsed as LinkCache).agent_id !== "string" ||
+    typeof (parsed as LinkCache).team_id !== "string"
+  ) {
+    return null;
+  }
+  const { agent_id, team_id } = parsed as LinkCache;
+  const resolved_at =
+    typeof (parsed as LinkCache).resolved_at === "string"
+      ? (parsed as LinkCache).resolved_at
+      : "";
+  return { agent_id, team_id, resolved_at };
+}
+
+/** Persist `.pome/link.json`, stamping `resolved_at` now. Creates `.pome/`. */
+export async function writeLinkCache(
+  projectDir: string,
+  entry: { agent_id: string; team_id: string },
+): Promise<void> {
+  await mkdir(join(projectDir, POME_DIR), { recursive: true });
+  const body: LinkCache = {
+    agent_id: entry.agent_id,
+    team_id: entry.team_id,
+    resolved_at: new Date().toISOString(),
+  };
+  await writeFile(linkPath(projectDir), `${JSON.stringify(body, null, 2)}\n`);
+}
+
+/** The team gate: the cached id is usable only when it was resolved under the
+ *  caller's own team. Any mismatch (or unknown caller team) → undefined, so the
+ *  caller re-resolves by slug instead of sending a foreign `agt_` id. */
+export function resolveCachedAgentId(
+  cache: LinkCache | null,
+  callerTeamId: string | undefined,
+): string | undefined {
+  if (!cache || !callerTeamId) return undefined;
+  return cache.team_id === callerTeamId ? cache.agent_id : undefined;
+}
+
+/** Ensure the project's `.gitignore` ignores `.pome/`. Creates the file when
+ *  absent; appends the entry when missing. Idempotent, and a bare `.pome`
+ *  (no trailing slash) already counts as ignored. */
+export async function ensurePomeGitignored(projectDir: string): Promise<void> {
+  const path = join(projectDir, ".gitignore");
+  let existing: string | null;
+  try {
+    existing = await readFile(path, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    existing = null;
+  }
+  if (existing === null) {
+    await writeFile(path, `${GITIGNORE_ENTRY}\n`);
+    return;
+  }
+  const alreadyIgnored = existing
+    .split(/\r?\n/)
+    .some((line) => line.trim() === GITIGNORE_ENTRY || line.trim() === POME_DIR);
+  if (alreadyIgnored) return;
+  const separator = existing.length === 0 || existing.endsWith("\n") ? "" : "\n";
+  await writeFile(path, `${existing}${separator}${GITIGNORE_ENTRY}\n`);
+}

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -3,7 +3,7 @@
 import { Command } from "commander";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { cp, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
-import { dirname, join, relative, resolve } from "node:path";
+import { basename, dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   readLatestRun,
@@ -56,12 +56,11 @@ import {
   DEFAULT_CONTROL_PLANE_URL,
   DEFAULT_DASHBOARD_URL,
 } from "./defaults.js";
+import { deriveAgentSlug } from "@pome-sh/shared-types";
 import {
-  CONFIG_FILE,
-  normalizeConfigAgentCommand,
-  readProjectConfig,
-  writeProjectConfig,
-  type ProjectConfig,
+  MANIFEST_JSON,
+  readManifest,
+  writeManifest,
 } from "./project-config.js";
 import { createGitHubCloneApp } from "../twin/githubCloneAdapter.js";
 import {
@@ -80,6 +79,7 @@ import type { RecorderEvent } from "../types/shared.js";
 const PACKAGE_VERSION = readPackageVersion();
 const SESSION_CREATE_FORMATS = new Set(["text", "json", "env"]);
 const DEFAULT_AGENT_COMMAND = "npx tsx examples/agents/scripted-triage-agent.ts";
+const MANIFEST_SCHEMA_URL = "https://pome.sh/schemas/v1/pome.json";
 
 function readPackageVersion(): string {
   try {
@@ -117,7 +117,7 @@ export function createProgram() {
     .description("Create starter Pome config and folders")
     .option(
       "--sdk <name>",
-      "Scaffold for a specific agent SDK (claude | claude-managed). Adds the SDK-specific example file and pre-fills agent.sdk so the dashboard badges runs correctly.",
+      "Scaffold for a specific agent SDK (claude | claude-managed). Adds the SDK-specific example file and pre-fills agent.framework so the dashboard badges runs correctly.",
     )
     .action(async (opts: { sdk?: string }) => {
       const sdk = opts.sdk?.trim();
@@ -143,14 +143,13 @@ export function createProgram() {
       await mkdir("runs", { recursive: true });
       await copyStarterFiles();
 
-      let agentBlock: ProjectConfig["agent"] = {
-        command: DEFAULT_AGENT_COMMAND,
-      };
+      let command = DEFAULT_AGENT_COMMAND;
+      let framework: string | undefined;
       let postInitMessage =
         "Pome initialized.\n" +
         "Next steps:\n" +
         "  1. pome login                    # one-time, opens the dashboard to sign in\n" +
-        "  2. pome register agent <name>    # scopes runs to this project (writes agentId + agentSlug to pome.config.json)\n" +
+        "  2. pome register agent <name>    # scopes runs to this project (writes agent.slug to pome.json)\n" +
         "  3. pome run scenarios/01-bug-happy-path.md\n" +
         "\n" +
         "Optional follow-ups:\n" +
@@ -161,32 +160,39 @@ export function createProgram() {
 
       if (sdk) {
         const scaffold = await writeSdkScaffold(sdk);
-        agentBlock = {
-          sdk: scaffold.agentSdkValue,
-          command: scaffold.agentCommand,
-        };
+        command = scaffold.agentCommand;
+        framework = scaffold.agentSdkValue;
         postInitMessage =
           `Pome initialized with --sdk ${sdk}. Scaffolded ${scaffold.exampleAgentRelativePath}.\n` +
           scaffold.postInstallHint;
       }
 
-      const existingConfig = await readProjectConfig(process.cwd());
-      if (!existingConfig) {
-        await writeProjectConfig(CONFIG_FILE, {
-          agent: agentBlock,
-          artifactsDir: "runs",
-          passThreshold: 100,
+      // The manifest requires `agent.slug` (F-804). `pome init` runs before
+      // `pome register`, so seed a portable slug derived from the directory
+      // name; register later overwrites it with the server-canonical slug.
+      const existing = await readManifest(process.cwd());
+      if (!existing) {
+        const slug = deriveAgentSlug(basename(process.cwd())) || "my-agent";
+        const agent: Record<string, unknown> = { slug };
+        if (framework) agent.framework = framework;
+        await writeManifest(join(process.cwd(), MANIFEST_JSON), "json", {
+          $schema: MANIFEST_SCHEMA_URL,
+          agent,
+          command,
+          artifacts_dir: "runs",
+          pass_threshold: 100,
         });
       } else if (sdk) {
-        await writeProjectConfig(existingConfig.path, {
-          ...existingConfig.config,
-          agent: {
-            ...(typeof existingConfig.config.agent === "object" &&
-            existingConfig.config.agent !== null
-              ? existingConfig.config.agent
-              : {}),
-            ...agentBlock,
-          },
+        const priorAgent =
+          typeof existing.raw.agent === "object" && existing.raw.agent !== null
+            ? (existing.raw.agent as Record<string, unknown>)
+            : {};
+        const nextAgent = { ...priorAgent };
+        if (framework) nextAgent.framework = framework;
+        await writeManifest(existing.path, existing.format, {
+          ...existing.raw,
+          agent: nextAgent,
+          command,
         });
       }
       console.error(postInitMessage);
@@ -389,7 +395,7 @@ export function createProgram() {
     )
     .option(
       "--force",
-      "Overwrite an existing agentId in pome.config.json",
+      "Re-resolve the agent even when .pome/link.json already links one",
       false,
     )
     .option(
@@ -397,7 +403,7 @@ export function createProgram() {
       "Comma-separated services this agent may exercise (e.g. github,slack). Default: the cloud's default enablement.",
     )
     .description(
-      "Create a cloud agent under the current team and write agentId to pome.config.json",
+      "Create a cloud agent under the current team and write agent.slug to pome.json",
     )
     .action(
       async (name: string, opts: { apiUrl: string; force: boolean; twins?: string }) => {
@@ -565,6 +571,10 @@ export function createProgram() {
     )
     .option("--agent-model <name>", "Informational; recorded on the cloud run.", "unknown")
     .option(
+      "--agent-version <version>",
+      "Override the manifest's agent.version for this run (stamped on the session/run).",
+    )
+    .option(
       "--no-capture",
       "Self-host only: skip spawning the capture-server child and don't inject HTTP_PROXY/HTTPS_PROXY into the agent. Used by the CI overhead gate (FDRS-405) to baseline proxy-on-vs-off latency. No-op on hosted runs.",
     )
@@ -586,6 +596,7 @@ export function createProgram() {
           local?: boolean;
           apiUrl: string;
           agentModel: string;
+          agentVersion?: string;
           capture: boolean;
         }
       ) => {
@@ -641,10 +652,8 @@ export function createProgram() {
           return;
         }
 
-        const configRead = await readProjectConfig(process.cwd());
-        const configCommand = configRead
-          ? normalizeConfigAgentCommand(configRead.config)
-          : undefined;
+        const manifestRead = await readManifest(process.cwd()).catch(() => null);
+        const configCommand = manifestRead?.manifest.command;
         const agentCommand =
           options.agent ?? configCommand ?? DEFAULT_AGENT_COMMAND;
         let worstExit = 0;
@@ -759,7 +768,7 @@ export function createProgram() {
                   agentCommandSource: options.agent
                     ? "--agent"
                     : configCommand
-                      ? "pome.config.json"
+                      ? "pome.json"
                       : "built-in default",
                   trials: k,
                   artifactsDir: options.artifactsDir,
@@ -770,6 +779,7 @@ export function createProgram() {
                   dashboardBaseUrl:
                     process.env.POME_DASHBOARD_URL ?? DEFAULT_DASHBOARD_URL,
                   agentModel: options.agentModel,
+                  agentVersion: options.agentVersion,
                   rerunCommand,
                 });
                 if (groupResult.exitCode > worstExit) {
@@ -784,6 +794,7 @@ export function createProgram() {
                 artifactsDir: options.artifactsDir,
                 hosted: { baseUrl: hostedCreds.apiBaseUrl, apiKey: hostedCreds.apiKey },
                 agentModel: options.agentModel,
+                agentVersion: options.agentVersion,
               });
               const status = scoreStatus(
                 result.score,
@@ -896,7 +907,7 @@ export function createProgram() {
   program
     .command("doctor")
     .description(
-      "Check the agent↔twin wiring: pome.config.json present + valid, twin reachable, requests routed to the twin (not a hardcoded production host), egress floor active. On failure prints one named cause (file:line where knowable) + one concrete fix and exits non-zero.",
+      "Check the agent↔twin wiring: pome.json (or pome.yaml) present + valid, twin reachable, requests routed to the twin (not a hardcoded production host), egress floor active. On failure prints one named cause (file:line where knowable) + one concrete fix and exits non-zero.",
     )
     .action(async () => {
       const { runDoctorChecks } = await import("../doctor/checks.js");
@@ -919,7 +930,7 @@ export function createProgram() {
     )
     .option(
       "--agent <slug>",
-      "Agent identity for the eval session. Defaults to agentSlug/agentId from pome.config.json.",
+      "Agent identity for the eval session. Defaults to agent.slug from pome.json.",
     )
     .option(
       "--task <name>",

--- a/cli/src/cli/project-config.ts
+++ b/cli/src/cli/project-config.ts
@@ -1,40 +1,77 @@
 // SPDX-License-Identifier: Apache-2.0
+//
+// The pome MANIFEST loader (F-819, format spec F-804). Replaces the legacy
+// `pome.config.json` handling — no back-compat, 0 users. The committed manifest
+// is `pome.json` (canonical) with `pome.yaml` / `pome.yml` as interchangeable
+// carriers of the same snake_case keys. One canonical zod schema
+// (`@pome-sh/shared-types` `manifestSchema`) validates every carrier.
+//
+// The registered `agt_` id is deliberately NOT in the manifest — it lives in
+// the gitignored `.pome/link.json` cache (see link-cache.ts). The portable
+// identity is `agent.slug`; the platform resolver maps slug → id per team.
+
 import { readFile, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 
+import {
+  SLUG_RE,
+  deriveAgentSlug,
+  manifestSchema,
+  type Manifest,
+} from "@pome-sh/shared-types";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+
 import { HostedOrchError } from "../hosted/errors.js";
 
-export const CONFIG_FILE = "pome.config.json";
+export const MANIFEST_JSON = "pome.json";
+export const MANIFEST_YAML = "pome.yaml";
+export const MANIFEST_YML = "pome.yml";
+/** Discovery order is fixed; a directory carrying more than one is a hard
+ *  error (a repo must have exactly one manifest). */
+export const MANIFEST_FILES = [MANIFEST_JSON, MANIFEST_YAML, MANIFEST_YML] as const;
 
-export interface ProjectConfig {
-  agent?: {
-    command?: unknown;
-    sdk?: unknown;
-    [key: string]: unknown;
-  };
-  agentId?: unknown;
-  agentSlug?: unknown;
-  [key: string]: unknown;
-}
+export type ManifestFormat = "json" | "yaml";
 
-export interface ProjectConfigRead {
+export interface ManifestLocation {
   path: string;
-  config: ProjectConfig;
+  format: ManifestFormat;
 }
 
-export async function findProjectConfigPath(
-  startDir = process.cwd(),
-): Promise<string | null> {
+export interface ManifestRead extends ManifestLocation {
+  /** Validated + defaulted view — read fields off this. */
+  manifest: Manifest;
+  /** Pre-validation object, for format-preserving round-trip writes
+   *  (`pome register --force` must not drop unrelated top-level keys). */
+  raw: Record<string, unknown>;
+}
+
+const SCHEMA_URL = "https://pome.sh/schemas/v1/pome.json";
+const YAML_SCHEMA_COMMENT = `# yaml-language-server: $schema=${SCHEMA_URL}`;
+
+function formatFor(fileName: string): ManifestFormat {
+  return fileName === MANIFEST_JSON ? "json" : "yaml";
+}
+
+/** Walk up from `startDir` looking for a manifest. In each directory a single
+ *  manifest is required; two present (e.g. `pome.json` + `pome.yaml`) is a hard
+ *  error naming both files. Returns null when none is found up to the root. */
+export async function findManifestPath(
+  startDir: string = process.cwd(),
+): Promise<ManifestLocation | null> {
   let dir = resolve(startDir);
   for (;;) {
-    const candidate = join(dir, CONFIG_FILE);
-    try {
-      await readFile(candidate, "utf8");
-      return candidate;
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-        throw err;
-      }
+    const present: string[] = [];
+    for (const fileName of MANIFEST_FILES) {
+      if (await fileExists(join(dir, fileName))) present.push(fileName);
+    }
+    if (present.length > 1) {
+      throw new HostedOrchError(
+        `Multiple pome manifests in ${dir}: ${present.join(", ")}. Keep exactly one (pome.json is canonical).`,
+      );
+    }
+    if (present.length === 1) {
+      const fileName = present[0]!;
+      return { path: join(dir, fileName), format: formatFor(fileName) };
     }
     const parent = dirname(dir);
     if (parent === dir) return null;
@@ -42,74 +79,104 @@ export async function findProjectConfigPath(
   }
 }
 
-export async function readProjectConfig(
-  startDir = process.cwd(),
-): Promise<ProjectConfigRead | null> {
-  const path = await findProjectConfigPath(startDir);
-  if (!path) return null;
-  const raw = await readFile(path, "utf8");
-  const parsed = JSON.parse(raw) as unknown;
-  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-    throw new Error(`${CONFIG_FILE} is not a JSON object`);
-  }
-  return { path, config: parsed as ProjectConfig };
+export async function readManifest(
+  startDir: string = process.cwd(),
+): Promise<ManifestRead | null> {
+  const found = await findManifestPath(startDir);
+  if (!found) return null;
+  const text = await readFile(found.path, "utf8");
+  const raw = parseManifestText(text, found);
+  const manifest = validateManifest(raw, found.path);
+  return { ...found, manifest, raw };
 }
 
-export async function readRequiredProjectConfig(
-  startDir = process.cwd(),
-): Promise<ProjectConfigRead> {
-  const read = await readProjectConfig(startDir);
+export async function readRequiredManifest(
+  startDir: string = process.cwd(),
+): Promise<ManifestRead> {
+  const read = await readManifest(startDir);
   if (!read) {
-    throw new HostedOrchError(`${CONFIG_FILE} not found. Run \`pome init\` first.`);
+    throw new HostedOrchError(
+      `No pome manifest found (${MANIFEST_JSON} or ${MANIFEST_YAML}). Run \`pome init\` first.`,
+    );
   }
   return read;
 }
 
-export async function writeProjectConfig(
+/** Serialize a manifest object to `path` in the given format. JSON is
+ *  pretty-printed with a trailing newline; YAML carries the schema pointer as a
+ *  language-server comment (the `$schema` key is dropped from the YAML body). */
+export async function writeManifest(
   path: string,
-  config: ProjectConfig,
+  format: ManifestFormat,
+  data: Record<string, unknown>,
 ): Promise<void> {
-  await writeFile(path, `${JSON.stringify(config, null, 2)}\n`);
+  if (format === "json") {
+    await writeFile(path, `${JSON.stringify(data, null, 2)}\n`);
+    return;
+  }
+  const { $schema: _dropped, ...body } = data;
+  await writeFile(path, `${YAML_SCHEMA_COMMENT}\n${stringifyYaml(body)}`);
 }
 
-export function normalizeConfigAgentId(config: ProjectConfig): string | undefined {
-  if (config.agentId === undefined) return undefined;
-  if (typeof config.agentId !== "string") {
-    throw new HostedOrchError(`${CONFIG_FILE} has malformed agentId; expected a string.`);
-  }
-  const trimmed = config.agentId.trim();
-  if (!trimmed.startsWith("agt_")) {
+function parseManifestText(
+  text: string,
+  found: ManifestLocation,
+): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = found.format === "json" ? JSON.parse(text) : parseYaml(text);
+  } catch (err) {
     throw new HostedOrchError(
-      `${CONFIG_FILE} has malformed agentId; expected an agt_ identifier.`,
+      `${found.path} is not valid ${found.format.toUpperCase()}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
     );
   }
-  return trimmed;
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new HostedOrchError(`${found.path} is not a ${found.format} object`);
+  }
+  return parsed as Record<string, unknown>;
 }
 
-/** FDRS-665 — the registered slug (written next to agentId by
- *  `pome register agent` / `pome install`). Server-canonical; treated as
- *  opaque here. Absent or malformed → undefined (the URL print falls back
- *  to the legacy /runs/task shape). */
-export function normalizeConfigAgentSlug(
-  config: ProjectConfig,
-): string | undefined {
-  if (typeof config.agentSlug !== "string") return undefined;
-  const trimmed = config.agentSlug.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
+function validateManifest(
+  raw: Record<string, unknown>,
+  path: string,
+): Manifest {
+  const result = manifestSchema.safeParse(raw);
+  if (result.success) return result.data;
+
+  const slugIssue = result.error.issues.find(
+    (issue) => issue.path[0] === "agent" && issue.path[1] === "slug",
+  );
+  if (slugIssue) {
+    throw new HostedOrchError(slugErrorMessage(raw, path));
+  }
+  const summary = result.error.issues
+    .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+    .join("; ");
+  throw new HostedOrchError(`Invalid pome manifest ${path}: ${summary}`);
 }
 
-export function normalizeConfigAgentSdk(config: ProjectConfig): string | null {
-  const sdk = config.agent?.sdk;
-  if (typeof sdk !== "string") return null;
-  const trimmed = sdk.trim();
-  return trimmed.length > 0 ? trimmed : null;
+/** The invalid-slug message names `SLUG_RE` and offers a slugified suggestion,
+ *  derived from `agent.name` when present else the offending slug value. */
+function slugErrorMessage(raw: Record<string, unknown>, path: string): string {
+  const agent =
+    typeof raw.agent === "object" && raw.agent !== null
+      ? (raw.agent as Record<string, unknown>)
+      : {};
+  const name = typeof agent.name === "string" ? agent.name : "";
+  const badSlug = typeof agent.slug === "string" ? agent.slug : "";
+  const suggestion = deriveAgentSlug(name || badSlug);
+  const base = `Invalid agent.slug in ${path}: must match ${SLUG_RE} (lowercase kebab-case, max 64 chars).`;
+  return suggestion.length > 0 ? `${base} Did you mean "${suggestion}"?` : base;
 }
 
-export function normalizeConfigAgentCommand(
-  config: ProjectConfig,
-): string | undefined {
-  const command = config.agent?.command;
-  if (typeof command !== "string") return undefined;
-  const trimmed = command.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await readFile(path, "utf8");
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw err;
+  }
 }

--- a/cli/src/cli/register.ts
+++ b/cli/src/cli/register.ts
@@ -1,80 +1,56 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// `pome register agent <name>` — equivalent of `vercel link`. Creates the
-// agent in the cloud control-plane and writes the returned `agentId` into
-// `pome.config.json` so subsequent `pome run` is auto-scoped to it.
+// `pome register agent <name>` / `pome install` — the vercel-link seam. POSTs
+// the manifest identity to `POST /v1/agents` (the F-820 slug resolver: live
+// slug → alias → near-miss 409 → auto-create under the caller's team), then
+// persists the server-canonical identity into `pome.json` and caches the
+// resolved `agt_` id in gitignored `.pome/link.json`.
 //
-// Wire shape (see pome-cloud `docs/05-api-spec.md` and ADR-013):
-//   POST /v1/agents  { name, twins? }
-//     200 { id: "agt_…", slug, display_name, judge_model, enabled_services? }
-//     401 invalid_auth | 409 conflict (slug exists) | 422 validation_failed
+// Wire shape (pome-cloud `docs/05-api-spec.md`, ADR-013, F-820):
+//   POST /v1/agents  { name, slug?, description?, version?, framework?, twins?, confirm? }
+//     200 AgentResponse { id, slug, display_name, judge_model, framework?, … }
+//     401/403 auth | 404 route skew | 409 conflict (near-miss w/ details.suggestion)
 //
-// The CLI does not invent a slug — server is canonical. We persist whatever
-// slug the server returns next to the id. Multi-twin (M3): `--twins` narrows
-// the services this agent may exercise; an older cloud that predates the field
-// omits `enabled_services` from its response (we warn but still succeed).
+// The registered `agt_` id is NEVER written to the committed manifest (that is
+// the fork-404 bug class): the manifest carries only the portable `agent.slug`.
 
 import { basename, dirname } from "node:path";
 
-import { MOUNTED_TWINS } from "@pome-sh/shared-types";
+import { MOUNTED_TWINS, type AgentResponse } from "@pome-sh/shared-types";
 import {
-  HostedAuthError,
-  HostedOrchError,
-} from "../hosted/errors.js";
-import { resolveCredentials } from "./credentials.js";
-import { friendlyHostedError } from "./session.js";
+  postAgentResolver,
+  resolveSeams,
+  type AgentPostBody,
+  type InteractiveSeams,
+} from "./agent-resolver.js";
+import { resolveCredentials, type ResolvedCredentials } from "./credentials.js";
+import { suggestFramework } from "./frameworks.js";
 import {
-  CONFIG_FILE,
-  normalizeConfigAgentId,
-  readProjectConfig,
-  readRequiredProjectConfig,
-  writeProjectConfig,
-  type ProjectConfigRead,
+  ensurePomeGitignored,
+  readLinkCache,
+  resolveCachedAgentId,
+  writeLinkCache,
+} from "./link-cache.js";
+import {
+  readManifest,
+  readRequiredManifest,
+  writeManifest,
+  type ManifestRead,
 } from "./project-config.js";
+import { friendlyHostedError } from "./session.js";
 
-interface RegisterAgentOptions {
+const SCHEMA_URL = "https://pome.sh/schemas/v1/pome.json";
+
+interface RegisterAgentOptions extends InteractiveSeams {
   apiBaseUrl: string;
   name: string;
   force: boolean;
-  /** Multi-twin (M3): the services this agent is allowed to exercise. Absent =
-   *  the server's default enablement. Validated against MOUNTED_TWINS locally
-   *  for a friendly error before the round-trip. */
   twins?: string[];
+  /** Test seam — forwarded to resolveCredentials. */
+  credentialsPath?: string;
 }
 
-interface AgentResponse {
-  id: string;
-  slug: string;
-  display_name: string;
-  judge_model: string;
-  /** Multi-twin (M3): services the agent may exercise. Absent on an older
-   *  cloud that predates the field. */
-  enabled_services?: string[];
-}
-
-function parseAgentResponse(raw: unknown): AgentResponse {
-  if (
-    typeof raw === "object" &&
-    raw !== null &&
-    typeof (raw as { id?: unknown }).id === "string" &&
-    typeof (raw as { slug?: unknown }).slug === "string" &&
-    typeof (raw as { display_name?: unknown }).display_name === "string" &&
-    typeof (raw as { judge_model?: unknown }).judge_model === "string"
-  ) {
-    const enabled = (raw as { enabled_services?: unknown }).enabled_services;
-    const enabledServices =
-      Array.isArray(enabled) && enabled.every((s) => typeof s === "string")
-        ? (enabled as string[])
-        : undefined;
-    return { ...(raw as AgentResponse), enabled_services: enabledServices };
-  }
-  throw new HostedOrchError("POST /v1/agents returned unexpected shape");
-}
-
-/** Normalize a `--twins github,slack` comma list to a validated twin array.
- *  Validates against MOUNTED_TWINS locally so a typo fails with a friendly
- *  error before the network round-trip. Returns undefined for an empty input
- *  (the server picks its default enablement). */
+/** Normalize a `--twins github,slack` comma list to a validated twin array. */
 export function normalizeRegisterTwins(raw: string | undefined): string[] | undefined {
   if (raw === undefined) return undefined;
   const twins = raw
@@ -89,122 +65,126 @@ export function normalizeRegisterTwins(raw: string | undefined): string[] | unde
       `Unknown twin(s) ${unknown.map((t) => `"${t}"`).join(", ")}. Supported: ${MOUNTED_TWINS.join(", ")}.`,
     );
   }
-  // De-dupe while preserving order.
   return [...new Set(twins)];
 }
 
-/** POST /v1/agents and persist the returned identity into the config read.
- *  Shared by `pome register agent` and `pome install` (FDRS-669). */
+// ── Persist: manifest + link cache + gitignore ──────────────────────────────
+
+/** Read the manifest's existing agent block (for round-trip preservation and
+ *  did-you-mean input) without forcing schema defaults. */
+function rawAgentBlock(manifestRead: ManifestRead): Record<string, unknown> {
+  const agent = manifestRead.raw.agent;
+  return typeof agent === "object" && agent !== null && !Array.isArray(agent)
+    ? (agent as Record<string, unknown>)
+    : {};
+}
+
+/** Warn (never block) when the manifest declares an unrecognized framework. */
+function warnUnknownFramework(existingAgent: Record<string, unknown>): void {
+  const framework = existingAgent.framework;
+  if (typeof framework !== "string" || framework.trim().length === 0) return;
+  const result = suggestFramework(framework);
+  if (result.known) return;
+  const hint = result.suggestion ? ` Did you mean "${result.suggestion}"?` : "";
+  console.error(`Unknown agent.framework "${framework}".${hint} (Recorded as-is.)`);
+}
+
+/** POST the resolver, then write the server-canonical identity into the
+ *  manifest (preserving format + unrelated keys), cache the id in
+ *  `.pome/link.json` (team-gated), and ensure `.pome/` is gitignored. */
 async function createAndPersistAgent(input: {
-  apiBaseUrl: string;
+  creds: ResolvedCredentials;
   name: string;
-  configRead: ProjectConfigRead;
-  credentialsPath?: string;
-  /** Multi-twin (M3): when set, POSTed as `twins` so the cloud records the
-   *  agent's enabled services. Omitted from the body when absent so an older
-   *  cloud (and the byte-identical `pome install` path) is unchanged. */
+  manifestRead: ManifestRead;
+  projectDir: string;
   twins?: string[];
+  seams: Required<InteractiveSeams>;
 }): Promise<AgentResponse> {
-  const creds = await resolveCredentials({
-    apiBaseUrl: input.apiBaseUrl,
-    credentialsPath: input.credentialsPath,
-  });
-  const body: Record<string, unknown> = { name: input.name };
-  if (input.twins && input.twins.length > 0) {
-    body.twins = input.twins;
-  }
-  const res = await fetch(`${creds.apiBaseUrl}/v1/agents`, {
-    method: "POST",
-    headers: {
-      "x-api-key": creds.apiKey,
-      "content-type": "application/json",
-    },
-    body: JSON.stringify(body),
-  }).catch((err: unknown) => {
-    throw new HostedOrchError(
-      err instanceof Error ? err.message : "network error",
-    );
-  });
+  const existingAgent = rawAgentBlock(input.manifestRead);
+  warnUnknownFramework(existingAgent);
 
-  const text = await res.text();
-  let json: unknown = {};
-  try {
-    json = text.length ? JSON.parse(text) : {};
-  } catch {
-    throw new HostedOrchError(`non-JSON response (status ${res.status})`);
-  }
-  if (!res.ok) {
-    const errObj = (json as { error?: { message?: string; type?: string } })
-      .error;
-    if (res.status === 401 || res.status === 403) {
-      throw new HostedAuthError(errObj?.message ?? `HTTP ${res.status}`);
-    }
-    if (res.status === 404) {
-      throw new HostedOrchError(
-        errObj?.message ??
-          "POST /v1/agents is not available at this API URL. Upgrade pome-cloud or check that --api-url/POME_API_URL points at a version that supports agent registration.",
-      );
-    }
-    throw new HostedOrchError(
-      errObj?.message ?? `POST /v1/agents → HTTP ${res.status}`,
-    );
-  }
+  const body: AgentPostBody = { name: input.name, twins: input.twins };
+  if (typeof existingAgent.description === "string") body.description = existingAgent.description;
+  if (typeof existingAgent.version === "string") body.version = existingAgent.version;
+  if (typeof existingAgent.framework === "string") body.framework = existingAgent.framework;
 
-  const agent = parseAgentResponse(json);
-  input.configRead.config.agentId = agent.id;
-  input.configRead.config.agentSlug = agent.slug;
-  await writeProjectConfig(input.configRead.path, input.configRead.config);
+  const agent = await postAgentResolver(input.creds, body, input.seams);
+
+  // Write the manifest from the response — slug + display name are canonical;
+  // description/version/framework fall back to the manifest when the cloud
+  // returns nothing (older control plane).
+  const nextAgent: Record<string, unknown> = { ...existingAgent, slug: agent.slug };
+  nextAgent.name = agent.display_name;
+  const description = agent.description ?? existingAgent.description;
+  if (typeof description === "string") nextAgent.description = description;
+  const version = agent.version ?? existingAgent.version;
+  if (typeof version === "string") nextAgent.version = version;
+  const framework = agent.framework ?? existingAgent.framework;
+  if (typeof framework === "string") nextAgent.framework = framework;
+
+  const nextRaw: Record<string, unknown> = {
+    ...input.manifestRead.raw,
+    agent: nextAgent,
+  };
+  if (typeof nextRaw.$schema !== "string") nextRaw.$schema = SCHEMA_URL;
+  await writeManifest(input.manifestRead.path, input.manifestRead.format, nextRaw);
+
+  // Cache the resolved id only when we know the caller's team (env-key auth
+  // has no local team; the cache stays absent and every run re-resolves).
+  if (input.creds.teamId) {
+    await writeLinkCache(input.projectDir, { agent_id: agent.id, team_id: input.creds.teamId });
+  }
+  await ensurePomeGitignored(input.projectDir);
   return agent;
 }
 
-export async function runRegisterAgent(
-  opts: RegisterAgentOptions,
-): Promise<void> {
-  const configRead = await readRequiredProjectConfig();
-  const existing = normalizeConfigAgentId(configRead.config) ?? null;
-  if (existing && !opts.force) {
-    console.error(
-      `Already registered agent ${existing}. Re-run with --force to overwrite.`,
-    );
-    return;
+export async function runRegisterAgent(opts: RegisterAgentOptions): Promise<void> {
+  const manifestRead = await readRequiredManifest();
+  const projectDir = dirname(manifestRead.path);
+  const creds = await resolveCredentials({
+    apiBaseUrl: opts.apiBaseUrl,
+    credentialsPath: opts.credentialsPath,
+  });
+
+  if (!opts.force) {
+    const cachedId = resolveCachedAgentId(await readLinkCache(projectDir), creds.teamId);
+    if (cachedId) {
+      console.error(
+        `Already linked to ${cachedId} (slug=${manifestRead.manifest.agent.slug}). Re-run with --force to re-resolve.`,
+      );
+      return;
+    }
   }
 
   const agent = await createAndPersistAgent({
-    apiBaseUrl: opts.apiBaseUrl,
+    creds,
     name: opts.name,
-    configRead,
+    manifestRead,
+    projectDir,
     twins: opts.twins,
+    seams: resolveSeams(opts),
   });
 
   const displayName = stripControlCharacters(agent.display_name);
-  console.error(
-    `Registered agent "${displayName}" (${agent.id}, slug=${agent.slug}).`,
-  );
-  console.error(`Wrote agentId to ${CONFIG_FILE}.`);
+  console.error(`Registered agent "${displayName}" (${agent.id}, slug=${agent.slug}).`);
+  console.error(`Wrote agent.slug to ${basename(manifestRead.path)}.`);
   console.error(`Judge model: ${agent.judge_model}.`);
-  // Multi-twin (M3): echo the services the cloud enabled. An older cloud that
-  // predates `enabled_services` omits it — warn so the user knows the twin
-  // scoping did not take effect on this control plane.
   if (agent.enabled_services !== undefined) {
     console.error(
       `Enabled services: ${agent.enabled_services.length > 0 ? agent.enabled_services.join(", ") : "(none)"}.`,
     );
   } else if (opts.twins && opts.twins.length > 0) {
-    // Only warn when the user asked to scope twins (`--twins`). An older cloud
-    // that predates `enabled_services` omits it; without `--twins` there was no
-    // scoping request to warn about, so a default `pome register agent` stays
-    // quiet (matches origin/main's silence in that path).
     console.error(
       "Enabled services: not reported by this pome cloud (older control plane) — twin scoping may not have taken effect.",
     );
   }
 }
 
-// ── FDRS-669 — `pome install` registration ─────────────────────────────────
+// ── `pome install` registration seam ────────────────────────────────────────
 
-export interface EnsureAgentRegisteredOptions {
+export interface EnsureAgentRegisteredOptions extends InteractiveSeams {
   apiBaseUrl: string;
-  /** Where to look for pome.config.json. Defaults to process.cwd(). */
+  /** Where to look for the manifest. Defaults to process.cwd(). */
   cwd?: string;
   /** Test seam — forwarded to resolveCredentials. */
   credentialsPath?: string;
@@ -215,31 +195,37 @@ export type EnsureAgentRegisteredResult =
   | { status: "already-registered"; agentId: string; agentSlug?: string }
   | { status: "no-config" };
 
-/** Idempotent registration for `pome install`: a repo with an agentId keeps
- *  it (no duplicate agents, no error, same slug); a fresh repo registers
- *  under the config directory's basename (vercel-link shape — the server
- *  canonicalizes the slug; we persist whatever it returns). */
+/** Idempotent registration for `pome install`: a repo already linked under the
+ *  caller's team keeps its id (no network, no duplicate); a fresh repo registers
+ *  under the manifest name (or the config directory's basename). */
 export async function ensureAgentRegistered(
   opts: EnsureAgentRegisteredOptions,
 ): Promise<EnsureAgentRegisteredResult> {
-  const configRead = await readProjectConfig(opts.cwd ?? process.cwd());
-  if (!configRead) return { status: "no-config" };
+  const manifestRead = await readManifest(opts.cwd ?? process.cwd());
+  if (!manifestRead) return { status: "no-config" };
 
-  const existing = normalizeConfigAgentId(configRead.config);
-  if (existing) {
-    const slug = configRead.config.agentSlug;
+  const projectDir = dirname(manifestRead.path);
+  const creds = await resolveCredentials({
+    apiBaseUrl: opts.apiBaseUrl,
+    credentialsPath: opts.credentialsPath,
+  });
+
+  const cachedId = resolveCachedAgentId(await readLinkCache(projectDir), creds.teamId);
+  if (cachedId) {
     return {
       status: "already-registered",
-      agentId: existing,
-      agentSlug: typeof slug === "string" && slug.trim() ? slug.trim() : undefined,
+      agentId: cachedId,
+      agentSlug: manifestRead.manifest.agent.slug,
     };
   }
 
+  const name = manifestRead.manifest.agent.name ?? basename(projectDir);
   const agent = await createAndPersistAgent({
-    apiBaseUrl: opts.apiBaseUrl,
-    name: basename(dirname(configRead.path)),
-    configRead,
-    credentialsPath: opts.credentialsPath,
+    creds,
+    name,
+    manifestRead,
+    projectDir,
+    seams: resolveSeams(opts),
   });
   return { status: "registered", agentId: agent.id, agentSlug: agent.slug };
 }

--- a/cli/src/cli/session.ts
+++ b/cli/src/cli/session.ts
@@ -11,9 +11,9 @@ import {
   HostedOrchError,
   HostedQuotaError,
 } from "../hosted/errors.js";
+import { resolveRunAgentIdentity } from "./agent-identity.js";
 import { resolveCredentials } from "./credentials.js";
 import { DEFAULT_DASHBOARD_URL } from "./defaults.js";
-import { normalizeConfigAgentId, readProjectConfig } from "./project-config.js";
 
 // Defensive append: the server's per_twin.mcp_url has been observed missing
 // the `/mcp` suffix that agents need to mount the MCP transport (F19). The
@@ -147,16 +147,17 @@ export async function runSessionCreate(opts: {
     baseUrl: creds.apiBaseUrl,
     apiKey: creds.apiKey,
   });
-  const configRead = await readProjectConfig(process.cwd());
-  const agentId = configRead
-    ? normalizeConfigAgentId(configRead.config)
-    : undefined;
+  const identity = await resolveRunAgentIdentity({
+    startDir: process.cwd(),
+    apiBaseUrl: creds.apiBaseUrl,
+  });
 
   const session = await client.createSession({
     twins,
     scenarioSource: "# ..\n",
     idempotencyKey: randomUUID(),
-    agentId,
+    agentId: identity.agentId,
+    agentVersion: identity.agentVersion,
   });
 
   if (opts.secretsFile) {

--- a/cli/src/doctor/checks.ts
+++ b/cli/src/doctor/checks.ts
@@ -12,10 +12,10 @@
 
 import { serve } from "@hono/node-server";
 import { randomBytes, randomUUID } from "node:crypto";
-import { dirname, relative } from "node:path";
+import { basename, dirname, relative } from "node:path";
 import { sign } from "hono/jwt";
 import { buildEgressAllowlist } from "../capture-server/egress.js";
-import { findProjectConfigPath, readProjectConfig } from "../cli/project-config.js";
+import { findManifestPath, readManifest } from "../cli/project-config.js";
 import { getAvailablePort } from "../runner/ports.js";
 import { scanAgentSources } from "./scan.js";
 
@@ -79,49 +79,49 @@ export async function runDoctorChecks(
 type ConfigCheck = DoctorCheck & { configDir?: string };
 
 async function checkConfig(cwd: string): Promise<ConfigCheck> {
-  const path = await findProjectConfigPath(cwd);
-  if (!path) {
+  let found;
+  try {
+    found = await findManifestPath(cwd);
+  } catch (err) {
+    // Two manifests in one directory (pome.json + pome.yaml) is a hard error.
     return {
       id: "config",
       status: "fail",
-      label: "pome.config.json not found",
-      cause: `no pome.config.json found in ${cwd} or any parent directory.`,
+      label: "pome manifest is ambiguous",
+      cause: err instanceof Error ? err.message : String(err),
+      fix: "keep exactly one manifest (pome.json is canonical), then re-run pome doctor",
+    };
+  }
+  if (!found) {
+    return {
+      id: "config",
+      status: "fail",
+      label: "pome manifest not found",
+      cause: `no pome.json or pome.yaml found in ${cwd} or any parent directory.`,
       fix: "run pome init to scaffold one, then re-run pome doctor",
     };
   }
 
+  // readManifest validates against the shared-types schema (slug shape,
+  // command non-empty, etc.) and throws a named cause on any violation.
   let read;
   try {
-    read = await readProjectConfig(cwd);
-  } catch {
-    read = null;
-  }
-  if (!read) {
+    read = await readManifest(cwd);
+  } catch (err) {
     return {
       id: "config",
       status: "fail",
-      label: "pome.config.json is not valid",
-      cause: `${path} exists but is not parseable JSON.`,
-      fix: "fix the JSON (or delete the file and run pome init), then re-run pome doctor",
-    };
-  }
-
-  const command = read.config.agent?.command;
-  if (command !== undefined && (typeof command !== "string" || command.trim().length === 0)) {
-    return {
-      id: "config",
-      status: "fail",
-      label: "pome.config.json is not valid",
-      cause: `${path} has an agent.command that is not a non-empty string.`,
-      fix: 'set agent.command to the command that starts your agent, e.g. "npx tsx src/index.ts"',
+      label: `${basename(found.path)} is not valid`,
+      cause: err instanceof Error ? err.message : String(err),
+      fix: "fix the manifest (or delete it and run pome init), then re-run pome doctor",
     };
   }
 
   return {
     id: "config",
     status: "pass",
-    label: "pome.config.json found",
-    configDir: dirname(read.path),
+    label: `${basename(read!.path)} found`,
+    configDir: dirname(read!.path),
   };
 }
 

--- a/cli/src/hosted/client.ts
+++ b/cli/src/hosted/client.ts
@@ -98,11 +98,16 @@ export interface CreateSessionInput {
   twins: string[];
   /** Omit for one-off sessions; reuse only when intentionally replaying a create after network uncertainty. */
   idempotencyKey?: string;
-  /** Agents-as-first-class-entity (ADR-013). Resolved from pome.config.json's
-   *  `agentId` by callers. Server validates `agent.team_id === apiKey.team_id`
-   *  and `requested_twins ⊆ agent_enabled_services`. Optional during rollout;
+  /** Agents-as-first-class-entity (ADR-013). Resolved by callers from the
+   *  manifest slug via `.pome/link.json` / the `POST /v1/agents` resolver
+   *  (F-819). Server validates `agent.team_id === apiKey.team_id` and
+   *  `requested_twins ⊆ agent_enabled_services`. Optional during rollout;
    *  will become required once the dashboard / control-plane catch up. */
   agentId?: string;
+  /** F-818 (spec F-804): per-run agent version. The manifest's `agent.version`,
+   *  or the `--agent-version` override. Opaque, user-declared; stamped onto the
+   *  session/run rows (F-820). An older cloud strips it, so sending is safe. */
+  agentVersion?: string;
   /** Pre-resolved seed JSON. When supplied, cloud uses it directly and skips
    *  extracting JSON from the scenario markdown — required for the post-2026-05-22
    *  prose `## Seed State` shape, where the markdown has no fenced JSON block. */
@@ -156,8 +161,8 @@ export interface SubmitResultInput {
   judgeTokensIn: number | null;
   judgeTokensOut: number | null;
   // Free-form SDK / framework label persisted to runs.agent_sdk (pome-cloud
-  // ADR-013). CLI reads it from `pome.config.json` { agent: { sdk: "..." } };
-  // common values: "claude-agent-sdk", "openai-agents", "openclaw", "hermes",
+  // ADR-013). CLI reads it from the manifest's `agent.framework` (F-819);
+  // common values: "claude-agent-sdk", "openai-agents", "langgraph",
   // "custom". Omit / null when the user has not declared it — control-plane
   // accepts both shapes.
   agentSdk?: string | null;
@@ -790,6 +795,9 @@ export function createHostedClient(config: HostedClientConfig): HostedClient {
       }
       if (input.agentId) {
         body.agent_id = input.agentId;
+      }
+      if (input.agentVersion) {
+        body.agent_version = input.agentVersion;
       }
       if (input.seed !== undefined) {
         body.seed = input.seed;

--- a/cli/src/runner/groupRender.ts
+++ b/cli/src/runner/groupRender.ts
@@ -3,9 +3,9 @@
 // matching the design-of-record (CLI moments.dc.html moment 04,
 // task/code-model vocabulary):
 //
-//   -n sets how many isolated trials to run · the agent command comes from pome.config.json
+//   -n sets how many isolated trials to run · the agent command comes from pome.json
 //   provisioning 5 isolated github twins … ready
-//   spawning agent <cmd> · from pome.config.json …
+//   spawning agent <cmd> · from pome.json …
 //   trial 1  ✓  100      14.3s
 //   trial 2  ✓  96       12.1s
 //   trial 3  ✗  58       15.9s  <failing criteria summary>
@@ -36,7 +36,7 @@ export type TrialRow =
   | { kind: "errored"; reason: string };
 
 /** The muted hint under the command echo, naming where the agent command
- *  came from (pome.config.json / --agent / the built-in default). */
+ *  came from (pome.json / --agent / the built-in default). */
 export function flagHintLine(agentCommandSource: string): string {
   return `-n sets how many isolated trials to run · the agent command comes from ${agentCommandSource}`;
 }

--- a/cli/src/runner/runScenarioHosted.ts
+++ b/cli/src/runner/runScenarioHosted.ts
@@ -22,11 +22,7 @@ import {
   scoreFromFinalizeResponse,
   uploadRunBlobs,
 } from "../hosted/uploadAndFinalize.js";
-import {
-  normalizeConfigAgentId,
-  normalizeConfigAgentSdk,
-  readProjectConfig,
-} from "../cli/project-config.js";
+import { resolveRunAgentIdentity } from "../cli/agent-identity.js";
 import { HostedOrchError, HostedTrialError } from "../hosted/errors.js";
 import type {
   CreateSessionResponse,
@@ -47,6 +43,9 @@ export interface RunScenarioHostedOptions {
   client?: HostedClient;
   /** Informational; passed through to `runs.agent_model`. Defaults to "unknown". */
   agentModel?: string;
+  /** F-819 — `--agent-version` override. Wins over the manifest's
+   *  `agent.version` when stamping the session/run. */
+  agentVersion?: string;
   /** FDRS-636 — a session minted by the caller (trial groups mint all k
    *  upfront with one shared `group_id`). When set, the runner skips its own
    *  POST /v1/sessions and runs against this session; the `finally` teardown
@@ -216,18 +215,19 @@ export async function runScenarioHosted(
     options.client ??
     createHostedClient({ baseUrl: options.hosted.baseUrl, apiKey: options.hosted.apiKey });
 
-  // ADR-013 — resolve agentId + agent.sdk from pome.config.json. Hosted runs
-  // are grouped under the agent the user registered with `pome register
-  // agent`. `agent.sdk` is a free-form string ("claude-agent-sdk",
-  // "openai-agents", "openclaw", "hermes", "custom") that the dashboard
-  // surfaces as a badge on every run. Both are optional during rollout.
-  let agentId: string | undefined;
-  let agentSdk: string | null = null;
-  const configRead = await readProjectConfig(dirname(options.scenarioPath));
-  if (configRead) {
-    agentId = normalizeConfigAgentId(configRead.config);
-    agentSdk = normalizeConfigAgentSdk(configRead.config);
-  }
+  // F-819 — resolve the agent id + version from the manifest (`agent.slug` →
+  // `.pome/link.json` cache, team-gated, re-resolved by slug on miss) and the
+  // `agent.framework` (the dashboard "SDK badge", formerly `agent.sdk`). The
+  // `agent_version` stamps the session; `--agent-version` overrides it. All are
+  // optional during rollout — a manifest-less repo runs unattributed.
+  const identity = await resolveRunAgentIdentity({
+    startDir: dirname(options.scenarioPath),
+    apiBaseUrl: options.hosted.baseUrl,
+    agentVersionOverride: options.agentVersion,
+  });
+  const agentId = identity.agentId;
+  const agentVersion = identity.agentVersion;
+  const agentSdk = identity.framework ?? null;
 
   // Per-run signals file. POME_ADAPTER_SIGNALS_PATH is injected into the agent
   // env so adapter-rich correlator gets step/tool_call signals when the agent
@@ -252,6 +252,7 @@ export async function runScenarioHosted(
       scenarioSource,
       twins: scenario.config.twins,
       agentId,
+      agentVersion,
       seed: scenario.seedState,
     },
   );
@@ -720,6 +721,7 @@ async function createSessionOrExplain(
     scenarioSource: string;
     twins: string[];
     agentId?: string;
+    agentVersion?: string;
     seed: unknown;
   },
 ): Promise<CreateSessionResponse> {

--- a/cli/src/runner/runTrialGroup.ts
+++ b/cli/src/runner/runTrialGroup.ts
@@ -43,11 +43,7 @@ import { newGroupId } from "../demo/ids.js";
 import { criterionPhrase } from "../demo/render.js";
 import { parseScenarioFile } from "../scenario/parseScenario.js";
 import { outcomeOf } from "../hosted/evalResultView.js";
-import {
-  normalizeConfigAgentId,
-  normalizeConfigAgentSlug,
-  readProjectConfig,
-} from "../cli/project-config.js";
+import { resolveRunAgentIdentity } from "../cli/agent-identity.js";
 import { runScenarioHosted } from "./runScenarioHosted.js";
 import {
   fixHandoffLines,
@@ -76,7 +72,7 @@ export interface RunTrialGroupOptions {
   scenarioPath: string;
   agentCommand: string;
   /** Where the agent command came from, for the header copy
-   *  ("pome.config.json" | "--agent" | "built-in default"). */
+   *  ("pome.json" | "--agent" | "built-in default"). */
   agentCommandSource?: string;
   /** Effective k (2..20). k=1 must take the single-run path instead. */
   trials: number;
@@ -87,6 +83,8 @@ export interface RunTrialGroupOptions {
   dashboardBaseUrl: string;
   /** Informational; forwarded to every trial's `runs.agent_model`. */
   agentModel?: string;
+  /** F-819 — `--agent-version` override, forwarded to every trial's session. */
+  agentVersion?: string;
   /** FDRS-644 — the literal command the fix handoff tells the user to
    *  re-run after their coding agent applies a fix. The caller knows the
    *  invocation shape (bare `pome run` vs an explicit path + -n); default
@@ -126,19 +124,20 @@ export async function runTrialGroup(
       timeoutMs: GROUP_FINALIZE_TIMEOUT_MS,
     });
   const groupId = options.groupId ?? newGroupId();
-  const agentCommandSource = options.agentCommandSource ?? "pome.config.json";
+  const agentCommandSource = options.agentCommandSource ?? "pome.json";
 
   const scenario = await parseScenarioFile(options.scenarioPath);
   const scenarioSource = await readFile(options.scenarioPath, "utf8");
-  // Same agent resolution as the single-run path (ADR-013): the group's
-  // trials are recorded under the agent pinned in pome.config.json.
-  const configRead = await readProjectConfig(dirname(options.scenarioPath));
-  const agentId = configRead
-    ? normalizeConfigAgentId(configRead.config)
-    : undefined;
-  const agentSlug = configRead
-    ? normalizeConfigAgentSlug(configRead.config)
-    : undefined;
+  // Same agent resolution as the single-run path (F-819): the group's trials
+  // are recorded under the agent the manifest's `agent.slug` resolves to.
+  const identity = await resolveRunAgentIdentity({
+    startDir: dirname(options.scenarioPath),
+    apiBaseUrl: options.hosted.baseUrl,
+    agentVersionOverride: options.agentVersion,
+  });
+  const agentId = identity.agentId;
+  const agentVersion = identity.agentVersion;
+  const agentSlug = identity.agentSlug;
 
   out(flagHintLine(agentCommandSource));
   out("");
@@ -151,6 +150,7 @@ export async function runTrialGroup(
       scenarioSource,
       twins: scenario.config.twins,
       agentId,
+      agentVersion,
       seed: scenario.seedState,
       groupId,
       // Fresh idempotency key per mint — the mint bodies are otherwise

--- a/cli/test/e2e/doctor.test.ts
+++ b/cli/test/e2e/doctor.test.ts
@@ -16,8 +16,8 @@ describe("pome doctor — wired triage-agent acceptance (FDRS-634)", () => {
     const exampleSrc = new URL("../../../examples/triage-agent/src/", import.meta.url).pathname;
     await cp(exampleSrc, join(dir, "src"), { recursive: true });
     await writeFile(
-      join(dir, "pome.config.json"),
-      JSON.stringify({ agent: { command: "npm start", sdk: "claude" } }, null, 2) + "\n",
+      join(dir, "pome.json"),
+      JSON.stringify({ agent: { slug: "triage-agent", framework: "claude" }, command: "npm start" }, null, 2) + "\n",
     );
 
     const report = await runDoctorChecks({ cwd: dir, env: {} });

--- a/cli/test/e2e/runScenarioHosted.test.ts
+++ b/cli/test/e2e/runScenarioHosted.test.ts
@@ -123,8 +123,8 @@ describe("pome run --hosted (e2e via spawn)", () => {
     // runs). Make tmp a wired repo and spawn the CLI from it, matching what
     // a real post-`pome install` project looks like.
     await writeFile(
-      join(tmp, "pome.config.json"),
-      JSON.stringify({ agent: { command: "true" } }, null, 2),
+      join(tmp, "pome.json"),
+      JSON.stringify({ agent: { slug: "e2e-agent" }, command: "true" }, null, 2),
       "utf8"
     );
     await mkdir(join(tmp, "src"), { recursive: true });

--- a/cli/test/unit/agent-identity.test.ts
+++ b/cli/test/unit/agent-identity.test.ts
@@ -1,0 +1,122 @@
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { resolveRunAgentIdentity } from "../../src/cli/agent-identity.js";
+import { writeLinkCache } from "../../src/cli/link-cache.js";
+
+const tempDirs: string[] = [];
+const savedKey = process.env.POME_API_KEY;
+
+function response(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function makeProject(manifest: unknown): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "pome-identity-"));
+  tempDirs.push(dir);
+  await writeFile(join(dir, "pome.json"), JSON.stringify(manifest));
+  return dir;
+}
+
+async function writeCreds(dir: string, teamId: string): Promise<string> {
+  const path = join(dir, "creds.json");
+  await writeFile(
+    path,
+    JSON.stringify({ api_key: "pme_test", api_url: "https://api.example.com", dashboard_url: "https://app", team_id: teamId }),
+  );
+  await chmod(path, 0o600);
+  return path;
+}
+
+beforeEach(() => {
+  delete process.env.POME_API_KEY;
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+afterEach(async () => {
+  if (savedKey === undefined) delete process.env.POME_API_KEY;
+  else process.env.POME_API_KEY = savedKey;
+  vi.restoreAllMocks();
+  await Promise.all(tempDirs.splice(0).map((d) => rm(d, { recursive: true, force: true })));
+});
+
+describe("resolveRunAgentIdentity", () => {
+  it("returns {} with only the version override when no manifest is present", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pome-identity-empty-"));
+    tempDirs.push(dir);
+    const id = await resolveRunAgentIdentity({ startDir: dir, apiBaseUrl: "https://api.example.com" });
+    expect(id).toEqual({});
+
+    const withOverride = await resolveRunAgentIdentity({
+      startDir: dir,
+      apiBaseUrl: "https://api.example.com",
+      agentVersionOverride: "9.9.9",
+    });
+    expect(withOverride).toEqual({ agentVersion: "9.9.9" });
+  });
+
+  it("short-circuits to the cached agent_id when the team matches (no network)", async () => {
+    const dir = await makeProject({ agent: { slug: "pr-review-agent", version: "0.2.0", framework: "langgraph" } });
+    const credentialsPath = await writeCreds(dir, "tm_team");
+    await writeLinkCache(dir, { agent_id: "agt_cached", team_id: "tm_team" });
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+
+    const id = await resolveRunAgentIdentity({ startDir: dir, apiBaseUrl: "https://api.example.com", credentialsPath });
+
+    expect(id).toMatchObject({ agentId: "agt_cached", agentVersion: "0.2.0", framework: "langgraph" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("re-resolves by slug (silently) when the cached team differs, and refreshes the cache", async () => {
+    const dir = await makeProject({ agent: { slug: "pr-review-agent" } });
+    const credentialsPath = await writeCreds(dir, "tm_new");
+    // Cache belongs to a FOREIGN team — must never be surfaced.
+    await writeLinkCache(dir, { agent_id: "agt_foreign", team_id: "tm_old" });
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(response({ id: "agt_fresh", slug: "pr-review-agent", display_name: "PR", judge_model: "m" }));
+
+    const id = await resolveRunAgentIdentity({ startDir: dir, apiBaseUrl: "https://api.example.com", credentialsPath });
+
+    expect(id.agentId).toBe("agt_fresh");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(String((fetchMock.mock.calls[0]![1] as RequestInit).body));
+    expect(body.slug).toBe("pr-review-agent");
+    // Cache refreshed under the caller's team.
+    expect(JSON.parse(readFileSync(join(dir, ".pome", "link.json"), "utf8"))).toMatchObject({
+      agent_id: "agt_fresh",
+      team_id: "tm_new",
+    });
+  });
+
+  it("the version override wins over the manifest agent.version", async () => {
+    const dir = await makeProject({ agent: { slug: "pr-review-agent", version: "0.2.0" } });
+    const credentialsPath = await writeCreds(dir, "tm_team");
+    await writeLinkCache(dir, { agent_id: "agt_cached", team_id: "tm_team" });
+
+    const id = await resolveRunAgentIdentity({
+      startDir: dir,
+      apiBaseUrl: "https://api.example.com",
+      credentialsPath,
+      agentVersionOverride: "1.2.3",
+    });
+    expect(id.agentVersion).toBe("1.2.3");
+  });
+
+  it("degrades to unattributed (no throw) when resolution fails", async () => {
+    const dir = await makeProject({ agent: { slug: "pr-review-agent", version: "0.2.0" } });
+    const credentialsPath = await writeCreds(dir, "tm_team");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response({ error: { type: "internal_error", message: "boom", request_id: "r" } }, 500));
+
+    const id = await resolveRunAgentIdentity({ startDir: dir, apiBaseUrl: "https://api.example.com", credentialsPath });
+    // No cache, resolution 500s → agentId undefined, but version still flows.
+    expect(id.agentId).toBeUndefined();
+    expect(id.agentVersion).toBe("0.2.0");
+  });
+});

--- a/cli/test/unit/doctor/checks.test.ts
+++ b/cli/test/unit/doctor/checks.test.ts
@@ -29,35 +29,35 @@ async function repo(files: Record<string, string>): Promise<string> {
   return dir;
 }
 
-const VALID_CONFIG = JSON.stringify({ agent: { command: "npx tsx src/agent.ts", sdk: "claude" } });
+const VALID_CONFIG = JSON.stringify({ agent: { slug: "test-agent", framework: "claude" }, command: "npx tsx src/agent.ts" });
 
 describe("runDoctorChecks", () => {
-  it("fails the config check when no pome.config.json exists, pointing at pome init", async () => {
+  it("fails the config check when no pome manifest exists, pointing at pome init", async () => {
     const dir = await repo({ "src/agent.ts": WIRED_AGENT });
 
     const report = await runDoctorChecks({ cwd: dir });
     expect(report.ok).toBe(false);
     expect(report.checks).toHaveLength(1);
     expect(report.checks[0]).toMatchObject({ id: "config", status: "fail" });
-    expect(report.checks[0]!.cause).toContain("pome.config.json");
+    expect(report.checks[0]!.cause).toContain("pome.json");
     expect(report.checks[0]!.fix).toContain("pome init");
   });
 
   it("fails the config check on unparseable JSON, naming the file", async () => {
     const dir = await repo({
-      "pome.config.json": "{ not json",
+      "pome.json": "{ not json",
       "src/agent.ts": WIRED_AGENT,
     });
 
     const report = await runDoctorChecks({ cwd: dir });
     expect(report.ok).toBe(false);
     expect(report.checks[0]).toMatchObject({ id: "config", status: "fail" });
-    expect(report.checks[0]!.cause).toContain("pome.config.json");
+    expect(report.checks[0]!.cause).toContain("pome.json");
   });
 
   it("passes all four checks on a correctly wired repo", async () => {
     const dir = await repo({
-      "pome.config.json": VALID_CONFIG,
+      "pome.json": VALID_CONFIG,
       "src/agent.ts": WIRED_AGENT,
     });
 
@@ -73,7 +73,7 @@ describe("runDoctorChecks", () => {
 
   it("fails routing on a hardcoded production host with file:line cause and env-read fix", async () => {
     const dir = await repo({
-      "pome.config.json": VALID_CONFIG,
+      "pome.json": VALID_CONFIG,
       "src/agent.ts": [
         'import fetch from "node-fetch";',
         'const gh = "https://api.github.com";',
@@ -96,7 +96,7 @@ describe("runDoctorChecks", () => {
 
   it("fails routing when no wiring evidence exists at all", async () => {
     const dir = await repo({
-      "pome.config.json": VALID_CONFIG,
+      "pome.json": VALID_CONFIG,
       "src/agent.ts": "export const nothing = 1;",
     });
 
@@ -109,7 +109,7 @@ describe("runDoctorChecks", () => {
 
   it("skips the local twin boot in hosted mode but still gates config/routing/egress", async () => {
     const dir = await repo({
-      "pome.config.json": VALID_CONFIG,
+      "pome.json": VALID_CONFIG,
       "src/agent.ts": WIRED_AGENT,
     });
 
@@ -124,7 +124,7 @@ describe("runDoctorChecks", () => {
 
   it("fails the egress check when a wildcard disables the floor", async () => {
     const dir = await repo({
-      "pome.config.json": VALID_CONFIG,
+      "pome.json": VALID_CONFIG,
       "src/agent.ts": WIRED_AGENT,
     });
 

--- a/cli/test/unit/eval-command.test.ts
+++ b/cli/test/unit/eval-command.test.ts
@@ -304,16 +304,15 @@ describe("pome eval meta parsing + identity derivation (FDRS-656)", () => {
     expect(() => deriveEvalIdentity(meta, { agent: "a" }, null)).toThrow(/--task/);
   });
 
-  it("agent precedence: --agent > config agentSlug > config agentId", () => {
+  it("agent precedence: --agent > manifest agent.slug", () => {
     const meta = parseRunMeta(META);
-    const config = { agentSlug: "triage-bot", agentId: "agt_123" };
-    expect(deriveEvalIdentity(meta, { agent: "cli-agent" }, config).agent).toBe(
+    const identity = { agentSlug: "triage-bot" };
+    expect(deriveEvalIdentity(meta, { agent: "cli-agent" }, identity).agent).toBe(
       "cli-agent",
     );
-    expect(deriveEvalIdentity(meta, {}, config).agent).toBe("triage-bot");
-    expect(deriveEvalIdentity(meta, {}, { agentId: "agt_123" }).agent).toBe(
-      "agt_123",
-    );
+    expect(deriveEvalIdentity(meta, {}, identity).agent).toBe("triage-bot");
+    // No id fallback — identity is the portable slug (agt_ ids never leak here).
+    expect(() => deriveEvalIdentity(meta, {}, {})).toThrow(/--agent/);
   });
 
   it("no agent anywhere → usage error naming --agent and pome register", () => {
@@ -777,8 +776,8 @@ describe("pome eval review fixes (FDRS-656 follow-up)", () => {
     const projectDir = join(tmp, "project");
     await mkdir(projectDir, { recursive: true });
     await writeFile(
-      join(projectDir, "pome.config.json"),
-      JSON.stringify({ agentSlug: "cfg-bot" }),
+      join(projectDir, "pome.json"),
+      JSON.stringify({ agent: { slug: "cfg-bot" } }),
     );
     const externalRoot = join(tmp, "external");
     await mkdir(externalRoot, { recursive: true });
@@ -799,10 +798,10 @@ describe("pome eval review fixes (FDRS-656 follow-up)", () => {
     ]);
   });
 
-  it("corrupt pome.config.json → named usage error", async () => {
+  it("corrupt pome manifest → named usage error", async () => {
     const projectDir = join(tmp, "project-corrupt");
     await mkdir(projectDir, { recursive: true });
-    await writeFile(join(projectDir, "pome.config.json"), "{nope");
+    await writeFile(join(projectDir, "pome.json"), "{nope");
     const runDir = await writeRunDir(projectDir);
     const { client } = makeEvalClient();
     mockPutFetch();
@@ -817,7 +816,7 @@ describe("pome eval review fixes (FDRS-656 follow-up)", () => {
       (e: unknown) => e,
     );
     expect(err).toBeInstanceOf(HostedUsageError);
-    expect((err as Error).message).toContain("pome.config.json is corrupt");
+    expect((err as Error).message).toContain("pome manifest is corrupt");
   });
 
   it("meta exit_code accepts integer-like strings; unknown sends -1, never 0", async () => {

--- a/cli/test/unit/frameworks.test.ts
+++ b/cli/test/unit/frameworks.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { KNOWN_FRAMEWORKS, suggestFramework } from "../../src/cli/frameworks.js";
+
+describe("suggestFramework", () => {
+  it("accepts a known framework (case-insensitive)", () => {
+    expect(suggestFramework("langgraph")).toEqual({ known: true });
+    expect(suggestFramework("LangGraph")).toEqual({ known: true });
+    expect(suggestFramework("claude-agent-sdk")).toEqual({ known: true });
+  });
+
+  it("suggests the nearest known framework for a close typo", () => {
+    expect(suggestFramework("langraph")).toEqual({ known: false, suggestion: "langgraph" });
+    expect(suggestFramework("openai-agent")).toEqual({ known: false, suggestion: "openai-agents" });
+  });
+
+  it("returns no suggestion for something far from every known framework", () => {
+    expect(suggestFramework("totally-made-up-xyz")).toEqual({ known: false });
+  });
+
+  it("exposes the known set as a non-empty list", () => {
+    expect(KNOWN_FRAMEWORKS.length).toBeGreaterThan(0);
+    expect(KNOWN_FRAMEWORKS).toContain("langgraph");
+  });
+});

--- a/cli/test/unit/init-sdk.test.ts
+++ b/cli/test/unit/init-sdk.test.ts
@@ -18,7 +18,7 @@ afterEach(async () => {
 });
 
 describe("pome init --sdk", () => {
-  it("--sdk claude scaffolds the Claude Agent SDK starter and sets agent.sdk", async () => {
+  it("--sdk claude scaffolds the Claude Agent SDK starter and sets agent.framework", async () => {
     const projectDir = await mkdtemp(join(tmpdir(), "pome-init-sdk-"));
     tempDirs.push(projectDir);
     process.chdir(projectDir);
@@ -39,11 +39,11 @@ describe("pome init --sdk", () => {
     expect(agentSource).toContain("withPome()");
     expect(agentSource).toContain("POME_GITHUB_REST_URL");
 
-    const cfg = JSON.parse(readFileSync("pome.config.json", "utf8")) as {
-      agent: { sdk?: string; command?: string };
+    const cfg = JSON.parse(readFileSync("pome.json", "utf8")) as {
+      agent: { framework?: string }; command?: string;
     };
-    expect(cfg.agent.sdk).toBe("claude");
-    expect(cfg.agent.command).toBe(
+    expect(cfg.agent.framework).toBe("claude");
+    expect(cfg.command).toBe(
       "npx tsx examples/agents/claude-sdk-agent.ts",
     );
   });
@@ -66,7 +66,7 @@ describe("pome init --sdk", () => {
     const messages = errSpy.mock.calls.map((c) => String(c[0])).join("\n");
     expect(messages).toContain('Unknown --sdk value "made-up"');
     // Validation happens before any filesystem writes.
-    expect(existsSync("pome.config.json")).toBe(false);
+    expect(existsSync("pome.json")).toBe(false);
     expect(existsSync("scenarios")).toBe(false);
     expect(existsSync("runs")).toBe(false);
     expect(existsSync("examples/agents/claude-sdk-agent.ts")).toBe(false);
@@ -91,14 +91,14 @@ describe("pome init --sdk", () => {
     const messages = errSpy.mock.calls.map((c) => String(c[0])).join("\n");
     expect(messages).toContain("Claude Managed Agent is not yet supported");
     // The deferred SDK is rejected before starter files/directories are copied.
-    expect(existsSync("pome.config.json")).toBe(false);
+    expect(existsSync("pome.json")).toBe(false);
     expect(existsSync("scenarios")).toBe(false);
     expect(existsSync("runs")).toBe(false);
     expect(existsSync("examples/agents/claude-sdk-agent.ts")).toBe(false);
     process.exitCode = 0;
   });
 
-  it("plain `pome init` (no --sdk) still scaffolds the scripted agent and omits agent.sdk", async () => {
+  it("plain `pome init` (no --sdk) still scaffolds the scripted agent and omits agent.framework", async () => {
     const projectDir = await mkdtemp(join(tmpdir(), "pome-init-plain-"));
     tempDirs.push(projectDir);
     process.chdir(projectDir);
@@ -106,16 +106,16 @@ describe("pome init --sdk", () => {
 
     await createProgram().parseAsync(["node", "pome", "init"]);
 
-    const cfg = JSON.parse(readFileSync("pome.config.json", "utf8")) as {
-      agent: { sdk?: string; command?: string };
+    const cfg = JSON.parse(readFileSync("pome.json", "utf8")) as {
+      agent: { framework?: string }; command?: string;
     };
-    expect(cfg.agent.sdk).toBeUndefined();
-    expect(cfg.agent.command).toBe(
+    expect(cfg.agent.framework).toBeUndefined();
+    expect(cfg.command).toBe(
       "npx tsx examples/agents/scripted-triage-agent.ts",
     );
   });
 
-  it("rerunning a plain project with --sdk claude upgrades agent.sdk/command", async () => {
+  it("rerunning a plain project with --sdk claude upgrades agent.framework/command", async () => {
     const projectDir = await mkdtemp(join(tmpdir(), "pome-init-sdk-upgrade-"));
     tempDirs.push(projectDir);
     process.chdir(projectDir);
@@ -131,11 +131,11 @@ describe("pome init --sdk", () => {
     ]);
 
     expect(process.exitCode ?? 0).toBe(0);
-    const cfg = JSON.parse(readFileSync("pome.config.json", "utf8")) as {
-      agent: { sdk?: string; command?: string };
+    const cfg = JSON.parse(readFileSync("pome.json", "utf8")) as {
+      agent: { framework?: string }; command?: string;
     };
-    expect(cfg.agent.sdk).toBe("claude");
-    expect(cfg.agent.command).toBe(
+    expect(cfg.agent.framework).toBe("claude");
+    expect(cfg.command).toBe(
       "npx tsx examples/agents/claude-sdk-agent.ts",
     );
     expect(existsSync("examples/agents/claude-sdk-agent.ts")).toBe(true);

--- a/cli/test/unit/init.test.ts
+++ b/cli/test/unit/init.test.ts
@@ -30,7 +30,9 @@ describe("pome init", () => {
 
     const githubTwin = findTwin("github");
     expect(githubTwin).not.toBeNull();
-    expect(existsSync("pome.config.json")).toBe(true);
+    expect(existsSync("pome.json")).toBe(true);
+    // The manifest is valid: it carries a slug derived from the project dir.
+    expect(JSON.parse(readFileSync("pome.json", "utf8")).agent.slug).toMatch(/^[a-z0-9-]+$/);
     for (const scenario of runnableScenarios(githubTwin!)) {
       expect(existsSync(join("scenarios", scenario.filename))).toBe(true);
     }
@@ -48,7 +50,7 @@ describe("pome init", () => {
 
     await createProgram().parseAsync(["node", "pome", "init"]);
 
-    expect(readFileSync("pome.config.json", "utf8")).toContain("scripted-triage-agent.ts");
+    expect(readFileSync("pome.json", "utf8")).toContain("scripted-triage-agent.ts");
     const messages = errSpy.mock.calls.map((c) => String(c[0])).join("\n");
     expect(messages).toContain("pome register agent <name>");
 

--- a/cli/test/unit/install-command.test.ts
+++ b/cli/test/unit/install-command.test.ts
@@ -10,7 +10,7 @@
 
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { promisify } from "node:util";
@@ -48,16 +48,28 @@ async function tempDir(prefix: string): Promise<string> {
   return dir;
 }
 
-/** A repo the doctor engine can walk: config + one agent source file. */
+/** A repo the doctor engine can walk: manifest + one agent source file. */
 async function fixtureRepo(agentSource: string): Promise<string> {
   const dir = await tempDir("pome-install-repo-");
   await mkdir(join(dir, "src"), { recursive: true });
   await writeFile(
-    join(dir, "pome.config.json"),
-    JSON.stringify({ agent: { command: 'node -e "process.exit(0)"' } }, null, 2),
+    join(dir, "pome.json"),
+    JSON.stringify({ agent: { slug: "fixture-repo" }, command: 'node -e "process.exit(0)"' }, null, 2),
   );
   await writeFile(join(dir, "src/agent.ts"), agentSource);
   return dir;
+}
+
+/** A 0600 creds file so ensureAgentRegistered surfaces a team_id (the link
+ *  cache is team-gated; env-key auth carries no local team). */
+async function writeCredsFile(dir: string, teamId: string): Promise<string> {
+  const path = join(dir, "creds.json");
+  await writeFile(
+    path,
+    JSON.stringify({ api_key: "pme_test", api_url: API_URL, dashboard_url: DASHBOARD_URL, team_id: teamId }),
+  );
+  await chmod(path, 0o600);
+  return path;
 }
 
 /** A stubbed HOME with ~/.claude present so runSkillsInstall has a dest. */
@@ -253,9 +265,9 @@ describe("pome install (FDRS-642)", () => {
     const { binDir } = await fakeClaudeBin();
     const home = await fakeHome();
     const repo = await fixtureRepo(WIRED_SOURCE);
+    const credentialsPath = await writeCredsFile(repo, "tm_team");
     vi.stubEnv("PATH", binDir);
     vi.stubEnv("HOME", home);
-    vi.stubEnv("POME_API_KEY", "pme_test");
     vi.stubEnv("POME_CLI_DISABLE_KEYCHAIN", "1");
     const realFetch = globalThis.fetch;
     const agentPosts: unknown[] = [];
@@ -281,15 +293,21 @@ describe("pome install (FDRS-642)", () => {
       dashboardUrl: DASHBOARD_URL,
       stdinIsTTY: true,
       cwd: repo,
+      credentialsPath,
       confirm: async () => true,
     });
 
     expect(agentPosts).toHaveLength(1);
-    const config = JSON.parse(
-      await readFile(join(repo, "pome.config.json"), "utf8"),
+    // The resolved id lands in the gitignored link cache, not the manifest.
+    const link = JSON.parse(
+      await readFile(join(repo, ".pome", "link.json"), "utf8"),
     ) as Record<string, unknown>;
-    expect(config.agentId).toBe("agt_fresh");
-    expect(config.agentSlug).toBe("fixture-repo");
+    expect(link.agent_id).toBe("agt_fresh");
+    expect(link.team_id).toBe("tm_team");
+    const manifest = JSON.parse(
+      await readFile(join(repo, "pome.json"), "utf8"),
+    ) as { agent: { slug?: string } };
+    expect(manifest.agent.slug).toBe("fixture-repo");
     const text = stderrText();
     expect(text).toContain("registered agent");
     expect(text).toContain("fixture-repo");
@@ -301,20 +319,18 @@ describe("pome install (FDRS-642)", () => {
     const home = await fakeHome();
     const repo = await fixtureRepo(WIRED_SOURCE);
     await writeFile(
-      join(repo, "pome.config.json"),
-      JSON.stringify(
-        {
-          agent: { command: 'node -e "process.exit(0)"' },
-          agentId: "agt_existing",
-          agentSlug: "already-there",
-        },
-        null,
-        2,
-      ),
+      join(repo, "pome.json"),
+      JSON.stringify({ agent: { slug: "already-there" }, command: 'node -e "process.exit(0)"' }, null, 2),
     );
+    // Already linked under the caller's team → the short-circuit path.
+    await mkdir(join(repo, ".pome"), { recursive: true });
+    await writeFile(
+      join(repo, ".pome", "link.json"),
+      JSON.stringify({ agent_id: "agt_existing", team_id: "tm_team", resolved_at: "2026-07-19T00:00:00Z" }),
+    );
+    const credentialsPath = await writeCredsFile(repo, "tm_team");
     vi.stubEnv("PATH", binDir);
     vi.stubEnv("HOME", home);
-    vi.stubEnv("POME_API_KEY", "pme_test");
     vi.stubEnv("POME_CLI_DISABLE_KEYCHAIN", "1");
     const realFetch = globalThis.fetch;
     let agentPosts = 0;
@@ -332,15 +348,15 @@ describe("pome install (FDRS-642)", () => {
       dashboardUrl: DASHBOARD_URL,
       stdinIsTTY: true,
       cwd: repo,
+      credentialsPath,
       confirm: async () => true,
     });
 
     expect(agentPosts).toBe(0);
-    const config = JSON.parse(
-      await readFile(join(repo, "pome.config.json"), "utf8"),
+    const link = JSON.parse(
+      await readFile(join(repo, ".pome", "link.json"), "utf8"),
     ) as Record<string, unknown>;
-    expect(config.agentId).toBe("agt_existing");
-    expect(config.agentSlug).toBe("already-there");
+    expect(link.agent_id).toBe("agt_existing");
     expect(stderrText()).toContain("already-there");
     expect(process.exitCode).toBeFalsy();
   }, 60_000);

--- a/cli/test/unit/link-cache.test.ts
+++ b/cli/test/unit/link-cache.test.ts
@@ -1,0 +1,90 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  ensurePomeGitignored,
+  readLinkCache,
+  resolveCachedAgentId,
+  writeLinkCache,
+} from "../../src/cli/link-cache.js";
+
+const tempDirs: string[] = [];
+
+async function makeProject(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "pome-link-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("link cache", () => {
+  it("writes .pome/link.json with agent_id, team_id and an ISO resolved_at, and reads it back", async () => {
+    const dir = await makeProject();
+    await writeLinkCache(dir, { agent_id: "agt_abc", team_id: "tm_xyz" });
+
+    const onDisk = JSON.parse(await readFile(join(dir, ".pome", "link.json"), "utf8"));
+    expect(onDisk.agent_id).toBe("agt_abc");
+    expect(onDisk.team_id).toBe("tm_xyz");
+    expect(() => new Date(onDisk.resolved_at).toISOString()).not.toThrow();
+    expect(Number.isNaN(Date.parse(onDisk.resolved_at))).toBe(false);
+
+    const cache = await readLinkCache(dir);
+    expect(cache).toMatchObject({ agent_id: "agt_abc", team_id: "tm_xyz" });
+  });
+
+  it("readLinkCache returns null when absent or malformed", async () => {
+    const dir = await makeProject();
+    expect(await readLinkCache(dir)).toBeNull();
+
+    await mkdir(join(dir, ".pome"), { recursive: true });
+    await writeFile(join(dir, ".pome", "link.json"), "{not json");
+    expect(await readLinkCache(dir)).toBeNull();
+
+    await writeFile(join(dir, ".pome", "link.json"), JSON.stringify({ agent_id: 123 }));
+    expect(await readLinkCache(dir)).toBeNull();
+  });
+
+  it("resolveCachedAgentId short-circuits only when team_id matches the caller's team", async () => {
+    const cache = { agent_id: "agt_abc", team_id: "tm_a", resolved_at: "2026-07-19T00:00:00Z" };
+    expect(resolveCachedAgentId(cache, "tm_a")).toBe("agt_abc");
+    // Foreign team: never surface the cached (foreign) id.
+    expect(resolveCachedAgentId(cache, "tm_b")).toBeUndefined();
+    expect(resolveCachedAgentId(cache, undefined)).toBeUndefined();
+    expect(resolveCachedAgentId(null, "tm_a")).toBeUndefined();
+  });
+
+  it("ensurePomeGitignored creates .gitignore when absent", async () => {
+    const dir = await makeProject();
+    await ensurePomeGitignored(dir);
+    const text = await readFile(join(dir, ".gitignore"), "utf8");
+    expect(text.split(/\r?\n/)).toContain(".pome/");
+  });
+
+  it("appends .pome/ to an existing .gitignore that lacks it, and is idempotent", async () => {
+    const dir = await makeProject();
+    await writeFile(join(dir, ".gitignore"), "node_modules\nruns\n");
+    await ensurePomeGitignored(dir);
+    let text = await readFile(join(dir, ".gitignore"), "utf8");
+    expect(text.split(/\r?\n/)).toContain(".pome/");
+    expect(text).toContain("node_modules");
+
+    await ensurePomeGitignored(dir);
+    text = await readFile(join(dir, ".gitignore"), "utf8");
+    expect(text.split(/\r?\n/).filter((l) => l === ".pome/")).toHaveLength(1);
+  });
+
+  it("treats a bare .pome entry as already ignored (no duplicate)", async () => {
+    const dir = await makeProject();
+    await writeFile(join(dir, ".gitignore"), ".pome\n");
+    await ensurePomeGitignored(dir);
+    const text = await readFile(join(dir, ".gitignore"), "utf8");
+    expect(text.split(/\r?\n/).filter((l) => l === ".pome/")).toHaveLength(0);
+  });
+});

--- a/cli/test/unit/project-config.test.ts
+++ b/cli/test/unit/project-config.test.ts
@@ -1,17 +1,25 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { SLUG_RE } from "@pome-sh/shared-types";
 
 import {
-  findProjectConfigPath,
-  normalizeConfigAgentCommand,
-  normalizeConfigAgentId,
-  normalizeConfigAgentSdk,
-  readProjectConfig,
+  MANIFEST_JSON,
+  MANIFEST_YAML,
+  findManifestPath,
+  readManifest,
+  readRequiredManifest,
+  writeManifest,
 } from "../../src/cli/project-config.js";
 
 const tempDirs: string[] = [];
+
+async function makeProject(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "pome-manifest-"));
+  tempDirs.push(dir);
+  return dir;
+}
 
 afterEach(async () => {
   await Promise.all(
@@ -19,37 +27,114 @@ afterEach(async () => {
   );
 });
 
-describe("project config helpers", () => {
-  it("walks up from a scenario directory to find pome.config.json", async () => {
-    const projectDir = await mkdtemp(join(tmpdir(), "pome-config-"));
-    tempDirs.push(projectDir);
-    const scenarioDir = join(projectDir, "scenarios", "nested");
-    await import("node:fs/promises").then((fs) =>
-      fs.mkdir(scenarioDir, { recursive: true }),
-    );
+describe("manifest loader", () => {
+  it("walks up from a nested dir to find pome.json and parses the agent block", async () => {
+    const projectDir = await makeProject();
+    const nested = join(projectDir, "tasks", "nested");
+    await mkdir(nested, { recursive: true });
     await writeFile(
-      join(projectDir, "pome.config.json"),
+      join(projectDir, MANIFEST_JSON),
       JSON.stringify({
-        agentId: "agt_registered",
-        agent: {
-          sdk: " claude-agent-sdk ",
-          command: " node custom-agent.js ",
-        },
+        agent: { slug: "pr-review-agent", name: "PR Review Agent", version: "0.2.0", framework: "langgraph" },
+        command: "npm start",
+        twins: ["github"],
       }),
     );
 
-    const path = await findProjectConfigPath(scenarioDir);
-    expect(path).toBe(join(projectDir, "pome.config.json"));
-    const read = await readProjectConfig(scenarioDir);
-    expect(read?.path).toBe(path);
-    expect(normalizeConfigAgentId(read!.config)).toBe("agt_registered");
-    expect(normalizeConfigAgentSdk(read!.config)).toBe("claude-agent-sdk");
-    expect(normalizeConfigAgentCommand(read!.config)).toBe("node custom-agent.js");
+    const found = await findManifestPath(nested);
+    expect(found).toEqual({ path: join(projectDir, MANIFEST_JSON), format: "json" });
+
+    const read = await readManifest(nested);
+    expect(read?.path).toBe(join(projectDir, MANIFEST_JSON));
+    expect(read?.format).toBe("json");
+    expect(read?.manifest.agent.slug).toBe("pr-review-agent");
+    expect(read?.manifest.agent.version).toBe("0.2.0");
+    expect(read?.manifest.agent.framework).toBe("langgraph");
+    expect(read?.manifest.command).toBe("npm start");
+    expect(read?.manifest.twins).toEqual(["github"]);
+    // run-config defaults injected by the schema
+    expect(read?.manifest.artifacts_dir).toBe("runs");
+    expect(read?.manifest.pass_threshold).toBe(100);
   });
 
-  it("rejects malformed registered agent ids instead of silently dropping them", () => {
-    expect(() => normalizeConfigAgentId({ agentId: "bad-id" })).toThrow(
-      /agt_/,
+  it("reads a pome.yaml carrier with identical keys", async () => {
+    const projectDir = await makeProject();
+    await writeFile(
+      join(projectDir, MANIFEST_YAML),
+      [
+        "agent:",
+        "  slug: pr-review-agent",
+        "  name: PR Review Agent",
+        "  version: 0.2.0",
+        "command: npm start",
+        "twins: [github]",
+      ].join("\n"),
     );
+
+    const found = await findManifestPath(projectDir);
+    expect(found).toEqual({ path: join(projectDir, MANIFEST_YAML), format: "yaml" });
+    const read = await readManifest(projectDir);
+    expect(read?.manifest.agent.slug).toBe("pr-review-agent");
+    expect(read?.manifest.agent.version).toBe("0.2.0");
+    expect(read?.manifest.command).toBe("npm start");
+  });
+
+  it("hard-errors when both pome.json and pome.yaml are present in the same dir, naming both", async () => {
+    const projectDir = await makeProject();
+    await writeFile(
+      join(projectDir, MANIFEST_JSON),
+      JSON.stringify({ agent: { slug: "a" } }),
+    );
+    await writeFile(join(projectDir, MANIFEST_YAML), "agent:\n  slug: a\n");
+
+    await expect(findManifestPath(projectDir)).rejects.toThrow(/pome\.json.*pome\.yaml|pome\.yaml.*pome\.json/s);
+  });
+
+  it("invalid slug error shows SLUG_RE and a suggestion slugified from agent.name", async () => {
+    const projectDir = await makeProject();
+    await writeFile(
+      join(projectDir, MANIFEST_JSON),
+      JSON.stringify({ agent: { slug: "Not A Slug!", name: "PR Review Agent" } }),
+    );
+
+    const err = await readManifest(projectDir).then(
+      () => null,
+      (e: unknown) => e as Error,
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect(err!.message).toContain(String(SLUG_RE));
+    expect(err!.message).toContain("pr-review-agent");
+  });
+
+  it("missing slug with a name still suggests a slugification of the name", async () => {
+    const projectDir = await makeProject();
+    await writeFile(
+      join(projectDir, MANIFEST_JSON),
+      JSON.stringify({ agent: { name: "Triage Bot" } }),
+    );
+    await expect(readManifest(projectDir)).rejects.toThrow(/triage-bot/);
+  });
+
+  it("returns null when no manifest exists; readRequired throws pointing at pome init", async () => {
+    const projectDir = await makeProject();
+    expect(await findManifestPath(projectDir)).toBeNull();
+    expect(await readManifest(projectDir)).toBeNull();
+    await expect(readRequiredManifest(projectDir)).rejects.toThrow(/pome init/);
+  });
+
+  it("writeManifest (json) round-trips through the loader and pretty-prints with a trailing newline", async () => {
+    const projectDir = await makeProject();
+    const path = join(projectDir, MANIFEST_JSON);
+    await writeManifest(path, "json", {
+      $schema: "https://pome.sh/schemas/v1/pome.json",
+      agent: { slug: "my-agent" },
+      command: "node a.js",
+    });
+    const text = await readFile(path, "utf8");
+    expect(text.endsWith("\n")).toBe(true);
+    expect(text).toContain('  "agent": {');
+    const read = await readManifest(projectDir);
+    expect(read?.manifest.agent.slug).toBe("my-agent");
+    expect(read?.manifest.command).toBe("node a.js");
   });
 });

--- a/cli/test/unit/register.test.ts
+++ b/cli/test/unit/register.test.ts
@@ -1,8 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { basename } from "node:path";
+import { basename, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HostedOrchError } from "../../src/hosted/errors.js";
 import {
@@ -15,6 +14,7 @@ const originalCwd = process.cwd();
 const tempDirs: string[] = [];
 const savedKey = process.env.POME_API_KEY;
 const savedUrl = process.env.POME_API_URL;
+const savedCi = process.env.CI;
 
 function response(body: unknown, init: ResponseInit = {}) {
   return new Response(JSON.stringify(body), {
@@ -23,15 +23,43 @@ function response(body: unknown, init: ResponseInit = {}) {
   });
 }
 
-async function writeConfig(body: unknown) {
-  await writeFile("pome.config.json", `${JSON.stringify(body, null, 2)}\n`);
+const AGENT_OK = {
+  id: "agt_123",
+  slug: "triage-bot",
+  display_name: "Triage Bot",
+  judge_model: "google/gemini-2.5-flash",
+};
+
+async function writeManifest(body: unknown) {
+  await writeFile("pome.json", `${JSON.stringify(body, null, 2)}\n`);
 }
 
-function readConfig() {
-  return JSON.parse(readFileSync("pome.config.json", "utf8")) as Record<
+function readManifestFile() {
+  return JSON.parse(readFileSync("pome.json", "utf8")) as Record<string, unknown>;
+}
+
+function readLink() {
+  return JSON.parse(readFileSync(join(".pome", "link.json"), "utf8")) as Record<
     string,
     unknown
   >;
+}
+
+/** Write a 0600 credentials file so resolveCredentials surfaces a team_id
+ *  (the env-key path has no team, so link.json can't be team-gated there). */
+async function writeCreds(dir: string, teamId: string): Promise<string> {
+  const path = join(dir, "creds.json");
+  await writeFile(
+    path,
+    JSON.stringify({
+      api_key: "pme_test",
+      api_url: "https://api.example.com",
+      dashboard_url: "https://app.example.com",
+      team_id: teamId,
+    }),
+  );
+  await chmod(path, 0o600);
+  return path;
 }
 
 beforeEach(async () => {
@@ -40,6 +68,7 @@ beforeEach(async () => {
   process.chdir(projectDir);
   process.env.POME_API_KEY = "pme_test";
   delete process.env.POME_API_URL;
+  delete process.env.CI;
   vi.spyOn(console, "error").mockImplementation(() => undefined);
 });
 
@@ -49,6 +78,8 @@ afterEach(async () => {
   else process.env.POME_API_KEY = savedKey;
   if (savedUrl === undefined) delete process.env.POME_API_URL;
   else process.env.POME_API_URL = savedUrl;
+  if (savedCi === undefined) delete process.env.CI;
+  else process.env.CI = savedCi;
   vi.restoreAllMocks();
   await Promise.all(
     tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
@@ -56,25 +87,10 @@ afterEach(async () => {
 });
 
 describe("runRegisterAgent", () => {
-  it("posts to the caller-supplied apiBaseUrl (F0-6 precedence: caller wins)", async () => {
-    await writeConfig({ agent: { command: "node agent.js" } });
-    // POME_API_URL is intentionally set to a *different* URL than the caller
-    // passes. Per F0-6, env folding happens in `cli/main.ts`'s Commander
-    // option default before reaching the runner, so by the time we land in
-    // `resolveCredentials`, the caller-supplied value is the canonical
-    // resolved override. Re-checking env here would shadow an explicit
-    // `--api-url` flag — see `credentials.ts` precedence doc-comment.
+  it("posts name + manifest identity to the caller-supplied apiBaseUrl and writes pome.json from the response", async () => {
+    await writeManifest({ agent: { slug: "old-slug", version: "0.2.0", framework: "langgraph" }, command: "node a.js" });
     process.env.POME_API_URL = "https://env-should-not-win.example.com/";
-    const fetchMock = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(
-        response({
-          id: "agt_123",
-          slug: "triage-bot",
-          display_name: "Triage Bot",
-          judge_model: "google/gemini-2.5-flash",
-        }),
-      );
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(response(AGENT_OK));
 
     await runRegisterAgent({
       apiBaseUrl: "https://input.example.com",
@@ -82,121 +98,121 @@ describe("runRegisterAgent", () => {
       force: false,
     });
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://input.example.com/v1/agents",
-      expect.objectContaining({
-        headers: expect.objectContaining({ "x-api-key": "pme_test" }),
-      }),
-    );
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("https://input.example.com/v1/agents");
+    const body = JSON.parse(String((init as RequestInit).body));
+    expect(body).toMatchObject({ name: "Triage Bot", version: "0.2.0", framework: "langgraph" });
+    // Manifest now carries the server-canonical slug (no agt_ id in the file).
+    const manifest = readManifestFile();
+    expect(manifest).toMatchObject({
+      agent: { slug: "triage-bot", name: "Triage Bot" },
+      command: "node a.js",
+    });
+    expect("agentId" in manifest).toBe(false);
+    expect(JSON.stringify(manifest)).not.toContain("agt_");
   });
 
-  it("fails clearly when pome.config.json is missing", async () => {
+  it("writes .pome/link.json (team-gated) and appends .pome/ to .gitignore", async () => {
+    const dir = process.cwd();
+    const credentialsPath = await writeCreds(dir, "tm_team");
+    delete process.env.POME_API_KEY;
+    await writeManifest({ agent: { slug: "triage-bot" } });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response(AGENT_OK));
+
+    await runRegisterAgent({
+      apiBaseUrl: "https://api.example.com",
+      name: "Triage Bot",
+      force: false,
+      credentialsPath,
+    });
+
+    expect(readLink()).toMatchObject({ agent_id: "agt_123", team_id: "tm_team" });
+    expect(readFileSync(".gitignore", "utf8").split(/\r?\n/)).toContain(".pome/");
+  });
+
+  it("fails clearly when no manifest is present", async () => {
     await expect(
-      runRegisterAgent({
-        apiBaseUrl: "https://api.example.com",
-        name: "Triage Bot",
-        force: false,
-      }),
-    ).rejects.toThrow(/pome\.config\.json not found/);
+      runRegisterAgent({ apiBaseUrl: "https://api.example.com", name: "Triage Bot", force: false }),
+    ).rejects.toThrow(/pome init/);
   });
 
-  it("is idempotent when agentId already exists without --force", async () => {
-    await writeConfig({ agentId: "agt_existing", agent: { command: "node a.js" } });
+  it("short-circuits (no network) when link.json already resolves under the caller's team", async () => {
+    const dir = process.cwd();
+    const credentialsPath = await writeCreds(dir, "tm_team");
+    delete process.env.POME_API_KEY;
+    await writeManifest({ agent: { slug: "triage-bot" } });
+    // Pre-seed a matching link cache.
+    const { writeLinkCache } = await import("../../src/cli/link-cache.js");
+    await writeLinkCache(dir, { agent_id: "agt_existing", team_id: "tm_team" });
     const fetchMock = vi.spyOn(globalThis, "fetch");
 
     await runRegisterAgent({
       apiBaseUrl: "https://api.example.com",
       name: "Triage Bot",
       force: false,
+      credentialsPath,
     });
 
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(readConfig().agentId).toBe("agt_existing");
   });
 
-  it("force overwrites agent fields while preserving unrelated keys", async () => {
-    await writeConfig({
-      agentId: "agt_old",
-      artifactsDir: "runs",
-      agent: { command: "node a.js" },
-    });
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      response({
-        id: "agt_new",
-        slug: "new-agent",
-        display_name: "New\nAgent",
-        judge_model: "google/gemini-2.5-flash",
-      }),
-    );
+  it("--force re-resolves even when a matching link cache exists", async () => {
+    const dir = process.cwd();
+    const credentialsPath = await writeCreds(dir, "tm_team");
+    delete process.env.POME_API_KEY;
+    await writeManifest({ agent: { slug: "triage-bot" } });
+    const { writeLinkCache } = await import("../../src/cli/link-cache.js");
+    await writeLinkCache(dir, { agent_id: "agt_existing", team_id: "tm_team" });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(response(AGENT_OK));
 
     await runRegisterAgent({
       apiBaseUrl: "https://api.example.com",
-      name: "New Agent",
+      name: "Triage Bot",
       force: true,
+      credentialsPath,
     });
 
-    expect(readConfig()).toMatchObject({
-      agentId: "agt_new",
-      agentSlug: "new-agent",
-      artifactsDir: "runs",
-      agent: { command: "node a.js" },
-    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(readLink().agent_id).toBe("agt_123");
   });
 
-  it("rejects unexpected response shapes", async () => {
-    await writeConfig({ agent: { command: "node a.js" } });
+  it("warns (not blocks) on an unknown framework via did-you-mean", async () => {
+    await writeManifest({ agent: { slug: "triage-bot", framework: "langraph" } });
+    const errors: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((m?: unknown) => void errors.push(String(m)));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response(AGENT_OK));
+
+    await runRegisterAgent({ apiBaseUrl: "https://api.example.com", name: "Triage Bot", force: false });
+
+    expect(errors.join("\n")).toMatch(/langraph/);
+    expect(errors.join("\n")).toMatch(/langgraph/);
+  });
+
+  it("rejects an unexpected response shape via the shared zod schema", async () => {
+    await writeManifest({ agent: { slug: "triage-bot" } });
     vi.spyOn(globalThis, "fetch").mockResolvedValue(response({ id: "agt_only" }));
 
     await expect(
-      runRegisterAgent({
-        apiBaseUrl: "https://api.example.com",
-        name: "Bad Shape",
-        force: false,
-      }),
+      runRegisterAgent({ apiBaseUrl: "https://api.example.com", name: "Bad", force: false }),
     ).rejects.toBeInstanceOf(HostedOrchError);
   });
 
   it("explains /v1/agents 404 as route/version skew", async () => {
-    await writeConfig({ agent: { command: "node a.js" } });
+    await writeManifest({ agent: { slug: "triage-bot" } });
     vi.spyOn(globalThis, "fetch").mockResolvedValue(response({}, { status: 404 }));
 
     await expect(
-      runRegisterAgent({
-        apiBaseUrl: "https://api.example.com",
-        name: "Triage Bot",
-        force: false,
-      }),
+      runRegisterAgent({ apiBaseUrl: "https://api.example.com", name: "Triage Bot", force: false }),
     ).rejects.toThrow(/not available|version/);
   });
 
-  it("rejects malformed agentId instead of treating it as idempotent", async () => {
-    await writeConfig({ agentId: "   " });
-    await expect(
-      runRegisterAgent({
-        apiBaseUrl: "https://api.example.com",
-        name: "Triage Bot",
-        force: false,
-      }),
-    ).rejects.toThrow(/malformed agentId/);
-    expect(existsSync("pome.config.json")).toBe(true);
-  });
-
-  // ── Multi-twin (M3): --twins body + enabled_services print + old-cloud warn ──
   it("POSTs {name, twins} and prints the cloud's enabled services", async () => {
-    await writeConfig({ agent: { command: "node a.js" } });
+    await writeManifest({ agent: { slug: "triage-bot" } });
     const errors: string[] = [];
-    vi.spyOn(console, "error").mockImplementation((msg?: unknown) => {
-      errors.push(String(msg));
-    });
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      response({
-        id: "agt_123",
-        slug: "triage-bot",
-        display_name: "Triage Bot",
-        judge_model: "google/gemini-2.5-flash",
-        enabled_services: ["github", "slack"],
-      }),
-    );
+    vi.spyOn(console, "error").mockImplementation((m?: unknown) => void errors.push(String(m)));
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(response({ ...AGENT_OK, enabled_services: ["github", "slack"] }));
 
     await runRegisterAgent({
       apiBaseUrl: "https://api.example.com",
@@ -206,80 +222,73 @@ describe("runRegisterAgent", () => {
     });
 
     const body = JSON.parse(String((fetchMock.mock.calls[0]![1] as RequestInit).body));
-    expect(body).toEqual({ name: "Triage Bot", twins: ["github", "slack"] });
+    expect(body).toMatchObject({ name: "Triage Bot", twins: ["github", "slack"] });
     expect(errors.join("\n")).toContain("Enabled services: github, slack");
   });
+});
 
-  it("warns when an older cloud omits enabled_services", async () => {
-    await writeConfig({ agent: { command: "node a.js" } });
-    const errors: string[] = [];
-    vi.spyOn(console, "error").mockImplementation((msg?: unknown) => {
-      errors.push(String(msg));
-    });
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      response({
-        id: "agt_123",
-        slug: "triage-bot",
-        display_name: "Triage Bot",
-        judge_model: "google/gemini-2.5-flash",
-      }),
+describe("runRegisterAgent near-miss", () => {
+  const conflict = () =>
+    response(
+      { error: { type: "conflict", message: "near-miss", details: { suggestion: "triage-bot" }, request_id: "req_1" } },
+      { status: 409 },
     );
 
-    await runRegisterAgent({
-      apiBaseUrl: "https://api.example.com",
-      name: "Triage Bot",
-      force: false,
-      twins: ["github", "slack"],
-    });
+  it("non-TTY / CI: warns and proceeds to create with confirm:true", async () => {
+    process.env.CI = "1";
+    await writeManifest({ agent: { slug: "triage-bott" } });
+    const errors: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((m?: unknown) => void errors.push(String(m)));
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(conflict())
+      .mockResolvedValueOnce(response(AGENT_OK));
 
-    expect(errors.join("\n")).toMatch(/not reported by this pome cloud/i);
+    await runRegisterAgent({ apiBaseUrl: "https://api.example.com", name: "Triage Bott", force: false });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const retry = JSON.parse(String((fetchMock.mock.calls[1]![1] as RequestInit).body));
+    expect(retry.confirm).toBe(true);
+    expect(errors.join("\n")).toMatch(/triage-bot/);
   });
 
-  it("omits twins from the body when none are passed (byte-identical to pre-M3)", async () => {
-    await writeConfig({ agent: { command: "node a.js" } });
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      response({
-        id: "agt_123",
-        slug: "triage-bot",
-        display_name: "Triage Bot",
-        judge_model: "google/gemini-2.5-flash",
-      }),
-    );
+  it("interactive YES: re-resolves the suggested existing slug", async () => {
+    await writeManifest({ agent: { slug: "triage-bott" } });
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(conflict())
+      .mockResolvedValueOnce(response(AGENT_OK));
 
     await runRegisterAgent({
       apiBaseUrl: "https://api.example.com",
-      name: "Triage Bot",
+      name: "Triage Bott",
       force: false,
+      stdinIsTTY: true,
+      confirm: async () => true,
     });
 
-    const body = JSON.parse(String((fetchMock.mock.calls[0]![1] as RequestInit).body));
-    expect(body).toEqual({ name: "Triage Bot" });
+    const retry = JSON.parse(String((fetchMock.mock.calls[1]![1] as RequestInit).body));
+    expect(retry.slug).toBe("triage-bot");
+    expect(retry.confirm).toBeUndefined();
   });
 
-  it("stays silent about enabled_services when no --twins was passed (older cloud)", async () => {
-    await writeConfig({ agent: { command: "node a.js" } });
-    const errors: string[] = [];
-    vi.spyOn(console, "error").mockImplementation((msg?: unknown) => {
-      errors.push(String(msg));
-    });
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      response({
-        id: "agt_123",
-        slug: "triage-bot",
-        display_name: "Triage Bot",
-        judge_model: "google/gemini-2.5-flash",
-      }),
-    );
+  it("interactive NO: creates the typed slug with confirm:true", async () => {
+    await writeManifest({ agent: { slug: "triage-bott" } });
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(conflict())
+      .mockResolvedValueOnce(response(AGENT_OK));
 
     await runRegisterAgent({
       apiBaseUrl: "https://api.example.com",
-      name: "Triage Bot",
+      name: "Triage Bott",
       force: false,
+      stdinIsTTY: true,
+      confirm: async () => false,
     });
 
-    // No twin scoping was requested, so an absent enabled_services must not warn.
-    expect(errors.join("\n")).not.toMatch(/not reported by this pome cloud/i);
-    expect(errors.join("\n")).not.toMatch(/enabled services/i);
+    const retry = JSON.parse(String((fetchMock.mock.calls[1]![1] as RequestInit).body));
+    expect(retry.confirm).toBe(true);
   });
 });
 
@@ -296,79 +305,47 @@ describe("normalizeRegisterTwins", () => {
   });
 });
 
-// FDRS-669 — the `pome install` registration seam: same machinery as
-// `pome register agent`, but derives the name from the repo directory and
-// never errors on an already-registered repo (idempotent by design).
-describe("ensureAgentRegistered (FDRS-669)", () => {
-  it("registers a fresh repo under the config directory's name and writes agentId + agentSlug", async () => {
-    await writeConfig({ agent: { command: "node a.js" } });
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      response({
-        id: "agt_123",
-        slug: "my-repo",
-        display_name: "my-repo",
-        judge_model: "google/gemini-2.5-flash",
-      }),
-    );
+describe("ensureAgentRegistered", () => {
+  it("registers a fresh repo, writing the manifest slug + link.json under the caller's team", async () => {
+    const dir = process.cwd();
+    const credentialsPath = await writeCreds(dir, "tm_team");
+    delete process.env.POME_API_KEY;
+    await writeManifest({ agent: { slug: "old" }, command: "node a.js" });
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(response({ ...AGENT_OK, slug: "my-repo", display_name: "my-repo" }));
 
-    const result = await ensureAgentRegistered({
-      apiBaseUrl: "https://api.example.com",
-    });
+    const result = await ensureAgentRegistered({ apiBaseUrl: "https://api.example.com", credentialsPath });
 
-    expect(result).toEqual({
-      status: "registered",
-      agentId: "agt_123",
-      agentSlug: "my-repo",
-    });
-    // The server-side name is the repo directory's basename (vercel-link
-    // shape: identity defaults to where you ran it).
-    const [url, init] = fetchMock.mock.calls[0]!;
-    expect(url).toBe("https://api.example.com/v1/agents");
-    expect(JSON.parse(String((init as RequestInit).body))).toEqual({
-      name: basename(process.cwd()),
-    });
-    expect(readConfig()).toMatchObject({
-      agentId: "agt_123",
-      agentSlug: "my-repo",
-      agent: { command: "node a.js" },
-    });
+    expect(result).toEqual({ status: "registered", agentId: "agt_123", agentSlug: "my-repo" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(readManifestFile()).toMatchObject({ agent: { slug: "my-repo" }, command: "node a.js" });
+    expect(readLink()).toMatchObject({ agent_id: "agt_123", team_id: "tm_team" });
+    expect(basename(dir)).toBeTruthy();
   });
 
-  it("is idempotent: an already-registered repo makes no request and keeps the same slug", async () => {
-    await writeConfig({
-      agentId: "agt_existing",
-      agentSlug: "existing-agent",
-      agent: { command: "node a.js" },
-    });
+  it("is idempotent: a repo already linked under the caller's team makes no request", async () => {
+    const dir = process.cwd();
+    const credentialsPath = await writeCreds(dir, "tm_team");
+    delete process.env.POME_API_KEY;
+    await writeManifest({ agent: { slug: "existing-agent" } });
+    const { writeLinkCache } = await import("../../src/cli/link-cache.js");
+    await writeLinkCache(dir, { agent_id: "agt_existing", team_id: "tm_team" });
     const fetchMock = vi.spyOn(globalThis, "fetch");
 
-    const first = await ensureAgentRegistered({
-      apiBaseUrl: "https://api.example.com",
-    });
-    const second = await ensureAgentRegistered({
-      apiBaseUrl: "https://api.example.com",
-    });
+    const result = await ensureAgentRegistered({ apiBaseUrl: "https://api.example.com", credentialsPath });
 
-    expect(first).toEqual({
+    expect(result).toEqual({
       status: "already-registered",
       agentId: "agt_existing",
       agentSlug: "existing-agent",
     });
-    expect(second).toEqual(first);
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(readConfig()).toMatchObject({
-      agentId: "agt_existing",
-      agentSlug: "existing-agent",
-    });
   });
 
-  it("returns no-config without fetching when pome.config.json is absent", async () => {
+  it("returns no-config without fetching when no manifest is present", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch");
-
-    const result = await ensureAgentRegistered({
-      apiBaseUrl: "https://api.example.com",
-    });
-
+    const result = await ensureAgentRegistered({ apiBaseUrl: "https://api.example.com" });
     expect(result).toEqual({ status: "no-config" });
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/cli/test/unit/run-default-task.test.ts
+++ b/cli/test/unit/run-default-task.test.ts
@@ -77,8 +77,8 @@ async function fixtureRepo(opts: { wired?: boolean } = {}): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), "pome-run-default-"));
   await mkdir(join(dir, "src"), { recursive: true });
   await writeFile(
-    join(dir, "pome.config.json"),
-    JSON.stringify({ agent: { command: 'node -e "process.exit(0)"' } }, null, 2),
+    join(dir, "pome.json"),
+    JSON.stringify({ agent: { slug: "fixture-agent" }, command: 'node -e "process.exit(0)"' }, null, 2),
   );
   if (opts.wired !== false) {
     await writeFile(join(dir, "src/agent.ts"), WIRED_AGENT_SOURCE);

--- a/cli/test/unit/run-doctor-gate.test.ts
+++ b/cli/test/unit/run-doctor-gate.test.ts
@@ -19,8 +19,8 @@ async function fixtureRepo(agentSource: string): Promise<string> {
   await mkdir(join(dir, "src"), { recursive: true });
   await mkdir(join(dir, "scenarios"), { recursive: true });
   await writeFile(
-    join(dir, "pome.config.json"),
-    JSON.stringify({ agent: { command: 'node -e "process.exit(0)"' } }, null, 2),
+    join(dir, "pome.json"),
+    JSON.stringify({ agent: { slug: "gate-agent" }, command: 'node -e "process.exit(0)"' }, null, 2),
   );
   await writeFile(join(dir, "src/agent.ts"), agentSource);
   await cp(SCENARIO_SRC, join(dir, "scenarios/01-bug-happy-path.md"));

--- a/cli/test/unit/run-n-flag.test.ts
+++ b/cli/test/unit/run-n-flag.test.ts
@@ -72,8 +72,8 @@ async function fixtureRepo(scenarioSource: string): Promise<string> {
   await mkdir(join(dir, "src"), { recursive: true });
   await mkdir(join(dir, "scenarios"), { recursive: true });
   await writeFile(
-    join(dir, "pome.config.json"),
-    JSON.stringify({ agent: { command: 'node -e "process.exit(0)"' } }, null, 2),
+    join(dir, "pome.json"),
+    JSON.stringify({ agent: { slug: "fixture-agent" }, command: 'node -e "process.exit(0)"' }, null, 2),
   );
   await writeFile(join(dir, "src/agent.ts"), WIRED_AGENT_SOURCE);
   await writeFile(join(dir, "scenarios/scn.md"), scenarioSource, "utf8");
@@ -142,7 +142,7 @@ describe("pome run -n (FDRS-636)", () => {
     const options = vi.mocked(runTrialGroup).mock.calls[0]![0];
     expect(options.trials).toBe(5);
     expect(options.agentCommand).toBe('node -e "process.exit(0)"');
-    expect(options.agentCommandSource).toBe("pome.config.json");
+    expect(options.agentCommandSource).toBe("pome.json");
     expect(options.hosted.apiKey).toBe("pme_test_env_key");
     expect(options.dashboardBaseUrl).toBe("https://app.pome.sh");
   }, 30_000);

--- a/cli/test/unit/runner/runScenarioHosted.upload.test.ts
+++ b/cli/test/unit/runner/runScenarioHosted.upload.test.ts
@@ -7,6 +7,11 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { gunzipSync } from "node:zlib";
+const identityMock = vi.hoisted(() => ({
+  resolveRunAgentIdentity: vi.fn(async () => ({}) as Record<string, unknown>),
+}));
+vi.mock("../../../src/cli/agent-identity.js", () => identityMock);
+
 import { runScenarioHosted } from "../../../src/runner/runScenarioHosted.js";
 import type { HostedClient } from "../../../src/hosted/client.js";
 import { HostedOrchError } from "../../../src/hosted/errors.js";
@@ -647,24 +652,24 @@ describe("runScenarioHosted events.jsonl upload orchestration (FDRS-357)", () =>
     });
   });
 
-  it("reads agentId and agent.sdk from the nearest pome.config.json", async () => {
+  it("threads the resolved agent id + version into the create-session request", async () => {
     const { client, getCreateSessionInput } = makeStubClient({
       requestEventsUploadUrlImpl: async () => {
         throw new HostedOrchError("no route");
       },
+    });
+    // Identity resolution (manifest → link cache → slug re-resolve) is covered
+    // by agent-identity.test.ts; here we assert the runner threads its result.
+    identityMock.resolveRunAgentIdentity.mockResolvedValueOnce({
+      agentId: "agt_registered",
+      agentVersion: "0.2.0",
+      framework: "claude-agent-sdk",
     });
 
     const projectDir = join(tmp, "project");
     const scenarioDir = join(projectDir, "scenarios");
     await import("node:fs/promises").then((fs) =>
       fs.mkdir(scenarioDir, { recursive: true }),
-    );
-    await writeFile(
-      join(projectDir, "pome.config.json"),
-      JSON.stringify({
-        agentId: "agt_registered",
-        agent: { sdk: "claude-agent-sdk" },
-      }),
     );
     const scenarioPath = join(scenarioDir, "scn.md");
     await writeFile(scenarioPath, TRIVIAL_PASSING_SCENARIO, "utf8");
@@ -679,6 +684,7 @@ describe("runScenarioHosted events.jsonl upload orchestration (FDRS-357)", () =>
 
     expect(getCreateSessionInput()).toMatchObject({
       agentId: "agt_registered",
+      agentVersion: "0.2.0",
     });
   });
 });

--- a/cli/test/unit/runner/runTrialGroup.test.ts
+++ b/cli/test/unit/runner/runTrialGroup.test.ts
@@ -39,6 +39,13 @@ vi.mock("../../../src/hosted/client.js", async (importOriginal) => {
   return { ...original, createHostedClient: vi.fn(original.createHostedClient) };
 });
 
+// Identity resolution has its own test (agent-identity.test.ts); mock the
+// boundary so the URL/mint tests control the resolved slug + id directly.
+const identityMock = vi.hoisted(() => ({
+  resolveRunAgentIdentity: vi.fn(async () => ({}) as Record<string, unknown>),
+}));
+vi.mock("../../../src/cli/agent-identity.js", () => identityMock);
+
 const SCENARIO =
   "# Trivial\n\n## Prompt\nPretend prompt.\n\n## Success Criteria\n- [code] No unsupported endpoint was called\n";
 
@@ -727,18 +734,12 @@ describe("runTrialGroup — dashboard link + client construction", () => {
   // FDRS-669) the CLI prints /agents/<slug>/tasks/<name>?group=grp_… — the
   // run set's reliability view, never the agent-less empty state. ?group is
   // forward-compat: the page honors it in M1.
-  it("prints /agents/<slug>/tasks/<name>?group=grp_… when pome.config.json carries the registered slug", async () => {
+  it("prints /agents/<slug>/tasks/<name>?group=grp_… when the manifest slug resolves", async () => {
     const scenarioPath = await scenarioFixture();
-    const dir = join(scenarioPath, "..");
-    await writeFile(
-      join(dir, "pome.config.json"),
-      JSON.stringify({
-        agentId: "agt_123",
-        agentSlug: "triage-bot",
-        agent: { command: "node agent.js" },
-      }),
-      "utf8",
-    );
+    identityMock.resolveRunAgentIdentity.mockResolvedValueOnce({
+      agentId: "agt_123",
+      agentSlug: "triage-bot",
+    });
     const cloud = makeFakeClient();
     const out: string[] = [];
 
@@ -768,14 +769,9 @@ describe("runTrialGroup — dashboard link + client construction", () => {
     );
   });
 
-  it("appends ?agent=<agentId> when pome.config.json pins one (page groups per agent)", async () => {
+  it("appends ?agent=<agentId> when the manifest resolves an id but no slug (page groups per agent)", async () => {
     const scenarioPath = await scenarioFixture();
-    const dir = join(scenarioPath, "..");
-    await writeFile(
-      join(dir, "pome.config.json"),
-      JSON.stringify({ agentId: "agt_123", agent: { command: "node agent.js" } }),
-      "utf8",
-    );
+    identityMock.resolveRunAgentIdentity.mockResolvedValueOnce({ agentId: "agt_123" });
     const cloud = makeFakeClient();
 
     const result = await runTrialGroup({

--- a/cli/test/unit/session.test.ts
+++ b/cli/test/unit/session.test.ts
@@ -13,9 +13,8 @@ vi.mock("../../src/cli/credentials.js", () => ({
   resolveCredentials: mocks.resolveCredentials,
 }));
 
-vi.mock("../../src/cli/project-config.js", () => ({
-  normalizeConfigAgentId: vi.fn(),
-  readProjectConfig: vi.fn(async () => null),
+vi.mock("../../src/cli/agent-identity.js", () => ({
+  resolveRunAgentIdentity: vi.fn(async () => ({})),
 }));
 
 vi.mock("../../src/hosted/client.js", async (importOriginal) => {


### PR DESCRIPTION
## What

Replaces the CLI's `pome.config.json` (`{agentId, agentSlug, agent.{sdk,command}}`) with the shared-types **`pome.json` / `pome.yaml` manifest** (canonical `agent.slug`, **no committed `agt_` id**) plus a gitignored **`.pome/link.json`** resolver cache `{agent_id, team_id, resolved_at}`, trusted only when `team_id` matches the caller's team. Durable identity for the CLI path: re-clones/forks self-onboard by slug and never carry a foreign `agt_` id.

## How it maps to the acceptance criteria

- **Loader** (`project-config.ts` rewrite): `pome.json`/`pome.yaml`/`.yml` walk-up discovery; both-present → hard error naming both files; zod validation; invalid-slug error shows `SLUG_RE` + a `deriveAgentSlug(agent.name)` suggestion; format-preserving writer.
- **`.pome/link.json`** (`link-cache.ts`): team-gated `resolveCachedAgentId` (short-circuit only on team match; silent slug re-resolution otherwise — never sends a foreign id); registration appends `.pome/` to `.gitignore` (creates it if absent).
- **`register` / `ensureAgentRegistered`** write `pome.json` + `.pome/link.json` from the resolver response; unknown-framework values get a client-side did-you-mean warning (never block).
- **Near-miss**: server-detected 409 → interactive "did you mean X?" (yes re-resolves the suggestion, no force-creates the typed slug); non-TTY/CI warns and proceeds.
- **Run paths** read `agent.version` from the manifest and send `agent_version` at session create; new **`--agent-version`** flag overrides. The old `agent.sdk` run badge now maps to `agent.framework`.
- **DRY**: `register.ts` drops the hand-rolled `parseAgentResponse` for the shared `agentResponseSchema`.

## ⚠️ Cross-repo contract with F-820 (please confirm)

F-820 (the pome-cloud resolver half) is not deployed yet, so two wire details are **chosen here and must match F-820**:
1. **Force-past-near-miss** = an extra `confirm: true` key on the `POST /v1/agents` body (the request schema is non-strict, so it is additive).
2. **Near-miss suggestion** is read from `error.details.suggestion` (409 `conflict`), tolerating `details.suggestions[]` / `details.slug` as fallbacks.

## Scope notes

- Examples migration is **out of scope** (that is F-825) — left untouched.
- `@pome-sh/shared-types` bumped `0.11.0 → 0.12.0` (published; carries the manifest schema).

## Verification

- `npm test` — **696 passing** (83 files); new suites for the loader, link cache, frameworks, agent-identity, and the rewritten register/near-miss cases.
- `tsc --noEmit` clean; `build` clean; gates green (`no-eval`, `no-native`, `code-health`, `no-catch`, root `knip` unchanged).
- Drove the real CLI: `pome init` in a fresh dir writes a valid `pome.json` (derived slug, `$schema`, top-level `command`, snake_case run-config) and **no** `pome.config.json`.

<!-- Closes F-819 -->