### PR TITLE
Skill evidence lives outside the published docs tree

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -44,7 +44,11 @@ This directory in `pome-sh/digital-twins` is the canonical home of the coach
 skill set (decided 2026-07-22, F-850); it versions with the repo. Copies
 elsewhere (e.g. the pome-cloud docs site) are mirrors or pointers. Historical
 test evidence (fixtures, kept e2e transcripts) stays in the pome-cloud repo
-under `apps/docs/docs/skills/`.
+under `docs/agents/skill-evidence/` — deliberately *outside* `apps/docs/`, because
+Mintlify publishes every markdown file under that root whether or not the nav
+lists it, so evidence parked there rendered as public pages on `docs.pome.sh`
+(moved 2026-07-27, F-996 follow-up). Each directory there is named for what the
+skill was called when its evidence was produced, so two keep pre-rename names.
 
 The Gen-1 CLI-era skills `pome-setup` / `pome-test` (once installed by the
 `pome skills install` command, and injected by `pome install`) were **retired at


### PR DESCRIPTION
Executive summary: The `skills/README.md` pointer to the historical test-evidence archive was stale. The archive moved out of the pome-cloud Mintlify content root, because Mintlify publishes every markdown file under that root whether or not the navigation lists it — so internal e2e transcripts and examinee system prompts were rendering as public pages on `docs.pome.sh`. This is a one-paragraph docs fix that records the new path and the reason, so it does not drift back.

## What

`skills/README.md` — the "Source of truth" section now points the evidence archive at `docs/agents/skill-evidence/` in pome-cloud instead of `apps/docs/docs/skills/`, and says why it must stay outside `apps/docs/`. Also notes that archive directories are named for what a skill was called when its evidence was produced, so two of them keep pre-rename names.

## Why

The old path was inside the Mintlify content root. Confirmed empirically before moving:

```
curl -sL docs.pome.sh/docs/skills/pome-verify-seed/e2e/transcript-deep-check
→ 200,  <title>Transcript deep check - Pome</title>
```

A real rendered page, not a soft-404 — the title was derived from the filename, and the file has no frontmatter and no nav entry. Internal evidence is not documentation, so it moved. The decision this README records ("evidence stays in the pome-cloud repo") is unchanged; only the path within that repo changed.

## Notes for reviewer

**Ordering:** the destination path is created by the matching pome-cloud PR. Land this one after that merges, or the README points at a directory that does not exist yet. Nothing reads this path programmatically in either repo, so a brief window is harmless either way.

## Tests / CI

Docs-only, one file, no code paths touched. No local suite applies.