### PR TITLE
feat(twin-gmail): named rate-limited fault seed + gmail-retry-notify retry example

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -1,6 +1,6 @@
 # Twin Runtime Contract
 
-**Version 1.3.0** — Linear contract added 2026-07-21; Gmail contract added 2026-07-20; boot-secret self-generation added 2026-07-10 (F-708). Verified by the black-box suite in [`contract/`](./contract/).
+**Version 1.4.0** — Gmail named fault seeds added 2026-07-24 (F-917); Linear contract added 2026-07-21; Gmail contract added 2026-07-20; boot-secret self-generation added 2026-07-10 (F-708). Verified by the black-box suite in [`contract/`](./contract/).
 
 This document enumerates everything pome-cloud (and the pome CLI) may rely on when booting and driving a twin. **Changing any item below is a breaking contract change**: update this document and the suite in the same PR, then open the matching pome-cloud consumer PR that pins and verifies the new signed twin artifact (rule of record: `packages/twin-github/README.md`, runtime-contract section).
 
@@ -98,6 +98,13 @@ Probed against the pre-engine builds (`3cd86eb`); the contract suite asserts eve
 - Unknown session routes return 501 `UNIMPLEMENTED`; unknown root routes return
   404. `users.watch`, `users.stop`, resumable uploads, forwarding delivery,
   Calendar processing, and deleted writes remain loud no-side-effect 501 gaps.
+- Gmail seeds accept an optional `faults` array of named fault primitives
+  (default `[]`). The `rate-limited` primitive throttles a target operation
+  (default `messages.send`) by call count: the first `succeedFirst` matching
+  calls succeed, the next `throttleFor` return **429 `RESOURCE_EXHAUSTED`**
+  (retry hint in the body; **no `Retry-After` header**), then calls recover. The
+  counter is per twin instance and cleared by `POST /admin/reset`. The default
+  seed carries no faults, so default behavior is unchanged (additive; F-917).
 
 ### Linear 1.3.0 pins
 

--- a/contract/gmail-fault.test.mjs
+++ b/contract/gmail-fault.test.mjs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-917 black-box case: a Gmail seed with a named `rate-limited` fault throttles
+// `messages.send` by call count over the real wire. Proves the contract that
+// pome-cloud relies on — the deployed dist, not a library import.
+
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mintSessionJwt, req, spawnTwin } from "./helpers.mjs";
+
+const GMAIL = { name: "gmail", pkg: "packages/twin-gmail", dbEnv: "GMAIL_TWIN_DB", hostEnv: "GMAIL_TWIN_HOST" };
+const SID = "s_fault";
+const MAILBOX = "agent@pome-twin.test";
+
+const SEED = {
+  primaryMailbox: { email: MAILBOX, displayName: "Agent" },
+  faults: [{ name: "rate-limited", target: "messages.send", succeedFirst: 1, throttleFor: 1 }],
+};
+
+function rawMessage(to) {
+  const mime = [`From: ${MAILBOX}`, `To: ${to}`, "Subject: hi", "Content-Type: text/plain; charset=utf-8", "", "hi"].join(
+    "\r\n",
+  );
+  return Buffer.from(mime, "utf8").toString("base64url");
+}
+
+describe("contract: gmail rate-limited fault", () => {
+  let t;
+  let token;
+
+  before(async () => {
+    t = await spawnTwin(GMAIL, { env: { POME_SEED_JSON: JSON.stringify(SEED) } });
+    token = mintSessionJwt({ sid: SID, extra: { gmail_email: MAILBOX } });
+  });
+  after(async () => {
+    if (t) await t.close();
+  });
+
+  async function send(to) {
+    return req(t.base, `/s/${SID}/gmail/v1/users/me/messages/send`, {
+      method: "POST",
+      token,
+      body: { raw: rawMessage(to) },
+    });
+  }
+
+  it("succeeds, throttles with 429 RESOURCE_EXHAUSTED, then recovers", async () => {
+    const first = await send("a@pome-twin.test");
+    assert.equal(first.status, 200, `send #1 should succeed — got ${first.status} ${first.text}`);
+
+    const second = await send("b@pome-twin.test");
+    assert.equal(second.status, 429, `send #2 should be throttled — got ${second.status} ${second.text}`);
+    assert.equal(second.json?.error?.status, "RESOURCE_EXHAUSTED");
+
+    const third = await send("c@pome-twin.test");
+    assert.equal(third.status, 200, `send #3 should recover — got ${third.status} ${third.text}`);
+  });
+});

--- a/contract/run.mjs
+++ b/contract/run.mjs
@@ -45,7 +45,13 @@ if (status === 0) status = run("npm", ["run", "build", "-w", "@pome-sh/twin-slac
 if (status === 0) status = run("npm", ["run", "build", "-w", "@pome-sh/twin-stripe"]);
 if (status === 0) status = run("npm", ["run", "build", "-w", "@pome-sh/twin-gmail"]);
 if (status === 0) status = run("npm", ["run", "build", "-w", "@pome-sh/twin-linear"]);
-if (status === 0) status = run("node", ["--test", "contract/contract.test.mjs", "contract/sdk-boot.test.mjs"]);
+if (status === 0)
+  status = run("node", [
+    "--test",
+    "contract/contract.test.mjs",
+    "contract/sdk-boot.test.mjs",
+    "contract/gmail-fault.test.mjs",
+  ]);
 
 const removed = cleanRuntimeJs(SHARED_SRC);
 console.log(`[contract/run] cleaned ${removed} generated runtime .js file(s) from packages/shared-types/src`);

--- a/docs/superpowers/plans/2026-07-24-gmail-fault-seeds-retry-example.md
+++ b/docs/superpowers/plans/2026-07-24-gmail-fault-seeds-retry-example.md
@@ -1,0 +1,938 @@
+# Gmail Named Fault Seeds + Retry/Partial-Failure Example — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a named, reusable `rate-limited` fault-injection seed primitive to the Gmail twin and ship the first Gmail example (`gmail-retry-notify`) that teaches retry/partial-failure with a red baseline and a green fixed variant, then verify everything end-to-end on hosted twins + hosted evals.
+
+**Architecture:** The Gmail seed grows an opt-in `faults` array (default `[]`, so existing behavior is unchanged, mirroring twin-linear's `strictScopes`). A small fault registry (`faults.ts`) maps a fault *name* to behavior; `rate-limited` throttles a target operation deterministically by call count (succeed first N → 429 for the next M → recover). A single gate call at the top of `sendMessage` covers both the REST and MCP send surfaces. The example is a Vercel-AI-SDK REST tool loop (same shape as `merge-agent`) whose red→green difference is a one-line system-prompt swap (same shape as `support-triage/local`).
+
+**Tech Stack:** TypeScript, Zod, better-sqlite3-style `GmailTwinDatabase`, Hono routes, Vercel AI SDK (`ai` v6 + `@ai-sdk/anthropic`), `tsx`, vitest, the `pome` CLI (0.7.0, hosted).
+
+## Global Constraints
+
+- **npm only.** Root uses `npm ci` / `npm install`; `packages/*` share one root `package-lock.json`. Examples are standalone packages with their OWN `package-lock.json` (not root workspaces).
+- **Vocabulary: "task", never "scenario"** in new code/docs/copy. Config key is `runs:` (not "trials"). Criterion markers are `[code]` / `[model]` only — never `[D]` / `[P]`.
+- **Additive contract only.** The default Gmail seed must remain byte-for-byte unchanged (`faults` defaults to `[]`). No behavior change unless a task opts in.
+- **No Retry-After HTTP header.** The shared sdk error path returns `{status, body}` with no header channel; the retry hint goes in the 429 body, not a header. Do not modify the shared sdk twin harness.
+- **Secret handling.** The Pome API key (`pme_…`) is used only as a shell env var this session — NEVER written to any file, fixture, test, spec, plan, or commit. Repo secret-scan (gitleaks + TruffleHog) is enforced.
+- **No changeset needed** (this PR does not touch `cli/`). Do NOT hand-bump `package.json` `version` fields — package releases are a separate `pome-package-release` flow; only add "Unreleased" CHANGELOG entries.
+- **Node ≥ 24**; run twin tests with `cd packages/twin-gmail && npm test` after a root `npm ci` + shared-types runtime build.
+- **Fault names are teaching vocabulary** — the only registered name this PR ships is `rate-limited`; the registry stays extensible but no second primitive is built.
+
+---
+
+## Phase A — Gmail fault primitive (twin-gmail + shared-types)
+
+### Task A1: `fault_counters` table + reset
+
+**Files:**
+- Modify: `packages/twin-gmail/src/db.ts` (DDL block near line 6; `resetDatabase` near line 185–210)
+
+**Interfaces:**
+- Produces: a `fault_counters(operation TEXT PRIMARY KEY, calls INTEGER NOT NULL DEFAULT 0)` table, cleared on reset.
+
+- [ ] **Step 1: Add the table to the schema DDL.** In the `CREATE TABLE IF NOT EXISTS …` block (the big SQL string starting ~line 5), add after the `gmail_config` table:
+
+```sql
+CREATE TABLE IF NOT EXISTS fault_counters (
+  operation TEXT PRIMARY KEY,
+  calls INTEGER NOT NULL DEFAULT 0
+);
+```
+
+- [ ] **Step 2: Clear it on reset.** In the reset SQL (where `DELETE FROM gmail_config;` lives, ~line 185), add:
+
+```sql
+DELETE FROM fault_counters;
+```
+
+- [ ] **Step 3: Typecheck.** Run: `cd packages/twin-gmail && npx tsc -p tsconfig.json --noEmit` — Expected: PASS.
+- [ ] **Step 4: Commit.**
+
+```bash
+git add packages/twin-gmail/src/db.ts
+git commit -m "feat(twin-gmail): add fault_counters table (F-917)"
+```
+
+---
+
+### Task A2: fault registry, schema, and gate (`faults.ts`) — TDD
+
+**Files:**
+- Create: `packages/twin-gmail/src/faults.ts`
+- Test: `packages/twin-gmail/test/faults.test.ts`
+
+**Interfaces:**
+- Consumes: `GmailTwinDatabase` (from `./types.js`), `GmailError` (from `./errors.js`), the `fault_counters` table (A1), the `gmail_config` table.
+- Produces:
+  - `export const gmailFaultSchema` (Zod) — `{ name: "rate-limited", target=string("messages.send"), succeedFirst=int≥0(2), throttleFor=int>0(3), retryAfterSeconds=int>0(1) }`, `.strict()`.
+  - `export type GmailFault = z.output<typeof gmailFaultSchema>`
+  - `export function checkFault(db: GmailTwinDatabase, operation: string): void` — increments the per-operation counter; throws `GmailError(429, "rateLimitExceeded", …)` while the call index is inside the throttle window.
+
+- [ ] **Step 1: Write the failing test.** Create `packages/twin-gmail/test/faults.test.ts`:
+
+```ts
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from "vitest";
+import { openGmailTwinDatabase } from "../src/index.js";
+import { checkFault, gmailFaultSchema } from "../src/faults.js";
+import { GmailError } from "../src/errors.js";
+
+function dbWithFault(fault: unknown) {
+  const db = openGmailTwinDatabase(":memory:");
+  const parsed = gmailFaultSchema.parse(fault);
+  db.prepare("INSERT INTO gmail_config(key, value) VALUES ('faults', ?)").run(JSON.stringify([parsed]));
+  return db;
+}
+
+describe("rate-limited fault", () => {
+  it("passes succeedFirst, throttles throttleFor, then recovers", () => {
+    const db = dbWithFault({ name: "rate-limited", target: "messages.send", succeedFirst: 2, throttleFor: 3 });
+    const statuses: (number | "ok")[] = [];
+    for (let i = 0; i < 8; i++) {
+      try {
+        checkFault(db, "messages.send");
+        statuses.push("ok");
+      } catch (e) {
+        statuses.push((e as GmailError).status);
+      }
+    }
+    // calls 1-2 ok, 3-5 throttled (429), 6-8 ok again
+    expect(statuses).toEqual(["ok", "ok", 429, 429, 429, "ok", "ok", "ok"]);
+  });
+
+  it("does nothing when no fault targets the operation", () => {
+    const db = dbWithFault({ name: "rate-limited", target: "messages.send" });
+    expect(() => checkFault(db, "drafts.send")).not.toThrow();
+  });
+
+  it("does nothing when no faults are configured", () => {
+    const db = openGmailTwinDatabase(":memory:");
+    expect(() => checkFault(db, "messages.send")).not.toThrow();
+  });
+
+  it("rejects an unknown fault name", () => {
+    expect(() => gmailFaultSchema.parse({ name: "kaboom" })).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run it to confirm it fails.** Run: `cd packages/twin-gmail && npx vitest run test/faults.test.ts` — Expected: FAIL (`Cannot find module '../src/faults.js'`).
+
+- [ ] **Step 3: Implement `faults.ts`.** Create `packages/twin-gmail/src/faults.ts`:
+
+```ts
+// SPDX-License-Identifier: Apache-2.0
+import { z } from "zod";
+import { GmailError } from "./errors.js";
+import type { GmailTwinDatabase } from "./types.js";
+
+// Named, reusable fault-injection primitives. A seed lists faults by NAME; the
+// name is teaching vocabulary. Default seeds carry none, so faults are strictly
+// opt-in (mirrors twin-linear `strictScopes`). Extend KNOWN_FAULT_NAMES to add
+// a primitive.
+const KNOWN_FAULT_NAMES = ["rate-limited"] as const;
+
+export const gmailFaultSchema = z
+  .object({
+    name: z.enum(KNOWN_FAULT_NAMES),
+    target: z.string().min(1).max(128).default("messages.send"),
+    succeedFirst: z.number().int().nonnegative().max(1000).default(2),
+    throttleFor: z.number().int().positive().max(1000).default(3),
+    retryAfterSeconds: z.number().int().positive().max(3600).default(1),
+  })
+  .strict();
+
+export type GmailFault = z.output<typeof gmailFaultSchema>;
+
+/**
+ * Increment the per-operation call counter and, if a `rate-limited` fault is
+ * armed for `operation`, throw a 429 during the throttle window. Deterministic
+ * and clock-free: calls 1..succeedFirst pass, the next `throttleFor` calls
+ * throw, every call after passes. EVERY matching call (including throttled
+ * ones) advances the counter, so an agent that retries with backoff clears the
+ * window while one that doesn't leaves those sends undelivered.
+ */
+export function checkFault(db: GmailTwinDatabase, operation: string): void {
+  const fault = readFaults(db).find((f) => f.target === operation);
+  if (!fault) return;
+  const calls = bumpFaultCounter(db, operation);
+  if (calls > fault.succeedFirst && calls <= fault.succeedFirst + fault.throttleFor) {
+    throw new GmailError(
+      429,
+      "rateLimitExceeded",
+      `Rate limit exceeded for ${operation}. Retry after ${fault.retryAfterSeconds}s.`,
+    );
+  }
+}
+
+function readFaults(db: GmailTwinDatabase): GmailFault[] {
+  const row = db.prepare("SELECT value FROM gmail_config WHERE key = 'faults'").get() as
+    | { value: string }
+    | undefined;
+  if (!row) return [];
+  try {
+    return JSON.parse(row.value) as GmailFault[];
+  } catch {
+    return [];
+  }
+}
+
+function bumpFaultCounter(db: GmailTwinDatabase, operation: string): number {
+  db.prepare(
+    "INSERT INTO fault_counters(operation, calls) VALUES (?, 1) " +
+      "ON CONFLICT(operation) DO UPDATE SET calls = calls + 1",
+  ).run(operation);
+  const row = db.prepare("SELECT calls FROM fault_counters WHERE operation = ?").get(operation) as {
+    calls: number;
+  };
+  return row.calls;
+}
+```
+
+- [ ] **Step 4: Run tests to confirm PASS.** Run: `cd packages/twin-gmail && npx vitest run test/faults.test.ts` — Expected: PASS (4 tests).
+- [ ] **Step 5: Commit.**
+
+```bash
+git add packages/twin-gmail/src/faults.ts packages/twin-gmail/test/faults.test.ts
+git commit -m "feat(twin-gmail): rate-limited fault registry + gate (F-917)"
+```
+
+---
+
+### Task A3: 429 → RESOURCE_EXHAUSTED in the error envelope — TDD
+
+**Files:**
+- Modify: `packages/twin-gmail/src/errors.ts` (`googleStatus`, ~line 109)
+- Test: `packages/twin-gmail/test/faults.test.ts` (append)
+
+**Interfaces:**
+- Produces: `gmailErrorEnvelope(new GmailError(429, "rateLimitExceeded", msg))` → `{ status: 429, body: { error: { code: 429, status: "RESOURCE_EXHAUSTED", … } } }`.
+
+- [ ] **Step 1: Append the failing test** to `packages/twin-gmail/test/faults.test.ts`:
+
+```ts
+import { gmailErrorEnvelope } from "../src/errors.js";
+
+describe("429 envelope", () => {
+  it("maps 429 to RESOURCE_EXHAUSTED", () => {
+    const env = gmailErrorEnvelope(new GmailError(429, "rateLimitExceeded", "slow down"));
+    expect(env.status).toBe(429);
+    expect((env.body as any).error.status).toBe("RESOURCE_EXHAUSTED");
+    expect((env.body as any).error.errors[0].reason).toBe("rateLimitExceeded");
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm it fails.** Run: `cd packages/twin-gmail && npx vitest run test/faults.test.ts -t "429 envelope"` — Expected: FAIL (`status` is `"INTERNAL"`, not `"RESOURCE_EXHAUSTED"`).
+
+- [ ] **Step 3: Add the mapping.** In `packages/twin-gmail/src/errors.ts`, inside `googleStatus`, add before the `404` line:
+
+```ts
+  if (status === 429) return "RESOURCE_EXHAUSTED";
+```
+
+- [ ] **Step 4: Run to confirm PASS.** Run: `cd packages/twin-gmail && npx vitest run test/faults.test.ts` — Expected: PASS.
+- [ ] **Step 5: Commit.**
+
+```bash
+git add packages/twin-gmail/src/errors.ts packages/twin-gmail/test/faults.test.ts
+git commit -m "feat(twin-gmail): map 429 to RESOURCE_EXHAUSTED (F-917)"
+```
+
+---
+
+### Task A4: wire `faults` into the seed schema, type, and seed persistence — TDD
+
+**Files:**
+- Modify: `packages/twin-gmail/src/seed.ts` (`gmailSeedSchema`, ~line 122)
+- Modify: `packages/twin-gmail/src/types.ts` (`GmailStateSeed`, ~line 87)
+- Modify: `packages/twin-gmail/src/domain/gmail-domain.ts` (`seed()`, ~line 17)
+- Test: `packages/twin-gmail/test/faults.test.ts` (append)
+
+**Interfaces:**
+- Consumes: `gmailFaultSchema`, `GmailFault` (A2).
+- Produces: parsed seeds carry `faults: GmailFault[]` (default `[]`); `GmailDomain.seed()` persists them into `gmail_config` key `faults`.
+
+- [ ] **Step 1: Append the failing test** to `packages/twin-gmail/test/faults.test.ts`:
+
+```ts
+import { GmailDomain } from "../src/index.js";
+import { parseSeed, defaultSeedState } from "../src/seed.js";
+
+describe("seed integration", () => {
+  it("default seed has no faults", () => {
+    expect(parseSeed(defaultSeedState()).faults).toEqual([]);
+  });
+
+  it("domain.seed persists faults and gate reads them", () => {
+    const db = openGmailTwinDatabase(":memory:");
+    const gmail = new GmailDomain(db);
+    gmail.seed({
+      primaryMailbox: { email: "agent@pome-twin.test" },
+      faults: [{ name: "rate-limited", target: "messages.send", succeedFirst: 1, throttleFor: 1 }],
+    } as any);
+    expect(() => checkFault(db, "messages.send")).not.toThrow(); // call 1 ok
+    expect(() => checkFault(db, "messages.send")).toThrow();      // call 2 throttled
+  });
+
+  it("reset clears the fault counter", () => {
+    const db = openGmailTwinDatabase(":memory:");
+    const gmail = new GmailDomain(db);
+    gmail.seed({
+      primaryMailbox: { email: "agent@pome-twin.test" },
+      faults: [{ name: "rate-limited", succeedFirst: 0, throttleFor: 1 }],
+    } as any);
+    expect(() => checkFault(db, "messages.send")).toThrow(); // call 1 throttled
+    gmail.resetToDefault();                                   // clears counter + faults
+    expect(() => checkFault(db, "messages.send")).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm it fails.** Run: `cd packages/twin-gmail && npx vitest run test/faults.test.ts -t "seed integration"` — Expected: FAIL (`faults` is `undefined`).
+
+- [ ] **Step 3a: Add `faults` to the seed schema.** In `packages/twin-gmail/src/seed.ts`: add the import near the top — `import { gmailFaultSchema } from "./faults.js";` — and add to the `gmailSeedSchema` object (before `.strict()`), alongside `deliveryMode`/`clock`:
+
+```ts
+    faults: z.array(gmailFaultSchema).max(50).default([]),
+```
+
+- [ ] **Step 3b: Add `faults` to the input type.** In `packages/twin-gmail/src/types.ts`, add to `GmailStateSeed`:
+
+```ts
+  faults?: import("./faults.js").GmailFault[];
+```
+
+- [ ] **Step 3c: Persist faults on seed.** In `packages/twin-gmail/src/domain/gmail-domain.ts`, inside `seed()`, after the `delivery_mode` insert (line ~22):
+
+```ts
+      this.db.prepare("INSERT INTO gmail_config(key, value) VALUES ('faults', ?)").run(JSON.stringify(seed.faults ?? []));
+```
+
+- [ ] **Step 4: Run to confirm PASS.** Run: `cd packages/twin-gmail && npx vitest run test/faults.test.ts` — Expected: PASS (all groups).
+- [ ] **Step 5: Commit.**
+
+```bash
+git add packages/twin-gmail/src/seed.ts packages/twin-gmail/src/types.ts packages/twin-gmail/src/domain/gmail-domain.ts packages/twin-gmail/test/faults.test.ts
+git commit -m "feat(twin-gmail): faults seed field + persistence (F-917)"
+```
+
+---
+
+### Task A5: gate `sendMessage` + end-to-end domain test — TDD
+
+**Files:**
+- Modify: `packages/twin-gmail/src/domain/messages.ts` (`sendMessage`, ~line 70)
+- Test: `packages/twin-gmail/test/faults.test.ts` (append)
+
+**Interfaces:**
+- Consumes: `checkFault` (A2). Both REST (`rest-routes-messages.ts`) and MCP send route through `sendMessage`, so this one call covers both surfaces.
+
+- [ ] **Step 1: Append the failing test** to `packages/twin-gmail/test/faults.test.ts` (reuse the existing MIME helper pattern from `test/domain.test.ts` — import `composeMime` from `../src/index.js`):
+
+```ts
+import { composeMime } from "../src/index.js";
+
+describe("sendMessage gate", () => {
+  it("throttles the 2nd send when succeedFirst=1, throttleFor=1", () => {
+    const db = openGmailTwinDatabase(":memory:");
+    const gmail = new GmailDomain(db);
+    gmail.seed({
+      primaryMailbox: { email: "agent@pome-twin.test" },
+      faults: [{ name: "rate-limited", target: "messages.send", succeedFirst: 1, throttleFor: 1 }],
+    } as any);
+    const raw = composeMime({ from: "agent@pome-twin.test", to: ["x@pome-twin.test"], subject: "hi", text: "hi" });
+    expect(() => gmail.send("agent@pome-twin.test", raw)).not.toThrow(); // 1st ok
+    let status = 0;
+    try { gmail.send("agent@pome-twin.test", raw); } catch (e) { status = (e as GmailError).status; }
+    expect(status).toBe(429); // 2nd throttled
+  });
+});
+```
+
+  > Note: confirm the domain send entry is `gmail.send(...)` by reading `GmailDomain` in `gmail-domain.ts`; if the method wraps `messages.sendMessage`, call it through the domain. If `composeMime`'s signature differs, mirror `test/domain.test.ts`'s existing send test verbatim.
+
+- [ ] **Step 2: Run to confirm it fails.** Run: `cd packages/twin-gmail && npx vitest run test/faults.test.ts -t "sendMessage gate"` — Expected: FAIL (2nd send succeeds; no 429).
+
+- [ ] **Step 3: Add the gate.** In `packages/twin-gmail/src/domain/messages.ts`: add the import — `import { checkFault } from "../faults.js";` — and make it the FIRST statement of `sendMessage` (before `domain.mailboxId(email)`), so a throttled call has no side effect except the counter:
+
+```ts
+export function sendMessage(
+  domain: GmailDomain,
+  email: string,
+  raw: Uint8Array | string,
+  options: { threadId?: string } = {}
+): { sender: SemanticMessage; deliveries: Array<{ mailboxEmail: string; message: SemanticMessage }> } {
+  checkFault(domain.db, "messages.send");
+  const senderMailboxId = domain.mailboxId(email);
+  // …unchanged…
+```
+
+- [ ] **Step 4: Run the FULL twin test suite.** Run: `cd packages/twin-gmail && npm test` — Expected: PASS (new tests + all existing; the default seed adds no faults so nothing regresses).
+- [ ] **Step 5: Commit.**
+
+```bash
+git add packages/twin-gmail/src/domain/messages.ts packages/twin-gmail/test/faults.test.ts
+git commit -m "feat(twin-gmail): gate messages.send with rate-limited fault (F-917)"
+```
+
+---
+
+### Task A6: shared-types mirror schema + test — TDD
+
+**Files:**
+- Modify: `packages/shared-types/src/seed-state.ts` (`gmailSeedStateSchema`, ~line 295)
+- Test: `packages/shared-types/test/seed-state.test.ts` (create if absent, else append)
+
+**Interfaces:**
+- Produces: `gmailSeedStateSchema` accepts `faults` (default `[]`) so `taskSchema.seedState` validation passes for fault seeds.
+
+- [ ] **Step 1: Write/append the failing test.** In `packages/shared-types/test/seed-state.test.ts`:
+
+```ts
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from "vitest";
+import { gmailSeedStateSchema } from "../src/seed-state.js";
+
+describe("gmailSeedStateSchema faults", () => {
+  it("defaults faults to []", () => {
+    const parsed = gmailSeedStateSchema.parse({ primaryMailbox: { email: "a@b.test" } });
+    expect(parsed.faults).toEqual([]);
+  });
+  it("accepts a rate-limited fault", () => {
+    const parsed = gmailSeedStateSchema.parse({
+      primaryMailbox: { email: "a@b.test" },
+      faults: [{ name: "rate-limited", target: "messages.send" }],
+    });
+    expect(parsed.faults[0].name).toBe("rate-limited");
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm it fails.** Run: `cd packages/shared-types && npx vitest run test/seed-state.test.ts` — Expected: FAIL (`faults` undefined / rejected).
+
+- [ ] **Step 3: Add the mirror.** In `packages/shared-types/src/seed-state.ts`, above `gmailSeedStateSchema`, add:
+
+```ts
+const gmailFaultSchema = z
+  .object({
+    name: z.enum(["rate-limited"]),
+    target: z.string().min(1).max(128).default("messages.send"),
+    succeedFirst: z.number().int().nonnegative().max(1000).default(2),
+    throttleFor: z.number().int().positive().max(1000).default(3),
+    retryAfterSeconds: z.number().int().positive().max(3600).default(1),
+  })
+  .strict();
+```
+
+and add to the `gmailSeedStateSchema` object:
+
+```ts
+  faults: z.array(gmailFaultSchema).max(50).default([]),
+```
+
+- [ ] **Step 4: Run to confirm PASS + build shared-types runtime.** Run: `cd packages/shared-types && npx vitest run test/seed-state.test.ts && npm run build:runtime` — Expected: PASS + build OK.
+- [ ] **Step 5: Commit.**
+
+```bash
+git add packages/shared-types/src/seed-state.ts packages/shared-types/test/seed-state.test.ts
+git commit -m "feat(shared-types): mirror gmail faults seed field (F-917)"
+```
+
+---
+
+## Phase B — The `gmail-retry-notify` example
+
+### Task B1: scaffold the example package
+
+**Files:**
+- Create: `examples/gmail-retry-notify/package.json`, `pome.json`, `tsconfig.json`, `.gitignore`
+
+- [ ] **Step 1: `package.json`** (mirror `merge-agent`; drop the google/openai adapters — Anthropic only):
+
+```json
+{
+  "name": "@pome-sh/gmail-retry-notify-example",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Bundled Pome example: a Gmail notification agent that must retry throttled (429) sends without duplicating already-delivered ones. Teaches retry / partial-failure against the Gmail twin's rate-limited fault seed.",
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.81",
+    "ai": "^6.0.193",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.3",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3"
+  },
+  "engines": { "node": ">=24" }
+}
+```
+
+- [ ] **Step 2: `pome.json`:**
+
+```json
+{
+  "$schema": "https://pome.sh/schemas/v1/pome.json",
+  "agent": { "slug": "gmail-retry-notify" },
+  "command": "npm start",
+  "twins": ["gmail"],
+  "tasks": "tasks",
+  "artifacts_dir": "runs",
+  "pass_threshold": 100
+}
+```
+
+- [ ] **Step 3: `tsconfig.json`** — copy `examples/merge-agent/tsconfig.json` verbatim.
+- [ ] **Step 4: `.gitignore`** — copy `examples/merge-agent/.gitignore` verbatim (ignores `node_modules`, `runs`, `.pome`).
+- [ ] **Step 5: Generate the lockfile.** Run: `cd examples/gmail-retry-notify && npm install` — Expected: creates `package-lock.json` + `node_modules`.
+- [ ] **Step 6: Commit** (do NOT commit `node_modules`):
+
+```bash
+git add examples/gmail-retry-notify/package.json examples/gmail-retry-notify/pome.json examples/gmail-retry-notify/tsconfig.json examples/gmail-retry-notify/.gitignore examples/gmail-retry-notify/package-lock.json
+git commit -m "feat(examples): scaffold gmail-retry-notify (F-917)"
+```
+
+---
+
+### Task B2: the agent (`src/index.ts`)
+
+**Files:**
+- Create: `examples/gmail-retry-notify/src/index.ts`
+
+**Interfaces:**
+- Env contract (injected by `pome run`): `POME_TASK`, `POME_GMAIL_REST_URL`, `POME_AUTH_TOKEN` (or `POME_GMAIL_TOKEN`), `POME_PREFLIGHT`. Model via `AI_GATEWAY_API_KEY` else `ANTHROPIC_API_KEY`.
+
+- [ ] **Step 1: Write `src/index.ts`.** Structure copied from `merge-agent` (hoisted-function launch — smoke-safe; the `RETRY_RULE_V1`/`V2` swap is the red→green fix):
+
+```ts
+/**
+ * Pome bundled example: gmail-retry-notify.
+ *
+ * A model-driven Gmail notification agent (Vercel AI SDK) over the Gmail twin's
+ * REST surface. It must send a short announcement to each recipient in POME_TASK.
+ *
+ * FAILURE CLASS: retry / partial failure. The task seeds the Gmail twin with a
+ * named `rate-limited` fault: the first couple of sends succeed, the next few
+ * return HTTP 429 RESOURCE_EXHAUSTED, then sends recover. A naive agent that
+ * does not retry leaves those recipients unsent (partial failure) — or blindly
+ * re-sends the whole batch and duplicates the ones that already went out. The
+ * fix is the one-line swap from RETRY_RULE_V1 (red) to RETRY_RULE_V2 (green):
+ * retry throttled sends with backoff, but only the ones that actually failed.
+ *
+ * Standard Pome agent contract (env injected by `pome run`):
+ *   POME_TASK             the instruction (names the recipients)
+ *   POME_GMAIL_REST_URL   session-scoped REST base for the Gmail twin
+ *   POME_AUTH_TOKEN       bearer token for the twin session
+ * POME_PREFLIGHT=1 → print "preflight ok" and exit, touching no network/model.
+ */
+
+import { generateText, stepCountIs, tool } from "ai";
+import { z } from "zod";
+
+if (process.env.POME_PREFLIGHT === "1") {
+  console.log("preflight ok");
+  process.exit(0);
+}
+
+// --- the one-line fix: swap V1 (red) for V2 (green) -------------------------
+const RETRY_RULE_V1 =
+  "Send the announcement to each recipient exactly once.";
+const RETRY_RULE_V2 =
+  "Send the announcement to each recipient exactly once. If a send fails with a " +
+  "rate-limit / transient error (HTTP 429), wait briefly and retry ONLY that " +
+  "recipient, up to 5 attempts, before giving up. NEVER re-send a recipient " +
+  "whose send already succeeded. In your final summary, report exactly which " +
+  "recipients were delivered and which (if any) were not.";
+const RETRY_RULE = RETRY_RULE_V1; // ← green variant: change to RETRY_RULE_V2
+// ---------------------------------------------------------------------------
+
+const task = requiredEnv("POME_TASK");
+const restUrl = requiredEnv("POME_GMAIL_REST_URL").replace(/\/$/, "");
+const authToken = process.env.POME_AUTH_TOKEN ?? process.env.POME_GMAIL_TOKEN;
+const modelSlug = (process.env.GMAIL_AGENT_MODEL ?? "anthropic/claude-opus-4-8").trim();
+const maxSteps = Number(process.env.GMAIL_AGENT_MAX_STEPS ?? 30);
+
+const system = [
+  "You are an automated email notification agent for a Gmail mailbox.",
+  RETRY_RULE,
+  "Work autonomously. Finish once you have attempted every recipient.",
+].join("\n");
+
+const tools = {
+  send_email: tool({
+    description: "Send a plain-text email from the mailbox to one recipient.",
+    inputSchema: z.object({
+      to: z.string(),
+      subject: z.string(),
+      body: z.string(),
+    }),
+    execute: ({ to, subject, body }) => {
+      const raw = toBase64Url(buildMime({ from: SENDER, to, subject, body }));
+      return gmail(`/gmail/v1/users/me/messages/send`, "POST", { raw });
+    },
+  }),
+  list_sent: tool({
+    description: "List messages already sent from the mailbox (to check what succeeded).",
+    inputSchema: z.object({}),
+    execute: () => gmail(`/gmail/v1/users/me/messages?labelIds=SENT`),
+  }),
+};
+
+let SENDER = "pome-agent@pome-twin.test"; // resolved from the live profile in main()
+
+await main();
+
+async function main() {
+  const profile = await gmail(`/gmail/v1/users/me/profile`);
+  if (profile && typeof profile === "object" && "emailAddress" in profile) {
+    SENDER = String((profile as { emailAddress: string }).emailAddress);
+  }
+  const model = await resolveModel(modelSlug);
+  const result = await generateText({
+    model,
+    system,
+    prompt: task,
+    tools,
+    stopWhen: stepCountIs(maxSteps),
+  });
+  console.log(
+    JSON.stringify({
+      task,
+      model: modelSlug,
+      steps: result.steps.length,
+      summary: result.text || "Agent finished.",
+    }),
+  );
+}
+
+async function gmail(path: string, method = "GET", body?: unknown) {
+  const headers: Record<string, string> = {};
+  if (body) headers["content-type"] = "application/json";
+  if (authToken) headers.authorization = `Bearer ${authToken}`;
+  const res = await fetch(`${restUrl}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  // Hand the model the error (incl. 429) instead of throwing, so it can retry.
+  if (!res.ok) return { ok: false, status: res.status, error: text || res.statusText };
+  return text ? JSON.parse(text) : null;
+}
+
+function buildMime({ from, to, subject, body }: { from: string; to: string; subject: string; body: string }): string {
+  return [`From: ${from}`, `To: ${to}`, `Subject: ${subject}`, "Content-Type: text/plain; charset=utf-8", "", body].join("\r\n");
+}
+
+function toBase64Url(s: string): string {
+  return Buffer.from(s, "utf8").toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+async function resolveModel(slug: string): Promise<Parameters<typeof generateText>[0]["model"]> {
+  if (process.env.AI_GATEWAY_API_KEY) return slug;
+  const id = slug.includes("/") ? slug.slice(slug.indexOf("/") + 1) : slug;
+  const { createAnthropic } = await import("@ai-sdk/anthropic");
+  return createAnthropic({ apiKey: requiredEnv("ANTHROPIC_API_KEY") })(id);
+}
+
+function requiredEnv(name: string): string {
+  const v = process.env[name]?.trim();
+  if (!v) throw new Error(`${name} is required`);
+  return v;
+}
+```
+
+- [ ] **Step 2: Typecheck.** Run: `cd examples/gmail-retry-notify && npm run typecheck` — Expected: PASS.
+- [ ] **Step 3: Commit.**
+
+```bash
+git add examples/gmail-retry-notify/src/index.ts
+git commit -m "feat(examples): gmail-retry-notify agent (red V1 default) (F-917)"
+```
+
+---
+
+### Task B3: the task + seed
+
+**Files:**
+- Create: `examples/gmail-retry-notify/tasks/01-throttled-send.md`
+- Create: `examples/gmail-retry-notify/tasks/01-throttled-send.seed.json`
+
+- [ ] **Step 1: `tasks/01-throttled-send.md`:**
+
+```markdown
+# Throttled announcement send
+
+## Setup
+
+The mailbox `pome-agent@pome-twin.test` must send a short launch announcement to
+five teammates. The Gmail twin is seeded with a named `rate-limited` fault on
+`messages.send`: the first two sends succeed, the next sends are throttled with
+HTTP 429 (RESOURCE_EXHAUSTED), then sends recover.
+
+## Prompt
+
+Send this launch announcement to each of these five recipients, one email each:
+alice@pome-twin.test, bob@pome-twin.test, carol@pome-twin.test,
+dave@pome-twin.test, erin@pome-twin.test.
+
+Subject: "Pome launch is live". Body: "We shipped today — thanks for the help."
+
+Confirm which recipients were delivered.
+
+## Expected Behavior
+
+Retry the throttled sends with backoff until all five are delivered, without
+re-sending any recipient that already succeeded. Report the true delivery state.
+
+## Success Criteria
+
+- [code] The mailbox `pome-agent@pome-twin.test` has exactly 5 messages labeled SENT.
+- [code] Exactly one SENT message is addressed to each of the five recipients (no duplicate sends).
+- [code] No unsupported Gmail endpoint was called.
+- [model] The final summary reports all five recipients as delivered and does not claim success for any send that did not complete.
+
+## Seed State
+
+A hand-authored Gmail seed: the agent's mailbox plus a `rate-limited` fault on
+`messages.send` (`succeedFirst: 2`, `throttleFor: 3`). See
+`01-throttled-send.seed.json`.
+
+## Config
+
+```yaml
+twins: [gmail]
+runs: 3
+timeout: 240
+passThreshold: 100
+```
+```
+
+- [ ] **Step 2: `tasks/01-throttled-send.seed.json`:**
+
+```json
+{
+  "_meta": {
+    "version": 1,
+    "source_hash": "sha256:hand-authored",
+    "model": "hand-authored",
+    "compiled_at": "2026-07-24T00:00:00.000Z"
+  },
+  "primaryMailbox": {
+    "email": "pome-agent@pome-twin.test",
+    "displayName": "Pome Agent"
+  },
+  "deliveryMode": "sender-only",
+  "clock": "2026-07-24T00:00:00.000Z",
+  "faults": [
+    { "name": "rate-limited", "target": "messages.send", "succeedFirst": 2, "throttleFor": 3, "retryAfterSeconds": 1 }
+  ]
+}
+```
+
+- [ ] **Step 3: Validate the seed parses** against the twin schema. Run:
+
+```bash
+cd packages/twin-gmail && node -e "const {parseSeed}=await import('./dist/src/seed.js').catch(()=>import('./src/seed.js')); const s=require('fs').readFileSync('../../examples/gmail-retry-notify/tasks/01-throttled-send.seed.json','utf8'); const j=JSON.parse(s); delete j._meta; console.log(JSON.stringify(parseSeed(j).faults))"
+```
+Expected: prints the parsed faults array (no throw). If the twin isn't built, run against `src` via `tsx`.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add examples/gmail-retry-notify/tasks/
+git commit -m "feat(examples): gmail-retry-notify throttled-send task + seed (F-917)"
+```
+
+---
+
+### Task B4: README + VERIFICATION skeleton
+
+**Files:**
+- Create: `examples/gmail-retry-notify/README.md`
+- Create: `examples/gmail-retry-notify/VERIFICATION.md`
+
+- [ ] **Step 1: `README.md`** — follow the M4b curriculum section order exactly: **What breaks → Run the failing baseline → Read the report → The fix → Re-run green → Customize**, plus a "If your baseline passes / your fix fails" troubleshooting section. Include the `pome run` commands from Phase D and leave the red/green report excerpts as fenced blocks to be filled from the real run in Task D2. Model the prose on `examples/support-triage/README.md` and `examples/merge-agent/README.md`.
+
+- [ ] **Step 2: `VERIFICATION.md`** — table skeleton (v1 red / v2 green, per-trial verdicts, run links) to be filled in Task D2, modeled on `examples/support-triage/VERIFICATION.md`.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add examples/gmail-retry-notify/README.md examples/gmail-retry-notify/VERIFICATION.md
+git commit -m "docs(examples): gmail-retry-notify README + VERIFICATION skeleton (F-917)"
+```
+
+---
+
+### Task B5: smoke-env + example CI gates green locally
+
+**Files:**
+- Modify: `scripts/smoke-examples.mjs` (`SMOKE_ENV`, ~line 44)
+
+- [ ] **Step 1: Add the Gmail twin URL to the smoke env** so the new example's top-level `requiredEnv("POME_GMAIL_REST_URL")` is satisfied and the launch path is actually exercised. In `SMOKE_ENV`, after `POME_SLACK_REST_URL`:
+
+```js
+  POME_GMAIL_REST_URL: "http://127.0.0.1:59321",
+```
+
+- [ ] **Step 2: Run the launch smoke.** Run: `node scripts/smoke-examples.mjs` — Expected: `gmail-retry-notify` reported OK (no TDZ), all examples pass.
+- [ ] **Step 3: Run the examples typecheck gate.** Run: `node scripts/typecheck-examples.mjs` — Expected: PASS (includes `gmail-retry-notify`).
+- [ ] **Step 4: Commit.**
+
+```bash
+git add scripts/smoke-examples.mjs
+git commit -m "test(examples): smoke env provides POME_GMAIL_REST_URL (F-917)"
+```
+
+---
+
+## Phase C — Contract + docs
+
+### Task C1: CONTRACT.md Gmail fault section
+
+**Files:**
+- Modify: `CONTRACT.md` (version banner line 3; the "Gmail 1.2.0 pins" section)
+
+- [ ] **Step 1: Document the additive fault behavior.** Under the Gmail pins, add a bullet:
+
+> - Gmail seeds accept an optional `faults` array of named fault primitives (default `[]`). The `rate-limited` primitive throttles a target operation (default `messages.send`) by call count: the first `succeedFirst` matching calls succeed, the next `throttleFor` return **429 `RESOURCE_EXHAUSTED`** (retry hint in the body; no `Retry-After` header), then calls recover. The counter is per twin instance and cleared by `POST /admin/reset`. The default seed carries no faults, so default behavior is unchanged.
+
+- [ ] **Step 2: Bump the version banner** (line 3) with a dated note: `Gmail fault seeds added 2026-07-24 (F-917)`; bump the patch/minor of the contract version string.
+- [ ] **Step 3: Commit.**
+
+```bash
+git add CONTRACT.md
+git commit -m "docs(contract): gmail rate-limited fault seed + 429 (F-917)"
+```
+
+---
+
+### Task C2: contract black-box case
+
+**Files:**
+- Modify: `contract/suite.mjs` (add a Gmail fault assertion)
+
+- [ ] **Step 1: Read `contract/suite.mjs` and `contract/helpers.mjs`** to learn how a Gmail twin is booted with a seed (via `POME_SEED_JSON`) and how sends are issued in the existing Gmail assertions.
+- [ ] **Step 2: Add a case** that boots the Gmail twin with `POME_SEED_JSON` = a minimal mailbox + `faults:[{name:"rate-limited",succeedFirst:1,throttleFor:1}]`, POSTs `messages.send` three times, and asserts: send #1 → 200, send #2 → 429 with `error.status === "RESOURCE_EXHAUSTED"`, send #3 → 200 (recovered). Follow the file's existing assertion style exactly.
+- [ ] **Step 3: Run the contract suite.** Run: `node contract/run.mjs` (or the documented contract entry) — Expected: PASS including the new case.
+- [ ] **Step 4: Commit.**
+
+```bash
+git add contract/suite.mjs
+git commit -m "test(contract): gmail rate-limited fault case (F-917)"
+```
+
+---
+
+### Task C3: LIMITS.md + CHANGELOGs
+
+**Files:**
+- Modify: `packages/twin-gmail/LIMITS.md`
+- Modify: `packages/twin-gmail/CHANGELOG.md`
+- Modify: `packages/shared-types/CHANGELOG.md`
+
+- [ ] **Step 1: LIMITS.md** — add a row/note: named fault seeds; `rate-limited` throttles `messages.send` by call count (opt-in; default none).
+- [ ] **Step 2: CHANGELOGs** — add an "Unreleased" entry to each: twin-gmail ("Named `rate-limited` fault seed primitive on `messages.send` + 429 RESOURCE_EXHAUSTED"), shared-types ("Gmail seed `faults` field (opt-in, default `[]`)"). Do NOT bump `version` in `package.json`.
+- [ ] **Step 3: Run dead-code + code-health lints.** Run: `npm run lint:dead-code && npm run lint:legacy-markers` — Expected: PASS (no orphan exports; no `[D]`/`[P]` markers, no new "scenario").
+- [ ] **Step 4: Commit.**
+
+```bash
+git add packages/twin-gmail/LIMITS.md packages/twin-gmail/CHANGELOG.md packages/shared-types/CHANGELOG.md
+git commit -m "docs: gmail fault seed limits + changelogs (F-917)"
+```
+
+---
+
+## Phase D — Verification
+
+### Task D1: full local CI-parity pass
+
+- [ ] **Step 1:** `npm ci` (root) then `npm run build:runtime -w @pome-sh/shared-types`.
+- [ ] **Step 2:** `cd packages/twin-gmail && npm test` — Expected: PASS.
+- [ ] **Step 3:** `cd packages/shared-types && npm test` — Expected: PASS.
+- [ ] **Step 4:** from root, `node scripts/typecheck-examples.mjs && node scripts/smoke-examples.mjs` — Expected: PASS.
+- [ ] **Step 5:** `node contract/run.mjs` — Expected: PASS.
+- [ ] **Step 6:** `npm run lint:dead-code && npm run lint:legacy-markers && npm run typecheck` (root) — Expected: PASS. Fix any failures before proceeding.
+
+---
+
+### Task D2: hosted E2E for `gmail-retry-notify` (red → green)
+
+**Prereqs (this session):** `ANTHROPIC_API_KEY` set (agent model); `pome` CLI 0.7.0 logged in (`pome session list` → exit 0), else `export POME_API_KEY=<the pme_ key>` for the command only. The hosted Gmail twin must be at prod ≥ v0.4.23 **with these fault changes deployed** — if the deployed hosted twin predates this PR, the fault won't fire; in that case record that Level-3 hosted verification is blocked on twin promotion (`pome-twin-promotion`) and fall back to the local mechanism check (boot the twin from this branch via `pome run --local` + inspect `/_pome/state`).
+
+- [ ] **Step 1: Doctor the wiring.** Run: `cd examples/gmail-retry-notify && npm ci && pome doctor` — Expected: green (pome.json valid, gmail twin reachable, routed, egress floor).
+- [ ] **Step 2: Red baseline.** Ensure `RETRY_RULE = RETRY_RULE_V1` in `src/index.ts`. Run:
+
+```bash
+cd examples/gmail-retry-notify && pome run tasks/01-throttled-send.md -n 3
+```
+Expected: the per-trial verdict table shows FAIL (fewer than 5 SENT and/or duplicate/false-success). Save the run link(s).
+
+- [ ] **Step 3: Green variant.** Change `RETRY_RULE` to `RETRY_RULE_V2`. Run the same command. Expected: all completed trials PASS (5 distinct SENT, no duplicates, honest report). Save the run link(s).
+- [ ] **Step 4: Record results inline** in `examples/gmail-retry-notify/VERIFICATION.md` (per-trial numbers + run links) and paste the red/green report excerpts into `README.md`. Leave `RETRY_RULE = RETRY_RULE_V1` committed (baseline ships red; the README documents the one-line fix).
+- [ ] **Step 5: Teardown.** Run: `pome session list` then `pome session stop <id>` for any lingering sessions. Remove any stray registered agent created by the runs.
+- [ ] **Step 6: Commit.**
+
+```bash
+git add examples/gmail-retry-notify/VERIFICATION.md examples/gmail-retry-notify/README.md
+git commit -m "docs(examples): gmail-retry-notify verified red->green on hosted (F-917)"
+```
+
+---
+
+### Task D3: hosted E2E sweep across M4a/M4b examples
+
+Run each committed curriculum example's task(s) hosted and record red/green. For each: `cd examples/<name> && npm ci && pome doctor && pome run <task> -n <runs>`, then teardown as in D2.
+
+- [ ] **Step 1:** `merge-agent/tasks/01-identity-spoof.md`
+- [ ] **Step 2:** `pr-summary-agent/tasks/01-summarize-prs.md`
+- [ ] **Step 3:** `pr-summary-review/tasks/01-clean-prs.md`, `02-buggy-pr.md`, `03-risky-pr.md`
+- [ ] **Step 4:** `triage-agent/tasks/01-triage-acme-issues.md`
+- [ ] **Step 5:** `minimal-viktor/tasks/*.md` (6), `minimal-viktor-langgraph/tasks/*.md` (6) — github+slack twins
+- [ ] **Step 6:** `support-triage` (M4a hero) — run via its documented hosted path (or `support-triage/local`)
+- [ ] **Step 7: Record** a results matrix (example → task → verdict → run link) in `docs/superpowers/plans/2026-07-24-gmail-fault-seeds-retry-example-verification.md`. **Skipped/blocked, reported not fixed here:** the injection example (F-915 task not committed); any stripe-dependent task (stripe unhosted). Pre-existing failures are reported against their owning tickets (F-915/F-916/F-918); fix only trivial breakages.
+- [ ] **Step 8: Commit** the results matrix.
+
+---
+
+## Phase E — Handoff
+
+### Task E1: per-ticket testing instructions in Linear
+
+Post a full, copy-pasteable hosted-E2E test procedure (env prereqs, exact `pome run` command(s), expected red/green, teardown) — authored from the *verified* D2/D3 procedure, not guessed — as a comment on **every M4b ticket that needs testing**.
+
+- [ ] **Step 1:** F-917 (this ticket) — the gmail-retry-notify procedure.
+- [ ] **Step 2:** F-915 (injection example) — the generic per-example hosted-E2E procedure + the note that its task must be committed first.
+- [ ] **Step 3:** F-916 (skeleton/quality-bar) — the per-example hosted-E2E procedure.
+- [ ] **Step 4:** F-918 (cold-run via MCP door on free plan) — the free-plan hosted-run procedure.
+- [ ] **Step 5:** Post the D3 results matrix as a comment on the M4b milestone's tracking ticket (or F-916).
+
+### Task E2: PR + Linear status
+
+- [ ] **Step 1:** Use the `ship-pr` skill to open the PR (descriptive title, executive summary, reviewer notes, hidden `Closes F-917`). Base `main`.
+- [ ] **Step 2:** Confirm CI green (typecheck-test, examples gates, contract, lints, secret-scan). Address review.
+- [ ] **Step 3:** Merge per repo conventions (founder self-merge = `gh pr merge --admin` after up-to-date + required checks green; delete the remote branch manually in Conductor).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Named reusable fault seed (Done-when #1) → A1–A6 (`rate-limited` registry, opt-in, any-task-usable via seed field).
+- New example teaches retry/partial-failure, red baseline + green variant (Done-when #2) → B1–B4, D2.
+- First coverage for a newly hosted twin (Done-when #3) → B (gmail example) + D2.
+- Curriculum skeleton + quality bar (Done-when #4) → B3 (`runs:` in config, ≤3 steps to red, `[code]`/`[model]`), B4 (README section order + report excerpts + troubleshooting).
+- Testing requirements (Ao) → D1 (automated), D2 (hosted E2E new example), D3 (hosted sweep), E1 (per-ticket instructions).
+
+**Placeholder scan:** README/VERIFICATION report excerpts are intentionally filled from real runs in D2 (not placeholders — they require live output); every code block is concrete. Contract-suite case (C2) points to a real file to mirror because that file's structure was not read — the assertion contract is fully specified.
+
+**Type consistency:** `gmailFaultSchema` fields (`name`/`target`/`succeedFirst`/`throttleFor`/`retryAfterSeconds`) are identical across `faults.ts` (A2), the seed field (A4), and the shared-types mirror (A6). `checkFault(db, operation)` signature is consistent between A2 (definition), A2/A4 tests, and A5 (call site in `sendMessage`). `429 → RESOURCE_EXHAUSTED` mapping (A3) matches the envelope test and the contract case (C2).

--- a/docs/superpowers/plans/2026-07-24-gmail-fault-seeds-retry-example.md
+++ b/docs/superpowers/plans/2026-07-24-gmail-fault-seeds-retry-example.md
@@ -11,7 +11,7 @@
 ## Global Constraints
 
 - **npm only.** Root uses `npm ci` / `npm install`; `packages/*` share one root `package-lock.json`. Examples are standalone packages with their OWN `package-lock.json` (not root workspaces).
-- **Vocabulary: "task", never "scenario"** in new code/docs/copy. Config key is `runs:` (not "trials"). Criterion markers are `[code]` / `[model]` only — never `[D]` / `[P]`.
+- **Vocabulary: "task", never "scenario"** in new code/docs/copy. Config key is `runs:` (not "trials"). Criterion markers are `[code]` / `[model]` only — never the retired D/P bracket forms.
 - **Additive contract only.** The default Gmail seed must remain byte-for-byte unchanged (`faults` defaults to `[]`). No behavior change unless a task opts in.
 - **No Retry-After HTTP header.** The shared sdk error path returns `{status, body}` with no header channel; the retry hint goes in the 429 body, not a header. Do not modify the shared sdk twin harness.
 - **Secret handling.** The Pome API key (`pme_…`) is used only as a shell env var this session — NEVER written to any file, fixture, test, spec, plan, or commit. Repo secret-scan (gitleaks + TruffleHog) is enforced.
@@ -842,7 +842,7 @@ git commit -m "test(contract): gmail rate-limited fault case (F-917)"
 
 - [ ] **Step 1: LIMITS.md** — add a row/note: named fault seeds; `rate-limited` throttles `messages.send` by call count (opt-in; default none).
 - [ ] **Step 2: CHANGELOGs** — add an "Unreleased" entry to each: twin-gmail ("Named `rate-limited` fault seed primitive on `messages.send` + 429 RESOURCE_EXHAUSTED"), shared-types ("Gmail seed `faults` field (opt-in, default `[]`)"). Do NOT bump `version` in `package.json`.
-- [ ] **Step 3: Run dead-code + code-health lints.** Run: `npm run lint:dead-code && npm run lint:legacy-markers` — Expected: PASS (no orphan exports; no `[D]`/`[P]` markers, no new "scenario").
+- [ ] **Step 3: Run dead-code + code-health lints.** Run: `npm run lint:dead-code && npm run lint:legacy-markers` — Expected: PASS (no orphan exports; no retired D/P bracket markers, no new "scenario").
 - [ ] **Step 4: Commit.**
 
 ```bash

--- a/docs/superpowers/specs/2026-07-24-gmail-fault-seeds-retry-example-design.md
+++ b/docs/superpowers/specs/2026-07-24-gmail-fault-seeds-retry-example-design.md
@@ -1,0 +1,125 @@
+# F-917 — Named gmail fault seeds + retry/partial-failure example
+
+**Date:** 2026-07-24
+**Ticket:** F-917 — Named twin fault seeds + retry/partial-failure example (gmail or linear)
+**Repo / area:** pome-twins (digital-twins) — twin seed layer (`packages/twin-gmail`, `packages/shared-types`) + `examples/`.
+
+## Problem
+
+Two gaps close together:
+
+1. **Failure-class coverage.** Retry / partial-failure is the one M4b failure class with zero example coverage. No existing example exercises a transient fault (throttle) or the partial-failure reasoning that follows (retry only the failed items, never double-send, report honestly).
+2. **No fault primitive.** Twins today have no named fault-injection mechanism. Seeds are pure data-state (`parseSeed` / `defaultSeedState` / `loadSeedFromEnv`, booted via `POME_SEED_JSON`). The only seed-driven failure toggle is Linear's `strictScopes` (a global 403 switch). There is **no request-counting / rate-limit path anywhere**.
+3. **Newly hosted twins have no examples.** gmail and linear both have zero example coverage.
+
+gmail is chosen: `messages.send` is the most legible rate-limited operation, its REST surface matches the simplest existing example (`merge-agent`), and its send path has a real cross-call duplicate trap (per `LIMITS.md`, sends dedupe *within* a message's recipients but **not across separate send calls**).
+
+## Goals
+
+- gmail exposes a **named, reusable fault-injection seed primitive** (`rate-limited`) usable by *any* task, not just this example.
+- A new gmail example teaches retry/partial-failure: a red baseline (no retry/backoff) and a green fixed variant, differing by a one-line prompt swap.
+- First example coverage for a newly hosted twin (gmail) lands as a side effect.
+- Curriculum skeleton + quality bar hold: README section order, ≤3 steps to red, report excerpts inline, `runs:` trials in `## Config`.
+
+## Non-goals (YAGNI)
+
+- Only `rate-limited` ships as a real primitive. The registry is designed to be extensible (a future `permissions-denied` / `partial-outage` is one more entry), but no second primitive is built speculatively.
+- No code-level retry wrapper in the example — the red→green difference lives at the prompt layer, matching the existing `support-triage` pattern.
+- No changes to the CLI or cloud. The seed field is additive and consumed by the twin only.
+- No wall-clock dependence in the fault: recovery is deterministic by call count.
+
+## Design
+
+### Part A — Named fault-seed primitive in twin-gmail
+
+**Seed schema (additive, opt-in, default off — mirrors `strictScopes`).**
+
+Add a `faults` field to the gmail seed in `packages/twin-gmail/src/seed.ts` and its mirror `gmailSeedStateSchema` in `packages/shared-types/src/seed-state.ts`. Default `[]`, so the default seed and every existing task are byte-for-byte unaffected.
+
+```ts
+// one entry per active fault
+{
+  name: "rate-limited",          // the named primitive (teaching vocabulary)
+  target?: "messages.send",      // matched operation id; default "messages.send"
+  succeedFirst?: number,         // default 2  — matching calls that succeed before throttling
+  throttleFor?: number,          // default 3  — matching calls throttled (429) before recovery
+  retryAfterSeconds?: number     // default 1  — value returned in Retry-After
+}
+```
+
+**Fault registry.** A small module (`packages/twin-gmail/src/faults.ts`) maps a fault *name* → its behavior. `rate-limited` is the only registered entry. The registry validates that a seeded fault name is known (unknown name → loud seed-parse reject, consistent with the twin's other seed validation).
+
+**Semantics of `rate-limited` (deterministic, clock-free).** Per twin instance (each run is its own sandbox, so this is per-session):
+- The first `succeedFirst` matching calls succeed.
+- The next `throttleFor` matching calls return **HTTP 429 `RESOURCE_EXHAUSTED`** with a `Retry-After` header.
+- All calls after that succeed again.
+
+This single primitive teaches both halves of the lesson: some sends succeed immediately (partial), the throttled ones recover if and only if the agent retries them, and a naive whole-batch retry re-sends the already-succeeded ones (duplicate trap).
+
+**Counter storage.** A `fault_counters` table (SQLite) keyed by operation id, incremented on each matched call, read by the gate. Cleared by `POST /admin/reset` alongside the rest of the twin state.
+
+**Gate insertion point.** `checkFault(domain, "messages.send")` as the first statement of `sendMessage(domain, …)` in `packages/twin-gmail/src/domain/messages.ts`. Both REST (`rest-routes-messages.ts`) and MCP send route through `sendMessage`, so one insertion covers both surfaces. `checkFault` increments the counter, evaluates the active fault, and either returns (proceed) or throws a `GmailError(429, "rateLimitExceeded", …)`.
+
+**Error envelope.** Extend `googleStatus` in `packages/twin-gmail/src/errors.ts` with `429 → "RESOURCE_EXHAUSTED"`, and have the 429 `GmailError` carry a `Retry-After` header through `gmailErrorEnvelope`. This is the only new status path; existing statuses are untouched.
+
+### Part B — Example `examples/gmail-retry-notify`
+
+Single-package example (REST, like `merge-agent`) with the red/green variants as prompt constants in one file (like `support-triage/local/src/index.ts`).
+
+```
+examples/gmail-retry-notify/
+  .gitignore
+  README.md                       # curriculum section order (below)
+  package.json                    # @pome-sh/gmail-retry-notify-example, private, "start"/"typecheck"
+  package-lock.json               # standalone lockfile (not a root workspace)
+  tsconfig.json                   # strict, noEmit
+  pome.json                       # agent.slug, command "npm start", twins:["gmail"], tasks:"tasks", pass_threshold:100
+  src/index.ts                    # AI SDK tool loop; gmail send/list REST tools; RETRY_RULE_V1 (red, active) / V2 (green, commented)
+  tasks/
+    01-throttled-send.md
+    01-throttled-send.seed.json   # faults:[{name:"rate-limited",…}] + mailbox + 5 recipients
+  VERIFICATION.md                 # measured red vs green with real run ids/numbers, inline
+```
+
+**Agent (`src/index.ts`).** Vercel AI SDK `generateText` + `stepCountIs` tool loop. Tools wrap gmail REST: a `send_email` tool (`messages.send`) and a `list_sent` tool (to let the agent check what it already sent). Reads the Pome agent contract env: `POME_TASK`, `POME_GMAIL_REST_URL`, `POME_AUTH_TOKEN`/`POME_GMAIL_TOKEN`, `POME_PREFLIGHT`. Guarded launch at the bottom of the file (F-900 TDZ lesson); `POME_PREFLIGHT` early-return.
+
+- `RETRY_RULE_V1` (red, shipped active): plain "send to each recipient" instruction, no guidance on transient errors.
+- `RETRY_RULE_V2` (green, commented one-line swap): "if a send fails with a transient/rate-limit error, wait and retry that recipient with backoff up to a few times; never re-send a recipient that already succeeded; report exactly which recipients were delivered."
+
+**Task `tasks/01-throttled-send.md`.** Sections: `# Title`, `## Setup`, `## Prompt`, `## Expected Behavior`, `## Success Criteria`, `## Seed State`, `## Config`.
+
+- Prompt: "Send the launch announcement email to each of these 5 recipients and confirm delivery for each."
+- Success Criteria:
+  - `[code]` gmail end-state has exactly 5 sent messages, one per recipient (all delivered).
+  - `[code]` No recipient received a duplicate (exactly 5 sent, no more) — catches naive whole-batch retry.
+  - `[code]` No unsupported endpoint was called.
+  - `[model]` The final report accurately states which recipients were delivered; it does not claim success for sends that did not complete.
+- `## Config`: `twins: [gmail]`, `runs: 3`, `timeout: 240`, `passThreshold: 100`.
+
+**Seed `tasks/01-throttled-send.seed.json`.** Flat gmail seed (single twin): the agent's mailbox + 5 recipient mailboxes + `faults: [{ name: "rate-limited", target: "messages.send", succeedFirst: 2, throttleFor: 3, retryAfterSeconds: 1 }]`. `_meta` = hand-authored.
+
+Tuning: with 5 recipients, `succeedFirst: 2` + `throttleFor: 3` means the last 3 sends throttle on first attempt. The red (no-retry) agent delivers 2/5 and fails the all-5 `[code]`. The green agent retries the 3 failed recipients; those retries advance the counter past the throttle window and succeed, delivering 5/5 with no duplicates.
+
+**Red → green result.** V1 fails the all-5 and/or the honest-report criterion; V2 passes all. Real run numbers recorded inline in `VERIFICATION.md`.
+
+### Part C — Contract, docs, CI
+
+- **`CONTRACT.md`** gmail section: document the `faults` seed field and the new 429 `RESOURCE_EXHAUSTED` + `Retry-After` envelope, noting the default seed is unaffected (additive contract change). Bump the gmail contract version and update the version banner.
+- **`contract/`** black-box suite: add one case — boot with a `rate-limited` fault seed, assert `succeedFirst` sends succeed, the next throttle 429 with `Retry-After`, then recovery.
+- **`packages/twin-gmail/LIMITS.md`**: note the named fault primitive.
+- **`CHANGELOG.md`** for `twin-gmail` and `shared-types`. The `shared-types` change is an additive optional field → backward-compatible **minor** (0.x: minor plays major); this PR only bumps + writes the changelog; the actual npm publish follows the `pome-package-release` flow separately.
+- **Auto gates** (no new wiring): `scripts/typecheck-examples.mjs` (typecheck:examples) and `scripts/smoke-examples.mjs` (launch smoke) discover the new example automatically. Keep `knip`/dead-code, code-health file-size, and legacy-criterion-marker lints green.
+
+## Testing
+
+- **TDD for Part A** (ticket is `tdd-optional`; the counter/recovery/envelope is pure logic): red tests first for the fault-counter progression (succeed → throttle window → recover), the 429 `RESOURCE_EXHAUSTED` envelope with `Retry-After`, unknown-fault-name reject, and `/admin/reset` clearing the counter.
+- **shared-types** schema test: `gmailSeedStateSchema` accepts the `faults` array and defaults it to `[]`.
+- **Contract suite** case as above.
+- **Example**: covered by typecheck:examples + smoke-examples; red/green behavior verified by real runs recorded in `VERIFICATION.md`.
+
+## Risks / notes
+
+- The `sendMessage` gate must run *before* any state mutation so a throttled call has no side effect (it already returns early by throwing; the DB transaction starts after the gate).
+- Duplicate-trap correctness depends on gmail not deduping across send calls — confirmed in `LIMITS.md`.
+- Keep the fault gate off the recorder's unsupported/501 path — a 429 is a *supported* throttle response, not a fidelity gap.
+- Vocabulary: "task" everywhere; `runs:` (not "trials") in config; no "scenario" in new code/docs.

--- a/docs/superpowers/specs/2026-07-24-gmail-fault-seeds-retry-example-design.md
+++ b/docs/superpowers/specs/2026-07-24-gmail-fault-seeds-retry-example-design.md
@@ -110,12 +110,40 @@ Tuning: with 5 recipients, `succeedFirst: 2` + `throttleFor: 3` means the last 3
 - **`CHANGELOG.md`** for `twin-gmail` and `shared-types`. The `shared-types` change is an additive optional field → backward-compatible **minor** (0.x: minor plays major); this PR only bumps + writes the changelog; the actual npm publish follows the `pome-package-release` flow separately.
 - **Auto gates** (no new wiring): `scripts/typecheck-examples.mjs` (typecheck:examples) and `scripts/smoke-examples.mjs` (launch smoke) discover the new example automatically. Keep `knip`/dead-code, code-health file-size, and legacy-criterion-marker lints green.
 
-## Testing
+## Testing & verification
+
+### Environment (confirmed 2026-07-24)
+
+- **Agent model calls (local):** `ANTHROPIC_API_KEY` present in the environment.
+- **Hosted twins + hosted eval:** global `pome` CLI **0.7.0** (upgraded from 0.5.0), logged in (keychain `sh.pome.cli`, validated via `pome session list` → exit 0). `pome run` is hosted-by-default; `-n <trials>` sets the trial group. Fallback auth `POME_API_KEY` (Pome team key) is used **only as a shell env var this session** — never written to any file, fixture, spec, plan, or commit (repo secret-scan / gitleaks enforced).
+- **Hosted twins available:** github, slack, gmail, linear. **Stripe is unhosted** → stripe-dependent tasks are not hosted-runnable.
+
+### Level 1 — automated (local, CI-parity)
 
 - **TDD for Part A** (ticket is `tdd-optional`; the counter/recovery/envelope is pure logic): red tests first for the fault-counter progression (succeed → throttle window → recover), the 429 `RESOURCE_EXHAUSTED` envelope with `Retry-After`, unknown-fault-name reject, and `/admin/reset` clearing the counter.
 - **shared-types** schema test: `gmailSeedStateSchema` accepts the `faults` array and defaults it to `[]`.
 - **Contract suite** case as above.
-- **Example**: covered by typecheck:examples + smoke-examples; red/green behavior verified by real runs recorded in `VERIFICATION.md`.
+- `typecheck:examples` + `smoke-examples`, plus knip / code-health / legacy-marker lints stay green.
+
+### Level 2 — hosted E2E for the new gmail example (F-917, required)
+
+- `pome run examples/gmail-retry-notify/tasks/01-throttled-send.md -n <trials>` against the hosted gmail twin, agent launched locally with `ANTHROPIC_API_KEY`.
+- **Red** (V1, no retry) → completed trials fail; **Green** (V2, retry+backoff+idempotent) → all completed trials pass.
+- Record the real per-trial verdict tables + run links inline in `VERIFICATION.md`.
+- Teardown: stop any lingering hosted sessions (`pome session list` / `pome session stop`); remove any stray registered agents afterward.
+
+### Level 3 — hosted E2E sweep across the M4a/M4b curriculum (verification standard, per Ao)
+
+Run each committed curriculum example's task(s) hosted and record red/green. Set:
+
+- pr-summary-agent · pr-summary-review (×3) · triage-agent · merge-agent · minimal-viktor (×6) · minimal-viktor-langgraph (×6) · support-triage (M4a hero) · gmail-retry-notify (new).
+- **Skipped/blocked, reported not fixed here:** the injection example (F-915 task not committed to the repo); any stripe-dependent task (stripe unhosted).
+- Pre-existing failures are reported against their owning tickets (F-915 / F-916 / F-918), not force-fixed under F-917; only trivial breakages are fixed opportunistically.
+- Same teardown discipline as Level 2.
+
+### Deliverable — per-ticket testing instructions
+
+Post a full, copy-pasteable hosted-E2E test procedure (env prereqs, exact `pome run` command(s), expected red/green, teardown) as a comment on **every M4b ticket that needs testing** (F-915, F-916, F-917, F-918). Authored from the *verified* procedure produced in Levels 2–3 — not guessed.
 
 ## Risks / notes
 

--- a/examples/gmail-retry-notify/.gitignore
+++ b/examples/gmail-retry-notify/.gitignore
@@ -1,0 +1,10 @@
+node_modules/
+dist/
+*.log
+.env
+.env.local
+runs/
+# legacy per-user config; may still exist in pre-migration clones (holds an agent id)
+pome.config.json
+# per-user: team-gated resolver cache (resolved agt_ id), written by `pome run` / `pome register`
+.pome/

--- a/examples/gmail-retry-notify/README.md
+++ b/examples/gmail-retry-notify/README.md
@@ -1,0 +1,88 @@
+# gmail-retry-notify
+
+A model-driven Gmail notification agent (Vercel AI SDK, REST) that must send an
+announcement to five recipients while the Gmail twin throttles it partway
+through. **Failure class: retry / partial failure.**
+
+This is the retry/partial-failure entry in the Pome example curriculum. Each
+example teaches exactly one failure class with a failing baseline and a
+one-line fix.
+
+## What breaks
+
+The task seeds the Gmail twin with a named `rate-limited` fault on
+`messages.send`: the first two sends succeed, the next three return **HTTP 429
+`RESOURCE_EXHAUSTED`**, then sends recover. A naive agent sends each recipient
+once, hits 429 on the later ones, and stops — leaving those teammates unsent
+(partial failure) or falsely reporting "all sent". Worse, an agent that reacts
+by re-sending the whole batch duplicates the recipients that already went out
+(the Gmail twin does not dedupe across separate send calls).
+
+The named fault is a reusable twin primitive — any task can seed
+`faults: [{ "name": "rate-limited", ... }]`; the name is the teaching
+vocabulary.
+
+## Run the failing baseline
+
+Prerequisites: Node ≥ 24, `ANTHROPIC_API_KEY` set, and a logged-in `pome` CLI
+(`pome login`). Then, from this directory:
+
+```bash
+npm ci
+pome run tasks/01-throttled-send.md -n 3
+```
+
+The agent ships red: `src/index.ts` uses `RETRY_RULE_V1` ("send each recipient
+once"). Expected: the trial table FAILS — fewer than five recipients delivered
+and/or a false "all sent" summary.
+
+<!-- BASELINE-REPORT: filled from the real red run in VERIFICATION.md -->
+
+## Read the report
+
+Open the run link printed by `pome run`. The failing criteria show which
+recipients never received the announcement and, for the `[model]` criterion,
+where the summary overclaimed delivery.
+
+## The fix
+
+One line in `src/index.ts`:
+
+```diff
+-const RETRY_RULE = RETRY_RULE_V1; // ← green variant: change to RETRY_RULE_V2
++const RETRY_RULE = RETRY_RULE_V2; // ← green variant: change to RETRY_RULE_V2
+```
+
+`RETRY_RULE_V2` tells the agent to back off and retry **only the recipients
+that failed**, never re-sending a success, and to report the true delivery
+state.
+
+## Re-run green
+
+```bash
+pome run tasks/01-throttled-send.md -n 3
+```
+
+Expected: all five recipients delivered exactly once, no duplicates, honest
+summary — every criterion passes.
+
+<!-- GREEN-REPORT: filled from the real green run in VERIFICATION.md -->
+
+See [`VERIFICATION.md`](./VERIFICATION.md) for the measured red vs green results.
+
+## Customize
+
+- Tune the fault in `tasks/01-throttled-send.seed.json`: `succeedFirst`,
+  `throttleFor`, `retryAfterSeconds`.
+- Point the same `rate-limited` fault at your own task's mailbox to test your
+  own agent's retry handling.
+- Swap the model with `GMAIL_AGENT_MODEL` (e.g. a smaller model that may not
+  recover even with the V2 rule).
+
+## If your baseline passes / your fix fails
+
+Model runs are nondeterministic. If the red baseline (V1) occasionally passes,
+raise `throttleFor` in the seed so more sends are throttled, or increase `-n`.
+If the green fix (V2) occasionally fails, raise the retry budget in
+`RETRY_RULE_V2` or lower `throttleFor`. The `runs: 3` trial count in the task
+config is there because reliability is part of the lesson.

--- a/examples/gmail-retry-notify/VERIFICATION.md
+++ b/examples/gmail-retry-notify/VERIFICATION.md
@@ -1,0 +1,31 @@
+# Verification — gmail-retry-notify
+
+Measured red (baseline, `RETRY_RULE_V1`) vs green (fixed, `RETRY_RULE_V2`) on
+the hosted Gmail twin + hosted evals via `pome run tasks/01-throttled-send.md -n 3`.
+
+> Status: **PENDING** — filled in by the F-917 hosted E2E step (plan Task D2).
+> Requires the hosted Gmail twin to carry the F-917 fault changes (prod
+> promotion via `pome-twin-promotion`). If the deployed hosted twin predates
+> this change, this section records that hosted verification is blocked on twin
+> promotion and reports the local-twin mechanism check instead.
+
+## Results
+
+| Variant | Rule | Trials | Passed | Delivered (per trial) | Duplicates | Verdict |
+| --- | --- | --- | --- | --- | --- | --- |
+| Baseline (red) | `RETRY_RULE_V1` | 3 | _tbd_ | _tbd_ | _tbd_ | _tbd_ |
+| Fixed (green) | `RETRY_RULE_V2` | 3 | _tbd_ | _tbd_ | _tbd_ | _tbd_ |
+
+## Per-criterion flip (red → green)
+
+| Criterion | Red | Green |
+| --- | --- | --- |
+| `[code]` exactly 5 SENT | _tbd_ | _tbd_ |
+| `[code]` one per recipient, no duplicate | _tbd_ | _tbd_ |
+| `[code]` no unsupported endpoint | _tbd_ | _tbd_ |
+| `[model]` honest delivery report | _tbd_ | _tbd_ |
+
+## Run links
+
+- Baseline (red): _tbd_
+- Fixed (green): _tbd_

--- a/examples/gmail-retry-notify/package-lock.json
+++ b/examples/gmail-retry-notify/package-lock.json
@@ -1,0 +1,702 @@
+{
+  "name": "@pome-sh/gmail-retry-notify-example",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@pome-sh/gmail-retry-notify-example",
+      "version": "0.1.0",
+      "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.81",
+        "ai": "^6.0.193",
+        "zod": "^4.1.13"
+      },
+      "devDependencies": {
+        "@types/node": "^25.0.3",
+        "tsx": "^4.21.0",
+        "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.102",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.102.tgz",
+      "integrity": "sha512-QV4QH8ugKBzGsrIqHzI9jzxIuYbXmddwSPEKwv80KD5U1D0ewyVr+9BoaFNvXtMxLQUhcIw1GSaAb3V86CpnJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.14",
+        "@ai-sdk/provider-utils": "4.0.40"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.157",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.157.tgz",
+      "integrity": "sha512-jO0LUsIQC+FeJRQI1KFiNcfTGp6a0lXrymekaXfBIvhVEOyt0NUyc9wiVi/dYGHQmWFXUo8QgmghgGAGLOPTAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.14",
+        "@ai-sdk/provider-utils": "4.0.40",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
+      "integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.40",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.40.tgz",
+      "integrity": "sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.14",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.235",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.235.tgz",
+      "integrity": "sha512-Uyeuvowo20XChpFC0lUaQq8xf0Kg7OElA56fEjUYoeWMJIzqshDTz4S57KXobcJ4m+iDQxMeJoUj06CIxSLx7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.157",
+        "@ai-sdk/provider": "3.0.14",
+        "@ai-sdk/provider-utils": "4.0.40",
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/examples/gmail-retry-notify/package.json
+++ b/examples/gmail-retry-notify/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@pome-sh/gmail-retry-notify-example",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Bundled Pome example: a Gmail notification agent that must retry throttled (429) sends without duplicating already-delivered ones. Teaches retry / partial-failure against the Gmail twin's rate-limited fault seed.",
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.81",
+    "ai": "^6.0.193",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.3",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3"
+  },
+  "engines": {
+    "node": ">=24"
+  }
+}

--- a/examples/gmail-retry-notify/pome.json
+++ b/examples/gmail-retry-notify/pome.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://pome.sh/schemas/v1/pome.json",
+  "agent": { "slug": "gmail-retry-notify" },
+  "command": "npm start",
+  "twins": ["gmail"],
+  "tasks": "tasks",
+  "artifacts_dir": "runs",
+  "pass_threshold": 100
+}

--- a/examples/gmail-retry-notify/src/index.ts
+++ b/examples/gmail-retry-notify/src/index.ts
@@ -1,0 +1,137 @@
+/**
+ * Pome bundled example: gmail-retry-notify.
+ *
+ * A model-driven Gmail notification agent (Vercel AI SDK) over the Gmail twin's
+ * REST surface. It must send a short announcement to each recipient named in
+ * POME_TASK.
+ *
+ * FAILURE CLASS: retry / partial failure. The task seeds the Gmail twin with a
+ * named `rate-limited` fault: the first couple of sends succeed, the next few
+ * return HTTP 429 RESOURCE_EXHAUSTED, then sends recover. A naive agent that
+ * does not retry leaves those recipients unsent (partial failure) — or blindly
+ * re-sends the whole batch and duplicates the ones that already went out. The
+ * fix is the one-line swap from RETRY_RULE_V1 (red) to RETRY_RULE_V2 (green):
+ * retry throttled sends with backoff, but only the ones that actually failed.
+ *
+ * Standard Pome agent contract (env injected by `pome run`):
+ *   POME_TASK             the instruction (names the recipients)
+ *   POME_GMAIL_REST_URL   session-scoped REST base for the Gmail twin
+ *   POME_AUTH_TOKEN       bearer token for the twin session
+ * POME_PREFLIGHT=1 → print "preflight ok" and exit, touching no network/model.
+ */
+
+import { generateText, stepCountIs, tool } from "ai";
+import { z } from "zod";
+
+if (process.env.POME_PREFLIGHT === "1") {
+  console.log("preflight ok");
+  process.exit(0);
+}
+
+// --- the one-line fix: swap V1 (red) for V2 (green) -------------------------
+const RETRY_RULE_V1 = "Send the announcement to each recipient exactly once.";
+const RETRY_RULE_V2 =
+  "Send the announcement to each recipient exactly once. If a send fails with a " +
+  "rate-limit / transient error (HTTP 429), wait briefly and retry ONLY that " +
+  "recipient, up to 5 attempts, before giving up. NEVER re-send a recipient " +
+  "whose send already succeeded. In your final summary, report exactly which " +
+  "recipients were delivered and which (if any) were not.";
+const RETRY_RULE = RETRY_RULE_V1; // ← green variant: change to RETRY_RULE_V2
+// ---------------------------------------------------------------------------
+
+const task = requiredEnv("POME_TASK");
+const restUrl = requiredEnv("POME_GMAIL_REST_URL").replace(/\/$/, "");
+const authToken = process.env.POME_AUTH_TOKEN ?? process.env.POME_GMAIL_TOKEN;
+const modelSlug = (process.env.GMAIL_AGENT_MODEL ?? "anthropic/claude-opus-4-8").trim();
+const maxSteps = Number(process.env.GMAIL_AGENT_MAX_STEPS ?? 30);
+
+const system = [
+  "You are an automated email notification agent for a Gmail mailbox.",
+  RETRY_RULE,
+  "Work autonomously. Finish once you have attempted every recipient.",
+].join("\n");
+
+let sender = "pome-agent@pome-twin.test"; // resolved from the live profile in main()
+
+const tools = {
+  send_email: tool({
+    description: "Send a plain-text email from the mailbox to one recipient.",
+    inputSchema: z.object({
+      to: z.string(),
+      subject: z.string(),
+      body: z.string(),
+    }),
+    execute: ({ to, subject, body }: { to: string; subject: string; body: string }) => {
+      const raw = toBase64Url(buildMime({ from: sender, to, subject, body }));
+      return gmail(`/gmail/v1/users/me/messages/send`, "POST", { raw });
+    },
+  }),
+  list_sent: tool({
+    description: "List messages already sent from the mailbox (to check what succeeded).",
+    inputSchema: z.object({}),
+    execute: () => gmail(`/gmail/v1/users/me/messages?labelIds=SENT`),
+  }),
+};
+
+await main();
+
+async function main() {
+  const profile = await gmail(`/gmail/v1/users/me/profile`);
+  if (profile && typeof profile === "object" && "emailAddress" in profile) {
+    sender = String((profile as { emailAddress: string }).emailAddress);
+  }
+  const model = await resolveModel(modelSlug);
+  const result = await generateText({
+    model,
+    system,
+    prompt: task,
+    tools,
+    stopWhen: stepCountIs(maxSteps),
+  });
+  console.log(
+    JSON.stringify({
+      task,
+      model: modelSlug,
+      steps: result.steps.length,
+      summary: result.text || "Agent finished.",
+    }),
+  );
+}
+
+async function gmail(path: string, method = "GET", body?: unknown) {
+  const headers: Record<string, string> = {};
+  if (body) headers["content-type"] = "application/json";
+  if (authToken) headers.authorization = `Bearer ${authToken}`;
+  const res = await fetch(`${restUrl}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  // Hand the model the error (incl. 429) instead of throwing, so it can retry.
+  if (!res.ok) return { ok: false, status: res.status, error: text || res.statusText };
+  return text ? JSON.parse(text) : null;
+}
+
+function buildMime({ from, to, subject, body }: { from: string; to: string; subject: string; body: string }): string {
+  return [`From: ${from}`, `To: ${to}`, `Subject: ${subject}`, "Content-Type: text/plain; charset=utf-8", "", body].join(
+    "\r\n",
+  );
+}
+
+function toBase64Url(s: string): string {
+  return Buffer.from(s, "utf8").toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+async function resolveModel(slug: string): Promise<Parameters<typeof generateText>[0]["model"]> {
+  if (process.env.AI_GATEWAY_API_KEY) return slug;
+  const id = slug.includes("/") ? slug.slice(slug.indexOf("/") + 1) : slug;
+  const { createAnthropic } = await import("@ai-sdk/anthropic");
+  return createAnthropic({ apiKey: requiredEnv("ANTHROPIC_API_KEY") })(id);
+}
+
+function requiredEnv(name: string): string {
+  const v = process.env[name]?.trim();
+  if (!v) throw new Error(`${name} is required`);
+  return v;
+}

--- a/examples/gmail-retry-notify/tasks/01-throttled-send.md
+++ b/examples/gmail-retry-notify/tasks/01-throttled-send.md
@@ -1,0 +1,45 @@
+# Throttled announcement send
+
+## Setup
+
+The mailbox `pome-agent@pome-twin.test` must send a short launch announcement to
+five teammates. The Gmail twin is seeded with a named `rate-limited` fault on
+`messages.send`: the first two sends succeed, the next sends are throttled with
+HTTP 429 (RESOURCE_EXHAUSTED), then sends recover.
+
+## Prompt
+
+Send this launch announcement to each of these five recipients, one email each:
+alice@pome-twin.test, bob@pome-twin.test, carol@pome-twin.test,
+dave@pome-twin.test, erin@pome-twin.test.
+
+Subject: "Pome launch is live". Body: "We shipped today — thanks for the help."
+
+Confirm which recipients were delivered.
+
+## Expected Behavior
+
+Retry the throttled sends with backoff until all five are delivered, without
+re-sending any recipient that already succeeded. Report the true delivery state.
+
+## Success Criteria
+
+- [code] The mailbox `pome-agent@pome-twin.test` has exactly 5 messages labeled SENT.
+- [code] Exactly one SENT message is addressed to each of the five recipients (no duplicate sends).
+- [code] No unsupported Gmail endpoint was called.
+- [model] The final summary reports all five recipients as delivered and does not claim success for any send that did not complete.
+
+## Seed State
+
+A hand-authored Gmail seed: the agent's mailbox plus a `rate-limited` fault on
+`messages.send` (`succeedFirst: 2`, `throttleFor: 3`). See
+`01-throttled-send.seed.json`.
+
+## Config
+
+```yaml
+twins: [gmail]
+runs: 3
+timeout: 240
+passThreshold: 100
+```

--- a/examples/gmail-retry-notify/tasks/01-throttled-send.seed.json
+++ b/examples/gmail-retry-notify/tasks/01-throttled-send.seed.json
@@ -1,0 +1,17 @@
+{
+  "_meta": {
+    "version": 1,
+    "source_hash": "sha256:hand-authored",
+    "model": "hand-authored",
+    "compiled_at": "2026-07-24T00:00:00.000Z"
+  },
+  "primaryMailbox": {
+    "email": "pome-agent@pome-twin.test",
+    "displayName": "Pome Agent"
+  },
+  "deliveryMode": "sender-only",
+  "clock": "2026-07-24T00:00:00.000Z",
+  "faults": [
+    { "name": "rate-limited", "target": "messages.send", "succeedFirst": 2, "throttleFor": 3, "retryAfterSeconds": 1 }
+  ]
+}

--- a/examples/gmail-retry-notify/tsconfig.json
+++ b/examples/gmail-retry-notify/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/shared-types/CHANGELOG.md
+++ b/packages/shared-types/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pome-sh/shared-types — CHANGELOG
 
+## Unreleased
+
+### Added
+
+- Gmail seed `faults` field (F-917): an optional array of named fault primitives
+  (`rate-limited`) mirroring twin-gmail. Optional, default `[]` — no change for
+  existing seeds or the pre-F-917 cloud.
+
 ## 0.12.1
 
 ### Added

--- a/packages/shared-types/src/seed-state.ts
+++ b/packages/shared-types/src/seed-state.ts
@@ -292,11 +292,24 @@ const gmailMailboxSeedSchema = z.object({
   sendAs: z.array(z.record(z.string(), z.unknown())).max(1000).default([]),
 });
 
+// Named fault-injection primitives (mirror of twin-gmail `faults.ts`). Opt-in;
+// default seeds carry none. See CONTRACT.md (Gmail pins).
+const gmailFaultSchema = z
+  .object({
+    name: z.enum(["rate-limited"]),
+    target: z.string().min(1).max(128).default("messages.send"),
+    succeedFirst: z.number().int().nonnegative().max(1000).default(2),
+    throttleFor: z.number().int().positive().max(1000).default(3),
+    retryAfterSeconds: z.number().int().positive().max(3600).default(1),
+  })
+  .strict();
+
 export const gmailSeedStateSchema = z.object({
   primaryMailbox: gmailMailboxSeedSchema,
   mailboxes: z.array(gmailMailboxSeedSchema).max(100).default([]),
   deliveryMode: z.enum(["sender-only", "seeded-mailboxes"]).default("sender-only"),
   clock: z.string().datetime({ offset: true }).default("2025-01-01T00:00:00.000Z"),
+  faults: z.array(gmailFaultSchema).max(50).default([]),
 });
 export type GmailSeedState = z.infer<typeof gmailSeedStateSchema>;
 

--- a/packages/shared-types/test/seed-state.test.ts
+++ b/packages/shared-types/test/seed-state.test.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from "vitest";
+import { gmailSeedStateSchema } from "../src/seed-state.js";
+
+describe("gmailSeedStateSchema faults", () => {
+  it("defaults faults to []", () => {
+    const parsed = gmailSeedStateSchema.parse({ primaryMailbox: { email: "a@b.test" } });
+    expect(parsed.faults).toEqual([]);
+  });
+
+  it("accepts a rate-limited fault", () => {
+    const parsed = gmailSeedStateSchema.parse({
+      primaryMailbox: { email: "a@b.test" },
+      faults: [{ name: "rate-limited", target: "messages.send" }],
+    });
+    expect(parsed.faults[0].name).toBe("rate-limited");
+  });
+
+  it("rejects an unknown fault name", () => {
+    expect(() =>
+      gmailSeedStateSchema.parse({ primaryMailbox: { email: "a@b.test" }, faults: [{ name: "kaboom" }] }),
+    ).toThrow();
+  });
+});

--- a/packages/twin-gmail/CHANGELOG.md
+++ b/packages/twin-gmail/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @pome-sh/twin-gmail — CHANGELOG
 
+## Unreleased
+
+### Added
+
+- Named `rate-limited` fault-injection seed primitive (F-917). Gmail seeds accept
+  an optional `faults` array (default `[]`, opt-in). `rate-limited` throttles a
+  target operation (default `messages.send`) by call count: the first
+  `succeedFirst` calls succeed, the next `throttleFor` return 429
+  `RESOURCE_EXHAUSTED` (retry hint in the body, no `Retry-After` header), then
+  calls recover; the counter is per twin instance and cleared by
+  `POST /admin/reset`. Default seed behavior is unchanged.
+
 ## 0.1.2 — 2026-07-23
 
 Fix: declare `@hono/node-server` as a direct dependency. The twin's

--- a/packages/twin-gmail/LIMITS.md
+++ b/packages/twin-gmail/LIMITS.md
@@ -38,4 +38,14 @@ query/filter, and the mailbox history high-water mark. The signing key resolves 
 There is no forgeable public default string. Cross-mailbox, cross-query, and stale
 snapshot tokens fail with `invalidArgument`.
 
+## Fault seeds
+
+Opt-in named fault-injection primitives (default none; a seed's `faults` array
+defaults to `[]`). The name is reusable teaching vocabulary — any task may seed
+it. See CONTRACT.md (Gmail pins).
+
+| Fault | Target (default) | Behavior |
+| --- | --- | --- |
+| `rate-limited` | `messages.send` | First `succeedFirst` (default 2) matching calls succeed; the next `throttleFor` (default 3) return **429 `RESOURCE_EXHAUSTED`** (retry hint in body; `retryAfterSeconds` default 1); then calls recover. Counter is per twin instance, cleared by `POST /admin/reset`. |
+
 See `performanceBudgets` in [`fidelity.inventory.json`](fidelity.inventory.json).

--- a/packages/twin-gmail/src/db.ts
+++ b/packages/twin-gmail/src/db.ts
@@ -8,6 +8,11 @@ CREATE TABLE IF NOT EXISTS gmail_config (
   value TEXT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS fault_counters (
+  operation TEXT PRIMARY KEY,
+  calls INTEGER NOT NULL DEFAULT 0
+);
+
 CREATE TABLE IF NOT EXISTS mailboxes (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   email TEXT NOT NULL COLLATE NOCASE UNIQUE,
@@ -183,6 +188,7 @@ CREATE INDEX IF NOT EXISTS idx_filters_mailbox
 
 const RESET_SQL = `
 DELETE FROM gmail_config;
+DELETE FROM fault_counters;
 DELETE FROM send_as;
 DELETE FROM forwarding_addresses;
 DELETE FROM filters;

--- a/packages/twin-gmail/src/domain/gmail-domain.ts
+++ b/packages/twin-gmail/src/domain/gmail-domain.ts
@@ -20,6 +20,7 @@ export class GmailDomain {
       resetDatabase(this.db);
       this.db.prepare("INSERT INTO gmail_config(key, value) VALUES ('clock', ?)").run(seed.clock);
       this.db.prepare("INSERT INTO gmail_config(key, value) VALUES ('delivery_mode', ?)").run(seed.deliveryMode);
+      this.db.prepare("INSERT INTO gmail_config(key, value) VALUES ('faults', ?)").run(JSON.stringify(seed.faults ?? []));
       for (const mailbox of [seed.primaryMailbox, ...seed.mailboxes]) seedMailbox(this.db, mailbox);
     }).immediate();
   }

--- a/packages/twin-gmail/src/domain/messages.ts
+++ b/packages/twin-gmail/src/domain/messages.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { invalidArgument, notFound } from "../errors.js";
+import { checkFault } from "../faults.js";
 import { canonicalRaw, decodeGmailRaw, parseMime, stripBcc } from "../mime.js";
 import { matchesSearch } from "../search-match.js";
 import { SEARCH_MAILBOX_MESSAGE_BUDGET, validateSearchQuery } from "../search-parse.js";
@@ -73,6 +74,7 @@ export function sendMessage(
   raw: Uint8Array | string,
   options: { threadId?: string } = {}
 ): { sender: SemanticMessage; deliveries: Array<{ mailboxEmail: string; message: SemanticMessage }> } {
+  checkFault(domain.db, "messages.send");
   const senderMailboxId = domain.mailboxId(email);
   const bytes = acceptedRaw(raw);
   const parsed = parseMime(bytes);

--- a/packages/twin-gmail/src/errors.ts
+++ b/packages/twin-gmail/src/errors.ts
@@ -111,6 +111,7 @@ function googleStatus(status: number): string {
   if (status === 401) return "UNAUTHENTICATED";
   if (status === 403) return "PERMISSION_DENIED";
   if (status === 404) return "NOT_FOUND";
+  if (status === 429) return "RESOURCE_EXHAUSTED";
   if (status === 409) return "ALREADY_EXISTS";
   if (status === 501) return "UNIMPLEMENTED";
   return "INTERNAL";

--- a/packages/twin-gmail/src/faults.ts
+++ b/packages/twin-gmail/src/faults.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+import { z } from "zod";
+import { GmailError } from "./errors.js";
+import type { GmailTwinDatabase } from "./types.js";
+
+// Named, reusable fault-injection primitives. A seed lists faults by NAME; the
+// name is teaching vocabulary. Default seeds carry none, so faults are strictly
+// opt-in (mirrors twin-linear `strictScopes`). Extend KNOWN_FAULT_NAMES to add
+// a primitive.
+const KNOWN_FAULT_NAMES = ["rate-limited"] as const;
+
+export const gmailFaultSchema = z
+  .object({
+    name: z.enum(KNOWN_FAULT_NAMES),
+    target: z.string().min(1).max(128).default("messages.send"),
+    succeedFirst: z.number().int().nonnegative().max(1000).default(2),
+    throttleFor: z.number().int().positive().max(1000).default(3),
+    retryAfterSeconds: z.number().int().positive().max(3600).default(1),
+  })
+  .strict();
+
+export type GmailFault = z.output<typeof gmailFaultSchema>;
+
+/**
+ * Increment the per-operation call counter and, if a `rate-limited` fault is
+ * armed for `operation`, throw a 429 during the throttle window. Deterministic
+ * and clock-free: calls 1..succeedFirst pass, the next `throttleFor` calls
+ * throw, every call after passes. EVERY matching call (including throttled
+ * ones) advances the counter, so an agent that retries with backoff clears the
+ * window while one that doesn't leaves those sends undelivered.
+ */
+export function checkFault(db: GmailTwinDatabase, operation: string): void {
+  const fault = readFaults(db).find((f) => f.target === operation);
+  if (!fault) return;
+  const calls = bumpFaultCounter(db, operation);
+  if (calls > fault.succeedFirst && calls <= fault.succeedFirst + fault.throttleFor) {
+    throw new GmailError(
+      429,
+      "rateLimitExceeded",
+      `Rate limit exceeded for ${operation}. Retry after ${fault.retryAfterSeconds}s.`,
+    );
+  }
+}
+
+function readFaults(db: GmailTwinDatabase): GmailFault[] {
+  const row = db.prepare("SELECT value FROM gmail_config WHERE key = 'faults'").get() as
+    | { value: string }
+    | undefined;
+  if (!row) return [];
+  try {
+    return JSON.parse(row.value) as GmailFault[];
+  } catch {
+    return [];
+  }
+}
+
+function bumpFaultCounter(db: GmailTwinDatabase, operation: string): number {
+  db.prepare(
+    "INSERT INTO fault_counters(operation, calls) VALUES (?, 1) " +
+      "ON CONFLICT(operation) DO UPDATE SET calls = calls + 1",
+  ).run(operation);
+  const row = db.prepare("SELECT calls FROM fault_counters WHERE operation = ?").get(operation) as {
+    calls: number;
+  };
+  return row.calls;
+}

--- a/packages/twin-gmail/src/seed.ts
+++ b/packages/twin-gmail/src/seed.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { z } from "zod";
+import { gmailFaultSchema } from "./faults.js";
 import { validateSearchQuery } from "./search-parse.js";
 import type { GmailStateSeed, SeedMailbox } from "./types.js";
 
@@ -125,6 +126,7 @@ export const gmailSeedSchema = z
     mailboxes: z.array(mailboxSchema).max(100).default([]),
     deliveryMode: z.enum(["sender-only", "seeded-mailboxes"]).default("sender-only"),
     clock: z.string().datetime({ offset: true }).default("2025-01-01T00:00:00.000Z"),
+    faults: z.array(gmailFaultSchema).max(50).default([]),
   })
   .strict()
   .superRefine((seed, ctx) => {

--- a/packages/twin-gmail/src/types.ts
+++ b/packages/twin-gmail/src/types.ts
@@ -89,6 +89,7 @@ export type GmailStateSeed = {
   mailboxes?: SeedMailbox[];
   deliveryMode?: DeliveryMode;
   clock?: string;
+  faults?: import("./faults.js").GmailFault[];
 };
 
 export type MessageRow = {

--- a/packages/twin-gmail/test/faults.test.ts
+++ b/packages/twin-gmail/test/faults.test.ts
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from "vitest";
-import { openGmailTwinDatabase } from "../src/index.js";
+import { GmailDomain, openGmailTwinDatabase } from "../src/index.js";
 import { checkFault, gmailFaultSchema } from "../src/faults.js";
 import { GmailError, gmailErrorEnvelope } from "../src/errors.js";
+import { defaultSeedState, parseSeed } from "../src/seed.js";
 
 function dbWithFault(fault: unknown) {
   const db = openGmailTwinDatabase(":memory:");
@@ -48,5 +49,34 @@ describe("429 envelope", () => {
     expect(env.status).toBe(429);
     expect((env.body as any).error.status).toBe("RESOURCE_EXHAUSTED");
     expect((env.body as any).error.errors[0].reason).toBe("rateLimitExceeded");
+  });
+});
+
+describe("seed integration", () => {
+  it("default seed has no faults", () => {
+    expect(parseSeed(defaultSeedState()).faults).toEqual([]);
+  });
+
+  it("domain.seed persists faults and gate reads them", () => {
+    const db = openGmailTwinDatabase(":memory:");
+    const gmail = new GmailDomain(db);
+    gmail.seed({
+      primaryMailbox: { email: "agent@pome-twin.test" },
+      faults: [{ name: "rate-limited", target: "messages.send", succeedFirst: 1, throttleFor: 1 }],
+    } as never);
+    expect(() => checkFault(db, "messages.send")).not.toThrow(); // call 1 ok
+    expect(() => checkFault(db, "messages.send")).toThrow(); // call 2 throttled
+  });
+
+  it("reset clears the fault counter", () => {
+    const db = openGmailTwinDatabase(":memory:");
+    const gmail = new GmailDomain(db);
+    gmail.seed({
+      primaryMailbox: { email: "agent@pome-twin.test" },
+      faults: [{ name: "rate-limited", succeedFirst: 0, throttleFor: 1 }],
+    } as never);
+    expect(() => checkFault(db, "messages.send")).toThrow(); // call 1 throttled
+    gmail.resetToDefault(); // clears counter + faults
+    expect(() => checkFault(db, "messages.send")).not.toThrow();
   });
 });

--- a/packages/twin-gmail/test/faults.test.ts
+++ b/packages/twin-gmail/test/faults.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from "vitest";
-import { GmailDomain, openGmailTwinDatabase } from "../src/index.js";
+import { composeMime, GmailDomain, openGmailTwinDatabase } from "../src/index.js";
 import { checkFault, gmailFaultSchema } from "../src/faults.js";
 import { GmailError, gmailErrorEnvelope } from "../src/errors.js";
 import { defaultSeedState, parseSeed } from "../src/seed.js";
@@ -78,5 +78,32 @@ describe("seed integration", () => {
     expect(() => checkFault(db, "messages.send")).toThrow(); // call 1 throttled
     gmail.resetToDefault(); // clears counter + faults
     expect(() => checkFault(db, "messages.send")).not.toThrow();
+  });
+});
+
+describe("sendMessage gate", () => {
+  it("throttles the 2nd send when succeedFirst=1, throttleFor=1", () => {
+    const db = openGmailTwinDatabase(":memory:");
+    const gmail = new GmailDomain(db);
+    gmail.seed({
+      primaryMailbox: { email: "agent@pome-twin.test", displayName: "Agent" },
+      faults: [{ name: "rate-limited", target: "messages.send", succeedFirst: 1, throttleFor: 1 }],
+    } as never);
+    const raw = composeMime({
+      from: "agent@pome-twin.test",
+      to: ["x@pome-twin.test"],
+      subject: "hi",
+      text: "hi",
+      date: "2026-07-24T12:00:00.000Z",
+      messageId: "gate@test",
+    });
+    expect(() => gmail.sendMessage("agent@pome-twin.test", raw)).not.toThrow(); // 1st ok
+    let status = 0;
+    try {
+      gmail.sendMessage("agent@pome-twin.test", raw);
+    } catch (e) {
+      status = (e as GmailError).status;
+    }
+    expect(status).toBe(429); // 2nd throttled
   });
 });

--- a/packages/twin-gmail/test/faults.test.ts
+++ b/packages/twin-gmail/test/faults.test.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it } from "vitest";
 import { openGmailTwinDatabase } from "../src/index.js";
 import { checkFault, gmailFaultSchema } from "../src/faults.js";
-import { GmailError } from "../src/errors.js";
+import { GmailError, gmailErrorEnvelope } from "../src/errors.js";
 
 function dbWithFault(fault: unknown) {
   const db = openGmailTwinDatabase(":memory:");
@@ -39,5 +39,14 @@ describe("rate-limited fault", () => {
 
   it("rejects an unknown fault name", () => {
     expect(() => gmailFaultSchema.parse({ name: "kaboom" })).toThrow();
+  });
+});
+
+describe("429 envelope", () => {
+  it("maps 429 to RESOURCE_EXHAUSTED", () => {
+    const env = gmailErrorEnvelope(new GmailError(429, "rateLimitExceeded", "slow down"));
+    expect(env.status).toBe(429);
+    expect((env.body as any).error.status).toBe("RESOURCE_EXHAUSTED");
+    expect((env.body as any).error.errors[0].reason).toBe("rateLimitExceeded");
   });
 });

--- a/packages/twin-gmail/test/faults.test.ts
+++ b/packages/twin-gmail/test/faults.test.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from "vitest";
+import { openGmailTwinDatabase } from "../src/index.js";
+import { checkFault, gmailFaultSchema } from "../src/faults.js";
+import { GmailError } from "../src/errors.js";
+
+function dbWithFault(fault: unknown) {
+  const db = openGmailTwinDatabase(":memory:");
+  const parsed = gmailFaultSchema.parse(fault);
+  db.prepare("INSERT INTO gmail_config(key, value) VALUES ('faults', ?)").run(JSON.stringify([parsed]));
+  return db;
+}
+
+describe("rate-limited fault", () => {
+  it("passes succeedFirst, throttles throttleFor, then recovers", () => {
+    const db = dbWithFault({ name: "rate-limited", target: "messages.send", succeedFirst: 2, throttleFor: 3 });
+    const statuses: (number | "ok")[] = [];
+    for (let i = 0; i < 8; i++) {
+      try {
+        checkFault(db, "messages.send");
+        statuses.push("ok");
+      } catch (e) {
+        statuses.push((e as GmailError).status);
+      }
+    }
+    // calls 1-2 ok, 3-5 throttled (429), 6-8 ok again
+    expect(statuses).toEqual(["ok", "ok", 429, 429, 429, "ok", "ok", "ok"]);
+  });
+
+  it("does nothing when no fault targets the operation", () => {
+    const db = dbWithFault({ name: "rate-limited", target: "messages.send" });
+    expect(() => checkFault(db, "drafts.send")).not.toThrow();
+  });
+
+  it("does nothing when no faults are configured", () => {
+    const db = openGmailTwinDatabase(":memory:");
+    expect(() => checkFault(db, "messages.send")).not.toThrow();
+  });
+
+  it("rejects an unknown fault name", () => {
+    expect(() => gmailFaultSchema.parse({ name: "kaboom" })).toThrow();
+  });
+});

--- a/scripts/smoke-examples.mjs
+++ b/scripts/smoke-examples.mjs
@@ -48,6 +48,7 @@ const SMOKE_ENV = {
   POME_GITHUB_REST_URL: "http://127.0.0.1:59321",
   POME_GITHUB_MCP_URL: "http://127.0.0.1:59321/s/smoke/mcp",
   POME_SLACK_REST_URL: "http://127.0.0.1:59321",
+  POME_GMAIL_REST_URL: "http://127.0.0.1:59321",
   // triage-agent / pr-summary-* accept a pre-minted bearer token verbatim, so
   // resolveAuthToken() returns immediately and reaches `new TwinMcpClient(...)`
   // (the TDZ site) instead of throwing on missing auth.


### PR DESCRIPTION
## What

- **twin-gmail `rate-limited` fault primitive**: opt-in `faults` field on the Gmail seed (additive, default `[]`) — a named, reusable fault-injection seed. `fault_counters` table + reset, 429 → `RESOURCE_EXHAUSTED` error mapping, `checkFault` gate on `sendMessage`. Retry hint lives in the 429 body (no `Retry-After` header — the sdk error path has no header channel).
- **shared-types mirror**: `faults` on `gmailSeedStateSchema` + tests.
- **`examples/gmail-retry-notify/`**: the retry/partial-failure curriculum example. Ships a red baseline (`RETRY_RULE_V1`, code-layer flaw — the model never gets a chance to compensate); the fix is a one-line swap to `RETRY_RULE_V2`.
- **Contract**: CONTRACT.md v1.4.0 + Gmail fault pin; black-box case `contract/gmail-fault.test.mjs` wired into `contract/run.mjs` — passes over real HTTP against the built dist.
- Docs: `packages/twin-gmail/LIMITS.md`, Unreleased CHANGELOG entries (twin-gmail + shared-types), smoke env support (`POME_GMAIL_REST_URL`).

## Why

M4b curriculum, retry/partial-failure class (F-917): the failure mode is baked into the twin as a named seed instead of a bespoke per-example hack, and the seed name becomes teaching vocabulary. First example coverage for the newly hosted Gmail twin rides along.

## Verification

Local gates green: `node contract/run.mjs` (104 pass) · twin-gmail tests (56) · shared-types tests (362) · `npm run typecheck` · `typecheck-examples` (7/7) · `smoke-examples` (7/7) · `lint:dead-code` · `lint:legacy-markers`.

Hosted E2E (red/green trials against the deployed Gmail twin) is pending the release chain (shared-types → cli → twin promotion) and will be recorded in `examples/gmail-retry-notify/VERIFICATION.md`.

## Notes

- Versions not hand-bumped — release automation owns that; only Unreleased CHANGELOG entries added.
- No `cli/` code changed → no CLI changeset in this PR.

Closes F-917