### PR TITLE
fix(adapter-claude-sdk): span-lane input tokens are the OTel-semconv total

### DIFF
--- a/packages/adapter-claude-sdk/src/genai-spans.ts
+++ b/packages/adapter-claude-sdk/src/genai-spans.ts
@@ -77,9 +77,9 @@ function totalInputTokens(usage: Record<string, unknown>): number | null {
 export async function* withGenAiSpans<T extends WithType>(
   source: AsyncIterable<T>,
 ): AsyncGenerator<T, void, unknown> {
-  // Boundary marking the start of the current turn. Initialized when iteration
-  // begins; advanced after every yielded message so each assistant span spans
-  // only the gap since the previous message.
+  // Boundary marking the start of the next turn. Initialized when iteration
+  // begins; advanced after every yielded message, so a turn's span starts at
+  // the message yielded before its first content block.
   let turnStartMs = Date.now();
   let pending: PendingTurn | null = null;
 

--- a/packages/adapter-claude-sdk/src/genai-spans.ts
+++ b/packages/adapter-claude-sdk/src/genai-spans.ts
@@ -3,13 +3,24 @@
 // withGenAiSpans — stream wrapper that turns the SDK message stream into
 // `gen_ai` OTLP spans (see otel.ts for the why and the wire contract).
 //
-// One CLIENT span per assistant turn: every `assistant` message that carries
-// `message.usage` is one LLM round-trip, so it becomes one span tagged with the
-// model and that turn's input/output tokens. The span window is approximated
-// from message timing — start = the moment we began awaiting this turn (the
-// previous yielded message), end = now — which yields real p50/p95 latency
+// One CLIENT span per API turn, tagged with the model and that turn's
+// input/output tokens. The span window is approximated from message timing —
+// start = the moment we began awaiting this turn (the previous yielded
+// message), end = the turn's last message — which yields real p50/p95 latency
 // samples for the rollup without needing per-call API timings the SDK doesn't
 // surface per turn.
+//
+// A turn is NOT an `assistant` message. One API turn may arrive as several
+// `assistant` messages sharing a `message.id`, one per content block (thinking,
+// text, tool_use), and every one of them repeats the SAME `usage` object. So we
+// accumulate by `message.id` and emit a single span when the turn closes — on
+// the next turn, on `result`, or on stream end. Emitting per message would
+// multiply the turn's cache-token counts by its content-block count (F-994: a
+// live 5-turn run over-reported its input total by 79%).
+//
+// The id check is deliberately against the turn being accumulated rather than
+// every id ever seen: a resumed session can legitimately replay a message id,
+// and that is a real second turn, not a duplicate block.
 //
 // On the terminal `result` message we `await flushPomeTelemetry()` BEFORE
 // yielding it, so all spans are exported before the agent's loop ends and it
@@ -22,12 +33,45 @@ type WithType = { type?: string };
 
 type AssistantLike = {
   type: "assistant";
-  message?: { model?: unknown; usage?: unknown };
+  message?: { id?: unknown; model?: unknown; usage?: unknown };
   error?: unknown;
 };
 
+/** One API turn being accumulated across its content-block messages. */
+interface PendingTurn {
+  /** `message.id`, or null when the message carried none (then never merged). */
+  id: string | null;
+  model: string | null;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  startTimeMs: number;
+  endTimeMs: number;
+  isError: boolean;
+}
+
 function asNumber(v: unknown): number | null {
   return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+/**
+ * The OTel-semconv `gen_ai.usage.input_tokens`: the TOTAL input for the turn.
+ *
+ * Anthropic's `usage.input_tokens` counts only the tokens that missed the
+ * cache — the cached prefix is reported separately in `cache_read_input_tokens`
+ * and `cache_creation_input_tokens`. Claude Code keeps a cache breakpoint at the
+ * tail of the prompt, so on a cached run the raw field is a ~2-token constant
+ * and essentially the whole prompt lives in the two cache fields.
+ *
+ * Each component is read defensively: absent or null contributes 0. Returns
+ * null only when the turn reported no input at all, so a usage-less assistant
+ * message is still recognised as "not a completed round-trip".
+ */
+function totalInputTokens(usage: Record<string, unknown>): number | null {
+  const uncached = asNumber(usage.input_tokens);
+  const cacheRead = asNumber(usage.cache_read_input_tokens);
+  const cacheCreation = asNumber(usage.cache_creation_input_tokens);
+  if (uncached == null && cacheRead == null && cacheCreation == null) return null;
+  return (uncached ?? 0) + (cacheRead ?? 0) + (cacheCreation ?? 0);
 }
 
 export async function* withGenAiSpans<T extends WithType>(
@@ -37,31 +81,62 @@ export async function* withGenAiSpans<T extends WithType>(
   // begins; advanced after every yielded message so each assistant span spans
   // only the gap since the previous message.
   let turnStartMs = Date.now();
+  let pending: PendingTurn | null = null;
 
-  for await (const msg of source) {
-    if (msg.type === "assistant") {
-      const a = msg as AssistantLike & WithType;
-      const usage = (a.message?.usage ?? {}) as Record<string, unknown>;
-      const inputTokens = asNumber(usage.input_tokens);
-      const outputTokens = asNumber(usage.output_tokens);
-      // Only a turn that reported usage is a real, completed LLM round-trip.
-      if (inputTokens != null || outputTokens != null) {
-        recordGenAiSpan({
-          model: typeof a.message?.model === "string" ? a.message.model : null,
-          inputTokens,
-          outputTokens,
-          startTimeMs: turnStartMs,
-          endTimeMs: Date.now(),
-          isError: a.error != null,
-        });
+  function closeTurn(): void {
+    if (!pending) return;
+    recordGenAiSpan({
+      model: pending.model,
+      inputTokens: pending.inputTokens,
+      outputTokens: pending.outputTokens,
+      startTimeMs: pending.startTimeMs,
+      endTimeMs: pending.endTimeMs,
+      isError: pending.isError,
+    });
+    pending = null;
+  }
+
+  try {
+    for await (const msg of source) {
+      if (msg.type === "assistant") {
+        const a = msg as AssistantLike & WithType;
+        const usage = (a.message?.usage ?? {}) as Record<string, unknown>;
+        const inputTokens = totalInputTokens(usage);
+        const outputTokens = asNumber(usage.output_tokens);
+        // Only a turn that reported usage is a real, completed LLM round-trip.
+        if (inputTokens != null || outputTokens != null) {
+          const id = typeof a.message?.id === "string" ? a.message.id : null;
+          if (pending && id != null && pending.id === id) {
+            // Another content block of the turn already being accumulated: the
+            // usage is a repeat, so only widen the window and keep any error.
+            pending.endTimeMs = Date.now();
+            pending.isError ||= a.error != null;
+          } else {
+            closeTurn();
+            pending = {
+              id,
+              model: typeof a.message?.model === "string" ? a.message.model : null,
+              inputTokens,
+              outputTokens,
+              startTimeMs: turnStartMs,
+              endTimeMs: Date.now(),
+              isError: a.error != null,
+            };
+          }
+        }
+      } else if (msg.type === "result") {
+        // Drain the exporter before the final message escapes to the agent's
+        // loop, which exits the process right after.
+        closeTurn();
+        await flushPomeTelemetry();
       }
-    } else if (msg.type === "result") {
-      // Drain the exporter before the final message escapes to the agent's
-      // loop, which exits the process right after.
-      await flushPomeTelemetry();
-    }
 
-    yield msg;
-    turnStartMs = Date.now();
+      yield msg;
+      turnStartMs = Date.now();
+    }
+  } finally {
+    // A stream that ends without a `result` — error, abort, or a consumer that
+    // breaks out of its loop — must not swallow the turn still accumulating.
+    closeTurn();
   }
 }

--- a/packages/adapter-claude-sdk/src/turn-usage.ts
+++ b/packages/adapter-claude-sdk/src/turn-usage.ts
@@ -4,10 +4,11 @@
 // assistant turn into the signals JSONL (see signals.ts for the single-writer
 // contract). It is the JSONL source-of-truth counterpart to the OTLP
 // `withGenAiSpans` lane (genai-spans.ts): both use the SAME turn detection —
-// every `assistant` message carrying `message.usage` is one LLM round-trip —
-// but this lane also captures the cache-read / cache-creation token counts and
-// `finish_reasons` that the OTLP side-lane drops, and it never reaches the
-// OTLP exporter, so the two lanes stay independent (the OTLP lane is untouched).
+// one API turn, accumulated by `message.id` (F-994; see that file for why a
+// turn is not an `assistant` message) — but this lane keeps the cache-read /
+// cache-creation counts and `finish_reasons` as distinct fields where the OTLP
+// lane folds the cache counts into one semconv input total, and it never
+// reaches the OTLP exporter, so the two lanes stay independent.
 //
 // The span window is approximated from message timing exactly as genai-spans.ts
 // does — start = the moment we began awaiting this turn (the previous yielded
@@ -26,8 +27,22 @@ type WithType = { type?: string };
 
 type AssistantLike = {
   type: "assistant";
-  message?: { model?: unknown; usage?: unknown; stop_reason?: unknown };
+  message?: { id?: unknown; model?: unknown; usage?: unknown; stop_reason?: unknown };
 };
+
+/** One API turn being accumulated across its content-block messages. */
+interface PendingTurn {
+  /** `message.id`, or null when the message carried none (then never merged). */
+  id: string | null;
+  model: string | null;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  cacheReadTokens: number | null;
+  cacheCreationTokens: number | null;
+  stopReason: string | null;
+  startTimeMs: number;
+  endTimeMs: number;
+}
 
 function asNumber(v: unknown): number | null {
   return typeof v === "number" && Number.isFinite(v) ? v : null;
@@ -47,37 +62,74 @@ export async function* withTurnUsage<T extends WithType>(
   // 0-based counter, per this query() stream. Advances only for turns that
   // actually reported usage (a usage-less assistant message is not a turn).
   let turnIndex = 0;
+  let pending: PendingTurn | null = null;
 
-  for await (const msg of source) {
-    if (msg.type === "assistant") {
-      const a = msg as AssistantLike & WithType;
-      const usage = (a.message?.usage ?? {}) as Record<string, unknown>;
-      const inputTokens = asNumber(usage.input_tokens);
-      const outputTokens = asNumber(usage.output_tokens);
-      // Only a turn that reported usage is a real, completed LLM round-trip.
-      if (inputTokens != null || outputTokens != null) {
-        const stopReason = asString(a.message?.stop_reason);
-        writeLlmTurnEvent({
-          ts: new Date().toISOString(),
-          event_id: newEventId(),
-          parent_id: null,
-          kind: "LlmTurnEvent",
-          turn_index: turnIndex,
-          model: asString(a.message?.model),
-          input_tokens: inputTokens,
-          output_tokens: outputTokens,
-          cache_read_input_tokens: asNumber(usage.cache_read_input_tokens),
-          cache_creation_input_tokens: asNumber(usage.cache_creation_input_tokens),
-          finish_reasons: stopReason != null ? [stopReason] : null,
-          latency_ms: Math.max(0, Date.now() - turnStartMs),
-          latency_ms_estimated: true,
-          session_id: null,
-        });
-        turnIndex += 1;
+  function closeTurn(): void {
+    if (!pending) return;
+    writeLlmTurnEvent({
+      ts: new Date().toISOString(),
+      event_id: newEventId(),
+      parent_id: null,
+      kind: "LlmTurnEvent",
+      turn_index: turnIndex,
+      model: pending.model,
+      input_tokens: pending.inputTokens,
+      output_tokens: pending.outputTokens,
+      cache_read_input_tokens: pending.cacheReadTokens,
+      cache_creation_input_tokens: pending.cacheCreationTokens,
+      finish_reasons: pending.stopReason != null ? [pending.stopReason] : null,
+      latency_ms: Math.max(0, pending.endTimeMs - pending.startTimeMs),
+      latency_ms_estimated: true,
+      session_id: null,
+    });
+    turnIndex += 1;
+    pending = null;
+  }
+
+  try {
+    for await (const msg of source) {
+      if (msg.type === "assistant") {
+        const a = msg as AssistantLike & WithType;
+        const usage = (a.message?.usage ?? {}) as Record<string, unknown>;
+        const inputTokens = asNumber(usage.input_tokens);
+        const outputTokens = asNumber(usage.output_tokens);
+        // Only a turn that reported usage is a real, completed LLM round-trip.
+        if (inputTokens != null || outputTokens != null) {
+          const id = asString(a.message?.id);
+          const stopReason = asString(a.message?.stop_reason);
+          if (pending && id != null && pending.id === id) {
+            // Another content block of the turn already being accumulated: the
+            // usage is a repeat, so only widen the window and take a stop
+            // reason if this block is the one that finally carries it.
+            pending.endTimeMs = Date.now();
+            if (stopReason != null) pending.stopReason = stopReason;
+          } else {
+            closeTurn();
+            pending = {
+              id,
+              model: asString(a.message?.model),
+              inputTokens,
+              outputTokens,
+              cacheReadTokens: asNumber(usage.cache_read_input_tokens),
+              cacheCreationTokens: asNumber(usage.cache_creation_input_tokens),
+              stopReason,
+              startTimeMs: turnStartMs,
+              endTimeMs: Date.now(),
+            };
+          }
+        }
+      } else if (msg.type === "result") {
+        // Land the last turn before the terminal message escapes to the agent's
+        // loop — the pome CLI reads the signals file as soon as it returns.
+        closeTurn();
       }
-    }
 
-    yield msg;
-    turnStartMs = Date.now();
+      yield msg;
+      turnStartMs = Date.now();
+    }
+  } finally {
+    // A stream that ends without a `result` — error, abort, or a consumer that
+    // breaks out of its loop — must not swallow the turn still accumulating.
+    closeTurn();
   }
 }

--- a/packages/adapter-claude-sdk/src/turn-usage.ts
+++ b/packages/adapter-claude-sdk/src/turn-usage.ts
@@ -11,8 +11,9 @@
 // reaches the OTLP exporter, so the two lanes stay independent.
 //
 // The span window is approximated from message timing exactly as genai-spans.ts
-// does — start = the moment we began awaiting this turn (the previous yielded
-// message), end = now — so `latency_ms` is an estimate and every M1 row is
+// does — start = the moment we began awaiting this turn (the message yielded
+// before its first content block), end = the turn's last content block — so
+// `latency_ms` is an estimate and every M1 row is
 // stamped `latency_ms_estimated: true` (the SDK surfaces no per-call API
 // timing). `turn_index` is 0-based per `query()` stream. `parent_id` and
 // `session_id` are null in M1.

--- a/packages/adapter-claude-sdk/test/genaiSpans.test.ts
+++ b/packages/adapter-claude-sdk/test/genaiSpans.test.ts
@@ -91,6 +91,26 @@ async function drive(messages: Array<{ type: string; [k: string]: unknown }>): P
   for await (const _ of withGenAiSpans(src())) void _;
 }
 
+type ExportedSpan = { name: string; attributes: Array<{ key: string; value: Record<string, unknown> }> };
+
+// Every span the collector received, across all export requests.
+function collectSpans(): ExportedSpan[] {
+  const spans: ExportedSpan[] = [];
+  for (const c of captured) {
+    const rs = ((c.body as { resourceSpans?: unknown[] }).resourceSpans ?? []) as Array<Record<string, unknown>>;
+    for (const r of rs) {
+      for (const ss of (r.scopeSpans ?? []) as Array<{ spans?: unknown[] }>) {
+        for (const s of (ss.spans ?? []) as ExportedSpan[]) spans.push(s);
+      }
+    }
+  }
+  return spans;
+}
+
+function inputTokensOf(span: ExportedSpan): number {
+  return Number(flattenAttrs(span.attributes)["gen_ai.usage.input_tokens"]);
+}
+
 describe("withGenAiSpans → OTLP/JSON export", () => {
   it("emits a gen_ai span per assistant turn with token usage, then flushes on result", async () => {
     await drive([
@@ -178,5 +198,109 @@ describe("withGenAiSpans → OTLP/JSON export", () => {
     ]);
 
     expect(captured.length).toBe(0);
+  });
+});
+
+// F-994. Anthropic's `usage.input_tokens` counts only the tokens that missed the
+// cache; OTel semconv 1.27+ defines `gen_ai.usage.input_tokens` as the TOTAL.
+// The usage objects below are verbatim from a live Opus run (see the probe
+// evidence on the ticket) — Claude Code keeps a cache breakpoint at the tail of
+// the prompt, so the uncached residue is a constant 2 and the real input sits in
+// the two cache fields.
+describe("withGenAiSpans → gen_ai.usage.input_tokens is the semconv total", () => {
+  it("sums input_tokens + cache_read + cache_creation", async () => {
+    await drive([
+      {
+        type: "assistant",
+        message: {
+          id: "msg_01",
+          model: "claude-opus-4-8",
+          usage: {
+            input_tokens: 2,
+            output_tokens: 31,
+            cache_read_input_tokens: 15000,
+            cache_creation_input_tokens: 3000,
+          },
+        },
+      },
+      { type: "result", subtype: "success" },
+    ]);
+
+    const spans = collectSpans();
+    expect(spans.length).toBe(1);
+    expect(inputTokensOf(spans[0]!)).toBe(18002);
+    // Output tokens are not a cached quantity — passed through untouched.
+    expect(Number(flattenAttrs(spans[0]!.attributes)["gen_ai.usage.output_tokens"])).toBe(31);
+  });
+
+  it("treats absent cache components as 0 instead of null-propagating", async () => {
+    await drive([
+      { type: "assistant", message: { id: "msg_01", model: "claude-opus-4-8", usage: { input_tokens: 10, output_tokens: 5 } } },
+      { type: "result", subtype: "success" },
+    ]);
+
+    expect(inputTokensOf(collectSpans()[0]!)).toBe(10);
+  });
+
+  it("treats null cache components as 0 (the SDK types them `number | null`)", async () => {
+    await drive([
+      {
+        type: "assistant",
+        message: {
+          id: "msg_01",
+          model: "claude-opus-4-8",
+          usage: {
+            input_tokens: 7,
+            output_tokens: 5,
+            cache_read_input_tokens: null,
+            cache_creation_input_tokens: null,
+          },
+        },
+      },
+      { type: "result", subtype: "success" },
+    ]);
+
+    expect(inputTokensOf(collectSpans()[0]!)).toBe(7);
+  });
+
+  // One API turn may arrive as several `assistant` messages sharing a
+  // `message.id` (one per content block), each repeating the SAME usage. Once
+  // the cache components are summed, counting each block would multiply the
+  // cache read by the block count — a live 5-turn run over-reported by 79%.
+  it("counts one API turn split across content blocks exactly once", async () => {
+    const turnA = { input_tokens: 2, output_tokens: 2, cache_read_input_tokens: 0, cache_creation_input_tokens: 36276 };
+    const turnB = {
+      input_tokens: 2,
+      output_tokens: 55,
+      cache_read_input_tokens: 36276,
+      cache_creation_input_tokens: 250,
+    };
+    await drive([
+      { type: "assistant", message: { id: "msg_A", model: "claude-opus-4-8", usage: turnA } },
+      { type: "assistant", message: { id: "msg_A", model: "claude-opus-4-8", usage: turnA } },
+      { type: "user" },
+      { type: "assistant", message: { id: "msg_B", model: "claude-opus-4-8", usage: turnB } },
+      { type: "result", subtype: "success" },
+    ]);
+
+    const spans = collectSpans();
+    expect(spans.length).toBe(2);
+    // Matches the SDK's own `SDKResultMessage.usage` rollup for this stream.
+    expect(spans.map(inputTokensOf)).toEqual([36278, 36528]);
+  });
+
+  it("still emits the final turn when the stream ends without a result message", async () => {
+    await drive([
+      {
+        type: "assistant",
+        message: { id: "msg_01", model: "claude-opus-4-8", usage: { input_tokens: 2, cache_read_input_tokens: 900 } },
+      },
+    ]);
+    const { flushPomeTelemetry } = await import("../src/otel.js");
+    await flushPomeTelemetry();
+
+    const spans = collectSpans();
+    expect(spans.length).toBe(1);
+    expect(inputTokensOf(spans[0]!)).toBe(902);
   });
 });

--- a/packages/adapter-claude-sdk/test/turnUsage.test.ts
+++ b/packages/adapter-claude-sdk/test/turnUsage.test.ts
@@ -138,3 +138,48 @@ describe("withTurnUsage → LlmTurnEvent signals", () => {
     expect(seen).toEqual(["assistant", "result"]);
   });
 });
+
+// F-994. One API turn may arrive as several `assistant` messages sharing a
+// `message.id` — one per content block — each repeating the SAME `usage`. A row
+// per message duplicates the turn and makes `turn_index` count content blocks.
+describe("withTurnUsage → one row per API turn, not per content block", () => {
+  const usage = {
+    input_tokens: 2,
+    output_tokens: 2,
+    cache_read_input_tokens: 36276,
+    cache_creation_input_tokens: 250,
+  };
+
+  it("collapses content-block messages sharing a message.id into one row", async () => {
+    await drive([
+      { type: "assistant", message: { id: "msg_A", model: "claude-opus-4-8", usage } },
+      { type: "assistant", message: { id: "msg_A", model: "claude-opus-4-8", usage, stop_reason: "tool_use" } },
+      { type: "result", subtype: "success" },
+    ]);
+
+    const rows = readRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.cache_read_input_tokens).toBe(36276);
+    // A stop reason arriving on a later block of the turn is still captured.
+    expect(rows[0]!.finish_reasons).toEqual(["tool_use"]);
+  });
+
+  it("counts turns rather than content blocks in turn_index", async () => {
+    await drive([
+      { type: "assistant", message: { id: "msg_A", model: "m", usage } },
+      { type: "assistant", message: { id: "msg_A", model: "m", usage } },
+      { type: "user" },
+      { type: "assistant", message: { id: "msg_B", model: "m", usage } },
+      { type: "assistant", message: { id: "msg_B", model: "m", usage } },
+      { type: "result", subtype: "success" },
+    ]);
+
+    expect(readRows().map((r) => r.turn_index)).toEqual([0, 1]);
+  });
+
+  it("still writes the final turn when the stream ends without a result message", async () => {
+    await drive([{ type: "assistant", message: { id: "msg_A", model: "m", usage } }]);
+
+    expect(readRows()).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
<!-- Closes F-994 -->

Executive summary: The OTLP span lane reported `gen_ai.usage.input_tokens = 18` for a run that really consumed ~200k input tokens — wrong by four orders of magnitude, on the number F-981 just promoted to the headline of the run report. Two independent defects produce it: Anthropic's `usage.input_tokens` excludes the cached prefix, and one API turn arrives as several `assistant` messages that each repeat the same usage. Fixing only the first over-reports by 79%, so both are fixed here. Reviewers should focus on the dedup rule and on why `output_tokens` is deliberately left wrong.

## What

- `gen_ai.usage.input_tokens` is now `input_tokens + cache_read_input_tokens + cache_creation_input_tokens`, each read defensively — absent or null contributes 0, no null-propagation.
- Both telemetry lanes now accumulate a turn by `message.id` and emit once when it closes: one span per API turn, one `LlmTurnEvent` per API turn. `turn_index` counted content blocks before.
- The pending turn is flushed on `result` and again on stream end, so a stream that errors out no longer swallows its last turn.
- 8 new tests across `genaiSpans.test.ts` / `turnUsage.test.ts`. No public API change, and no changeset — this is `packages/`, not `cli/`.

## Why

Anthropic reports the cached prefix separately in `cache_read_input_tokens` / `cache_creation_input_tokens`; OTel semconv 1.27+ defines `gen_ai.usage.input_tokens` as the total. Claude Code keeps its `cache_control` breakpoint at the tail of the prompt, so the uncached remainder is a constant **2** every turn — even on a total cache miss, where the whole prompt lands in `cache_creation` instead. Production `run_TtKKRvLu3qzj5IXt`: 9 spans, `agent_tokens_in = 18`. Nine times two.

The second defect is required for the first, not a bonus. The SDK emits one `assistant` message per content block — thinking, text, tool_use — all sharing `message.id` and repeating the same `usage` object; its own `SDKAssistantMessage.timestamp` docstring says so. Summing the cache components per message multiplies a turn's cache read by its block count: on a live 5-turn run, **+79%**.

## Notes for reviewer

**The dedup compares against the turn being accumulated, not every id ever seen.** A resumed session can legitimately replay a `message.id`, and that is a real second turn, not a duplicate block — a `Set` of seen ids would silently drop it.

**`output_tokens` is knowingly left ~5x low, and that is not this PR.** It is a `message_start` snapshot: the assistant message's `usage` is byte-identical to the `message_start` stream event's, and the tell is `stop_reason: null` on every assistant message. The true per-turn value exists only on `message_delta`, reachable only if the caller sets `includePartialMessages` — which the adapter cannot force without injecting it into every hosted run and then filtering `stream_event` back out of the yielded stream. Different mechanism, much wider blast radius, and output is 0.2% of a run's tokens (438 vs 203k). Split out.

**The second commit fixes a lane with zero consumers, on purpose.** `LlmTurnEvent` carried the identical duplication. Doing it now is free; once anything sums those rows it becomes a migration.

**Latency moves, and that is the fix working.** Hosted p50 goes 614ms to ~2.4s because the old 9 "spans" counted the gaps between content blocks of a single turn (2ms, 78ms) as LLM round-trips. Each span is now one API turn.

## Tests / CI

- `vitest run` in `packages/adapter-claude-sdk` → **107 passed (13 files)**; `npm run typecheck` clean; `lint:code-health` and `lint:dead-code` pass. Full repo suite green across all 8 workspaces — run `npm run build` first, since the twins import built `shared-types` dist and a bare `npm test` after `npm ci` reds ~30 files on a clean tree too.
- 5 of the 8 new tests were written first and watched fail: `18002` got `2`; 3 spans expected 2; dropped final turn; 2 rows expected 1; `turn_index [0,1,2,3]` expected `[0,1]`. The other 3 guard behaviour that must **not** change — the two defensive cache reads, and the JSONL lane still writing without a `result` — and passed before the fix, which is what shows the change did not simply disable emission.
- **Live, through the built adapter against a local OTLP sink:** 9 assistant messages collapse to 5 spans and the emitted total equals the SDK's own `SDKResultMessage.usage` rollup **exactly** (202896 == 202896). Both lanes agree: 5 spans, 5 `LlmTurnEvent` rows, same total.
- **Hosted, same task as the regression** (`02-injection-issue-body`, 5 trials, all 100/100): `agent_tokens_in` 18 → ~155,200, span count 9 → 4.

## Review required

Yes — changes both the values and the cardinality of a shipped telemetry stream that pome-cloud rolls up onto every run.