### PR TITLE
docs(skills): post-fix rerun opens a fresh group_id + baseline_group_id

### DIFF
--- a/skills/pome-run-task/README.md
+++ b/skills/pome-run-task/README.md
@@ -61,7 +61,8 @@ https://mcp.pome.sh/mcp`) so the `run_task` / `finalize_run` / `get_report` /
 
 1. **Mint** — `run_task(task_id, agent_id, group_id)` → `session_id`,
    `agent_token` (SENSITIVE, memory-only), `examinee_task`, `examinee_launch`.
-   Mint the `group_id` upfront so reruns aggregate as one exam; for a `runs: N`
+   Mint the `group_id` upfront so an attempt's trials aggregate as one exam (a
+   post-fix rerun opens a new group and links back — see step 5); for a `runs: N`
    task use `run_trials(n, task_id, group_id)`, the batch form. Heal a
    `twins not enabled` 400 with one additive `register_agent` (F-784).
 2. **Launch** — dispatch on the Runtime line: managed agent → `ant`
@@ -75,9 +76,11 @@ https://mcp.pome.sh/mcp`) so the `run_task` / `finalize_run` / `get_report` /
    `hosted`, the `app.pome.sh` link.
 5. **Fix loop** — on a failure, hand the report's `## Handoff (fix prompt)` to the
    builder; they edit the **examinee** prompt; re-run only the failed tasks
-   (same `agent_id`, reusing the `group_id`); diff the two reports and show the
-   delta. Anti-cheat guardrail: never weaken a criterion/`passThreshold` or edit
-   the seed to force a green — a criterion fix goes back through author/verify.
+   (same `agent_id`) as a fresh run-set — a **new** `group_id` carrying the
+   failing run's group_id as `baseline_group_id` (the report's `## Rerun after
+   fixing` section pre-fills both); diff the two reports and show the delta.
+   Anti-cheat guardrail: never weaken a criterion/`passThreshold` or edit the
+   seed to force a green — a criterion fix goes back through author/verify.
 
 ## Test evidence
 

--- a/skills/pome-run-task/SKILL.md
+++ b/skills/pome-run-task/SKILL.md
@@ -28,10 +28,12 @@ a log. It dies at `expires_at`; `finalize_run` is the last thing that needs it.
 
 ## 1. Mint the run
 
-Mint a `grp_`-prefixed `group_id` **now** and reuse it for every run of this
-task — the baseline and any fix-loop reruns — so they aggregate as one exam
-(aggregation keys on `(group_id, task)`; never reuse a `group_id` across
-different tasks). Then call `run_task(task_id, agent_id, group_id)` (the
+Mint a `grp_`-prefixed `group_id` **now** and reuse it for every trial of this
+attempt — the baseline and any *pre-fix* flaky retries — so they aggregate as
+one exam (aggregation keys on `(group_id, task)`; never reuse a `group_id`
+across different tasks). A **post-fix** rerun is the exception: it opens a *new*
+`group_id` and links back to the baseline via `baseline_group_id` (see §5).
+Then call `run_task(task_id, agent_id, group_id)` (the
 `agent_id` from intake). It seeds live twin sandboxes and returns `session_id`,
 `expires_at`, `agent_token`, `examinee_task` (the prompt + twins the examinee
 sees — no criteria), and `examinee_launch` (the full launch spec).
@@ -106,13 +108,21 @@ mis-specified), that is **not** a fix-loop edit — stop the loop and route it b
 to `pome-author-task` / `pome-verify-seed`, where any criterion or seed change is
 re-verified as a fair exam before it counts. Then:
 
-1. Re-run **only the failed tasks** — one `run_task` (or `run_trials` for a
-   flaky task) each against the same `agent_id`, reusing the `group_id` from
-   step 1 so the reruns line up with the baseline as one exam on the dashboard.
+1. Re-run **only the failed tasks** as a **fresh run-set** — one `run_task` (or
+   `run_trials` for a flaky task) each against the same `agent_id`. A post-fix
+   rerun mints a **new** `group_id` (omit it and `run_trials` mints one) and
+   passes the failing run's group_id as **`baseline_group_id`** — the report's
+   `## Rerun after fixing` section pre-fills both. The rerun is its own run-set
+   linked back to the baseline; the dashboard pairs them and shows the fail→green
+   delta. Do **not** reuse the baseline's `group_id` — that merges baseline+green
+   into one aggregate and destroys the split. (A *pre-fix* flaky retry — same
+   examinee, no edit — still shares the group_id; only a post-fix rerun opens a
+   new one and links back with `baseline_group_id`.)
 2. There is no delta field in the report — compute it: pull `get_report` for the
-   prior run and the new one, diff the Status column per criterion, and report
-   the flips (`"leaked to #general: failed → passed"`). `list_runs(group_id)`
-   gives the cross-run view.
+   baseline run and the rerun, diff the Status column per criterion, and report
+   the flips (`"leaked to #general: failed → passed"`). Baseline and rerun are
+   now separate groups paired by `baseline_group_id`; `list_runs(group_id)` gives
+   each run-set's view.
 3. Repeat until every re-run is green (or the builder accepts the behavior).
    Only failed tasks re-run; the green ones are not re-billed.
 


### PR DESCRIPTION
Executive summary: The `pome-run-task` fix loop told the coach to reuse the baseline run's `group_id` for post-fix reruns. Since run tools and the reliability page aggregate on `(group_id, task)`, that merged the failing baseline and the fixed green run into one aggregate — polluting the pass rate and hiding the fail→green delta. This updates the recipe so a post-fix rerun mints a **new** `group_id` and links back to the failing set via `baseline_group_id`.

## What
- `skills/pome-run-task/SKILL.md` — fix-loop step 1/2 rewritten: a post-fix rerun opens a fresh `group_id` and passes the failing run's group_id as `baseline_group_id` (the report's `## Rerun after fixing` section pre-fills both). A pre-fix flaky retry (same examinee, no edit) still shares the group_id.
- `skills/pome-run-task/README.md` — the one-line fix-loop summary updated to match.

## Why
The coach-facing rerun recipe must not merge the baseline and the fixed run into one run-set — the two need to stay separate so the delta is visible and the green set's pass rate is honest.

## Notes for reviewer
Docs-only; no code or contract-invariant changes.