### PR TITLE
fix(examples): deleteSession confirms discard on an ungraded_session 409 (F-999)

### DIFF
--- a/examples/minimal-viktor-langgraph/scripts/pome-api.ts
+++ b/examples/minimal-viktor-langgraph/scripts/pome-api.ts
@@ -137,10 +137,60 @@ export async function createSlackSession(creds: PomeCredentials): Promise<SlackS
   return { sessionId: body.session_id, twinUrl: twinUrl.replace(/\/$/, ""), agentToken: body.agent_token };
 }
 
+/**
+ * Delete a sandbox session. The control plane refuses to destroy a session
+ * whose run has never been graded (409, `error.details.reason ===
+ * "ungraded_session"`) and hands back a one-time `discard_token` to confirm
+ * the discard. Every session this teardown deletes was created by the run
+ * itself and is either already finalized or was never launched -- there is
+ * nothing worth grading -- so we auto-confirm without prompting. A 409 that
+ * is NOT that reason (e.g. an already-closed session carrying
+ * `details.current_state`) is idempotent success: the sandbox is already
+ * gone. An unrecognized/unparseable 409 body, or a recognized refusal with
+ * no usable token, is neither of those -- it falls through to the existing
+ * warning so a real leak stays visible in the run output.
+ */
 export async function deleteSession(creds: PomeCredentials, sessionId: string): Promise<void> {
-  const res = await controlPlane(creds, "DELETE", `/v1/sessions/${encodeURIComponent(sessionId)}`);
+  const path = `/v1/sessions/${encodeURIComponent(sessionId)}`;
+  let res = await controlPlane(creds, "DELETE", path);
+
+  if (res.status === 409) {
+    const details = parseConflictDetails(res.text);
+    if (details) {
+      if (details.reason === "ungraded_session") {
+        const token = details.discard_token;
+        if (typeof token === "string" && token.length > 0) {
+          res = await controlPlane(
+            creds,
+            "DELETE",
+            `${path}?confirm_discard=${encodeURIComponent(token)}`,
+          );
+        }
+        // else: a recognized refusal with no usable discard_token -- fall
+        // through to the warning below instead of swallowing it silently.
+      } else {
+        // Some other named reason (already-closed session, etc.): the
+        // sandbox is already gone.
+        return;
+      }
+    }
+    // else: unparseable body -- fall through to the warning below rather
+    // than treating an unrecognized 409 as success.
+  }
+
   if (res.status >= 400 && res.status !== 404) {
     console.warn(`[run-trials] DELETE ${sessionId} -> ${res.status} (sandbox may be leaked): ${res.text}`);
+  }
+}
+
+function parseConflictDetails(text: string): { reason?: string; discard_token?: string } | undefined {
+  try {
+    const parsed = JSON.parse(text) as {
+      error?: { details?: { reason?: string; discard_token?: string } };
+    };
+    return parsed.error?.details;
+  } catch {
+    return undefined;
   }
 }
 

--- a/examples/minimal-viktor/scripts/pome-api.ts
+++ b/examples/minimal-viktor/scripts/pome-api.ts
@@ -137,10 +137,60 @@ export async function createSlackSession(creds: PomeCredentials): Promise<SlackS
   return { sessionId: body.session_id, twinUrl: twinUrl.replace(/\/$/, ""), agentToken: body.agent_token };
 }
 
+/**
+ * Delete a sandbox session. The control plane refuses to destroy a session
+ * whose run has never been graded (409, `error.details.reason ===
+ * "ungraded_session"`) and hands back a one-time `discard_token` to confirm
+ * the discard. Every session this teardown deletes was created by the run
+ * itself and is either already finalized or was never launched -- there is
+ * nothing worth grading -- so we auto-confirm without prompting. A 409 that
+ * is NOT that reason (e.g. an already-closed session carrying
+ * `details.current_state`) is idempotent success: the sandbox is already
+ * gone. An unrecognized/unparseable 409 body, or a recognized refusal with
+ * no usable token, is neither of those -- it falls through to the existing
+ * warning so a real leak stays visible in the run output.
+ */
 export async function deleteSession(creds: PomeCredentials, sessionId: string): Promise<void> {
-  const res = await controlPlane(creds, "DELETE", `/v1/sessions/${encodeURIComponent(sessionId)}`);
+  const path = `/v1/sessions/${encodeURIComponent(sessionId)}`;
+  let res = await controlPlane(creds, "DELETE", path);
+
+  if (res.status === 409) {
+    const details = parseConflictDetails(res.text);
+    if (details) {
+      if (details.reason === "ungraded_session") {
+        const token = details.discard_token;
+        if (typeof token === "string" && token.length > 0) {
+          res = await controlPlane(
+            creds,
+            "DELETE",
+            `${path}?confirm_discard=${encodeURIComponent(token)}`,
+          );
+        }
+        // else: a recognized refusal with no usable discard_token -- fall
+        // through to the warning below instead of swallowing it silently.
+      } else {
+        // Some other named reason (already-closed session, etc.): the
+        // sandbox is already gone.
+        return;
+      }
+    }
+    // else: unparseable body -- fall through to the warning below rather
+    // than treating an unrecognized 409 as success.
+  }
+
   if (res.status >= 400 && res.status !== 404) {
     console.warn(`[run-trials] DELETE ${sessionId} -> ${res.status} (sandbox may be leaked): ${res.text}`);
+  }
+}
+
+function parseConflictDetails(text: string): { reason?: string; discard_token?: string } | undefined {
+  try {
+    const parsed = JSON.parse(text) as {
+      error?: { details?: { reason?: string; discard_token?: string } };
+    };
+    return parsed.error?.details;
+  } catch {
+    return undefined;
   }
 }
 


### PR DESCRIPTION
<!-- Closes F-999 -->

## What
The control plane's `DELETE /v1/sessions/:id` now refuses to destroy a session whose run has never been graded (409, `error.details.reason === "ungraded_session"`, plus a one-time `error.details.discard_token` to confirm). The `minimal-viktor` and `minimal-viktor-langgraph` examples' `deleteSession` didn't know about this and treated it like any other non-404 4xx: log a `console.warn(...sandbox may be leaked...)` and give up.

**Today:** every teardown of a session that hasn't been finalized hits this refusal, logs the warning, and really does leak the sandbox — the firecracker microVM stays up holding a concurrency slot until TTL. This isn't an edge case: `run-trials.ts`'s `probe()` deletes a session in its `finally` block that was *never finalized in the first place*, so it takes the refusal on every single probe run, not just on failures.

**After this change:** `deleteSession` parses the 409 body defensively and, when it recognizes `reason === "ungraded_session"` with a usable `discard_token`, re-issues the DELETE with `?confirm_discard=<token>` and honours that second response. A 409 with any other reason (e.g. an already-closed session carrying `details.current_state`) is still treated as idempotent success — the sandbox is already gone, matching `@pome-sh/cli@0.9.0` and the dashboard. An unparseable body, or a recognized refusal with no usable token, falls through to the existing warning instead of being silently swallowed, so a real leak still shows up in run output.

## Why
Auto-confirming (no prompt) is correct here specifically because this is a cleanup teardown path: every session these scripts delete was created by the run itself, and is either already finalized or was never launched — there is nothing left to grade. That's different from a human calling stop on a session they might still want graded, which is why the control plane makes confirmation an explicit second call rather than a query param on the first DELETE.

## Notes for reviewer
- `examples/minimal-viktor/scripts/pome-api.ts` and `examples/minimal-viktor-langgraph/scripts/pome-api.ts` are deliberately standalone near-duplicates (not factored into a shared module); both got the identical change and are still byte-identical after the edit.
- `run-trials.ts` needed no changes in either example — all three call sites (error rollback, `probe()`'s `finally`, `--cleanup`) go through `deleteSession`, so the fix is fully contained in `pome-api.ts`.
- No changeset, no CLI version bump: these root-level `examples/` aren't in `cli/package.json`'s `files` array and don't ship in the npm package.

## Review required
<!-- none -->