### PR TITLE
Run declared manifest tasks on bare pome run

### DIFF
--- a/cli/.changeset/bare-run-manifest-tasks.md
+++ b/cli/.changeset/bare-run-manifest-tasks.md
@@ -1,0 +1,13 @@
+---
+"@pome-sh/cli": minor
+---
+
+Wire the manifest `tasks` key into bare `pome run` (F-865). A migrated project
+that declares a task directory (`tasks: "tasks"` in `pome.json`) now has bare
+`pome run` run that whole declared set — exactly like `pome run <that-dir>`,
+each file at its own `runs`/`-n` — instead of ignoring it and dropping the
+`tasks/first-run-demo.md` demo. Un-migrated projects (no manifest, or no
+`tasks` key) keep today's "that was ours, run yours" demo default unchanged. A
+declared-but-missing directory errors as a usage error (exit 5) rather than
+silently falling back to the demo; an empty declared directory prints a
+"0 tasks found" note and exits 0.

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -590,23 +590,42 @@ export function createProgram() {
           }
         }
 
-        // FDRS-645 — "run yours": bare `pome run` defaults to the demo task
-        // via a user-visible copy (tasks/first-run-demo.md, dropped on
-        // first use; its Config pins runs: 5 so an explicit -n still wins).
-        // The moment-05 frame prints later, once the doctor + credential
-        // gates have passed.
+        // Read the manifest once — both bare-run task resolution (F-865) and
+        // the agent command below consume it.
+        const manifestRead = await readManifest(process.cwd()).catch(() => null);
+
+        // FDRS-645 / F-865 — bare `pome run` (no path) resolves its default:
+        //   - a MIGRATED project (manifest with a `tasks` key) runs that whole
+        //     declared directory, exactly like `pome run <that-dir>`: no demo
+        //     drop, no "run yours" frame, each file at its own `runs`/-n;
+        //   - an UN-MIGRATED project (no manifest / no `tasks` key) keeps the
+        //     "run yours" demo default — a user-visible copy at
+        //     tasks/first-run-demo.md (dropped on first use; its Config pins
+        //     runs: 5 so an explicit -n still wins). The moment-05 frame prints
+        //     later, once the doctor + credential gates have passed.
         let defaultTask: DefaultTaskResolution | null = null;
+        let bareViaManifestTasks = false;
         if (target === undefined) {
-          try {
-            defaultTask = await ensureDefaultTask();
-          } catch (err) {
-            console.error(err instanceof Error ? err.message : String(err));
-            process.exitCode = exitCodeFor(err);
-            return;
+          const declaredTasks = manifestRead?.manifest.tasks;
+          if (manifestRead && declaredTasks) {
+            // Resolve the declared dir relative to the manifest, not cwd — the
+            // manifest can be discovered up-tree. A declared-but-missing dir
+            // surfaces as taskFiles' usage error below (exit 5); we never
+            // silently fall back to the demo drop once intent is declared.
+            target = resolve(dirname(manifestRead.path), declaredTasks);
+            bareViaManifestTasks = true;
+          } else {
+            try {
+              defaultTask = await ensureDefaultTask();
+            } catch (err) {
+              console.error(err instanceof Error ? err.message : String(err));
+              process.exitCode = exitCodeFor(err);
+              return;
+            }
+            if (defaultTask.copied) console.error(copyAnnounceLine(defaultTask));
+            if (!defaultTask.trialsApplied) console.error(trialsPinFallbackLine());
+            target = defaultTask.path;
           }
-          if (defaultTask.copied) console.error(copyAnnounceLine(defaultTask));
-          if (!defaultTask.trialsApplied) console.error(trialsPinFallbackLine());
-          target = defaultTask.path;
         }
 
         let files: string[];
@@ -620,7 +639,22 @@ export function createProgram() {
           return;
         }
 
-        const manifestRead = await readManifest(process.cwd()).catch(() => null);
+        // F-865 — make a manifest-driven bare run legible: name where the set
+        // came from, and never let an empty declared dir no-op silently.
+        if (bareViaManifestTasks) {
+          const manifestFile = basename(manifestRead!.path);
+          const declared = manifestRead!.manifest.tasks;
+          if (files.length === 0) {
+            console.error(
+              `no task .md files found in ${declared}/ (declared in ${manifestFile}) — add tasks or copy some with \`pome tasks <twin> --copy\`.`,
+            );
+          } else {
+            console.error(
+              `resolved ${files.length} task(s) from ${manifestFile} (tasks: "${declared}")`,
+            );
+          }
+        }
+
         const configCommand = manifestRead?.manifest.command;
         const agentCommand =
           options.agent ?? configCommand ?? DEFAULT_AGENT_COMMAND;

--- a/cli/test/unit/run-default-task.test.ts
+++ b/cli/test/unit/run-default-task.test.ts
@@ -290,4 +290,86 @@ describe("bare `pome run` glue (FDRS-645)", () => {
     expect(runTrialGroup).not.toHaveBeenCalled();
     expect(runTaskHosted).not.toHaveBeenCalled();
   }, 30_000);
+
+  // F-865 — a MIGRATED project declares its task directory in the manifest;
+  // bare `pome run` runs that whole declared set instead of the demo drop.
+  async function fixtureRepoWithTasks(
+    taskFiles: Record<string, string>,
+    tasksKey = "tasks",
+  ): Promise<string> {
+    const dir = await fixtureRepo();
+    await writeFile(
+      join(dir, "pome.json"),
+      JSON.stringify(
+        {
+          agent: { slug: "fixture-agent" },
+          command: 'node -e "process.exit(0)"',
+          tasks: tasksKey,
+        },
+        null,
+        2,
+      ),
+    );
+    await mkdir(join(dir, tasksKey), { recursive: true });
+    for (const [name, body] of Object.entries(taskFiles)) {
+      await writeFile(join(dir, tasksKey, name), body);
+    }
+    return dir;
+  }
+
+  it("bare run with manifest.tasks runs the whole declared set, no demo drop", async () => {
+    const dir = await fixtureRepoWithTasks({
+      "01-a.md": EXPLICIT_SCENARIO,
+      "02-b.md": EXPLICIT_SCENARIO,
+    });
+    process.chdir(dir);
+    await run();
+
+    expect(process.exitCode ?? 0).toBe(0);
+    // One hosted run per declared file; the demo trial-group path never fires.
+    expect(runTaskHosted).toHaveBeenCalledTimes(2);
+    expect(runTrialGroup).not.toHaveBeenCalled();
+    // No demo drop and no "run yours" framing on the migrated path.
+    expect(existsSync(join(dir, "tasks", "first-run-demo.md"))).toBe(false);
+    const err = stderr.join("\n");
+    expect(err).not.toContain("copied the demo task into");
+    expect(err).not.toContain(runYoursFrameLines()[0]);
+    expect(err).toContain('resolved 2 task(s) from pome.json (tasks: "tasks")');
+  }, 30_000);
+
+  it("a declared-but-missing tasks dir errors (exit 5), never the demo drop", async () => {
+    const dir = await fixtureRepo();
+    await writeFile(
+      join(dir, "pome.json"),
+      JSON.stringify(
+        {
+          agent: { slug: "fixture-agent" },
+          command: 'node -e "process.exit(0)"',
+          tasks: "does-not-exist",
+        },
+        null,
+        2,
+      ),
+    );
+    process.chdir(dir);
+    await run();
+
+    expect(process.exitCode).toBe(5);
+    expect(existsSync(join(dir, "tasks", "first-run-demo.md"))).toBe(false);
+    expect(runTaskHosted).not.toHaveBeenCalled();
+    expect(runTrialGroup).not.toHaveBeenCalled();
+  }, 30_000);
+
+  it("an empty declared tasks dir notes 0 tasks and no-ops (exit 0)", async () => {
+    const dir = await fixtureRepoWithTasks({});
+    process.chdir(dir);
+    await run();
+
+    expect(process.exitCode ?? 0).toBe(0);
+    const err = stderr.join("\n");
+    expect(err).toContain("no task .md files found in tasks/");
+    expect(runTaskHosted).not.toHaveBeenCalled();
+    expect(runTrialGroup).not.toHaveBeenCalled();
+    expect(existsSync(join(dir, "tasks", "first-run-demo.md"))).toBe(false);
+  }, 30_000);
 });


### PR DESCRIPTION
## What

Wire the manifest `tasks` key into bare `pome run`'s default-path resolution. The key was declared in `manifestSchema` but no CLI consumer read it, so a migrated project shipping its tasks under `tasks/` had a bare `pome run` ignore the declared set and drop/re-run an unrelated `first-run-demo.md` starter.

## Behavior

Bare `pome run` (no path), in the `target === undefined` branch:

- **Migrated project** (manifest present with a `tasks` key) → runs that whole declared directory, exactly like `pome run <that-dir>`: every `*.md`, each at its own `runs`/`-n`. No demo drop, no "run yours" frame, no `runs:5` pin.
- **Un-migrated project** (no manifest, or no `tasks` key) → today's `ensureDefaultTask()` demo default, unchanged — the "that was ours, run yours" first-run experience is preserved.
- **Declared-but-missing dir** → usage error (exit 5); never silently falls back to the demo once intent is declared.
- **Empty declared dir** → prints a "0 tasks found" note and exits 0.

A one-line `resolved N task(s) from pome.json (tasks: "…")` signal makes the fan-out legible.

## Implementation notes

- `cli/src/cli/main.ts`: hoisted the manifest read to one call (it was read twice — once here, once for `command`) and reused it. The re-run-command logic already keys off `defaultTask` (null on the manifest path), so a failed manifest-driven task re-runs by explicit path — no change needed there.
- Directory resolution is relative to the manifest's directory (it can be discovered up-tree), not cwd.

## Tests

`cli/test/unit/run-default-task.test.ts` — 3 new cases: fan-out over the declared dir (no demo drop/frame), declared-but-missing dir → exit 5, empty dir → note + exit 0. `run-default-task` 17 passed; adjacent `run-n-flag`/`run-doctor-gate`/`tasks-command`/`init` 28 passed; `npm run typecheck` clean.

Changeset: `@pome-sh/cli` minor.

<!-- Closes F-865 -->