### PR TITLE
shared-types 0.12.1 — resolved_via + hint on agentResponseSchema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5998,6 +5998,14 @@
         }
       }
     },
+    "packages/adapter-claude-sdk/node_modules/@pome-sh/shared-types": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.12.0.tgz",
+      "integrity": "sha512-6YTujcaSInyNB4ZQnLs/5k9J9/AS4pEl5njxEOV+U8QYiq+LF1LswTC7fGIe9XOuaM3+e6pWcMhuvihBhqDjtA==",
+      "peerDependencies": {
+        "zod": "^4.1.13"
+      }
+    },
     "packages/sdk": {
       "name": "@pome-sh/sdk",
       "version": "0.5.1",
@@ -6025,9 +6033,17 @@
         }
       }
     },
+    "packages/sdk/node_modules/@pome-sh/shared-types": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.12.0.tgz",
+      "integrity": "sha512-6YTujcaSInyNB4ZQnLs/5k9J9/AS4pEl5njxEOV+U8QYiq+LF1LswTC7fGIe9XOuaM3+e6pWcMhuvihBhqDjtA==",
+      "peerDependencies": {
+        "zod": "^4.1.13"
+      }
+    },
     "packages/shared-types": {
       "name": "@pome-sh/shared-types",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "devDependencies": {
         "@types/node": "^26.1.0",
         "typescript": "^5.9.3",
@@ -6064,6 +6080,14 @@
       },
       "engines": {
         "node": ">=24"
+      }
+    },
+    "packages/twin-github/node_modules/@pome-sh/shared-types": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.12.0.tgz",
+      "integrity": "sha512-6YTujcaSInyNB4ZQnLs/5k9J9/AS4pEl5njxEOV+U8QYiq+LF1LswTC7fGIe9XOuaM3+e6pWcMhuvihBhqDjtA==",
+      "peerDependencies": {
+        "zod": "^4.1.13"
       }
     },
     "packages/twin-gmail": {
@@ -6141,6 +6165,14 @@
         "node": ">=24"
       }
     },
+    "packages/twin-slack/node_modules/@pome-sh/shared-types": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.12.0.tgz",
+      "integrity": "sha512-6YTujcaSInyNB4ZQnLs/5k9J9/AS4pEl5njxEOV+U8QYiq+LF1LswTC7fGIe9XOuaM3+e6pWcMhuvihBhqDjtA==",
+      "peerDependencies": {
+        "zod": "^4.1.13"
+      }
+    },
     "packages/twin-stripe": {
       "name": "@pome-sh/twin-stripe",
       "version": "0.2.5",
@@ -6165,6 +6197,14 @@
       },
       "engines": {
         "node": ">=24"
+      }
+    },
+    "packages/twin-stripe/node_modules/@pome-sh/shared-types": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.12.0.tgz",
+      "integrity": "sha512-6YTujcaSInyNB4ZQnLs/5k9J9/AS4pEl5njxEOV+U8QYiq+LF1LswTC7fGIe9XOuaM3+e6pWcMhuvihBhqDjtA==",
+      "peerDependencies": {
+        "zod": "^4.1.13"
       }
     }
   }

--- a/packages/shared-types/CHANGELOG.md
+++ b/packages/shared-types/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @pome-sh/shared-types — CHANGELOG
 
+## 0.12.1
+
+### Added
+
+- `agentResponseSchema` (`POST /v1/agents`) gains optional `resolved_via` and
+  `hint` (F-861). `resolved_via` is an open string enum — known values today are
+  `slug` (live match), `alias` (an old slug renamed to the returned canonical),
+  and `created` (fresh auto-register); an unknown future resolver mode is
+  tolerated as an additive value, not rejected. `hint` is an optional
+  human-readable nudge. Both optional and tolerant — no change for the pre-F-820
+  cloud. Consumed by the CLI to surface a one-time slug-rename notice on the
+  alias branch.
+
 ## 0.12.0
 
 ### Added

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/shared-types",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Shared wire-format contract for Pome — Zod schemas for traces, recorder events, runs, OTel mapping, and secret redaction.",
   "private": false,
   "type": "module",

--- a/packages/shared-types/trace-contract.json
+++ b/packages/shared-types/trace-contract.json
@@ -1,6 +1,6 @@
 {
   "package": "@pome-sh/shared-types",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "zod": {
     "range": "^4.1.13",
     "major": 4


### PR DESCRIPTION
Version + changelog bump for the F-861 slug-rename fields already merged to `main` (#193). This is the packages-v* batch step (per `PACKAGE_RELEASE.md`) that makes `@pome-sh/shared-types@0.12.1` publishable.

## Scope

- `packages/shared-types/package.json`: `0.12.0 → 0.12.1` (**patch** — additive optional fields `resolved_via` + `hint` on `agentResponseSchema`; contract surface unchanged, `test:contract` green).
- `CHANGELOG.md`: 0.12.1 entry.
- `package-lock.json`: root ref → 0.12.1; consumers (sdk/adapter/twins) keep their exact `0.12.0` pins, so the lock nests the still-published `0.12.0` for them.

## Notes for reviewer

- **Only shared-types bumps.** sdk/adapter/twins don't consume the new fields (only the CLI does), so they are not republished. They keep pinning `0.12.0`, which remains on npm — the publish workflow's `publish_one` skips already-published versions.
- The nested `0.12.0` consumer entries in the lockfile are the established shape for a solo shared-types bump (cf. 5b0a141: shared-types 0.6.1→0.7.0 with consumers nested at 0.6.0).
- After merge: cut a GitHub Release tagged `packages-v16` to fire `sdk-publish.yml` (OIDC provenance). Then the CLI dep bump (`@pome-sh/shared-types` → 0.12.1) + CLI release follow, so the F-861 notice becomes functional in the published CLI.

<!-- Closes F-861 (release step) -->