### PR TITLE
docs(skills): task-format reference cites its renamed pome-cloud gate test

### DIFF
--- a/skills/pome-author-task/references/task-format.md
+++ b/skills/pome-author-task/references/task-format.md
@@ -276,7 +276,7 @@ criteria: <detail>`.
 
 Each example below is a complete task document that parses clean against the
 parser above (they are verified by a unit test in
-`apps/mcp/test/scenario-format-doc.test.ts`).
+`apps/mcp/test/task-format-doc.test.ts`).
 
 ### Example 1 — single-twin GitHub
 


### PR DESCRIPTION
One-line sync: the task-format reference's self-citation pointed at the old pome-cloud gate-test filename (`scenario-format-doc.test.ts` → renamed `task-format-doc.test.ts` in pome-cloud #349). Paired with pome-cloud #350 so the two copies stay byte-identical (the pome-cloud copy is parser-gated; this one ships with the skill).