### PR TITLE
Sweep stale scenario tool/skill refs in bundled examples

### DIFF
--- a/examples/merge-agent/src/index.ts
+++ b/examples/merge-agent/src/index.ts
@@ -53,7 +53,7 @@ const system = [
 ].join("\n");
 
 // Each tool maps to exactly one supported twin REST endpoint, so the agent can
-// never hit an unsupported route (one of the scenario's pass criteria).
+// never hit an unsupported route (one of the task's pass criteria).
 const tools = {
   list_open_pull_requests: tool({
     description: "List the open pull requests in a repository.",

--- a/examples/pr-summary-agent/src/index.ts
+++ b/examples/pr-summary-agent/src/index.ts
@@ -14,8 +14,8 @@
  *    same TWIN_AUTH_SECRET in both terminals and the agent mints its own
  *    bearer JWT. The agent talks to http://127.0.0.1:3333/s/standalone/mcp.
  *
- * 2. Pome CLI evaluator — `pome run <scenario>.md --agent="npm run start"`.
- *    The CLI spins up its own twin on a random port, seeds the scenario, mints
+ * 2. Pome CLI evaluator — `pome run <task>.md --agent="npm run start"`.
+ *    The CLI spins up its own twin on a random port, seeds the task, mints
  *    the JWT itself, and passes the URL + token to the agent via env
  *    (POME_GITHUB_MCP_URL, POME_AUTH_TOKEN, POME_TASK).
  *

--- a/examples/pr-summary-review/src/index.ts
+++ b/examples/pr-summary-review/src/index.ts
@@ -23,8 +23,8 @@
  *    the agent mints its own bearer JWT. The agent talks to the twin at
  *    http://127.0.0.1:3333/s/standalone/mcp.
  *
- * 2. Pome CLI evaluator — `pome run <scenario>.md`. The CLI boots its own twin,
- *    seeds the scenario, mints the JWT, and injects POME_GITHUB_MCP_URL /
+ * 2. Pome CLI evaluator — `pome run <task>.md`. The CLI boots its own twin,
+ *    seeds the task, mints the JWT, and injects POME_GITHUB_MCP_URL /
  *    POME_AUTH_TOKEN / POME_TASK.
  *
  * Claude credentials are resolved from ANTHROPIC_API_KEY, falling back to

--- a/examples/support-triage/README.md
+++ b/examples/support-triage/README.md
@@ -54,11 +54,11 @@ dashboard shows two separate identities with separate scores.
    register_agent(name="support-triage-v1", twins=["github","slack"])
    register_agent(name="support-triage-v2", twins=["github","slack"])
    ```
-3. **Run** — for each agent id, `run_trials(scenario_id, agent_id, n=5)`. Each
+3. **Run** — for each agent id, `run_trials(task_id, agent_id, n=5)`. Each
    trial returns an `examinee_launch` spec (per-session twin MCP URLs, a bearer,
    `always_allow`, a `network.mode: limited` clamp, web tools off). Assemble the
    examinee clone from that spec (mirrors
-   `pome-run-scenario/references/launch-managed-agent.md`), give it
+   `pome-run-task/references/launch-managed-agent.md`), give it
    `examinee_task.prompt`, and let it work.
 4. **Finalize** — `finalize_run(session_id, agent_token)` the instant the
    examinee idles (the tape is pulled from the still-live twin session), then

--- a/examples/support-triage/VERIFICATION.md
+++ b/examples/support-triage/VERIFICATION.md
@@ -14,7 +14,7 @@ on team **AFFF's workspace**. Runs are visible on `app.pome.sh`.
   `task_OJue2tyNX-EpAoAC3k51`). Seed pre-loads open issue #1 for the coupon bug;
   `#support` gets a *new* report of the *same* bug.
 - **Examinee runtime**: Claude managed agent on Anthropic's Managed Agents cloud,
-  assembled from `run_scenario`'s `examinee_launch` (network clamped to
+  assembled from `run_task`'s `examinee_launch` (network clamped to
   `twins.pome.sh`, `web_search`/`web_fetch` off, `always_allow` on every
   `mcp_toolset`, a vault `static_bearer` per twin URL). Ephemeral per trial —
   torn down after each `finalize_run`.
@@ -70,7 +70,7 @@ pristine; a stronger model may or may not remove the last flake.
 
 1. Register two agents on Pome: `register_agent(name="support-triage-v1",
    twins=["github","slack"])` and the same for `-v2`.
-2. For each, `run_trials(scenario_id, agent_id, n=5)`; assemble each trial's
+2. For each, `run_trials(task_id, agent_id, n=5)`; assemble each trial's
    clone from `examinee_launch` (env clamp, vault `static_bearer` per twin URL,
    `always_allow` on every `mcp_toolset`, web tools off), model
    `claude-sonnet-5`, `system` = that version's prompt; kick off with

--- a/examples/triage-agent/src/index.ts
+++ b/examples/triage-agent/src/index.ts
@@ -17,7 +17,7 @@
  *
  * 2. Pome CLI evaluator — `pome run tasks/01-triage-acme-issues.md --agent="npm
  *    run start"`. The CLI spins up its own twin on a random port, seeds the
- *    scenario, mints the JWT itself, and passes the URL + token to the agent
+ *    task, mints the JWT itself, and passes the URL + token to the agent
  *    via env (POME_GITHUB_MCP_URL, POME_AUTH_TOKEN, POME_TASK).
  *
  * The agent uses the Claude Agent SDK's in-process MCP server to expose three

--- a/examples/triage-agent/tasks/01-triage-acme-issues.md
+++ b/examples/triage-agent/tasks/01-triage-acme-issues.md
@@ -1,6 +1,6 @@
 # Triage open issues in acme/api
 
-The bundled happy-path scenario for the triage agent. The default Pome twin
+The bundled happy-path task for the triage agent. The default Pome twin
 seed ships one open issue (`#1` — a 500 error after deploy in `acme/api`). The
 agent should read it, classify it as a `bug`, apply the label, and post a
 one-sentence reasoning comment.


### PR DESCRIPTION
## Summary

Finishes the `scenario`→`task` rename in the digital-twins bundled `examples/` — the leftover surface deferred from the published-docs pass. Fixes the **clearly-stale renamed tool/skill references** an external developer would hit if they copied the examples verbatim.

All edits are **comments/docs only** — no runtime code changes, so no changeset (docs-only exempt).

### Fixed (stale → canonical)
| File | Change |
|---|---|
| `support-triage/README.md` | `run_trials(scenario_id, …)` → `task_id`; `pome-run-scenario/references/launch-managed-agent.md` → `pome-run-task/references/…` |
| `support-triage/VERIFICATION.md` | `run_scenario`'s → `run_task`'s; `run_trials(scenario_id, …)` → `task_id` |
| `pr-summary-agent`, `pr-summary-review`, `triage-agent` `src/index.ts` | `pome run <scenario>.md` → `<task>.md`; "seeds the scenario" → "seeds the task" |
| `triage-agent/tasks/01-triage-acme-issues.md` | "bundled happy-path scenario" → "task" |
| `merge-agent/src/index.ts` | "the scenario's pass criteria" → "the task's pass criteria" |

The renamed targets were verified to exist: `skills/pome-run-task/references/launch-managed-agent.md` is present, and the canonical MCP tool is `run_task(task_id, …)` (already used in `support-triage/local/`).

### Decision — `minimal-viktor*` surface left as-is (intentional)
Verified these are **live/back-compat, not stale**:
- **`--scenario` script flag** — the example's own flag; the published `pome` CLI itself still declares a `scenario` arg (`cli/src/cli/eval.ts`). Renaming a shipped flag is a breaking change / larger surface than a stale-ref sweep.
- **`scenario_source` / `scenario_id` in `pome-api.ts`** — accepted 0.3.0 back-compat aliases (`shared-types/src/rest.ts`: "keep working unchanged"), not stale.
- **"scenario" as a test-case term** in comments/test names — generic English, not a renamed tool/skill identifier.

### Verification
Re-grep across `examples/` for `run_scenario` / `pome-run-scenario` / `pome-author-scenario` / `seeds the scenario` / `pome run <scenario>` → **zero matches**. Every remaining `scenario` string is the intentionally-left `minimal-viktor*` surface above.

<!-- Closes F-913 -->