### PR TITLE
Run artifacts speak "task": latest.json `task`, verdict.json `task_path`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,9 +28,16 @@ live at **https://docs.pome.sh**.
   (`./tasks/`), and the internal runner/schema surface (`src/task/`, `runTask*`,
   the `Task` type, `parseTask`, `taskSchema`). `pome scenarios` survives only as
   a hidden deprecated alias. The ONLY remaining sanctioned survivors are the
-  serialized `scenario` / `scenario_*` keys — the run-artifact `scenario` key and
-  the finalize/result wire fields (server contract; flip with W3/FDRS-653) — and
-  the in-memory carriers whose value flows straight into them.
+  serialized `scenario` / `scenario_*` keys that have a contract behind them —
+  `meta.json`'s `scenario` slug (uploaded to cloud finalize; also read back by
+  `pome eval` / `pome inspect` from run dirs older CLIs wrote) and the
+  finalize / result / compile-seed wire fields (server contract; flip with
+  W3/FDRS-653) — and the in-memory carriers whose value flows straight into
+  them. F-933 renamed the two artifact keys that had no such contract:
+  `runs/latest.json` now writes `task` (was `scenario`) and
+  `runs/<task>/<session>/verdict.json` writes `task_path` (was
+  `scenario_path`); the verdict READ path still accepts `scenario_path` so
+  `pome fix-prompt` can read trials recorded by `@pome-sh/cli` <= 0.8.x.
 - **The CLI (`cli/`) is not a root workspace** — use `cd cli && npm ...`, not
   `npm run -w` from the root.
 - **`cli/pnpm-workspace.yaml` is not pnpm** — it is only the changesets/manypkg

--- a/cli/.changeset/task-artifact-keys.md
+++ b/cli/.changeset/task-artifact-keys.md
@@ -1,0 +1,5 @@
+---
+"@pome-sh/cli": minor
+---
+
+Run artifacts now speak "task", not the retired "scenario": `runs/latest.json` records the task slug under `task` (was `scenario`), and each trial's `verdict.json` records `task_path` (was `scenario_path`, next to the already-correct `task_name`). Scripts reading `latest.json` for `run_dir`/`run_id` are unaffected; anything reading the `scenario` key must switch to `task`. `pome fix-prompt` still reads `verdict.json` files written by earlier CLI versions — the old `scenario_path` spelling is accepted on read.

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -802,7 +802,7 @@ export function createProgram() {
             // documented exit codes. Anything else falls through to Commander
             // (treated like self-host).
             try {
-              // FDRS-636 — effective trial count: -n wins, else the scenario
+              // FDRS-636 — effective trial count: -n wins, else the task
               // config's `runs` field (both capped at 20). k>1 takes the
               // trial-group path; k=1 stays EXACTLY the single-run path
               // below (no group is ever stamped for it).
@@ -1081,7 +1081,7 @@ export function createProgram() {
       "Assemble a paste-into-IDE fix prompt (no LLM call, no network). With no args, reads the latest FAILED run set under ./runs: the persisted cloud verdicts (verdict.json) become grouped failure signatures over the raw traces, in one prompt. Point it at a trial run dir to target that set, or use the legacy `<events.jsonl> <task.md>` form for a single trace.",
     )
     .action(async (target?: string, taskArg?: string) => {
-      // Legacy 2-arg form: <events.jsonl> <scenario.md> — unchanged
+      // Legacy 2-arg form: <events.jsonl> <task.md> — unchanged
       // (CAPTURE-ONLY, FDRS-657: raw trace + declared criteria, no verdict).
       if (target !== undefined && target.endsWith(".jsonl")) {
         if (!taskArg) {
@@ -1091,7 +1091,7 @@ export function createProgram() {
           process.exitCode = 5;
           return;
         }
-        const [eventsRaw, scenario] = await Promise.all([
+        const [eventsRaw, task] = await Promise.all([
           readFile(resolve(target), "utf8"),
           parseTaskFile(resolve(taskArg)),
         ]);
@@ -1100,7 +1100,7 @@ export function createProgram() {
           .map((line) => line.trim())
           .filter((line) => line.length > 0)
           .map((line) => JSON.parse(line) as RecorderEvent);
-        console.log(buildFixPrompt({ events, scenario }));
+        console.log(buildFixPrompt({ events, task }));
         return;
       }
       if (taskArg !== undefined) {
@@ -1131,13 +1131,13 @@ export function createProgram() {
         return;
       }
       const set = discovery.set;
-      let scenario: Task | null = null;
+      let task: Task | null = null;
       try {
-        scenario = await parseTaskFile(resolve(set.taskPath));
+        task = await parseTaskFile(resolve(set.taskPath));
       } catch {
         // Task file moved/edited since the run — the prompt degrades to the
         // verdict-embedded criteria.
-        scenario = null;
+        task = null;
       }
       const trials: TrialFixInput[] = [];
       for (const [idx, t] of set.trials.entries()) {
@@ -1152,7 +1152,7 @@ export function createProgram() {
         buildGroupFixPrompt({
           taskName: set.taskName,
           groupId: set.groupId,
-          scenario,
+          task,
           trials,
         }),
       );

--- a/cli/src/fix-prompt/index.ts
+++ b/cli/src/fix-prompt/index.ts
@@ -4,7 +4,7 @@
 // (FDRS-657). CAPTURE-ONLY: no LLM/judge call happens here. The former BYOK
 // CLI-side judge call (`callJudge`) that generated the handoff was removed;
 // this now returns the fully-assembled prompt (system instructions + the
-// scenario's criteria + the captured trace) for the developer to paste into
+// task's criteria + the captured trace) for the developer to paste into
 // their own coding assistant.
 
 import {
@@ -16,7 +16,7 @@ import {
 } from "./prompt.js";
 
 /**
- * Build the paste-into-IDE fix prompt from the raw trace + the scenario's
+ * Build the paste-into-IDE fix prompt from the raw trace + the task's
  * criteria. PURE + synchronous — no network, no LLM, no local judge.
  *
  * The output is a complete prompt: the system instructions (how to write the

--- a/cli/src/fix-prompt/prompt.ts
+++ b/cli/src/fix-prompt/prompt.ts
@@ -269,7 +269,7 @@ export function buildGroupFixUserPrompt(ctx: GroupFixPromptContext): string {
       ) as string);
   const promptBlock = ctx.scenario
     ? (redactSecrets(ctx.scenario.prompt) as string)
-    : `(task file not found at ${ctx.trials[0]?.verdict.scenario_path ?? "?"} — criteria above come from the cloud verdicts)`;
+    : `(task file not found at ${ctx.trials[0]?.verdict.task_path ?? "?"} — criteria above come from the cloud verdicts)`;
 
   const sections: string[] = [];
   sections.push(`## Run set (cloud-judged)

--- a/cli/src/fix-prompt/prompt.ts
+++ b/cli/src/fix-prompt/prompt.ts
@@ -3,7 +3,7 @@
 // Assembles the paste-into-IDE fix prompt for a failed run (FDRS-657).
 //
 // CAPTURE-ONLY: the OSS CLI does NOT call an LLM here. `pome fix-prompt`
-// assembles a self-contained prompt — system instructions + the scenario's
+// assembles a self-contained prompt — system instructions + the task's
 // criteria + the raw captured trace — and prints it so the developer can paste
 // it into THEIR own coding assistant (Cursor / Claude Code). The former BYOK
 // local-judge call that generated the handoff CLI-side was removed under
@@ -53,7 +53,7 @@ export function escapeTagContent(text: string): string {
 
 export interface FixPromptContext {
   events: RecorderEvent[];
-  scenario: Task;
+  task: Task;
 }
 
 function truncateBody(body: unknown): unknown {
@@ -102,10 +102,10 @@ function renderCriteria(criteria: Criterion[]): string {
 }
 
 export function buildFixUserPrompt(ctx: FixPromptContext): string {
-  const criteria = redactSecrets(renderCriteria(ctx.scenario.criteria)) as string;
+  const criteria = redactSecrets(renderCriteria(ctx.task.criteria)) as string;
   const trace = renderEvents(ctx.events.map((event) => redactEvent(event)));
-  const taskTitle = redactSecrets(ctx.scenario.title) as string;
-  const taskPrompt = redactSecrets(ctx.scenario.prompt) as string;
+  const taskTitle = redactSecrets(ctx.task.title) as string;
+  const taskPrompt = redactSecrets(ctx.task.prompt) as string;
 
   return `## Task
 ${taskTitle}
@@ -144,7 +144,7 @@ export interface GroupFixPromptContext {
   groupId: string | null;
   /** Parsed task file when it still resolves. Null degrades the prompt to
    *  the verdict-embedded criteria (the file may have moved since the run). */
-  scenario: Task | null;
+  task: Task | null;
   /** Completed trials of the run set (verdict.json present), run order. */
   trials: TrialFixInput[];
 }
@@ -257,8 +257,8 @@ export function buildGroupFixUserPrompt(ctx: GroupFixPromptContext): string {
   const signatures = redactSecrets(
     renderGroupedSignatures(ctx.trials),
   ) as string;
-  const criteriaBlock = ctx.scenario
-    ? (redactSecrets(renderCriteria(ctx.scenario.criteria)) as string)
+  const criteriaBlock = ctx.task
+    ? (redactSecrets(renderCriteria(ctx.task.criteria)) as string)
     : (redactSecrets(
         renderCriteria(
           (ctx.trials[0]?.verdict.criteria_results ?? []).map((r) => ({
@@ -267,8 +267,8 @@ export function buildGroupFixUserPrompt(ctx: GroupFixPromptContext): string {
           })) as Criterion[],
         ),
       ) as string);
-  const promptBlock = ctx.scenario
-    ? (redactSecrets(ctx.scenario.prompt) as string)
+  const promptBlock = ctx.task
+    ? (redactSecrets(ctx.task.prompt) as string)
     : `(task file not found at ${ctx.trials[0]?.verdict.task_path ?? "?"} — criteria above come from the cloud verdicts)`;
 
   const sections: string[] = [];

--- a/cli/src/hosted/evalResultCache.ts
+++ b/cli/src/hosted/evalResultCache.ts
@@ -35,9 +35,9 @@ export interface VerdictArtifact {
   /** Provenance: the only writer is the /finalize response path. */
   source: "cloud-finalize";
   task_name: string;
-  /** The scenario path as the run invocation saw it (may move later —
-   *  readers must tolerate a dangling path). */
-  scenario_path: string;
+  /** The task path as the run invocation saw it (may move later — readers
+   *  must tolerate a dangling path). */
+  task_path: string;
   /** Shared trial-group id (`grp_` + nanoid21); null on single runs. */
   group_id: string | null;
   session_id: string;
@@ -69,19 +69,32 @@ export async function writeVerdictArtifact(
   );
 }
 
+/** F-933 — the on-disk shape, which may predate the `scenario_path` →
+ *  `task_path` rename. `@pome-sh/cli` <= 0.8.x wrote `scenario_path`; unlike
+ *  latest.json (rewritten by every run), verdict.json files accumulate under
+ *  runs/ and outlive a CLI upgrade, so the READ path accepts either spelling
+ *  and normalizes to `task_path` before anything downstream sees it. The
+ *  WRITE path emits `task_path` only. Drop the legacy branch once pre-0.9 run
+ *  dirs are no longer worth reading. */
+type OnDiskVerdictArtifact = Omit<VerdictArtifact, "task_path"> & {
+  task_path?: string;
+  /** Retired pre-F-933 spelling of `task_path`. */
+  scenario_path?: string;
+};
+
 /** Read one trial's verdict.json. Returns null when absent or when the file
  *  isn't a recognizable verdict artifact (foreign/corrupt files are skipped,
  *  never thrown on — fix-prompt discovery must survive a messy runs/). */
 /** Every field the fix-prompt pipeline dereferences must hold its declared
  *  shape, or the FILE is rejected — discovery treats a half-recognizable
  *  verdict.json as foreign rather than crashing downstream on it. */
-function isVerdictArtifact(parsed: unknown): parsed is VerdictArtifact {
+function isVerdictArtifact(parsed: unknown): parsed is OnDiskVerdictArtifact {
   if (typeof parsed !== "object" || parsed === null) return false;
   const v = parsed as Record<string, unknown>;
   if (v.source !== "cloud-finalize") return false;
   if (typeof v.session_id !== "string") return false;
   if (typeof v.task_name !== "string") return false;
-  if (typeof v.scenario_path !== "string") return false;
+  if (typeof v.task_path !== "string" && typeof v.scenario_path !== "string") return false;
   if (v.group_id !== null && typeof v.group_id !== "string") return false;
   if (typeof v.finalized_at !== "string") return false;
   if (typeof v.passed !== "boolean") return false;
@@ -102,6 +115,14 @@ function isVerdictArtifact(parsed: unknown): parsed is VerdictArtifact {
   });
 }
 
+/** F-933 — collapse the legacy `scenario_path` onto `task_path` so callers
+ *  only ever deal with one spelling. Validation ran first, so at least one of
+ *  the two is a string. */
+function normalizeVerdictArtifact(parsed: OnDiskVerdictArtifact): VerdictArtifact {
+  const { scenario_path: legacyPath, task_path: taskPath, ...rest } = parsed;
+  return { ...rest, task_path: taskPath ?? legacyPath! };
+}
+
 export async function readVerdictArtifact(
   runDir: string,
 ): Promise<TrialVerdict | null> {
@@ -115,7 +136,7 @@ export async function readVerdictArtifact(
   try {
     const parsed: unknown = JSON.parse(raw);
     if (!isVerdictArtifact(parsed)) return null;
-    return { runDir, verdict: parsed };
+    return { runDir, verdict: normalizeVerdictArtifact(parsed) };
   } catch {
     return null;
   }
@@ -154,7 +175,7 @@ export interface RunSet {
   /** null = a single run that never had a group. */
   groupId: string | null;
   taskName: string;
-  /** The scenario path recorded at run time (first trial's). */
+  /** The task path recorded at run time (first trial's). */
   taskPath: string;
   /** Trials sorted by finalized_at ascending. */
   trials: TrialVerdict[];
@@ -181,7 +202,7 @@ export function groupRunSets(trials: TrialVerdict[]): RunSet[] {
     sets.push({
       groupId: bucket[0]!.verdict.group_id,
       taskName: bucket[0]!.verdict.task_name,
-      taskPath: bucket[0]!.verdict.scenario_path,
+      taskPath: bucket[0]!.verdict.task_path,
       trials: bucket,
       latestFinalizedAt: last.verdict.finalized_at,
       anyFailed: bucket.some((t) => !t.verdict.passed),

--- a/cli/src/recorder/artifacts.ts
+++ b/cli/src/recorder/artifacts.ts
@@ -100,9 +100,16 @@ export async function writeRunArtifactsCore(input: RunArtifactCoreInput): Promis
   await writeJson(join(runDir, "state_final.json"), input.stateFinal);
   await writeFile(join(runDir, "stdout.txt"), redactText(input.stdout));
   await writeFile(join(runDir, "stderr.log"), redactText(input.stderr));
+  // F-933 — `task`, not `scenario`. latest.json is a purely local pointer:
+  // every run overwrites it and its only readers are `pome eval` / `pome
+  // inspect`, which dereference `run_dir`/`run_id`. Nothing on the wire and
+  // nothing in the cloud parses it, so the rename needs no compat window.
+  // meta.json's `scenario` key is deliberately NOT renamed here — that one is
+  // uploaded to cloud finalize and read back out of older run dirs (see
+  // AGENTS.md's sanctioned-survivor list).
   await writeJson(join(input.artifactsDir, "latest.json"), {
     run_id: input.runId,
-    scenario: input.scenario.slug,
+    task: input.scenario.slug,
     run_dir: runDir
   });
 
@@ -112,7 +119,7 @@ export async function writeRunArtifactsCore(input: RunArtifactCoreInput): Promis
 export async function readLatestRun(artifactsDir: string) {
   const latestPath = join(artifactsDir, "latest.json");
   if (!existsSync(latestPath)) return undefined;
-  return JSON.parse(await readFile(latestPath, "utf8")) as { run_id: string; scenario: string; run_dir: string };
+  return JSON.parse(await readFile(latestPath, "utf8")) as { run_id: string; task: string; run_dir: string };
 }
 
 export type RunMetaSummary = {

--- a/cli/src/runner/runTaskHosted.ts
+++ b/cli/src/runner/runTaskHosted.ts
@@ -660,7 +660,7 @@ export async function runTaskHosted(
         version: VERDICT_ARTIFACT_VERSION,
         source: "cloud-finalize",
         task_name: scenario.slug,
-        scenario_path: options.taskPath,
+        task_path: options.taskPath,
         group_id: options.groupId ?? null,
         session_id: session.session_id,
         cloud_run_id: finalized.run_id,

--- a/cli/test/unit/fix-prompt-command.test.ts
+++ b/cli/test/unit/fix-prompt-command.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // FDRS-644 — `pome fix-prompt` command surface:
-//   - legacy 2-arg form (<events.jsonl> <scenario.md>) is unchanged;
-//   - an events.jsonl target without a scenario is a usage error (exit 5);
+//   - legacy 2-arg form (<events.jsonl> <task.md>) is unchanged;
+//   - an events.jsonl target without a task file is a usage error (exit 5);
 //   - a second argument with a dir target is a usage error (exit 5);
 //   - 0-arg reads ./runs and emits the latest FAILED run set's grouped
 //     prompt; all-green roots print "nothing to fix" (exit 0); empty roots
@@ -19,7 +19,7 @@ import {
   type VerdictArtifact,
 } from "../../src/hosted/evalResultCache.js";
 
-const SCENARIO =
+const TASK_MD =
   "# scn\n\n## Prompt\nTriage the bug.\n\n## Success Criteria\n- [model] Severity is set correctly\n";
 
 const EVENT =
@@ -95,7 +95,7 @@ describe("pome fix-prompt command (FDRS-644)", () => {
   it("legacy 2-arg form is unchanged", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fixcmd-legacy-"));
     await writeFile(join(dir, "events.jsonl"), EVENT, "utf8");
-    await writeFile(join(dir, "scn.md"), SCENARIO, "utf8");
+    await writeFile(join(dir, "scn.md"), TASK_MD, "utf8");
     await run(join(dir, "events.jsonl"), join(dir, "scn.md"));
 
     expect(process.exitCode ?? 0).toBe(0);
@@ -104,7 +104,7 @@ describe("pome fix-prompt command (FDRS-644)", () => {
     expect(text).toContain("Severity is set correctly");
   });
 
-  it("an events.jsonl target without a scenario is a usage error", async () => {
+  it("an events.jsonl target without a task file is a usage error", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fixcmd-usage-"));
     await writeFile(join(dir, "events.jsonl"), EVENT, "utf8");
     await run(join(dir, "events.jsonl"));
@@ -138,8 +138,8 @@ describe("pome fix-prompt command (FDRS-644)", () => {
         },
       ],
     });
-    await mkdir(join(dir, "scenarios"), { recursive: true });
-    await writeFile(join(dir, "scenarios", "scn.md"), SCENARIO, "utf8");
+    await mkdir(join(dir, "tasks"), { recursive: true });
+    await writeFile(join(dir, "tasks", "scn.md"), TASK_MD, "utf8");
     process.chdir(dir);
 
     await run();
@@ -149,6 +149,9 @@ describe("pome fix-prompt command (FDRS-644)", () => {
     expect(text).toContain("under-rated");
     expect(text).toContain("1 of 2 completed trials passed");
     expect(text).toContain("## Variance note");
+    // The on-disk task file must match the verdict's `task_path`, or this
+    // whole test silently exercises the degraded (file-missing) branch.
+    expect(text).not.toContain("task file not found");
   });
 
   it("all-green roots print nothing-to-fix (exit 0)", async () => {

--- a/cli/test/unit/fix-prompt-command.test.ts
+++ b/cli/test/unit/fix-prompt-command.test.ts
@@ -30,7 +30,7 @@ function verdict(over: Partial<VerdictArtifact>): VerdictArtifact {
     version: VERDICT_ARTIFACT_VERSION,
     source: "cloud-finalize",
     task_name: "scn",
-    scenario_path: "scenarios/scn.md",
+    task_path: "tasks/scn.md",
     group_id: "grp_cmd",
     session_id: "ses_1",
     cloud_run_id: "run_1",

--- a/cli/test/unit/fix-prompt-group.test.ts
+++ b/cli/test/unit/fix-prompt-group.test.ts
@@ -61,7 +61,7 @@ function trial(
   return { label: `trial ${n} · ses_${n}`, runDir: `runs/scn/ses_${n}`, verdict, events };
 }
 
-const scenario: Task = {
+const task: Task = {
   slug: "scn",
   title: "scn",
   setup: "",
@@ -118,7 +118,7 @@ describe("run-set fix prompt (FDRS-644)", () => {
     const prompt = buildGroupFixUserPrompt({
       taskName: "scn",
       groupId: "grp_test",
-      scenario,
+      task,
       trials: mixedTrials(),
     });
 
@@ -143,7 +143,7 @@ describe("run-set fix prompt (FDRS-644)", () => {
     const prompt = buildGroupFixUserPrompt({
       taskName: "scn",
       groupId: "grp_test",
-      scenario,
+      task,
       trials,
     });
     expect(prompt).toContain("## Trace of the most-failing trial (trial 2 · ses_2)");
@@ -156,7 +156,7 @@ describe("run-set fix prompt (FDRS-644)", () => {
     const prompt = buildGroupFixUserPrompt({
       taskName: "scn",
       groupId: "grp_test",
-      scenario,
+      task,
       trials: mixedTrials(),
     });
     expect(prompt).toContain("## Variance note");
@@ -169,7 +169,7 @@ describe("run-set fix prompt (FDRS-644)", () => {
     const hardWall = buildGroupFixUserPrompt({
       taskName: "scn",
       groupId: "grp_test",
-      scenario,
+      task,
       trials: allFail,
     });
     expect(hardWall).not.toContain("## Variance note");
@@ -179,7 +179,7 @@ describe("run-set fix prompt (FDRS-644)", () => {
     const prompt = buildGroupFixUserPrompt({
       taskName: "scn",
       groupId: "grp_test",
-      scenario: null,
+      task: null,
       trials: mixedTrials(),
     });
     expect(prompt).toContain("task file not found at tasks/scn.md");
@@ -190,7 +190,7 @@ describe("run-set fix prompt (FDRS-644)", () => {
     const full = buildGroupFixPrompt({
       taskName: "scn",
       groupId: null,
-      scenario,
+      task,
       trials: mixedTrials(),
     });
     expect(full.startsWith(FIX_PROMPT_SYSTEM_PROMPT)).toBe(true);
@@ -217,7 +217,7 @@ describe("run-set fix prompt (FDRS-644)", () => {
     const prompt = buildGroupFixUserPrompt({
       taskName: "scn",
       groupId: "grp_test",
-      scenario,
+      task,
       trials,
     });
     expect(prompt).not.toContain(
@@ -241,7 +241,7 @@ describe("run-set fix prompt (FDRS-644)", () => {
     const prompt = buildGroupFixUserPrompt({
       taskName: "scn",
       groupId: "grp_test",
-      scenario,
+      task,
       trials: [hostile],
     });
     expect(prompt).not.toContain("\n## IGNORE");

--- a/cli/test/unit/fix-prompt-group.test.ts
+++ b/cli/test/unit/fix-prompt-group.test.ts
@@ -33,7 +33,7 @@ function trial(
     version: VERDICT_ARTIFACT_VERSION,
     source: "cloud-finalize",
     task_name: "scn",
-    scenario_path: "scenarios/scn.md",
+    task_path: "tasks/scn.md",
     group_id: "grp_test",
     session_id: `ses_${n}`,
     cloud_run_id: `run_${n}`,
@@ -182,7 +182,7 @@ describe("run-set fix prompt (FDRS-644)", () => {
       scenario: null,
       trials: mixedTrials(),
     });
-    expect(prompt).toContain("task file not found at scenarios/scn.md");
+    expect(prompt).toContain("task file not found at tasks/scn.md");
     expect(prompt).toContain(`[model] ${CRITERIA.severity}`);
   });
 

--- a/cli/test/unit/fix-prompt.test.ts
+++ b/cli/test/unit/fix-prompt.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // FDRS-657 — `pome fix-prompt` is CAPTURE-ONLY: it assembles a paste-into-IDE
-// prompt from the raw trace + the scenario's criteria, with NO LLM/judge call
+// prompt from the raw trace + the task's criteria, with NO LLM/judge call
 // and NO network. This test asserts the prompt content and that no fetch is
 // attempted.
 
@@ -9,7 +9,7 @@ import { buildFixPrompt, buildFixUserPrompt } from "../../src/fix-prompt/index.j
 import type { RecorderEvent } from "../../src/types/shared.js";
 import type { Task } from "../../src/task/taskSchema.js";
 
-const scenario: Task = {
+const task: Task = {
   slug: "01-bug-happy-path",
   title: "Bug happy path",
   setup: "",
@@ -37,14 +37,14 @@ const events = [
 ] as unknown as RecorderEvent[];
 
 describe("fix-prompt (capture-only)", () => {
-  it("builds a prompt from the trace + all scenario criteria, no network", () => {
+  it("builds a prompt from the trace + all task criteria, no network", () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
 
-    const out = buildFixPrompt({ events, scenario });
+    const out = buildFixPrompt({ events, task });
 
     // System instructions are prepended.
     expect(out).toContain("You are a senior engineer");
-    // The scenario prompt + every criterion are included (no verdict needed).
+    // The task prompt + every criterion are included (no verdict needed).
     expect(out).toContain("Triage the incoming bug and label it.");
     expect(out).toContain("[code] The issue is labeled `bug`");
     expect(out).toContain("[model] The agent left a helpful triage comment");
@@ -58,7 +58,7 @@ describe("fix-prompt (capture-only)", () => {
   });
 
   it("lists criteria as 'had to satisfy', not a local pass/fail verdict", () => {
-    const user = buildFixUserPrompt({ events, scenario });
+    const user = buildFixUserPrompt({ events, task });
     expect(user).toContain("## Criteria the run had to satisfy");
     expect(user).not.toMatch(/\bpassed\b|\bfailed\b|judge confidence/);
   });

--- a/cli/test/unit/hosted/evalResultCache.test.ts
+++ b/cli/test/unit/hosted/evalResultCache.test.ts
@@ -4,7 +4,7 @@
 // and the fix-prompt discovery semantics (trial dir → its set regardless of
 // outcome; root → latest failed set). Foreign/corrupt files never throw.
 
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -25,7 +25,7 @@ function verdict(over: Partial<VerdictArtifact>): VerdictArtifact {
     version: VERDICT_ARTIFACT_VERSION,
     source: "cloud-finalize",
     task_name: "scn",
-    scenario_path: "scenarios/scn.md",
+    task_path: "tasks/scn.md",
     group_id: null,
     session_id: "ses_x",
     cloud_run_id: "run_x",
@@ -81,6 +81,40 @@ describe("verdict artifact (FDRS-644)", () => {
     expect(await readVerdictArtifact(foreign)).toBeNull();
 
     expect(await readVerdictArtifact(join(tmp, "scn", "nope"))).toBeNull();
+  });
+
+  it("writes `task_path` and still reads pre-F-933 `scenario_path` trials (normalized)", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "verdict-legacy-"));
+
+    // Write path: the retired spelling never lands on disk again.
+    const fresh = join(tmp, "scn", "ses_new");
+    await mkdir(fresh, { recursive: true });
+    await writeVerdictArtifact(fresh, verdict({ session_id: "ses_new" }));
+    const onDisk = JSON.parse(
+      await readFile(join(fresh, "verdict.json"), "utf8"),
+    ) as Record<string, unknown>;
+    expect(onDisk.task_path).toBe("tasks/scn.md");
+    expect(onDisk).not.toHaveProperty("scenario_path");
+
+    // Read path: a run dir written by cli <= 0.8.x still resolves, and the
+    // legacy key is surfaced to callers as `task_path`.
+    const legacyDir = join(tmp, "scn", "ses_old");
+    await mkdir(legacyDir, { recursive: true });
+    const { task_path: _tp, ...withoutTaskPath } = verdict({ session_id: "ses_old" });
+    await writeFile(
+      join(legacyDir, "verdict.json"),
+      JSON.stringify({ ...withoutTaskPath, scenario_path: "scenarios/scn.md" }),
+      "utf8",
+    );
+    const legacy = await readVerdictArtifact(legacyDir);
+    expect(legacy?.verdict.task_path).toBe("scenarios/scn.md");
+    expect(groupRunSets([legacy!])[0]!.taskPath).toBe("scenarios/scn.md");
+
+    // Neither spelling present → still foreign.
+    const neither = join(tmp, "scn", "ses_none");
+    await mkdir(neither, { recursive: true });
+    await writeFile(join(neither, "verdict.json"), JSON.stringify(withoutTaskPath), "utf8");
+    expect(await readVerdictArtifact(neither)).toBeNull();
   });
 
   it("rejects half-recognizable files instead of crashing downstream (adversarial fix)", async () => {

--- a/cli/test/unit/recorder/artifacts.test.ts
+++ b/cli/test/unit/recorder/artifacts.test.ts
@@ -301,4 +301,35 @@ describe("writeRunArtifactsCore — file-set contract (F-689 / D6)", () => {
     expect(Object.keys(meta.twin_versions)).toEqual(["github"]);
     expect(meta.twin_versions.github).toMatch(/^\d+\.\d+\.\d+/);
   });
+
+  it("latest.json names the task under `task`, never `scenario` (F-933)", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pome-art-"));
+    const task = fakeTask();
+    const runId = "run_test_latest";
+
+    await writeRunArtifactsCore({
+      artifactsDir: root,
+      runId,
+      scenario: task,
+      startedAt: "2026-05-26T11:59:59.000Z",
+      completedAt: "2026-05-26T12:00:02.000Z",
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+      events: [],
+      stateInitial: {},
+      stateFinal: {},
+    });
+
+    const latest = JSON.parse(await readFile(join(root, "latest.json"), "utf8")) as Record<
+      string,
+      unknown
+    >;
+    expect(latest).toEqual({
+      run_id: runId,
+      task: task.slug,
+      run_dir: join(root, task.slug, runId),
+    });
+    expect(latest).not.toHaveProperty("scenario");
+  });
 });


### PR DESCRIPTION
<!-- Closes F-933 -->

Executive summary: two user-visible CLI run artifacts still carried the retired "scenario" vocabulary, so a first `pome run` taught the old word at the exact moment the quickstart teaches the new one. `runs/latest.json` now writes `task`, and each trial's `verdict.json` writes `task_path`. Neither key has a contract behind it, but they differ in one way that matters: `verdict.json` files outlive a CLI upgrade, so the read path still accepts the old spelling.

## What

- `runs/latest.json`: `scenario` → `task`
- `runs/<task>/<session>/verdict.json`: `scenario_path` → `task_path` (beside its already-correct `task_name`)
- second commit: `pome fix-prompt`'s in-memory context field `scenario` → `task` — internal only; the package publishes a `bin`, no library exports
- `AGENTS.md`'s sanctioned-survivor list now names `meta.json`'s `scenario` key precisely instead of blanket-covering "the run-artifact `scenario` key"

## Why

The CLI's command surface was swept to "task" earlier; these two artifact keys were missed. Users read them, and any CI script parsing `latest.json` reads them, so they kept teaching the retired word right where the docs teach the new one.

## Notes for reviewer

Two artifacts, two different compat decisions — that asymmetry is the substance of the PR:

- **`latest.json` — straight rename, no compat.** Every run overwrites it, and all five readers (`pome eval`, `pome inspect`, and three repo scripts) only dereference `run_dir`/`run_id`. No consumer outside this repo reads it.
- **`verdict.json` — write new, read either.** These files accumulate under `runs/` and survive a CLI upgrade, and the reader *rejects* any file missing the path key. A straight rename would have silently hidden pre-upgrade trials from `pome fix-prompt` (it would just say "nothing to fix"). `OnDiskVerdictArtifact` + `normalizeVerdictArtifact` accept either spelling on read; only `task_path` is ever written. The legacy branch can go once pre-0.9 run dirs stop being worth reading.

`meta.json`'s `scenario` key is deliberately untouched — it ships with the trace and is read back out of older run dirs by `pome eval` / `pome inspect`. Flipping it stays gated on the separate contract change.

Also worth confirming I drew the boundary right: I left `scenario_path` in the compile-seed request body (a `/v1` wire field) and the runner's in-memory `scenario` carriers whose value flows into `meta.json`.

The second commit also fixes a fixture drift the first one introduced: the command test's verdict fixture moved to `task_path: "tasks/scn.md"` while the test still wrote the task file to `scenarios/scn.md`, so its assertions silently exercised the degraded "task file not found" branch. Now pinned with an assertion.

## Tests

- `cli/`: `npm test` → 691 passed / 81 files; `npm run typecheck` clean; `lint-code-health` and `no-eval-in-oss` gates pass.
- Exercised on the real binary, not only in unit tests: built the CLI, scaffolded a project, `pome run <task> --local` → `latest.json` came out with `"task"`, and `grep -rn scenario runs/` found only `meta.json`'s key. `pome inspect latest` still resolves.
- Hand-wrote a pre-rename `verdict.json` (legacy `scenario_path`) into a run dir: `pome fix-prompt` discovered it and, because the normalized `task_path` resolved, rendered the full prompt instead of the degraded branch. The legacy 2-arg form was checked too.

Changeset: `minor` — a user-visible artifact key rename.