### PR TITLE
PACKAGE_RELEASE.md: the batch PR carries the CLI pin, and the CLI release waits by itself

### DIFF
--- a/PACKAGE_RELEASE.md
+++ b/PACKAGE_RELEASE.md
@@ -5,15 +5,27 @@ The CLI package (`@pome-sh/cli`) keeps using the existing Changesets flow in
 
 1. In a PR, update each changed package's `package.json` version and package
    changelog entry together. Keep internal `@pome-sh/*` dependencies pinned to
-   the exact versions that will exist after the batch publishes.
+   the exact versions that will exist after the batch publishes — **including
+   `cli/package.json`'s pins**, which must equal the new `packages/*` versions
+   in this same PR or `ci.yml` fails
+   (`scripts/check-cli-pins-match-workspace.mjs`, F-1135). Pinning a version
+   that is not on npm yet is expected: `cli-ci` packs it from `packages/`, and
+   step 4 waits. Add a changeset under `cli/.changeset/` too — a moved pin is a
+   shipping change (`bundleDependencies` bakes it into the tarball), so without
+   one the re-pin never reaches users.
 2. Run `node scripts/pack-publishable.mjs --out dist-tarballs` and the clean-room
    smoke from `.github/workflows/sdk-publish.yml`.
 3. After merge, create a GitHub Release whose tag starts with `packages-v`.
    The `package publish` workflow publishes `@pome-sh/shared-types`,
    `@pome-sh/sdk`, `@pome-sh/adapter-claude-sdk`, and the first-party twins with
    npm OIDC provenance.
-4. Publish the CLI only after the exact package versions in `cli/package.json`
-   exist on npm.
+4. The CLI release waits for this batch on its own — no manual sequencing.
+   `cli-release.yml` reads the pins from `cli/package.json` and probes npm
+   (`scripts/check-cli-pins-published.mjs`): a pin that matches `packages/*` but
+   is not published yet sets `ready=false` and skips, naming what it is waiting
+   for; a pin that is unpublished *and* disagrees with `packages/*` fails,
+   because no batch will ever publish it. Rerun the workflow after this batch
+   lands, and refresh the committed `cli/package-lock.json` against the registry.
 
 ## Versioning
 


### PR DESCRIPTION
<!-- Refs F-1135 -->

## What

Bring `PACKAGE_RELEASE.md` in line with the gates #261 added. Docs-only.

## Why

#261 taught `ci.yml` to fail when `cli/package.json`'s `@pome-sh/*` pins disagree with `packages/*`, and taught `cli-release.yml` to read the versions it probes from the manifest. `AGENTS.md` got both rules — **this file, which describes the same batch flow, did not**, so the two documents disagreed about the step that now has a gate behind it. My miss in #261.

**Step 1** said to keep internal `@pome-sh/*` deps pinned to the versions that will exist after the batch — meaning only the deps *between* packages. `cli/package.json` was never mentioned, so following this file to the letter now opens a PR that `ci.yml` fails. Added the pin plus the changeset requirement (the pin is `bundleDependencies`, baked into the tarball at publish time, so a re-pin with no version bump never reaches users).

**Step 4** said to publish the CLI only after the pinned versions exist on npm. That manual sequencing no longer exists: `check-cli-pins-published.mjs` sets `ready=false` and skips while a pin matches `packages/` but has not published yet — naming what it waits for — and fails when a pin is unpublished *and* disagrees with `packages/`, since no batch will ever publish that one.

## Notes for reviewer

Every path this file now names is verified present on `main` at `55730ea`: `check-cli-pins-match-workspace.mjs`, `check-cli-pins-published.mjs`, `check-cli-version-bump.sh`, `pack-publishable.mjs`.

The matching `pome-package-release` skill in `pome-sh/agent-skills` carried copies of both stale steps; fixed there in the same pass.

No changeset — docs-only, nothing under `cli/src/**`, no pin moved (version-bump gate skips, verified locally).
