### PR TITLE
pome init: detect existing project, skip starter library

### DIFF
--- a/cli/.changeset/init-detect-existing-project.md
+++ b/cli/.changeset/init-detect-existing-project.md
@@ -1,0 +1,15 @@
+---
+"@pome-sh/cli": minor
+---
+
+`pome init` now detects an existing project and skips the starter library
+(F-904). When the current directory already has a `package.json` (the "bring
+your own agent" case), `init` writes only the `pome.json` manifest — no more
+dumping the 28-file starter set (the GitHub twin's task+seed pairs into `tasks/`
+and the sample agents into `examples/agents/`) into a repo that already has
+source. In this bare mode the manifest omits `command` so the user points it at
+their own launch command, and if a `tasks/` directory already exists it records
+`tasks: "tasks"` so bare `pome run` (F-865) can resolve it. The fresh/empty-dir
+starter drop is unchanged, and now also records `tasks: "tasks"`. Two override
+flags: `--bare` forces manifest-only anywhere, `--starter` forces the full
+library even in an existing project.

--- a/cli/.changeset/init-detect-existing-project.md
+++ b/cli/.changeset/init-detect-existing-project.md
@@ -13,3 +13,8 @@ their own launch command, and if a `tasks/` directory already exists it records
 starter drop is unchanged, and now also records `tasks: "tasks"`. Two override
 flags: `--bare` forces manifest-only anywhere, `--starter` forces the full
 library even in an existing project.
+
+Relatedly, `pome run` no longer silently falls back to the starter scaffold
+(`examples/agents/scripted-triage-agent.ts`) when no `command` is configured and
+that file does not exist — it now fails with a clear "set command / pass
+--agent" message instead of a cryptic missing-file spawn error.

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -77,7 +77,8 @@ import type { RecorderEvent } from "../types/shared.js";
 
 const PACKAGE_VERSION = readPackageVersion();
 const SESSION_CREATE_FORMATS = new Set(["text", "json", "env"]);
-const DEFAULT_AGENT_COMMAND = "npx tsx examples/agents/scripted-triage-agent.ts";
+const DEFAULT_AGENT_FILE = "examples/agents/scripted-triage-agent.ts";
+const DEFAULT_AGENT_COMMAND = `npx tsx ${DEFAULT_AGENT_FILE}`;
 const MANIFEST_SCHEMA_URL = "https://pome.sh/schemas/v1/pome.json";
 
 function readPackageVersion(): string {
@@ -671,8 +672,20 @@ export function createProgram() {
 
         const manifestRead = await readManifest(process.cwd()).catch(() => null);
         const configCommand = manifestRead?.manifest.command;
-        const agentCommand =
-          options.agent ?? configCommand ?? DEFAULT_AGENT_COMMAND;
+        const resolvedCommand = options.agent ?? configCommand;
+        // Bare `pome init` (existing project) writes no `command`. Don't
+        // silently fall back to the starter scaffold it never created — a
+        // spawn of a missing file gives a cryptic error. Use the default only
+        // when that file actually exists; otherwise fail with guidance.
+        if (resolvedCommand === undefined && !existsSync(DEFAULT_AGENT_FILE)) {
+          console.error(
+            'No agent command configured. Set "command" in pome.json to your ' +
+              'agent\'s launch command, or pass --agent "<command>".',
+          );
+          process.exitCode = 2;
+          return;
+        }
+        const agentCommand = resolvedCommand ?? DEFAULT_AGENT_COMMAND;
         let worstExit = 0;
 
         // Hosted is the default. Self-host runs against an in-process twin via

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -118,7 +118,15 @@ export function createProgram() {
       "--sdk <name>",
       "Scaffold for a specific agent SDK (claude | claude-managed). Adds the SDK-specific example file and pre-fills agent.framework so the dashboard badges runs correctly.",
     )
-    .action(async (opts: { sdk?: string }) => {
+    .option(
+      "--bare",
+      "Write only the manifest — skip the starter task library and sample agents. Auto-selected when the current directory already has a package.json (the bring-your-own-agent case).",
+    )
+    .option(
+      "--starter",
+      "Force the full starter library even in an existing project.",
+    )
+    .action(async (opts: { sdk?: string; bare?: boolean; starter?: boolean }) => {
       const sdk = opts.sdk?.trim();
       if (
         sdk !== undefined &&
@@ -136,26 +144,59 @@ export function createProgram() {
         process.exitCode = 2;
         return;
       }
+      if (opts.bare && opts.starter) {
+        console.error("Pass at most one of --bare / --starter.");
+        process.exitCode = 2;
+        return;
+      }
 
-      await mkdir("tasks", { recursive: true });
-      await mkdir("examples/agents", { recursive: true });
-      await mkdir("runs", { recursive: true });
-      await copyStarterFiles();
+      // F-904 — a directory that already has a package.json is the "bring your
+      // own agent" case: scaffold only the manifest, never the starter library
+      // (a 2026-07-24 cold walk dumped 28 untracked files into a real project).
+      // --starter / --bare override the auto-decision in either direction.
+      const looksLikeExistingProject = existsSync(
+        join(process.cwd(), "package.json"),
+      );
+      const bare = opts.starter
+        ? false
+        : Boolean(opts.bare) || looksLikeExistingProject;
 
-      let command = DEFAULT_AGENT_COMMAND;
+      if (!bare) {
+        await mkdir("tasks", { recursive: true });
+        await mkdir("examples/agents", { recursive: true });
+        await mkdir("runs", { recursive: true });
+        await copyStarterFiles();
+      }
+
+      // Bare mode omits `command`: the BYO user launches their own agent, so a
+      // default pointer at an unscaffolded examples/agents/... file would be a
+      // broken instruction. --sdk still writes a real file and sets command.
+      let command: string | undefined = bare ? undefined : DEFAULT_AGENT_COMMAND;
       let framework: string | undefined;
-      let postInitMessage =
-        "Pome initialized.\n" +
-        "Next steps:\n" +
-        "  1. pome login                    # one-time, opens the dashboard to sign in\n" +
-        "  2. pome register agent <name>    # scopes runs to this project (writes agent.slug to pome.json)\n" +
-        "  3. pome run tasks/01-bug-happy-path.md\n" +
-        "\n" +
-        "Optional follow-ups:\n" +
-        "  - pome init --sdk claude         # scaffold a Claude Agent SDK starter\n" +
-        "  - pome tasks stripe --copy       # add Stripe payment tasks when needed\n" +
-        "\n" +
-        "See `pome docs getting-started` for a narrative walkthrough.";
+      let postInitMessage = bare
+        ? "Pome initialized (existing project — starter library skipped).\n" +
+          "Next steps:\n" +
+          '  1. Set "command" in pome.json to your agent\'s launch command\n' +
+          "  2. pome login                    # one-time, opens the dashboard to sign in\n" +
+          "  3. pome register agent <name>    # scopes runs to this project (writes agent.slug to pome.json)\n" +
+          "  4. pome run <your-task>.md\n" +
+          "\n" +
+          "Optional follow-ups:\n" +
+          "  - pome tasks github --copy       # drop the starter task library into tasks/\n" +
+          "  - pome init --sdk claude         # scaffold a Claude Agent SDK starter\n" +
+          "\n" +
+          "See `pome docs getting-started` for a narrative walkthrough."
+        : "Pome initialized.\n" +
+          "Next steps:\n" +
+          "  1. pome login                    # one-time, opens the dashboard to sign in\n" +
+          "  2. pome register agent <name>    # scopes runs to this project (writes agent.slug to pome.json)\n" +
+          "  3. pome run tasks/01-bug-happy-path.md\n" +
+          "\n" +
+          "Optional follow-ups:\n" +
+          "  - pome init --sdk claude         # scaffold a Claude Agent SDK starter\n" +
+          "  - pome tasks stripe --copy       # add Stripe payment tasks when needed\n" +
+          "\n" +
+          "See `pome docs getting-started` for a narrative walkthrough.";
 
       if (sdk) {
         const scaffold = await writeSdkScaffold(sdk);
@@ -166,6 +207,12 @@ export function createProgram() {
           scaffold.postInstallHint;
       }
 
+      // Point the manifest at an existing task directory so bare `pome run`
+      // (F-865) resolves it. The starter path always creates tasks/; bare mode
+      // only claims it when the user already keeps their tasks there.
+      const tasksDir =
+        !bare || (await hasMarkdownTasks("tasks")) ? "tasks" : undefined;
+
       // The manifest requires `agent.slug` (F-804). `pome init` runs before
       // `pome register`, so seed a portable slug derived from the directory
       // name; register later overwrites it with the server-canonical slug.
@@ -174,13 +221,15 @@ export function createProgram() {
         const slug = deriveAgentSlug(basename(process.cwd())) || "my-agent";
         const agent: Record<string, unknown> = { slug };
         if (framework) agent.framework = framework;
-        await writeManifest(join(process.cwd(), MANIFEST_JSON), "json", {
+        const manifest: Record<string, unknown> = {
           $schema: MANIFEST_SCHEMA_URL,
           agent,
-          command,
-          artifacts_dir: "runs",
-          pass_threshold: 100,
-        });
+        };
+        if (command) manifest.command = command;
+        if (tasksDir) manifest.tasks = tasksDir;
+        manifest.artifacts_dir = "runs";
+        manifest.pass_threshold = 100;
+        await writeManifest(join(process.cwd(), MANIFEST_JSON), "json", manifest);
       } else if (sdk) {
         const priorAgent =
           typeof existing.raw.agent === "object" && existing.raw.agent !== null
@@ -1242,6 +1291,20 @@ async function taskFiles(target: string) {
     .filter((entry) => entry.endsWith(".md"))
     .sort()
     .map((entry) => join(resolved, entry));
+}
+
+// F-904 — does the cwd already carry a task directory worth recording in the
+// manifest? A directory named `dir` counts only when it holds at least one
+// `.md` (an empty scaffold dir is not a task set).
+async function hasMarkdownTasks(dir: string): Promise<boolean> {
+  const abs = join(process.cwd(), dir);
+  if (!existsSync(abs)) return false;
+  try {
+    const entries = await readdir(abs);
+    return entries.some((f) => f.toLowerCase().endsWith(".md"));
+  } catch {
+    return false;
+  }
 }
 
 async function copyStarterFiles() {

--- a/cli/test/unit/init.test.ts
+++ b/cli/test/unit/init.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, writeFileSync, mkdirSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -32,7 +32,11 @@ describe("pome init", () => {
     expect(githubTwin).not.toBeNull();
     expect(existsSync("pome.json")).toBe(true);
     // The manifest is valid: it carries a slug derived from the project dir.
-    expect(JSON.parse(readFileSync("pome.json", "utf8")).agent.slug).toMatch(/^[a-z0-9-]+$/);
+    const freshManifest = JSON.parse(readFileSync("pome.json", "utf8"));
+    expect(freshManifest.agent.slug).toMatch(/^[a-z0-9-]+$/);
+    // The starter path always creates tasks/, so the manifest points at it
+    // (F-904 — forward-compatible with F-865's bare `pome run` resolution).
+    expect(freshManifest.tasks).toBe("tasks");
     for (const task of runnableTasks(githubTwin!)) {
       expect(existsSync(join("tasks", task.filename))).toBe(true);
     }
@@ -78,5 +82,91 @@ describe("pome init", () => {
           .join(", ")}`,
       ).toEqual([]);
     }
+  });
+
+  async function initIn(
+    setup: (dir: string) => void,
+    args: string[],
+  ): Promise<{ dir: string; exitCode: number | string | undefined; messages: string }> {
+    const dir = await mkdtemp(join(tmpdir(), "pome-init-"));
+    tempDirs.push(dir);
+    process.chdir(dir);
+    setup(dir);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const priorExit = process.exitCode;
+    process.exitCode = undefined;
+    await createProgram().parseAsync(["node", "pome", ...args]);
+    const exitCode = process.exitCode;
+    process.exitCode = priorExit;
+    return {
+      dir,
+      exitCode,
+      messages: errSpy.mock.calls.map((c) => String(c[0])).join("\n"),
+    };
+  }
+
+  it("skips the starter library in an existing project (package.json present)", async () => {
+    await initIn(
+      (dir) => writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "my-agent" })),
+      ["init"],
+    );
+
+    // No 28-file dump: neither the task library nor the sample agents land.
+    expect(existsSync("tasks")).toBe(false);
+    expect(existsSync("examples")).toBe(false);
+    // The manifest is still written...
+    expect(existsSync("pome.json")).toBe(true);
+    const manifest = JSON.parse(readFileSync("pome.json", "utf8"));
+    expect(manifest.agent.slug).toMatch(/^[a-z0-9-]+$/);
+    // ...but `command` is omitted — the BYO user supplies their own launcher.
+    expect(manifest.command).toBeUndefined();
+    // No task directory exists, so no `tasks` key is claimed.
+    expect(manifest.tasks).toBeUndefined();
+  });
+
+  it("writes the tasks key when an existing project already has a tasks dir", async () => {
+    await initIn((dir) => {
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "my-agent" }));
+      mkdirSync(join(dir, "tasks"));
+      writeFileSync(join(dir, "tasks", "my-real-task.md"), "# a task\n");
+    }, ["init"]);
+
+    const manifest = JSON.parse(readFileSync("pome.json", "utf8"));
+    expect(manifest.tasks).toBe("tasks");
+    // The user's own task file is untouched; no starter library dumped over it.
+    expect(existsSync("tasks/my-real-task.md")).toBe(true);
+    expect(existsSync("tasks/01-bug-happy-path.md")).toBe(false);
+  });
+
+  it("--starter forces the full library even in an existing project", async () => {
+    await initIn(
+      (dir) => writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "my-agent" })),
+      ["init", "--starter"],
+    );
+
+    const githubTwin = findTwin("github");
+    for (const task of runnableTasks(githubTwin!)) {
+      expect(existsSync(join("tasks", task.filename))).toBe(true);
+    }
+    expect(existsSync("examples/agents/scripted-triage-agent.ts")).toBe(true);
+    expect(JSON.parse(readFileSync("pome.json", "utf8")).command).toContain(
+      "scripted-triage-agent.ts",
+    );
+  });
+
+  it("--bare skips the library in an otherwise-fresh dir", async () => {
+    await initIn(() => undefined, ["init", "--bare"]);
+
+    expect(existsSync("tasks")).toBe(false);
+    expect(existsSync("examples")).toBe(false);
+    expect(existsSync("pome.json")).toBe(true);
+    expect(JSON.parse(readFileSync("pome.json", "utf8")).command).toBeUndefined();
+  });
+
+  it("rejects --bare and --starter together", async () => {
+    const { exitCode } = await initIn(() => undefined, ["init", "--bare", "--starter"]);
+    expect(exitCode).toBe(2);
+    expect(existsSync("pome.json")).toBe(false);
   });
 });

--- a/cli/test/unit/run-default-task.test.ts
+++ b/cli/test/unit/run-default-task.test.ts
@@ -278,6 +278,26 @@ describe("bare `pome run` glue (FDRS-645)", () => {
     expect(runTaskHosted).toHaveBeenCalledTimes(1);
   }, 30_000);
 
+  it("a bare manifest (no command) errors with guidance instead of spawning a missing scaffold", async () => {
+    // F-904: `pome init` in an existing project writes no `command`. `pome run`
+    // must not silently fall back to the starter scaffold it never created.
+    const dir = await mkdtemp(join(tmpdir(), "pome-run-bare-"));
+    process.chdir(dir);
+    await writeFile(
+      join(dir, "pome.json"),
+      JSON.stringify({ agent: { slug: "byo-agent" } }, null, 2),
+    );
+    await mkdir(join(dir, "tasks"), { recursive: true });
+    await writeFile(join(dir, "tasks", "scn.md"), EXPLICIT_SCENARIO);
+
+    await run("tasks/scn.md");
+
+    expect(process.exitCode).toBe(2);
+    expect(stderr.join("\n")).toContain("No agent command configured");
+    expect(runTaskHosted).not.toHaveBeenCalled();
+    expect(runTrialGroup).not.toHaveBeenCalled();
+  }, 30_000);
+
   it("a failing doctor gate refuses before the frame ever prints", async () => {
     const dir = await fixtureRepo({ wired: false });
     process.chdir(dir);


### PR DESCRIPTION
<!-- Closes F-904 -->

Executive summary: `pome init` no longer dumps the 28-file starter library into a repo that already has source. When the cwd has a `package.json` (the bring-your-own-agent case) it scaffolds only the `pome.json` manifest; the fresh/empty-dir starter drop is unchanged. Reviewers should focus on the mode-selection logic and the choice to omit `command` in bare mode.

## What
`pome init` now branches on whether the cwd is an existing project. An existing project (cwd has a `package.json`) gets **bare mode**: only the manifest is written — no `tasks/` library, no `examples/agents/` samples. Bare mode omits `command` (the user launches their own agent) and records `tasks: "tasks"` when a task directory already exists. Two override flags: `--bare` (force manifest-only anywhere) and `--starter` (force the full library even in a project); both together is a usage error. The fresh-dir starter path is unchanged and now also records `tasks: "tasks"`.

## Why
The 2026-07-24 M2 cold walk dumped 28 untracked files (the GitHub twin's task+seed pairs and 6 sample agents) into a real user project, and left the manifest blind to the repo's existing `tasks/` — the coach had to verify+delete the files and hand-add the `tasks` key. This is CLI-only; the manifest schema already carries an optional `tasks` key, so no contract change.

## Notes for reviewer
- **Detection signal** is `package.json` in the cwd — matches the ticket's "already has source + package.json" litmus; `--starter`/`--bare` are the escape hatches.
- **Bare mode omits `command`** rather than writing the default `npx tsx examples/agents/scripted-triage-agent.ts` pointer at a file it didn't scaffold. `--sdk` still writes a real example + sets `command`, and composes with bare mode.
- **`tasks` key**: written whenever `tasks/` has ≥1 `.md` (always in starter mode; in bare mode only when the user already keeps tasks there) — forward-compatible with F-865's bare-`pome run` resolution.

## Tests / CI
- New/extended `cli/test/unit/init.test.ts`: existing-project skips library + omits `command`; existing `tasks/` → `tasks` key; `--starter` override; `--bare` in empty dir; `--bare`+`--starter` rejected (exit 2); fresh path records `tasks`.
- Local: `cli` unit suite 633 passed, `tsc --noEmit` clean, built-CLI smoke verified both modes.