### PR TITLE
Order task authoring file-first, then publish to catalog

### DIFF
--- a/skills/pome-author-task/README.md
+++ b/skills/pome-author-task/README.md
@@ -2,7 +2,7 @@
 
 Author a graded Pome task for a builder's agent and save it to their team
 catalog: library-first adaptation, a fear-driven interview, then a
-validate → dry-run → save loop. The skill itself is [`SKILL.md`](./SKILL.md); the
+write-to-repo → validate → dry-run → publish loop. The skill itself is [`SKILL.md`](./SKILL.md); the
 task grammar it links to is
 [`references/task-format.md`](./references/task-format.md).
 
@@ -45,12 +45,15 @@ https://mcp.pome.sh/mcp`) so the `list_tasks` / `validate_task` /
    (`save_task` upserts on name — never overwrite someone else's).
 2. **Interview** — fear surfaces: worst fear / prompt-injection / wrong-channel /
    severity misjudgment; only the ones the covered twins can exercise.
-3. **Draft** — task markdown, `[code]` / `[model]` criteria; grammar lives in
-   the reference, not inlined.
-4. **Validate + dry-run** — `validate_task` → `verify_seed` → `evaluate_criteria`,
-   loop until validation is clean and no criterion is `unmatched` or
-   pre-satisfied.
-5. **Save** — `save_task`, confirm the new name in `list_tasks`.
+3. **Draft into the repo** — write the task markdown into the manifest's
+   `tasks/` dir (the source of truth, not a scratch file), `[code]` / `[model]`
+   criteria; grammar lives in the reference, not inlined.
+4. **Validate + dry-run** — `validate_task` → `verify_seed` → `evaluate_criteria`
+   on that repo file, loop until validation is clean and no criterion is
+   `unmatched` or pre-satisfied.
+5. **Publish** — `save_task` copies the repo file to the team catalog; confirm
+   the new name in `list_tasks` and commit the `tasks/…md` (ADR-019 decision 3:
+   file first, catalog follows).
 
 ## Test evidence
 

--- a/skills/pome-author-task/SKILL.md
+++ b/skills/pome-author-task/SKILL.md
@@ -7,9 +7,9 @@ description: Author a graded Pome task for a builder's agent and save it to thei
 
 You are the **coach**: you talk to the builder and to the Pome control MCP
 (`mcp.pome.sh`). The **examinee** is the sandbox clone Skill 0 (`pome-intake`)
-registered. This skill turns "what should I test?" into one saved, graded
-task in the team catalog. It authors — it never runs the test (that is a
-later skill).
+registered. This skill turns "what should I test?" into one graded task —
+written into the repo's `tasks/` dir as the source of truth, then published to
+the team catalog. It authors — it never runs the test (that is a later skill).
 
 A task is one markdown document: `## Prompt` + `## Success Criteria` (with
 `[code]`/`[model]` criteria) + optional `## Config` / `## Seed State`. The full
@@ -84,10 +84,19 @@ reasoning behind it.
 Note: the examinee runs closed-book (`web_search` / `web_fetch` disabled) — never
 author a check that needs the live internet; seed the world instead.
 
-## 3. Draft the task
+## 3. Draft the task — into the repo, not a scratch file
 
-Write the markdown to a scratch file. Two criterion kinds — canonical
-`code` / `model`, written as `[code]` / `[model]` markers:
+Write the task markdown straight into the manifest's tasks directory
+(`pome.json`'s `tasks` key, default `tasks/`) — **the repo file is the source
+of truth**: committable, reviewable, and the exact document `save_task` later
+publishes. Name it `<NN>-<kebab-fear>.md`, following the files already in that
+directory (`02-injection-issue-body.md`) and picking the next free number.
+Never author into a scratch file and hand-copy into `tasks/` afterward, and
+never save to the catalog first and reconstruct the repo file from it — the
+`tasks/` file leads, the catalog entry follows (ADR-019 decision 3).
+
+Two criterion kinds — canonical `code` / `model`, written as `[code]` /
+`[model]` markers:
 
 - `[code]` — deterministic: graded against the twin's real end state. Its text
   must match a registered predicate (e.g. `Issue #1 has the "bug" label`) or it
@@ -104,7 +113,7 @@ reference for tags, seed shapes, and config.
 
 ## 4. Validate, then dry-run — loop until clean
 
-Never save blind. Run, in order, on the scratch markdown:
+Never save blind. Run, in order, on the `tasks/` file you just wrote:
 
 1. `validate_task` — grammar. Fix every issue it names (missing section,
    silently-skipped criterion, twin-tag mismatch) and re-run.
@@ -126,11 +135,14 @@ Loop until validation is clean, no criterion is `unmatched`, and every
 seed-passing criterion is an intentional guard backed by a positive
 discriminator.
 
-## 5. Save
+## 5. Publish to the catalog
 
-Call `save_task` (it re-validates, then upserts on name). Confirm the new
-name appears in `list_tasks`, and report the `task_id` back to the
-builder with a one-line summary of what the task grades.
+With the `tasks/` file clean, call `save_task` **on that file** (it re-validates,
+then upserts on name) — this publishes a copy of the source-of-truth document to
+the team catalog for hosted runs. The repo file stays canonical; the catalog
+entry is the downstream copy. Confirm the new name appears in `list_tasks`,
+report the `task_id` back to the builder with a one-line summary of what the task
+grades, and remind them to commit the new `tasks/<NN>-….md`.
 
 ## Next
 

--- a/skills/pome-suggest-tasks/SKILL.md
+++ b/skills/pome-suggest-tasks/SKILL.md
@@ -64,8 +64,10 @@ needed, move on.
 ## Hand off
 
 **Next:** `pome-author-task` (Skill 1) with the chosen candidate — its prompt,
-the fear, the target twin, and the bad/good end-state. Author-task drafts,
-validates, dry-runs `verify_seed`, and saves; it does **not** re-interview from a
-blank page — it starts from this candidate. The full one-session journey
+the fear, the target twin, and the bad/good end-state. Author-task writes the
+task into the repo's `tasks/` dir (the source of truth), validates, dry-runs
+`verify_seed`, then publishes it to the catalog with `save_task`; it does **not**
+re-interview from a blank page — it starts from this candidate. The full
+one-session journey
 (registration → suggestion → authoring → verified seed → run → report) is the
 cold walk in [`references/cold-walk.md`](references/cold-walk.md).

--- a/skills/pome-suggest-tasks/references/cold-walk.md
+++ b/skills/pome-suggest-tasks/references/cold-walk.md
@@ -29,9 +29,12 @@ ONLY on the failure named in its row — no founder rescue otherwise (Done-when 
 
 4. **Authoring** (`pome-author-task`)
    - Input: the chosen candidate.
-   - Coach: draft the task markdown, `validate_task`, dry-run `verify_seed`,
-     `evaluate_criteria`, then `save_task`.
-   - Artifact: a saved task (`task_id`) in the team catalog.
+   - Coach: write the task markdown into the repo's `tasks/` dir (the source of
+     truth), `validate_task`, dry-run `verify_seed`, `evaluate_criteria`, then
+     `save_task` to publish that file to the catalog (ADR-019 decision 3: file
+     first, catalog follows — never the reverse).
+   - Artifact: a committed `tasks/<NN>-….md` source file plus its published
+     catalog entry (`task_id`).
    - Stops if: `validate_task` errors or a `code` criterion is `unmatched` → fix
      with the builder, never save blind.
 


### PR DESCRIPTION
## Summary

Reorders the own-agent authoring flow so the task markdown is written into the manifest's `tasks/` dir — the committable, reviewable **source of truth** — *before* `save_task` publishes a copy to the team catalog for hosted runs. This kills the reversed order seen on the 2026-07-24 cold walk (coach saved to the catalog, then hand-copied to `tasks/02-injection-issue-body.md` as an afterthought).

## Changes (skills-docs only)

- **`pome-author-task/SKILL.md`** — §3 now writes straight into `tasks/` as `<NN>-<kebab-fear>.md` and forbids both the scratch-then-copy path and the save-first-then-reconstruct order; §4 validates that repo file; §5 renamed to "Publish to the catalog" (the file stays canonical, the catalog entry is the downstream copy).
- **`pome-author-task/README.md`** — authoring-loop steps + summary updated to `write-to-repo → validate → dry-run → publish`.
- **`pome-suggest-tasks/SKILL.md`** — hand-off note describes the file-first order.
- **`pome-suggest-tasks/references/cold-walk.md`** — step 4 artifact is now the committed `tasks/<NN>-….md` source *plus* its published catalog entry.

No code or parser touched; changeset-exempt (skills-only).

<!-- Closes F-910 -->