### PR TITLE
cli: bundle @pome-sh/shared-types 0.12.1 (enables the F-861 rename notice)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -12,6 +12,7 @@
         "@pome-sh/shared-types",
         "@pome-sh/twin-gmail",
         "@pome-sh/twin-github",
+        "@pome-sh/twin-linear",
         "@pome-sh/twin-slack",
         "@pome-sh/twin-stripe"
       ],
@@ -24,10 +25,11 @@
         "@anthropic-ai/sdk": "^0.110.0",
         "@hono/node-server": "^2.0.10",
         "@openrouter/ai-sdk-provider": "^3.0.0",
-        "@pome-sh/sdk": "0.5.0",
-        "@pome-sh/shared-types": "0.12.0",
+        "@pome-sh/sdk": "0.5.1",
+        "@pome-sh/shared-types": "0.12.1",
         "@pome-sh/twin-github": "0.2.1",
         "@pome-sh/twin-gmail": "0.1.0",
+        "@pome-sh/twin-linear": "0.1.0",
         "@pome-sh/twin-slack": "0.2.1",
         "@pome-sh/twin-stripe": "0.2.4",
         "ai": "^7.0.18",
@@ -1148,12 +1150,12 @@
       }
     },
     "node_modules/@pome-sh/sdk": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@pome-sh/sdk/-/sdk-0.5.0.tgz",
-      "integrity": "sha512-tY9aEii2cUthCLMv2Em83jnfHuo2FtyxpY6D1ghWWwu/OPj7DiuSs+TkG2QaGRr3urwWkA+Vk/Wv6Ki5Sz5WHA==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@pome-sh/sdk/-/sdk-0.5.1.tgz",
+      "integrity": "sha512-v0nmdFsdla+IMsTn5qm2N5YC8S0fzacOrvT+pKgWSCcdwgV0hJkoaZMuYd8SmJ+ki+mIlOoGox/y7knc4Dxpbw==",
       "inBundle": true,
       "dependencies": {
-        "@pome-sh/shared-types": "0.11.0",
+        "@pome-sh/shared-types": "0.12.0",
         "hono": "^4.12.27",
         "zod": "^4.1.13"
       },
@@ -1170,18 +1172,18 @@
       }
     },
     "node_modules/@pome-sh/sdk/node_modules/@pome-sh/shared-types": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.11.0.tgz",
-      "integrity": "sha512-UY1wyInHK6I15UK8PchH1Hpt0Wbuu80/3H0mVEuFZzDUvnXG/Q6EU/xhUTnrX4hAEhNFdrXqanT9XMl+6EOOwA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.12.0.tgz",
+      "integrity": "sha512-6YTujcaSInyNB4ZQnLs/5k9J9/AS4pEl5njxEOV+U8QYiq+LF1LswTC7fGIe9XOuaM3+e6pWcMhuvihBhqDjtA==",
       "inBundle": true,
       "peerDependencies": {
         "zod": "^4.1.13"
       }
     },
     "node_modules/@pome-sh/shared-types": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.12.0.tgz",
-      "integrity": "sha512-6YTujcaSInyNB4ZQnLs/5k9J9/AS4pEl5njxEOV+U8QYiq+LF1LswTC7fGIe9XOuaM3+e6pWcMhuvihBhqDjtA==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.12.1.tgz",
+      "integrity": "sha512-RbRQMCR6Fd3q4GX64QuvXnGoF64bm7eOyNFnjltt1nYhMpX/7NyYTzvv9rwDM02DO0p35tZufx+isfMfXA2M4g==",
       "inBundle": true,
       "peerDependencies": {
         "zod": "^4.1.13"
@@ -1205,6 +1207,28 @@
       },
       "engines": {
         "node": ">=24"
+      }
+    },
+    "node_modules/@pome-sh/twin-github/node_modules/@pome-sh/sdk": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/sdk/-/sdk-0.5.0.tgz",
+      "integrity": "sha512-tY9aEii2cUthCLMv2Em83jnfHuo2FtyxpY6D1ghWWwu/OPj7DiuSs+TkG2QaGRr3urwWkA+Vk/Wv6Ki5Sz5WHA==",
+      "inBundle": true,
+      "dependencies": {
+        "@pome-sh/shared-types": "0.11.0",
+        "hono": "^4.12.27",
+        "zod": "^4.1.13"
+      },
+      "engines": {
+        "node": ">=24"
+      },
+      "peerDependencies": {
+        "@hono/node-server": "^2.0.8"
+      },
+      "peerDependenciesMeta": {
+        "@hono/node-server": {
+          "optional": true
+        }
       }
     },
     "node_modules/@pome-sh/twin-github/node_modules/@pome-sh/shared-types": {
@@ -1234,6 +1258,57 @@
         "node": ">=24"
       }
     },
+    "node_modules/@pome-sh/twin-gmail/node_modules/@pome-sh/sdk": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/sdk/-/sdk-0.5.0.tgz",
+      "integrity": "sha512-tY9aEii2cUthCLMv2Em83jnfHuo2FtyxpY6D1ghWWwu/OPj7DiuSs+TkG2QaGRr3urwWkA+Vk/Wv6Ki5Sz5WHA==",
+      "inBundle": true,
+      "dependencies": {
+        "@pome-sh/shared-types": "0.11.0",
+        "hono": "^4.12.27",
+        "zod": "^4.1.13"
+      },
+      "engines": {
+        "node": ">=24"
+      },
+      "peerDependencies": {
+        "@hono/node-server": "^2.0.8"
+      },
+      "peerDependenciesMeta": {
+        "@hono/node-server": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@pome-sh/twin-gmail/node_modules/@pome-sh/shared-types": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.11.0.tgz",
+      "integrity": "sha512-UY1wyInHK6I15UK8PchH1Hpt0Wbuu80/3H0mVEuFZzDUvnXG/Q6EU/xhUTnrX4hAEhNFdrXqanT9XMl+6EOOwA==",
+      "inBundle": true,
+      "peerDependencies": {
+        "zod": "^4.1.13"
+      }
+    },
+    "node_modules/@pome-sh/twin-linear": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/twin-linear/-/twin-linear-0.1.0.tgz",
+      "integrity": "sha512-6VFc+a/1AhR1J4OgEw4K/9MzZxXSwdOH5UtcPK1YKNetC0jpm7j0JcezVI7V2lQ1wS5/IcZlQJYsPSSY0Xdmbg==",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@hono/node-server": "^2.0.10",
+        "@pome-sh/sdk": "0.5.1",
+        "graphql": "^16.11.0",
+        "hono": "^4.12.27",
+        "zod": "^4.1.13"
+      },
+      "bin": {
+        "twin-linear": "dist/src/server.js"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
     "node_modules/@pome-sh/twin-slack": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@pome-sh/twin-slack/-/twin-slack-0.2.1.tgz",
@@ -1252,6 +1327,28 @@
       },
       "engines": {
         "node": ">=24"
+      }
+    },
+    "node_modules/@pome-sh/twin-slack/node_modules/@pome-sh/sdk": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/sdk/-/sdk-0.5.0.tgz",
+      "integrity": "sha512-tY9aEii2cUthCLMv2Em83jnfHuo2FtyxpY6D1ghWWwu/OPj7DiuSs+TkG2QaGRr3urwWkA+Vk/Wv6Ki5Sz5WHA==",
+      "inBundle": true,
+      "dependencies": {
+        "@pome-sh/shared-types": "0.11.0",
+        "hono": "^4.12.27",
+        "zod": "^4.1.13"
+      },
+      "engines": {
+        "node": ">=24"
+      },
+      "peerDependencies": {
+        "@hono/node-server": "^2.0.8"
+      },
+      "peerDependenciesMeta": {
+        "@hono/node-server": {
+          "optional": true
+        }
       }
     },
     "node_modules/@pome-sh/twin-slack/node_modules/@pome-sh/shared-types": {
@@ -1281,6 +1378,28 @@
       },
       "engines": {
         "node": ">=24"
+      }
+    },
+    "node_modules/@pome-sh/twin-stripe/node_modules/@pome-sh/sdk": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/sdk/-/sdk-0.5.0.tgz",
+      "integrity": "sha512-tY9aEii2cUthCLMv2Em83jnfHuo2FtyxpY6D1ghWWwu/OPj7DiuSs+TkG2QaGRr3urwWkA+Vk/Wv6Ki5Sz5WHA==",
+      "inBundle": true,
+      "dependencies": {
+        "@pome-sh/shared-types": "0.11.0",
+        "hono": "^4.12.27",
+        "zod": "^4.1.13"
+      },
+      "engines": {
+        "node": ">=24"
+      },
+      "peerDependencies": {
+        "@hono/node-server": "^2.0.8"
+      },
+      "peerDependenciesMeta": {
+        "@hono/node-server": {
+          "optional": true
+        }
       }
     },
     "node_modules/@pome-sh/twin-stripe/node_modules/@pome-sh/shared-types": {
@@ -2191,6 +2310,16 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/graphql": {
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
     },
     "node_modules/hono": {
       "version": "4.12.29",

--- a/cli/package.json
+++ b/cli/package.json
@@ -67,7 +67,7 @@
     "@hono/node-server": "^2.0.10",
     "@openrouter/ai-sdk-provider": "^3.0.0",
     "@pome-sh/sdk": "0.5.1",
-    "@pome-sh/shared-types": "0.12.0",
+    "@pome-sh/shared-types": "0.12.1",
     "@pome-sh/twin-gmail": "0.1.0",
     "@pome-sh/twin-github": "0.2.1",
     "@pome-sh/twin-linear": "0.1.0",


### PR DESCRIPTION
Bumps the CLI's exact `@pome-sh/shared-types` pin `0.12.0 → 0.12.1` (now published on npm, packages-v16).

## Why
The F-861 rename-notice code (already on `main`, #193) reads `agent.resolved_via` / `agent.hint`. Those fields ship in shared-types **0.12.1**. The published CLI *bundles* shared-types, so without this bump:
- `cli-release`'s registry `npm ci` installs `0.12.0` (no fields), and
- `npm run build` (`tsc`) fails on the unknown `resolved_via` field.

So this pin bump is required for the CLI release to build *and* for the notice to actually fire at runtime.

## Verification
Against the **registry** `shared-types@0.12.1` (clean `npm ci`, not the tarball lane): `typecheck` ✓, `build` ✓, `register.test.ts` 24/24 ✓ — `dist/rest.d.ts` confirmed to carry `resolved_via`.

## Notes for reviewer
- Touches only `cli/package.json` + `cli/package-lock.json` (no `cli/src`), so the version-bump/changeset gate is a no-op — the user-facing changeset (`slug-rename-hint.md`) is already queued for the next CLI release.
- After merge: `cli-release.yml`'s "deps published" gate now passes (all bundled deps incl. `twin-linear@0.1.0` are on npm), so the Version Packages PR (#164) refreshes to include F-861 and ships **cli 0.4.0** bundling shared-types 0.12.1.

<!-- Closes F-861 (CLI publish step) -->