### PR TITLE
Stop pome doctor's twin check from overstating liveness

### DIFF
--- a/cli/.changeset/doctor-twin-boots-copy.md
+++ b/cli/.changeset/doctor-twin-boots-copy.md
@@ -1,0 +1,14 @@
+---
+"@pome-sh/cli": patch
+---
+
+Re-word `pome doctor`'s twin check so it no longer overstates liveness (F-906).
+The check boots a throwaway local twin, probes its health + session routes, and
+tears it down — it never proves a twin is listening — so the pass line now reads
+`✓ twin boots locally  github · health + session ok` (was `✓ twin reachable`,
+which read as "a twin is up"); the failure label is `local twin check failed`.
+`pome doctor` also prints a one-line note on a green report that it verifies the
+wiring, not that the examinee's own code launches — the preflight probe
+(`POME_PREFLIGHT=1`) early-returns the agent before its body runs, so a
+launch-fatal bug there (e.g. a TDZ crash) surfaces only on a real run. The note
+is opt-in, so the `run`/`install` gates are unchanged.

--- a/cli/.changeset/doctor-twin-boots-copy.md
+++ b/cli/.changeset/doctor-twin-boots-copy.md
@@ -7,8 +7,9 @@ The check boots a throwaway local twin, probes its health + session routes, and
 tears it down — it never proves a twin is listening — so the pass line now reads
 `✓ twin boots locally  github · health + session ok` (was `✓ twin reachable`,
 which read as "a twin is up"); the failure label is `local twin check failed`.
-`pome doctor` also prints a one-line note on a green report that it verifies the
-wiring, not that the examinee's own code launches — the preflight probe
-(`POME_PREFLIGHT=1`) early-returns the agent before its body runs, so a
-launch-fatal bug there (e.g. a TDZ crash) surfaces only on a real run. The note
-is opt-in, so the `run`/`install` gates are unchanged.
+`pome doctor` also prints a note on a green report that a green check means the
+wiring is right, not that the examinee runs cleanly: `pome doctor` never
+launches the agent, and a `pome run` preflight probe launches it with
+`POME_PREFLIGHT=1`, which most scaffolds honour by exiting before their real
+work path — so a bug on that skipped path surfaces only on a full trial run. The
+note is opt-in, so the `run`/`install` gates are unchanged.

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -875,13 +875,13 @@ export function createProgram() {
   program
     .command("doctor")
     .description(
-      "Check the agent↔twin wiring: pome.json (or pome.yaml) present + valid, twin reachable, requests routed to the twin (not a hardcoded production host), egress floor active. On failure prints one named cause (file:line where knowable) + one concrete fix and exits non-zero.",
+      "Check the agent↔twin wiring: pome.json (or pome.yaml) present + valid, the local twin boots + serves, requests routed to the twin (not a hardcoded production host), egress floor active. On failure prints one named cause (file:line where knowable) + one concrete fix and exits non-zero.",
     )
     .action(async () => {
       const { runDoctorChecks } = await import("../doctor/checks.js");
       const { renderDoctorReport } = await import("../doctor/render.js");
       const report = await runDoctorChecks();
-      for (const line of renderDoctorReport(report)) console.error(line);
+      for (const line of renderDoctorReport(report, { passNote: true })) console.error(line);
       if (!report.ok) process.exitCode = 1;
     });
 

--- a/cli/src/doctor/checks.ts
+++ b/cli/src/doctor/checks.ts
@@ -132,7 +132,7 @@ async function checkTwinReachable(_configDir: string): Promise<DoctorCheck> {
   const fail = (cause: string): DoctorCheck => ({
     id: "twin",
     status: "fail",
-    label: "twin not reachable",
+    label: "local twin check failed",
     cause,
     fix: "npm install (twin dependencies), then re-run pome doctor — if it persists, file an issue with the error above",
   });
@@ -178,7 +178,16 @@ async function checkTwinReachable(_configDir: string): Promise<DoctorCheck> {
       );
     }
 
-    return { id: "twin", status: "pass", label: "twin reachable", detail: "github · local" };
+    // "boots locally", not "reachable": this check brings a throwaway twin up
+    // on an ephemeral port and tears it down — it does NOT prove a twin is
+    // listening now. Overstating that (the F-906 cold walk read "reachable" as
+    // "a twin is up") is exactly what this wording avoids.
+    return {
+      id: "twin",
+      status: "pass",
+      label: "twin boots locally",
+      detail: "github · health + session ok",
+    };
   } catch (err) {
     return fail(`could not reach the locally served twin: ${firstLine(err)}`);
   } finally {

--- a/cli/src/doctor/render.ts
+++ b/cli/src/doctor/render.ts
@@ -15,12 +15,14 @@ export interface RenderDoctorReportOptions {
    *  moment-03 default; `pome install` passes moment 02's
    *  "verifying the wiring …" (FDRS-642). */
   header?: string;
-  /** F-906 — when the report passes, append a one-line caveat that a green
-   *  doctor verifies wiring, not that the examinee's own code launches: the
-   *  preflight probe (POME_PREFLIGHT=1) early-returns the agent before its
-   *  body runs, so a launch-fatal bug there surfaces only on a real run.
-   *  Opt-in so only `pome doctor` shows it — the `run`/`install` consumers
-   *  print the report as a gate, not as a self-diagnosis. */
+  /** F-906 — when the report passes, append a caveat that a green check means
+   *  the wiring is right, not that the examinee runs cleanly. `pome doctor`
+   *  never launches the agent; and a `pome run` preflight probe launches it
+   *  with POME_PREFLIGHT=1, which most scaffolds honour by exiting before
+   *  their real work path — so a bug on that skipped path (as in F-900)
+   *  surfaces only on a full trial run. Opt-in so only `pome doctor` shows it
+   *  — the `run`/`install` consumers print the report as a gate, not as a
+   *  self-diagnosis. */
   passNote?: boolean;
 }
 
@@ -51,14 +53,15 @@ export function renderDoctorReport(
   } else if (options.passNote) {
     lines.push("");
     lines.push(
-      "note: this checks the wiring, not that your agent launches cleanly — the",
+      "note: a green check means the wiring is right, not that your agent runs",
     );
     lines.push(
-      "preflight probe exits your agent early (POME_PREFLIGHT=1), so a startup bug",
+      "cleanly — pome doctor never launches it, and a run's preflight probe exits",
     );
     lines.push(
-      "in its own code (e.g. a TDZ crash) can still surface only on a real run.",
+      "it early (POME_PREFLIGHT=1), so a bug on the code path they skip surfaces",
     );
+    lines.push("only on a full trial run.");
   }
 
   return lines;

--- a/cli/src/doctor/render.ts
+++ b/cli/src/doctor/render.ts
@@ -15,6 +15,13 @@ export interface RenderDoctorReportOptions {
    *  moment-03 default; `pome install` passes moment 02's
    *  "verifying the wiring …" (FDRS-642). */
   header?: string;
+  /** F-906 — when the report passes, append a one-line caveat that a green
+   *  doctor verifies wiring, not that the examinee's own code launches: the
+   *  preflight probe (POME_PREFLIGHT=1) early-returns the agent before its
+   *  body runs, so a launch-fatal bug there surfaces only on a real run.
+   *  Opt-in so only `pome doctor` shows it — the `run`/`install` consumers
+   *  print the report as a gate, not as a self-diagnosis. */
+  passNote?: boolean;
 }
 
 export function renderDoctorReport(
@@ -41,6 +48,17 @@ export function renderDoctorReport(
     lines.push("");
     lines.push("until this passes, your agent would hit production.");
     lines.push("pome will not run trials against a live API.");
+  } else if (options.passNote) {
+    lines.push("");
+    lines.push(
+      "note: this checks the wiring, not that your agent launches cleanly — the",
+    );
+    lines.push(
+      "preflight probe exits your agent early (POME_PREFLIGHT=1), so a startup bug",
+    );
+    lines.push(
+      "in its own code (e.g. a TDZ crash) can still surface only on a real run.",
+    );
   }
 
   return lines;

--- a/cli/test/unit/doctor/checks.test.ts
+++ b/cli/test/unit/doctor/checks.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // FDRS-634 — unit tests for the doctor check engine.
 //
-// Four checks, in order: config present+valid → twin reachable → routing →
+// Four checks, in order: config present+valid → twin boots locally → routing →
 // egress floor. The engine stops at the first failure so the report carries
 // exactly ONE named cause + one concrete fix ("never a false success" wants
 // one clear next step, not a wall of maybes).

--- a/cli/test/unit/doctor/render.test.ts
+++ b/cli/test/unit/doctor/render.test.ts
@@ -13,7 +13,7 @@ describe("renderDoctorReport", () => {
       ok: true,
       checks: [
         { id: "config", status: "pass", label: "pome.config.json found" },
-        { id: "twin", status: "pass", label: "twin reachable", detail: "github · local" },
+        { id: "twin", status: "pass", label: "twin boots locally", detail: "github · health + session ok" },
         { id: "routing", status: "pass", label: "requests route to the twin", detail: "reads POME_GITHUB_REST_URL" },
         { id: "egress", status: "pass", label: "egress floor active", detail: "deny-by-default · 6 pattern(s) + loopback" },
       ],
@@ -22,9 +22,46 @@ describe("renderDoctorReport", () => {
     const text = renderDoctorReport(report).join("\n");
     expect(text).toContain("checking your wiring …");
     expect(text).toContain("✓ pome.config.json found");
-    expect(text).toContain("✓ twin reachable  github · local");
+    expect(text).toContain("✓ twin boots locally  github · health + session ok");
     expect(text).not.toContain("cause");
     expect(text).not.toContain("your agent would hit production");
+  });
+
+  it("omits the preflight pass-note by default, but appends it when passNote is set (F-906)", () => {
+    const report: DoctorReport = {
+      ok: true,
+      checks: [
+        { id: "config", status: "pass", label: "pome.json found" },
+        { id: "twin", status: "pass", label: "twin boots locally", detail: "github · health + session ok" },
+      ],
+    };
+
+    // The run/install consumers render without the note.
+    expect(renderDoctorReport(report).join("\n")).not.toContain("POME_PREFLIGHT");
+
+    // `pome doctor` opts in — a green report is not "the agent can launch".
+    const text = renderDoctorReport(report, { passNote: true }).join("\n");
+    expect(text).toContain("this checks the wiring, not that your agent launches cleanly");
+    expect(text).toContain("POME_PREFLIGHT=1");
+  });
+
+  it("never shows the pass-note on a failing report, even when passNote is set", () => {
+    const report: DoctorReport = {
+      ok: false,
+      checks: [
+        {
+          id: "config",
+          status: "fail",
+          label: "pome manifest not found",
+          cause: "no pome.json or pome.yaml found.",
+          fix: "run pome init, then re-run pome doctor",
+        },
+      ],
+    };
+
+    const text = renderDoctorReport(report, { passNote: true }).join("\n");
+    expect(text).not.toContain("POME_PREFLIGHT");
+    expect(text).toContain("until this passes, your agent would hit production.");
   });
 
   it("renders one cause/fix card and the production warning on failure", () => {
@@ -32,7 +69,7 @@ describe("renderDoctorReport", () => {
       ok: false,
       checks: [
         { id: "config", status: "pass", label: "pome.config.json found" },
-        { id: "twin", status: "pass", label: "twin reachable", detail: "github · local" },
+        { id: "twin", status: "pass", label: "twin boots locally", detail: "github · health + session ok" },
         {
           id: "routing",
           status: "fail",

--- a/cli/test/unit/doctor/render.test.ts
+++ b/cli/test/unit/doctor/render.test.ts
@@ -41,7 +41,8 @@ describe("renderDoctorReport", () => {
 
     // `pome doctor` opts in — a green report is not "the agent can launch".
     const text = renderDoctorReport(report, { passNote: true }).join("\n");
-    expect(text).toContain("this checks the wiring, not that your agent launches cleanly");
+    expect(text).toContain("a green check means the wiring is right, not that your agent runs");
+    expect(text).toContain("pome doctor never launches it");
     expect(text).toContain("POME_PREFLIGHT=1");
   });
 


### PR DESCRIPTION
## What & why

`pome doctor`'s twin check prints a pass line that **overstates liveness**. The check (`checkTwinReachable`) boots a *throwaway* `github` twin in-process on an ephemeral loopback port, probes `/healthz` + the bearer-authed `/_pome/health` session route, then tears it all down in `finally` — **nothing is left listening.** Yet it printed `✓ twin reachable — github · local`, which the 2026-07-24 M2 cold walk misread as "a twin is up" while nothing answered on `127.0.0.1:3333`.

The ticket's option 2 ("probe liveness, report 'not running yet'") doesn't fit the architecture — there's no persistent twin to probe; the check *creates* one. So this takes option 1: **make the copy match what it verifies.**

## Changes

- **Re-word the twin check** (`cli/src/doctor/checks.ts`)
  - pass `twin reachable` → **`twin boots locally`**, detail `github · local` → **`github · health + session ok`**
  - fail `twin not reachable` → **`local twin check failed`** (covers boot / bad-health / rejected-session; the cause line keeps the specifics)
  - update the `pome doctor` command description string that also said "twin reachable"
- **POME_PREFLIGHT caveat (the bonus)** (`cli/src/doctor/render.ts`) — `docs/troubleshooting` doesn't exist (no `docs/` tree at all), so per the ticket's "output *or* docs" it goes in the output. `renderDoctorReport` gains an opt-in `passNote`; **only `pome doctor` sets it**, so the `run`/`install` gates are byte-for-byte unchanged. On a green report:
  > note: this checks the wiring, not that your agent launches cleanly — the preflight probe exits your agent early (POME_PREFLIGHT=1), so a startup bug in its own code (e.g. a TDZ crash) can still surface only on a real run.
- Patch changeset for `@pome-sh/cli`.

## Real output (drove the engine, not just unit assertions)

```
✓ pome.json found
✓ twin boots locally  github · health + session ok
✓ requests route to the twin  reads POME_GITHUB_MCP_URL
✓ egress floor active  deny-by-default · 6 pattern(s) + loopback

note: this checks the wiring, not that your agent launches cleanly — the
preflight probe exits your agent early (POME_PREFLIGHT=1), so a startup bug
in its own code (e.g. a TDZ crash) can still surface only on a real run.
```
Verified the run/install gate render omits the note, and a failing report suppresses it while keeping the cause/fix card.

## Scope note

Left `skills/pome-run-task/*` and `skills/pome/SKILL.md`, which say "twin reachable" for the **REST-launcher** preflight — there the session twin is genuinely provisioned and answering at `rest_urls[<twin>]`, so "reachable" is accurate and isn't the overstatement this fixes.

## Tests
`typecheck` clean · 630 unit tests + doctor e2e pass · copy-marker / code-health / no-catch / legacy-marker lint gates pass.

<!-- Closes F-906 -->
