### PR TITLE
Register agent sends manifest twins to POST /v1/agents

### DIFF
--- a/cli/.changeset/register-manifest-twins.md
+++ b/cli/.changeset/register-manifest-twins.md
@@ -1,0 +1,5 @@
+---
+"@pome-sh/cli": patch
+---
+
+`pome register agent` now sends the manifest's `twins` to `POST /v1/agents`, so the cloud agent's enabled services match the manifest instead of falling back to the server's `github` default. Previously a manifest like `twins: ["gmail"]` was ignored and the first `pome run` errored with `Requested twins are not enabled`. Any `--twins` flag is unioned with the manifest's twins (the server still merges additively).

--- a/cli/src/cli/agent-identity.ts
+++ b/cli/src/cli/agent-identity.ts
@@ -23,7 +23,7 @@ import {
   resolveCachedAgentId,
   writeLinkCache,
 } from "./link-cache.js";
-import { readManifest } from "./project-config.js";
+import { normalizeManifestTwins, readManifest } from "./project-config.js";
 
 export interface RunAgentIdentity {
   /** The resolved agent id to send at session create; absent = unattributed. */
@@ -74,7 +74,11 @@ export async function resolveRunAgentIdentity(
     if (cachedId) {
       return { ...base, agentId: cachedId };
     }
-    // Silent re-resolution — a run never prompts for a near-miss.
+    // Silent re-resolution — a run never prompts for a near-miss. Send the
+    // manifest's twins so a fork / first `pome run` that auto-creates the agent
+    // enables the declared services instead of the server's `github` default
+    // (F-926); the server merges additively, so this is safe when the agent
+    // already exists.
     const resolved = await postAgentResolver(
       creds,
       {
@@ -83,6 +87,7 @@ export async function resolveRunAgentIdentity(
         description: agent.description,
         version: agent.version,
         framework: agent.framework,
+        twins: normalizeManifestTwins(manifestRead.manifest.twins),
       },
       resolveSeams({ stdinIsTTY: false }),
     );

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -418,7 +418,7 @@ export function createProgram() {
     )
     .option(
       "--twins <list>",
-      "Comma-separated services this agent may exercise (e.g. github,slack). Default: the cloud's default enablement.",
+      "Comma-separated services this agent may exercise (e.g. github,slack), unioned with the manifest's twins. Default: the manifest's twins, else the cloud's default enablement.",
     )
     .description(
       "Create a cloud agent under the current team and write agent.slug to pome.json",

--- a/cli/src/cli/project-config.ts
+++ b/cli/src/cli/project-config.ts
@@ -171,6 +171,25 @@ function slugErrorMessage(raw: Record<string, unknown>, path: string): string {
   return suggestion.length > 0 ? `${base} Did you mean "${suggestion}"?` : base;
 }
 
+/** Normalize the manifest's `twins` to canonical (trim + lowercase, de-duped)
+ *  twin ids for the `POST /v1/agents` body. The manifest schema keeps `twins`
+ *  open (min(1) strings, not checked against MOUNTED_TWINS), so entries are
+ *  normalized but NOT validated here — the server returns a friendly error for
+ *  an unknown twin. Returns undefined when nothing survives so the cloud's
+ *  default enablement still applies. Shared by the register command and the
+ *  run-path identity resolver (F-926). */
+export function normalizeManifestTwins(
+  manifestTwins: readonly string[] | undefined,
+): string[] | undefined {
+  if (manifestTwins === undefined) return undefined;
+  const out = new Set<string>();
+  for (const twin of manifestTwins) {
+    const norm = twin.trim().toLowerCase();
+    if (norm.length > 0) out.add(norm);
+  }
+  return out.size > 0 ? [...out] : undefined;
+}
+
 async function fileExists(path: string): Promise<boolean> {
   try {
     await readFile(path, "utf8");

--- a/cli/src/cli/register.ts
+++ b/cli/src/cli/register.ts
@@ -32,6 +32,7 @@ import {
   writeLinkCache,
 } from "./link-cache.js";
 import {
+  normalizeManifestTwins,
   readRequiredManifest,
   writeManifest,
   type ManifestRead,
@@ -69,6 +70,29 @@ export function normalizeRegisterTwins(raw: string | undefined): string[] | unde
     );
   }
   return [...new Set(twins)];
+}
+
+/** Effective register twins = the manifest's declared `twins` (the default twin
+ *  set for runs) unioned with any `--twins` flag additions (F-926). Before this,
+ *  the CLI sent only the flag, so a manifest like `twins: ["gmail"]` never
+ *  reached `POST /v1/agents` and the server's `github` default won — the first
+ *  `pome run` then errored with "Requested twins are not enabled".
+ *
+ *  Union is the correct client shape because the server merges additively (never
+ *  removes), so there is no "reduce" semantics to preserve; sending more is
+ *  always safe. Manifest entries are normalized (trim + lowercase) to match the
+ *  flag path and the canonical lowercase twin ids; they are intentionally NOT
+ *  validated against MOUNTED_TWINS here (the manifest schema keeps `twins` open,
+ *  and the server returns a friendly error for an unknown twin). Returns
+ *  undefined when neither source contributes so the cloud's default enablement
+ *  still applies. */
+export function mergeRegisterTwins(
+  manifestTwins: readonly string[] | undefined,
+  flagTwins: readonly string[] | undefined,
+): string[] | undefined {
+  const merged = new Set<string>(normalizeManifestTwins(manifestTwins) ?? []);
+  for (const twin of flagTwins ?? []) merged.add(twin);
+  return merged.size > 0 ? [...merged] : undefined;
 }
 
 // ── Persist: manifest + link cache + gitignore ──────────────────────────────
@@ -190,12 +214,16 @@ export async function runRegisterAgent(opts: RegisterAgentOptions): Promise<void
     }
   }
 
+  // Send the manifest's declared twins (unioned with any --twins flag) so the
+  // cloud's enabled services match the manifest, not the server default (F-926).
+  const twins = mergeRegisterTwins(manifestRead.manifest.twins, opts.twins);
+
   const agent = await createAndPersistAgent({
     creds,
     name: opts.name,
     manifestRead,
     projectDir,
-    twins: opts.twins,
+    twins,
     seams: resolveSeams(opts),
   });
 
@@ -207,7 +235,7 @@ export async function runRegisterAgent(opts: RegisterAgentOptions): Promise<void
     console.error(
       `Enabled services: ${agent.enabled_services.length > 0 ? agent.enabled_services.join(", ") : "(none)"}.`,
     );
-  } else if (opts.twins && opts.twins.length > 0) {
+  } else if (twins && twins.length > 0) {
     console.error(
       "Enabled services: not reported by this pome cloud (older control plane) — twin scoping may not have taken effect.",
     );

--- a/cli/test/unit/agent-identity.test.ts
+++ b/cli/test/unit/agent-identity.test.ts
@@ -95,6 +95,23 @@ describe("resolveRunAgentIdentity", () => {
     });
   });
 
+  it("sends the manifest's twins on the auto-create re-resolve so a fork's first run enables them (F-926)", async () => {
+    const dir = await makeProject({ agent: { slug: "gmail-retry-notify" }, twins: ["gmail"] });
+    const credentialsPath = await writeCreds(dir, "tm_new");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(response({ id: "agt_fresh", slug: "gmail-retry-notify", display_name: "G", judge_model: "m" }));
+
+    await resolveRunAgentIdentity({ startDir: dir, apiBaseUrl: "https://api.example.com", credentialsPath });
+
+    const body = JSON.parse(String((fetchMock.mock.calls[0]![1] as RequestInit).body));
+    expect(body.twins).toEqual(["gmail"]);
+    expect(JSON.parse(readFileSync(join(dir, ".pome", "link.json"), "utf8"))).toMatchObject({
+      agent_id: "agt_fresh",
+      team_id: "tm_new",
+    });
+  });
+
   it("the version override wins over the manifest agent.version", async () => {
     const dir = await makeProject({ agent: { slug: "pr-review-agent", version: "0.2.0" } });
     const credentialsPath = await writeCreds(dir, "tm_team");

--- a/cli/test/unit/register.test.ts
+++ b/cli/test/unit/register.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HostedOrchError } from "../../src/hosted/errors.js";
 import {
+  mergeRegisterTwins,
   normalizeRegisterTwins,
   runRegisterAgent,
 } from "../../src/cli/register.js";
@@ -230,6 +231,39 @@ describe("runRegisterAgent", () => {
     expect(errors.join("\n")).toContain("Enabled services: github, slack");
   });
 
+  it("sends the manifest's twins to POST /v1/agents when no --twins flag is given (F-926)", async () => {
+    await writeManifest({ agent: { slug: "gmail-retry-notify" }, twins: ["gmail"] });
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(response({ ...AGENT_OK, slug: "gmail-retry-notify", enabled_services: ["gmail"] }));
+
+    await runRegisterAgent({
+      apiBaseUrl: "https://api.example.com",
+      dashboardBaseUrl: "https://app.example.com",
+      name: "Gmail Retry Notify",
+      force: false,
+    });
+
+    const body = JSON.parse(String((fetchMock.mock.calls[0]![1] as RequestInit).body));
+    expect(body.twins).toEqual(["gmail"]);
+  });
+
+  it("unions the manifest twins with the --twins flag (server merges additively)", async () => {
+    await writeManifest({ agent: { slug: "triage-bot" }, twins: ["gmail"] });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(response(AGENT_OK));
+
+    await runRegisterAgent({
+      apiBaseUrl: "https://api.example.com",
+      dashboardBaseUrl: "https://app.example.com",
+      name: "Triage Bot",
+      force: false,
+      twins: ["slack"],
+    });
+
+    const body = JSON.parse(String((fetchMock.mock.calls[0]![1] as RequestInit).body));
+    expect(new Set(body.twins)).toEqual(new Set(["gmail", "slack"]));
+  });
+
   it("prints a Dashboard line deep-linking the registered agent's page", async () => {
     await writeManifest({ agent: { slug: "triage-bot" } });
     const errors: string[] = [];
@@ -409,5 +443,23 @@ describe("normalizeRegisterTwins", () => {
   });
   it("rejects an unknown twin against MOUNTED_TWINS", () => {
     expect(() => normalizeRegisterTwins("github,notion")).toThrow(/Unknown twin/);
+  });
+});
+
+describe("mergeRegisterTwins", () => {
+  it("returns manifest twins when no flag twins are given", () => {
+    expect(mergeRegisterTwins(["gmail"], undefined)).toEqual(["gmail"]);
+  });
+  it("returns flag twins when the manifest declares none", () => {
+    expect(mergeRegisterTwins(undefined, ["slack"])).toEqual(["slack"]);
+  });
+  it("unions and de-dupes both sources, normalizing manifest entries", () => {
+    expect(new Set(mergeRegisterTwins([" Gmail ", "github"], ["github", "slack"]))).toEqual(
+      new Set(["gmail", "github", "slack"]),
+    );
+  });
+  it("returns undefined when neither source contributes", () => {
+    expect(mergeRegisterTwins(undefined, undefined)).toBeUndefined();
+    expect(mergeRegisterTwins([" ", ""], [])).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

`pome register agent` and the run-path auto-create resolver both `POST /v1/agents` but only ever sent the `--twins` **flag**. A manifest declaring `twins: ["gmail"]` never reached the server, so the server's `github` default won — and the first `pome run` errored with `Requested twins are not enabled on agent '…': gmail`. This is an onboarding-funnel break for every curriculum example on a non-github twin (the cold-run walk).

Both POST sites now send the manifest's declared `twins`.

## What changed (`cli/`)

- **`project-config.ts`** — new `normalizeManifestTwins()` (trim + lowercase + de-dupe of `manifest.twins`); the shared normalizer for both POST paths. Manifest twins are normalized but not validated against `MOUNTED_TWINS` here — the schema keeps `twins` open and the server returns a friendly error for an unknown twin.
- **`register.ts`** — `runRegisterAgent` sends `mergeRegisterTwins(manifest.twins, --twins)` — the **union** of the manifest's twins and any flag additions. Union is correct because the server merges additively (there is no "reduce" to preserve), so re-register additively merges as required. The older-cloud "services not reported" warning now keys off the effective twins.
- **`agent-identity.ts`** — the register-on-first-run path (a fork / first `pome run` without explicit register auto-creates the agent) now also sends the manifest's twins. Safe/idempotent since the server merges additively.
- **`main.ts`** — `--twins` help text updated: unioned with the manifest; default is the manifest's twins, else the cloud default.

## Tests

`cli/test/unit/` — register carries manifest `twins` with no flag; flag ∪ manifest union; `mergeRegisterTwins` unit table; run-path re-resolve sends manifest twins. All three F-926 assertions were confirmed to go **red** when the wiring is reverted, then green after.

## Verification

- `npm run typecheck` — clean
- `npm run build` — clean
- Full unit suite — **647 passed**
- Patch changeset: `cli/.changeset/register-manifest-twins.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)