### PR TITLE
fix(cli): compile-seeds preserves seeds it did not author

### DIFF
--- a/cli/.changeset/compile-seeds-preserve-hand-authored.md
+++ b/cli/.changeset/compile-seeds-preserve-hand-authored.md
@@ -1,0 +1,7 @@
+---
+"@pome-sh/cli": patch
+---
+
+`pome compile-seeds` no longer overwrites seeds it did not author. Sidecars marked `"model": "hand-authored"` (or `"source_hash": "sha256:hand-authored"`) are now an explicit skip, reported as `keep … hand-authored seed left untouched`. Previously the sentinel could never equal a real sha256, so the cache check always missed and the seed was silently recompiled — rewriting the adversarial setups the starter tasks depend on (a backdoored PR, a fabricated green CI status, an exfiltration lure) while the run still reported normally. The skip outranks `--force`, since it states authorship rather than staleness; delete the sidecar or drop its `_meta` to recompile.
+
+Tasks naming another twin alongside `github` are now skipped too. Their seed is a per-twin envelope (`{ github: {...}, slack: {...} }`) and the compiler only emits a flat `github` seed, so compiling one replaced the envelope and dropped the other twin's half — reachable today via the six `examples/minimal-viktor-langgraph` tasks, whose envelopes carry no `_meta` to protect them.

--- a/cli/src/cli/compile-seeds.ts
+++ b/cli/src/cli/compile-seeds.ts
@@ -20,6 +20,18 @@ import { exitCodeFor } from "../hosted/errors.js";
 
 const SIDECAR_META_VERSION = 1;
 
+/**
+ * Sidecars written by hand rather than by the compiler mark themselves with
+ * this sentinel. It is a statement of provenance, not a cache state: the seeds
+ * that carry it encode adversarial setups (a backdoored PR, a fabricated green
+ * CI status, an exfiltration lure) that a recompile would quietly rewrite,
+ * changing what the task tests while the run still reports normally. So it
+ * outranks even `--force`; to recompile one, delete the sidecar or drop its
+ * `_meta` first.
+ */
+const HAND_AUTHORED_MARKER = "hand-authored";
+const HAND_AUTHORED_SOURCE_HASH = `sha256:${HAND_AUTHORED_MARKER}`;
+
 interface CompileOptions {
   force: boolean;
   hosted: boolean;
@@ -28,7 +40,14 @@ interface CompileOptions {
 
 interface FileResult {
   path: string;
-  status: "compiled" | "skipped-cached" | "skipped-no-seed" | "skipped-unsupported-twin" | "skipped-inline-json" | "error";
+  status:
+    | "compiled"
+    | "skipped-cached"
+    | "skipped-hand-authored"
+    | "skipped-no-seed"
+    | "skipped-unsupported-twin"
+    | "skipped-inline-json"
+    | "error";
   message?: string;
   inputTokens?: number;
   outputTokens?: number;
@@ -80,15 +99,20 @@ async function compileOne(taskPath: string, opts: CompileOptions): Promise<FileR
     return { path: taskPath, status: "skipped-no-seed", message: "no ## Seed State section" };
   }
 
-  // Stripe scenarios use a different schema; v1 only supports github. Check
-  // twin first so Stripe scenarios are silently skipped without surfacing
-  // misleading "still on inline JSON" warnings.
+  // Other twins use a different schema; v1 only emits a flat github seed. Check
+  // twin first so those tasks are silently skipped without surfacing misleading
+  // "still on inline JSON" warnings.
+  //
+  // A task naming github *alongside* another twin is seeded from a per-twin
+  // envelope (`{ github: {...}, linear: {...} }`), so compiling it would replace
+  // the envelope with a github-only seed and drop the other twin's half.
   const twins = readTwinsFromConfig(markdown);
-  if (twins.length > 0 && !twins.includes("github")) {
+  const githubOnly = twins.length === 1 && twins[0] === "github";
+  if (twins.length > 0 && !githubOnly) {
     return {
       path: taskPath,
       status: "skipped-unsupported-twin",
-      message: `twins=${twins.join(",")} not supported yet`
+      message: `twins=${twins.join(",")} — only single-twin github tasks are supported yet`
     };
   }
 
@@ -105,6 +129,17 @@ async function compileOne(taskPath: string, opts: CompileOptions): Promise<FileR
 
   const sidecarPath = sidecarPathFor(taskPath);
   const proseHash = hashProse(seedText);
+
+  // Checked ahead of `--force` and ahead of the cache: this is authorship, not
+  // staleness. The sentinel can never equal a real sha256, so without this the
+  // cache always misses and the hand-authored seed is silently overwritten.
+  if (existsSync(sidecarPath) && (await isHandAuthored(sidecarPath))) {
+    return {
+      path: taskPath,
+      status: "skipped-hand-authored",
+      message: `hand-authored seed left untouched (${sidecarPath}) — delete it or drop its _meta to recompile`
+    };
+  }
 
   // Cache check only applies to local compile — hosted callers may have
   // different model versions than the locally-pinned COMPILER_MODEL, and the
@@ -219,6 +254,23 @@ async function readSidecarMeta(path: string): Promise<{ source_hash: string; mod
   }
 }
 
+/**
+ * Deliberately more lenient than `sidecarMetaSchema`: a hand-edited sidecar may
+ * carry only the sentinel and omit `version`/`compiled_at`. Failing that parse
+ * would fall through to a recompile — the exact overwrite this guards against —
+ * so any `_meta` bearing either sentinel field counts.
+ */
+async function isHandAuthored(path: string): Promise<boolean> {
+  try {
+    const raw = await readFile(path, "utf8");
+    const meta = (JSON.parse(raw) as { _meta?: { source_hash?: unknown; model?: unknown } })._meta;
+    if (!meta) return false;
+    return meta.model === HAND_AUTHORED_MARKER || meta.source_hash === HAND_AUTHORED_SOURCE_HASH;
+  } catch {
+    return false;
+  }
+}
+
 async function resolveTaskFiles(target: string): Promise<string[]> {
   const abs = resolve(target);
   if (!existsSync(abs)) throw new Error(`Path not found: ${target}`);
@@ -234,6 +286,8 @@ function statusStamp(status: FileResult["status"]): string {
       return "OK  ";
     case "skipped-cached":
       return "skip";
+    case "skipped-hand-authored":
+      return "keep";
     case "skipped-no-seed":
       return "skip";
     case "skipped-unsupported-twin":

--- a/cli/test/unit/compile-seeds.test.ts
+++ b/cli/test/unit/compile-seeds.test.ts
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * `pome compile-seeds` must never destroy a seed it did not author.
+ *
+ * The starter library ships adversarial seeds (a backdoored PR, a green-but-
+ * fabricated CI status, an exfiltration lure) that were written by hand
+ * precisely because a compiler cannot be trusted to reproduce them. Those files
+ * mark themselves with a `hand-authored` sentinel in `_meta`. Recompiling one
+ * changes what the exam tests while the run still reports normally, so the
+ * corruption is silent — hence these tests assert byte-identity, not just
+ * "looks about right".
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// Keep COMPILER_MODEL real — the cache contract compares against it, so a
+// hardcoded copy here would silently rot if the pinned model changes.
+vi.mock("../../src/task/seed-compiler.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/task/seed-compiler.js")>();
+  return {
+    ...actual,
+    compileSeed: vi.fn(async () => ({
+      seed: {
+        repositories: [
+          {
+            owner: "acme",
+            name: "api",
+            labels: [{ name: "bug" }],
+            collaborators: ["alice"],
+            issues: [{ number: 1, title: "recompiled", body: "recompiled", labels: [], assignee: null }],
+          },
+        ],
+      },
+      model: COMPILER_MODEL,
+      inputTokens: 10,
+      outputTokens: 20,
+      durationMs: 30,
+    })),
+  };
+});
+
+import { runCompileSeeds } from "../../src/cli/compile-seeds.js";
+import { compileSeed, COMPILER_MODEL } from "../../src/task/seed-compiler.js";
+
+const OPTS = { force: false, hosted: false, apiBaseUrl: "https://api.pome.sh" };
+
+function taskMarkdown(prose: string, twins = "[github]"): string {
+  return `# Fixture task
+
+## Prompt
+
+Triage issue #1.
+
+## Success Criteria
+
+- [code] Stub criterion
+
+## Seed State
+
+${prose}
+
+## Config
+
+\`\`\`yaml
+twins: ${twins}
+passThreshold: 100
+\`\`\`
+`;
+}
+
+const HAND_AUTHORED_SIDECAR = JSON.stringify(
+  {
+    _meta: {
+      version: 1,
+      source_hash: "sha256:hand-authored",
+      model: "hand-authored",
+      compiled_at: "2026-06-02T00:00:00.000Z",
+    },
+    repositories: [
+      {
+        owner: "acme",
+        name: "api",
+        labels: [{ name: "bug" }],
+        collaborators: ["alice"],
+        issues: [
+          { number: 1, title: "carefully staged", body: "adversarial setup", labels: [], assignee: null },
+        ],
+      },
+    ],
+  },
+  null,
+  2,
+) + "\n";
+
+/** Writes a task + sidecar pair into a fresh tmpdir and returns their paths. */
+async function fixture(sidecar: string, prose = "One repo, acme/api, with a single open bug.", twins = "[github]") {
+  const dir = await mkdtemp(join(tmpdir(), "pome-compile-seeds-"));
+  const mdPath = join(dir, "task.md");
+  const sidecarPath = join(dir, "task.seed.json");
+  await writeFile(mdPath, taskMarkdown(prose, twins));
+  await writeFile(sidecarPath, sidecar);
+  return { dir, mdPath, sidecarPath };
+}
+
+describe("compile-seeds hand-authored protection", () => {
+  let stderr: string[];
+
+  beforeEach(() => {
+    stderr = [];
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      stderr.push(args.map(String).join(" "));
+    });
+    vi.mocked(compileSeed).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("leaves a hand-authored sidecar byte-identical", async () => {
+    const { dir, sidecarPath } = await fixture(HAND_AUTHORED_SIDECAR);
+
+    const code = await runCompileSeeds(dir, OPTS);
+
+    expect(code).toBe(0);
+    expect(await readFile(sidecarPath, "utf8")).toBe(HAND_AUTHORED_SIDECAR);
+  });
+
+  it("does not invoke the compiler for a hand-authored sidecar", async () => {
+    const { dir } = await fixture(HAND_AUTHORED_SIDECAR);
+
+    await runCompileSeeds(dir, OPTS);
+
+    expect(compileSeed).not.toHaveBeenCalled();
+  });
+
+  it("reports hand-authored as its own status, not a generic cache skip", async () => {
+    const { dir } = await fixture(HAND_AUTHORED_SIDECAR);
+
+    await runCompileSeeds(dir, OPTS);
+
+    expect(stderr.join("\n")).toMatch(/hand-authored/);
+  });
+
+  it("still refuses to overwrite a hand-authored sidecar under --force", async () => {
+    const { dir, sidecarPath } = await fixture(HAND_AUTHORED_SIDECAR);
+
+    await runCompileSeeds(dir, { ...OPTS, force: true });
+
+    expect(await readFile(sidecarPath, "utf8")).toBe(HAND_AUTHORED_SIDECAR);
+    expect(compileSeed).not.toHaveBeenCalled();
+  });
+
+  it("treats a partial _meta carrying the sentinel as hand-authored", async () => {
+    // A hand-edited sidecar may omit `version`/`compiled_at`; the sentinel is
+    // still an unambiguous statement of provenance and must be honoured.
+    const partial = JSON.stringify({ _meta: { model: "hand-authored" }, repositories: [] }, null, 2) + "\n";
+    const { dir, sidecarPath } = await fixture(partial);
+
+    await runCompileSeeds(dir, OPTS);
+
+    expect(await readFile(sidecarPath, "utf8")).toBe(partial);
+    expect(compileSeed).not.toHaveBeenCalled();
+  });
+
+  it("skips a task needing twins beyond github rather than flattening its envelope", async () => {
+    // Multi-twin tasks carry a per-twin envelope ({github: {...}, linear: {...}}).
+    // The v1 compiler only emits a flat github seed, so compiling one would
+    // silently drop the other twin's half.
+    const envelope = JSON.stringify({ github: { repositories: [] }, linear: { teams: [] } }, null, 2) + "\n";
+    const { dir, sidecarPath } = await fixture(envelope, "A github repo and a linear team.", '["github", "linear"]');
+
+    await runCompileSeeds(dir, OPTS);
+
+    expect(await readFile(sidecarPath, "utf8")).toBe(envelope);
+    expect(compileSeed).not.toHaveBeenCalled();
+  });
+});
+
+describe("compile-seeds cache behaviour is preserved", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(compileSeed).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("skips a genuinely compiler-authored sidecar whose prose is unchanged", async () => {
+    const { dir, sidecarPath } = await fixture("(placeholder — overwritten by the first run)");
+
+    // First run writes real compiler provenance...
+    await runCompileSeeds(dir, { ...OPTS, force: true });
+    expect(compileSeed).toHaveBeenCalledTimes(1);
+    const compiled = await readFile(sidecarPath, "utf8");
+    expect(compiled).toContain(`"model": "${COMPILER_MODEL}"`);
+
+    // ...and the second run hits the cache instead of recompiling.
+    await runCompileSeeds(dir, OPTS);
+
+    expect(compileSeed).toHaveBeenCalledTimes(1);
+    expect(await readFile(sidecarPath, "utf8")).toBe(compiled);
+  });
+
+  it("recompiles a compiler-authored sidecar when the prose changes", async () => {
+    const { dir, mdPath } = await fixture("(placeholder — overwritten by the first run)");
+    await runCompileSeeds(dir, { ...OPTS, force: true });
+    expect(compileSeed).toHaveBeenCalledTimes(1);
+
+    await writeFile(mdPath, taskMarkdown("Two repos now, acme/api and acme/web."));
+    await runCompileSeeds(dir, OPTS);
+
+    expect(compileSeed).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
<!-- Closes F-987 -->

Executive summary: `pome compile-seeds` silently overwrote seeds it did not write. Two independent paths led there, and both are reachable by a first-run user following the published docs — the sentinel that marks a hand-authored seed can never satisfy the cache check, and the twin gate let multi-twin tasks through to a compiler that can only emit a flat `github` seed. Both destroy the adversarial setup a task exists to test while the run still reports normally, so the corruption is silent. Reviewers should focus on one judgment call: the hand-authored skip now outranks `--force`.

## What

- `_meta` carrying `"model": "hand-authored"` (or `"source_hash": "sha256:hand-authored"`) is now an explicit skip with its own status, printed as `keep … hand-authored seed left untouched — delete it or drop its _meta to recompile`.
- The twin gate now requires `github` to be the *only* twin. It previously skipped a task only when `github` was absent, so `twins: [github, slack]` compiled.
- New `cli/test/unit/compile-seeds.test.ts` (8 tests); changeset added. No production behaviour outside `compile-seeds.ts` changes.

## Why

A cache hit required `cached.source_hash === hashProse(prose)`. The literal `"sha256:hand-authored"` is not a sha256, so the comparison could never be true — guaranteed miss, LLM re-invoked, sidecar overwritten. Ten of the nineteen sidecars in `cli/tasks/` carry that sentinel, and they encode setups their tasks depend on: a backdoored PR, a fabricated green CI status, an exfiltration lure. Recompiling one changes what the exam tests while the score still looks normal.

The multi-twin case is the same failure with a different trigger, found while fixing the first. Those tasks are seeded from a per-twin envelope (`{ github: {...}, slack: {...} }`), so compiling one replaced the envelope with a github-only seed and dropped the other twin's half.

## Notes for reviewer

**The one judgment call: hand-authored outranks `--force`.** The flag's own help text is *"Recompile even if the sidecar's source hash matches"* — it says the hash is stale, not "discard my hand-written work". Without this ordering, running `--force` over a directory to refresh a few stale compiler seeds still destroys every hand-authored one alongside them. The escape hatch is explicit and local: delete the sidecar, or drop its `_meta`. Easy to flip if you disagree.

**The multi-twin gate is not theoretical.** The six `examples/minimal-viktor-langgraph` tasks are `twins: [github, slack]` with prose `## Seed State` sections, and their envelopes carry **no `_meta` at all** — so the sentinel fix alone would not have saved them. Verified against a scratch copy: with the fix stashed all six reached the compiler (`FAIL … compile failed: ANTHROPIC_API_KEY is not set`); with it applied all six skip.

**Sentinel detection is deliberately more lenient than `sidecarMetaSchema`.** A hand-edited `_meta` may omit `version`/`compiled_at`; failing that strict parse would fall through to a recompile, which is the exact overwrite being guarded against.

Deliberately left alone, to keep the diff to the defect: the now-dead prose `## Seed State` in those ten files, and `--hosted` targeting a control-plane endpoint that no longer exists.

## Tests / CI

- `npx vitest run test/unit` → **657 passed (67 files)**; `npm run typecheck` clean.
- The 8 new tests were written first and watched fail; the envelope case failed by printing `{github, linear}` flattened to github-only. Two of the eight assert the existing cache still works — those passed *before* the fix, which is what shows compilation was not simply disabled.
- End-to-end, with **no `ANTHROPIC_API_KEY` set** so anything still reaching the compiler fails loudly rather than overwriting: `compile-seeds cli/tasks` compiles nothing, exits 0, and leaves `git status --porcelain cli/tasks/` empty.

## Review required

Yes — changes the semantics of a shipped CLI flag (`--force` no longer overrides a hand-authored sidecar) and adds a skip path that suppresses compilation for multi-twin tasks.