### PR TITLE
Retire Gen-1 pome-setup/pome-test skills; graft doctor preflight into Gen-2

### DIFF
--- a/cli/.changeset/retire-gen1-skill-pointers.md
+++ b/cli/.changeset/retire-gen1-skill-pointers.md
@@ -1,0 +1,9 @@
+---
+"@pome-sh/cli": patch
+---
+
+Retire the Gen-1 `/pome-setup` and `/pome-test` skills to redirect pointers
+(F-859). `pome skills install`'s post-install banner and the `pome skills`
+help text now say the skills are retired and point to the Gen-2 coach set
+(`npx skills add pome-sh/digital-twins`) instead of advertising them as the
+way to wire and test an agent.

--- a/cli/README.md
+++ b/cli/README.md
@@ -53,8 +53,33 @@ pome run --local scenarios/01-bug-happy-path.md   # captures a raw trace only �
 pome eval runs/01-bug-happy-path/<run-id>         # uploads it for a cloud verdict
 ```
 
-See [docs.pome.sh](https://docs.pome.sh) for the task library, exit-code
-contract, authentication, the Stripe/Slack twins, and everything else.
+See [docs.pome.sh](https://docs.pome.sh) for the task library, authentication,
+the Stripe/Slack twins, and everything else.
+
+## CI one-shot — the exit-code contract
+
+`pome run <task>` is the CI one-shot: one hosted, scored run, and its **exit
+code is the verdict**. Gate CI on it directly.
+
+| Exit code | Meaning |
+| --- | --- |
+| `0` | pass (hosted/scored run), or trace captured (`--local`, not scored) |
+| `1` | ran and scored **below** the pass threshold |
+| `2` | twin / orchestration error (network, 5xx, twin spawn failed) |
+| `3` | auth error (401/403) — `pome login` again, or set `POME_API_KEY` in CI |
+| `4` | quota exceeded (402/429) |
+| `5` | usage error (bad flags, missing task file) |
+
+Two rules CI must honor:
+
+- **`--local` is not a verdict.** A `--local` run captures a raw trace and never
+  scores, so its exit `0` means "trace captured," not "passed." Never gate CI on
+  a `--local` exit code — score it later with `pome eval <run-dir>`.
+- **Trial groups map as a whole.** `pome run -n k` (k>1) collapses the whole
+  group to one code: `0` = at least one trial completed and every completed
+  trial passed; `1` = at least one completed trial failed its threshold; `2` =
+  no trial completed. Errored trials are excluded from the verdict fraction and
+  never drag a passing group below `0` on their own.
 
 ## Development
 

--- a/cli/skills/pome-setup/SKILL.md
+++ b/cli/skills/pome-setup/SKILL.md
@@ -1,150 +1,26 @@
 ---
 name: pome-setup
-description: Use when wiring a repository's coding agent to pome so pome can run it against deterministic SaaS twins (GitHub, Stripe, Slack) — first-time setup, after the agent's third-party services change, when `pome doctor` reports the repo unwired, or when a `pome install` session hands off to you. Triggers on "wire my agent to pome", "set up pome", "make this repo pome-ready", or "/pome-setup".
+description: RETIRED (F-859). The Gen-1 CLI-era wiring skill, superseded by the unified Gen-2 coach set (install with `npx skills add pome-sh/digital-twins`). Resolves only on the explicit "/pome-setup" invocation, so a user who still has Gen-1 installed and types it lands on a pointer to the Gen-2 skills instead of dead air. It wires nothing itself — it redirects. The shared natural-language phrases ("wire my agent to pome", "set up pome") belong to the `pome` router.
 ---
 
-# pome-setup
+# pome-setup — retired (F-859)
 
-Wire an existing coding agent's repository to pome (`https://pome.sh`), adapter-first, and prove the wiring with `pome doctor`. The job is not done until doctor exits green.
+This Gen-1 CLI-era skill is **retired**. Its job — wire a repo's agent to pome
+and prove the wiring — now lives in the unified **Gen-2 coach skill set** (the
+top-level `skills/` directory in this repo; install with
+`npx skills add pome-sh/digital-twins`).
 
-Pome runs agents against deterministic SaaS twins — local, resettable copies of the GitHub/Stripe/Slack APIs — and records every tool call as a trace. The OSS CLI is capture-only: a local run (`pome run --local`) records a raw trace and never scores; verdicts come from Pome cloud (`pome eval <run-dir>` on a captured trace, or a hosted `pome run`).
+**Where its job went:**
 
-Wiring changes nothing about production behavior: the adapter only emits trace signals during a pome run, and twin base URLs come from env vars the pome runner injects at run time.
+- **Register the examinee** → the **`pome-intake`** skill (collect the clone
+  scope, report twin coverage). For a self-hosted REST agent, one
+  `register_agent(name, twins)` call — the single "register an agent" verb.
+- **Prove the wiring** — the `pome doctor` preflight (config → twin reachable →
+  routing → egress floor) → the **`pome-run-task`** REST launcher
+  (`skills/pome-run-task/references/launch-rest.md`), which runs exactly those
+  checks before launching a REST examinee, stopping at the first failure with
+  one cause + one fix. Repos that have the CLI still run `pome doctor` directly.
 
-## Hard rules
-
-Follow these on every step. They are not optional.
-
-1. **Never write secrets into source, config, or chat.** No API keys, tokens, or credential values in any file you edit or any message you print. The pome runner injects `POME_*` env vars at run time; read them, never inline their values.
-2. **Read every file immediately before you write it**, even if you already read it earlier in the session. Stale edits break repos.
-3. **Minimal, targeted edits.** Change what the wiring requires and nothing else — no refactors, no reformatting, no drive-by fixes.
-4. **Show the diff and get explicit user approval before applying any edit.** If your harness has an edit-approval UI, that gate counts. If it doesn't, print the proposed change in chat and wait for a yes.
-5. **Never weaken the capture layer.** Don't remove `withPome()`, don't add `*` to `POME_EGRESS_ALLOW`, don't route around the twin.
-6. **No production-host literals in agent source.** `pome doctor` treats a hardcoded `https://api.github.com` — even as a `??` fallback — as a twin bypass and fails. Production fallbacks belong in deployment env, not in source literals. (Loopback fallbacks like `http://127.0.0.1:3333` are fine.)
-7. **Don't guess service coverage.** If the agent talks to a service pome has no twin for, say so explicitly and skip that service — never fake wiring.
-8. **Finish with `pome doctor` and iterate until green.** Never report success while any check is red.
-
-## Steps
-
-### 0. Preflight
-
-```bash
-pome version
-```
-
-If the command is missing, install it (`npm install -g @pome-sh/cli`), then continue.
-
-Auth — any one of these passing is enough (the macOS Keychain item is service `sh.pome.cli`, account `hosted`):
-
-```bash
-security find-generic-password -s "sh.pome.cli" -a hosted -w >/dev/null 2>&1 \
-  || test -f ~/.pome/credentials.json \
-  || [ -n "$POME_API_KEY" ] \
-  && echo ok
-```
-
-If this does not print `ok`, run `pome login` (opens a browser; stores credentials in the macOS Keychain, or `~/.pome/credentials.json` on other platforms). When a `pome install` session handed off to you, auth was already checked — the probe just confirms instantly.
-
-### 1. Identify the agent and its services
-
-Read the repo (`package.json` / `pyproject.toml` / agent source / README) and establish three things:
-
-- **Entrypoint + start command** — the exact command that starts the agent (e.g. `npm run src/index.ts`).
-- **Framework** — Claude Agent SDK (`@anthropic-ai/claude-agent-sdk`), another SDK, or a custom script driving an LLM.
-- **Services** — which third-party APIs the agent calls (GitHub? Stripe? Slack?). Run `pome scenarios` to see which twins exist.
-
-**Pause: confirm the agent and its services with the user in one short message** before touching anything. Misidentified services produce irrelevant wiring.
-
-### 2. Ensure pome.config.json
-
-```bash
-test -f pome.config.json && echo ready || echo "needs pome init"
-```
-
-If absent, tell the user `pome init` will scaffold `pome.config.json`, `scenarios/`, and example agents — after they confirm, run it.
-
-Then set `agent.command` in `pome.config.json` to the real start command from step 1. The scaffold default runs a bundled example, not the user's agent. Show the line you set; confirm before moving on.
-
-### 3. Wire the adapter (Claude Agent SDK repos)
-
-For repos built on `@anthropic-ai/claude-agent-sdk`:
-
-1. Add the dependency, matching the repo's package manager (lockfile tells you): `npm install @pome-sh/adapter-claude-sdk`.
-2. Swap imports — `query` and `tool` come from the adapter as drop-in replacements; `createSdkMcpServer` and everything else stay on the SDK:
-
-   ```ts
-   import { query, tool, withPome } from "@pome-sh/adapter-claude-sdk";
-   import { createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
-   ```
-
-3. Call `withPome()` once at agent startup, before any requests are made. It hooks `fetch` to emit trace signals and correlation headers — only during a pome run.
-
-For other stacks there is no adapter yet: wiring is step 4 alone, and the trace comes from the twin side. Say so explicitly in the confirmation message.
-
-### 4. Route requests through the env pome injects
-
-Find every place the agent reaches a twinned service and read the base URL from env instead of a literal:
-
-```ts
-// twin URL + token injected by the pome runner — never production
-const { POME_GITHUB_REST_URL: baseUrl, POME_AUTH_TOKEN: token } = process.env;
-```
-
-| Env var | What the runner injects |
-| --- | --- |
-| `POME_<SERVICE>_REST_URL` | REST base URL of that service's twin (e.g. `POME_GITHUB_REST_URL`) |
-| `POME_<SERVICE>_MCP_URL` | MCP endpoint of that twin |
-| `POME_AUTH_TOKEN` | Bearer token for the twin session |
-| `POME_TASK` | The task's prompt |
-
-Remove hardcoded production hosts entirely (hard rule 6).
-
-### 5. Verify: pome doctor to green
-
-```bash
-pome doctor
-```
-
-Doctor runs four checks in order — config → twin reachable → routing → egress floor — and stops at the first failure with ONE named cause (file:line where knowable) and ONE concrete fix. Apply the minimal fix (hard rules 2–4 still apply) and re-run. Loop until it ends green:
-
-```
-✓ pome.config.json found
-✓ twin reachable  github · local
-✓ requests route to the twin  reads POME_GITHUB_REST_URL
-✓ egress floor active  deny-by-default · N pattern(s) + loopback
-```
-
-### 6. Print next steps — don't run them
-
-End the session by printing exactly this shape (substitute the twin and task):
-
-```
-wiring verified — pome doctor is green.
-
-next steps:
-  pome scenarios github --copy               # pull runnable tasks into ./scenarios/
-  pome run scenarios/01-bug-happy-path.md    # 5 isolated trials against the twin
-  pome register agent <name>                 # optional: group dashboard runs under one agent
-```
-
-## Common pitfalls
-
-| Symptom | Fix |
-| --- | --- |
-| `npm install @pome-sh/adapter-claude-sdk` fails | Confirm registry access (`npm view @pome-sh/adapter-claude-sdk version`). Inside a pome-twins checkout you can also pin `"@pome-sh/adapter-claude-sdk": "file:<checkout>/packages/adapter-claude-sdk"` while iterating on unpublished workspace changes. |
-| doctor: "reads from a hardcoded https://api.github.com" | A production-host literal survives in agent source — even a `?? "https://api.github.com"` fallback triggers it. Move the fallback out of source; read `POME_GITHUB_REST_URL`. |
-| doctor: "twin not reachable" | Twin dependencies missing — run the repo's install (`npm install` / `npm install`) and re-run `pome doctor`. |
-| doctor: "egress floor disabled" | Remove `*` from `POME_EGRESS_ALLOW`. Never widen egress to pass a check. |
-| Hosted commands fail 401/403 | Re-run `pome login` (or set `POME_API_KEY` in CI). |
-| `agent.command` is still the scaffold default | Point it at the user's real agent (step 1's start command); the default runs a bundled example. |
-| The agent talks to a service with no twin | Name it in the confirmation message and skip it (hard rule 7). The user can request the twin from pome. |
-
-## Output contract
-
-When this skill finishes successfully:
-
-- `pome.config.json` exists with a real `agent.command`.
-- Claude Agent SDK repos: `@pome-sh/adapter-claude-sdk` resolves and `withPome()` runs at startup.
-- No hardcoded production hosts remain in agent source; twinned-service base URLs are read from `POME_*` env.
-- `pome doctor` exits green — all four checks.
-- The session ends with the next-steps block printed, not executed.
+Do not follow the old steps below-the-fold from memory — they referenced retired
+surfaces (`pome.config.json`, now `pome.json`; `pome scenarios`;
+`pome run --local`). Redirect the user to the Gen-2 set above.

--- a/cli/skills/pome-test/SKILL.md
+++ b/cli/skills/pome-test/SKILL.md
@@ -1,137 +1,26 @@
 ---
 name: pome-test
-description: Use when the user wants to test an already-registered coding agent against pome's deterministic SaaS twins, run their TESTS.md, or re-run scenarios after changing the agent. Triggers on phrases like "test my agent with pome", "run pome", "use /pome-test", or "run the pome tests". Reads TESTS.md, runs each scenario against the hosted twin, and reports pass/fail plus a dashboard URL.
+description: RETIRED (F-859). The Gen-1 CLI-era test-runner skill, superseded by the unified Gen-2 coach set (install with `npx skills add pome-sh/digital-twins`). Resolves only on the explicit "/pome-test" invocation, so a user who still has Gen-1 installed and types it lands on a pointer to the Gen-2 `pome-run-task` skill instead of dead air. It runs nothing itself — it redirects. The shared natural-language phrases ("test my agent with pome", "run pome") belong to the `pome` router (F-801).
 ---
 
-# pome-test
+# pome-test — retired (F-859)
 
-Runs the scenarios listed in the repo's `TESTS.md` against pome's hosted twins, reports pass/fail per scenario, and points the user at the dashboard for the trace and the LLM-judge handoff on any failures.
+This Gen-1 CLI-era skill is **retired**. Its job — run a repo's tasks against
+pome's twins and report pass/fail — now lives in the unified **Gen-2 coach skill
+set** (the top-level `skills/` directory in this repo; install with
+`npx skills add pome-sh/digital-twins`).
 
-This skill assumes the agent is already wired up. If `pome.config.json` or `TESTS.md` is missing, invoke `pome-setup` first.
+**Where its job went:**
 
-## Prerequisites — check first
+- **Run + score** → the **`pome-run-task`** skill: `run_task` mints the session,
+  you launch the examinee, `finalize_run` scores from the **live twin tape**,
+  and `get_report` narrates the verdict. Verifying a task's seed is a fair exam
+  is a separate step first (**`pome-verify-seed`**).
+- **CI one-shot / the 0–5 exit-code contract** → `pome run <task>` in CI. The
+  exit-code table now lives in **`cli/README.md`** (the "CI one-shot" section)
+  so it survives this retirement.
 
-```bash
-test -f pome.config.json && test -f TESTS.md && echo ok
-```
-
-If this does not print `ok`, stop and invoke `pome-setup` — the project isn't pome-ready yet.
-
-Also verify auth (any of these passes is sufficient — Keychain on macOS is preferred):
-
-```bash
-security find-generic-password -s "pome-sh" -w >/dev/null 2>&1 \
-  || test -f ~/.pome/credentials.json \
-  || [ -n "$POME_API_KEY" ] \
-  && echo ok
-```
-
-If not, run `pome login` (or ask the user to).
-
-## Steps
-
-### 1. Read TESTS.md
-
-Parse the file as Markdown. Collect every line that looks like a relative path to a scenario file — typically bullets under a `## Scenarios` heading. Example:
-
-```markdown
-## Scenarios
-
-- scenarios/01-bug-happy-path.md
-- scenarios/02-missing-label.md
-```
-
-Yields the list `["scenarios/01-bug-happy-path.md", "scenarios/02-missing-label.md"]`. Ignore commented-out lines (`<!-- … -->`) and anything that doesn't end with `.md`.
-
-If the list is empty, stop and report: "TESTS.md has no scenarios. Run `pome scenarios <twin> --copy` to add some, then list them under `## Scenarios`."
-
-### 2. Confirm scope with the user
-
-Print the planned runs in one short message:
-
-```
-About to run 2 scenarios (hosted):
-  - scenarios/01-bug-happy-path.md
-  - scenarios/02-missing-label.md
-```
-
-Wait for the user to confirm before spending hosted credits. If they want to skip a scenario or add one, edit TESTS.md and re-read.
-
-### 3. Run each scenario
-
-For every scenario path, run:
-
-```bash
-pome run <path>
-```
-
-Pome handles agent spawning, twin routing, recording, and scoring. A `--local`
-run is not scored, so its exit code only reflects whether the agent ran
-cleanly (`0`) or errored/timed out (`3`); exit `0` from `--local` means "trace
-captured," not "scenario passed." Do not gate CI on a `--local` exit code.
-
-The exit code tells you the result:
-
-| Exit code | Meaning |
-| --- | --- |
-| 0 | All scenarios passed (hosted/scored run), or trace captured (`--local`, not scored) |
-| 1 | At least one scenario scored below threshold |
-| 2 | Twin or runner error (network, 5xx, twin spawn failed) |
-| 3 | Auth error — `pome login` again; also a `--local` agent that failed to start or timed out |
-| 4 | Quota exceeded |
-| 5 | Usage error (bad flags, missing files) |
-
-Capture stderr from each run — `pome` prints `PASS`/`FAIL`, the score, the local run dir, and the cloud dashboard URL on a successful invocation.
-
-### 4. Report inline
-
-After all runs finish, print a single summary block:
-
-```
-Pome results — 2 scenarios
-
-  ✓ scenarios/01-bug-happy-path.md   score 100/100   <cloud-url>
-  ✗ scenarios/02-missing-label.md    score 60/100    <cloud-url>
-
-1 failed. Open the dashboard for the trace and the LLM-judge handoff:
-  https://app.pome.sh
-```
-
-Use the cloud URL pome printed on stderr for each run. For scenarios with a non-zero exit code from the runner (codes 2-5), surface the error verbatim — don't try to recover.
-
-### 5. On failures, surface the judge handoff
-
-The dashboard's run page shows an LLM-judge handoff: a one-paragraph diagnosis and a concrete next step to fix the agent. **Do not invent your own fix suggestion** — the judge has the full trace and the agent's tool calls; you don't.
-
-Tell the user, once, at the end:
-
-```
-For each failed run, open the dashboard URL above and copy the "judge handoff" section
-into a new prompt. That's the most reliable next step.
-```
-
-## Output contract
-
-When this skill finishes:
-
-- Each scenario has been attempted (or skipped explicitly with a reason).
-- A pass/fail summary is in the chat.
-- Each run has a `cloud` URL in the summary (hosted runs always land on the dashboard).
-- For failed runs, the user knows how to retrieve the judge handoff.
-
-## Common pitfalls
-
-| Symptom | Fix |
-| --- | --- |
-| Every scenario exits 3 (auth) | `pome login` and re-run. |
-| Scenarios exit 2 with "agent command failed" | The `agent.command` in `pome.config.json` is wrong. Open it, fix, retry one scenario. |
-| `pome run` blocks waiting for input | The agent is reading stdin. Make sure the agent reads its task from `POME_TASK`, not stdin. |
-| User asks "what changed since last run?" | Pome stores per-run artifacts under `runs/<scenario>/<run-id>/` locally, and the dashboard page diffs clone state between runs. |
-| User asks for an automatic fix | Decline — surface the dashboard handoff instead. The handoff is grounded in the full trace; an unguided fix attempt usually regresses. |
-
-## Reference
-
-- Dashboard layout: `pome docs dashboard`
-- Scenarios catalog: `pome scenarios`
-- CLI flags and exit codes: `pome docs cli-reference`
-- Re-wire from scratch: invoke `pome-setup`
+Auth uses the macOS Keychain service **`sh.pome.cli`** (account `hosted`) — the
+canonical CLI service name. Do not follow the old steps from memory: they
+referenced retired surfaces (`TESTS.md`, `pome scenarios`). Redirect the user to
+the Gen-2 set above.

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -347,13 +347,13 @@ export function createProgram() {
   const skills = program
     .command("skills")
     .description(
-      "Manage the bundled pome agent skills (/pome-setup, /pome-test)",
+      "Manage the bundled pome agent skills (/pome-setup, /pome-test — retired; use `npx skills add pome-sh/digital-twins`)",
     );
 
   skills
     .command("install")
     .description(
-      "Install /pome-setup and /pome-test into ~/.claude/skills/ (symlinked to this pome install by default)",
+      "Install the retired /pome-setup and /pome-test redirect pointers into ~/.claude/skills/ (Gen-2 set: `npx skills add pome-sh/digital-twins`)",
     )
     .option(
       "--copy",

--- a/cli/src/cli/skills.ts
+++ b/cli/src/cli/skills.ts
@@ -115,9 +115,13 @@ export async function runSkillsInstall(
 
   if (outcome.installed.length > 0) {
     console.log("");
-    console.log("Invoke them from your agent:");
-    console.log(`  ${bold("/pome-setup")}   — wire your agent up to pome`);
-    console.log(`  ${bold("/pome-test")}    — run tasks for a registered agent`);
+    console.log(
+      "These Gen-1 skills are retired (F-859) — they now redirect to the Gen-2",
+    );
+    console.log("coach set, which is the current way to test an agent with pome:");
+    console.log(`  ${bold("npx skills add pome-sh/digital-twins")}`);
+    console.log(`  ${dim("/pome-setup → pome-intake + the REST-launch preflight")}`);
+    console.log(`  ${dim("/pome-test  → pome-run-task")}`);
   }
 }
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -46,8 +46,14 @@ test evidence (fixtures, kept e2e transcripts) stays in the pome-cloud repo
 under `apps/docs/docs/skills/`.
 
 The Gen-1 CLI-era skills in [`cli/skills/`](../cli/skills/) (`pome-setup`,
-`pome-test`, installed by `pome skills install`) are a separate legacy surface
-scheduled for retirement (F-859, M2); the `skills` CLI does not pick them up —
-only this top-level `skills/` directory is a standard discovery location. The
-[`pome`](./pome/SKILL.md) router supersedes Gen-1 `pome-test`'s trigger
-phrases so the two generations never collide on an entry point (F-801).
+`pome-test`, installed by `pome skills install`) were **retired at F-859 (M2)**:
+their `SKILL.md` files are now tombstones that redirect to this set (`pome-setup`
+→ `pome-intake` + the REST-launch preflight; `pome-test` → `pome-run-task`).
+Their rescue-worthy assets landed here — the `pome doctor` preflight and the
+adapter/`withPome()` REST wiring depth in
+[`pome-run-task/references/launch-rest.md`](./pome-run-task/references/launch-rest.md),
+and the 0–5 CI exit-code contract in [`cli/README.md`](../cli/README.md). The
+`skills` CLI does not pick the tombstones up — only this top-level `skills/`
+directory is a standard discovery location — and the [`pome`](./pome/SKILL.md)
+router owns Gen-1's shared trigger phrases so the two generations never collide
+on an entry point (F-801).

--- a/skills/pome-run-task/SKILL.md
+++ b/skills/pome-run-task/SKILL.md
@@ -65,9 +65,11 @@ task, and watches for idle:
   cloud via the `ant` CLI. Recipe:
   [`references/launch-managed-agent.md`](references/launch-managed-agent.md).
 - **Anything else** (`transport: "rest"`) → the REST path (`rest_urls` + `env`).
-  Recipe: [`references/launch-rest.md`](references/launch-rest.md). Dispatch
-  honestly — a non-Claude examinee on Managed Agents runs as Claude, testing
-  nothing.
+  Recipe: [`references/launch-rest.md`](references/launch-rest.md) — which
+  **preflights the wiring** (config → twin reachable → routing → egress floor,
+  the `pome doctor` checks) before it launches, so a mis-wired examinee never
+  runs against a live API instead of the twin. Dispatch honestly — a non-Claude
+  examinee on Managed Agents runs as Claude, testing nothing.
 
 ## 3. Finalize the instant it idles
 

--- a/skills/pome-run-task/references/launch-rest.md
+++ b/skills/pome-run-task/references/launch-rest.md
@@ -10,6 +10,36 @@ return to SKILL.md §3 to `finalize_run` while the twin session is live.
 The spec still owns policy — you execute it. Field names are verbatim from
 `examinee_launch`.
 
+## 0. Preflight the wiring (before you launch)
+
+A REST examinee is a repo you run yourself, so its wiring is yours to get right:
+if the process reaches a real API instead of the twin, the run is silently
+worthless — it tested nothing and may have touched production. Validate the
+wiring **before** you start the process, the same four checks `pome doctor`
+runs, **in order, stopping at the first failure** with one named cause + one
+fix. There is no `--force`: a red check means do not launch.
+
+1. **config** — the examinee repo has a valid `pome.json` manifest with a real
+   `agent.command` (not the scaffold default).
+2. **twin reachable** — the twin the task needs is up and answering:
+   `examinee_launch.rest_urls[<twin>]` (and the bearer-authed session route)
+   respond, not a connection refusal.
+3. **routing** — the process reads its twin base URL from the injected env /
+   `rest_urls`, and **no production-host literal survives in agent source** —
+   even a `?? "https://api.github.com"` fallback is a twin bypass. (Loopback
+   fallbacks like `http://127.0.0.1:3333` are fine.) For a Claude Agent SDK
+   examinee this also means `withPome()` runs once at startup and `query`/`tool`
+   come from `@pome-sh/adapter-claude-sdk`; for other stacks the trace comes
+   from the twin side and routing is env alone.
+4. **egress floor** — deny-by-default egress is intact: `POME_EGRESS_ALLOW`
+   carries the twin patterns + loopback and **no `*` wildcard**. Never widen
+   egress to make a check pass.
+
+If the examinee repo has the pome CLI installed, just run `pome doctor` in it —
+it executes exactly these checks and exits non-zero on the first failure, with
+the cause (`file:line` where knowable) and the fix. Otherwise reason through the
+four above. Only once the wiring is green do you map the spec and launch.
+
 ## Map the spec into the process
 
 | `examinee_launch` field | Becomes, for the REST examinee |

--- a/skills/pome/SKILL.md
+++ b/skills/pome/SKILL.md
@@ -8,9 +8,9 @@ Naming decision (F-801, 2026-07-22): this router is named `pome`, NOT
 `pome-test`. The Gen-1 skill installed by `pome skills install` already
 occupies `pome-test` in users' skills directories, so a Gen-2 skill with the
 same name would collide at install time for anyone who has Gen-1. Gen-1
-(`cli/skills/pome-setup`, `cli/skills/pome-test`) retires at F-859 (M2);
-until then this router owns the shared trigger phrases and the two
-generations never claim the same entry point.
+(`cli/skills/pome-setup`, `cli/skills/pome-test`) was retired at F-859 (M2)
+to tombstones that redirect here; this router owns the shared trigger phrases
+so the two generations never claim the same entry point.
 -->
 
 # Pome (entry router)
@@ -30,7 +30,7 @@ browser): `claude mcp add --transport http pome https://mcp.pome.sh/mcp`.
 | The builder arrives with… | Route |
 | --- | --- |
 | A **Claude managed-agent YAML** (pasted, or "test my managed agent") | `pome-intake` — collect the clone scope, register via `intake_clone_scope`, report twin coverage |
-| A **local repo agent / self-hosted process** (talks REST, no managed-agent YAML) | The local-examinee path: register once with `register_agent(name, twins)`, then `pome-run-task` — `run_task` mints the session and the launch spec; launch the process yourself via the REST launcher (`pome-run-task/references/launch-rest.md`) |
+| A **local repo agent / self-hosted process** (talks REST, no managed-agent YAML) | The local-examinee path: register once with `register_agent(name, twins)`, then `pome-run-task` — `run_task` mints the session and the launch spec; launch the process yourself via the REST launcher (`pome-run-task/references/launch-rest.md`), which **preflights the wiring** (config → twin reachable → routing → egress floor, the `pome doctor` checks) before it launches |
 | "**What should I test?**" / a worry to turn into a graded check | `pome-author-task` — library-first authoring, `[code]`/`[model]` criteria, validate → dry-run → `save_task` |
 | A drafted task, first run coming up ("is my seed right?") | `pome-verify-seed` — fair-exam triage before anything runs |
 | A verified task to execute ("run my tasks", "how did my agent do?") | `pome-run-task` — mint, launch, `finalize_run` on idle, narrate `get_report` |


### PR DESCRIPTION
## Summary

Merges the two generations of Pome coach skills (per the 2026-07-21 two-generation audit). Gen 2 (intake → author → verify → run) is the spine; this PR grafts Gen 1's rescue-worthy assets into it and retires the Gen-1 skills.

**Key framing:** the `doctor` engine and its `pome run` preflight gate already exist in code (`cli/src/doctor/*`, FDRS-641). This is a **skills-merge / docs** change — it brings the preflight *concept* into the Gen-2 flow and sunsets the Gen-1 skill surface.

## What changed

**① Doctor preflight → Gen-2 REST launch**
- `skills/pome-run-task/references/launch-rest.md` — new **"0. Preflight the wiring"** section: the four `doctor` checks (config → twin reachable → routing → egress floor), first-failure-stops, no `--force`; plus the rescued adapter/`withPome()` REST wiring rules. Only the local/REST path gets this — a managed (`ant`) examinee has no local wiring.
- One-line preflight pointers in `pome-run-task/SKILL.md` §2 and the `pome` router's local/REST route.

**② Retire Gen-1 skills (tombstone, not delete)**
- `cli/skills/{pome-setup,pome-test}/SKILL.md` gutted to redirect pointers. Frontmatter `name` kept + triggers narrowed to the explicit `/pome-setup` / `/pome-test` invocations (shared natural-language phrases stay owned by the `pome` router — F-801). The stale `pome-sh` Keychain service name dies with `pome-test`; canonical stays `sh.pome.cli`.
- `skills/README.md` retirement paragraph → past tense with live pointers.

**③ Rescue the CI exit-code contract**
- `cli/README.md` gains a **"CI one-shot"** section with the 0–5 exit-code table, the `--local`-is-not-a-verdict caveat, and the trial-group whole-group mapping (FDRS-636) — before it dies with `pome-test`.

**CLI banner honesty (scope note)**
- `cli/src/cli/skills.ts` + `main.ts` — the `pome skills install` banner and `pome skills` help no longer advertise the retired skills as functional; they point at `npx skills add pome-sh/digital-twins`. Touches `cli/src/**` → patch changeset added.
- Fully retiring the `pome install` / `pome skills` commands + embedded-wiring is deliberately **out of scope** here (a code + test change) and tracked in the follow-up below.

## Verification

- `cli`: `npm run typecheck` clean; `skills-command` + `install-command` + `embedded-wiring` unit tests — 36/36 pass.
- Greps: `pome-sh` no longer appears as a Keychain service in `cli/skills/`; the four preflight checks are named on the REST path; the 0–5 table is present in `cli/README.md`.
- CLI version-bump gate: satisfied by the changeset.
- Docs-only skill files have no runtime surface to exercise.

## Reviewer notes

- `docs-topics.ts` `skills-setup`/`skills-test` entries point at the docs-site mirror, not the tombstoned files — left as-is, reconciled in the follow-up.
- Follow-up filed for the CLI-command teardown that this PR intentionally defers.

<!-- Closes F-859. Follow-up: F-893. -->
