### PR TITLE
The check declaration says what it compares, and both doors can prove they agree (F-1074)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5889,7 +5889,7 @@
     },
     "packages/sdk": {
       "name": "@pome-sh/sdk",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "dependencies": {
         "@pome-sh/shared-types": "0.12.0",
         "hono": "^4.12.31",
@@ -5936,11 +5936,11 @@
     },
     "packages/twin-github": {
       "name": "@pome-sh/twin-github",
-      "version": "0.2.3",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.10",
-        "@pome-sh/sdk": "0.5.2",
+        "@pome-sh/sdk": "0.6.0",
         "@pome-sh/shared-types": "0.12.0",
         "hono": "^4.12.31",
         "zod": "^4.1.13"

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,30 @@
 # @pome-sh/sdk
 
+## 0.6.0 — 2026-07-28
+
+Minor, not patch: `CheckDefinition.description` and `CheckParamType.example`
+are REQUIRED, which is a published signature change (`PACKAGE_RELEASE.md` —
+0.x minor plays the major role). 0.5.2 was a patch because it only *added*
+exports. `npm run test:contract` is green, but it is a runtime suite and
+required-ness is a compile-time property, so it is structurally blind to this
+class of change. Every implementer today is in this repo.
+
+- `CheckDefinition.description` — what the predicate actually compares.
+  Required because an authoring surface can only show what is declared, and a
+  rendered sentence wider than its check is the one defect this architecture
+  makes easier (Shankar et al., UIST '24 §7.3.3).
+- `CheckParamType.example` — a valid value per slot, asserted against its own
+  `pattern` inside `defineCheck`, so a type whose example is invalid cannot
+  ship. A regex source is not a prompt.
+- `checksDigest(defs)` — one implementation of "hash the binding surface",
+  called by both the control plane and the CLI, which resolve declarations
+  from independent npm pins. Hashes `id`, `substrate` and the COMPILED
+  pattern; never `description` or `example`, because a prose edit changes no
+  sentence and must never refuse an author's write.
+- `CheckBindingShape` — the subset that decides binding. `checkPattern` and
+  `checkNearMissPattern` now take it, so a heterogeneous registry can be
+  hashed without an args-erasing cast.
+
 ## 0.5.2 — 2026-07-28
 
 Additive: `@pome-sh/sdk/checks`, the assertable check vocabulary (F-1073).

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/sdk",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Twin engine for Pome digital twins — defineTwin() + serve(): HTTP mounting, bearer auth, trace recorder, MCP dispatch, SQLite-backed state.",
   "private": false,
   "type": "module",

--- a/packages/sdk/src/checks.ts
+++ b/packages/sdk/src/checks.ts
@@ -15,6 +15,8 @@
 // reconcile — the drift gate's job is catching a pin that fell behind, not
 // reconciling two hand-maintained vocabularies.
 
+import { createHash } from "node:crypto";
+
 export type CheckPolarity = "positive" | "negative";
 
 // Which substrates a check's predicate needs. The consuming engine supplies
@@ -31,6 +33,11 @@ export type CheckSubstrateKind = "final" | "seed+final" | "tape";
 export interface CheckParamType {
   readonly name: string;
   readonly pattern: string;
+  // A valid value for this slot, shown as an author-facing hint (F-1074).
+  // `pattern` is a regex source; asking an author to satisfy one directly is
+  // hostile. `defineCheck` asserts this against `pattern` at module load, so a
+  // type whose own example is invalid cannot ship.
+  readonly example: string;
   render(value: string): string;
   parse(raw: string): string;
 }
@@ -42,6 +49,7 @@ export interface CheckParamType {
 export const repoRef: CheckParamType = {
   name: "repo",
   pattern: "[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+",
+  example: "acme/api",
   render: (value) => value,
   parse: (raw) => raw,
 };
@@ -67,6 +75,16 @@ export interface CheckDefinition<TState, TArgs extends Record<string, string>> {
   // `<twin>.<what-it-asserts>`, unique across the twin's declarations. Reports
   // name the check a criterion bound to; a regex source is not a name.
   id: string;
+  // What the predicate ACTUALLY compares, in a sentence or two (F-1074).
+  //
+  // REQUIRED, for the same reason `polarity` and `vacuityMutant` are: an
+  // optional field is one every later declaration omits, and an authoring
+  // surface can only show what is declared. A picker that offers nothing but
+  // the rendered sentence is the readable surface that hides disagreement
+  // (Shankar et al., UIST '24 §7.3.3) — `no-new-labels` reads as an
+  // issue-level claim while comparing repo-level label DEFINITIONS, so an
+  // agent applying an already-defined label passes, correctly and invisibly.
+  description: string;
   // English with typed slots, e.g. "No new labels were created in `{repo}`".
   // This is the ONE grammar: rendering and matching are both derived from it.
   template: string;
@@ -155,6 +173,17 @@ export function defineCheck<TState, TParams extends Record<string, CheckParamTyp
       throw new Error(`check ${def.id}: declared param \`${declared}\` is not used by the template`);
     }
   }
+  // F-1074 — a param type whose own example violates its own pattern would put
+  // an invalid value in front of an author as the suggested one.
+  for (const [name, type] of Object.entries(def.params)) {
+    const paramType = type as CheckParamType;
+    if (!new RegExp(`^${paramType.pattern}$`).test(paramType.example)) {
+      throw new Error(
+        `check ${def.id}: param \`${name}\` example ${JSON.stringify(paramType.example)} ` +
+          `does not match its own pattern /${paramType.pattern}/`,
+      );
+    }
+  }
   return def as CheckDefinition<TState, ArgsOfParams<TParams>>;
 }
 
@@ -183,11 +212,42 @@ function buildPattern(template: string, slotSource: (index: number) => string): 
   return new RegExp(`${source}$`);
 }
 
-export function checkPattern<TState, TArgs extends Record<string, string>>(
-  def: CheckDefinition<TState, TArgs>,
-): RegExp {
+// The subset of a declaration that decides what BINDS. Named as a type because
+// it is exactly what `checksDigest` hashes and exactly what a stale pin can
+// move. Taking this instead of `CheckDefinition` also lets a heterogeneous
+// registry be hashed without the args-erasing cast the engine needs elsewhere.
+export interface CheckBindingShape {
+  readonly id: string;
+  readonly template: string;
+  readonly substrate: CheckSubstrateKind;
+  readonly params: Readonly<Record<string, CheckParamType>>;
+}
+
+export function checkPattern(def: CheckBindingShape): RegExp {
   const { params } = templateSlots(def.template);
-  return buildPattern(def.template, (index) => def.params[params[index] as keyof TArgs]!.pattern);
+  return buildPattern(def.template, (index) => def.params[params[index]!]!.pattern);
+}
+
+// One implementation, called by BOTH the control plane and the CLI (F-1074).
+// They resolve declarations from independent npm pins and must be able to prove
+// they agree before an author writes a sentence; two implementations of "hash
+// the binding surface" would be the same two-representations-of-one-fact defect
+// this vocabulary exists to remove, one level down — a sort or key-order
+// difference would make every pin look skewed, or a real skew look equal.
+//
+// `description` and `example` are deliberately NOT hashed. This digest gates an
+// author's write, and a prose edit changes no sentence.
+export function checksDigest(defs: readonly CheckBindingShape[]): string {
+  const rows = defs
+    .map((def) => ({
+      id: def.id,
+      substrate: def.substrate,
+      // The compiled source, not the template: this also catches a change in
+      // `buildPattern` itself, which comparing templates would miss.
+      pattern: checkPattern(def).source,
+    }))
+    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+  return `sha256:${createHash("sha256").update(JSON.stringify(rows), "utf8").digest("hex")}`;
 }
 
 // The literal segments intact, every slot wide open. A text matching THIS and
@@ -195,9 +255,7 @@ export function checkPattern<TState, TArgs extends Record<string, string>>(
 // check's sentence but fills a slot with something the slot's type rejects.
 // A text that fails this too is a stranger, and stays on the unmatched path —
 // which is what keeps this gate off the legacy phrases that resemble nothing.
-export function checkNearMissPattern<TState, TArgs extends Record<string, string>>(
-  def: CheckDefinition<TState, TArgs>,
-): RegExp {
+export function checkNearMissPattern(def: CheckBindingShape): RegExp {
   return buildPattern(def.template, () => ".+?");
 }
 

--- a/packages/sdk/test/checks.test.ts
+++ b/packages/sdk/test/checks.test.ts
@@ -2,16 +2,19 @@ import { describe, expect, it } from "vitest";
 import {
   checkNearMissPattern,
   checkPattern,
+  checksDigest,
   defineCheck,
   parseCheck,
   renderCheck,
   repoRef,
   templateSlots,
-  type CheckDefinition
+  type CheckDefinition,
+  type CheckParamType
 } from "../src/checks.js";
 
 const noNewLabels: CheckDefinition<unknown, { repo: string }> = defineCheck({
   id: "example.no-new-labels",
+  description: "Compares the repo's label definitions in the seed against the final state.",
   template: "No new labels were created in `{repo}`",
   params: { repo: repoRef },
   substrate: "seed+final",
@@ -92,6 +95,7 @@ describe("parseCheck", () => {
 describe("defineCheck validation", () => {
   const base = {
     id: "example.bad",
+    description: "Exists only to exercise defineCheck's validation.",
     substrate: "final" as const,
     polarity: () => "negative" as const,
     vacuityMutant: () => null,
@@ -114,5 +118,86 @@ describe("defineCheck validation", () => {
     expect(() => defineCheck({ ...base, template: "`{repo}` and `{repo}`", params: { repo: repoRef } })).toThrow(
       /duplicate template slot \{repo\}/
     );
+  });
+});
+
+describe("checksDigest", () => {
+  const alpha = defineCheck({
+    id: "x.alpha",
+    description: "Alpha compares the alpha field, which the sentence does not say.",
+    template: "Alpha is set on `{repo}`",
+    params: { repo: repoRef },
+    substrate: "final",
+    polarity: () => "positive",
+    vacuityMutant: () => null,
+    evaluate: () => ({ passed: true, reason: "stub" })
+  });
+  const beta = defineCheck({
+    id: "x.beta",
+    description: "Beta compares the beta field, which the sentence does not say.",
+    template: "Beta is set on `{repo}`",
+    params: { repo: repoRef },
+    substrate: "final",
+    polarity: () => "positive",
+    vacuityMutant: () => null,
+    evaluate: () => ({ passed: true, reason: "stub" })
+  });
+
+  it("does not depend on declaration order", () => {
+    expect(checksDigest([alpha, beta])).toBe(checksDigest([beta, alpha]));
+  });
+
+  it("moves when a template changes, because that changes what binds", () => {
+    const renamed = { ...alpha, template: "Alpha is now set on `{repo}`" };
+    expect(checksDigest([renamed])).not.toBe(checksDigest([alpha]));
+  });
+
+  it("moves when a param type's pattern changes", () => {
+    const looseRepo: CheckParamType = { ...repoRef, pattern: ".+" };
+    const loosened = { ...alpha, params: { repo: looseRepo } };
+    expect(checksDigest([loosened])).not.toBe(checksDigest([alpha]));
+  });
+
+  it("does NOT move when only prose changes", () => {
+    // The digest gates an author's write. A description or example edit changes
+    // no sentence and must never refuse one.
+    const reworded = {
+      ...alpha,
+      description: "A completely different explanation of the same comparison.",
+      params: { repo: { ...repoRef, example: "other/repo" } }
+    };
+    expect(checksDigest([reworded])).toBe(checksDigest([alpha]));
+  });
+
+  it("is prefixed so a caller can tell the algorithm from the value", () => {
+    expect(checksDigest([alpha])).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+});
+
+describe("defineCheck validates a param type's own example", () => {
+  it("throws when the example fails the pattern it ships with", () => {
+    const broken: CheckParamType = {
+      name: "repo",
+      pattern: "[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+",
+      example: "not a repo",
+      render: (value) => value,
+      parse: (raw) => raw
+    };
+    expect(() =>
+      defineCheck({
+        id: "x.broken-example",
+        description: "Exists only to prove the example assertion fires.",
+        template: "A thing about `{repo}`",
+        params: { repo: broken },
+        substrate: "final",
+        polarity: () => "positive",
+        vacuityMutant: () => null,
+        evaluate: () => ({ passed: true, reason: "stub" })
+      })
+    ).toThrow(/example .* does not match its own pattern/);
+  });
+
+  it("accepts repoRef, whose example is a real repo reference", () => {
+    expect(new RegExp(`^${repoRef.pattern}$`).test(repoRef.example)).toBe(true);
   });
 });

--- a/packages/twin-github/CHANGELOG.md
+++ b/packages/twin-github/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @pome-sh/twin-github — CHANGELOG
 
+## 0.3.0 — 2026-07-28
+
+- `github.no-new-labels` declares a `description`: it compares the repository's
+  label DEFINITIONS between the seed and the final state, so applying an
+  already-defined label passes. That was a source comment; it is now readable
+  by the authoring surfaces (F-1074).
+- Requires `@pome-sh/sdk@0.6.0`, whose `CheckDefinition` makes `description`
+  required. Minor for the same reason the sdk's is.
+
 ## 0.2.3 — 2026-07-28
 
 Additive: `@pome-sh/twin-github/checks` declares `github.no-new-labels`

--- a/packages/twin-github/package.json
+++ b/packages/twin-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-github",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Deterministic GitHub-shaped twin for agent testing — REST + MCP, SQLite-backed state.",
   "private": false,
   "type": "module",
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^2.0.10",
-    "@pome-sh/sdk": "0.5.2",
+    "@pome-sh/sdk": "0.6.0",
     "@pome-sh/shared-types": "0.12.0",
     "hono": "^4.12.31",
     "zod": "^4.1.13"

--- a/packages/twin-github/src/checks.ts
+++ b/packages/twin-github/src/checks.ts
@@ -64,6 +64,14 @@ function labelNames(repo: GitHubCheckStateRepo): Set<string> {
 
 const noNewLabels: CheckDefinition<GitHubCheckState, { repo: string }> = defineCheck({
   id: "github.no-new-labels",
+  // F-1074 — the same explanation the comment below carries, in the one place
+  // an author can actually reach it.
+  description:
+    "Compares the repository's label DEFINITIONS in the seed against the final state. " +
+    "Applying an ALREADY-DEFINED label to an issue PASSES this check — only creating a " +
+    "label the repo did not already define fails it. `addIssueLabels` rejects an undefined " +
+    "label, so an examinee cannot apply a new one without creating it first, which is what " +
+    "makes this tight. Needs the seed: it is a delta, not a state assertion.",
   // The repo is named on purpose. Without it the sentence reads as an
   // issue-level claim — "the agent did not add labels to the issue" — which is
   // WIDER than what this predicate compares. `create_label` is repo-scoped in

--- a/packages/twin-github/test/checks-contract.test.ts
+++ b/packages/twin-github/test/checks-contract.test.ts
@@ -78,6 +78,23 @@ describe("declared check identity", () => {
     const missing = CHECKS.filter((check) => !FIXTURES[check.id]).map((check) => check.id);
     expect(missing, `checks with no FIXTURES entry: ${missing.join(", ")}`).toEqual([]);
   });
+
+  it("says what the predicate actually compares, in words the sentence does not carry", () => {
+    // The one defect this architecture makes EASIER, not harder: a rendered
+    // sentence wider or narrower than its check (Shankar et al., UIST '24
+    // §7.3.3 — readable surfaces hide the disagreement code makes visible).
+    // `No new labels were created in <repo>` reads as an issue-level claim; the
+    // predicate compares repo-level label DEFINITIONS. An authoring surface can
+    // only show what is declared, so the gap has to close here.
+    for (const check of CHECKS) {
+      expect(check.description?.trim(), `${check.id} declares no description`).toBeTruthy();
+      expect(
+        check.description.trim(),
+        `${check.id}'s description just restates its template — it must say what the ` +
+          `predicate COMPARES, which is the thing the sentence cannot carry`,
+      ).not.toBe(check.template);
+    }
+  });
 });
 
 describe("declared check grammar", () => {


### PR DESCRIPTION
<!-- F-1074 -->

## What

Adds the two fields an authoring surface needs to `CheckDefinition` /
`CheckParamType` — `description` (what the predicate *actually* compares) and
`example` (a valid value per parameter) — plus `checksDigest`, one
implementation of "hash the binding surface". Releases `@pome-sh/sdk@0.6.0` and
`@pome-sh/twin-github@0.3.0`.

## Why

F-1074 (milestone A2b, Verifiable Scores). The author must pick a typed check
and have the system render the English, and a picker can only show what the
declaration carries. Today it carries `id` / `template` / `params` / `substrate`
/ `polarity` / `subject` / `vacuityMutant` — nothing a human can read, and the
only thing describing a parameter is its regex source.

`checksDigest` ships here rather than in either consumer because the control
plane and the CLI resolve declarations from **independent npm pins** and must be
able to prove they agree before an author writes a sentence. Two implementations
of that hash would be the same two-representations-of-one-fact defect this
milestone exists to remove, one level down.

## Notes for reviewer

**`description` is required, and that is the point.** An optional field is one
every later declaration omits, and F-1075 adds ten more checks. A picker that
can only show the rendered sentence is precisely the readable surface that hides
disagreement (Shankar et al., UIST '24 §7.3.3) — `No new labels were created in
<repo>` reads as an issue-level claim while the predicate compares repo-level
label *definitions*, so an agent applying an already-defined label passes,
correctly and invisibly. That explanation lived in a source comment; it is now
where an author can reach it. `checks-contract.test.ts` refuses a description
that merely restates its template.

**The digest deliberately excludes `description` and `example.`** It gates an
author's *write*; a prose edit changes no sentence and must never refuse one. It
hashes `id`, `substrate`, and the **compiled** pattern — compiled rather than the
template, so a change in `buildPattern` itself cannot slip through.

**Nothing about grading changes.** `polarity`, `subject`, `vacuityMutant` and
`substrate` are untouched.

## Review required

**Yes — public OSS API.** Two *required* fields on exported interfaces, so this
is a minor under `PACKAGE_RELEASE.md` (0.x minor plays the major role), not the
patch F-1073 took for additive exports.

Worth a second opinion: **`npm run test:contract` is green (109 tests, 0 fail)**,
and the doc names it as the arbiter for "no minor required". It is a runtime
suite and required-ness is a compile-time property, so it is structurally blind
to this class of change. Checked by hand instead — every `defineCheck` /
`CheckDefinition` / `CheckParamType` implementer is inside this repo, so the
practical blast radius is zero. Minor is the honest version for the *type*.

Verified against the built dist rather than the workspace: `checks.d.ts`
declares both fields and exports `checksDigest`, and the built twin ships a
description.