### PR TITLE
Let adapter examples pin options.model and log the resolved model

### DIFF
--- a/examples/pr-summary-agent/src/index.ts
+++ b/examples/pr-summary-agent/src/index.ts
@@ -76,6 +76,16 @@ summary comment.`;
 
 const TASK = process.env.POME_TASK?.trim() || DEFAULT_TASK;
 
+// Optional model override (F-928). When set, it is forwarded verbatim as the
+// Claude Agent SDK's `options.model`, which the SDK turns into the `claude`
+// CLI's `--model` flag. Omit it to run the CLI's own default model. Accepts an
+// alias (`haiku`, `sonnet`, `opus`) or a full id (`claude-haiku-4-5`). The
+// runtime can still override the request (subscription/OAuth login, or an
+// environment/gateway model pin), and the CLI does not error on an unknown id —
+// so this run logs the model the SDK actually resolved (the `system`/`init`
+// line below).
+const MODEL = process.env.POME_PR_SUMMARY_MODEL?.trim() || undefined;
+
 async function main() {
   const token = await resolveAuthToken();
 
@@ -106,6 +116,9 @@ async function main() {
         "Use the provided tools to enumerate open pull requests, then for each one read its metadata and base/head branch names, list the changed files, and read each changed file's content on BOTH the base and head branches to see what actually changed (file content is base64-encoded — decode it), then post exactly one summary comment. " +
         "Ground every statement in the actual file contents — never describe changes that are not present. Be concise and useful to a human reviewer. " +
         "Stop once every open pull request has a summary comment.",
+      // Only set `model` when overridden — omitting it lets the CLI pick its
+      // default, and setting it to `undefined` is not the same as omitting.
+      ...(MODEL ? { model: MODEL } : {}),
       permissionMode: "bypassPermissions",
       maxTurns: 30,
       allowedTools: tools.map((t) => t.name),
@@ -120,7 +133,14 @@ async function main() {
   try {
     for await (const msg of run) {
       thinking.reset();
-      if (msg.type === "assistant") {
+      if (msg.type === "system" && msg.subtype === "init") {
+        // Log the model the CLI actually resolved so a downshift (or a silent
+        // runtime override) is visible, never guessed (F-928).
+        console.log(
+          `model:    ${msg.model}` +
+            (MODEL ? ` (requested "${MODEL}")` : " (SDK default — no options.model set)")
+        );
+      } else if (msg.type === "assistant") {
         logAssistantMessage(msg);
       } else if (msg.type === "result") {
         if (msg.subtype === "success") {

--- a/examples/pr-summary-review/src/index.ts
+++ b/examples/pr-summary-review/src/index.ts
@@ -71,6 +71,16 @@ pull request has both a summary comment and a review verdict.`;
 
 const TASK = process.env.POME_TASK?.trim() || DEFAULT_TASK;
 
+// Optional model override (F-928). When set, it is forwarded verbatim as the
+// Claude Agent SDK's `options.model`, which the SDK turns into the `claude`
+// CLI's `--model` flag. Omit it to run the CLI's own default model. Accepts an
+// alias (`haiku`, `sonnet`, `opus`) or a full id (`claude-haiku-4-5`). The
+// runtime can still override the request (subscription/OAuth login, or an
+// environment/gateway model pin), and the CLI does not error on an unknown id —
+// so this run logs the model the SDK actually resolved (the `system`/`init`
+// line below).
+const MODEL = process.env.POME_PR_REVIEW_MODEL?.trim() || undefined;
+
 async function main() {
   const token = await resolveAuthToken();
 
@@ -104,6 +114,9 @@ async function main() {
         "Approve only changes that are clearly correct and low-risk. Request changes when the change contains a real defect, a removed safety check, a hardcoded secret, or another blocking problem. Use COMMENT when a human's judgment is needed but there is no clear blocker. " +
         "Ground every statement in the actual file contents — never describe changes that are not present. Never merge a pull request. " +
         "Stop once every open pull request has both a summary comment and a review verdict.",
+      // Only set `model` when overridden — omitting it lets the CLI pick its
+      // default, and setting it to `undefined` is not the same as omitting.
+      ...(MODEL ? { model: MODEL } : {}),
       permissionMode: "bypassPermissions",
       maxTurns: 40,
       allowedTools: tools.map((t) => t.name),
@@ -118,7 +131,14 @@ async function main() {
   try {
     for await (const msg of run) {
       thinking.reset();
-      if (msg.type === "assistant") {
+      if (msg.type === "system" && msg.subtype === "init") {
+        // Log the model the CLI actually resolved so a downshift (or a silent
+        // runtime override) is visible, never guessed (F-928).
+        console.log(
+          `model:    ${msg.model}` +
+            (MODEL ? ` (requested "${MODEL}")` : " (SDK default — no options.model set)")
+        );
+      } else if (msg.type === "assistant") {
         logAssistantMessage(msg);
       } else if (msg.type === "result") {
         if (msg.subtype === "success") {

--- a/examples/triage-agent/README.md
+++ b/examples/triage-agent/README.md
@@ -264,3 +264,28 @@ All optional. Defaults match `npx @pome-sh/cli twin start github`.
 | `POME_REPO_OWNER` / `POME_REPO_NAME` | `acme` / `api` | Override the default repo named in the bundled task. |
 | `TWIN_AUTH_SECRET` | — | The secret the twin was started with. Used to mint the JWT locally when `POME_AUTH_TOKEN` is unset. |
 | `POME_TRIAGE_BASELINE` | unset | Set to `1` to run the **vulnerable** prompt from the injection lesson (default is the hardened prompt). Under `pome run`, also add it to `POME_AGENT_ENV_ALLOWLIST` so it reaches the agent. |
+| `POME_TRIAGE_MODEL` | unset (CLI default) | Pin/downshift the model — an alias (`haiku`, `sonnet`, `opus`) or a full id (`claude-haiku-4-5`). Forwarded as the Agent SDK's `options.model`. Under `pome run`, also add it to `POME_AGENT_ENV_ALLOWLIST` so it reaches the agent. See [Pinning the model](#pinning-the-model). |
+
+### Pinning the model
+
+By default this example sets **no** model, so the Claude Agent SDK runs the
+`claude` CLI's own default (this is why the dashboard shows whatever the CLI
+picked — e.g. `sonnet` — not a model Pome chose). To pin or downshift it, set
+`POME_TRIAGE_MODEL`:
+
+```bash
+POME_TRIAGE_MODEL=claude-haiku-4-5 npm run start
+```
+
+The value is forwarded verbatim to `options.model` and becomes the CLI's
+`--model` flag. Two caveats, both surfaced by the `model:` line the run now
+prints on startup:
+
+- The **runtime** has the final say. A subscription/OAuth login, or an
+  environment/gateway model pin, can override your request.
+- An **unknown id does not error** — the CLI silently falls back to its default.
+
+So don't trust the value you passed; trust the `model:` line, which reports what
+the SDK actually resolved (it's the same `message.model` that feeds the
+dashboard's gen_ai spans). This is the resolution for
+[F-928](https://linear.app/pome-sh/issue/F-928).

--- a/examples/triage-agent/src/index.ts
+++ b/examples/triage-agent/src/index.ts
@@ -97,6 +97,18 @@ const BASELINE_TRUST =
 const USE_BASELINE = process.env.POME_TRIAGE_BASELINE === "1";
 const SYSTEM_PROMPT = SYSTEM_PROMPT_CORE + (USE_BASELINE ? BASELINE_TRUST : INJECTION_HARDENING);
 
+// Optional model override (F-928). When set, it is forwarded verbatim as the
+// Claude Agent SDK's `options.model`, which the SDK turns into the `claude`
+// CLI's `--model` flag. Omit it to run the CLI's own default model. Accepts an
+// alias (`haiku`, `sonnet`, `opus`) or a full id (`claude-haiku-4-5`).
+//
+// Caveat worth knowing: the value is forwarded, but the *runtime* has the final
+// say. A subscription/OAuth login, or an environment/gateway model pin, can
+// override it — and the CLI does not error on an unknown id, it silently falls
+// back. That is exactly why this run prints the model the SDK actually resolved
+// (the `system`/`init` line below): the running model is never a silent guess.
+const MODEL = process.env.POME_TRIAGE_MODEL?.trim() || undefined;
+
 async function main() {
   const token = await resolveAuthToken();
 
@@ -118,6 +130,9 @@ async function main() {
     prompt: TASK,
     options: {
       systemPrompt: SYSTEM_PROMPT,
+      // Only set `model` when overridden — omitting it lets the CLI pick its
+      // default, and setting it to `undefined` is not the same as omitting.
+      ...(MODEL ? { model: MODEL } : {}),
       permissionMode: "bypassPermissions",
       maxTurns: 25,
       allowedTools: tools.map((t) => t.name),
@@ -132,7 +147,15 @@ async function main() {
   try {
     for await (const msg of run) {
       thinking.reset();
-      if (msg.type === "assistant") {
+      if (msg.type === "system" && msg.subtype === "init") {
+        // The SDK's init message carries the model the CLI actually resolved —
+        // log it so a downshift (or a silent runtime override) is visible, never
+        // guessed (F-928).
+        console.log(
+          `model:    ${msg.model}` +
+            (MODEL ? ` (requested "${MODEL}")` : " (SDK default — no options.model set)")
+        );
+      } else if (msg.type === "assistant") {
         logAssistantMessage(msg);
       } else if (msg.type === "result") {
         if (msg.subtype === "success") {

--- a/packages/adapter-claude-sdk/src/query.ts
+++ b/packages/adapter-claude-sdk/src/query.ts
@@ -22,6 +22,17 @@ type HooksConfig = Partial<Record<HookEvent, HookCallbackMatcher[]>>;
  * User-supplied hooks in `params.options.hooks` are preserved — pome's
  * matchers are prepended per event so they fire alongside user callbacks.
  *
+ * Pinning the model: pass `params.options.model` (an alias like `"haiku"` /
+ * `"sonnet"` / `"opus"`, or a full id like `"claude-haiku-4-5"`). This wrapper
+ * forwards it verbatim to the upstream SDK, which passes it to the `claude` CLI
+ * as `--model`; omit it to run the CLI's default model. Note the wrapper only
+ * forwards the request — it cannot force the runtime to honor it. A
+ * subscription/OAuth login or an environment/gateway model pin can still
+ * override the choice, and the CLI does not error on an unknown id (it silently
+ * falls back). To see the model that actually ran, read `model` off the SDK's
+ * `system`/`init` message, or the per-turn `message.model` (both flow into the
+ * gen_ai spans and `LlmTurnEvent` this wrapper emits). See F-928.
+ *
  * v0: returns an AsyncGenerator, not the full `Query` interface — control
  * methods (`interrupt`, `setPermissionMode`, …) are not re-exposed yet. Use
  * the underlying SDK directly if you need them.


### PR DESCRIPTION
<!-- Closes F-928 -->

## What & why

Validating F-928 turned up that its premise is inaccurate for the pinned SDK: **`options.model` is not stripped by pome's code.** The adapter spreads params verbatim (only overriding `hooks`), and `@anthropic-ai/claude-agent-sdk` (example lockfile resolves 0.3.218) forwards `options.model` → the `claude` CLI's `--model` flag. I confirmed this empirically by pointing the SDK at a fake executable and capturing argv:

- `model:"haiku"` → `--model haiku`; `model:"claude-haiku-4-5"` → `--model claude-haiku-4-5`; a bogus id → passed through verbatim; omitted → no `--model`.

The "always Opus / bogus id runs clean" behavior originates in the **`claude` CLI subprocess / hosted runtime** (a subscription-OAuth login or an env/gateway model pin overrides the request, and the CLI does not error on an unknown id — it silently falls back). The adapter can forward the request but can't force the runtime to honor it, so `throw`/`warn` would be wrong. This also explains a "sonnet in the dashboard" sighting: the three Agent-SDK examples never set `options.model`, so they run the CLI default, and the dashboard shows `message.model` from the stream — the model that actually ran. It's the Agent SDK path (local `claude` CLI subprocess), not Cloud Managed Agents.

## Changes (examples + adapter JSDoc only)

Since the value *is* forwarded, the fix makes pinning **demonstrable** and the running model **visible**:

- `triage-agent`, `pr-summary-agent`, `pr-summary-review`: optional `POME_TRIAGE_MODEL` / `POME_PR_SUMMARY_MODEL` / `POME_PR_REVIEW_MODEL` env → forwarded as `options.model` (omit → CLI default; `undefined` ≠ omitting).
- Each run logs the model the SDK actually resolved (the `system`/`init` message's `model`): `model: <resolved> (requested "<x>")` or `(SDK default — no options.model set)`.
- `query()` JSDoc + `triage-agent/README.md` document the supported pinning path and the runtime-override / unknown-id-no-error caveats.

## Verification

- End-to-end run against a stream-json fake CLI: `POME_TRIAGE_MODEL=claude-haiku-4-5` → `--model claude-haiku-4-5` → logged `model: claude-haiku-4-5 (requested ...)`; omitted → CLI default, labeled as such.
- `npm run typecheck:examples` — all 7 examples clean.
- `npm run smoke:examples` — all 7 boot, no TDZ.
- Adapter typecheck clean.

No changeset — examples + adapter JSDoc only, no shipped package behavior change.