### PR TITLE
Anti-cheat guardrail + run_trials batch form in the coach run skill

### DIFF
--- a/skills/pome-author-task/SKILL.md
+++ b/skills/pome-author-task/SKILL.md
@@ -68,9 +68,10 @@ GitHub-only agent has no wrong-Slack-channel to test):
   benign thing it might over-escalate?
 - **Flakiness tolerance** — how many trials per exam, and what fraction must
   pass? Record the answer in `## Config` (`runs`, `passThreshold`) so it
-  travels with the task — but the platform does not enforce these keys:
-  the run skill executes trials as N `run_task` calls sharing a
-  `group_id`, and the pass-rate judgment happens there.
+  travels with the task — but the platform does not enforce these keys: the run
+  skill (`pome-run-task`) reads them, provisions `runs` trials with `run_trials`
+  under one `group_id`, and judges the pass-rate against `passThreshold` itself
+  via `list_runs` — the platform scores each trial, not the trial-set.
 
 Each answered fear becomes ONE task: a concrete bad/good end-state plus the
 reasoning behind it.

--- a/skills/pome-run-task/README.md
+++ b/skills/pome-run-task/README.md
@@ -59,9 +59,11 @@ https://mcp.pome.sh/mcp`) so the `run_task` / `finalize_run` / `get_report` /
 
 ## The run loop
 
-1. **Mint** — `run_task(task_id, agent_id)` → `session_id`,
+1. **Mint** — `run_task(task_id, agent_id, group_id)` → `session_id`,
    `agent_token` (SENSITIVE, memory-only), `examinee_task`, `examinee_launch`.
-   Heal a `twins not enabled` 400 with one additive `register_agent` (F-784).
+   Mint the `group_id` upfront so reruns aggregate as one exam; for a `runs: N`
+   task use `run_trials(n, task_id, group_id)`, the batch form. Heal a
+   `twins not enabled` 400 with one additive `register_agent` (F-784).
 2. **Launch** — dispatch on the Runtime line: managed agent → `ant`
    (`references/launch-managed-agent.md`); anything else → REST
    (`references/launch-rest.md`). The launcher assembles from `examinee_launch`,
@@ -73,7 +75,9 @@ https://mcp.pome.sh/mcp`) so the `run_task` / `finalize_run` / `get_report` /
    `hosted`, the `app.pome.sh` link.
 5. **Fix loop** — on a failure, hand the report's `## Handoff (fix prompt)` to the
    builder; they edit the **examinee** prompt; re-run only the failed tasks
-   (same `agent_id`, shared `group_id`); diff the two reports and show the delta.
+   (same `agent_id`, reusing the `group_id`); diff the two reports and show the
+   delta. Anti-cheat guardrail: never weaken a criterion/`passThreshold` or edit
+   the seed to force a green — a criterion fix goes back through author/verify.
 
 ## Test evidence
 

--- a/skills/pome-run-task/SKILL.md
+++ b/skills/pome-run-task/SKILL.md
@@ -28,11 +28,24 @@ a log. It dies at `expires_at`; `finalize_run` is the last thing that needs it.
 
 ## 1. Mint the run
 
-Call `run_task(task_id, agent_id)` (the `agent_id` from intake). It seeds
-live twin sandboxes and returns `session_id`, `expires_at`, `agent_token`,
-`examinee_task` (the prompt + twins the examinee sees — no criteria), and
-`examinee_launch` (the full launch spec).
+Mint a `grp_`-prefixed `group_id` **now** and reuse it for every run of this
+task — the baseline and any fix-loop reruns — so they aggregate as one exam
+(aggregation keys on `(group_id, task)`; never reuse a `group_id` across
+different tasks). Then call `run_task(task_id, agent_id, group_id)` (the
+`agent_id` from intake). It seeds live twin sandboxes and returns `session_id`,
+`expires_at`, `agent_token`, `examinee_task` (the prompt + twins the examinee
+sees — no criteria), and `examinee_launch` (the full launch spec).
 
+- **Trials-of-N (the batch form)** — when the task's `## Config` sets `runs: N`
+  (a flakiness budget), don't hand-loop `run_task`: call
+  `run_trials(n, task_id, group_id)`, the batch form that provisions all N
+  trials up front under one shared `group_id` and returns a `trials[]` array,
+  each with its own `session_id` + `agent_token`. You still launch and
+  `finalize_run` **each** trial (all N sandboxes share the concurrency quota —
+  launch + finalize promptly to free slots). Pass-rate is judged here, not by
+  the platform: once the trials finalize, `list_runs(group_id)` gives the
+  cross-trial view — compute the fraction passed and compare it to the task's
+  `passThreshold` (default 100%).
 - **`twins not enabled` (HTTP 400)** — the agent's allowlist is missing a twin
   the task needs. Heal with one additive `register_agent(name, twins:[…])`
   (it merges, never removes — F-784), then re-run. Do not re-intake the scope.
@@ -79,12 +92,23 @@ criterion is an unregistered predicate, not a failing grade — route it back to
 
 A green run is done. On a failure, the report's `## Handoff (fix prompt)` section
 is the driver: it names what the agent did wrong. Hand it to the builder, they
-edit the **examinee's** prompt (never the task — that would move the goal
-posts), then:
+edit the **examinee's** prompt, then re-run.
 
-1. Re-run **only the failed tasks** — one `run_task` each against the
-   same `agent_id`, sharing a `group_id` with the first attempt so they line up
-   as one exam on the dashboard.
+**The one thing you never do: make the exam easier to pass.** Every fix goes into
+the examinee's prompt — never into the task. Do not weaken or delete a criterion,
+lower a `passThreshold`, loosen a `[code]` predicate, or edit/remove the seed or
+its expected end-state to turn a red run green. That is the "vibe-coder" failure
+DeepEval names — gaming the metric by rewriting the test instead of fixing the
+work — and it silently destroys the exam: a task that no longer discriminates a
+working agent from a broken one grades nothing, so a green it produces is
+worthless. If a criterion is genuinely wrong (unfair, `unmatched`, or
+mis-specified), that is **not** a fix-loop edit — stop the loop and route it back
+to `pome-author-task` / `pome-verify-seed`, where any criterion or seed change is
+re-verified as a fair exam before it counts. Then:
+
+1. Re-run **only the failed tasks** — one `run_task` (or `run_trials` for a
+   flaky task) each against the same `agent_id`, reusing the `group_id` from
+   step 1 so the reruns line up with the baseline as one exam on the dashboard.
 2. There is no delta field in the report — compute it: pull `get_report` for the
    prior run and the new one, diff the Status column per criterion, and report
    the flips (`"leaked to #general: failed → passed"`). `list_runs(group_id)`

--- a/skills/pome/SKILL.md
+++ b/skills/pome/SKILL.md
@@ -49,7 +49,7 @@ verbatim from the frozen control MCP contract v1.0:
 | --- | --- |
 | `pome register` | `register_agent` via the control MCP — the **one** "register an agent" verb (the CLI command remains for CLI-era users; both land the same registration) |
 | `pome run <task>` | `run_task` (mints the session) → launch the examinee → `finalize_run` the instant it idles → `get_report` |
-| `pome run -n 3` (N trials) | `run_task` ×3, all sharing one `group_id`, `finalize_run` each; `list_runs(group_id)` is the cross-run view |
+| `pome run -n 3` (N trials) | `run_trials(n, task_id)` — the batch form that provisions all N under one shared `group_id` (or `run_task` ×N reusing one `group_id`); `finalize_run` each; `list_runs(group_id)` is the cross-run view |
 | Local task files on disk | `save_task` into your team catalog on first use; browse with `list_tasks` (no cross-team library) |
 | "Where are my results?" | `get_report(run_id)` / `list_runs`, and the dashboard on `app.pome.sh` |
 


### PR DESCRIPTION
## Summary

Hardens the Gen-2 coach skills' run loop against eval-gaming and closes two
Greptile P1 findings from the skills-move PR (digital-twins#195). Docs-only
(skills markdown) — changeset-exempt.

- **Anti-cheat guardrail** (`pome-run-task/SKILL.md` fix loop) — extends the
  existing "edit the examinee's prompt, never the task" line into the full
  guardrail: never weaken/delete a criterion, lower `passThreshold`, loosen a
  `[code]` predicate, or edit the seed / expected end-state to force a red run
  green. Names DeepEval's "vibe-coder" failure (gaming the metric by rewriting
  the test) and routes genuine criterion/seed fixes back through
  `pome-author-task` / `pome-verify-seed`, where they're re-verified as a fair
  exam.
- **`run_trials` as the batch form of trials-of-N** — the run skill now teaches
  `run_trials(n, task_id, group_id)` to provision N trials up front (still
  launch + `finalize_run` each), reads `runs`/`passThreshold` from the task
  Config, and judges pass-rate via `list_runs(group_id)`.
- **Greptile #1** (`SKILL.md:31`) — mint the `group_id` **upfront** at the mint
  step so the baseline and every fix-loop rerun share one group and aggregate
  as a single exam (`aggregation keys on (group_id, task)`).
- **Greptile #2** (`pome-author-task/SKILL.md:73`) — the `runs`/`passThreshold`
  cross-reference is now accurate: the run skill genuinely reads and aggregates
  them, so the author skill no longer promises behaviour that didn't exist.
- Router (`pome/SKILL.md`) + `pome-run-task/README.md` updated for consistency.

## Reviewer notes

- The anti-cheat paragraph is the one prose-heavy change — read `SKILL.md:97`.
- Lints run green locally: `lint:legacy-markers`, `lint:copy-markers`.

## Not in this PR (handed off)

F-856 also has a docs leg: the live audit of `docs.pome.sh/llms.txt` +
`/llms-full.txt` **failed** — both lead with the retired CLI-first story and the
skills entries still point to Gen-1 `/pome-setup` `/pome-test`. That fix lands in
**pome-cloud** `apps/docs/` (Mintlify nav/config) and is being done in a separate
workspace. This PR is the pome-twins leg only.

<!-- Part of F-856 — pome-twins legs only; apps/docs lead fix tracked separately in pome-cloud. Do not auto-close the ticket on merge. -->