### PR TITLE
fix(cli): repoint `pome docs tasks` to /docs/cli/tasks (F-912)

### DIFF
--- a/cli/.changeset/docs-cli-tasks-route.md
+++ b/cli/.changeset/docs-cli-tasks-route.md
@@ -1,0 +1,9 @@
+---
+"@pome-sh/cli": patch
+---
+
+`pome docs tasks` now points at the renamed docs.pome.sh page. The M4 docs door
+(F-912) renamed `/docs/cli/scenarios` to `/docs/cli/tasks` on docs.pome.sh; this
+repoints the `cli-tasks` topic's `path` to match. A redirect on the docs site
+keeps the old `/docs/cli/scenarios` URL alive, and the `scenarios` keyword stays
+on the topic so `pome docs scenarios` still resolves to the `pome tasks` page.

--- a/cli/src/cli/docs-topics.ts
+++ b/cli/src/cli/docs-topics.ts
@@ -131,9 +131,11 @@ export const DOCS_TOPICS: DocsTopic[] = [
   {
     id: "cli-tasks",
     title: "pome tasks",
-    // F-892 — `path` still points at /docs/cli/scenarios: the docs.pome.sh page
-    // is renamed by the M4 docs door, not here. Repoint once that lands.
-    path: "/docs/cli/scenarios",
+    // F-912 — the M4 docs door renamed the docs.pome.sh page from
+    // /docs/cli/scenarios to /docs/cli/tasks (a redirect keeps the old URL
+    // alive), so `path` now points at the new route. The "scenarios" keyword
+    // stays so `pome docs scenarios` still resolves to this topic.
+    path: "/docs/cli/tasks",
     keywords: ["tasks", "scenarios", "catalog", "copy", "library", "twin"],
   },
   {


### PR DESCRIPTION
## What

Repoints the `cli-tasks` topic `path` in `cli/src/cli/docs-topics.ts` from `/docs/cli/scenarios` to `/docs/cli/tasks`, matching the docs.pome.sh page rename landing in the M4 docs door (pome-cloud F-912). Adds a `@pome-sh/cli` patch changeset.

## Why

F-892 renamed `pome scenarios` → `pome tasks` in the shipped CLI but deliberately left the `pome docs` topic pointing at `/docs/cli/scenarios`, with a comment to repoint "once the M4 docs door lands." The pome-cloud docs PR renames `apps/docs/docs/cli/scenarios.mdx` → `tasks.mdx` (route `/docs/cli/tasks`) and adds a site redirect from the old URL. This coordinates the CLI side so `pome docs tasks` deep-links directly at the new page.

## Notes

- The docs-site redirect `/docs/cli/scenarios` → `/docs/cli/tasks` means the currently-shipped CLI (0.7.0, which still points at `/docs/cli/scenarios`) keeps working; this change just removes the redirect hop for the next CLI release.
- The `scenarios` keyword stays on the topic, so `pome docs scenarios` still resolves to the `pome tasks` page.

## Tests

- `bun test test/unit/docs-command.test.ts` → 6 pass / 0 fail. (Pre-existing unrelated typecheck failures in this clone come from stale local shared-types; not touched here.)

## Review

Single string change + comment + changeset. Coordinated with pome-cloud F-912 docs PR.