### PR TITLE
docs(cli): add "Bring your own agent" to the pome docs topic index

### DIFF
--- a/cli/.changeset/existing-agent-docs-topic.md
+++ b/cli/.changeset/existing-agent-docs-topic.md
@@ -1,0 +1,8 @@
+---
+"@pome-sh/cli": patch
+---
+
+Add the `existing-agent` ("Bring your own agent") topic to the `pome docs`
+index (F-858), so `pome docs existing-agent` opens the new docs.pome.sh entry
+path for connecting an already-built local agent (register → `pome.json` as a
+side effect).

--- a/cli/src/cli/docs-topics.ts
+++ b/cli/src/cli/docs-topics.ts
@@ -26,6 +26,20 @@ export const DOCS_TOPICS: DocsTopic[] = [
     keywords: ["install", "quickstart", "setup", "begin"],
   },
   {
+    id: "existing-agent",
+    title: "Bring your own agent",
+    path: "/existing-agent",
+    keywords: [
+      "existing agent",
+      "own agent",
+      "already have an agent",
+      "bring your own",
+      "register",
+      "pome.json",
+      "connect",
+    ],
+  },
+  {
     id: "how-pome-works",
     title: "How Pome works",
     path: "/docs/how-pome-works",


### PR DESCRIPTION
Executive summary: Registers a new `existing-agent` topic in the CLI's `pome docs` index so `pome docs existing-agent` opens the new "Bring your own agent" entry-path page on docs.pome.sh. This is the pome-twins half of the F-858 entry path; the page content itself ships in pome-cloud.

## What
Adds one `DocsTopic` (`existing-agent` → `/existing-agent`, keyworded for "existing agent / own agent / register / pome.json") to `cli/src/cli/docs-topics.ts`, plus a patch changeset.

## Why
F-858 adds a docs entry path for users who already have a locally-developed agent. The `pome docs` command indexes public Mintlify pages by topic; the new page needs an entry here so the CLI can navigate to it.

## Tests / CI
- `test/unit/docs-command.test.ts` — 5/5 pass (topic resolution, no count assertion to break).
- `tsc -p tsconfig.build.json --noEmit` clean.
- Changeset added (`@pome-sh/cli` patch) to satisfy the cli version-bump gate.

<!-- Closes F-858 -->