### PR TITLE
release: shared-types 0.12.2 + twin-gmail 0.2.0 (packages-v17)

### DIFF
--- a/packages/shared-types/CHANGELOG.md
+++ b/packages/shared-types/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @pome-sh/shared-types — CHANGELOG
 
-## Unreleased
+## 0.12.2 — 2026-07-24
 
 ### Added
 

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/shared-types",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Shared wire-format contract for Pome — Zod schemas for traces, recorder events, runs, OTel mapping, and secret redaction.",
   "private": false,
   "type": "module",

--- a/packages/shared-types/trace-contract.json
+++ b/packages/shared-types/trace-contract.json
@@ -1,6 +1,6 @@
 {
   "package": "@pome-sh/shared-types",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "zod": {
     "range": "^4.1.13",
     "major": 4

--- a/packages/twin-gmail/CHANGELOG.md
+++ b/packages/twin-gmail/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @pome-sh/twin-gmail — CHANGELOG
 
-## Unreleased
+## 0.2.0 — 2026-07-24
 
 ### Added
 

--- a/packages/twin-gmail/package.json
+++ b/packages/twin-gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-gmail",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Deterministic Gmail-shaped twin for agent testing — SQLite-backed domain core.",
   "private": false,
   "type": "module",


### PR DESCRIPTION
## What

Version + changelog batch for the F-917 fault-seed release (#229):

- **@pome-sh/shared-types 0.12.1 → 0.12.2** (patch: additive optional Gmail seed `faults` field, default `[]`, no change for existing seeds)
- **@pome-sh/twin-gmail 0.1.2 → 0.2.0** (minor: runtime-contract change — named `rate-limited` fault primitive, 429 RESOURCE_EXHAUSTED surface, CONTRACT pin)

## Why

Unblocks the F-917 release chain: hosted Gmail twin + CLI + cloud all reject the `faults` seed key until these publish (CLI zod strict / twin seed schema strict).

## Verification

`node scripts/pack-publishable.mjs --out dist-tarballs` clean-room pack green locally (8 tarballs, correct versions). Publish itself is the `packages-v17` GitHub Release → `sdk-publish.yml` OIDC flow after merge.