### PR TITLE
fix(twin-gmail): declare @hono/node-server direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6092,9 +6092,10 @@
     },
     "packages/twin-gmail": {
       "name": "@pome-sh/twin-gmail",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
+        "@hono/node-server": "^2.0.10",
         "@pome-sh/sdk": "0.5.1",
         "hono": "^4.12.27",
         "zod": "^4.1.13"

--- a/packages/twin-gmail/CHANGELOG.md
+++ b/packages/twin-gmail/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @pome-sh/twin-gmail — CHANGELOG
 
+## 0.1.2 — 2026-07-23
+
+Fix: declare `@hono/node-server` as a direct dependency. The twin's
+`server.js` boots via the SDK `serve()` helper, which imports
+`@hono/node-server` (an optional peer of `@pome-sh/sdk`). Without a direct
+dependency, a clean install (e.g. the hosted Vercel Sandbox snapshot build)
+failed to start the server with `ERR_MODULE_NOT_FOUND`. twin-github and
+twin-linear already declared it; gmail now matches. No twin surface change.
+
 ## 0.1.1 — 2026-07-21
 
 Dependency-only patch: repin `@pome-sh/sdk` to 0.5.1 (F-818 batch). No twin

--- a/packages/twin-gmail/package.json
+++ b/packages/twin-gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-gmail",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Deterministic Gmail-shaped twin for agent testing — SQLite-backed domain core.",
   "private": false,
   "type": "module",
@@ -44,6 +44,7 @@
     "preview:drift": "tsx scripts/preview-drift.ts"
   },
   "dependencies": {
+    "@hono/node-server": "^2.0.10",
     "@pome-sh/sdk": "0.5.1",
     "hono": "^4.12.27",
     "zod": "^4.1.13"


### PR DESCRIPTION
## What
Add `@hono/node-server` to twin-gmail's direct dependencies (0.1.1 -> 0.1.2).

## Why
twin-gmail's `server.js` boots via the SDK `serve()` helper, which imports `@hono/node-server` — an *optional peer* of `@pome-sh/sdk`, so a clean install doesn't pull it. A standalone/clean install (the hosted Vercel Sandbox snapshot build) crashes on boot with `ERR_MODULE_NOT_FOUND: @hono/node-server`. twin-github and twin-linear already declare it directly; gmail now matches. Verified: clean-room install + `node dist/src/server.js` now serves `/healthz` 200.

## Notes for reviewer
No twin surface change. Unblocks the gmail hosted snapshot for pome-cloud.