### PR TITLE
cli: fix package.json repo URL to pome-sh/digital-twins (unblocks cli 0.4.0 publish)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -18,11 +18,11 @@
   "homepage": "https://pome.sh",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pome-sh/pome-twins.git",
+    "url": "git+https://github.com/pome-sh/digital-twins.git",
     "directory": "cli"
   },
   "bugs": {
-    "url": "https://github.com/pome-sh/pome-twins/issues"
+    "url": "https://github.com/pome-sh/digital-twins/issues"
   },
   "author": "Pome <founders@pome.sh> (https://pome.sh)",
   "license": "Apache-2.0",


### PR DESCRIPTION
`cli/package.json` still pointed `repository.url` / `bugs.url` at the **old** repo name `pome-twins`. The repo was renamed `pome-twins → digital-twins` (2026-07-20) and every `packages/*` manifest was updated, but the CLI was missed.

npm's provenance publishing (OIDC) validates `package.json` `repository.url` against the workflow's repo claim, so the `@pome-sh/cli@0.4.0` release (which bundles the F-861 rename notice) failed:

```
E422 ... "repository.url" is "…/pome-twins.git", expected to match "…/digital-twins" from provenance
```

This aligns both URLs to `digital-twins`. After merge, `cli-release.yml` (no pending changesets) re-attempts `changeset publish` for the already-bumped `0.4.0`, now with matching provenance.

Metadata-only (`cli/package.json`), no `cli/src` change → version-bump/changeset gate is a no-op.

<!-- Closes F-861 (CLI publish step) -->