### PR TITLE
A declared check can read the ordered tape (F-1076)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5889,7 +5889,7 @@
     },
     "packages/sdk": {
       "name": "@pome-sh/sdk",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "@pome-sh/shared-types": "0.12.0",
         "hono": "^4.12.31",
@@ -5936,11 +5936,11 @@
     },
     "packages/twin-github": {
       "name": "@pome-sh/twin-github",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.10",
-        "@pome-sh/sdk": "0.7.0",
+        "@pome-sh/sdk": "0.8.0",
         "@pome-sh/shared-types": "0.12.0",
         "hono": "^4.12.31",
         "zod": "^4.1.13"

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,38 @@
 # @pome-sh/sdk
 
+## 0.8.0 — 2026-07-29
+
+A declared check can read the ordered call tape (F-1076, settling D1's open
+half). Minor, not patch: `CheckSubstrate.tape` is a REQUIRED key, so a consumer
+that constructs a substrate — pome-cloud's declaration adapter is the one that
+does — fails to typecheck until it supplies one (`PACKAGE_RELEASE.md` — 0.x
+minor plays the major role).
+
+- `CheckSubstrate.tape: readonly CheckTapeEvent[] | null` — the recorded HTTP
+  call tape, scoped to the criterion's twin by the consuming engine and ordered
+  oldest-first. **That ordering is a contract**, not an artifact of how the blob
+  happened to be parsed; a check may rely on it.
+- Required key, nullable value, deliberately mirroring `seed`. An optional key
+  is one every later consumer forgets to pass, and forgetting it would hand a
+  tape check a hole — letting a negative criterion pass over a tape nobody read,
+  which is the one failure D4 forbids. `null` and `[]` are different worlds:
+  "nobody handed me a tape" versus "the agent called nothing".
+- `CheckTapeEvent` — one recorded call, as a `substrate: "tape"` check sees it.
+  The frozen v1.0 `TwinHttpEvent` with every field optional/nullable so a
+  malformed row cannot crash a predicate. It lives here rather than in the
+  consuming engine for the same reason the declarations do: a consumer-side copy
+  drifts silently, surfacing only when a predicate reads a field the copy forgot.
+- **No `headers`, and this is not an oversight.** The recorder never captured
+  them, so an assertion like "the retry includes X-PAYMENT" is unanswerable at
+  any substrate width. Verified against `recorder-events.ts` rather than assumed.
+  Closing that gap is a recorder change, tracked separately.
+- `CheckOutcome.evidenceEventIds?: string[]` — the calls an outcome asserted
+  against. Without it, moving a tape predicate into a declaration would have
+  dropped F-980's citations on the floor: a silent downgrade sold as a refactor.
+  Omit the key rather than sending `[]`; absent and empty mean the same thing
+  downstream, and an empty affordance would have to be special-cased by every
+  reader of the persisted row.
+
 ## 0.7.0 — 2026-07-29
 
 Minor, not patch: `defineCheck` now REJECTS a declaration it used to accept, so

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/sdk",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Twin engine for Pome digital twins — defineTwin() + serve(): HTTP mounting, bearer auth, trace recorder, MCP dispatch, SQLite-backed state.",
   "private": false,
   "type": "module",

--- a/packages/sdk/src/checks.ts
+++ b/packages/sdk/src/checks.ts
@@ -111,6 +111,60 @@ export interface CheckOutcome {
   // so the criterion leaves the score denominator instead of vacuously
   // passing a wrong agent.
   status?: "passed" | "failed" | "unmatched" | "skipped";
+  // F-1076 — the recorded calls this outcome asserted against, by
+  // `TwinHttpEvent.event_id`. Only a `substrate: "tape"` check can fill it;
+  // state-reading checks leave it absent, because their evidence is a path into
+  // the state tree and this pointer does not model that.
+  //
+  // It exists because moving a tape predicate into a declaration would
+  // otherwise have DROPPED F-980's citations on the floor: the consuming
+  // engine's outcome type has carried this field since F-980, and a declaration
+  // that could not express it would have been a silent downgrade sold as a
+  // refactor.
+  //
+  // Absent and `[]` mean the same thing downstream, so a check with nothing to
+  // cite must OMIT the key rather than send an empty array — the consumer
+  // persists this into a jsonb row, and an empty affordance would have to be
+  // special-cased by every reader of it.
+  evidenceEventIds?: string[];
+}
+
+// One recorded twin HTTP call, as a `substrate: "tape"` check sees it.
+//
+// This is the frozen v1.0 `TwinHttpEvent` (`@pome-sh/shared-types`
+// recorder-events) minus two things:
+//
+//   - `headers`, which DOES NOT EXIST on the recorded event. F-1076 verified
+//     this rather than assuming it — the recorder never captured them, so
+//     `The retry includes X-PAYMENT` is unanswerable at any substrate width.
+//     That is a recorder gap, tracked separately; it is not a narrowing anyone
+//     can lift here.
+//   - required-ness. Every field is optional/nullable so a malformed row can
+//     never crash a predicate.
+//
+// It lives HERE, not in the consuming engine, for the same reason the
+// declarations do: the checks that read it are declared in twin packages, and a
+// consumer-side copy of this shape would drift the way the mirrored state shape
+// did before F-1075 deleted it — silently, surfacing only when a predicate
+// reads a field the copy forgot.
+//
+// ORDER IS A CONTRACT. The consumer supplies these oldest-first, and a check
+// may rely on it. That is the half of D1 this type settles.
+export interface CheckTapeEvent {
+  ts?: string | null;
+  twin?: string | null;
+  method?: string | null;
+  path?: string | null;
+  request_body?: unknown;
+  status?: number | null;
+  response_body?: unknown;
+  latency_ms?: number | null;
+  fidelity?: string | null;
+  state_mutation?: boolean | null;
+  error?: string | null;
+  // F-980 — the citable identity of this call. `event_id` rather than
+  // `request_id` because only `event_id` survives onto the OTLP span lane.
+  event_id?: string | null;
 }
 
 export interface CheckSubstrate<TState> {
@@ -119,6 +173,17 @@ export interface CheckSubstrate<TState> {
   // consumer that forgets produces a named skip rather than a crash.
   seed: TState | null;
   final: TState;
+  // F-1076 — non-null whenever the declaration asked for "tape", already scoped
+  // to this criterion's twin by the engine. Ordered oldest-first.
+  //
+  // Required key, nullable value, exactly like `seed`. An OPTIONAL key is one
+  // every later consumer forgets to pass, and forgetting it here silently
+  // promotes every tape check to a skip — a fleet of negative criteria that
+  // stop asserting, quietly, which is the one failure D4 forbids.
+  //
+  // `null` and `[]` are DIFFERENT WORLDS and a check must treat them so: `null`
+  // is "nobody handed me a tape", `[]` is "the agent called nothing".
+  tape: readonly CheckTapeEvent[] | null;
 }
 
 export interface CheckDefinition<TState, TArgs extends Record<string, string>> {

--- a/packages/sdk/test/checks.test.ts
+++ b/packages/sdk/test/checks.test.ts
@@ -10,7 +10,8 @@ import {
   repoRef,
   templateSlots,
   type CheckDefinition,
-  type CheckParamType
+  type CheckParamType,
+  type CheckTapeEvent
 } from "../src/checks.js";
 
 const noNewLabels: CheckDefinition<unknown, { repo: string }> = defineCheck({
@@ -294,5 +295,97 @@ describe("defineCheck rejects a param pattern that opens its own capture group",
         evaluate: () => ({ passed: true, reason: "stub" })
       })
     ).not.toThrow();
+  });
+});
+
+// ── F-1076: the tape substrate ───────────────────────────────────────────────
+//
+// D1's open half. A declaration may now read the recorded call tape as an
+// ORDERED sequence of complete events, bodies included. Ordering is a contract
+// the consumer owes the check, not an artifact of how the blob got parsed.
+
+describe("tape substrate", () => {
+  it("hands a declaration the ordered tape and lets it cite events", () => {
+    const check = defineCheck({
+      id: "test.saw-a-call",
+      description: "Asserts the tape recorded at least one call, and cites the first.",
+      template: "A call was recorded",
+      params: {},
+      substrate: "tape",
+      polarity: () => "positive",
+      vacuityMutant: () => null,
+      evaluate(_args, { tape }) {
+        if (tape === null) return { passed: false, reason: "tape_missing", status: "skipped" };
+        const first = tape[0];
+        return first === undefined
+          ? { passed: false, reason: "no calls recorded" }
+          : {
+              passed: true,
+              reason: `first call was ${first.method} ${first.path}`,
+              evidenceEventIds: [first.event_id ?? ""]
+            };
+      }
+    });
+
+    const tape: CheckTapeEvent[] = [
+      { twin: "github", method: "POST", path: "/repos/acme/api/issues", event_id: "evt_1" },
+      { twin: "github", method: "GET", path: "/repos/acme/api", event_id: "evt_2" }
+    ];
+
+    // Order is the contract: the check reads tape[0] and must get the POST.
+    expect(check.evaluate({}, { seed: null, final: {}, tape })).toEqual({
+      passed: true,
+      reason: "first call was POST /repos/acme/api/issues",
+      evidenceEventIds: ["evt_1"]
+    });
+  });
+
+  it("lets a check refuse rather than pass when it was handed no tape", () => {
+    const check = defineCheck({
+      id: "test.refuses-without-tape",
+      description: "Exists to prove a tape check can name its own refusal.",
+      template: "Nothing unsupported was called",
+      params: {},
+      substrate: "tape",
+      polarity: () => "negative",
+      vacuityMutant: () => null,
+      evaluate(_args, { tape }) {
+        if (tape === null) return { passed: false, reason: "tape_missing", status: "skipped" };
+        return { passed: true, reason: `${tape.length} call(s) inspected` };
+      }
+    });
+
+    expect(check.evaluate({}, { seed: null, final: {}, tape: null })).toEqual({
+      passed: false,
+      reason: "tape_missing",
+      status: "skipped"
+    });
+    // An EMPTY tape is a real world — an agent that called nothing — and must
+    // reach a real verdict rather than collapsing into the refusal above.
+    expect(check.evaluate({}, { seed: null, final: {}, tape: [] })).toEqual({
+      passed: true,
+      reason: "0 call(s) inspected"
+    });
+  });
+
+  it("carries the fields a tape assertion actually needs", () => {
+    // Bodies are the load-bearing addition: task 19's charge id lives in the
+    // request body, not the path, and an MCP-transport call carries its tool
+    // name there too.
+    const event: CheckTapeEvent = {
+      ts: "2026-07-29T00:00:00.000Z",
+      twin: "stripe",
+      method: "POST",
+      path: "/v1/refunds",
+      request_body: '{"charge":"ch_test_200"}',
+      status: 400,
+      response_body: null,
+      latency_ms: 3,
+      fidelity: "semantic",
+      state_mutation: false,
+      error: "charge_already_refunded",
+      event_id: "evt_attempt"
+    };
+    expect(String(event.request_body)).toContain("ch_test_200");
   });
 });

--- a/packages/twin-github/CHANGELOG.md
+++ b/packages/twin-github/CHANGELOG.md
@@ -1,5 +1,35 @@
 # @pome-sh/twin-github — CHANGELOG
 
+## 0.5.0 — 2026-07-29
+
+`No unsupported endpoint was called` is declared here now (F-1076). It was the
+one GitHub predicate F-1075 left behind as a regex in pome-cloud, because
+whether a declaration may read the tape was D1's open half and declaring a
+substrate nothing supplied would have been a promise with no engine behind it.
+Minor for the same reason 0.4.0 was: the exported tuple changes shape.
+
+- **Requires `@pome-sh/sdk` >= 0.8.0.** The declaration reads
+  `CheckSubstrate.tape`, which does not exist before it.
+- `GITHUB_CHECKS` goes from eleven entries to twelve, adding
+  `github.no-unsupported-endpoint` — the first and so far only check declaring
+  `substrate: "tape"`. GitHub now has no hand-written predicate left anywhere.
+- Why this check cannot read state: an unsupported call leaves no state trace at
+  all. The twin answers 501 and mutates nothing, so `state_final.json` is
+  byte-identical whether the examinee reached for an unimplemented route or
+  never tried. The `fidelity: "unsupported"` stamp on the recorded event is the
+  only place the fact survives.
+- It does NOT name a repository, and that is deliberate. The repo rule exists to
+  stop a check selecting state ambiguously — the legacy patterns scanned
+  repositories first-match-wins. This one selects no state, so a `{repo}` it
+  never reads would tell a reader the assertion is repo-scoped when it is not.
+  The exception is ledgered in `checks-contract.test.ts` as `REPO_FREE_CHECKS`,
+  gated so that only a tape-substrate check may sit in it.
+- The legacy regex's alternate phrasings are retired rather than ported: the
+  optional twin word ("No unsupported GitHub endpoint was called") and the
+  plural/`were` variants. Under position 2 an author picks the check rather than
+  typing the sentence, and the corpus says the canonical form in all ten places
+  it appears.
+
 ## 0.4.0 — 2026-07-29
 
 The whole GitHub vocabulary is declared here now (F-1075). `GITHUB_CHECKS` goes

--- a/packages/twin-github/package.json
+++ b/packages/twin-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-github",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Deterministic GitHub-shaped twin for agent testing — REST + MCP, SQLite-backed state.",
   "private": false,
   "type": "module",
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^2.0.10",
-    "@pome-sh/sdk": "0.7.0",
+    "@pome-sh/sdk": "0.8.0",
     "@pome-sh/shared-types": "0.12.0",
     "hono": "^4.12.31",
     "zod": "^4.1.13"

--- a/packages/twin-github/src/check-tape.ts
+++ b/packages/twin-github/src/check-tape.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// What GitHub's declared checks can assert about the RUN — the recorded call
+// tape rather than the exported end state (F-1076, settling D1's open half).
+//
+// Why this class has to exist at all: an unsupported call leaves NO STATE
+// TRACE. The twin answers 501 and mutates nothing, so `state_final.json` is
+// byte-identical whether the examinee reached for an unimplemented route or
+// never tried. The runtime stamps `fidelity: "unsupported"` on the recorded
+// event instead, and that stamp is the only place the fact survives.
+//
+// This check was a hand-written regex in pome-cloud until now. It stayed behind
+// when F-1075 moved the other ten, for one reason: whether a declaration MAY
+// read the tape was D1's open half, and declaring a substrate nothing supplied
+// would have been a promise with no engine behind it.
+//
+// Declarations only. The grammar rules they obey are in `checks.ts`, which
+// assembles them.
+
+import { defineCheck } from "@pome-sh/sdk/checks";
+import type { Check } from "./check-kind.js";
+
+export const noUnsupportedEndpoint: Check<Record<string, never>> = defineCheck({
+  id: "github.no-unsupported-endpoint",
+  description:
+    "Scans the recorded call tape for any request the twin answered with " +
+    'fidelity "unsupported" — a route it does not implement, answered 501. It asserts ' +
+    "nothing about whether the run SUCCEEDED, and nothing about calls that were merely " +
+    "rejected: a 404 or a 422 from a route the twin does implement is a semantic answer " +
+    "and passes this check. The tape is scoped to this twin by the engine before the " +
+    "check sees it, so an unsupported call to a DIFFERENT twin in a multi-twin session " +
+    "cannot fail it.",
+  // No slots. The corpus says this exact sentence in all ten places it appears,
+  // and under position 2 an author PICKS the check rather than typing it — so
+  // the legacy regex's optional twin word ("No unsupported GitHub endpoint was
+  // called") and its plural/`were` variants are retired rather than ported,
+  // exactly as F-1075 retired `issue-has-label-generic`.
+  template: "No unsupported endpoint was called",
+  params: {},
+  substrate: "tape",
+  // A prohibition. Nothing is required to happen; only the examinee reaching
+  // for an unimplemented route can break it.
+  polarity: () => "negative",
+  // No caller-supplied literal is hunted for in any substrate, so there is
+  // nothing a redactor could silently delete out from under this check.
+  subject: () => null,
+  // No capture groups, so the sentence carries no literal to falsify. The
+  // trigger is "a call with fidelity=unsupported exists", which lives on the
+  // tape and not in the sentence. Reported as `no_trigger`, never as clean.
+  vacuityMutant: () => null,
+  evaluate(_args, { tape }) {
+    // The engine guards this before calling; the check guards too, so a
+    // consumer that forgets gets a named skip rather than a vacuous pass. For a
+    // NEGATIVE criterion that distinction is the whole ballgame — passing here
+    // would be a clean bill of health issued over a tape nobody read.
+    //
+    // Note `null` and `[]` are deliberately different: an EMPTY tape is a real
+    // world (the agent called nothing, so it called nothing unsupported) and
+    // reaches a real verdict below.
+    if (tape === null) return { passed: false, reason: "tape_missing", status: "skipped" };
+
+    const unsupported = tape.filter((event) => event.fidelity === "unsupported");
+    if (unsupported.length === 0) {
+      // No evidence on the pass branch (F-980). This asserts a NEGATIVE over the
+      // whole tape — "none of these calls was unsupported" — and a negative over
+      // an empty set has no single call to point at. Citing all N inspected
+      // calls would be a copy of the trace, not evidence.
+      return {
+        passed: true,
+        reason: `no unsupported GitHub endpoint was called (${tape.length} call(s) inspected)`,
+      };
+    }
+
+    // Cite the offenders. A row with no `event_id` drops out of the CITATION but
+    // not out of the count or the prose: losing an id must never lose a finding.
+    const evidenceEventIds = unsupported
+      .map((event) => event.event_id)
+      .filter((id): id is string => typeof id === "string" && id !== "");
+    const outcome = {
+      passed: false,
+      reason:
+        `${unsupported.length} unsupported GitHub call(s): ` +
+        `[${unsupported.map((event) => event.path ?? "?").join(", ")}]`,
+    };
+    return evidenceEventIds.length > 0 ? { ...outcome, evidenceEventIds } : outcome;
+  },
+});

--- a/packages/twin-github/src/checks.ts
+++ b/packages/twin-github/src/checks.ts
@@ -37,10 +37,13 @@
 //      more than one word order. Nothing renders the second one now, so it is
 //      retired rather than ported.
 //
-// What did NOT move: `No unsupported endpoint was called`. It reads the call
-// TAPE, and whether a check may read the ordered tape is D1's open half —
-// F-1076 settles it and brings that check here. Declaring it now would mean
-// declaring a substrate nothing supplies.
+// F-1076 brought the last one home. `No unsupported endpoint was called` reads
+// the call TAPE, and until D1's open half was settled there was no substrate to
+// declare — the promise would have had no engine behind it. There is one now:
+// `check-tape.ts` holds the declaration, and the consuming engine REFUSES to
+// evaluate it against a tape it was not given rather than skipping silently.
+//
+// So github now has no hand-written predicate left anywhere.
 
 import {
   issueAssignee,
@@ -52,6 +55,7 @@ import {
 } from "./check-issues.js";
 import { pullRequestReviewExists, pullRequestStateCheck } from "./check-pulls.js";
 import { commitStatus, fileExists, noNewLabels } from "./check-repos.js";
+import { noUnsupportedEndpoint } from "./check-tape.js";
 
 export type { Check } from "./check-kind.js";
 export type {
@@ -83,4 +87,8 @@ export const GITHUB_CHECKS = [
   pullRequestReviewExists,
   fileExists,
   commitStatus,
+  // Last, because the listing order runs from the assertion an author reaches
+  // for first to the ones a specialised task needs — and this is the only one
+  // that asserts about the RUN rather than the world it left behind.
+  noUnsupportedEndpoint,
 ] as const;

--- a/packages/twin-github/test/check-tape.test.ts
+++ b/packages/twin-github/test/check-tape.test.ts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-1076 — the tape substrate's first declaration, and the world in which it
+// fails.
+//
+// The failing-world case is the one that carries the weight. This is a NEGATIVE
+// criterion, and a negative criterion nobody can make fail is not a guard — it
+// is a clean bill of health issued automatically. The whole justification for
+// reading the tape is that `state_final.json` is byte-identical whether the
+// examinee reached for an unimplemented route or never tried, so the only
+// evidence that a violation happened lives on the tape.
+
+import { describe, expect, it } from "vitest";
+import type { CheckTapeEvent } from "@pome-sh/sdk/checks";
+import { parseCheck, renderCheck } from "@pome-sh/sdk/checks";
+import { noUnsupportedEndpoint } from "../src/check-tape.js";
+import type { GitHubCheckState } from "../src/check-state.js";
+
+const EMPTY_STATE: GitHubCheckState = { repositories: [] };
+
+function call(over: Partial<CheckTapeEvent> = {}): CheckTapeEvent {
+  return {
+    twin: "github",
+    method: "GET",
+    path: "/repos/acme/api",
+    status: 200,
+    fidelity: "semantic",
+    event_id: "evt_ok",
+    ...over,
+  };
+}
+
+const run = (tape: readonly CheckTapeEvent[] | null) =>
+  noUnsupportedEndpoint.evaluate({}, { seed: null, final: EMPTY_STATE, tape });
+
+describe("github.no-unsupported-endpoint", () => {
+  it("renders and binds its sentence", () => {
+    const sentence = "No unsupported endpoint was called";
+    expect(renderCheck(noUnsupportedEndpoint, {})).toBe(sentence);
+    expect(parseCheck(noUnsupportedEndpoint, sentence)).toEqual({});
+  });
+
+  it("declares the tape substrate and a negative polarity", () => {
+    expect(noUnsupportedEndpoint.substrate).toBe("tape");
+    // It should PASS on an untouched world and can only be broken by the
+    // examinee reaching for a route the twin does not implement.
+    expect(noUnsupportedEndpoint.polarity({})).toBe("negative");
+  });
+
+  it("passes on a clean tape, and cites nothing", () => {
+    const outcome = run([call(), call({ event_id: "evt_ok2" })]);
+    expect(outcome.passed).toBe(true);
+    expect(outcome.reason).toContain("2 call(s) inspected");
+    // A negative over an empty set has no single call to point at; citing all N
+    // inspected calls would be a copy of the trace, not evidence.
+    expect(outcome.evidenceEventIds).toBeUndefined();
+  });
+
+  it("THE FAILING WORLD — one unsupported call fails it, and is cited", () => {
+    const outcome = run([
+      call(),
+      call({
+        fidelity: "unsupported",
+        path: "/repos/acme/api/hooks",
+        status: 501,
+        event_id: "evt_bad",
+      }),
+    ]);
+    expect(outcome.passed).toBe(false);
+    expect(outcome.reason).toContain("/repos/acme/api/hooks");
+    expect(outcome.evidenceEventIds).toEqual(["evt_bad"]);
+  });
+
+  it("proves the FINAL STATE cannot reach either verdict", () => {
+    // The two tapes differ only in a `fidelity` stamp and produce opposite
+    // verdicts against a byte-identical state. That is what makes this a tape
+    // assertion rather than a state assertion in disguise — and it is why the
+    // criterion was unmeasurable before this substrate existed.
+    const clean = run([call()]);
+    const dirty = run([call({ fidelity: "unsupported" })]);
+    expect(clean.passed).toBe(true);
+    expect(dirty.passed).toBe(false);
+  });
+
+  it("refuses BY NAME rather than passing when handed no tape", () => {
+    // The failure this guards: a negative criterion silently passing over a
+    // tape nobody read (D4 — never false-pass).
+    expect(run(null)).toEqual({ passed: false, reason: "tape_missing", status: "skipped" });
+  });
+
+  it("treats an EMPTY tape as a real world, not a missing one", () => {
+    // An agent that called nothing called nothing unsupported. This must be a
+    // real pass, distinct from the refusal above — collapsing the two would make
+    // a null agent indistinguishable from an unobserved one.
+    const outcome = run([]);
+    expect(outcome.passed).toBe(true);
+    expect(outcome.status).toBeUndefined();
+    expect(outcome.reason).toContain("0 call(s) inspected");
+  });
+
+  it("keeps the finding when an offending row carries no event_id", () => {
+    const outcome = run([call({ fidelity: "unsupported", event_id: null })]);
+    expect(outcome.passed).toBe(false);
+    // Losing an id must never lose a finding: the count and the prose survive,
+    // only the citation drops.
+    expect(outcome.reason).toContain("1 unsupported");
+    expect(outcome.evidenceEventIds).toBeUndefined();
+  });
+
+  it("does not treat a merely REJECTED call as unsupported", () => {
+    // A 404 or 422 from a route the twin DOES implement is a semantic answer.
+    // Reading any non-2xx as unsupported would fail every task whose examinee
+    // legitimately probed for something absent.
+    const outcome = run([call({ status: 404, fidelity: "semantic" })]);
+    expect(outcome.passed).toBe(true);
+  });
+});

--- a/packages/twin-github/test/checks-contract.test.ts
+++ b/packages/twin-github/test/checks-contract.test.ts
@@ -39,6 +39,9 @@ const FIXTURES: Record<string, Record<string, string>> = {
   "github.pr-review-exists": { review: "APPROVED", pr: "1", repo: "acme/api" },
   "github.file-exists": { path: "src/index.ts", repo: "acme/api" },
   "github.commit-status": { context: "ci/build", repo: "acme/api", state: "success" },
+  // No slots — the sentence is a constant. An empty object is the honest
+  // fixture, and it still exercises render/parse/round-trip below.
+  "github.no-unsupported-endpoint": {},
 };
 
 // Every check whose `vacuityMutant` returns null, WITH the reason. A null
@@ -60,6 +63,26 @@ const HONEST_NULL_MUTANTS: Record<string, string> = {
   "github.pr-review-exists": "the review state is a closed set; the PR number only selects",
   "github.commit-status":
     "the status state is a closed set, and the context only filters the candidate rows",
+  "github.no-unsupported-endpoint":
+    "the sentence has no slots at all; the trigger is a fidelity stamp on the tape, " +
+    "which no mutation of the criterion text can reach",
+};
+
+// Every check that does NOT name a repository, WITH the reason. Same discipline
+// as the ledger above: the rule below is real, and an exception to it has to be
+// argued in writing rather than waved through by loosening the assertion.
+//
+// F-1076 opened this. The repo rule exists to stop a check SELECTING state
+// ambiguously — the legacy patterns scanned repositories first-match-wins, so a
+// two-repo world graded whichever sorted first. A check that selects no state at
+// all cannot have that bug, and naming a repo it never reads would be worse than
+// silent: it would tell a reader the assertion is repo-scoped when it is not.
+const REPO_FREE_CHECKS: Record<string, string> = {
+  "github.no-unsupported-endpoint":
+    "asserts about the RUN, not about any repository. It reads the call tape — already " +
+    "scoped to this twin by the engine — and selects no repo, so there is no " +
+    "first-match-wins hazard for a repo slot to close. A `{repo}` here would be a lie " +
+    "about what the predicate compares.",
 };
 
 const SUBSTRATES: CheckSubstrateKind[] = ["final", "seed+final", "tape"];
@@ -194,11 +217,32 @@ describe("declared check grammar", () => {
     // check the repo costs the author nothing, so the ambiguity is simply
     // removed. Asserting it here keeps a future declaration from reintroducing
     // it for the convenience of a shorter sentence.
+    //
+    // F-1076 — a check that selects NO state cannot have the bug this prevents,
+    // so it may sit in `REPO_FREE_CHECKS` with its reason. The exception is
+    // ledgered rather than folded into the assertion because "params is empty"
+    // would also excuse a state check that simply forgot its selector.
     for (const check of CHECKS) {
+      if (REPO_FREE_CHECKS[check.id]) continue;
       expect(
         Object.keys(check.params),
         `${check.id} does not name a repository, so it cannot say which repo it asserts about`,
       ).toContain("repo");
+    }
+  });
+
+  it("only lets a check skip the repo rule if it reads no state at all", () => {
+    // The ledger above is an escape hatch, so it needs its own gate. The ONLY
+    // defensible reason to assert without naming a repo is that the check reads
+    // the run rather than the world — anything reading `final` or `seed+final`
+    // is selecting state and owes the reader a scope.
+    for (const id of Object.keys(REPO_FREE_CHECKS)) {
+      const check = CHECKS.find((candidate) => candidate.id === id);
+      expect(check, `${id} is ledgered REPO_FREE but is not a declared check`).toBeTruthy();
+      expect(
+        check!.substrate,
+        `${id} skips the repo rule but reads state — it must name the repo it asserts about`,
+      ).toBe("tape");
     }
   });
 });

--- a/packages/twin-github/test/checks-predicates.test.ts
+++ b/packages/twin-github/test/checks-predicates.test.ts
@@ -9,6 +9,13 @@
 // plain strings, and `state` as a lowercase column. Every one of those is a
 // shape a hand-written fixture gets wrong, and getting it wrong here would make
 // the suite agree with a predicate that disagrees with production.
+//
+// F-1076 — every substrate below carries `tape: null`, and that is the honest
+// value rather than boilerplate: these checks declare `final` or `seed+final`,
+// so the engine hands them no tape and they must never read one. The key is
+// REQUIRED precisely so a call site cannot forget it, because forgetting it
+// would hand a tape check a hole and let a negative criterion pass over a tape
+// nobody read.
 
 import { parseCheck, renderCheck, type CheckDefinition } from "@pome-sh/sdk/checks";
 import { describe, expect, it } from "vitest";
@@ -58,13 +65,14 @@ describe("github.issue-exists", () => {
   it("passes when the issue is present", () => {
     const outcome = subject.evaluate(args, {
       seed: null,
+      tape: null,
       final: world({ issues: [{ number: 1, state: "open" }] }),
     });
     expect(outcome.passed).toBe(true);
   });
 
   it("fails, naming the issue, when it is absent", () => {
-    const outcome = subject.evaluate(args, { seed: null, final: world({ issues: [] }) });
+    const outcome = subject.evaluate(args, { seed: null, tape: null, final: world({ issues: [] }) });
     expect(outcome.passed).toBe(false);
     expect(outcome.reason).toContain("issue #1 not found");
   });
@@ -97,14 +105,14 @@ describe("github.issue-state", () => {
 
   it("compares against the issue row's state column", () => {
     const final = world({ issues: [{ number: 1, state: "closed" }] });
-    expect(subject.evaluate({ issue: "1", repo: REPO, state: "closed" }, { seed: null, final }).passed).toBe(true);
-    expect(subject.evaluate({ issue: "1", repo: REPO, state: "open" }, { seed: null, final }).passed).toBe(false);
+    expect(subject.evaluate({ issue: "1", repo: REPO, state: "closed" }, { seed: null, tape: null, final }).passed).toBe(true);
+    expect(subject.evaluate({ issue: "1", repo: REPO, state: "open" }, { seed: null, tape: null, final }).passed).toBe(false);
   });
 
   it("SKIPS when the export carries no state, rather than reading absent as open", () => {
     const outcome = subject.evaluate(
       { issue: "1", repo: REPO, state: "open" },
-      { seed: null, final: world({ issues: [{ number: 1 }] }) },
+      { seed: null, tape: null, final: world({ issues: [{ number: 1 }] }) },
     );
     expect(outcome.status).toBe("skipped");
     expect(outcome.reason).toContain("state_incomplete");
@@ -126,19 +134,19 @@ describe("github.issue-has-label", () => {
   });
 
   it("reads label ROWS, not strings — the shape exportState actually emits", () => {
-    expect(subject.evaluate(args, { seed: null, final: labelled("bug") }).passed).toBe(true);
+    expect(subject.evaluate(args, { seed: null, tape: null, final: labelled("bug") }).passed).toBe(true);
   });
 
   it("compares case-insensitively, because GitHub preserves the caller's casing", () => {
-    expect(subject.evaluate(args, { seed: null, final: labelled("Bug") }).passed).toBe(true);
+    expect(subject.evaluate(args, { seed: null, tape: null, final: labelled("Bug") }).passed).toBe(true);
   });
 
   it("passes when the right label sits alongside wrong ones — that is the OTHER check's job", () => {
-    expect(subject.evaluate(args, { seed: null, final: labelled("bug", "feature") }).passed).toBe(true);
+    expect(subject.evaluate(args, { seed: null, tape: null, final: labelled("bug", "feature") }).passed).toBe(true);
   });
 
   it("fails and lists what the issue does carry", () => {
-    const outcome = subject.evaluate(args, { seed: null, final: labelled("feature") });
+    const outcome = subject.evaluate(args, { seed: null, tape: null, final: labelled("feature") });
     expect(outcome.passed).toBe(false);
     expect(outcome.reason).toContain("feature");
   });
@@ -161,17 +169,17 @@ describe("github.issue-exactly-one-label", () => {
   });
 
   it("passes on exactly that one label", () => {
-    expect(subject.evaluate(args, { seed: null, final: labelled("bug") }).passed).toBe(true);
+    expect(subject.evaluate(args, { seed: null, tape: null, final: labelled("bug") }).passed).toBe(true);
   });
 
   it("fails when a correct label is piled on top of an incorrect one", () => {
     // The defect a triage task exists to catch, and the reason this check is
     // not the same as `issue-has-label`.
-    expect(subject.evaluate(args, { seed: null, final: labelled("bug", "feature") }).passed).toBe(false);
+    expect(subject.evaluate(args, { seed: null, tape: null, final: labelled("bug", "feature") }).passed).toBe(false);
   });
 
   it("fails when the issue carries no labels at all", () => {
-    expect(subject.evaluate(args, { seed: null, final: labelled() }).passed).toBe(false);
+    expect(subject.evaluate(args, { seed: null, tape: null, final: labelled() }).passed).toBe(false);
   });
 });
 
@@ -185,12 +193,12 @@ describe("github.issue-assignee", () => {
 
   it("reads assignees as plain logins — the one list that is strings, not rows", () => {
     const final = world({ issues: [{ number: 1, assignees: ["alice", "bob"] }] });
-    expect(subject.evaluate(args, { seed: null, final }).passed).toBe(true);
+    expect(subject.evaluate(args, { seed: null, tape: null, final }).passed).toBe(true);
   });
 
   it("fails when the login is absent, listing who is assigned", () => {
     const final = world({ issues: [{ number: 1, assignees: ["bob"] }] });
-    const outcome = subject.evaluate(args, { seed: null, final });
+    const outcome = subject.evaluate(args, { seed: null, tape: null, final });
     expect(outcome.passed).toBe(false);
     expect(outcome.reason).toContain("bob");
   });
@@ -215,15 +223,15 @@ describe("github.issue-comment-contains", () => {
   });
 
   it("matches the needle as a substring of a comment body", () => {
-    expect(subject.evaluate(args, { seed: null, final: commented("Deploy blocked by CI") }).passed).toBe(true);
+    expect(subject.evaluate(args, { seed: null, tape: null, final: commented("Deploy blocked by CI") }).passed).toBe(true);
   });
 
   it("is case-sensitive — free prose is not a name field", () => {
-    expect(subject.evaluate(args, { seed: null, final: commented("deploy blocked") }).passed).toBe(false);
+    expect(subject.evaluate(args, { seed: null, tape: null, final: commented("deploy blocked") }).passed).toBe(false);
   });
 
   it("fails, saying how many comments it scanned", () => {
-    const outcome = subject.evaluate(args, { seed: null, final: commented("Looks fine", "LGTM") });
+    const outcome = subject.evaluate(args, { seed: null, tape: null, final: commented("Looks fine", "LGTM") });
     expect(outcome.passed).toBe(false);
     expect(outcome.reason).toContain("2 comment(s) scanned");
   });
@@ -255,15 +263,15 @@ describe("github.pr-state", () => {
 
   it("reads merged as a SQLite integer boolean", () => {
     const final = pull({ merged: 1, state: "closed" });
-    expect(subject.evaluate({ pr: "1", repo: REPO, state: "merged" }, { seed: null, final }).passed).toBe(true);
-    expect(subject.evaluate({ pr: "1", repo: REPO, state: "not merged" }, { seed: null, final }).passed).toBe(false);
+    expect(subject.evaluate({ pr: "1", repo: REPO, state: "merged" }, { seed: null, tape: null, final }).passed).toBe(true);
+    expect(subject.evaluate({ pr: "1", repo: REPO, state: "not merged" }, { seed: null, tape: null, final }).passed).toBe(false);
   });
 
   it("keeps `closed` and `merged` distinct — a PR can be closed unmerged", () => {
     const final = pull({ merged: 0, state: "closed" });
-    expect(subject.evaluate({ pr: "1", repo: REPO, state: "closed" }, { seed: null, final }).passed).toBe(true);
-    expect(subject.evaluate({ pr: "1", repo: REPO, state: "not merged" }, { seed: null, final }).passed).toBe(true);
-    expect(subject.evaluate({ pr: "1", repo: REPO, state: "merged" }, { seed: null, final }).passed).toBe(false);
+    expect(subject.evaluate({ pr: "1", repo: REPO, state: "closed" }, { seed: null, tape: null, final }).passed).toBe(true);
+    expect(subject.evaluate({ pr: "1", repo: REPO, state: "not merged" }, { seed: null, tape: null, final }).passed).toBe(true);
+    expect(subject.evaluate({ pr: "1", repo: REPO, state: "merged" }, { seed: null, tape: null, final }).passed).toBe(false);
   });
 
   it("SKIPS when the field the sentence turns on is absent", () => {
@@ -271,7 +279,7 @@ describe("github.pr-state", () => {
     // green against `is not merged`.
     const outcome = subject.evaluate(
       { pr: "1", repo: REPO, state: "not merged" },
-      { seed: null, final: pull({ state: "open" }) },
+      { seed: null, tape: null, final: pull({ state: "open" }) },
     );
     expect(outcome.status).toBe("skipped");
     expect(outcome.reason).toContain("no merged field");
@@ -280,7 +288,7 @@ describe("github.pr-state", () => {
   it("cites only the field the assertion actually read", () => {
     const outcome = subject.evaluate(
       { pr: "1", repo: REPO, state: "merged" },
-      { seed: null, final: pull({ merged: 0 }) },
+      { seed: null, tape: null, final: pull({ merged: 0 }) },
     );
     expect(outcome.reason).toContain("merged=false");
     expect(outcome.reason).not.toContain("state=");
@@ -308,19 +316,19 @@ describe("github.pr-review-exists", () => {
     const final = world({
       pull_requests: [{ number: 1, reviews: [{ state: "APPROVED" }, { state: "CHANGES_REQUESTED" }] }],
     });
-    expect(subject.evaluate(args, { seed: null, final }).passed).toBe(true);
+    expect(subject.evaluate(args, { seed: null, tape: null, final }).passed).toBe(true);
   });
 
   it("fails on an empty reviews array — that is a real `no reviews`", () => {
     const final = world({ pull_requests: [{ number: 1, reviews: [] }] });
-    const outcome = subject.evaluate(args, { seed: null, final });
+    const outcome = subject.evaluate(args, { seed: null, tape: null, final });
     expect(outcome.passed).toBe(false);
     expect(outcome.status).toBeUndefined();
   });
 
   it("SKIPS on an absent reviews section — absent is not the same as none", () => {
     const final = world({ pull_requests: [{ number: 1 }] });
-    const outcome = subject.evaluate(args, { seed: null, final });
+    const outcome = subject.evaluate(args, { seed: null, tape: null, final });
     expect(outcome.status).toBe("skipped");
     expect(outcome.reason).toContain("state_incomplete");
   });
@@ -338,7 +346,7 @@ describe("github.file-exists", () => {
 
   it("finds the file on any branch, as its description says", () => {
     const final = world({ files: [{ path: "src/index.ts", branch: "feature/x" }] });
-    expect(subject.evaluate(args, { seed: null, final }).passed).toBe(true);
+    expect(subject.evaluate(args, { seed: null, tape: null, final }).passed).toBe(true);
   });
 
   it("is scoped to the named repo", () => {
@@ -348,12 +356,12 @@ describe("github.file-exists", () => {
         { full_name: "acme/other", files: [{ path: "src/index.ts" }] },
       ],
     };
-    expect(subject.evaluate(args, { seed: null, final: twoRepos }).passed).toBe(false);
+    expect(subject.evaluate(args, { seed: null, tape: null, final: twoRepos }).passed).toBe(false);
   });
 
   it("compares the path exactly", () => {
     const final = world({ files: [{ path: "src/Index.ts" }] });
-    expect(subject.evaluate(args, { seed: null, final }).passed).toBe(false);
+    expect(subject.evaluate(args, { seed: null, tape: null, final }).passed).toBe(false);
   });
 });
 
@@ -369,17 +377,17 @@ describe("github.commit-status", () => {
 
   it("passes when a status under that context carries the state", () => {
     const final = world({ commit_statuses: [{ context: "ci/build", state: "success" }] });
-    expect(subject.evaluate(args, { seed: null, final }).passed).toBe(true);
+    expect(subject.evaluate(args, { seed: null, tape: null, final }).passed).toBe(true);
   });
 
   it("ignores statuses reported under a different context", () => {
     const final = world({ commit_statuses: [{ context: "codecov/patch", state: "success" }] });
-    expect(subject.evaluate(args, { seed: null, final }).passed).toBe(false);
+    expect(subject.evaluate(args, { seed: null, tape: null, final }).passed).toBe(false);
   });
 
   it("fails, listing the states it did find under that context", () => {
     const final = world({ commit_statuses: [{ context: "ci/build", state: "failure" }] });
-    const outcome = subject.evaluate(args, { seed: null, final });
+    const outcome = subject.evaluate(args, { seed: null, tape: null, final });
     expect(outcome.passed).toBe(false);
     expect(outcome.reason).toContain("failure");
   });
@@ -403,7 +411,7 @@ describe("every check, against a repo that is not in the state", () => {
       "github.commit-status": { context: "ci/build", repo: "acme/missing", state: "success" },
     };
     for (const declared of GITHUB_CHECKS as readonly unknown[] as readonly OpenCheck[]) {
-      const outcome = declared.evaluate(fixtures[declared.id]!, { seed: world(), final: world() });
+      const outcome = declared.evaluate(fixtures[declared.id]!, { seed: world(), tape: null, final: world() });
       expect(outcome.passed, `${declared.id} passed against a missing repo`).toBe(false);
       expect(outcome.reason, `${declared.id} did not name the missing repo`).toContain(
         "acme/missing",

--- a/packages/twin-github/test/checks-predicates.test.ts
+++ b/packages/twin-github/test/checks-predicates.test.ts
@@ -411,11 +411,26 @@ describe("every check, against a repo that is not in the state", () => {
       "github.commit-status": { context: "ci/build", repo: "acme/missing", state: "success" },
     };
     for (const declared of GITHUB_CHECKS as readonly unknown[] as readonly OpenCheck[]) {
-      const outcome = declared.evaluate(fixtures[declared.id]!, { seed: world(), tape: null, final: world() });
+      const outcome = declared.evaluate(fixtures[declared.id] ?? {}, {
+        seed: world(),
+        tape: null,
+        final: world(),
+      });
+      // D18.5 holds for EVERY check, repo-taking or not: never throw, always
+      // return a named failure so the other criteria still score.
       expect(outcome.passed, `${declared.id} passed against a missing repo`).toBe(false);
-      expect(outcome.reason, `${declared.id} did not name the missing repo`).toContain(
-        "acme/missing",
-      );
+      expect(outcome.reason, `${declared.id} failed without naming a reason`).toBeTruthy();
+      // Only a check that SELECTS a repo can name the missing one. F-1076's
+      // tape check selects none — it is handed `tape: null` here and correctly
+      // answers `tape_missing`, which is the D18.5 property above and not a
+      // statement about repositories. `checks-contract.test.ts` is where a
+      // check earns the right to be repo-free, via the `REPO_FREE_CHECKS`
+      // ledger; this loop just declines to ask it the wrong question.
+      if (Object.keys(declared.params).includes("repo")) {
+        expect(outcome.reason, `${declared.id} did not name the missing repo`).toContain(
+          "acme/missing",
+        );
+      }
     }
   });
 });

--- a/packages/twin-github/test/checks.test.ts
+++ b/packages/twin-github/test/checks.test.ts
@@ -56,13 +56,14 @@ describe("github.no-new-labels — declaration", () => {
 
 describe("github.no-new-labels — predicate", () => {
   it("passes when the label set is untouched", () => {
-    const outcome = noNewLabels.evaluate(ARGS, { seed: state(SEEDED), final: state(SEEDED) });
+    const outcome = noNewLabels.evaluate(ARGS, { seed: state(SEEDED), tape: null, final: state(SEEDED) });
     expect(outcome.passed).toBe(true);
   });
 
   it("fails and names the labels the examinee created", () => {
     const outcome = noNewLabels.evaluate(ARGS, {
       seed: state(SEEDED),
+      tape: null,
       final: state([...SEEDED, "wontfix", "needs-triage"]),
     });
     expect(outcome.passed).toBe(false);
@@ -82,16 +83,16 @@ describe("github.no-new-labels — predicate", () => {
     final.repositories![0]!.issues = [
       { number: 1, labels: [{ name: "feature" }, { name: "question" }] },
     ];
-    expect(noNewLabels.evaluate(ARGS, { seed, final }).passed).toBe(true);
+    expect(noNewLabels.evaluate(ARGS, { seed, final, tape: null }).passed).toBe(true);
   });
 
   it("does not fail when a label is REMOVED — the sentence says `new`", () => {
-    const outcome = noNewLabels.evaluate(ARGS, { seed: state(SEEDED), final: state(["bug"]) });
+    const outcome = noNewLabels.evaluate(ARGS, { seed: state(SEEDED), tape: null, final: state(["bug"]) });
     expect(outcome.passed).toBe(true);
   });
 
   it("skips, named, when the seed is unavailable rather than passing vacuously", () => {
-    const outcome = noNewLabels.evaluate(ARGS, { seed: null, final: state(SEEDED) });
+    const outcome = noNewLabels.evaluate(ARGS, { seed: null, tape: null, final: state(SEEDED) });
     expect(outcome.status).toBe("skipped");
     expect(outcome.reason).toBe("seed_missing");
   });
@@ -99,7 +100,7 @@ describe("github.no-new-labels — predicate", () => {
   it("fails when the named repo is absent from the state", () => {
     const outcome = noNewLabels.evaluate(
       { repo: "acme/other" },
-      { seed: state(SEEDED), final: state(SEEDED) },
+      { seed: state(SEEDED), tape: null, final: state(SEEDED) },
     );
     expect(outcome.passed).toBe(false);
     expect(outcome.reason).toContain("acme/other");
@@ -109,18 +110,18 @@ describe("github.no-new-labels — predicate", () => {
     const noFullName: GitHubCheckState = {
       repositories: [{ owner: "acme", name: "api", labels: [{ name: "bug" }] }],
     };
-    expect(noNewLabels.evaluate(ARGS, { seed: noFullName, final: noFullName }).passed).toBe(true);
+    expect(noNewLabels.evaluate(ARGS, { seed: noFullName, tape: null, final: noFullName }).passed).toBe(true);
   });
 
   it("does not resolve a bare repo name — `repoRef` cannot produce one", () => {
     const bare: GitHubCheckState = { repositories: [{ name: "api", labels: [{ name: "bug" }] }] };
-    const outcome = noNewLabels.evaluate(ARGS, { seed: bare, final: bare });
+    const outcome = noNewLabels.evaluate(ARGS, { seed: bare, tape: null, final: bare });
     expect(outcome.passed).toBe(false);
     expect(outcome.reason).toContain("not found in the seed state");
   });
 
   it("tolerates a state export with no labels key at all", () => {
     const bare: GitHubCheckState = { repositories: [{ full_name: "acme/api" }] };
-    expect(noNewLabels.evaluate(ARGS, { seed: bare, final: bare }).passed).toBe(true);
+    expect(noNewLabels.evaluate(ARGS, { seed: bare, tape: null, final: bare }).passed).toBe(true);
   });
 });


### PR DESCRIPTION
<!-- Closes F-1076 -->

## What

`No unsupported endpoint was called` is now a declared check in `@pome-sh/twin-github`, reading a new `tape` substrate the SDK carries. It was the one GitHub predicate F-1075 left behind as a regex in pome-cloud.

- **sdk 0.8.0** — `CheckSubstrate.tape`, `CheckTapeEvent`, `CheckOutcome.evidenceEventIds`
- **twin-github 0.5.0** — `github.no-unsupported-endpoint`; `GITHUB_CHECKS` goes 11 → 12

## Why

F-1076 settles D1's open half: **a check may read the ordered call tape, with request and response bodies.** Ordering is a contract, not an accident.

F-1075 could not bring this check home because declaring `substrate: "tape"` would have been a promise with no engine behind it. Now there is one — and the consuming engine *refuses* to evaluate a tape check against a tape it was not given, rather than skipping silently.

Design: `docs/superpowers/specs/2026-07-29-f1076-tape-substrate-design.md` in pome-cloud.

## Notes for reviewer

**Headers are not in this PR because they are not on the tape at all.** D1's original wording asked for "ordered tape with bodies *and headers*"; `TwinHttpEvent` has no header field and never did. So `The retry includes X-PAYMENT` is unanswerable at any substrate width. That is a recorder gap, tracked separately — not a narrowing anyone can lift here. Verified against `recorder-events.ts`, not assumed.

**`CheckSubstrate.tape` is a required key with a nullable value**, mirroring `seed`. This is the deliberate breaking half: a consumer constructing a substrate stops typechecking until it supplies one. An optional key is one every later consumer forgets, and forgetting it would hand a tape check a hole — letting a negative criterion pass over a tape nobody read. `null` and `[]` are different worlds and the check treats them so.

**`CheckOutcome.evidenceEventIds` is not a nice-to-have.** Without it, moving this predicate into a declaration would have silently dropped F-980's citations — a downgrade sold as a refactor.

**Two contract properties needed an argued exception rather than a loosened assertion:**

1. `REPO_FREE_CHECKS` (new ledger). Every check must name a repo, because the legacy patterns scanned repositories first-match-wins. A check that selects *no state* cannot have that bug, and a `{repo}` it never reads would tell a reader the assertion is repo-scoped when it is not. The ledger has its own gate — only a `substrate: "tape"` check may sit in it.
2. The missing-repo sweep now asserts D18.5 (never throw, fail by name) of *every* check, and the repo-naming half only of repo-taking ones. It was asking a check with no repo to name one.

**`twin-github`'s sdk pin moves to 0.8.0**, which is load-bearing rather than tidiness: a published 0.5.0 resolving sdk 0.7.0 would install a twin whose own check cannot compile. The other four twins keep their pins — none declares checks.

**Verification:** build OK, typecheck clean, 1712 tests across 8 packages, plus the CLI's 746 run against locally-packed tarballs (the workspace excludes `cli/`, so `npm run test` alone would not have covered it).

## Review required

Yes — public OSS API. `CheckSubstrate` gains a required key and `GITHUB_CHECKS` changes shape; both are consumed by pome-cloud from npm.