### PR TITLE
Coach suggests a first task for a registered own agent

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -29,6 +29,7 @@ claude mcp add --transport http pome https://mcp.pome.sh/mcp
 | --- | --- |
 | [`pome`](./pome/SKILL.md) | **Entry router** — owns "test my agent with pome"; routes to the right coach skill by context |
 | [`pome-intake`](./pome-intake/SKILL.md) | Skill 0 — register the examinee clone scope, report twin coverage |
+| [`pome-suggest-tasks`](./pome-suggest-tasks/SKILL.md) | Own-agent front door — read a registered agent (`pome.json` + prompt/code), propose grounded candidate tasks, interview to pick one; runs before Skill 1 |
 | [`pome-author-task`](./pome-author-task/SKILL.md) | Skill 1 — author a graded task and save it to the team catalog |
 | [`pome-verify-seed`](./pome-verify-seed/SKILL.md) | Skill 2 — verify a task's seed is a fair exam before any run |
 | [`pome-run-task`](./pome-run-task/SKILL.md) | Skill 4 — run the exam, finalize from the live tape, narrate the report |

--- a/skills/pome-author-task/SKILL.md
+++ b/skills/pome-author-task/SKILL.md
@@ -55,6 +55,11 @@ replace their own task, and warn before any overwrite.
 
 ## 2. Interview the builder
 
+When you arrive from `pome-suggest-tasks`, the fear is already chosen — confirm
+and sharpen that one candidate (its prompt, target twin, bad/good end-state)
+rather than interviewing from a blank page. Starting cold with no candidate,
+interview as below.
+
 Author from fear, not from features. Ask what a bad run looks like, one surface
 at a time — and only surfaces the covered twins can actually exercise (a
 GitHub-only agent has no wrong-Slack-channel to test):
@@ -126,3 +131,10 @@ discriminator.
 Call `save_task` (it re-validates, then upserts on name). Confirm the new
 name appears in `list_tasks`, and report the `task_id` back to the
 builder with a one-line summary of what the task grades.
+
+## Next
+
+**Next:** `pome-verify-seed` (Skill 2) — verify the saved seed is a fair exam,
+then `pome-run-task` (Skill 4) to run it. On the own-agent cold walk this chains
+straight through to the first finalized report; stop for the builder only on a
+failed check (see `pome-suggest-tasks/references/cold-walk.md`).

--- a/skills/pome-suggest-tasks/README.md
+++ b/skills/pome-suggest-tasks/README.md
@@ -1,0 +1,39 @@
+# pome-suggest-tasks — coach own-agent front door
+
+Propose a builder's first Pome task by reading their already-registered agent:
+read `pome.json` (`twins`) + the agent's prompt/code, propose 2–3 grounded
+candidates, interview to pick one, then hand to `pome-author-task`. The skill
+itself is [`SKILL.md`](./SKILL.md); the one-session chain it fronts is
+[`references/cold-walk.md`](./references/cold-walk.md).
+
+## Layout
+
+One authored source per skill — this directory. Nothing is generated from it.
+
+```
+pome-suggest-tasks/
+├── SKILL.md      # the skill (frontmatter + instructions, <100 lines)
+├── references/   # cold-walk.md — the six-step chain, loaded on demand
+└── README.md     # this file
+```
+
+## Role
+
+Runs after registration (F-858), before Skill 1 (`pome-author-task`) — the
+own-agent parallel to `pome-intake` (Skill 0, for managed agents). It closes the
+M2 "users don't know how to write tasks" gap by **proposing** tasks grounded in
+what the agent actually does, not by docs (F-891). It authors nothing itself: it
+produces one chosen candidate and hands off to the authoring chain.
+
+## Install
+
+Part of the coach set — install the whole set with one command (see
+[`skills/README.md`](../README.md)); `references/` ships with the skill so the
+one-level-deep link resolves:
+
+```bash
+npx skills add pome-sh/digital-twins
+```
+
+Requires the Pome control MCP connection (`claude mcp add --transport http pome
+https://mcp.pome.sh/mcp`) so the `mcp__pome__*` tools resolve.

--- a/skills/pome-suggest-tasks/SKILL.md
+++ b/skills/pome-suggest-tasks/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: pome-suggest-tasks
+description: Propose a builder's first Pome task by reading their already-registered agent — reads the pome.json manifest (twins) and the agent's prompt/code, proposes 2–3 candidate tasks grounded in what the agent actually does, runs a short interview to pick one, then hands off to pome-author-task. Use in a repo that already has a pome.json but no task yet, when the builder says "test my agent" or "what should I test?" and doesn't know where to start.
+---
+
+# Pome suggest tasks (own-agent front door)
+
+You are the **coach**: you talk to the builder and to the Pome control MCP
+(`mcp.pome.sh`). The **examinee** is the builder's own agent, already registered
+(a `pome.json` is present). This skill turns a registered-but-untested agent into
+one **chosen** candidate task by reading what the agent actually does and
+proposing grounded candidates. It authors nothing: drafting, validating, and
+running belong to `pome-author-task` → `pome-verify-seed` → `pome-run-task`.
+
+Runs after registration (F-858), before Skill 1. If there is **no** `pome.json`,
+the agent is not registered yet — route back to the entry path, do not improvise
+a registration here.
+
+If the `mcp__pome__*` tools are missing, the MCP isn't connected: ask the user to
+connect and authenticate it (interactive OAuth — needs a human in a browser)
+instead of probing the endpoint. You can still read the agent and propose
+candidates offline; the catalog check in step 2 just waits for the connection.
+
+## 1. Read the agent
+
+Read the manifest and the code — this is the ground truth every candidate must
+stand on:
+
+- `pome.json` — `agent.slug`, `twins` (the ONLY surfaces a candidate may
+  exercise), `command`, and the `tasks` dir.
+- The agent's prompt + entry code — the system prompt and the tool set (e.g.
+  `src/index.ts`). What actions can it actually take, and what does the prompt
+  tell it to do — or, tellingly, NOT do? An unstated check (no authorization
+  step, no severity rule) is exactly where a fear lives.
+
+Name, per twin, the concrete actions the agent can take. A candidate that touches
+a twin not in `twins` is out of scope — drop it before you propose it.
+
+## 2. Propose 2–3 candidates grounded in the agent
+
+Author from fear, not from features (the `pome-author-task` framing): each
+candidate is one bad end-state the agent could reach and the good one it should.
+Ground every candidate in something you actually read — a missing check in the
+prompt, a tool it holds, a surface it trusts — never a generic template.
+
+Reuse the bundled example tasks as skeletons: `examples/*/tasks/*.md` (prefer
+same-twin ones) are the library-first adaptation source for a cold-start team
+with an empty catalog. When the MCP is connected, `list_tasks` shows the team
+catalog too — adapt the nearest existing task before writing a fresh shape.
+
+Present each candidate as one line — **the fear · the twin · bad end-state vs
+good end-state**. Example shape (a merge agent whose prompt never checks
+authorization): "Merges an impersonator's PR because it trusts the display name ·
+github · bad: the stranger's PR is merged / good: only the collaborator's PR is
+merged."
+
+## 3. Interview to pick one
+
+Ask the builder to pick one candidate — or amend one, or reject them all for
+another. This is the one place a human must choose: which fear becomes the first
+exam is the builder's call, not yours. Keep it short — pick, refine once if
+needed, move on.
+
+## Hand off
+
+**Next:** `pome-author-task` (Skill 1) with the chosen candidate — its prompt,
+the fear, the target twin, and the bad/good end-state. Author-task drafts,
+validates, dry-runs `verify_seed`, and saves; it does **not** re-interview from a
+blank page — it starts from this candidate. The full one-session journey
+(registration → suggestion → authoring → verified seed → run → report) is the
+cold walk in [`references/cold-walk.md`](references/cold-walk.md).

--- a/skills/pome-suggest-tasks/references/cold-walk.md
+++ b/skills/pome-suggest-tasks/references/cold-walk.md
@@ -1,0 +1,59 @@
+# M2 cold walk — registration → first own-agent report
+
+The one-session journey `pome-suggest-tasks` fronts. Each step lists **input ·
+what the coach does · expected artifact**. The two human checkpoints are marked
+⚑; every other step is automatic on the happy path. A step stops for the builder
+ONLY on the failure named in its row — no founder rescue otherwise (Done-when #3).
+
+1. **Registration** (upstream — F-858, not this skill)
+   - Input: a foreign repo with the agent's code.
+   - Coach: confirm the agent is registered — a `pome.json` (with `twins`) is
+     present and `register_agent` has run. This skill only verifies the manifest
+     is there and enters the chain.
+   - Artifact: `pome.json` at the repo root; an `agent_id` on the platform.
+   - Stops if: no `pome.json` → route back to the entry path.
+
+2. **Suggestion** (`pome-suggest-tasks`)
+   - Input: `pome.json` + the agent's prompt/code; empty `tasks/` and empty
+     `list_tasks`.
+   - Coach: read the agent, propose 2–3 grounded candidates.
+   - Artifact: 2–3 one-line candidates — each fear · twin · bad/good end-state.
+
+3. ⚑ **Pick** (checkpoint 1 — still `pome-suggest-tasks`)
+   - Input: the candidate list.
+   - Coach: short interview — the builder picks or refines one.
+   - Artifact: one chosen candidate (prompt + fear + twin + bad/good end-state).
+
+4. **Authoring** (`pome-author-task`)
+   - Input: the chosen candidate.
+   - Coach: draft the task markdown, `validate_task`, dry-run `verify_seed`,
+     `evaluate_criteria`, then `save_task`.
+   - Artifact: a saved task (`task_id`) in the team catalog.
+   - Stops if: `validate_task` errors or a `code` criterion is `unmatched` → fix
+     with the builder, never save blind.
+
+5. **Verified seed** (`pome-verify-seed`)
+   - Input: the saved task.
+   - Coach: judge the seed a fair exam — it boots, matches the prompt, and a
+     positive discriminator carries the signal.
+   - Artifact: verdict **HEALTHY seed**.
+   - Stops if: BROKEN / unfair → fix the seed or restate criteria, then
+     re-verify (never weaken the exam to pass it).
+
+6. **Run** (`pome-run-task`)
+   - Input: the verified task + `agent_id`.
+   - Coach: `run_task` mints the session, launch the examinee via the REST
+     launcher (preflighted), `finalize_run` the instant it idles.
+   - Artifact: a finalized `run_id` with a score, graded off the live twin tape.
+   - Stops if: the run comes back red → hand the fix prompt to the builder, who
+     edits the **examinee's** prompt (never the task), then re-run only what
+     failed.
+
+7. ⚑ **Report** (checkpoint 2 — still `pome-run-task`)
+   - Input: `run_id`.
+   - Coach: `get_report`, narrate the Score /100 + criteria + dashboard link.
+   - Artifact: the **first own-agent finalized report** (Done-when #2).
+
+**Pass criterion for the whole walk (Done-when #3):** a builder starts at a fresh
+registered repo and reaches step 7 in one session, the coach stopping only at the
+two ⚑ checkpoints and any genuine failure above — no founder help.

--- a/skills/pome/SKILL.md
+++ b/skills/pome/SKILL.md
@@ -30,10 +30,19 @@ browser): `claude mcp add --transport http pome https://mcp.pome.sh/mcp`.
 | The builder arrives with… | Route |
 | --- | --- |
 | A **Claude managed-agent YAML** (pasted, or "test my managed agent") | `pome-intake` — collect the clone scope, register via `intake_clone_scope`, report twin coverage |
+| A **registered own agent** — a repo with a `pome.json` but **no task yet** ("test my agent" / "what should I test?", `tasks/` empty and `list_tasks` empty) | `pome-suggest-tasks` — read the manifest (`twins`) + the agent's prompt/code, propose grounded candidates, interview to pick one, then the authoring chain |
 | A **local repo agent / self-hosted process** (talks REST, no managed-agent YAML) | The local-examinee path: register once with `register_agent(name, twins)`, then `pome-run-task` — `run_task` mints the session and the launch spec; launch the process yourself via the REST launcher (`pome-run-task/references/launch-rest.md`), which **preflights the wiring** (config → twin reachable → routing → egress floor, the `pome doctor` checks) before it launches |
 | "**What should I test?**" / a worry to turn into a graded check | `pome-author-task` — library-first authoring, `[code]`/`[model]` criteria, validate → dry-run → `save_task` |
 | A drafted task, first run coming up ("is my seed right?") | `pome-verify-seed` — fair-exam triage before anything runs |
 | A verified task to execute ("run my tasks", "how did my agent do?") | `pome-run-task` — mint, launch, `finalize_run` on idle, narrate `get_report` |
+
+**Registered but untested (the F-891 cold start).** Detect it locally first, so
+the route resolves even before the MCP is connected: a `pome.json` at the repo
+root whose `tasks` dir holds no `.md`, and — when the MCP is up — an empty
+`list_tasks`. Both empty → the builder has an agent but no first task →
+`pome-suggest-tasks`. If local task files exist but the catalog is empty (a
+bundled-example repo), don't auto-fire suggestion: offer the choice — run the
+existing task, or suggest a fresh one grounded in the agent.
 
 When in doubt, ask one question — "is your agent a Claude managed agent, or a
 process you run yourself?" — and route on the answer. The full journey is


### PR DESCRIPTION
## Summary

Adds the coach step that closes the M2 "users don't know how to write tasks" gap for **own agents**: in a foreign repo whose agent is already registered (`pome.json` present) but has no task yet, the coach now reads the agent and **proposes** a first task instead of dropping the builder onto a blank page.

New skill **`pome-suggest-tasks`** (own-agent front door, runs after registration and before `pome-author-task`):

1. **Reads the agent** — `pome.json` (`twins`, `slug`, `command`) + the agent's prompt/entry code, to ground candidates in what it actually does (and, tellingly, what its prompt does *not* check).
2. **Proposes 2–3 candidates** — each one line (fear · twin · bad vs good end-state), reusing the bundled `examples/*/tasks/*.md` as the library-first skeleton for a cold-start empty catalog.
3. **Interviews to pick one** — the single human checkpoint — then hands off.

It authors nothing itself; it produces one chosen candidate and chains into the existing `pome-author-task` → `pome-verify-seed` → `pome-run-task` flow, straight through to the first own-agent finalized report.

## Changes

- **`skills/pome-suggest-tasks/`** — new skill: `SKILL.md`, `references/cold-walk.md` (the six-step registration→report chain, with the two ⚑ checkpoints and per-step failure fallback — anchors the "M2 cold walk passes in one session, no founder help" acceptance), `README.md`.
- **`skills/pome/SKILL.md`** — router route for "registered own agent, no task yet", plus a local-first detection note (`pome.json` + empty `tasks/` + empty `list_tasks`) so the route resolves even before the MCP connects; guards against auto-firing in bundled-example repos.
- **`skills/README.md`** — set-table row for the new skill.
- **`skills/pome-author-task/SKILL.md`** — note that the interview may arrive pre-seeded with a chosen candidate; `Next:` pointer to verify → run so the journey needs no human prod between steps.

## Verification

Skills/docs-only (markdown prose, no runtime surface). Checked: valid frontmatter, `SKILL.md` under 100 lines, only contract-v1.0 tool names used, and every one-level relative link across the six touched files resolves.

No changeset — the version-bump gate fires only on `cli/src/**` / `cli/vendor/**` (`scripts/check-cli-version-bump.sh`); this touches only `skills/**`, matching recent skill-only PRs (#200–202).

<!-- Closes F-891 -->
