### PR TITLE
docs(twins): runtime-contract sections for gmail + linear; reconcile tool counts

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -80,7 +80,7 @@ Probed against the pre-engine builds (`3cd86eb`); the contract suite asserts eve
 
 - Packaged entry: `packages/twin-gmail/dist/src/server.js`; `GET /healthz`
   must answer within the shared three-second bound with `twin: "gmail"`,
-  `implementation: "gmail_twin"`, `fidelity: "semantic"`, and `tools: 10`.
+  `implementation: "gmail_twin"`, `fidelity: "semantic"`, and `tools: 13`.
 - Session identity is the normalized `gmail_email` JWT claim. Missing claims
   default locally to `pome-agent@pome-twin.test`; hosted issuers must mint the
   claim. `POME_GMAIL_TOKEN` is an alias of `POME_AUTH_TOKEN`. There is no
@@ -92,7 +92,7 @@ Probed against the pre-engine builds (`3cd86eb`); the contract suite asserts eve
   `INVALID_ARGUMENT`.
 - `GET /s/:sid/_pome/health` has exactly
   `fidelity, ok, twin, version`; `GET /s/:sid/healthz` is enabled.
-- MCP advertises exactly the captured ten launch tools. Legacy unknown-tool
+- MCP advertises exactly the captured thirteen launch tools. Legacy unknown-tool
   calls return 404 `NOT_FOUND`; strict alias/form/malformed bodies return 400
   `INVALID_ARGUMENT`.
 - Unknown session routes return 501 `UNIMPLEMENTED`; unknown root routes return
@@ -103,7 +103,7 @@ Probed against the pre-engine builds (`3cd86eb`); the contract suite asserts eve
 
 - Packaged entry: `packages/twin-linear/dist/src/server.js`; `GET /healthz`
   must answer within the shared three-second bound with `twin: "linear"`,
-  `implementation: "linear_twin"`, `fidelity: "semantic"`, and `tools: 20`.
+  `implementation: "linear_twin"`, `fidelity: "semantic"`, and `tools: 22`.
 - Session identity is the normalized `linear_email` JWT claim. Missing claims
   default locally to `admin@pome-twin.test`; hosted issuers must mint the
   claim. `POME_LINEAR_TOKEN` is an alias of `POME_AUTH_TOKEN`. There is no
@@ -120,7 +120,7 @@ Probed against the pre-engine builds (`3cd86eb`); the contract suite asserts eve
   `BAD_USER_INPUT`.
 - `GET /s/:sid/_pome/health` has exactly
   `fidelity, ok, twin, version`; `GET /s/:sid/healthz` is enabled.
-- MCP advertises exactly the captured twenty launch tools. Legacy unknown-tool
+- MCP advertises exactly the captured twenty-two launch tools. Legacy unknown-tool
   calls return 404 `NOT_FOUND`; strict alias/form/malformed bodies return 400
   `BAD_USER_INPUT`.
 - Unknown session routes return 501 with `fidelity: "unsupported"`; unknown

--- a/packages/twin-gmail/README.md
+++ b/packages/twin-gmail/README.md
@@ -86,6 +86,45 @@ Gmail follows the same SDK chassis as GitHub / Slack / Stripe:
 
 Intentional differences: no Google OAuth (Pome JWT only); watch/stop 501; Stripe-style idempotency/failure-injection middleware is Stripe-only.
 
+## Runtime contract (for snapshot consumers)
+
+`pome-cloud` builds a Vercel Sandbox snapshot from this package's signed source
+artifact. The following constraints must hold for that build to succeed and for
+the resulting snapshot to boot. Changing any of these is a breaking change for
+hosted; land the producer change here first, then open the cloud consumer PR
+that pins and verifies the new signed digest.
+
+### Build
+
+- Package is `npm install`-able from `package.json` alone (no `workspace:*`
+  protocols, no package-manager-specific deps; no committed lockfile is required, the snapshot
+  build regenerates one on each rebuild)
+- `npm run build` exits 0 and emits `dist/src/server.js`
+- Built output is loadable under Node 24 — the snapshot runs `runtime: "node24"`.
+  SQLite is the built-in `node:sqlite` (via the sdk's `openTwinDatabase()`) —
+  no native modules, no compiler toolchain.
+
+### Runtime
+
+- Server entry: `node dist/src/server.js` (cwd = package root)
+- Listens on `:3336` by default (`GMAIL_TWIN_PORT`, then the native default)
+- **Hosted normalizes the port to `PORT=3333`.** The server honors the `PORT`
+  env var first (`PORT` → `GMAIL_TWIN_PORT` → `3336`); the pome-cloud
+  control-plane sets `PORT=3333` at spawn for every twin, so the native `3336`
+  default is only used for standalone local runs.
+- Honors `GMAIL_TWIN_HOST=0.0.0.0` env (default `127.0.0.1` is unreachable via
+  Vercel Sandbox port forwarding)
+- `GET /healthz` returns 200 within ~3s of process start (the snapshot build
+  sleeps 3s after `node dist/src/server.js` before probing)
+- Seed via `POME_SEED_JSON` (strict Gmail seed schema)
+- Bearer auth at `Authorization: Bearer <jwt>` — Pome session JWT, not a Google
+  OAuth access token
+
+### Cloud consumer coordination
+
+- Bumping any of the above = publish a signed twin digest and open the matching
+  `pome-cloud` consumer PR.
+
 ## Development
 
 ```bash

--- a/packages/twin-linear/README.md
+++ b/packages/twin-linear/README.md
@@ -87,6 +87,50 @@ Linear follows the same SDK chassis as GitHub / Slack / Stripe / Gmail:
 | Session identity claim | `linear_email` | Peers use provider-shaped claims |
 | Root session mount | yes | `mountSessionAtRoot: true` |
 
+## Runtime contract (for snapshot consumers)
+
+`pome-cloud` builds a Vercel Sandbox snapshot from this package's signed source
+artifact. The following constraints must hold for that build to succeed and for
+the resulting snapshot to boot. Changing any of these is a breaking change for
+hosted; land the producer change here first, then open the cloud consumer PR
+that pins and verifies the new signed digest.
+
+### Build
+
+- Package is `npm install`-able from `package.json` alone (no `workspace:*`
+  protocols, no package-manager-specific deps; no committed lockfile is required, the snapshot
+  build regenerates one on each rebuild)
+- `npm run build` exits 0 and emits `dist/src/server.js`
+- Built output is loadable under Node 24 — the snapshot runs `runtime: "node24"`.
+  SQLite is the built-in `node:sqlite` (via the sdk's `openTwinDatabase()`) —
+  no native modules, no compiler toolchain.
+
+### Runtime
+
+- Server entry: `node dist/src/server.js` (cwd = package root)
+- Listens on `:3337` by default (`LINEAR_TWIN_PORT`, then the native default)
+- **Hosted normalizes the port to `PORT=3333`.** The server honors the `PORT`
+  env var first (`PORT` → `LINEAR_TWIN_PORT` → `3337`); the pome-cloud
+  control-plane sets `PORT=3333` at spawn for every twin, so the native `3337`
+  default is only used for standalone local runs.
+- Honors `LINEAR_TWIN_HOST=0.0.0.0` env (default `127.0.0.1` is unreachable via
+  Vercel Sandbox port forwarding)
+- Boots via a manual `@hono/node-server` path (not the SDK `serve()` helper),
+  with graceful `SIGINT`/`SIGTERM` handlers that flush and close the recorder
+  store before exit
+- Serves GraphQL at `/graphql` (in addition to the session MCP surface)
+- `GET /healthz` returns 200 within ~3s of process start (the snapshot build
+  sleeps 3s after `node dist/src/server.js` before probing)
+- Seed via `POME_SEED_JSON` (strict Linear seed schema; `LINEAR_TWIN_NO_SEED=1`
+  boots empty)
+- Bearer auth at `Authorization: Bearer <jwt>` — Pome session JWT, seeded Linear
+  tokens, or `lin_pome_*` provider tokens
+
+### Cloud consumer coordination
+
+- Bumping any of the above = publish a signed twin digest and open the matching
+  `pome-cloud` consumer PR.
+
 ## Development
 
 ```bash


### PR DESCRIPTION
## What
Add the `## Runtime contract (for snapshot consumers)` README section to the **Gmail** and **Linear** twins (parity with `twin-github`), and reconcile the MCP tool counts in `CONTRACT.md`.

## Why
The cloud snapshot-build + control-plane wiring (pome-cloud) consumes each twin's runtime contract (entry, port, host env, `/healthz`, seed-from-env). Gmail/Linear lacked the documented contract section GitHub carries, and `CONTRACT.md` had stale tool counts (Gmail 10, Linear 20) that disagreed with the READMEs/HOSTED docs.

## Notes for reviewer
- Docs-only; no `src/**` changes.
- True tool counts verified from the canonical MCP fixtures: **Gmail 13**, **Linear 22**. The drift was entirely in `CONTRACT.md`; the twin READMEs/HOSTED docs were already correct. All three docs now agree.
- Documents the hosted `PORT=3333` normalization the control-plane applies (native 3336/3337 are standalone-local only).
