### PR TITLE
Print a dashboard deep-link after `pome register agent`

### DIFF
--- a/cli/.changeset/register-dashboard-line.md
+++ b/cli/.changeset/register-dashboard-line.md
@@ -1,0 +1,10 @@
+---
+"@pome-sh/cli": patch
+---
+
+`pome register agent` now prints a `Dashboard:` line deep-linking the registered
+agent's page (`<dashboard>/agents/<slug>`) as the final handoff (F-905). The base
+resolves from `POME_DASHBOARD_URL` (default `https://app.pome.sh`), matching the
+runner's reliability-page handoff. This makes the docs.pome.sh onboarding walk —
+which asks for "the dashboard line register printed" — agree with reality; before
+this, register printed four lines and no URL.

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -378,6 +378,8 @@ export function createProgram() {
         try {
           await runRegisterAgent({
             apiBaseUrl: opts.apiUrl,
+            dashboardBaseUrl:
+              process.env.POME_DASHBOARD_URL ?? DEFAULT_DASHBOARD_URL,
             name,
             force: opts.force,
             twins: normalizeRegisterTwins(opts.twins),

--- a/cli/src/cli/register.ts
+++ b/cli/src/cli/register.ts
@@ -42,6 +42,10 @@ const SCHEMA_URL = "https://pome.sh/schemas/v1/pome.json";
 
 interface RegisterAgentOptions extends InteractiveSeams {
   apiBaseUrl: string;
+  /** Dashboard base for the post-register deep link (POME_DASHBOARD_URL /
+   *  DEFAULT_DASHBOARD_URL — resolved at the main.ts boundary, like the runner's
+   *  reliability-page handoff). */
+  dashboardBaseUrl: string;
   name: string;
   force: boolean;
   twins?: string[];
@@ -208,6 +212,12 @@ export async function runRegisterAgent(opts: RegisterAgentOptions): Promise<void
       "Enabled services: not reported by this pome cloud (older control plane) — twin scoping may not have taken effect.",
     );
   }
+
+  // Deep-link the registered agent's dashboard page. `/agents/<slug>` is the
+  // same IA the runner's reliability handoff relies on (/agents/<slug>/tasks/…),
+  // so this lands on the agent, not a generic root.
+  const base = opts.dashboardBaseUrl.replace(/\/$/, "");
+  console.error(`Dashboard: ${base}/agents/${encodeURIComponent(agent.slug)}`);
 }
 
 function stripControlCharacters(value: string): string {

--- a/cli/test/unit/register.test.ts
+++ b/cli/test/unit/register.test.ts
@@ -93,6 +93,7 @@ describe("runRegisterAgent", () => {
 
     await runRegisterAgent({
       apiBaseUrl: "https://input.example.com",
+      dashboardBaseUrl: "https://app.example.com",
       name: "Triage Bot",
       force: false,
     });
@@ -120,6 +121,7 @@ describe("runRegisterAgent", () => {
 
     await runRegisterAgent({
       apiBaseUrl: "https://api.example.com",
+      dashboardBaseUrl: "https://app.example.com",
       name: "Triage Bot",
       force: false,
       credentialsPath,
@@ -131,7 +133,7 @@ describe("runRegisterAgent", () => {
 
   it("fails clearly when no manifest is present", async () => {
     await expect(
-      runRegisterAgent({ apiBaseUrl: "https://api.example.com", name: "Triage Bot", force: false }),
+      runRegisterAgent({ apiBaseUrl: "https://api.example.com", dashboardBaseUrl: "https://app.example.com", name: "Triage Bot", force: false }),
     ).rejects.toThrow(/pome init/);
   });
 
@@ -147,6 +149,7 @@ describe("runRegisterAgent", () => {
 
     await runRegisterAgent({
       apiBaseUrl: "https://api.example.com",
+      dashboardBaseUrl: "https://app.example.com",
       name: "Triage Bot",
       force: false,
       credentialsPath,
@@ -166,6 +169,7 @@ describe("runRegisterAgent", () => {
 
     await runRegisterAgent({
       apiBaseUrl: "https://api.example.com",
+      dashboardBaseUrl: "https://app.example.com",
       name: "Triage Bot",
       force: true,
       credentialsPath,
@@ -181,7 +185,7 @@ describe("runRegisterAgent", () => {
     vi.spyOn(console, "error").mockImplementation((m?: unknown) => void errors.push(String(m)));
     vi.spyOn(globalThis, "fetch").mockResolvedValue(response(AGENT_OK));
 
-    await runRegisterAgent({ apiBaseUrl: "https://api.example.com", name: "Triage Bot", force: false });
+    await runRegisterAgent({ apiBaseUrl: "https://api.example.com", dashboardBaseUrl: "https://app.example.com", name: "Triage Bot", force: false });
 
     expect(errors.join("\n")).toMatch(/langraph/);
     expect(errors.join("\n")).toMatch(/langgraph/);
@@ -192,7 +196,7 @@ describe("runRegisterAgent", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(response({ id: "agt_only" }));
 
     await expect(
-      runRegisterAgent({ apiBaseUrl: "https://api.example.com", name: "Bad", force: false }),
+      runRegisterAgent({ apiBaseUrl: "https://api.example.com", dashboardBaseUrl: "https://app.example.com", name: "Bad", force: false }),
     ).rejects.toBeInstanceOf(HostedOrchError);
   });
 
@@ -201,7 +205,7 @@ describe("runRegisterAgent", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(response({}, { status: 404 }));
 
     await expect(
-      runRegisterAgent({ apiBaseUrl: "https://api.example.com", name: "Triage Bot", force: false }),
+      runRegisterAgent({ apiBaseUrl: "https://api.example.com", dashboardBaseUrl: "https://app.example.com", name: "Triage Bot", force: false }),
     ).rejects.toThrow(/not available|version/);
   });
 
@@ -215,6 +219,7 @@ describe("runRegisterAgent", () => {
 
     await runRegisterAgent({
       apiBaseUrl: "https://api.example.com",
+      dashboardBaseUrl: "https://app.example.com",
       name: "Triage Bot",
       force: false,
       twins: ["github", "slack"],
@@ -223,6 +228,23 @@ describe("runRegisterAgent", () => {
     const body = JSON.parse(String((fetchMock.mock.calls[0]![1] as RequestInit).body));
     expect(body).toMatchObject({ name: "Triage Bot", twins: ["github", "slack"] });
     expect(errors.join("\n")).toContain("Enabled services: github, slack");
+  });
+
+  it("prints a Dashboard line deep-linking the registered agent's page", async () => {
+    await writeManifest({ agent: { slug: "triage-bot" } });
+    const errors: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((m?: unknown) => void errors.push(String(m)));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response(AGENT_OK));
+
+    await runRegisterAgent({
+      apiBaseUrl: "https://api.example.com",
+      dashboardBaseUrl: "https://app.example.com/", // trailing slash trimmed
+      name: "Triage Bot",
+      force: false,
+    });
+
+    // Deep-links the agent by its server-canonical slug, not a generic root.
+    expect(errors.join("\n")).toContain("Dashboard: https://app.example.com/agents/triage-bot");
   });
 });
 
@@ -243,7 +265,7 @@ describe("runRegisterAgent near-miss", () => {
       .mockResolvedValueOnce(conflict())
       .mockResolvedValueOnce(response(AGENT_OK));
 
-    await runRegisterAgent({ apiBaseUrl: "https://api.example.com", name: "Triage Bott", force: false });
+    await runRegisterAgent({ apiBaseUrl: "https://api.example.com", dashboardBaseUrl: "https://app.example.com", name: "Triage Bott", force: false });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
     const retry = JSON.parse(String((fetchMock.mock.calls[1]![1] as RequestInit).body));
@@ -260,6 +282,7 @@ describe("runRegisterAgent near-miss", () => {
 
     await runRegisterAgent({
       apiBaseUrl: "https://api.example.com",
+      dashboardBaseUrl: "https://app.example.com",
       name: "Triage Bott",
       force: false,
       stdinIsTTY: true,
@@ -280,6 +303,7 @@ describe("runRegisterAgent near-miss", () => {
 
     await runRegisterAgent({
       apiBaseUrl: "https://api.example.com",
+      dashboardBaseUrl: "https://app.example.com",
       name: "Triage Bott",
       force: false,
       stdinIsTTY: true,
@@ -311,7 +335,7 @@ describe("slug-rename hint (F-861)", () => {
     const errors = spyErrors();
     vi.spyOn(globalThis, "fetch").mockResolvedValue(response(RENAMED));
 
-    await runRegisterAgent({ apiBaseUrl: "https://api.example.com", name: "PR Review Agent", force: false });
+    await runRegisterAgent({ apiBaseUrl: "https://api.example.com", dashboardBaseUrl: "https://app.example.com", name: "PR Review Agent", force: false });
 
     const out = errors.join("\n");
     expect(out).toContain("pr-reviewer"); // old slug named
@@ -330,7 +354,7 @@ describe("slug-rename hint (F-861)", () => {
       response({ ...AGENT_OK, resolved_via: "slug" }),
     );
 
-    await runRegisterAgent({ apiBaseUrl: "https://api.example.com", name: "Triage Bot", force: false });
+    await runRegisterAgent({ apiBaseUrl: "https://api.example.com", dashboardBaseUrl: "https://app.example.com", name: "Triage Bot", force: false });
 
     expect(errors.join("\n")).not.toMatch(/renamed/i);
   });
@@ -342,7 +366,7 @@ describe("slug-rename hint (F-861)", () => {
       response({ ...AGENT_OK, slug: "triage-bot", resolved_via: "created", created: true }),
     );
 
-    await runRegisterAgent({ apiBaseUrl: "https://api.example.com", name: "Triage Bot", force: false });
+    await runRegisterAgent({ apiBaseUrl: "https://api.example.com", dashboardBaseUrl: "https://app.example.com", name: "Triage Bot", force: false });
 
     expect(errors.join("\n")).not.toMatch(/renamed/i);
   });
@@ -355,7 +379,7 @@ describe("slug-rename hint (F-861)", () => {
       response({ ...AGENT_OK, slug: "triage-bot", hint: "Heads up: judge model changed." }),
     );
 
-    await runRegisterAgent({ apiBaseUrl: "https://api.example.com", name: "Triage Bot", force: false });
+    await runRegisterAgent({ apiBaseUrl: "https://api.example.com", dashboardBaseUrl: "https://app.example.com", name: "Triage Bot", force: false });
 
     expect(errors.join("\n")).not.toMatch(/renamed/i);
   });
@@ -368,7 +392,7 @@ describe("slug-rename hint (F-861)", () => {
       response({ ...AGENT_OK, slug: "triage-bot", resolved_via: "merged" }),
     );
 
-    await runRegisterAgent({ apiBaseUrl: "https://api.example.com", name: "Triage Bot", force: false });
+    await runRegisterAgent({ apiBaseUrl: "https://api.example.com", dashboardBaseUrl: "https://app.example.com", name: "Triage Bot", force: false });
 
     expect(errors.join("\n")).not.toMatch(/renamed/i);
     expect(readManifestFile()).toMatchObject({ agent: { slug: "triage-bot" } });


### PR DESCRIPTION
Executive summary: `pome register agent` printed four lines and no URL, but the docs.pome.sh onboarding walk's step 5 asks the coach to "show me the dashboard line register printed" — a promise the CLI never kept, which stalled the M2 cold walk. This adds a final `Dashboard:` handoff line that deep-links the registered agent's page, so docs and reality agree without any docs edit.

## What
`pome register agent` now prints a final line — `Dashboard: <base>/agents/<slug>` — deep-linking the just-registered agent's dashboard page. The base resolves from `POME_DASHBOARD_URL` (default `https://app.pome.sh`), resolved at the `main.ts` boundary and passed into `runRegisterAgent`, mirroring the runner's reliability-page handoff. Trailing slash trimmed; slug URL-encoded.

## Why
The onboarding walk's paste-prompt asks for "the dashboard line register printed," but no such line existed — the coach had to correct itself mid-walk ("the CLI prints no dashboard URL line … I'm not going to invent a URL"). Printing the line is the ticket's preferred fix and makes the docs prompt truthful without touching the docs.

## Notes for reviewer
- `/agents/<slug>` is the same dashboard IA the runner's reliability handoff already relies on (`/agents/<slug>/tasks/…`), so it lands on the agent, not a generic root.
- Scope: only the successful-register path prints the line. The `--force`-skipped "Already linked to …" early-return path is unchanged — the walk exercises a fresh register; adding the link there is an easy follow-up if wanted.
- Docs side (pome-cloud `apps/docs/existing-agent.mdx`) needs no change: its prompt is now satisfied. It lives in another repo and is untouched here.

## Tests / CI
- New unit test asserts the deep-link and the trailing-slash trim; threaded the new required `dashboardBaseUrl` through all existing `runRegisterAgent` call sites.
- `register.test.ts` 21/21; full CLI unit suite 629/629; `npm run typecheck` clean; build runs clean.

<!-- Closes F-905 -->