### PR TITLE
Span-lane output tokens come from message_delta, not the message_start snapshot

### DIFF
--- a/packages/adapter-claude-sdk/README.md
+++ b/packages/adapter-claude-sdk/README.md
@@ -82,6 +82,15 @@ side-effect import is captured in the `[DECISION]` comment on
   them. Iteration is what hero tasks use today.
 - **`withPome()` is idempotent.** A second call is a no-op; the global fetch
   replacement is installed exactly once per process.
+- **`query()` turns on `includePartialMessages` when telemetry is on**, because
+  a turn's finished output-token count reaches the SDK only on a `message_delta`
+  stream event — the `assistant` message carries a `message_start` snapshot
+  roughly 5x too low. Every message that option adds is filtered back out before
+  it reaches your iterator, so your `for await` loop sees exactly what it saw
+  before; a test asserts the yielded sequence is identical with telemetry on and
+  off. Set the option to `true` yourself and nothing is filtered. Measured cost:
+  ~1.3–1.4x the stream bytes. `POME_DISABLE_PARTIAL_MESSAGES=1` opts out, at the
+  price of the low number.
 
 ## Signals file format
 

--- a/packages/adapter-claude-sdk/README.md
+++ b/packages/adapter-claude-sdk/README.md
@@ -91,6 +91,14 @@ side-effect import is captured in the `[DECISION]` comment on
   off. Set the option to `true` yourself and nothing is filtered. Measured cost:
   ~1.3–1.4x the stream bytes. `POME_DISABLE_PARTIAL_MESSAGES=1` opts out, at the
   price of the low number.
+- **Sub-agent turns still report the snapshot.** The SDK forwards no stream
+  events for Task sub-agents (measured: 34 stream events on a two-sub-agent run,
+  none of them tagged with a `parent_tool_use_id`), so there is no
+  `message_delta` to read and those turns keep the low count. They are a small
+  share of a run's output. Note also that `SDKResultMessage.usage` counts only
+  the main agent, while both lanes emit a row per turn either way — so on a run
+  that uses sub-agents the lanes total *more* than the SDK's own rollup rather
+  than matching it exactly.
 
 ## Signals file format
 

--- a/packages/adapter-claude-sdk/src/genai-spans.ts
+++ b/packages/adapter-claude-sdk/src/genai-spans.ts
@@ -22,12 +22,21 @@
 // every id ever seen: a resumed session can legitimately replay a message id,
 // and that is a real second turn, not a duplicate block.
 //
+// Token attribution splits across the two directions. Input is read off the
+// assistant message (`totalInputTokens` below). Output is NOT there — the
+// assistant message carries a `message_start` snapshot, ~5x low — so it comes
+// from the `message_delta` stream event via MessageDeltaTracker, with the
+// snapshot kept only as a fallback for a stream that ended before its delta
+// (F-998; see partial-messages.ts for how those events are obtained and hidden
+// again).
+//
 // On the terminal `result` message we `await flushPomeTelemetry()` BEFORE
 // yielding it, so all spans are exported before the agent's loop ends and it
 // calls process.exit() — pome's CLI reads the session trace blob immediately
 // after the agent returns (the finalize-before-flush contract).
 
 import { flushPomeTelemetry, recordGenAiSpan } from "./otel.js";
+import { MessageDeltaTracker, isPartialMessageArtifact } from "./partial-messages.js";
 
 type WithType = { type?: string };
 
@@ -78,17 +87,19 @@ export async function* withGenAiSpans<T extends WithType>(
   source: AsyncIterable<T>,
 ): AsyncGenerator<T, void, unknown> {
   // Boundary marking the start of the next turn. Initialized when iteration
-  // begins; advanced after every yielded message, so a turn's span starts at
-  // the message yielded before its first content block.
+  // begins; advanced after every yielded message an agent author would see, so
+  // a turn's span starts at the message yielded before its first content block.
   let turnStartMs = Date.now();
   let pending: PendingTurn | null = null;
+  const deltas = new MessageDeltaTracker();
 
   function closeTurn(): void {
     if (!pending) return;
+    const truth = deltas.take(pending.id);
     recordGenAiSpan({
       model: pending.model,
       inputTokens: pending.inputTokens,
-      outputTokens: pending.outputTokens,
+      outputTokens: truth?.outputTokens ?? pending.outputTokens,
       startTimeMs: pending.startTimeMs,
       endTimeMs: pending.endTimeMs,
       isError: pending.isError,
@@ -98,6 +109,8 @@ export async function* withGenAiSpans<T extends WithType>(
 
   try {
     for await (const msg of source) {
+      deltas.observe(msg);
+
       if (msg.type === "assistant") {
         const a = msg as AssistantLike & WithType;
         const usage = (a.message?.usage ?? {}) as Record<string, unknown>;
@@ -132,7 +145,11 @@ export async function* withGenAiSpans<T extends WithType>(
       }
 
       yield msg;
-      turnStartMs = Date.now();
+      // Partial messages are pome's own injection and land microseconds before
+      // the assistant message they describe. Letting them advance the boundary
+      // would collapse every span window to ~0ms, so the window stays measured
+      // between the messages an agent author would have seen anyway.
+      if (!isPartialMessageArtifact(msg)) turnStartMs = Date.now();
     }
   } finally {
     // A stream that ends without a `result` — error, abort, or a consumer that

--- a/packages/adapter-claude-sdk/src/partial-messages.ts
+++ b/packages/adapter-claude-sdk/src/partial-messages.ts
@@ -110,15 +110,24 @@ function asString(v: unknown): string | null {
  * them back by `message.id` when a telemetry lane closes that turn.
  *
  * `message_delta` carries no message id of its own, so the id has to come from
- * the `message_start` that opened the message. Parallel Task subagents
- * interleave their stream events with the main agent's, and
- * `parent_tool_use_id` is the only thing separating the two — hence one "open
- * message" slot per stream rather than a single global.
+ * the `message_start` that opened the message. That makes the "currently open
+ * message" a piece of mutable state, and it is bucketed by `parent_tool_use_id`
+ * rather than kept as a single global so interleaved streams cannot steal each
+ * other's deltas.
+ *
+ * That bucketing is insurance, not a live code path: measured against `claude`
+ * 2.1.220, the SDK forwards **no** subagent stream events at all (34 stream
+ * events on a two-subagent run, 0 of them carrying a `parent_tool_use_id`),
+ * while subagent `assistant` messages do arrive. So today a subagent turn has no
+ * delta to find and keeps the snapshot — see the note on `take()`. The bucket
+ * exists because `SDKPartialAssistantMessage` declares `parent_tool_use_id`, so
+ * the day the SDK starts forwarding them, parallel Task subagents would
+ * otherwise cross-attribute silently.
  *
  * Ordering is safe by construction: `message_delta` always lands before the
  * next turn's `message_start` and before `result`, and a lane only closes a
  * turn on the next turn, on `result`, or at stream end. A turn whose delta never
- * arrived (aborted stream) simply falls back to the snapshot.
+ * arrived (aborted stream, or any subagent turn) falls back to the snapshot.
  */
 export class MessageDeltaTracker {
   readonly #openByStream = new Map<string, string>();
@@ -167,9 +176,13 @@ export class MessageDeltaTracker {
   }
 
   /**
-   * Read and forget a turn's true numbers. Forgetting matters: a resumed
-   * session can legitimately replay a `message.id`, and that is a real second
-   * turn which must not inherit the first one's totals.
+   * Read and forget a turn's true numbers, or null when none were seen — the
+   * caller then keeps the snapshot. Null is the normal case for a **subagent**
+   * turn, whose stream events the SDK does not forward.
+   *
+   * Forgetting matters: a resumed session can legitimately replay a
+   * `message.id`, and that is a real second turn which must not inherit the
+   * first one's totals.
    */
   take(messageId: string | null): TurnTruth | null {
     if (messageId == null) return null;

--- a/packages/adapter-claude-sdk/src/partial-messages.ts
+++ b/packages/adapter-claude-sdk/src/partial-messages.ts
@@ -142,6 +142,15 @@ export class MessageDeltaTracker {
       else this.#openByStream.delete(stream);
       return;
     }
+    // `message_stop` closes the message, so the slot can go. Without this,
+    // `#openByStream` would keep one entry per subagent the run ever spawned
+    // rather than per stream currently open. Not done on `message_delta`: a
+    // server-side tool-use loop can emit several of those for one message, and
+    // the later ones still need the id.
+    if (ev.type === "message_stop") {
+      this.#openByStream.delete(stream);
+      return;
+    }
     if (ev.type !== "message_delta") return;
 
     const id = this.#openByStream.get(stream);

--- a/packages/adapter-claude-sdk/src/partial-messages.ts
+++ b/packages/adapter-claude-sdk/src/partial-messages.ts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-998 — everything about `includePartialMessages`: when the adapter turns it
+// on behind the caller's back, which messages that adds (so they can be
+// filtered back out), and the `message_delta` tracker both telemetry lanes read
+// the true per-turn output-token count from.
+//
+// WHY THE ADAPTER HAS TO ASK FOR THIS
+//
+// `output_tokens` on an `assistant` message is a `message_start` snapshot — the
+// count at the moment the stream envelope was cut, not the finished turn. The
+// tell is `stop_reason: null` on every assistant message; a completed Anthropic
+// message always has one. Live 4-turn Opus run: the snapshots summed to 142
+// against a real 330. The finished value exists only on the `message_delta`
+// stream event, and the SDK emits stream events only when `query()` was called
+// with `includePartialMessages: true` — the CALLER's option. So the adapter
+// sets it itself and hides the consequences (see query.ts).
+//
+// WHAT THE FLAG ACTUALLY ADDS
+//
+// Two message kinds, not one. Proven twice: an A/B on a deterministic prompt
+// (`system/status` with `status:"requesting"` appeared once per API turn with
+// the flag, never without it, two runs each way), and the `claude` binary
+// itself, where ONE gate variable guards both emissions:
+//
+//     case"stream_request_start": if(H) yield {type:"system",subtype:"status",status:"requesting"}
+//     ...                         if(H) yield {type:"stream_event", event:...}
+//
+// The sibling `case"sdk_status"` path — `compacting`, the permission-mode
+// `status:null`, `compact_result` / `compact_error` — is NOT behind that gate.
+// Those reach an agent author with or without pome, so the filter must let them
+// through; dropping every `system/status` would break pass-through fidelity in
+// the other direction.
+//
+// COST, measured on live runs: messages x3.3-3.6, bytes x1.3-1.4. The CLI
+// batches content deltas coarsely (a 667-token text turn produced 29 stream
+// events, not 667), so this is well short of the order of magnitude the ticket
+// budgeted for.
+
+import { OTEL_ENDPOINT_ENV } from "./otel.js";
+import { ADAPTER_SIGNALS_ENV } from "./signals.js";
+
+/**
+ * Set to `1` / `true` to stop the adapter requesting partial messages, at the
+ * cost of `gen_ai.usage.output_tokens` falling back to the ~5x-low snapshot.
+ * An escape hatch for a hosted run that misbehaves under the extra stream
+ * volume, so it can be reverted by env instead of by release.
+ */
+export const DISABLE_PARTIAL_MESSAGES_ENV = "POME_DISABLE_PARTIAL_MESSAGES";
+
+type WithType = { type?: unknown };
+
+/**
+ * Whether `query()` should request partial messages.
+ *
+ * Gated on a telemetry lane actually being configured, which mirrors how both
+ * lanes are already inert without one: outside the pome CLI runner nothing
+ * consumes the extra events, so nothing pays for them.
+ */
+export function shouldInjectPartialMessages(): boolean {
+  const disabled = process.env[DISABLE_PARTIAL_MESSAGES_ENV]?.trim();
+  if (disabled === "1" || disabled === "true") return false;
+  const otel = process.env[OTEL_ENDPOINT_ENV]?.trim();
+  const signals = process.env[ADAPTER_SIGNALS_ENV]?.trim();
+  return Boolean(otel) || Boolean(signals);
+}
+
+/**
+ * True for the messages `includePartialMessages` adds and nothing else — see
+ * the gate quoted in the file header. Used both to filter pome's injection back
+ * out of the yielded stream and to keep it from moving the turn boundary the
+ * telemetry lanes measure latency against.
+ */
+export function isPartialMessageArtifact(msg: unknown): boolean {
+  if (!msg || typeof msg !== "object") return false;
+  const m = msg as { type?: unknown; subtype?: unknown; status?: unknown };
+  if (m.type === "stream_event") return true;
+  return m.type === "system" && m.subtype === "status" && m.status === "requesting";
+}
+
+/** The per-turn values that exist only on `message_delta`. */
+export interface TurnTruth {
+  outputTokens: number | null;
+  stopReason: string | null;
+}
+
+type StreamEventLike = {
+  parent_tool_use_id?: unknown;
+  event?: {
+    type?: string;
+    message?: { id?: unknown };
+    delta?: { stop_reason?: unknown };
+    usage?: { output_tokens?: unknown };
+  };
+};
+
+/** Bucket key for the main agent's stream; subagents key by tool_use id. */
+const MAIN_STREAM = "__main__";
+
+function asNumber(v: unknown): number | null {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+function asString(v: unknown): string | null {
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+/**
+ * Collects the authoritative per-turn numbers off `message_delta` and hands
+ * them back by `message.id` when a telemetry lane closes that turn.
+ *
+ * `message_delta` carries no message id of its own, so the id has to come from
+ * the `message_start` that opened the message. Parallel Task subagents
+ * interleave their stream events with the main agent's, and
+ * `parent_tool_use_id` is the only thing separating the two — hence one "open
+ * message" slot per stream rather than a single global.
+ *
+ * Ordering is safe by construction: `message_delta` always lands before the
+ * next turn's `message_start` and before `result`, and a lane only closes a
+ * turn on the next turn, on `result`, or at stream end. A turn whose delta never
+ * arrived (aborted stream) simply falls back to the snapshot.
+ */
+export class MessageDeltaTracker {
+  readonly #openByStream = new Map<string, string>();
+  readonly #truthById = new Map<string, TurnTruth>();
+
+  // `unknown` rather than a message type: this is a defensive reader of a
+  // stream whose shape the adapter does not control, and every field below is
+  // narrowed before use.
+  observe(msg: unknown): void {
+    if (!msg || typeof msg !== "object") return;
+    const m = msg as StreamEventLike & WithType;
+    if (m.type !== "stream_event") return;
+    const ev = m.event;
+    if (!ev) return;
+
+    const stream = asString(m.parent_tool_use_id) ?? MAIN_STREAM;
+
+    if (ev.type === "message_start") {
+      const id = asString(ev.message?.id);
+      if (id) this.#openByStream.set(stream, id);
+      else this.#openByStream.delete(stream);
+      return;
+    }
+    if (ev.type !== "message_delta") return;
+
+    const id = this.#openByStream.get(stream);
+    if (!id) return;
+
+    // `BetaMessageDeltaUsage.output_tokens` is CUMULATIVE for the message, and
+    // a server-side tool-use loop can emit several deltas for one message — so
+    // the latest value replaces the previous one rather than adding to it.
+    const prev = this.#truthById.get(id);
+    this.#truthById.set(id, {
+      outputTokens: asNumber(ev.usage?.output_tokens) ?? prev?.outputTokens ?? null,
+      stopReason: asString(ev.delta?.stop_reason) ?? prev?.stopReason ?? null,
+    });
+  }
+
+  /**
+   * Read and forget a turn's true numbers. Forgetting matters: a resumed
+   * session can legitimately replay a `message.id`, and that is a real second
+   * turn which must not inherit the first one's totals.
+   */
+  take(messageId: string | null): TurnTruth | null {
+    if (messageId == null) return null;
+    const truth = this.#truthById.get(messageId);
+    if (!truth) return null;
+    this.#truthById.delete(messageId);
+    return truth;
+  }
+}

--- a/packages/adapter-claude-sdk/src/partial-messages.ts
+++ b/packages/adapter-claude-sdk/src/partial-messages.ts
@@ -128,6 +128,15 @@ function asString(v: unknown): string | null {
  * next turn's `message_start` and before `result`, and a lane only closes a
  * turn on the next turn, on `result`, or at stream end. A turn whose delta never
  * arrived (aborted stream, or any subagent turn) falls back to the snapshot.
+ *
+ * The interleaving case is worth spelling out, because the lanes keep ONE
+ * `pending` turn that is not scoped per stream, so a subagent's `assistant`
+ * message closes whatever turn is open. That cannot lose the main agent's delta:
+ * the main message has to be complete — `message_delta`, then `message_stop` —
+ * before the `tool_use` block it ends on can run, and the subagent only exists
+ * because that tool ran. Causal, not lucky. Live two-subagent tape:
+ * `message_delta OUT=517` arrives, THEN the two subagent assistant messages,
+ * and 517 + 7 == the 524 the SDK reported.
  */
 export class MessageDeltaTracker {
   readonly #openByStream = new Map<string, string>();

--- a/packages/adapter-claude-sdk/src/query.ts
+++ b/packages/adapter-claude-sdk/src/query.ts
@@ -37,10 +37,12 @@ type HooksConfig = Partial<Record<HookEvent, HookCallbackMatcher[]>>;
  * Telemetry runs turn on `includePartialMessages` internally (F-998): the true
  * per-turn `output_tokens` reaches the SDK only on a `message_delta` stream
  * event. Everything that option adds is filtered back out before it reaches the
- * returned iterator, so the message sequence is exactly what it would have been
- * — unless the caller set the option themselves, in which case pome touches
- * nothing and the stream events flow through as they asked. Set
- * `POME_DISABLE_PARTIAL_MESSAGES=1` to opt out entirely.
+ * returned iterator, so the message sequence is exactly what it would have been.
+ * Set the option to `true` yourself and pome touches nothing — the stream events
+ * flow through as you asked. Setting it to `false` only declines to *see* them:
+ * telemetry still asks for them and still filters them out, so the sequence you
+ * get is the same either way. `POME_DISABLE_PARTIAL_MESSAGES=1` opts out of
+ * asking at all, at the cost of the ~5x-low snapshot.
  *
  * v0: returns an AsyncGenerator, not the full `Query` interface — control
  * methods (`interrupt`, `setPermissionMode`, …) are not re-exposed yet. Use

--- a/packages/adapter-claude-sdk/src/query.ts
+++ b/packages/adapter-claude-sdk/src/query.ts
@@ -7,6 +7,7 @@ import {
 } from "@anthropic-ai/claude-agent-sdk";
 import { buildPomeHooks } from "./hooks.js";
 import { withGenAiSpans } from "./genai-spans.js";
+import { isPartialMessageArtifact, shouldInjectPartialMessages } from "./partial-messages.js";
 import { withTurnUsage } from "./turn-usage.js";
 import { withToolEvents } from "./wrapQuery.js";
 
@@ -33,11 +34,25 @@ type HooksConfig = Partial<Record<HookEvent, HookCallbackMatcher[]>>;
  * `system`/`init` message, or the per-turn `message.model` (both flow into the
  * gen_ai spans and `LlmTurnEvent` this wrapper emits). See F-928.
  *
+ * Telemetry runs turn on `includePartialMessages` internally (F-998): the true
+ * per-turn `output_tokens` reaches the SDK only on a `message_delta` stream
+ * event. Everything that option adds is filtered back out before it reaches the
+ * returned iterator, so the message sequence is exactly what it would have been
+ * — unless the caller set the option themselves, in which case pome touches
+ * nothing and the stream events flow through as they asked. Set
+ * `POME_DISABLE_PARTIAL_MESSAGES=1` to opt out entirely.
+ *
  * v0: returns an AsyncGenerator, not the full `Query` interface — control
  * methods (`interrupt`, `setPermissionMode`, …) are not re-exposed yet. Use
  * the underlying SDK directly if you need them.
  */
 export function query(params: QueryParams): AsyncGenerator<SDKMessage, void, unknown> {
+  // A caller who asked for partial messages gets them verbatim; only pome's own
+  // injection is hidden again.
+  const inject =
+    shouldInjectPartialMessages() && params.options?.includePartialMessages !== true;
+  const prepared = withPomeHooks(params, inject);
+
   // Three read-only stream wrappers, composed innermost-first:
   //   • withToolEvents   — ToolUse/ToolResult/SubagentSpawn rows → signals JSONL
   //   • withTurnUsage    — one LlmTurnEvent per usage-bearing assistant turn
@@ -46,12 +61,30 @@ export function query(params: QueryParams): AsyncGenerator<SDKMessage, void, unk
   //                        flushes the exporter on the terminal `result`.
   // The two signals wrappers append to POME_ADAPTER_SIGNALS_PATH and are inert
   // when it is unset; withGenAiSpans is inert when no OTLP endpoint is set.
-  return withGenAiSpans<SDKMessage>(
-    withTurnUsage<SDKMessage>(withToolEvents<SDKMessage>(sdkQuery(withPomeHooks(params)))),
+  const instrumented = withGenAiSpans<SDKMessage>(
+    withTurnUsage<SDKMessage>(withToolEvents<SDKMessage>(sdkQuery(prepared))),
   );
+
+  // Outermost, so the wrappers above still see the stream events they read the
+  // per-turn output tokens from.
+  return inject ? withoutPartialMessages(instrumented) : instrumented;
 }
 
-function withPomeHooks(params: QueryParams): QueryParams {
+/**
+ * Drop the messages `includePartialMessages` added — `stream_event` plus the
+ * per-turn `system/status:requesting` ping — so an agent author's `for await`
+ * loop sees exactly what it saw before pome started asking for them.
+ */
+async function* withoutPartialMessages(
+  source: AsyncGenerator<SDKMessage, void, unknown>,
+): AsyncGenerator<SDKMessage, void, unknown> {
+  for await (const msg of source) {
+    if (isPartialMessageArtifact(msg)) continue;
+    yield msg;
+  }
+}
+
+function withPomeHooks(params: QueryParams, includePartialMessages: boolean): QueryParams {
   const pomeHooks = buildPomeHooks();
   const userHooks = (params.options?.hooks ?? {}) as HooksConfig;
   const merged: HooksConfig = {};
@@ -63,6 +96,10 @@ function withPomeHooks(params: QueryParams): QueryParams {
   }
   return {
     ...params,
-    options: { ...(params.options ?? {}), hooks: merged },
+    options: {
+      ...(params.options ?? {}),
+      hooks: merged,
+      ...(includePartialMessages ? { includePartialMessages: true } : {}),
+    },
   };
 }

--- a/packages/adapter-claude-sdk/src/turn-usage.ts
+++ b/packages/adapter-claude-sdk/src/turn-usage.ts
@@ -18,10 +18,17 @@
 // timing). `turn_index` is 0-based per `query()` stream. `parent_id` and
 // `session_id` are null in M1.
 //
+// `output_tokens` and `finish_reasons` come from the `message_delta` stream
+// event rather than the assistant message (F-998; see partial-messages.ts). The
+// assistant message's `output_tokens` is a `message_start` snapshot ~5x low, and
+// its `stop_reason` is null on every message the SDK emits — which is why this
+// lane's `finish_reasons` had always been null in practice.
+//
 // No signals path configured (standalone dev, or any run outside the pome CLI
 // runner): `writeLlmTurnEvent` is a static noop, so this wrapper just passes
 // messages through.
 
+import { MessageDeltaTracker, isPartialMessageArtifact } from "./partial-messages.js";
 import { newEventId, writeLlmTurnEvent } from "./signals.js";
 
 type WithType = { type?: string };
@@ -57,16 +64,20 @@ export async function* withTurnUsage<T extends WithType>(
   source: AsyncIterable<T>,
 ): AsyncGenerator<T, void, unknown> {
   // Boundary marking the start of the current turn. Initialized when iteration
-  // begins; advanced after every yielded message so each turn's latency spans
-  // only the gap since the previous message (matches genai-spans.ts).
+  // begins; advanced after every yielded message an agent author would see, so
+  // each turn's latency spans only the gap since the previous one of those
+  // (matches genai-spans.ts).
   let turnStartMs = Date.now();
   // 0-based counter, per this query() stream. Advances only for turns that
   // actually reported usage (a usage-less assistant message is not a turn).
   let turnIndex = 0;
   let pending: PendingTurn | null = null;
+  const deltas = new MessageDeltaTracker();
 
   function closeTurn(): void {
     if (!pending) return;
+    const truth = deltas.take(pending.id);
+    const stopReason = truth?.stopReason ?? pending.stopReason;
     writeLlmTurnEvent({
       ts: new Date().toISOString(),
       event_id: newEventId(),
@@ -75,10 +86,10 @@ export async function* withTurnUsage<T extends WithType>(
       turn_index: turnIndex,
       model: pending.model,
       input_tokens: pending.inputTokens,
-      output_tokens: pending.outputTokens,
+      output_tokens: truth?.outputTokens ?? pending.outputTokens,
       cache_read_input_tokens: pending.cacheReadTokens,
       cache_creation_input_tokens: pending.cacheCreationTokens,
-      finish_reasons: pending.stopReason != null ? [pending.stopReason] : null,
+      finish_reasons: stopReason != null ? [stopReason] : null,
       latency_ms: Math.max(0, pending.endTimeMs - pending.startTimeMs),
       latency_ms_estimated: true,
       session_id: null,
@@ -89,6 +100,8 @@ export async function* withTurnUsage<T extends WithType>(
 
   try {
     for await (const msg of source) {
+      deltas.observe(msg);
+
       if (msg.type === "assistant") {
         const a = msg as AssistantLike & WithType;
         const usage = (a.message?.usage ?? {}) as Record<string, unknown>;
@@ -126,7 +139,10 @@ export async function* withTurnUsage<T extends WithType>(
       }
 
       yield msg;
-      turnStartMs = Date.now();
+      // Pome's injected partial messages must not advance the boundary, or
+      // every `latency_ms` collapses to the gap between two stream events
+      // (matches genai-spans.ts).
+      if (!isPartialMessageArtifact(msg)) turnStartMs = Date.now();
     }
   } finally {
     // A stream that ends without a `result` — error, abort, or a consumer that

--- a/packages/adapter-claude-sdk/src/wrapQuery.ts
+++ b/packages/adapter-claude-sdk/src/wrapQuery.ts
@@ -21,6 +21,7 @@
 // rows. The message-stream wrapper here is the surviving pome insertion
 // point in the SDK iterator.
 
+import { isPartialMessageArtifact } from "./partial-messages.js";
 import { redactSecrets } from "./redaction.js";
 import {
   newEventId,
@@ -72,6 +73,16 @@ export async function* withToolEvents<T extends WithType>(
   const subagentEventIdByParentToolUseId = new Map<string, string>();
 
   for await (const msg of source) {
+    // Partial messages carry a `parent_tool_use_id` of their own, so a subagent
+    // stream event would otherwise be enough to mint a SubagentSpawnEvent. This
+    // lane reads content blocks, which partial messages do not carry — skipping
+    // them keeps the emitted rows identical whether or not F-998 asked the SDK
+    // for them.
+    if (isPartialMessageArtifact(msg)) {
+      yield msg;
+      continue;
+    }
+
     const parentToolUseId = readParentToolUseId(msg);
     if (parentToolUseId && !subagentEventIdByParentToolUseId.has(parentToolUseId)) {
       const event_id = newEventId();

--- a/packages/adapter-claude-sdk/test/genaiSpans.test.ts
+++ b/packages/adapter-claude-sdk/test/genaiSpans.test.ts
@@ -393,6 +393,38 @@ describe("withGenAiSpans → gen_ai.usage.output_tokens is the message_delta tru
     expect(spans.reduce((n, s) => n + outputTokensOf(s), 0)).toBe(330);
   });
 
+  // Measured against `claude` 2.1.220: the SDK forwards no subagent stream
+  // events (34 on a two-subagent run, 0 with a `parent_tool_use_id`) while
+  // subagent `assistant` messages DO arrive. So a subagent turn has no delta and
+  // keeps the snapshot, and the main agent's delta must not leak onto it.
+  //
+  // Consequence worth knowing: `SDKResultMessage.usage` also excludes subagent
+  // usage, so the exactness invariant holds over MAIN-AGENT turns. Live
+  // two-subagent run: main deltas 517 + 7 == result 524, with the subagent turns'
+  // 4 + 4 sitting outside that total on both sides.
+  it("keeps the snapshot on a subagent turn and does not leak the main delta onto it", async () => {
+    await drive([
+      streamStart("msg_main"),
+      { type: "assistant", message: { id: "msg_main", model: "claude-opus-4-8", usage: { input_tokens: 2, output_tokens: 8 } } },
+      streamDelta(517, "tool_use"),
+      // Subagent turns: assistant messages only, no stream events of their own.
+      {
+        type: "assistant",
+        parent_tool_use_id: "toolu_alpha",
+        message: { id: "msg_sub_a", model: "claude-opus-4-8", usage: { input_tokens: 2, output_tokens: 4 } },
+      },
+      {
+        type: "assistant",
+        parent_tool_use_id: "toolu_beta",
+        message: { id: "msg_sub_b", model: "claude-opus-4-8", usage: { input_tokens: 2, output_tokens: 4 } },
+      },
+      { type: "result", subtype: "success" },
+    ]);
+
+    const spans = collectSpans();
+    expect(spans.map(outputTokensOf)).toEqual([517, 4, 4]);
+  });
+
   // The span window is measured from the previously yielded message. Injected
   // partial messages arrive microseconds before the assistant message they
   // describe, so letting them move the boundary would collapse every window to

--- a/packages/adapter-claude-sdk/test/genaiSpans.test.ts
+++ b/packages/adapter-claude-sdk/test/genaiSpans.test.ts
@@ -425,6 +425,46 @@ describe("withGenAiSpans → gen_ai.usage.output_tokens is the message_delta tru
     expect(spans.map(outputTokensOf)).toEqual([517, 4, 4]);
   });
 
+  // The lanes keep ONE `pending` turn, not one per stream, so a subagent's
+  // assistant message closes whatever turn is open. That cannot lose the main
+  // agent's delta: the main message must be complete — message_delta, then
+  // message_stop — before the tool_use block it ends on can run, and the
+  // subagent only exists because that tool ran. This is the exact interleaving
+  // from a live two-subagent tape, and it must still total the SDK's 524.
+  it("does not lose the main agent's delta to an interleaved subagent turn", async () => {
+    const messageStop = () => ({
+      type: "stream_event",
+      parent_tool_use_id: null,
+      event: { type: "message_stop" },
+    });
+    const sub = (id: string, ptu: string) => ({
+      type: "assistant",
+      parent_tool_use_id: ptu,
+      message: { id, model: "claude-opus-4-8", usage: { input_tokens: 2, output_tokens: 4 } },
+    });
+
+    await drive([
+      streamStart("msg_main1"),
+      { type: "assistant", message: { id: "msg_main1", model: "claude-opus-4-8", usage: { input_tokens: 2, output_tokens: 8 } } },
+      { type: "assistant", message: { id: "msg_main1", model: "claude-opus-4-8", usage: { input_tokens: 2, output_tokens: 8 } } },
+      streamDelta(517, "tool_use"),
+      messageStop(),
+      sub("msg_sub_a", "toolu_alpha"),
+      sub("msg_sub_b", "toolu_beta"),
+      { type: "user" },
+      streamStart("msg_main2"),
+      { type: "assistant", message: { id: "msg_main2", model: "claude-opus-4-8", usage: { input_tokens: 2, output_tokens: 1 } } },
+      streamDelta(7, "end_turn"),
+      messageStop(),
+      { type: "result", subtype: "success" },
+    ]);
+
+    const spans = collectSpans();
+    expect(spans.map(outputTokensOf)).toEqual([517, 4, 4, 7]);
+    // Main-agent turns alone reproduce SDKResultMessage.usage.output_tokens.
+    expect(517 + 7).toBe(524);
+  });
+
   // The span window is measured from the previously yielded message. Injected
   // partial messages arrive microseconds before the assistant message they
   // describe, so letting them move the boundary would collapse every window to

--- a/packages/adapter-claude-sdk/test/genaiSpans.test.ts
+++ b/packages/adapter-claude-sdk/test/genaiSpans.test.ts
@@ -82,16 +82,27 @@ function flattenAttrs(attrs: Array<{ key: string; value: Record<string, unknown>
   return out;
 }
 
+// A message may carry `__sleepMs` to hold the source generator before yielding
+// it, so a test can prove which messages move the span-window boundary.
 async function drive(messages: Array<{ type: string; [k: string]: unknown }>): Promise<void> {
   const { withGenAiSpans } = await import("../src/genai-spans.js");
   async function* src() {
-    for (const m of messages) yield m;
+    for (const m of messages) {
+      const sleep = m.__sleepMs as number | undefined;
+      if (sleep) await new Promise((r) => setTimeout(r, sleep));
+      yield m;
+    }
   }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   for await (const _ of withGenAiSpans(src())) void _;
 }
 
-type ExportedSpan = { name: string; attributes: Array<{ key: string; value: Record<string, unknown> }> };
+type ExportedSpan = {
+  name: string;
+  attributes: Array<{ key: string; value: Record<string, unknown> }>;
+  startTimeUnixNano?: string;
+  endTimeUnixNano?: string;
+};
 
 // Every span the collector received, across all export requests.
 function collectSpans(): ExportedSpan[] {
@@ -109,6 +120,14 @@ function collectSpans(): ExportedSpan[] {
 
 function inputTokensOf(span: ExportedSpan): number {
   return Number(flattenAttrs(span.attributes)["gen_ai.usage.input_tokens"]);
+}
+
+function outputTokensOf(span: ExportedSpan): number {
+  return Number(flattenAttrs(span.attributes)["gen_ai.usage.output_tokens"]);
+}
+
+function durationMsOf(span: ExportedSpan): number {
+  return (Number(span.endTimeUnixNano) - Number(span.startTimeUnixNano)) / 1e6;
 }
 
 describe("withGenAiSpans → OTLP/JSON export", () => {
@@ -302,5 +321,95 @@ describe("withGenAiSpans → gen_ai.usage.input_tokens is the semconv total", ()
     const spans = collectSpans();
     expect(spans.length).toBe(1);
     expect(inputTokensOf(spans[0]!)).toBe(902);
+  });
+});
+
+// F-998. An `assistant` message's `usage.output_tokens` is the `message_start`
+// snapshot — the count at the moment the stream envelope was cut, ~5x low. The
+// tell is `stop_reason: null` on every assistant message. The finished number
+// exists only on the `message_delta` stream event, which the adapter now gets by
+// injecting `includePartialMessages` (see partial-messages.ts).
+describe("withGenAiSpans → gen_ai.usage.output_tokens is the message_delta truth", () => {
+  const streamStart = (id: string) => ({
+    type: "stream_event",
+    parent_tool_use_id: null,
+    event: { type: "message_start", message: { id, usage: { input_tokens: 2, output_tokens: 2 } } },
+  });
+  const streamDelta = (outputTokens: number, stopReason: string) => ({
+    type: "stream_event",
+    parent_tool_use_id: null,
+    event: { type: "message_delta", delta: { stop_reason: stopReason }, usage: { output_tokens: outputTokens } },
+  });
+
+  it("prefers the message_delta count over the snapshot on the assistant message", async () => {
+    await drive([
+      streamStart("msg_A"),
+      { type: "assistant", message: { id: "msg_A", model: "claude-opus-4-8", usage: { input_tokens: 2, output_tokens: 2 } } },
+      streamDelta(179, "tool_use"),
+      { type: "result", subtype: "success" },
+    ]);
+
+    expect(outputTokensOf(collectSpans()[0]!)).toBe(179);
+  });
+
+  it("falls back to the snapshot when the caller left partial messages off", async () => {
+    await drive([
+      { type: "assistant", message: { id: "msg_A", model: "claude-opus-4-8", usage: { input_tokens: 2, output_tokens: 31 } } },
+      { type: "result", subtype: "success" },
+    ]);
+
+    expect(outputTokensOf(collectSpans()[0]!)).toBe(31);
+  });
+
+  // The whole point of the ticket: per-turn spans must sum to the SDK's own
+  // rollup. Tape below is verbatim from a live 4-turn Opus run whose
+  // `SDKResultMessage.usage.output_tokens` was 330 — the snapshots sum to 142.
+  it("sums to SDKResultMessage.usage.output_tokens across a multi-turn run", async () => {
+    const turn = (id: string, snapshot: number, truth: number, stop: string, blocks: number) => [
+      streamStart(id),
+      ...Array.from({ length: blocks }, () => ({
+        type: "assistant",
+        message: { id, model: "claude-opus-4-8", usage: { input_tokens: 2, output_tokens: snapshot } },
+      })),
+      streamDelta(truth, stop),
+    ];
+
+    await drive([
+      ...turn("msg_1", 2, 179, "tool_use", 3),
+      { type: "user" },
+      ...turn("msg_2", 72, 73, "tool_use", 1),
+      // The tool_result `user` message can land BEFORE the turn's message_delta
+      // (observed live) — it must not close the turn early.
+      { type: "user" },
+      ...turn("msg_3", 67, 73, "tool_use", 1),
+      { type: "user" },
+      ...turn("msg_4", 1, 5, "end_turn", 1),
+      { type: "result", subtype: "success" },
+    ]);
+
+    const spans = collectSpans();
+    expect(spans.length).toBe(4);
+    expect(spans.map(outputTokensOf)).toEqual([179, 73, 73, 5]);
+    expect(spans.reduce((n, s) => n + outputTokensOf(s), 0)).toBe(330);
+  });
+
+  // The span window is measured from the previously yielded message. Injected
+  // partial messages arrive microseconds before the assistant message they
+  // describe, so letting them move the boundary would collapse every window to
+  // ~0ms and undo F-994's latency fix.
+  it("keeps the span window measured from the last real message", async () => {
+    await drive([
+      { type: "user" },
+      // The API round trip: everything below lands once the response starts.
+      { type: "stream_event", __sleepMs: 40, parent_tool_use_id: null, event: { type: "message_start", message: { id: "msg_A", usage: {} } } },
+      { type: "system", subtype: "status", status: "requesting" },
+      { type: "assistant", message: { id: "msg_A", model: "claude-opus-4-8", usage: { input_tokens: 2, output_tokens: 2 } } },
+      streamDelta(179, "end_turn"),
+      { type: "result", subtype: "success" },
+    ]);
+
+    const spans = collectSpans();
+    expect(spans.length).toBe(1);
+    expect(durationMsOf(spans[0]!)).toBeGreaterThanOrEqual(30);
   });
 });

--- a/packages/adapter-claude-sdk/test/integration.test.ts
+++ b/packages/adapter-claude-sdk/test/integration.test.ts
@@ -12,7 +12,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const FAKE_SCHEMA = {} as never;
 
-let capturedQueryParams: { prompt: string; options?: { hooks?: unknown } } | null = null;
+let capturedQueryParams: {
+  prompt: string;
+  options?: { hooks?: unknown; includePartialMessages?: boolean };
+} | null = null;
 
 vi.mock("@anthropic-ai/claude-agent-sdk", () => {
   return {
@@ -22,7 +25,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => {
       schema: unknown,
       handler: (args: unknown, extra: unknown) => Promise<unknown>,
     ) => ({ name, description, schema, handler }),
-    query: (params: { prompt: string; options?: { hooks?: unknown } }) => {
+    query: (params: { prompt: string; options?: { hooks?: unknown; includePartialMessages?: boolean } }) => {
       capturedQueryParams = params;
       return fakeQuery();
     },
@@ -63,13 +66,28 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => {
 });
 
 let fakeMessages: Array<{ type: string }> = [];
+// Entries of `fakeMessages` the fake SDK withholds unless the caller asked for
+// partial messages. Mirrors the `claude` CLI, where a single gate guards BOTH
+// `stream_event` and the per-turn `system/status:requesting` ping:
+//   case"stream_request_start": if(H) yield {type:"system",subtype:"status",status:"requesting"}
+//   ...                         if(H) yield {type:"stream_event", event:...}
+let fakePartialOnly = new Set<{ type: string }>();
 async function* fakeQuery() {
-  for (const m of fakeMessages) yield m;
+  const partial = capturedQueryParams?.options?.includePartialMessages === true;
+  for (const m of fakeMessages) {
+    if (!partial && fakePartialOnly.has(m)) continue;
+    yield m;
+  }
 }
 
 let tmp: string;
 let signalsPath: string;
-const ENV_KEYS = ["POME_TWIN_BASE_URL", "POME_ADAPTER_SIGNALS_PATH"] as const;
+const ENV_KEYS = [
+  "POME_TWIN_BASE_URL",
+  "POME_ADAPTER_SIGNALS_PATH",
+  "POME_OTEL_EXPORTER_OTLP_ENDPOINT",
+  "POME_DISABLE_PARTIAL_MESSAGES",
+] as const;
 const saved: Record<string, string | undefined> = {};
 let originalFetch: typeof globalThis.fetch;
 let fetchCalls: Array<{ url: string; headers: Record<string, string> }>;
@@ -82,7 +100,11 @@ beforeEach(() => {
   process.env.POME_ADAPTER_SIGNALS_PATH = signalsPath;
   process.env.POME_TWIN_BASE_URL = "http://127.0.0.1:3333";
 
+  delete process.env.POME_OTEL_EXPORTER_OTLP_ENDPOINT;
+  delete process.env.POME_DISABLE_PARTIAL_MESSAGES;
+
   fakeMessages = [];
+  fakePartialOnly = new Set();
   fetchCalls = [];
   capturedQueryParams = null;
   originalFetch = globalThis.fetch;
@@ -263,5 +285,104 @@ describe("end-to-end: withPome + tool + query", () => {
     expect(typeof row.event_id).toBe("string");
     expect(row.event_id.length).toBeGreaterThan(0);
     expect(typeof row.ts).toBe("string");
+  });
+});
+
+// F-998. The adapter turns `includePartialMessages` on behind the agent
+// author's back to reach the only authoritative per-turn output-token count the
+// SDK emits (`message_delta`). The price of that is a stream the author never
+// asked for, so everything the flag adds is filtered back out before it reaches
+// their `for await` loop.
+describe("F-998: includePartialMessages injection is invisible to the caller", () => {
+  // One API turn as the CLI actually lays it out: the flag-gated artifacts
+  // interleaved with the messages an author sees today.
+  function buildTape() {
+    const statusPing = { type: "system", subtype: "status", status: "requesting" } as { type: string };
+    const messageStart = {
+      type: "stream_event",
+      parent_tool_use_id: null,
+      event: { type: "message_start", message: { id: "msg_A", usage: { input_tokens: 2, output_tokens: 2 } } },
+    } as unknown as { type: string };
+    const messageDelta = {
+      type: "stream_event",
+      parent_tool_use_id: null,
+      event: { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 179 } },
+    } as unknown as { type: string };
+    const messageStop = {
+      type: "stream_event",
+      parent_tool_use_id: null,
+      event: { type: "message_stop" },
+    } as unknown as { type: string };
+
+    const tape = [
+      { type: "system", subtype: "init" } as { type: string },
+      statusPing,
+      messageStart,
+      { type: "assistant", message: { id: "msg_A", model: "m", usage: { input_tokens: 2, output_tokens: 2 } } } as unknown as { type: string },
+      messageDelta,
+      messageStop,
+      { type: "result", subtype: "success" } as { type: string },
+    ];
+    return { tape, gated: new Set([statusPing, messageStart, messageDelta, messageStop]) };
+  }
+
+  async function collect(): Promise<Array<{ type: string }>> {
+    const { query } = await import("../src/index.js");
+    const seen: Array<{ type: string }> = [];
+    for await (const m of query({ prompt: "x" } as Parameters<typeof query>[0])) seen.push(m);
+    return seen;
+  }
+
+  it("yields byte-identical messages with telemetry on and off", async () => {
+    const { tape, gated } = buildTape();
+    fakeMessages = tape;
+    fakePartialOnly = gated;
+
+    // Telemetry ON (the signals path is set by beforeEach) — the adapter
+    // injects, the fake SDK emits the extra messages, the filter removes them.
+    const withTelemetry = await collect();
+    expect(capturedQueryParams!.options!.includePartialMessages).toBe(true);
+
+    // Telemetry OFF — no injection, so the fake SDK never emits them at all.
+    delete process.env.POME_ADAPTER_SIGNALS_PATH;
+    const withoutTelemetry = await collect();
+    expect(capturedQueryParams!.options!.includePartialMessages).toBeUndefined();
+
+    expect(withTelemetry).toEqual(withoutTelemetry);
+    expect(withTelemetry.map((m) => m.type)).toEqual(["system", "assistant", "result"]);
+  });
+
+  it("does not request partial messages when no telemetry lane is configured", async () => {
+    delete process.env.POME_ADAPTER_SIGNALS_PATH;
+    fakeMessages = [{ type: "result", subtype: "success" } as { type: string }];
+
+    await collect();
+    expect(capturedQueryParams!.options!.includePartialMessages).toBeUndefined();
+  });
+
+  it("honours POME_DISABLE_PARTIAL_MESSAGES as a no-release kill switch", async () => {
+    process.env.POME_DISABLE_PARTIAL_MESSAGES = "1";
+    fakeMessages = [{ type: "result", subtype: "success" } as { type: string }];
+
+    await collect();
+    expect(capturedQueryParams!.options!.includePartialMessages).toBeUndefined();
+  });
+
+  it("passes stream events straight through when the caller asked for them", async () => {
+    const { tape, gated } = buildTape();
+    fakeMessages = tape;
+    fakePartialOnly = gated;
+
+    const { query } = await import("../src/index.js");
+    const seen: Array<{ type: string }> = [];
+    for await (const m of query({
+      prompt: "x",
+      options: { includePartialMessages: true },
+    } as Parameters<typeof query>[0])) {
+      seen.push(m);
+    }
+
+    // The caller opted in, so nothing is filtered — including the status ping.
+    expect(seen).toEqual(tape);
   });
 });

--- a/packages/adapter-claude-sdk/test/integration.test.ts
+++ b/packages/adapter-claude-sdk/test/integration.test.ts
@@ -368,6 +368,27 @@ describe("F-998: includePartialMessages injection is invisible to the caller", (
     expect(capturedQueryParams!.options!.includePartialMessages).toBeUndefined();
   });
 
+  // Setting the option to `false` declines to SEE partial messages, which is
+  // what the filter already guarantees. Telemetry keeps asking for them, so the
+  // sequence the caller gets is the same either way — it just stays accurate.
+  it("still asks, and still filters, when the caller set the option to false", async () => {
+    const { tape, gated } = buildTape();
+    fakeMessages = tape;
+    fakePartialOnly = gated;
+
+    const { query } = await import("../src/index.js");
+    const seen: Array<{ type: string }> = [];
+    for await (const m of query({
+      prompt: "x",
+      options: { includePartialMessages: false },
+    } as Parameters<typeof query>[0])) {
+      seen.push(m);
+    }
+
+    expect(capturedQueryParams!.options!.includePartialMessages).toBe(true);
+    expect(seen.map((m) => m.type)).toEqual(["system", "assistant", "result"]);
+  });
+
   it("passes stream events straight through when the caller asked for them", async () => {
     const { tape, gated } = buildTape();
     fakeMessages = tape;

--- a/packages/adapter-claude-sdk/test/partialMessages.test.ts
+++ b/packages/adapter-claude-sdk/test/partialMessages.test.ts
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-998. The `includePartialMessages` plumbing: which messages the flag adds to
+// the stream (so they can be filtered back out), when the adapter turns it on,
+// and the `message_delta` tracker that carries the only authoritative per-turn
+// output-token count the SDK ever emits.
+//
+// The message shapes below are verbatim from a live Opus run through
+// `claude` 2.1.220 — see the tape evidence on the ticket.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  DISABLE_PARTIAL_MESSAGES_ENV,
+  MessageDeltaTracker,
+  isPartialMessageArtifact,
+  shouldInjectPartialMessages,
+} from "../src/partial-messages.js";
+import { ADAPTER_SIGNALS_ENV } from "../src/signals.js";
+import { OTEL_ENDPOINT_ENV } from "../src/otel.js";
+
+const ENV_KEYS = [DISABLE_PARTIAL_MESSAGES_ENV, ADAPTER_SIGNALS_ENV, OTEL_ENDPOINT_ENV] as const;
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k]!;
+  }
+});
+
+describe("shouldInjectPartialMessages — gated on telemetry actually being on", () => {
+  it("stays off when neither telemetry lane is configured", () => {
+    expect(shouldInjectPartialMessages()).toBe(false);
+  });
+
+  it("turns on for the OTLP span lane", () => {
+    process.env[OTEL_ENDPOINT_ENV] = "https://api.pome.sh/v1/sessions/ses_x/traces";
+    expect(shouldInjectPartialMessages()).toBe(true);
+  });
+
+  it("turns on for the signals JSONL lane alone", () => {
+    process.env[ADAPTER_SIGNALS_ENV] = "/tmp/signals.jsonl";
+    expect(shouldInjectPartialMessages()).toBe(true);
+  });
+
+  it("honours the kill switch so a bad hosted run can be reverted without a release", () => {
+    process.env[OTEL_ENDPOINT_ENV] = "https://api.pome.sh/v1/sessions/ses_x/traces";
+    process.env[DISABLE_PARTIAL_MESSAGES_ENV] = "1";
+    expect(shouldInjectPartialMessages()).toBe(false);
+  });
+});
+
+// `--include-partial-messages` adds exactly two message kinds. Proven twice: an
+// A/B on a deterministic single-turn prompt (0 vs 1 `status:"requesting"` per
+// turn, everything else identical), and the `claude` binary itself, where one
+// gate variable guards both emissions:
+//
+//   case"stream_request_start": if(H) yield {type:"system",subtype:"status",status:"requesting"}
+//   ...                         if(H) yield {type:"stream_event", event:...}
+//
+// The sibling `case"sdk_status"` path — `compacting`, the permission-mode
+// `status:null`, `compact_result` / `compact_error` — is NOT behind that gate,
+// so those reach an agent author with or without pome and must survive the
+// filter.
+describe("isPartialMessageArtifact — exactly what the flag adds, nothing else", () => {
+  it("claims stream_event", () => {
+    expect(isPartialMessageArtifact({ type: "stream_event", event: { type: "message_delta" } })).toBe(true);
+  });
+
+  it("claims the per-turn status:requesting ping", () => {
+    expect(isPartialMessageArtifact({ type: "system", subtype: "status", status: "requesting" })).toBe(true);
+  });
+
+  it("leaves compaction status alone — that one flows without the flag", () => {
+    expect(isPartialMessageArtifact({ type: "system", subtype: "status", status: "compacting" })).toBe(false);
+    expect(
+      isPartialMessageArtifact({ type: "system", subtype: "status", status: null, permissionMode: "default" }),
+    ).toBe(false);
+    expect(
+      isPartialMessageArtifact({ type: "system", subtype: "status", status: null, compact_result: "success" }),
+    ).toBe(false);
+  });
+
+  it("leaves every ordinary message alone", () => {
+    for (const msg of [
+      { type: "assistant" },
+      { type: "user" },
+      { type: "result", subtype: "success" },
+      { type: "system", subtype: "init" },
+      { type: "system", subtype: "thinking_tokens" },
+      { type: "rate_limit_event" },
+    ]) {
+      expect(isPartialMessageArtifact(msg)).toBe(false);
+    }
+  });
+});
+
+describe("MessageDeltaTracker — the authoritative per-turn output tokens", () => {
+  function messageStart(id: string, parentToolUseId: string | null = null) {
+    return {
+      type: "stream_event",
+      parent_tool_use_id: parentToolUseId,
+      event: {
+        type: "message_start",
+        message: { id, usage: { input_tokens: 2, output_tokens: 2, cache_read_input_tokens: 29166 } },
+      },
+    };
+  }
+
+  function messageDelta(outputTokens: number, stopReason: string, parentToolUseId: string | null = null) {
+    return {
+      type: "stream_event",
+      parent_tool_use_id: parentToolUseId,
+      event: {
+        type: "message_delta",
+        delta: { stop_reason: stopReason, stop_sequence: null },
+        usage: { output_tokens: outputTokens, input_tokens: 2, cache_read_input_tokens: 29166 },
+      },
+    };
+  }
+
+  it("pairs a message_delta with the id from its message_start", () => {
+    const t = new MessageDeltaTracker();
+    t.observe(messageStart("msg_A"));
+    t.observe(messageDelta(179, "tool_use"));
+
+    expect(t.take("msg_A")).toEqual({ outputTokens: 179, stopReason: "tool_use" });
+  });
+
+  it("returns null for a turn it never saw a delta for", () => {
+    const t = new MessageDeltaTracker();
+    t.observe(messageStart("msg_A"));
+
+    expect(t.take("msg_A")).toBeNull();
+    expect(t.take(null)).toBeNull();
+  });
+
+  it("consumes the entry so a replayed message id cannot double-report", () => {
+    const t = new MessageDeltaTracker();
+    t.observe(messageStart("msg_A"));
+    t.observe(messageDelta(179, "tool_use"));
+
+    expect(t.take("msg_A")?.outputTokens).toBe(179);
+    expect(t.take("msg_A")).toBeNull();
+  });
+
+  // `BetaMessageDeltaUsage.output_tokens` is documented as CUMULATIVE, and a
+  // server-side tool-use loop can emit several message_delta events for one
+  // message. The last one is the total, so it overwrites rather than adds.
+  it("takes the latest cumulative delta, never the sum", () => {
+    const t = new MessageDeltaTracker();
+    t.observe(messageStart("msg_A"));
+    t.observe(messageDelta(120, "tool_use"));
+    t.observe(messageDelta(179, "end_turn"));
+
+    expect(t.take("msg_A")).toEqual({ outputTokens: 179, stopReason: "end_turn" });
+  });
+
+  // `message_delta` carries no message id of its own, so the tracker has to
+  // remember which message is open. Parallel Task subagents interleave their
+  // stream events with the main agent's, and `parent_tool_use_id` is the only
+  // thing separating them.
+  it("keeps interleaved subagent streams apart by parent_tool_use_id", () => {
+    const t = new MessageDeltaTracker();
+    t.observe(messageStart("msg_main"));
+    t.observe(messageStart("msg_sub", "toolu_01"));
+    t.observe(messageDelta(42, "end_turn", "toolu_01"));
+    t.observe(messageDelta(179, "tool_use"));
+
+    expect(t.take("msg_sub")).toEqual({ outputTokens: 42, stopReason: "end_turn" });
+    expect(t.take("msg_main")).toEqual({ outputTokens: 179, stopReason: "tool_use" });
+  });
+
+  it("ignores a delta that arrives with no message_start ahead of it", () => {
+    const t = new MessageDeltaTracker();
+    t.observe(messageDelta(179, "tool_use"));
+
+    expect(t.take("msg_A")).toBeNull();
+  });
+
+  it("ignores non-stream_event messages and malformed events", () => {
+    const t = new MessageDeltaTracker();
+    t.observe({ type: "assistant", message: { id: "msg_A", usage: { output_tokens: 2 } } });
+    t.observe({ type: "stream_event" });
+    t.observe({ type: "stream_event", event: { type: "content_block_delta" } });
+
+    expect(t.take("msg_A")).toBeNull();
+  });
+});

--- a/packages/adapter-claude-sdk/test/partialMessages.test.ts
+++ b/packages/adapter-claude-sdk/test/partialMessages.test.ts
@@ -199,6 +199,33 @@ describe("MessageDeltaTracker — the authoritative per-turn output tokens", () 
     expect(t.take("msg_A")).toEqual({ outputTokens: 179, stopReason: "end_turn" });
   });
 
+  // In the normal flow only one delta is ever outstanding, so a naive "return
+  // whatever delta we saw last" would pass every other test here. It is wrong as
+  // soon as two are pending at once — a turn that never produced an `assistant`
+  // message leaves its delta behind, and if the SDK ever forwards subagent
+  // stream events, two streams are in flight by construction. Pin the lookup.
+  it("hands each turn its OWN delta when several are outstanding", () => {
+    const t = new MessageDeltaTracker();
+    t.observe(messageStart("msg_A"));
+    t.observe(messageDelta(100, "tool_use"));
+    t.observe(messageStart("msg_B"));
+    t.observe(messageDelta(200, "end_turn"));
+
+    // Taken out of order on purpose: a positional implementation gets this wrong.
+    expect(t.take("msg_B")).toEqual({ outputTokens: 200, stopReason: "end_turn" });
+    expect(t.take("msg_A")).toEqual({ outputTokens: 100, stopReason: "tool_use" });
+  });
+
+  it("does not hand a turn a different turn's delta when its own is missing", () => {
+    const t = new MessageDeltaTracker();
+    t.observe(messageStart("msg_A"));
+    t.observe(messageDelta(100, "tool_use"));
+
+    // msg_B never got a delta — it must fall back to the snapshot, not inherit A's.
+    expect(t.take("msg_B")).toBeNull();
+    expect(t.take("msg_A")?.outputTokens).toBe(100);
+  });
+
   it("ignores a delta that arrives with no message_start ahead of it", () => {
     const t = new MessageDeltaTracker();
     t.observe(messageDelta(179, "tool_use"));

--- a/packages/adapter-claude-sdk/test/partialMessages.test.ts
+++ b/packages/adapter-claude-sdk/test/partialMessages.test.ts
@@ -178,6 +178,27 @@ describe("MessageDeltaTracker — the authoritative per-turn output tokens", () 
     expect(t.take("msg_main")).toEqual({ outputTokens: 179, stopReason: "tool_use" });
   });
 
+  // Several deltas can arrive for one message (server-side tool-use loop), so
+  // the open slot must survive them and only close on `message_stop`.
+  it("keeps the open slot across deltas and releases it on message_stop", () => {
+    const messageStop = (parentToolUseId: string | null = null) => ({
+      type: "stream_event",
+      parent_tool_use_id: parentToolUseId,
+      event: { type: "message_stop" },
+    });
+
+    const t = new MessageDeltaTracker();
+    t.observe(messageStart("msg_A"));
+    t.observe(messageDelta(120, "tool_use"));
+    t.observe(messageDelta(179, "end_turn"));
+    t.observe(messageStop());
+    // A delta arriving after the stop has no open message to attach to, so it
+    // cannot retroactively overwrite the finished turn.
+    t.observe(messageDelta(9999, "end_turn"));
+
+    expect(t.take("msg_A")).toEqual({ outputTokens: 179, stopReason: "end_turn" });
+  });
+
   it("ignores a delta that arrives with no message_start ahead of it", () => {
     const t = new MessageDeltaTracker();
     t.observe(messageDelta(179, "tool_use"));

--- a/packages/adapter-claude-sdk/test/toolEvents.test.ts
+++ b/packages/adapter-claude-sdk/test/toolEvents.test.ts
@@ -342,3 +342,33 @@ describe("withToolEvents", () => {
     expect(new Set(rows.map((r) => r.event_id)).size).toBe(2);
   });
 });
+
+// F-998. The adapter injects `includePartialMessages` for the token lanes, and
+// a subagent's stream events carry a `parent_tool_use_id` — enough to mint a
+// SubagentSpawnEvent on their own. This lane reads content blocks, which
+// partial messages do not carry, so the emitted rows must not move.
+describe("withToolEvents → injected partial messages emit nothing", () => {
+  it("ignores stream events and the status ping, including subagent ones", async () => {
+    const messages = [
+      {
+        type: "stream_event",
+        parent_tool_use_id: "toolu_sub",
+        event: { type: "message_start", message: { id: "msg_A" } },
+      },
+      { type: "system", subtype: "status", status: "requesting" },
+      {
+        type: "stream_event",
+        parent_tool_use_id: "toolu_sub",
+        event: { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 42 } },
+      },
+      { type: "result" },
+    ] as unknown as FakeMsg[];
+
+    const out: FakeMsg[] = [];
+    for await (const m of withToolEvents(fakeRun(messages))) out.push(m);
+
+    // Passed straight through, and nothing was written.
+    expect(out).toEqual(messages);
+    expect(existsSync(signalsPath)).toBe(false);
+  });
+});

--- a/packages/adapter-claude-sdk/test/turnUsage.test.ts
+++ b/packages/adapter-claude-sdk/test/turnUsage.test.ts
@@ -38,9 +38,15 @@ function readRows(): Array<Record<string, unknown>> {
     .map((l) => JSON.parse(l) as Record<string, unknown>);
 }
 
+// A message may carry `__sleepMs` to hold the source generator before yielding
+// it, so a test can prove which messages move the latency-window boundary.
 async function drive(messages: Array<{ type: string; [k: string]: unknown }>): Promise<void> {
   async function* src() {
-    for (const m of messages) yield m;
+    for (const m of messages) {
+      const sleep = m.__sleepMs as number | undefined;
+      if (sleep) await new Promise((r) => setTimeout(r, sleep));
+      yield m;
+    }
   }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   for await (const _ of withTurnUsage(src())) void _;
@@ -181,5 +187,77 @@ describe("withTurnUsage → one row per API turn, not per content block", () => 
     await drive([{ type: "assistant", message: { id: "msg_A", model: "m", usage } }]);
 
     expect(readRows()).toHaveLength(1);
+  });
+});
+
+// F-998. `output_tokens` on an assistant message is the `message_start`
+// snapshot, and `stop_reason` is null on every one of them — so this lane's
+// `finish_reasons` has always been null in practice. Both finished values live
+// on the `message_delta` stream event.
+describe("withTurnUsage → message_delta supplies output_tokens and finish_reasons", () => {
+  const streamStart = (id: string) => ({
+    type: "stream_event",
+    parent_tool_use_id: null,
+    event: { type: "message_start", message: { id, usage: { input_tokens: 2, output_tokens: 2 } } },
+  });
+  const streamDelta = (outputTokens: number, stopReason: string) => ({
+    type: "stream_event",
+    parent_tool_use_id: null,
+    event: { type: "message_delta", delta: { stop_reason: stopReason }, usage: { output_tokens: outputTokens } },
+  });
+
+  it("overrides the snapshot and fills in the finish reason", async () => {
+    await drive([
+      streamStart("msg_A"),
+      { type: "assistant", message: { id: "msg_A", model: "m", stop_reason: null, usage: { input_tokens: 2, output_tokens: 2 } } },
+      streamDelta(179, "tool_use"),
+      { type: "result", subtype: "success" },
+    ]);
+
+    const rows = readRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.output_tokens).toBe(179);
+    expect(rows[0]!.finish_reasons).toEqual(["tool_use"]);
+    // The input lane is untouched by F-998 — still the raw cache-miss residue.
+    expect(rows[0]!.input_tokens).toBe(2);
+  });
+
+  it("keeps the snapshot when no message_delta arrived", async () => {
+    await drive([
+      { type: "assistant", message: { id: "msg_A", model: "m", usage: { input_tokens: 2, output_tokens: 31 } } },
+      { type: "result", subtype: "success" },
+    ]);
+
+    expect(readRows()[0]!.output_tokens).toBe(31);
+  });
+
+  it("does not let injected partial messages shrink latency_ms", async () => {
+    await drive([
+      { type: "user" },
+      { type: "stream_event", __sleepMs: 40, parent_tool_use_id: null, event: { type: "message_start", message: { id: "msg_A", usage: {} } } },
+      { type: "system", subtype: "status", status: "requesting" },
+      { type: "assistant", message: { id: "msg_A", model: "m", usage: { input_tokens: 2, output_tokens: 2 } } },
+      streamDelta(179, "end_turn"),
+      { type: "result", subtype: "success" },
+    ]);
+
+    expect(readRows()[0]!.latency_ms as number).toBeGreaterThanOrEqual(30);
+  });
+
+  it("counts turns, not the stream events between them", async () => {
+    await drive([
+      streamStart("msg_A"),
+      { type: "assistant", message: { id: "msg_A", model: "m", usage: { input_tokens: 2, output_tokens: 2 } } },
+      streamDelta(179, "tool_use"),
+      { type: "user" },
+      streamStart("msg_B"),
+      { type: "assistant", message: { id: "msg_B", model: "m", usage: { input_tokens: 2, output_tokens: 72 } } },
+      streamDelta(73, "end_turn"),
+      { type: "result", subtype: "success" },
+    ]);
+
+    const rows = readRows();
+    expect(rows.map((r) => r.turn_index)).toEqual([0, 1]);
+    expect(rows.map((r) => r.output_tokens)).toEqual([179, 73]);
   });
 });


### PR DESCRIPTION
## Summary

`gen_ai.usage.output_tokens` was the `message_start` snapshot — the count at the moment the stream envelope was cut, not the finished turn. The tell is `stop_reason: null` on every `assistant` message; a completed Anthropic message always has one.

The finished value exists only on the `message_delta` stream event, which the SDK emits only when `query()` was called with `includePartialMessages: true` — the **caller's** option. So `query()` now sets it whenever a telemetry lane is configured, and filters the consequences back out so an agent author's `for await` loop is unchanged.

| `02-injection-issue-body`, hosted | before | after |
| -- | -- | -- |
| `agent_tokens_out` | **31** | **1059** |
| `agent_tokens_in` | 18 → 155,330 (F-994) | 155,330 |
| span count | 9 → 4 (F-994) | 4 |

## The flag adds two message kinds, not one

Alongside `stream_event` comes a `system/status` message with `status: "requesting"`, one per API turn. Proven twice:

1. An A/B on a deterministic single-turn prompt — 0 occurrences without the flag, 1 per turn with it, two runs each way.
2. The `claude` binary itself, where one gate guards both emissions:

```js
case"stream_request_start": if(H) yield {type:"system",subtype:"status",status:"requesting"}
...                        if(H) yield {type:"stream_event", event:...}
```

The sibling `case"sdk_status"` path — `compacting`, the permission-mode `status:null`, `compact_result` / `compact_error` — is **not** behind that gate, so those reach an agent author with or without pome. Filtering every `system/status` would have broken pass-through fidelity in the other direction; the filter matches `requesting` only.

## Two things that would have been silent regressions

- **`message_delta` carries no message id.** It comes from the `message_start` that opened the message. Parallel Task subagents interleave their stream events with the main agent's and `parent_tool_use_id` is the only separator, hence one open-message slot per stream rather than a single global.
- **Injected messages must not move the turn boundary.** They land microseconds before the assistant message they describe, so letting them advance it would collapse every span window to ~0 ms and undo F-994's latency fix. The same guard goes into `withToolEvents`, where a subagent stream event carries enough `parent_tool_use_id` to mint a spurious `SubagentSpawnEvent`.

`finish_reasons` on the `LlmTurnEvent` lane is fixed by the same event — it had always been null in practice, because it read the assistant message's `stop_reason`.

## Verification

Live, through the **built** adapter on a 4-turn run (`.context/verify-f998.mjs`), all seven checks green — and repeated four times on independent runs, exact every time (557, 655, 629, 611):

```
span output_tokens == result rollup                 (557 vs 557)
LlmTurnEvent output_tokens == result rollup         (557 vs 557)
span input_tokens == result rollup (F-994 intact)   (126966 vs 126966)
no partial-message artifacts leaked                 (none)
one span per LlmTurnEvent row                       (4 vs 4)
every turn has a finish reason                      (tool_use x3, end_turn)
span windows not collapsed                          (428, 2948, 5393, 5340 ms)
```

Hosted: `run_cE3D58umjFbI9H3B`, 100/100 PASS, `agent_tokens_out` 1059, span count 4, `agent_error_count` 0.

Tests: 141 in this package, 1586+ across all 8 workspaces, contract suite 104/104. **Mutation-checked 15/15, 0 survived** — every guard in the diff fails at least one test when broken, in both directions for the filter. That sweep found a real hole in my own tests, written up in a comment below.

**Scope of the exactness claim.** It holds over **main-agent** turns. `SDKResultMessage.usage` counts only the main agent, and the SDK forwards no sub-agent stream events, so sub-agent turns keep the snapshot and sit outside the rollup on both sides. Live two-sub-agent run: main deltas `517 + 7 == 524 == result`. Details and the two residuals that fall out of it are in a comment below; neither is a regression here (F-994 shows the same asymmetry on the input side).

## Reviewer notes

- **`agent_model = unknown`** in the hosted rollup is pre-existing — the F-994 baseline run `run_TtKKRvLu3qzj5IXt` shows the same. Not touched here.
- **Stream-volume cost**, measured live: messages x3.3–3.6, bytes x1.3–1.4. Well short of the order of magnitude the ticket budgeted for — the CLI batches content deltas coarsely, so a 667-token text turn produced 29 stream events, not 667.
- **`POME_DISABLE_PARTIAL_MESSAGES=1`** reverts to the old behaviour without a release — exercised live, and it doubles as a clean A/B isolating the fix: same build, same script, `11` vs `629` output tokens, with input attribution and stream fidelity unchanged either way.
- Injection is gated on a telemetry lane being configured, matching how both lanes are already inert without one — so standalone dev pays nothing.
- No changeset: that gate is `cli/`-only. No version bump, matching F-994 — `packages/` ships in a separate `packages-v*` batch and this adds no public API surface.
