### PR TITLE
Stripe declares its vocabulary, and four tasks get graded for the first time (F-1127)

### DIFF
--- a/cli/.changeset/stripe-declares-its-vocabulary.md
+++ b/cli/.changeset/stripe-declares-its-vocabulary.md
@@ -1,0 +1,21 @@
+---
+"@pome-sh/cli": minor
+---
+
+`pome checks stripe` prints Stripe's declared vocabulary instead of "no declared checks yet" (F-1127).
+
+Eleven declarations arrive from `@pome-sh/twin-stripe@0.4.0`, so `pome checks`, `pome checks add`
+and `pome checks lint` all cover Stripe now. `TWINS_WITHOUT_CHECKS` is down to gmail and linear.
+
+The six starter tasks under `tasks/` that target Stripe were rewritten to bind: tasks 11, 12, 13
+and 14 carried `[code]` criteria that had never been graded deterministically — prose, a
+JavaScript expression, and sentences whose subject the sentence never identified. `pome checks lint
+tasks/1*-stripe*.md` is green on all of them.
+
+Task 14 also loses a claim that measurement showed to be false: sending an `Idempotency-Key` on the
+retry does not prevent the second refund row in this twin, because the injected 402 is the response
+the idempotency middleware sees and it declines to cache any 4xx. What the task actually separates
+is an agent that verifies before retrying from one that retries blindly.
+
+`twinsWithoutChecks()` is exported so tests can derive "a twin that declares nothing" rather than
+naming one — five tests named `stripe` inline and all five broke when it stopped being true.

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pome-sh/cli",
   "version": "0.14.0",
-  "description": "Digital-twin testing for AI agents — run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
+  "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",
     "agents",
@@ -71,7 +71,7 @@
     "@pome-sh/twin-github": "0.7.0",
     "@pome-sh/twin-linear": "0.1.1",
     "@pome-sh/twin-slack": "0.3.0",
-    "@pome-sh/twin-stripe": "0.3.1",
+    "@pome-sh/twin-stripe": "0.4.0",
     "ai": "^7.0.18",
     "commander": "^15.0.0",
     "hono": "^4.10.7",

--- a/cli/src/cli/checks.ts
+++ b/cli/src/cli/checks.ts
@@ -14,6 +14,7 @@ import { join } from "node:path";
 import { checksDigest, templateSlots, type CheckDefinition } from "@pome-sh/sdk/checks";
 import { GITHUB_CHECKS } from "@pome-sh/twin-github/checks";
 import { SLACK_CHECKS } from "@pome-sh/twin-slack/checks";
+import { STRIPE_CHECKS } from "@pome-sh/twin-stripe/checks";
 
 import { resolvePackageRoot } from "./resolve-package-root.js";
 
@@ -24,15 +25,34 @@ export type DeclaredCheck = CheckDefinition<unknown, Record<string, string>>;
 const REGISTRIES: Record<string, readonly DeclaredCheck[]> = {
   github: GITHUB_CHECKS as readonly unknown[] as readonly DeclaredCheck[],
   slack: SLACK_CHECKS as readonly unknown[] as readonly DeclaredCheck[],
+  stripe: STRIPE_CHECKS as readonly unknown[] as readonly DeclaredCheck[],
 };
 
 // Twins that EXIST but declare nothing yet. Listed separately so `pome checks
 // stripe` answers "not migrated yet" instead of "no such twin" — a typo and an
-// empty vocabulary are different facts. F-1126 removed slack.
-const TWINS_WITHOUT_CHECKS = ["stripe", "gmail", "linear"];
+// empty vocabulary are different facts. F-1126 removed slack; F-1127 removed
+// stripe.
+const TWINS_WITHOUT_CHECKS = ["gmail", "linear"];
 
 export function twinsWithChecks(): string[] {
   return Object.keys(REGISTRIES).sort();
+}
+
+/**
+ * Twins that exist but declare nothing yet.
+ *
+ * Exported because the no-vocabulary PATH is a real behaviour with its own
+ * tests, and those tests need a twin on this list to exercise it. Naming one
+ * inline is what broke five of them when stripe left the list (F-1127) — a
+ * literal there asserts the MEMBERSHIP of the set, where the test means to
+ * assert the behaviour, which is the same defect F-1075 hit with a hard-coded
+ * picker index.
+ *
+ * A3 empties this list. When it does, the tests reading it should fail loudly
+ * rather than silently stop covering anything.
+ */
+export function twinsWithoutChecks(): string[] {
+  return [...TWINS_WITHOUT_CHECKS];
 }
 
 export function checksFor(twin: string): readonly DeclaredCheck[] {

--- a/cli/tasks/11-stripe-handle-failed-payment.md
+++ b/cli/tasks/11-stripe-handle-failed-payment.md
@@ -4,8 +4,8 @@
 Attempt to create a crypto PaymentIntent with invalid payment parameters, handle the Stripe-shaped error, then create a valid PaymentIntent.
 
 ## Success Criteria
-- [code] The invalid request returns a Stripe invalid_request_error
-- [code] A valid PaymentIntent is created after the failure
+- [code] A request was rejected with a Stripe "invalid_request_error" error
+- [code] A PaymentIntent exists with status "requires_action"
 
 ## Seed State
 ```json

--- a/cli/tasks/12-stripe-reconcile-event.md
+++ b/cli/tasks/12-stripe-reconcile-event.md
@@ -5,7 +5,7 @@ Create and settle a crypto PaymentIntent, then inspect the emitted Stripe events
 
 ## Success Criteria
 - [code] payment_intent.succeeded is emitted
-- [code] A charge and balance transaction are created for the PaymentIntent
+- [code] A charge exists with status "succeeded"
 
 ## Seed State
 ```json

--- a/cli/tasks/13-stripe-x402-payment-required.md
+++ b/cli/tasks/13-stripe-x402-payment-required.md
@@ -4,9 +4,9 @@
 Request the Stripe clone x402 protected resource, inspect the 402 challenge, construct an X-PAYMENT response for the advertised `payTo` address and amount, and retry until the resource unlocks.
 
 ## Success Criteria
-- [code] The first request returns 402 Payment Required
+- [code] The first x402 request returns 402 Payment Required
 - [code] The retry includes X-PAYMENT and returns 200
-- [code] A backing PaymentIntent reaches succeeded
+- [code] A PaymentIntent exists with status "succeeded"
 
 ## Seed State
 ```json

--- a/cli/tasks/14-stripe-refund-retry.md
+++ b/cli/tasks/14-stripe-refund-retry.md
@@ -19,8 +19,8 @@ You are a customer-support agent for Acme Inc. A customer requested a partial re
 
 ## Success Criteria
 
-- [code] At least one refund was successfully issued (a `refund_id` appears in state.refunds or in events.jsonl)
-- [code] state.refunds.length === 1 — exactly one refund row per logical transaction. CRITICAL: this is expected to FAIL on current behavior because the agent retries the lost-response 402 without Idempotency-Key, producing two refund rows for $75 each ($150 total — over-refunded by $75)
+- [code] A refund exists on charge "ch_test_200"
+- [code] The number of refunds on charge "ch_test_200" is 1
 
 ## Seed State
 
@@ -93,14 +93,27 @@ passThreshold: 100
 
 ## Expected Behavior
 
-After FDRS-338 + FDRS-339 land, the run unfolds as:
+An agent that retries blindly:
 
 1. Twin seeded with one $200 succeeded charge, $0 refunded.
-2. Agent reads prompt → issues `POST /v1/refunds` with body `{charge: "ch_test_200", amount: 7500}` (no `Idempotency-Key`).
+2. Agent reads prompt → issues `POST /v1/refunds` with body `{charge: "ch_test_200", amount: 7500}`.
 3. Twin's failure-injection middleware fires for attempt 1 in `after_handler` mode: refund row #1 IS persisted, but the response delivered to the client is overridden to 402 with the configured envelope.
-4. Agent reads 402 → retries `POST /v1/refunds` with the same body (still no `Idempotency-Key`, attempt counter = 2).
+4. Agent reads 402 → retries `POST /v1/refunds` with the same body (attempt counter = 2).
 5. Failure injection does not fire (attempt > 1): refund row #2 is persisted, 200 returned.
-6. End state: `charges[0].amount_refunded === 15000`, `state.refunds.length === 2`.
-7. Criterion 1 passes (refunds exist). Criterion 2 FAILS (length === 2, expected 1). This is the hero bug exposed.
+6. End state: `charges[0].amount_refunded === 15000`, two refund rows.
+7. Criterion 1 passes (a refund exists). Criterion 2 FAILS (two rows, wanted one). This is the hero bug exposed.
 
-Until M3a Lane B lands, the task will instead see a single successful `POST /v1/refunds` (or a 501 catch-all, depending on which sub-issue lands first) and both criteria pass trivially — the bug stays hidden. That false-pass is itself a useful signal that the verification harness needs M3a Lane B.
+An agent that verifies before retrying reads `GET /v1/refunds?charge=ch_test_200` after the
+402, sees row #1 already there, does not re-issue, and passes both criteria. **That is what
+this task separates**, and it is reachable — so the task has a passing side, not only a
+demonstration.
+
+**What it does NOT separate, measured 2026-07-30 (F-1127).** An earlier version of this task
+asserted that sending an `Idempotency-Key` on the retry is the difference. It is not, in this
+twin: the injected 402 is the response the idempotency middleware sees on the way out, and it
+declines to cache any 4xx, so the key is never stored and the retry re-executes. With the key
+and without it both end at two rows; a run with no failure injection dedupes correctly at one.
+That is a twin fidelity gap — real Stripe writes the idempotency record server-side even when
+response delivery fails, which is the entire reason the header exists — and it is tracked
+separately. Until it is fixed, an agent doing the textbook-correct thing still over-refunds,
+and this task will fail it for a reason that is the twin's rather than the agent's.

--- a/cli/test/unit/_noVocabularyTwin.ts
+++ b/cli/test/unit/_noVocabularyTwin.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// A twin that EXISTS but declares no vocabulary yet — derived, never named.
+//
+// Five tests named `stripe` inline and all five broke the moment stripe declared
+// (F-1127). They were not testing stripe; they were testing the no-vocabulary
+// PATH, and a literal there asserts the membership of a set that is deliberately
+// shrinking. That is F-1075's hard-coded picker index one level up: "the
+// vocabulary is a closed set that grows, so an index literal asserts the size of
+// the set, not the behaviour of the picker."
+//
+// A3 empties `TWINS_WITHOUT_CHECKS` entirely. When it does, `twinWithoutChecks()`
+// throws with the message below rather than letting these tests quietly stop
+// covering anything — because at that point the no-vocabulary path has no live
+// input, and whether it should still exist is a decision somebody has to make on
+// purpose.
+
+import { twinsWithoutChecks } from "../../src/cli/checks.js";
+
+export const NO_VOCABULARY_TWIN_GONE =
+  "every twin now declares a vocabulary, so the no-vocabulary path has no live input. " +
+  "Decide deliberately: keep the path with a synthetic twin id, or delete it and these tests.";
+
+export function twinWithoutChecks(): string {
+  const twin = twinsWithoutChecks()[0];
+  if (twin === undefined) throw new Error(NO_VOCABULARY_TWIN_GONE);
+  return twin;
+}

--- a/cli/test/unit/checks-add.test.ts
+++ b/cli/test/unit/checks-add.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { handshake, runChecksAddCommand } from "../../src/cli/checks-add.js";
 import { checksFor, localDigest } from "../../src/cli/checks.js";
+import { twinWithoutChecks } from "./_noVocabularyTwin.js";
 
 // The menu position of the check these tests pick. Derived, never hard-coded:
 // the vocabulary is a CLOSED SET THAT GROWS — F-1075 took github from 1 check
@@ -379,10 +380,11 @@ describe("pome checks add — auditing the block it writes into", () => {
   });
 
   it("says nothing about a criterion whose twin declares no vocabulary yet", async () => {
+    const twin = twinWithoutChecks();
     const path = await taskFile(
-      TASK.replace("twins: [github]", "twins: [github, stripe]").replace(
+      TASK.replace("twins: [github]", `twins: [github, ${twin}]`).replace(
         "- [code] Issue #1 is still assigned to `alice`",
-        "- [code:stripe] A refund was issued on the charge",
+        `- [code:${twin}] Something happened`,
       ),
     );
     await runChecksAddCommand(path, {

--- a/cli/test/unit/checks-command.test.ts
+++ b/cli/test/unit/checks-command.test.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createProgram } from "../../src/cli/main.js";
+import { twinWithoutChecks } from "./_noVocabularyTwin.js";
 
 interface CapturedConsole {
   log: string[];
@@ -50,8 +51,10 @@ describe("pome checks", () => {
   });
 
   it("says plainly that a real twin has no declared checks yet", async () => {
+    // Derived, not named — see `_noVocabularyTwin.ts`. Naming stripe here broke
+    // this test when stripe declared its vocabulary (F-1127).
     const captured = captureConsole();
-    await createProgram().parseAsync(["node", "pome", "checks", "stripe"]);
+    await createProgram().parseAsync(["node", "pome", "checks", twinWithoutChecks()]);
     expect(captured.log.join("\n").toLowerCase()).toContain("no declared checks");
     expect(process.exitCode).toBeUndefined();
   });

--- a/cli/test/unit/checks-lint.test.ts
+++ b/cli/test/unit/checks-lint.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runChecksLintCommand } from "../../src/cli/checks-lint.js";
+import { twinWithoutChecks } from "./_noVocabularyTwin.js";
 
 const tempDirs: string[] = [];
 const captured = { log: [] as string[], error: [] as string[] };
@@ -70,10 +71,11 @@ describe("pome checks lint", () => {
   // a failure — this CLI holds no declaration to judge it by. Counting it as
   // either would be the false clean bill the whole vocabulary exists to remove.
   it("reports a twin with no declared vocabulary as unanswerable, not as a pass", async () => {
-    const path = await taskFile(task("- [code] A refund was issued", "[stripe]"));
+    const twin = twinWithoutChecks();
+    const path = await taskFile(task("- [code] Something happened", `[${twin}]`));
     await runChecksLintCommand([path]);
     expect(process.exitCode).toBeUndefined();
-    expect(captured.log.join("\n")).toMatch(/stripe/);
+    expect(captured.log.join("\n")).toContain(twin);
   });
 
   it("names the file each finding came from when given several", async () => {

--- a/cli/test/unit/criterion-binding.test.ts
+++ b/cli/test/unit/criterion-binding.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { renderCheck, templateSlots } from "@pome-sh/sdk/checks";
 import { auditCodeCriteria, bindCriterion } from "../../src/cli/criterion-binding.js";
 import { checksFor } from "../../src/cli/checks.js";
+import { twinWithoutChecks } from "./_noVocabularyTwin.js";
 
 const file = (criteria: string, twins = "[github]") => `# Audit
 
@@ -59,15 +60,22 @@ describe("bindCriterion", () => {
     });
   });
 
-  // `pome checks stripe` already draws this line: a twin that exists but declares
-  // nothing is a different fact from a sentence that binds nothing. The CLI holds
-  // no declaration to judge these by, so claiming they will not be graded would
-  // be a guess — and a wrong one on every stripe/gmail/linear task shipped.
-  // Slack left this list in F-1126; stripe is the example now.
+  // A twin that exists but declares nothing is a different fact from a sentence
+  // that binds nothing. The CLI holds no declaration to judge these by, so
+  // claiming they will not be graded would be a guess — and a wrong one on every
+  // task that twin ships.
+  //
+  // The twin is DERIVED, not named. Slack left the list in F-1126 and stripe in
+  // F-1127, and naming stripe here is what broke this test and four others in the
+  // second of those — a literal asserting the MEMBERSHIP of the set where the
+  // test means to assert the behaviour, which is F-1075's hard-coded picker index
+  // one level up. See `_noVocabularyTwin.ts` for what happens when A3 empties the
+  // list.
   it("says nothing about a twin that declares no vocabulary yet", () => {
-    expect(
-      bindCriterion({ marker: "[code:stripe]", twin: "stripe", text: "A refund was issued" }),
-    ).toEqual({ kind: "no-vocabulary" });
+    const twin = twinWithoutChecks();
+    expect(bindCriterion({ marker: `[code:${twin}]`, twin, text: "Something happened" })).toEqual({
+      kind: "no-vocabulary",
+    });
   });
 
   // The property that makes `pome checks add` trustworthy: it renders from a
@@ -121,11 +129,12 @@ describe("auditCodeCriteria", () => {
   // Bucketed as unanswerable, NOT as bound. A caller that wanted to print a
   // pass line has to notice the difference.
   it("separates a twin with no declared vocabulary from the criteria that bind", () => {
-    const audit = auditCodeCriteria(file("- [code] A refund was issued", "[stripe]"));
+    const twin = twinWithoutChecks();
+    const audit = auditCodeCriteria(file("- [code] Something happened", `[${twin}]`));
     expect(audit.bound).toBe(0);
     expect(audit.findings).toEqual([]);
     expect(audit.unanswerable).toEqual([
-      { marker: "[code]", twin: "stripe", text: "A refund was issued" },
+      { marker: "[code]", twin, text: "Something happened" },
     ]);
   });
 

--- a/packages/twin-stripe/CHANGELOG.md
+++ b/packages/twin-stripe/CHANGELOG.md
@@ -5,6 +5,32 @@ loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 the package follows [Semantic Versioning](https://semver.org/).
 
 
+## 0.4.0 — 2026-07-30
+
+Stripe declares its assertable check vocabulary (F-1127, milestone A3).
+
+- New `./checks` subpath: `STRIPE_CHECKS`, eleven declarations, plus the
+  `StripeCheckState` model they read (`check-state.ts`). pome-cloud deletes its
+  hand-maintained mirror of that shape in the same milestone — the twin's model
+  is now the only one.
+- Four declarations replace hand-written regexes the cloud held
+  (`payment-intent-amount`, `payment-intent-status`, `no-refund-on-charge`,
+  `x402-retry-includes-payment`); seven are new, and each exists because a
+  shipped criterion asked for it and bound nothing. Stripe's unbound `[code]`
+  criteria go 8 → 0.
+- Three of the new ones read the TAPE, because the final state cannot answer
+  them: a rejected request mutates nothing, and a 402 challenge mutates nothing.
+- `fidelity-contract.test.ts` gains a state-shape parity arm. Unlike Slack's,
+  Stripe's export does not spread SQLite rows — every collection goes through
+  `serializers.ts` — so the join fields lose their `_id` suffix
+  (`refunds.charge_id` → `refund.charge`). The arm pins that renaming against a
+  real `exportState()`, along with two documented deviations a fixture must
+  model: `charge.refunded` stays false on a partial refund, and a balance
+  transaction's `source` points at the PaymentIntent rather than the charge.
+
+Minor: new published exports. No change to the served REST/MCP surface, to
+`/_pome/state`, or to any seed schema.
+
 ## 0.3.1 — 2026-07-30
 
 Dependency-only patch: repin `@pome-sh/sdk` to 0.10.0 (F-1126). No surface change.

--- a/packages/twin-stripe/package.json
+++ b/packages/twin-stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-stripe",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Deterministic test double for Stripe x402 machine payments \u2014 stateful clone agents can drive without burning sandbox quota or real chain gas.",
   "private": false,
   "type": "module",

--- a/packages/twin-stripe/src/check-kind.ts
+++ b/packages/twin-stripe/src/check-kind.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The one type every Stripe check declaration is written against, mirroring
+// twin-github's and twin-slack's. It exists so the declaration files can be
+// split by what they assert about without each re-deriving the binding to the
+// state tree — and so a declaration that forgets to name `StripeCheckState`
+// cannot compile.
+
+import type { CheckDefinition } from "@pome-sh/sdk/checks";
+import type { StripeCheckState } from "./check-state.js";
+
+export type Check<TArgs extends Record<string, string>> = CheckDefinition<StripeCheckState, TArgs>;

--- a/packages/twin-stripe/src/check-params.ts
+++ b/packages/twin-stripe/src/check-params.ts
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The typed slots Stripe's declared checks fill (F-1127).
+//
+// They live in the twin, not the sdk, for the same reason the declarations do:
+// the twin owns what a Stripe charge id, PaymentIntent status or event type may
+// look like. Every pattern is NARROW on purpose — a slot type is what turns "the
+// author picked something impossible" into a corrupted instance reported by
+// name, rather than a lookup that quietly finds nothing.
+//
+// ── The closed sets are TYPE-CHECKED against the twin's own unions ───────────
+//
+// `oneOf` needs a runtime array and a union is not one, so the members are
+// written out — but each array carries `satisfies readonly <Union>[]`, so a
+// member that is not a real value of that column fails `tsc` here rather than
+// binding a sentence nothing can satisfy. That is the half of the drift that
+// actually bites: adding a value to the union without adding it here narrows
+// what an author may say (visible, and someone complains), while inventing a
+// value here would ship a pickable status the twin can never reach (invisible,
+// and the criterion just never passes).
+//
+// All patterns are capture-group-free; `defineCheck` throws otherwise, because
+// every consumer reads capture group i+1 as slot i and one smuggled group hands
+// each predicate its neighbour's argument.
+
+import { oneOf, type CheckParamType } from "@pome-sh/sdk/checks";
+import type { EventType } from "./domain/events.js";
+import type { StripeErrorType } from "./errors.js";
+import type { ChargeRow, PIStatus } from "./types.js";
+
+// A charge id, as the twin mints it (`ids.ts` → `ch_<random>`) or as a seed
+// hand-writes it (`ch_test_200`).
+//
+// Deliberately WIDER than `ch_[A-Za-z0-9]+`, and the reason is the vacuity
+// probe rather than tolerance: `stripe.no-refund-on-charge`'s mutant substitutes
+// `VACUITY_SENTINEL` (`pome-vacuity-never`) into this slot, and a mutant that
+// does not re-bind measures nothing — it reads as "the verdict moved" and
+// blesses the very criterion the probe exists to catch. The hyphen and the
+// absent `ch_` prefix are both there for that.
+export const chargeId: CheckParamType = {
+  name: "charge",
+  pattern: "[A-Za-z0-9_-]+",
+  example: "ch_test_200",
+  render: (value) => value,
+  parse: (raw) => raw,
+};
+
+// `PIRow.amount` is an integer minor unit — cents for USD. Digits only, no
+// separators and no currency symbol: the state carries a number, and a slot that
+// accepted "$100.00" would have to decide how to parse it, which is a second
+// place for the same fact to live.
+//
+// Accepts `VACUITY_SENTINEL_NUMBER` (987654321) by construction.
+export const minorUnitAmount: CheckParamType = {
+  name: "amount",
+  pattern: "\\d+",
+  example: "10000",
+  render: (value) => value,
+  parse: (raw) => raw,
+};
+
+// A refund row count. Digits, including zero — "the number of refunds … is 0"
+// is a legitimate assertion an author may want, and excluding it would push
+// them back to prose.
+export const rowCount: CheckParamType = {
+  name: "count",
+  pattern: "\\d+",
+  example: "1",
+  render: (value) => value,
+  parse: (raw) => raw,
+};
+
+// `PIStatus` (`types.ts`) — the seven states the payment_intents column can
+// hold, which are also upstream Stripe's seven.
+const PAYMENT_INTENT_STATUSES = [
+  "requires_payment_method",
+  "requires_confirmation",
+  "requires_action",
+  "processing",
+  "requires_capture",
+  "canceled",
+  "succeeded",
+] as const satisfies readonly PIStatus[];
+
+export const paymentIntentStatus = oneOf("status", PAYMENT_INTENT_STATUSES, "succeeded");
+
+// `ChargeRow["status"]` (`types.ts`). Three, not the PI's seven — a charge is
+// created already settled or already declined.
+const CHARGE_STATUSES = [
+  "pending",
+  "succeeded",
+  "failed",
+] as const satisfies readonly ChargeRow["status"][];
+
+export const chargeStatus = oneOf("status", CHARGE_STATUSES, "succeeded");
+
+// `EventType` (`domain/events.ts`) — every event the twin can append. v1
+// delivers no webhooks, so this is also the whole set an examinee can observe by
+// polling `GET /v1/events`.
+const EVENT_TYPES = [
+  "payment_intent.created",
+  "payment_intent.requires_action",
+  "payment_intent.processing",
+  "payment_intent.succeeded",
+  "payment_intent.payment_failed",
+  "payment_intent.canceled",
+  "charge.succeeded",
+  "charge.failed",
+  "charge.refunded",
+  "refund.created",
+  "customer.created",
+  "customer.updated",
+  "customer.deleted",
+  "payment_method.attached",
+  "payment_method.detached",
+] as const satisfies readonly EventType[];
+
+// The one slot whose rendered form carries no quotes, because the corpus
+// already says `payment_intent.succeeded is emitted` and a migration that
+// re-renders an existing criterion differently rewrites it. The dot is inside
+// the member literals, which `oneOf` escapes — so it matches a dot and not
+// "any character".
+export const stripeEventType = oneOf("event_type", EVENT_TYPES, "payment_intent.succeeded");
+
+// `StripeErrorType` (`errors.ts`) — the five `error.type` values the twin's
+// envelope can carry. Named as a set rather than scanned as free text because
+// `type` is the field a Stripe SDK branches on, and an author asserting about a
+// value the twin never emits should be stopped at the picker.
+const ERROR_TYPES = [
+  "invalid_request_error",
+  "api_error",
+  "card_error",
+  "idempotency_error",
+  "rate_limit_error",
+] as const satisfies readonly StripeErrorType[];
+
+export const stripeErrorType = oneOf("error_type", ERROR_TYPES, "invalid_request_error");

--- a/packages/twin-stripe/src/check-payments.ts
+++ b/packages/twin-stripe/src/check-payments.ts
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// What Stripe's declared checks can assert about PAYMENT INTENTS, CHARGES and
+// EVENTS (F-1127).
+//
+// Two migrate from pome-cloud's `services/evaluators/deterministic/stripe.ts`,
+// where they were hand-written regexes over a cloud-side mirror of the state
+// shape. Three are new, and each one exists because a shipped criterion asked
+// for it and bound nothing:
+//
+//   A PaymentIntent exists with status "…"   ← task 13, `A backing PaymentIntent
+//                                              reaches succeeded`
+//   A charge exists with status "…"          ← task 12
+//   {event_type} is emitted                  ← task 12, and the one sentence in
+//                                              this file that re-renders the
+//                                              corpus BYTE-IDENTICALLY
+//
+// ── The definite and the indefinite are different checks ────────────────────
+//
+// `The PaymentIntent status is …` asserts about THE PaymentIntent and refuses
+// (`unmatched`) when a world holds more than one — the legacy rule's rule, kept
+// because it is right: `.some()` over every PI would let a wrong agent pass by
+// leaving an unrelated seed PI in the wanted status (D4).
+//
+// `A PaymentIntent exists with status …` asserts that SOME PI reached it. That
+// is a weaker claim and the corpus needs it: task 13's x402 middleware mints a
+// fresh PaymentIntent on every challenge leg, so a real run of that task holds
+// several and the definite form would refuse every time. Two readings, two
+// checks, and D6's collision arm keeps them from claiming one sentence.
+//
+// ── What was dropped in the migration, and why it is not a silent loss ──────
+//
+// The legacy `payment-intent-status` pattern carried an OPTIONAL qualifier —
+// `The PaymentIntent with amount 10000 status is …` / `… with id pi_123 …`. A
+// template has no optional slot, and the qualifier existed only to disambiguate
+// a multi-PI world, which the indefinite check above now answers directly. It
+// has zero corpus users, so nothing re-renders differently. An author who needs
+// to name ONE PaymentIntent by id wants a check whose template carries that id;
+// nothing asks for one yet, and inventing it here would ship a fourth
+// PaymentIntent template for the near-miss patterns to shadow each other with.
+
+import { defineCheck, VACUITY_SENTINEL_NUMBER } from "@pome-sh/sdk/checks";
+import type { Check } from "./check-kind.js";
+import {
+  chargeStatus,
+  minorUnitAmount,
+  paymentIntentStatus,
+  stripeEventType,
+} from "./check-params.js";
+import type { StripeCheckState } from "./check-state.js";
+import { charge, event, finalWorld, paymentIntent, stripeState } from "./check-worlds.js";
+
+const STATE_INCOMPLETE = { passed: false, status: "skipped" as const, reason: "state_incomplete" };
+
+// Every collection this file reads is absent-able, and every absence is the
+// same verdict: we were handed no `payment_intents` / `charges` / `events` key
+// at all, so nothing can be attested. Named once so the three checks cannot
+// drift on it — and so arm 3 of the discrimination gate has ONE degenerate
+// reason to compare against rather than three near-identical ones.
+function requireList<T>(list: T[] | null | undefined): T[] | null {
+  return list == null ? null : list;
+}
+
+export const paymentIntentAmount: Check<{ amount: string }> = defineCheck({
+  id: "stripe.payment-intent-amount",
+  description:
+    "Asserts SOME PaymentIntent in the account carries this exact amount, in the currency's " +
+    "minor unit (cents for USD) — the integer the `amount` field holds, never a formatted " +
+    "figure. It asserts nothing about that intent's status, its currency, or how many others " +
+    "exist. An absent `payment_intents` key is a SKIP: a positive criterion must not fail a " +
+    "correct agent over state nobody uploaded.",
+  template: "A PaymentIntent exists with amount {amount}",
+  params: { amount: minorUnitAmount },
+  substrate: "final",
+  polarity: () => "positive",
+  // The amount is COMPARED to a numeric field, not hunted for inside prose, so
+  // no redactor can silently delete it. `subject` is omitted rather than
+  // returning null for the same reason twin-github omits it on structural
+  // checks: absent means "nothing a redactor could reach", which is the truth.
+  vacuityMutant: (args) => ({ ...args, amount: String(VACUITY_SENTINEL_NUMBER) }),
+  discriminatingWorlds: ({ amount }) => ({
+    passing: finalWorld(stripeState({ payment_intents: [paymentIntent({ amount: Number(amount) })] })),
+    // A PaymentIntent that EXISTS and holds a different amount, not an empty
+    // list: the reason then names the amounts it scanned and cannot be confused
+    // with the one an absent collection produces.
+    failing: finalWorld(
+      stripeState({ payment_intents: [paymentIntent({ amount: Number(amount) + 1 })] }),
+    ),
+  }),
+  evaluate({ amount }, { final }) {
+    const pis = requireList(final.payment_intents);
+    if (pis === null) return STATE_INCOMPLETE;
+    const wanted = Number(amount);
+    const found = pis.some((pi) => pi.amount === wanted);
+    return {
+      passed: found,
+      reason: found
+        ? `a PaymentIntent exists with amount ${wanted}`
+        : `no PaymentIntent has amount ${wanted} (amounts: [${pis.map((pi) => pi.amount ?? "?").join(", ")}])`,
+    };
+  },
+});
+
+export const paymentIntentStatusIs: Check<{ status: string }> = defineCheck({
+  id: "stripe.payment-intent-status",
+  description:
+    "Asserts THE PaymentIntent — singular — is in this status. When the account holds more " +
+    "than one it returns `unmatched` rather than a verdict, because scanning all of them " +
+    "would let a wrong agent pass on an unrelated intent the seed left in the wanted state. " +
+    "Use `A PaymentIntent exists with status …` when several are expected. An absent " +
+    "`payment_intents` key is a SKIP.",
+  template: "The PaymentIntent status is {status}",
+  params: { status: paymentIntentStatus },
+  substrate: "final",
+  polarity: () => "positive",
+  // Null, and admitted in `HONEST_NULL_MUTANTS`. The only slot is a closed set,
+  // so no member is guaranteed false — a mutant naming a different status
+  // asserts something that may also be true — and a value outside the set does
+  // not re-bind at all, which reads as "the verdict moved" and blesses the very
+  // criterion the probe exists to catch. Task 10 carries this criterion AND
+  // `payment-intent-amount`, whose numeric slot keeps a real mutant, so the twin
+  // does not go dark in the probe.
+  vacuityMutant: () => null,
+  discriminatingWorlds: ({ status }) => ({
+    // Exactly ONE intent in both worlds. Two would return `unmatched`, which is
+    // neither a real pass nor a real fail, and would break arms 1 and 2.
+    passing: finalWorld(stripeState({ payment_intents: [paymentIntent({ status })] })),
+    failing: finalWorld(
+      stripeState({
+        payment_intents: [paymentIntent({ status: status === "canceled" ? "processing" : "canceled" })],
+      }),
+    ),
+  }),
+  evaluate({ status }, { final }) {
+    const pis = requireList(final.payment_intents);
+    if (pis === null) return STATE_INCOMPLETE;
+    if (pis.length > 1) {
+      return {
+        passed: false,
+        status: "unmatched",
+        reason: `ambiguous: ${pis.length} payment_intents and this sentence names one`,
+      };
+    }
+    const found = pis.some((pi) => pi.status === status);
+    return {
+      passed: found,
+      reason: found
+        ? `the PaymentIntent has status "${status}"`
+        : `the PaymentIntent does not have status "${status}" ` +
+          `(statuses: [${pis.map((pi) => pi.status ?? "?").join(", ")}])`,
+    };
+  },
+});
+
+export const paymentIntentWithStatusExists: Check<{ status: string }> = defineCheck({
+  id: "stripe.payment-intent-with-status-exists",
+  description:
+    "Asserts AT LEAST ONE PaymentIntent in the account reached this status, whichever one and " +
+    "however many others exist. This is the check for a flow that mints intents the author " +
+    "cannot name in advance — x402 creates a fresh one per challenge leg — where naming `the` " +
+    "PaymentIntent would be ambiguous by construction. An absent `payment_intents` key is a SKIP.",
+  template: 'A PaymentIntent exists with status "{status}"',
+  params: { status: paymentIntentStatus },
+  substrate: "final",
+  polarity: () => "positive",
+  // Closed set — see `stripe.payment-intent-status` above, same argument.
+  vacuityMutant: () => null,
+  discriminatingWorlds: ({ status }) => {
+    const other = status === "canceled" ? "processing" : "canceled";
+    return {
+      // Two intents in each world, because that plurality is the whole reason
+      // this check exists beside the definite one: a fixture with a single
+      // intent would pass identically under both and prove nothing about the
+      // difference.
+      passing: finalWorld(
+        stripeState({
+          payment_intents: [
+            paymentIntent({ id: "pi_a", status: other }),
+            paymentIntent({ id: "pi_b", status }),
+          ],
+        }),
+      ),
+      failing: finalWorld(
+        stripeState({
+          payment_intents: [
+            paymentIntent({ id: "pi_a", status: other }),
+            paymentIntent({ id: "pi_b", status: other }),
+          ],
+        }),
+      ),
+    };
+  },
+  evaluate({ status }, { final }) {
+    const pis = requireList(final.payment_intents);
+    if (pis === null) return STATE_INCOMPLETE;
+    const hits = pis.filter((pi) => pi.status === status);
+    return {
+      passed: hits.length > 0,
+      reason:
+        hits.length > 0
+          ? `${hits.length} of ${pis.length} PaymentIntent(s) have status "${status}"`
+          : `no PaymentIntent has status "${status}" ` +
+            `(statuses: [${pis.map((pi) => pi.status ?? "?").join(", ")}])`,
+    };
+  },
+});
+
+export const chargeWithStatusExists: Check<{ status: string }> = defineCheck({
+  id: "stripe.charge-exists-with-status",
+  description:
+    "Asserts AT LEAST ONE charge in the account is in this status. A charge is created already " +
+    "settled or already declined, so `succeeded` here means money moved — the twin writes the " +
+    "charge and its balance transaction inside one SQLite transaction, on both the card and the " +
+    "x402 crypto rails, so a charge in this state always has its ledger entry and asserting the " +
+    "balance transaction separately would assert a twin invariant rather than anything an " +
+    "examinee did. An absent `charges` key is a SKIP.",
+  template: 'A charge exists with status "{status}"',
+  params: { status: chargeStatus },
+  substrate: "final",
+  polarity: () => "positive",
+  // Closed set of three — same argument as the PaymentIntent status slots.
+  vacuityMutant: () => null,
+  discriminatingWorlds: ({ status }) => {
+    const other = status === "failed" ? "succeeded" : "failed";
+    return {
+      passing: finalWorld(stripeState({ charges: [charge({ status })] })),
+      failing: finalWorld(stripeState({ charges: [charge({ status: other })] })),
+    };
+  },
+  evaluate({ status }, { final }) {
+    const charges = requireList(final.charges);
+    if (charges === null) return STATE_INCOMPLETE;
+    const hits = charges.filter((row) => row.status === status);
+    return {
+      passed: hits.length > 0,
+      reason:
+        hits.length > 0
+          ? `${hits.length} of ${charges.length} charge(s) have status "${status}"`
+          : `no charge has status "${status}" ` +
+            `(statuses: [${charges.map((row) => row.status ?? "?").join(", ")}])`,
+    };
+  },
+});
+
+export const eventEmitted: Check<{ event_type: string }> = defineCheck({
+  id: "stripe.event-emitted",
+  description:
+    "Asserts the account's event log contains at least one event of this type. The twin delivers " +
+    "no webhooks in v1 — an examinee observes events by polling `GET /v1/events` — so this reads " +
+    "the log the twin appended, not anything the examinee received. It asserts nothing about " +
+    "WHICH resource the event names: `payment_intent.succeeded` is emitted by both the card " +
+    "confirm path and the x402 crypto-deposit settlement, and this check deliberately does not " +
+    "distinguish them, because the criterion asking for it is about the outcome rather than the " +
+    "rail. An absent `events` key is a SKIP.",
+  // No quotes, and that is load-bearing: the corpus already says
+  // `payment_intent.succeeded is emitted`, so this template re-renders task 12's
+  // existing criterion byte-identically and the migration rewrites it not at
+  // all. The dot lives inside the closed set's members, which `oneOf` escapes,
+  // so it matches a dot rather than any character.
+  template: "{event_type} is emitted",
+  params: { event_type: stripeEventType },
+  substrate: "final",
+  polarity: () => "positive",
+  // Closed set of fifteen — the twin's own `EventType` union — so no member is
+  // guaranteed false. Admitted in `HONEST_NULL_MUTANTS`.
+  vacuityMutant: () => null,
+  discriminatingWorlds: ({ event_type }) => {
+    const other =
+      event_type === "payment_intent.created" ? "payment_intent.canceled" : "payment_intent.created";
+    return {
+      passing: finalWorld(stripeState({ events: [event(other), event(event_type)] })),
+      // A log that EXISTS and holds a different event, so the reason names what
+      // was emitted instead and cannot be confused with an absent log.
+      failing: finalWorld(stripeState({ events: [event(other)] })),
+    };
+  },
+  evaluate({ event_type }, { final }) {
+    const events = requireList(final.events);
+    if (events === null) return STATE_INCOMPLETE;
+    const hits = events.filter((row) => row.type === event_type);
+    return {
+      passed: hits.length > 0,
+      reason:
+        hits.length > 0
+          ? `${hits.length} \`${event_type}\` event(s) among ${events.length} emitted`
+          : `no \`${event_type}\` event among ${events.length} emitted ` +
+            `([${events.map((row) => row.type ?? "?").join(", ")}])`,
+    };
+  },
+});
+
+// Re-exported for the state-shape parity arm, which asserts these field names
+// against a real `exportState()` rather than against this module's beliefs.
+export type { StripeCheckState };

--- a/packages/twin-stripe/src/check-refunds.ts
+++ b/packages/twin-stripe/src/check-refunds.ts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// What Stripe's declared checks can assert about REFUNDS in the final state
+// (F-1127).
+//
+// Both are new, and both replace prose. Task 14 shipped these two lines:
+//
+//   At least one refund was successfully issued (a `refund_id` appears in
+//     state.refunds or in events.jsonl)
+//   state.refunds.length === 1 — exactly one refund row per logical
+//     transaction. CRITICAL: this is expected to FAIL on current behavior …
+//
+// Neither is a sentence. The first names two substrates and an internal field;
+// the second is a JavaScript expression followed by a prediction about the
+// examinee. Under position 2 there is nothing there to render, so they are
+// re-expressed as two typed checks rather than pattern-matched.
+//
+// The prediction went with them, and deliberately: it asserted that an
+// `Idempotency-Key` on the retry is what separates one refund row from two, and
+// that is FALSE in this twin as measured (F-1138). Leaving a false causal claim
+// in a criterion is worse than leaving it in prose, because the criterion is
+// what a report quotes back.
+//
+// ── Why the charge is not a `subject`, and why the mutant is null ───────────
+//
+// Both checks RESOLVE the charge before asserting, so a charge id nobody minted
+// skips (`charge_not_found`) rather than reaching the assertion. That makes it a
+// selector: falsifying it moves the verdict for a reason that never touches what
+// the check is about, which is a clean bill the check did not earn.
+//
+// The same literal plays a different role one substrate over.
+// `stripe.no-refund-on-charge` hunts this id inside recorded request BODIES —
+// there is nothing to resolve, so it is genuinely scanned, and it keeps both a
+// real `subject` and a real mutant. One id, two roles, decided by whether the
+// substrate can look it up.
+
+import { defineCheck } from "@pome-sh/sdk/checks";
+import type { Check } from "./check-kind.js";
+import { chargeId, rowCount } from "./check-params.js";
+import { refundsOnCharge } from "./check-state.js";
+import { charge, finalWorld, refund, stripeState } from "./check-worlds.js";
+
+export const refundExists: Check<{ charge: string }> = defineCheck({
+  id: "stripe.refund-exists",
+  description:
+    "Resolves the named charge, then asserts at least one row in the account's `refunds` " +
+    "collection references it. It reads refund ROWS, not the charge's `amount_refunded`, and " +
+    "not `charge.refunded` — that flag is true only when a charge is FULLY refunded, so a " +
+    "partial refund leaves it false and a check reading it would miss every partial. It asserts " +
+    "nothing about the refunded amount or the refund's own status. A charge the account does " +
+    "not hold is a SKIP, not a fail: we cannot attest a positive over state we do not have.",
+  template: 'A refund exists on charge "{charge}"',
+  params: { charge: chargeId },
+  substrate: "final",
+  polarity: () => "positive",
+  // Selector, not a scanned literal — see the header.
+  subject: () => null,
+  vacuityMutant: () => null,
+  discriminatingWorlds: (args) => ({
+    passing: finalWorld(
+      stripeState({
+        charges: [charge({ id: args.charge })],
+        refunds: [refund({ charge: args.charge })],
+      }),
+    ),
+    // The charge RESOLVES in both worlds and only the refund list moves. A world
+    // without the charge would skip the way an empty one does.
+    failing: finalWorld(stripeState({ charges: [charge({ id: args.charge })], refunds: [] })),
+  }),
+  evaluate(args, { final }) {
+    const rows = refundsOnCharge(final, args.charge);
+    if ("missing" in rows) return { passed: false, status: "skipped", reason: rows.missing };
+    return {
+      passed: rows.found.length > 0,
+      reason:
+        rows.found.length > 0
+          ? `charge "${args.charge}" has ${rows.found.length} refund row(s)`
+          : `charge "${args.charge}" has no refund rows`,
+    };
+  },
+});
+
+export const refundCount: Check<{ charge: string; count: string }> = defineCheck({
+  id: "stripe.refund-count",
+  description:
+    "Resolves the named charge and asserts the account holds EXACTLY this many refund rows " +
+    "against it. This is the over-refund assertion: a lost-response retry that re-issues the " +
+    "same logical refund lands a second row, and only a count can see it — the amount is right " +
+    "on each row individually and wrong in aggregate. It asserts nothing about the amounts, so " +
+    "two rows fail it whether they total the intended refund or double it. A charge the account " +
+    "does not hold is a SKIP.",
+  template: 'The number of refunds on charge "{charge}" is {count}',
+  params: { charge: chargeId, count: rowCount },
+  substrate: "final",
+  // A function of the args, the way the GitHub PR check's is: `… is 0` is a
+  // prohibition the seed already satisfies and only the examinee can break,
+  // while any other count is something that must come to exist.
+  polarity: ({ count }) => (Number(count) === 0 ? "negative" : "positive"),
+  subject: () => null,
+  // The charge SELECTS and the count IS the assertion. Neither is a literal
+  // hunted for in the state, so no substitution falsifies a trigger clause:
+  // mutating the charge skips, and mutating the count asserts a different thing
+  // rather than falsifying this one. Admitted in `HONEST_NULL_MUTANTS`.
+  vacuityMutant: () => null,
+  discriminatingWorlds: (args) => {
+    const wanted = Number(args.count);
+    const rows = (n: number) =>
+      Array.from({ length: n }, (_unused, index) =>
+        refund({ id: `re_${index}`, charge: args.charge }),
+      );
+    return {
+      passing: finalWorld(
+        stripeState({ charges: [charge({ id: args.charge })], refunds: rows(wanted) }),
+      ),
+      // One MORE, never one fewer: the double-refund is the failure this check
+      // exists for, and a fixture that under-shot would demonstrate the
+      // uninteresting half.
+      failing: finalWorld(
+        stripeState({ charges: [charge({ id: args.charge })], refunds: rows(wanted + 1) }),
+      ),
+    };
+  },
+  evaluate(args, { final }) {
+    const rows = refundsOnCharge(final, args.charge);
+    if ("missing" in rows) return { passed: false, status: "skipped", reason: rows.missing };
+    const wanted = Number(args.count);
+    return {
+      passed: rows.found.length === wanted,
+      reason:
+        `charge "${args.charge}" has ${rows.found.length} refund row(s), wanted ${wanted}` +
+        (rows.found.length > wanted
+          ? ` — ${rows.found.length - wanted} more than one refund per logical transaction`
+          : ""),
+    };
+  },
+});

--- a/packages/twin-stripe/src/check-state.ts
+++ b/packages/twin-stripe/src/check-state.ts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// How a declared check READS the exported Stripe account (F-1127).
+//
+// pome-cloud kept a hand-maintained mirror of this shape in
+// `deterministic/stripe.ts` (`StripeStateTree`, `StripePaymentIntent`,
+// `StripeRefund`). That mirror is deleted in the same milestone; this is the
+// only model, and it lives next to the export that produces it.
+//
+// ── One difference from Slack's model, and it changes every field name ──────
+//
+// Slack's `exportState()` spreads raw SQLite rows. Stripe's does NOT: every
+// collection goes through `serializers.ts` first, so what a check reads is the
+// STRIPE WIRE OBJECT, not the row. The join columns are the ones that move:
+//
+//   table column              wire field           what a check must read
+//   refunds.charge_id         refund.charge        `charge`
+//   refunds.payment_intent_id refund.payment_intent
+//   charges.payment_intent_id charge.payment_intent
+//   charges.balance_transaction_id
+//                             charge.balance_transaction
+//   balance_transactions.source_id
+//                             balance_transaction.source
+//   payment_intents.latest_charge_id
+//                             payment_intent.latest_charge
+//
+// A model written against the SEED schema (`seed.ts`) would carry the `_id`
+// names and silently match nothing, which is a positive criterion failing a
+// correct agent. The state-shape parity arm in `fidelity-contract.test.ts`
+// asserts these names against a real `exportState()` rather than trusting this
+// comment.
+//
+// Every field is optional and every list nullable, for twin-github's and
+// twin-slack's reason: an older snapshot or a partial upload arrives here with
+// fields absent, and a predicate that assumes presence throws inside the
+// evaluator where a NAMED verdict was owed. A criterion may leave the
+// denominator; it may never fabricate one (D4).
+//
+// Three shapes are counter-intuitive and each has a wrong-verdict story:
+//   - `charge.refunded` is true only when the charge is FULLY refunded. A
+//     partial refund leaves `amount_refunded > 0` and `refunded === false`
+//     (`serializers.ts:206-208`). A predicate reading `refunded` to mean "has
+//     any refund" misses every partial one — which is the only kind task 14
+//     produces.
+//   - `balance_transaction.source` points at the PAYMENT INTENT, not the
+//     charge, and the domain says so out loud: "real Stripe links the balance
+//     txn to the charge, not the PI. Keep it pointed at the PI for now …  OK as
+//     v1 deviation" (`domain/stripe-domain.ts`, the crypto-deposit leg). A join
+//     written against upstream's semantics finds nothing here.
+//   - Every collection is exported `ORDER BY created DESC, rowid DESC` — NEWEST
+//     FIRST. `created` has unix-second resolution, so the rowid tiebreak is what
+//     makes it deterministic (F-683). Nothing in this vocabulary asserts on
+//     order, and that is deliberate: the ordered substrate is the TAPE, and a
+//     state check that leaned on export order would be reading an
+//     implementation detail the twin is free to change.
+
+export interface StripeCheckStatePaymentIntent {
+  id?: string;
+  amount?: number;
+  currency?: string;
+  status?: string;
+  latest_charge?: string | null;
+}
+
+export interface StripeCheckStateCharge {
+  id?: string;
+  amount?: number;
+  amount_refunded?: number;
+  currency?: string;
+  status?: string;
+  // FULLY refunded only — see the header. Present for completeness; no check in
+  // this vocabulary reads it, because the assertions authors write are about
+  // refund ROWS, which `amount_refunded` and the `refunds` collection carry.
+  refunded?: boolean;
+  paid?: boolean;
+  payment_intent?: string | null;
+  balance_transaction?: string | null;
+}
+
+export interface StripeCheckStateBalanceTransaction {
+  id?: string;
+  amount?: number;
+  // The PAYMENT INTENT id, not the charge id — see the header.
+  source?: string | null;
+  status?: string;
+  type?: string;
+}
+
+// `data` carries exactly one key, `object`, holding the full serialized
+// resource the event is about (`domain/events.ts` writes
+// `JSON.stringify({ object })`). Typed as `unknown` because it is a union of
+// every serializer's output and no check in this vocabulary reads inside it —
+// asserting on the event TYPE is what the corpus asks for, and reaching into
+// `data.object` would re-assert something the `payment_intents` / `charges`
+// collections already carry in a shape a check can read.
+export interface StripeCheckStateEvent {
+  id?: string;
+  type?: string;
+  data?: { object?: unknown } | null;
+  created?: number;
+}
+
+export interface StripeCheckStateRefund {
+  id?: string;
+  amount?: number;
+  currency?: string;
+  status?: string;
+  charge?: string | null;
+  payment_intent?: string | null;
+}
+
+// The five collections this vocabulary reads. `exportState` emits eleven —
+// `customers`, `payment_methods`, `products`, `prices` and `subscriptions` are
+// deliberately absent rather than forgotten: no shipped criterion asserts about
+// them, and a model field nothing reads is a field nothing keeps honest. They
+// join when a check needs them.
+export interface StripeCheckState {
+  payment_intents?: StripeCheckStatePaymentIntent[] | null;
+  charges?: StripeCheckStateCharge[] | null;
+  balance_transactions?: StripeCheckStateBalanceTransaction[] | null;
+  events?: StripeCheckStateEvent[] | null;
+  refunds?: StripeCheckStateRefund[] | null;
+}
+
+/** twin-github's and twin-slack's verdict type, same shape and same reason: a
+ *  resolver must be able to say WHY it found nothing, because the ways of
+ *  finding nothing get different verdicts. */
+export type Resolved<T> = { found: T } | { missing: string };
+
+/**
+ * The charge a criterion names, with the three outcomes a refund assertion has
+ * to tell apart:
+ *   - no `charges` key at all → `state_incomplete`; nothing can be attested
+ *   - present but this charge absent → `charge_not_found`. A SKIP rather than a
+ *     verdict, on twin-slack's `resolveChannel` precedent: we cannot attest a
+ *     positive over state we do not have, and for a negative a missing selector
+ *     would hand a wrong agent a free pass.
+ *   - found → the predicate evaluates. A present charge with zero refunds is a
+ *     TRUE vacuous pass for a negative and a TRUE fail for a positive.
+ *
+ * Comparison is EXACT. A Stripe charge id is an opaque identifier the twin
+ * minted, not a human-typed name, so the case-insensitive `#`-tolerant matching
+ * twin-slack does for channel names would only widen what a typo can hit.
+ */
+export function resolveCharge(
+  state: StripeCheckState,
+  chargeId: string,
+): Resolved<StripeCheckStateCharge> {
+  if (state.charges == null) return { missing: "state_incomplete" };
+  const hit = state.charges.find((charge) => charge.id === chargeId);
+  return hit ? { found: hit } : { missing: `charge_not_found ("${chargeId}")` };
+}
+
+/**
+ * Every refund row against a charge, or the reason we cannot say.
+ *
+ * Resolves the CHARGE first and skips when it is missing, so "this charge has
+ * no refunds" and "there is no such charge" never reach the same verdict —
+ * they are the two answers a count assertion must not conflate.
+ *
+ * An EMPTY list is a real answer, deliberately distinct from either skip: a
+ * seeded charge nobody refunded really does have zero refunds.
+ */
+export function refundsOnCharge(
+  state: StripeCheckState,
+  chargeId: string,
+): Resolved<StripeCheckStateRefund[]> {
+  const charge = resolveCharge(state, chargeId);
+  if ("missing" in charge) return charge;
+  if (state.refunds == null) return { missing: "state_incomplete" };
+  return { found: state.refunds.filter((refund) => refund.charge === chargeId) };
+}

--- a/packages/twin-stripe/src/check-tape.ts
+++ b/packages/twin-stripe/src/check-tape.ts
@@ -1,0 +1,369 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// What Stripe's declared checks can assert about the RUN — the recorded call
+// tape rather than the exported end state (F-1127).
+//
+// Four checks, and every one of them exists because the final state cannot
+// answer the question:
+//
+//   no-refund-on-charge         the twin REFUSES a second refund on an
+//                               already-refunded charge, so the attempt never
+//                               reaches `state.refunds`
+//   request-rejected-with-error a rejected request mutates nothing, so an error
+//                               the agent provoked and handled is invisible in
+//                               the end state
+//   x402-first-request-challenged  a 402 challenge mutates nothing
+//   x402-retry-includes-payment    the challenge leg and the paid leg are the
+//                               SAME method on the SAME path; only their headers
+//                               tell them apart
+//
+// ── The twin filter is GONE, and that is not an omission ────────────────────
+//
+// The legacy rules in pome-cloud each opened with
+// `(event.twin ?? "stripe") === "stripe"`, because a legacy `PhraseRule` was
+// handed the whole session's tape. A declaration is not: the engine scopes the
+// tape to the criterion's own twin before `evaluate` runs
+// (`declared.ts tapeForTwin`), precisely so a twin's check need not know that
+// multi-twin sessions exist and a new tape check cannot forget to. Re-filtering
+// here would be a second copy of that decision, and the copy is the one that
+// goes stale.
+//
+// ── `null` and `[]` are different worlds ────────────────────────────────────
+//
+// `null` is "nobody handed me a tape"; `[]` is "the agent called nothing". Every
+// check below guards `null` explicitly even though the engine guards it too, so
+// a consumer that forgets produces a named skip rather than a vacuous pass. For
+// a NEGATIVE criterion that distinction is the whole ballgame.
+
+import { defineCheck, VACUITY_SENTINEL, type CheckTapeEvent } from "@pome-sh/sdk/checks";
+import type { Check } from "./check-kind.js";
+import { chargeId, stripeErrorType } from "./check-params.js";
+import { call, tapeWorld, x402Leg } from "./check-worlds.js";
+
+const TAPE_MISSING = { passed: false, status: "skipped" as const, reason: "tape_missing" };
+
+/** The recorded ids backing an outcome, minus the rows that carry none. Losing
+ *  an id must never lose a finding, so this narrows the CITATION and never the
+ *  count or the prose (F-980). */
+function citations(events: readonly CheckTapeEvent[]): string[] {
+  return events
+    .map((event) => event.event_id)
+    .filter((id): id is string => typeof id === "string" && id !== "");
+}
+
+/** Attach citations only when there are some: absent and `[]` mean the same
+ *  thing downstream, and an empty affordance would have to be special-cased by
+ *  every reader of the persisted row. */
+function withCitations(
+  outcome: { passed: boolean; reason: string },
+  events: readonly CheckTapeEvent[],
+): { passed: boolean; reason: string; evidenceEventIds?: string[] } {
+  const ids = citations(events);
+  return ids.length > 0 ? { ...outcome, evidenceEventIds: ids } : outcome;
+}
+
+/** The `error.type` a recorded response carries, or null.
+ *
+ *  `response_body` is `unknown` on the wire — stripe records the parsed object,
+ *  but another recorder may hand back the raw text — so this reads both rather
+ *  than assuming. Reading only objects would silently miss the rejection, and
+ *  for a POSITIVE criterion a silent miss fails a correct agent. */
+function recordedErrorType(body: unknown): string | null {
+  const parsed =
+    typeof body === "string"
+      ? (() => {
+          try {
+            return JSON.parse(body) as unknown;
+          } catch {
+            return null;
+          }
+        })()
+      : body;
+  if (parsed === null || typeof parsed !== "object") return null;
+  const error = (parsed as { error?: unknown }).error;
+  if (error === null || typeof error !== "object") return null;
+  const type = (error as { type?: unknown }).type;
+  return typeof type === "string" ? type : null;
+}
+
+/** The x402 legs on a tape, in order. Scoped by PATH because the gated surface
+ *  is mounted at `/x402/*` (`session.ts`) and the recorded path carries the
+ *  session prefix — `/s/<sid>/x402/protected-resource`. The twin's own settlement
+ *  calls (`POST /v1/payment_intents`, `simulate_crypto_deposit`) travel back over
+ *  HTTP and are recorded by the REST routes that serve them, so they are NOT
+ *  x402 legs and must not be counted as ones. */
+function x402Legs(tape: readonly CheckTapeEvent[]): CheckTapeEvent[] {
+  return tape.filter((event) => (event.path ?? "").includes("/x402/"));
+}
+
+export const noRefundOnCharge: Check<{ charge: string }> = defineCheck({
+  id: "stripe.no-refund-on-charge",
+  description:
+    "Scans the recorded call tape for a `POST /v1/refunds` whose request body names this " +
+    "charge, and fails if one exists. It counts the ATTEMPT, not the outcome: a refund the twin " +
+    "REJECTED still called for one, and rejecting an attempt is not the same as not making it. " +
+    "That is the whole reason this reads the tape — the twin refuses a second refund on an " +
+    "already-refunded charge, so no examinee behaviour can put a matching row in " +
+    "`state.refunds`, and read against state the criterion could never fail. A GET that merely " +
+    "LISTS refunds is not an attempt and does not fail it.",
+  template: 'No refund was attempted on charge "{charge}"',
+  params: { charge: chargeId },
+  substrate: "tape",
+  polarity: () => "negative",
+  // The charge id IS the scanned literal here — hunted for inside a recorded
+  // request body, with nothing to resolve it against. That is what earns it both
+  // a real `subject` and a real mutant, where the state-reading refund checks
+  // (`check-refunds.ts`) get neither.
+  subject: (args) => args.charge,
+  vacuityMutant: (args) => ({ ...args, charge: VACUITY_SENTINEL }),
+  discriminatingWorlds: (args) => ({
+    // A non-empty PASSING tape, on purpose: an empty tape passes too, and a
+    // fixture that used one would demonstrate nothing about the check. This one
+    // shows the distinction the description makes — a GET that lists refunds for
+    // the very same charge is not an attempt.
+    passing: tapeWorld([
+      call({ method: "GET", path: `/s/test-session/v1/refunds?charge=${args.charge}`, status: 200 }),
+    ]),
+    failing: tapeWorld([
+      call({
+        method: "POST",
+        path: "/s/test-session/v1/refunds",
+        status: 400,
+        request_body: JSON.stringify({ charge: args.charge, amount: 20000 }),
+        event_id: "evt_attempt",
+      }),
+    ]),
+  }),
+  evaluate(args, { tape }) {
+    if (tape === null) return TAPE_MISSING;
+    const attempts = tape.filter((event) => {
+      if ((event.method ?? "").toUpperCase() !== "POST") return false;
+      if (!(event.path ?? "").includes("/v1/refunds")) return false;
+      // The charge id lives in the REQUEST BODY, which is why this needs the
+      // widened substrate rather than method+path. stripe records the raw text;
+      // another twin may record an object, and reading only strings would
+      // silently miss the attempt.
+      const body = event.request_body;
+      const haystack = typeof body === "string" ? body : JSON.stringify(body ?? "");
+      return haystack.includes(args.charge);
+    });
+    if (attempts.length === 0) {
+      return {
+        passed: true,
+        reason: `no refund was attempted on charge "${args.charge}" (${tape.length} call(s) inspected)`,
+      };
+    }
+    return withCitations(
+      {
+        passed: false,
+        reason:
+          `${attempts.length} refund attempt(s) on charge "${args.charge}" ` +
+          `(statuses: [${attempts.map((event) => event.status ?? "?").join(", ")}]) — ` +
+          `the twin rejecting an attempt is not the same as not attempting one`,
+      },
+      attempts,
+    );
+  },
+});
+
+export const requestRejectedWithError: Check<{ error_type: string }> = defineCheck({
+  id: "stripe.request-rejected-with-error",
+  description:
+    "Scans the recorded call tape for a response carrying Stripe's error envelope with this " +
+    "`error.type`, and passes if one exists. It asserts the agent PROVOKED and received that " +
+    "class of error — which mutates nothing, so the end state cannot show it — and asserts " +
+    "nothing about whether the agent then handled it, or about the error's `code`. It reads " +
+    "`error.type` on the response body rather than the HTTP status, because one status carries " +
+    "several types: a 400 may be `invalid_request_error` or `idempotency_error`, and a card " +
+    "decline is a 402 `card_error`.",
+  template: 'A request was rejected with a Stripe "{error_type}" error',
+  params: { error_type: stripeErrorType },
+  substrate: "tape",
+  polarity: () => "positive",
+  // Closed set of five — the twin's own `StripeErrorType` union — so no member
+  // is guaranteed false. Admitted in `HONEST_NULL_MUTANTS`.
+  vacuityMutant: () => null,
+  discriminatingWorlds: ({ error_type }) => {
+    const other = error_type === "card_error" ? "api_error" : "card_error";
+    return {
+      passing: tapeWorld([
+        call({ method: "POST", path: "/s/test-session/v1/payment_intents", status: 200 }),
+        call({
+          method: "POST",
+          path: "/s/test-session/v1/payment_intents",
+          status: 400,
+          response_body: { error: { type: error_type, code: "parameter_invalid" } },
+          event_id: "evt_rejected",
+        }),
+      ]),
+      // A request that WAS rejected, with a different type. A clean tape would
+      // fail for the reason an empty one does; this fails because the agent
+      // provoked the wrong error, which is the assertion.
+      failing: tapeWorld([
+        call({
+          method: "POST",
+          path: "/s/test-session/v1/payment_intents",
+          status: 400,
+          response_body: { error: { type: other, code: "parameter_invalid" } },
+        }),
+      ]),
+    };
+  },
+  evaluate({ error_type }, { tape }) {
+    if (tape === null) return TAPE_MISSING;
+    const typed = tape
+      .map((event) => ({ event, type: recordedErrorType(event.response_body) }))
+      .filter((row) => row.type !== null);
+    const hits = typed.filter((row) => row.type === error_type);
+    if (hits.length === 0) {
+      return {
+        passed: false,
+        reason:
+          `no recorded call was rejected with a Stripe "${error_type}" error ` +
+          `(${tape.length} call(s) inspected; error types seen: ` +
+          `[${typed.map((row) => row.type).join(", ")}])`,
+      };
+    }
+    return withCitations(
+      {
+        passed: true,
+        reason:
+          `${hits.length} call(s) were rejected with a Stripe "${error_type}" error ` +
+          `(${tape.length} call(s) inspected)`,
+      },
+      hits.map((row) => row.event),
+    );
+  },
+});
+
+export const x402FirstRequestChallenged: Check<Record<string, never>> = defineCheck({
+  id: "stripe.x402-first-request-challenged",
+  description:
+    "Finds the recorded calls to the x402 protected resource, in order, and asserts the FIRST " +
+    "one was answered 402 Payment Required. It is about the challenge leg specifically, not " +
+    "about any 402 anywhere — a card decline is also a 402 and does not satisfy it. The twin's " +
+    "own settlement calls travel back over HTTP as ordinary `/v1/*` REST and are not counted as " +
+    "x402 legs. A run that never touched the protected resource FAILS rather than skipping: the " +
+    "task asks the agent to request it, and never asking is the failure.",
+  // The sentence names x402 where the corpus said only "The first request".
+  // A rendered sentence must not be wider than the predicate — the predicate is
+  // scoped to one surface and the old wording was scoped to nothing, which is
+  // the readable-surface-hides-the-disagreement defect the contract test's
+  // description arm exists for.
+  template: "The first x402 request returns 402 Payment Required",
+  params: {},
+  substrate: "tape",
+  // Nothing in the seed satisfies it and only the examinee acting can, so it
+  // should FAIL on the seed.
+  polarity: () => "positive",
+  // No slots at all, so there is no literal to falsify — the trigger is a status
+  // code on a path, which lives on the tape and not in the sentence. Reported as
+  // `no_trigger`, never as clean.
+  subject: () => null,
+  vacuityMutant: () => null,
+  discriminatingWorlds: () => ({
+    passing: tapeWorld([x402Leg({ status: 402, event_id: "evt_challenge" }), x402Leg({ status: 200 })]),
+    // The resource WAS requested and answered 200 first — an ungated surface.
+    // A tape with no x402 leg at all would fail the way an empty one does.
+    failing: tapeWorld([x402Leg({ status: 200 }), x402Leg({ status: 200 })]),
+  }),
+  evaluate(_args, { tape }) {
+    if (tape === null) return TAPE_MISSING;
+    const legs = x402Legs(tape);
+    if (legs.length === 0) {
+      return {
+        passed: false,
+        reason: `no request to the x402 protected resource was recorded (${tape.length} call(s) inspected)`,
+      };
+    }
+    const first = legs[0]!;
+    const challenged = first.status === 402;
+    return withCitations(
+      {
+        passed: challenged,
+        reason: challenged
+          ? `the first of ${legs.length} x402 request(s) returned 402 Payment Required`
+          : `the first of ${legs.length} x402 request(s) returned ${first.status ?? "?"}, not 402`,
+      },
+      [first],
+    );
+  },
+});
+
+export const x402RetryIncludesPayment: Check<Record<string, never>> = defineCheck({
+  id: "stripe.x402-retry-includes-payment",
+  description:
+    "Asserts some recorded request carried an `X-PAYMENT` header AND was answered 200 — the " +
+    "agent constructed a payment for the advertised challenge and the resource unlocked. Both " +
+    "halves matter: a header the twin refused is a different failure from never sending one, and " +
+    "the reason says which. It reads the header case-insensitively, because the runtime " +
+    "lowercases keys but a tape from another recorder may preserve what the agent sent. A " +
+    "recording made before headers existed is a SKIP, never a verdict.",
+  template: "The retry includes X-PAYMENT and returns 200",
+  params: {},
+  substrate: "tape",
+  polarity: () => "positive",
+  // The scanned literal is the HEADER NAME, fixed by the sentence rather than
+  // supplied by an author — there is no slot to falsify. Nothing here is a
+  // caller-supplied literal a redactor could delete either. (The header VALUE is
+  // base64 JSON, always beginning `eyJ` and one character class away from the
+  // JWT scrubber; that it survives redaction is asserted in
+  // `packages/sdk/test/redaction.test.ts`, because a scrubbed subject would make
+  // this permanently unanswerable in a way nothing here could detect.)
+  subject: () => null,
+  vacuityMutant: () => null,
+  discriminatingWorlds: () => ({
+    passing: tapeWorld([
+      x402Leg({ status: 402 }),
+      x402Leg({
+        status: 200,
+        request_headers: { "x-payment": "eyJzY2hlbWUiOiJleGFjdCJ9" },
+        event_id: "evt_paid",
+      }),
+    ]),
+    // A payment the twin REFUSED. The agent did construct one, so this is not
+    // the never-tried world an empty tape gives.
+    failing: tapeWorld([
+      x402Leg({ status: 402 }),
+      x402Leg({ status: 402, request_headers: { "x-payment": "eyJzY2hlbWUiOiJ3cm9uZyJ9" } }),
+    ]),
+  }),
+  evaluate(_args, { tape }) {
+    if (tape === null) return TAPE_MISSING;
+
+    // A tape recorded before F-1125 carries no headers at all, and this turns
+    // entirely on one. "No row had X-PAYMENT" and "no row COULD have had it" are
+    // the same absence, so answering would be inventing a verdict — and because
+    // this criterion is POSITIVE, the invented verdict fails a correct agent.
+    // Name it instead.
+    if (tape.length > 0 && !tape.some((event) => event.request_headers !== undefined)) {
+      return { passed: false, status: "skipped", reason: "headers_not_recorded" };
+    }
+
+    const carriesPayment = (event: CheckTapeEvent): boolean =>
+      Object.keys(event.request_headers ?? {}).some((key) => key.toLowerCase() === "x-payment");
+
+    const unlocked = tape.filter((event) => carriesPayment(event) && event.status === 200);
+    if (unlocked.length === 0) {
+      const attempted = tape.filter(carriesPayment);
+      // Say WHICH half is missing. "Never sent one" and "sent one and the twin
+      // refused it" are different failures wanting different fixes.
+      const detail =
+        attempted.length === 0
+          ? "no recorded request carried an X-PAYMENT header"
+          : `${attempted.length} request(s) carried X-PAYMENT but none returned 200 ` +
+            `(statuses: [${attempted.map((event) => event.status ?? "?").join(", ")}])`;
+      return { passed: false, reason: `${detail} (${tape.length} call(s) inspected)` };
+    }
+
+    return withCitations(
+      {
+        passed: true,
+        reason:
+          `${unlocked.length} request(s) carried X-PAYMENT and returned 200 ` +
+          `(${tape.length} call(s) inspected)`,
+      },
+      unlocked,
+    );
+  },
+});

--- a/packages/twin-stripe/src/check-worlds.ts
+++ b/packages/twin-stripe/src/check-worlds.ts
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The fixture worlds Stripe's declarations name (F-1127).
+//
+// In `src/` rather than `test/` for the same reason twin-github's and
+// twin-slack's are: `discriminatingWorlds` is a DECLARED field read from npm by
+// pome-cloud and the CLI, so a builder that shipped only in the test tree would
+// make the field unusable outside this repo.
+//
+// ── Why `stripeState` fills every collection ────────────────────────────────
+//
+// Arm 3 of `probeDiscrimination` rejects a failing world whose reason is the one
+// an EMPTY world (`{}`) already gives. Every check here skips on an absent
+// collection, so an under-filled fixture reaches `state_incomplete` — which is
+// arm 1 and arm 2 territory, not a real verdict. Handing back `[]` for the
+// collections a check does not read is therefore load-bearing: it makes the
+// difference between the worlds the ASSERTED field, which is exactly what arm 3
+// is checking for.
+//
+// Same shape as twin-slack's `publicChannel`, and for the same reason its
+// comment gives: the explicitness is the fixture doing its job, not tidiness.
+
+import type { CheckSubstrate, CheckTapeEvent } from "@pome-sh/sdk/checks";
+import type {
+  StripeCheckState,
+  StripeCheckStateBalanceTransaction,
+  StripeCheckStateCharge,
+  StripeCheckStateEvent,
+  StripeCheckStatePaymentIntent,
+  StripeCheckStateRefund,
+} from "./check-state.js";
+
+/** Every collection present and empty. Never `{}` — see the header. */
+export function stripeState(overrides: StripeCheckState = {}): StripeCheckState {
+  return {
+    payment_intents: [],
+    charges: [],
+    balance_transactions: [],
+    events: [],
+    refunds: [],
+    ...overrides,
+  };
+}
+
+/** A `final`-only world. `seed`/`tape` are null because the engine gives a
+ *  `final` check neither, and a fixture richer than the runtime is a fixture
+ *  that tests a world the check will never see. */
+export function finalWorld(final: StripeCheckState): CheckSubstrate<StripeCheckState> {
+  return { seed: null, final, tape: null };
+}
+
+/** A `tape` world. `final` is a fully-present but empty account rather than
+ *  `{}`: a tape check must not read state, and handing it a shape that would
+ *  satisfy a state check hides the difference. */
+export function tapeWorld(tape: readonly CheckTapeEvent[]): CheckSubstrate<StripeCheckState> {
+  return { seed: null, final: stripeState(), tape };
+}
+
+export function paymentIntent(
+  overrides: Partial<StripeCheckStatePaymentIntent> = {},
+): StripeCheckStatePaymentIntent {
+  return {
+    id: "pi_test_200",
+    amount: 20000,
+    currency: "usd",
+    status: "succeeded",
+    latest_charge: "ch_test_200",
+    ...overrides,
+  };
+}
+
+export function charge(overrides: Partial<StripeCheckStateCharge> = {}): StripeCheckStateCharge {
+  return {
+    id: "ch_test_200",
+    amount: 20000,
+    amount_refunded: 0,
+    currency: "usd",
+    status: "succeeded",
+    refunded: false,
+    paid: true,
+    payment_intent: "pi_test_200",
+    balance_transaction: "txn_test_200",
+    ...overrides,
+  };
+}
+
+export function balanceTransaction(
+  overrides: Partial<StripeCheckStateBalanceTransaction> = {},
+): StripeCheckStateBalanceTransaction {
+  // `source` is the PAYMENT INTENT id, not the charge id — the twin's own
+  // documented v1 deviation. A fixture that pointed it at the charge would
+  // model a world the twin cannot produce.
+  return {
+    id: "txn_test_200",
+    amount: 20000,
+    source: "pi_test_200",
+    status: "available",
+    type: "charge",
+    ...overrides,
+  };
+}
+
+export function event(type: string, overrides: Partial<StripeCheckStateEvent> = {}): StripeCheckStateEvent {
+  return { id: `evt_${type.replace(/\W/g, "_")}`, type, data: { object: null }, created: 1700000000, ...overrides };
+}
+
+export function refund(overrides: Partial<StripeCheckStateRefund> = {}): StripeCheckStateRefund {
+  return {
+    id: "re_test_200",
+    amount: 7500,
+    currency: "usd",
+    status: "succeeded",
+    charge: "ch_test_200",
+    payment_intent: "pi_test_200",
+    ...overrides,
+  };
+}
+
+// ── Tape fixtures ───────────────────────────────────────────────────────────
+//
+// The engine scopes a tape to the criterion's own twin before a declaration sees
+// it (`declared.ts tapeForTwin`), so these carry `twin: "stripe"` for realism
+// rather than because any check filters on it.
+
+/** One recorded REST call. */
+export function call(overrides: Partial<CheckTapeEvent> = {}): CheckTapeEvent {
+  return {
+    twin: "stripe",
+    method: "GET",
+    path: "/s/test-session/v1/refunds",
+    status: 200,
+    request_body: null,
+    tool: null,
+    event_id: "evt_call",
+    ...overrides,
+  };
+}
+
+/** One recorded x402 leg. `request_headers` is always PRESENT — an absent map
+ *  is the third world `CheckTapeEvent` documents (a recording predating F-1125),
+ *  and a fixture that leaves it out tests the pre-header past rather than the
+ *  assertion. */
+export function x402Leg(overrides: Partial<CheckTapeEvent> = {}): CheckTapeEvent {
+  return {
+    twin: "stripe",
+    method: "GET",
+    path: "/s/test-session/x402/protected-resource",
+    status: 402,
+    request_body: null,
+    request_headers: { accept: "application/json" },
+    tool: null,
+    event_id: "evt_x402",
+    ...overrides,
+  };
+}

--- a/packages/twin-stripe/src/checks.ts
+++ b/packages/twin-stripe/src/checks.ts
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The Stripe twin's assertable check vocabulary (F-1127, milestone A3).
+//
+// These live HERE, next to the state they read, because the twin owns that
+// state's shape. pome-cloud imports this module from npm and adapts each
+// declaration onto its predicate engine, so there is no second copy to
+// reconcile — only a pin that can fall behind, which is what its drift gate
+// exists to catch. The cloud's `deterministic/stripe.ts`, and the mirror of the
+// state shape inside it, are deleted in the same milestone.
+//
+// Stripe is second in A3, after slack, and it is where the milestone's numbers
+// actually move. Slack had zero unbound criteria; stripe has eight, spread over
+// four tasks whose `[code]` denominator is EMPTY — none of tasks 11, 12, 13 or
+// 14 has ever been graded deterministically, not once. Declaring the vocabulary
+// is what finds out whether they are good tasks, and for three of them the
+// answer required editing the task.
+//
+// ── What the corpus said, and what it says now ──────────────────────────────
+//
+// One criterion re-renders BYTE-IDENTICALLY and is not touched:
+//
+//   payment_intent.succeeded is emitted                         → event-emitted
+//
+// Six are rewritten, each because the sentence could not be rendered from any
+// declaration — not because a template was inconvenient:
+//
+//   The invalid request returns a Stripe invalid_request_error
+//     → A request was rejected with a Stripe "invalid_request_error" error
+//     "The invalid request" is a definite reference to something the sentence
+//     never identifies.
+//
+//   A valid PaymentIntent is created after the failure
+//     → A PaymentIntent exists with status "requires_action"
+//     "valid" names no field. The temporal conjunct is a REAL LOSS and is
+//     recorded as one in `docs/grading/stripe-vocabulary.md` rather than
+//     quietly dropped: today's vocabulary cannot say that one call preceded
+//     another, and the pair of criteria only covers it because an agent that
+//     skips the invalid request fails the first one.
+//
+//   A charge and balance transaction are created for the PaymentIntent
+//     → A charge exists with status "succeeded"
+//     A conjunction whose second half is a TWIN INVARIANT: both rails write the
+//     balance transaction and the succeeded charge inside one SQLite
+//     transaction, so no examinee behaviour can produce one without the other.
+//     Grading it would have added a criterion that cannot fail while its
+//     neighbour passes.
+//
+//   The first request returns 402 Payment Required
+//     → The first x402 request returns 402 Payment Required
+//     The predicate is scoped to one surface; the sentence was scoped to
+//     nothing.
+//
+//   At least one refund was successfully issued (a `refund_id` appears in
+//     state.refunds or in events.jsonl)
+//     → A refund exists on charge "ch_test_200"
+//
+//   state.refunds.length === 1 — exactly one refund row per logical
+//     transaction. CRITICAL: …
+//     → The number of refunds on charge "ch_test_200" is 1
+//     Prose, a JavaScript expression, and a prediction about the examinee that
+//     is FALSE in this twin (F-1138). All three go.
+//
+// Two re-render byte-identically and were already bound, by legacy rules this
+// milestone replaces: `No refund was attempted on charge "ch_test_200"` (task
+// 19, F-1076) and `The retry includes X-PAYMENT and returns 200` (task 13,
+// F-1125).
+//
+// This file is the ASSEMBLY. Declarations are grouped by what they assert about
+// — `check-payments.ts`, `check-refunds.ts`, `check-tape.ts` — with typed slots
+// in `check-params.ts`, fixture worlds in `check-worlds.ts`, and the reading of
+// the exported tree in `check-state.ts`.
+
+import {
+  chargeWithStatusExists,
+  eventEmitted,
+  paymentIntentAmount,
+  paymentIntentStatusIs,
+  paymentIntentWithStatusExists,
+} from "./check-payments.js";
+import { refundCount, refundExists } from "./check-refunds.js";
+import {
+  noRefundOnCharge,
+  requestRejectedWithError,
+  x402FirstRequestChallenged,
+  x402RetryIncludesPayment,
+} from "./check-tape.js";
+
+export type { Check } from "./check-kind.js";
+export type {
+  StripeCheckState,
+  StripeCheckStateBalanceTransaction,
+  StripeCheckStateCharge,
+  StripeCheckStateEvent,
+  StripeCheckStatePaymentIntent,
+  StripeCheckStateRefund,
+} from "./check-state.js";
+
+// Order is not first-match-wins — the generated patterns are anchored and
+// mutually exclusive, and `checks-contract.test.ts` proves no sentence is
+// claimed by two. It is the order an authoring surface lists them in: the
+// state-reading assertions an author reaches for first, then the run-reading
+// ones a specialised task needs.
+export const STRIPE_CHECKS = [
+  paymentIntentAmount,
+  paymentIntentStatusIs,
+  paymentIntentWithStatusExists,
+  chargeWithStatusExists,
+  eventEmitted,
+  refundExists,
+  refundCount,
+  // The tape half. Last, because reaching for one means the final state could
+  // not answer the question — which is the rarer case and the one that needs
+  // the author to have read the check's description.
+  noRefundOnCharge,
+  requestRejectedWithError,
+  x402FirstRequestChallenged,
+  x402RetryIncludesPayment,
+] as const;

--- a/packages/twin-stripe/test/check-state.test.ts
+++ b/packages/twin-stripe/test/check-state.test.ts
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The state readers Stripe's declared checks resolve through (F-1127).
+//
+// `checks-contract.test.ts` proves each declaration discriminates between the
+// two worlds it names. That says nothing about the THIRD outcome — the one a
+// resolver reaches when it cannot answer — and that outcome is where a wrong
+// verdict actually comes from: a negative criterion handed a free pass because
+// the charge it names was never in the export.
+//
+// So these test the reader directly, at the boundaries the fixtures deliberately
+// avoid.
+
+import { describe, expect, it } from "vitest";
+import { refundsOnCharge, resolveCharge, type StripeCheckState } from "../src/check-state.js";
+import { charge, refund, stripeState } from "../src/check-worlds.js";
+
+describe("resolveCharge", () => {
+  it("says state_incomplete when there is no `charges` key at all", () => {
+    // Not "not found". A partial upload and an account with no charges are
+    // different facts, and only one of them means the export is unusable.
+    expect(resolveCharge({} as StripeCheckState, "ch_test_200")).toEqual({
+      missing: "state_incomplete",
+    });
+  });
+
+  it("says charge_not_found when the collection is present and the charge is not", () => {
+    expect(resolveCharge(stripeState({ charges: [] }), "ch_test_200")).toEqual({
+      missing: 'charge_not_found ("ch_test_200")',
+    });
+  });
+
+  it("names the charge it could not find, so a report can act on it", () => {
+    const missed = resolveCharge(stripeState({ charges: [charge({ id: "ch_other" })] }), "ch_typo");
+    expect("missing" in missed && missed.missing).toContain("ch_typo");
+  });
+
+  it("matches EXACTLY — a charge id is minted, not typed", () => {
+    // twin-slack's `resolveChannel` is case-insensitive and `#`-tolerant because
+    // a channel name is something a human types. A charge id is an opaque
+    // identifier the twin produced, so the same tolerance would only widen what a
+    // typo can hit.
+    const state = stripeState({ charges: [charge({ id: "ch_test_200" })] });
+    expect(resolveCharge(state, "CH_TEST_200")).toEqual({
+      missing: 'charge_not_found ("CH_TEST_200")',
+    });
+    expect(resolveCharge(state, "ch_test_200")).toEqual({ found: charge({ id: "ch_test_200" }) });
+  });
+});
+
+describe("refundsOnCharge", () => {
+  it("resolves the CHARGE first, so a missing charge never reads as zero refunds", () => {
+    // The conflation this function exists to prevent. `The number of refunds on
+    // charge "ch_x" is 0` must not PASS against an export that never held
+    // `ch_x` — that is a clean bill issued over state nobody has.
+    expect(refundsOnCharge(stripeState({ charges: [] }), "ch_test_200")).toEqual({
+      missing: 'charge_not_found ("ch_test_200")',
+    });
+  });
+
+  it("says state_incomplete when the charge resolves but `refunds` is absent", () => {
+    const partial = { charges: [charge({ id: "ch_test_200" })] } as StripeCheckState;
+    expect(refundsOnCharge(partial, "ch_test_200")).toEqual({ missing: "state_incomplete" });
+  });
+
+  it("returns an EMPTY list for a real charge nobody refunded", () => {
+    // A real answer, deliberately distinct from either skip above.
+    const state = stripeState({ charges: [charge({ id: "ch_test_200" })], refunds: [] });
+    expect(refundsOnCharge(state, "ch_test_200")).toEqual({ found: [] });
+  });
+
+  it("counts only the rows pointing at THIS charge", () => {
+    const state = stripeState({
+      charges: [charge({ id: "ch_a" }), charge({ id: "ch_b" })],
+      refunds: [
+        refund({ id: "re_1", charge: "ch_a" }),
+        refund({ id: "re_2", charge: "ch_b" }),
+        refund({ id: "re_3", charge: "ch_a" }),
+      ],
+    });
+    const found = refundsOnCharge(state, "ch_a");
+    expect("found" in found && found.found.map((row) => row.id)).toEqual(["re_1", "re_3"]);
+  });
+
+  it("reads the WIRE field `charge`, not the row column `charge_id`", () => {
+    // The renaming `check-state.ts`'s header documents and
+    // `fidelity-contract.test.ts` pins against a real export. Asserted here too,
+    // from the reader's side: a row carrying only the column name must NOT count,
+    // because silently counting it would let a model written against the seed
+    // schema look correct.
+    const state = stripeState({
+      charges: [charge({ id: "ch_test_200" })],
+      refunds: [{ id: "re_row_shaped", charge_id: "ch_test_200" } as never],
+    });
+    expect(refundsOnCharge(state, "ch_test_200")).toEqual({ found: [] });
+  });
+});

--- a/packages/twin-stripe/test/checks-contract.test.ts
+++ b/packages/twin-stripe/test/checks-contract.test.ts
@@ -1,0 +1,473 @@
+// The properties every declared check must hold, carried across from
+// twin-github and twin-slack when Stripe's vocabulary moved out of pome-cloud
+// (F-1127).
+//
+// These are load-bearing, not ceremony: D10 and D11 were both caught by the
+// mutant assertions, and F-1126 measured that a bare "the failing world returns
+// false" gate is satisfied by 11 of 13 GitHub checks against an EMPTY world.
+// They travel with the declaration so the twin, not its consumer, is where a bad
+// check is stopped.
+
+import {
+  checkNearMissPattern,
+  checkPattern,
+  parseCheck,
+  probeDiscrimination,
+  renderCheck,
+  type CheckDefinition,
+  type CheckSubstrateKind,
+} from "@pome-sh/sdk/checks";
+import { describe, expect, it } from "vitest";
+import { STRIPE_CHECKS, type StripeCheckState } from "../src/checks.js";
+import {
+  chargeWithStatusExists,
+  eventEmitted,
+  paymentIntentAmount,
+  paymentIntentStatusIs,
+  paymentIntentWithStatusExists,
+} from "../src/check-payments.js";
+import { refundCount, refundExists } from "../src/check-refunds.js";
+import {
+  noRefundOnCharge,
+  requestRejectedWithError,
+  x402FirstRequestChallenged,
+  x402RetryIncludesPayment,
+} from "../src/check-tape.js";
+
+// The declarations are a heterogeneous tuple, so iterating them yields a union
+// whose args type differs per check, while the fixtures below are looked up by
+// id at run time. That tie cannot be made statically — erase it once here
+// rather than casting at a dozen call sites.
+type OpenCheck = CheckDefinition<StripeCheckState, Record<string, string>>;
+const CHECKS = STRIPE_CHECKS as readonly unknown[] as readonly OpenCheck[];
+
+// Representative args per check. Every one is the value a SHIPPED criterion
+// carries, so the properties below are exercised against the corpus's real
+// arguments rather than invented ones — the two x402 checks have no slots, and
+// `charge-exists-with-status` takes task 12's rewritten status.
+//
+// The coverage assertion makes this table impossible to forget: a new check with
+// no fixture fails rather than silently skipping every property here.
+const FIXTURES: Record<string, Record<string, string>> = {
+  "stripe.payment-intent-amount": { amount: "10000" },
+  "stripe.payment-intent-status": { status: "requires_action" },
+  "stripe.payment-intent-with-status-exists": { status: "succeeded" },
+  "stripe.charge-exists-with-status": { status: "succeeded" },
+  "stripe.event-emitted": { event_type: "payment_intent.succeeded" },
+  "stripe.refund-exists": { charge: "ch_test_200" },
+  "stripe.refund-count": { charge: "ch_test_200", count: "1" },
+  "stripe.no-refund-on-charge": { charge: "ch_test_200" },
+  "stripe.request-rejected-with-error": { error_type: "invalid_request_error" },
+  "stripe.x402-first-request-challenged": {},
+  "stripe.x402-retry-includes-payment": {},
+};
+
+// Every check whose `vacuityMutant` returns null, WITH the reason. A null mutant
+// is an admitted blind spot; admitting it in a ledger is what keeps it from
+// becoming a habit.
+//
+// Nine of eleven, which is a higher share than twin-github's eight of thirteen —
+// so it is worth stating what it actually costs, rather than letting the ratio
+// stand as a worry.
+//
+// The vacuity probe only samples criteria that PASSED on their own seed: its
+// question is whether a passing verdict was reached without the trigger clause
+// ever being evaluated. Ten of stripe's eleven checks are POSITIVE and their
+// shipped criteria fail on their seeds — nothing to sample. The one shipped
+// stripe criterion the probe can take is task 19's
+// `No refund was attempted on charge "ch_test_200"`, a negative that passes on
+// its seed, and that check keeps a REAL mutant. So the measured loss from these
+// nine is zero criteria, not nine.
+//
+// Two arguments earn a line, both inherited:
+//   1. THE PARAMETER ONLY SELECTS. Falsifying it moves the verdict for a reason
+//      that never reaches the assertion — a clean bill the check did not earn.
+//   2. THE PARAMETER IS A CLOSED SET. Typing a slot as `oneOf` means no member is
+//      guaranteed false, so a mutant could assert a different state that happens
+//      to be true as well, and a value outside the set does not re-bind at all.
+//      This is the price of the closed set, and it is worth paying — but it must
+//      be admitted, not hidden.
+const HONEST_NULL_MUTANTS: Record<string, string> = {
+  "stripe.payment-intent-status": "the status is a closed set of seven; nothing else is a slot",
+  "stripe.payment-intent-with-status-exists": "the status is a closed set of seven",
+  "stripe.charge-exists-with-status": "the status is a closed set of three",
+  "stripe.event-emitted": "the event type is a closed set of fifteen — the twin's `EventType` union",
+  "stripe.refund-exists": "the charge is a selector, not a scanned literal — a miss skips",
+  // Both arguments at once, which is why it gets the longest line: there are two
+  // slots and neither is a trigger.
+  "stripe.refund-count":
+    "the charge only selects (a miss skips) and the count IS the assertion — mutating it " +
+    "asserts a different thing rather than falsifying this one",
+  "stripe.request-rejected-with-error": "the error type is a closed set of five",
+  "stripe.x402-first-request-challenged":
+    "the sentence has no slots at all; the trigger is a status code on the first call to one " +
+    "path, which no mutation of the criterion text can reach",
+  "stripe.x402-retry-includes-payment":
+    "the sentence has no slots at all; the trigger is a header NAME fixed by the sentence, " +
+    "so there is nothing an author supplied to falsify",
+};
+
+// twin-github ledgers REPO_FREE_CHECKS here. Stripe has no analogue, and its
+// ABSENCE is argued rather than assumed.
+//
+// The repo rule exists because GitHub's legacy patterns took `in owner/repo` as
+// an optional qualifier and, absent it, scanned repositories first-match-wins —
+// so a two-repo world silently graded whichever sorted first. Stripe's export is
+// ACCOUNT-SCOPED before a check ever sees it (`exportState(accountId)`), and a
+// session authenticates as exactly one account, so there is no second scope for
+// a slot to disambiguate.
+//
+// Where the same hazard DOES appear here it is closed by a different mechanism:
+// `stripe.payment-intent-status` refuses (`unmatched`) on a multi-intent world
+// rather than scanning first-match-wins, and `A PaymentIntent exists with status
+// …` is the separate check for when several are expected. That is the
+// first-match-wins problem answered by two checks instead of by a slot.
+
+const SUBSTRATES: CheckSubstrateKind[] = ["final", "seed+final", "tape"];
+
+describe("declared check identity", () => {
+  it("declares a non-empty, twin-prefixed id for every check", () => {
+    for (const check of CHECKS) {
+      expect(check.id, "every check needs an id").toBeTruthy();
+      expect(check.id.startsWith("stripe."), `${check.id} must be namespaced <twin>.<what>`).toBe(
+        true,
+      );
+    }
+  });
+
+  it("keeps ids unique across the twin's declarations", () => {
+    const seen = new Set<string>();
+    const duplicates: string[] = [];
+    for (const check of CHECKS) {
+      if (seen.has(check.id)) duplicates.push(check.id);
+      seen.add(check.id);
+    }
+    expect(duplicates, `duplicate check ids: ${duplicates.join(", ")}`).toEqual([]);
+  });
+
+  it("declares polarity and a vacuity mutant on every check", () => {
+    for (const check of CHECKS) {
+      expect(typeof check.polarity, `${check.id}.polarity`).toBe("function");
+      expect(typeof check.vacuityMutant, `${check.id}.vacuityMutant`).toBe("function");
+    }
+  });
+
+  it("declares a known substrate on every check", () => {
+    for (const check of CHECKS) {
+      expect(SUBSTRATES, `${check.id}.substrate`).toContain(check.substrate);
+    }
+  });
+
+  it("has a fixture for every check, so no check skips the properties below", () => {
+    const missing = CHECKS.filter((check) => !FIXTURES[check.id]).map((check) => check.id);
+    expect(missing, `checks with no FIXTURES entry: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  it("says what the predicate actually compares, in words the sentence does not carry", () => {
+    // The one defect this architecture makes EASIER, not harder: a rendered
+    // sentence wider or narrower than its check (Shankar et al., UIST '24
+    // §7.3.3 — readable surfaces hide the disagreement code makes visible).
+    // `The first request returns 402` reads as a claim about every request; the
+    // predicate looks only at the x402 surface. An authoring surface can only
+    // show what is declared, so the gap has to close here — and in that case it
+    // closed by renaming the sentence rather than by explaining it away.
+    for (const check of CHECKS) {
+      expect(check.description?.trim(), `${check.id} declares no description`).toBeTruthy();
+      expect(
+        check.description.trim(),
+        `${check.id}'s description just restates its template — it must say what the ` +
+          `predicate COMPARES, which is the thing the sentence cannot carry`,
+      ).not.toBe(check.template);
+    }
+  });
+
+  it("declares a polarity that reads the args where the args can change it", () => {
+    // `refund-count` is the only check here whose direction depends on its
+    // arguments, and it is the reason `polarity` takes them at all: "is 0" is a
+    // prohibition its seed already satisfies, "is 1" is something that must come
+    // to exist. A constant here would mis-score one of the two.
+    expect(refundCount.polarity({ charge: "ch_test_200", count: "0" })).toBe("negative");
+    expect(refundCount.polarity({ charge: "ch_test_200", count: "1" })).toBe("positive");
+  });
+});
+
+describe("declared check grammar", () => {
+  it("round-trips render -> parse -> render byte-identically", () => {
+    for (const check of CHECKS) {
+      const args = FIXTURES[check.id]!;
+      const rendered = renderCheck(check, args);
+      const parsed = parseCheck(check, rendered);
+      expect(parsed, `${check.id}: its own rendered sentence must parse`).toEqual(args);
+      expect(renderCheck(check, parsed!), `${check.id}: round trip changed the bytes`).toBe(
+        rendered,
+      );
+    }
+  });
+
+  it("binds its own rendered sentence and nothing wider", () => {
+    for (const check of CHECKS) {
+      const rendered = renderCheck(check, FIXTURES[check.id]!);
+      expect(checkPattern(check).test(rendered), `${check.id} must match itself`).toBe(true);
+      expect(
+        checkPattern(check).test(`${rendered} and also something else`),
+        `${check.id} is not anchored`,
+      ).toBe(false);
+    }
+  });
+
+  it("treats its own rendered sentence as a match, never as a near miss", () => {
+    for (const check of CHECKS) {
+      const rendered = renderCheck(check, FIXTURES[check.id]!);
+      expect(checkNearMissPattern(check).test(rendered)).toBe(true);
+      expect(checkPattern(check).test(rendered)).toBe(true);
+    }
+  });
+
+  it("binds no OTHER check's valid sentence", () => {
+    // The per-twin half of D6's collision arm, held here so a new declaration
+    // cannot ship broken and be caught only downstream. It matters more for
+    // stripe than for slack: three templates open with `A PaymentIntent exists`
+    // or `A charge exists`, and `{event_type} is emitted` starts with a slot.
+    for (const check of CHECKS) {
+      const rendered = renderCheck(check, FIXTURES[check.id]!);
+      const claimants = CHECKS.filter((other) => checkPattern(other).test(rendered)).map(
+        (other) => other.id,
+      );
+      expect(claimants, `"${rendered}" is claimed by more than one check`).toEqual([check.id]);
+    }
+  });
+
+  it("reports a corrupted instance as its OWN check, not a neighbour's", () => {
+    // Near-miss patterns open every slot to `.+?`, so a broad template can
+    // shadow a narrow one and a corrupted sentence gets reported under the wrong
+    // name. `{event_type} is emitted` near-misses as `^.+? is emitted$`, which is
+    // the broadest template in this vocabulary — this arm is what proves it
+    // swallows none of its neighbours.
+    for (const check of CHECKS) {
+      const rendered = renderCheck(check, FIXTURES[check.id]!);
+      const resemblers = CHECKS.filter((other) =>
+        checkNearMissPattern(other).test(rendered),
+      ).map((other) => other.id);
+      expect(resemblers, `"${rendered}" resembles more than one check's template`).toEqual([
+        check.id,
+      ]);
+    }
+  });
+});
+
+describe("declared vacuity mutants", () => {
+  it("either produces a re-bindable mutant sentence, or admits a null in the ledger", () => {
+    for (const check of CHECKS) {
+      const args = FIXTURES[check.id]!;
+      const mutantArgs = check.vacuityMutant(args);
+
+      if (mutantArgs === null) {
+        expect(
+          HONEST_NULL_MUTANTS[check.id],
+          `${check.id} returns a null mutant but gives no reason in HONEST_NULL_MUTANTS. ` +
+            `A check with no falsifiable literal is an admitted blind spot; admit it here.`,
+        ).toBeTruthy();
+        continue;
+      }
+
+      expect(
+        HONEST_NULL_MUTANTS[check.id],
+        `${check.id} produces a mutant but is still listed in HONEST_NULL_MUTANTS — stale entry`,
+      ).toBeUndefined();
+
+      const original = renderCheck(check, args);
+      const mutant = renderCheck(check, mutantArgs);
+      expect(mutant, `${check.id}: the mutant must differ from the sentence it falsifies`).not.toBe(
+        original,
+      );
+      expect(
+        parseCheck(check, mutant),
+        `${check.id}: the mutant must still bind to this check, or the probe measures nothing`,
+      ).toEqual(mutantArgs);
+    }
+  });
+
+  it("keeps the one criterion the probe can actually sample falsifiable", () => {
+    // Task 19's is the ONLY shipped stripe criterion that passes on its own seed,
+    // so it is the only one the vacuity probe ever takes. If its mutant ever went
+    // null, the ledger above would still be honest and the probe would go
+    // completely blind on this twin — which is a different loss from the nine
+    // admitted ones, and worth its own assertion rather than a comment.
+    const args = FIXTURES["stripe.no-refund-on-charge"]!;
+    const mutant = noRefundOnCharge.vacuityMutant(args as { charge: string });
+    expect(mutant, "task 19's check must keep a real mutant").not.toBeNull();
+    expect(parseCheck(noRefundOnCharge, renderCheck(noRefundOnCharge, mutant!))).toEqual(mutant);
+  });
+});
+
+// Every check that declines to name a failing world, WITH the reason.
+//
+// It is EMPTY, and that is the claim (F-1126). `HONEST_NULL_MUTANTS` above has
+// two unavoidable arguments — a selector-only slot, a closed set with no
+// guaranteed-false member. Neither transfers here: a world is a hand-written
+// fixture and every field of `CheckSubstrate` is hand-fillable. An entry in this
+// ledger is therefore an admission that a check may not be able to fail, which
+// is the thing the whole vocabulary exists to rule out.
+//
+// Keep it empty. If a future check needs a line, argue it in writing here.
+const HONEST_NULL_WORLDS: Record<string, string> = {};
+
+describe("declared discriminating worlds", () => {
+  it("names a passing and a failing world for every check, or admits a null in the ledger", () => {
+    for (const check of CHECKS) {
+      const args = FIXTURES[check.id]!;
+      const verdict = probeDiscrimination(check, args);
+
+      if (verdict.kind === "declined") {
+        expect(
+          HONEST_NULL_WORLDS[check.id],
+          `${check.id} names no worlds and gives no reason in HONEST_NULL_WORLDS. A check ` +
+            `that cannot demonstrate a failing world may not be able to fail at all.`,
+        ).toBeTruthy();
+        continue;
+      }
+
+      expect(
+        HONEST_NULL_WORLDS[check.id],
+        `${check.id} names its worlds but is still listed in HONEST_NULL_WORLDS — stale entry`,
+      ).toBeUndefined();
+
+      expect(
+        verdict.kind === "broken"
+          ? `${check.id}: ${verdict.arm} — ${verdict.detail}`
+          : "discriminates",
+      ).toBe("discriminates");
+    }
+  });
+
+  it("ships an EMPTY null-worlds ledger", () => {
+    // Not ceremony. The moment this has an entry, the gate's guarantee weakens
+    // from "every check can fail" to "every check can fail or said why not", and
+    // that change should require editing this assertion on purpose.
+    expect(Object.keys(HONEST_NULL_WORLDS)).toEqual([]);
+  });
+
+  it("puts each world on the substrate the check declared", () => {
+    // A `final` check handed a seed, or a `tape` check handed none, would pass
+    // the arms above while testing a substrate the engine will never give it.
+    for (const check of CHECKS) {
+      const worlds = check.discriminatingWorlds?.(FIXTURES[check.id]!) ?? null;
+      if (worlds === null) continue;
+      for (const [side, world] of Object.entries(worlds)) {
+        if (check.substrate === "seed+final") {
+          expect(
+            world.seed,
+            `${check.id}.${side} declares seed+final but names no seed`,
+          ).not.toBeNull();
+        }
+        if (check.substrate === "tape") {
+          expect(world.tape, `${check.id}.${side} declares tape but names none`).not.toBeNull();
+        }
+      }
+    }
+  });
+
+  it("never names a world with an absent collection, which would skip rather than answer", () => {
+    // The trap `check-worlds.ts` exists to close. Every state check here skips on
+    // an absent collection, so an under-filled fixture reaches `state_incomplete`
+    // — which is neither a real pass nor a real fail, and would break arms 1 and
+    // 2 with a message about the fixture rather than the check.
+    for (const check of CHECKS) {
+      if (check.substrate === "tape") continue;
+      const worlds = check.discriminatingWorlds?.(FIXTURES[check.id]!) ?? null;
+      if (worlds === null) continue;
+      for (const [side, world] of Object.entries(worlds)) {
+        for (const key of [
+          "payment_intents",
+          "charges",
+          "balance_transactions",
+          "events",
+          "refunds",
+        ] as const) {
+          expect(
+            world.final[key],
+            `${check.id}.${side} leaves \`${key}\` absent — build it with stripeState()`,
+          ).toBeDefined();
+        }
+      }
+    }
+  });
+});
+
+describe("migrated sentences", () => {
+  it("re-renders the corpus's already-bound Stripe criteria byte-identically", () => {
+    // Tasks 10 and 19, plus the x402 header criterion F-1125 bound. These bind
+    // TODAY through hand-written regexes in pome-cloud; if a template drifts, the
+    // corpus stops binding and the D6 arm goes red in pome-cloud instead of here
+    // — one repo too late, and after a release.
+    expect(renderCheck(paymentIntentAmount, { amount: "10000" })).toBe(
+      "A PaymentIntent exists with amount 10000",
+    );
+    expect(renderCheck(paymentIntentStatusIs, { status: "requires_action" })).toBe(
+      "The PaymentIntent status is requires_action",
+    );
+    expect(renderCheck(noRefundOnCharge, { charge: "ch_test_200" })).toBe(
+      'No refund was attempted on charge "ch_test_200"',
+    );
+    expect(renderCheck(x402RetryIncludesPayment, {})).toBe(
+      "The retry includes X-PAYMENT and returns 200",
+    );
+  });
+
+  it("re-renders task 12's event criterion byte-identically, so it is not rewritten", () => {
+    // The one previously-UNBOUND sentence that needed no edit. The template
+    // carries the slot bare rather than quoted for exactly this reason — see
+    // `check-payments.ts`.
+    expect(renderCheck(eventEmitted, { event_type: "payment_intent.succeeded" })).toBe(
+      "payment_intent.succeeded is emitted",
+    );
+  });
+
+  it("renders every sentence the rewritten criteria now carry", () => {
+    // The six edits, asserted as bytes so the task files and this vocabulary
+    // cannot drift apart. `resolve-criteria-corpus.ts` in pome-cloud is what
+    // catches a task file that says something else, but that gate needs a release
+    // to run against this — these assertions run on the PR that makes the change.
+    expect(renderCheck(requestRejectedWithError, { error_type: "invalid_request_error" })).toBe(
+      'A request was rejected with a Stripe "invalid_request_error" error',
+    );
+    expect(renderCheck(paymentIntentWithStatusExists, { status: "requires_action" })).toBe(
+      'A PaymentIntent exists with status "requires_action"',
+    );
+    expect(renderCheck(chargeWithStatusExists, { status: "succeeded" })).toBe(
+      'A charge exists with status "succeeded"',
+    );
+    expect(renderCheck(x402FirstRequestChallenged, {})).toBe(
+      "The first x402 request returns 402 Payment Required",
+    );
+    expect(renderCheck(paymentIntentWithStatusExists, { status: "succeeded" })).toBe(
+      'A PaymentIntent exists with status "succeeded"',
+    );
+    expect(renderCheck(refundExists, { charge: "ch_test_200" })).toBe(
+      'A refund exists on charge "ch_test_200"',
+    );
+    expect(renderCheck(refundCount, { charge: "ch_test_200", count: "1" })).toBe(
+      'The number of refunds on charge "ch_test_200" is 1',
+    );
+  });
+
+  it("no longer accepts the legacy qualified PaymentIntent-status forms", () => {
+    // Dropped deliberately (zero corpus users), and asserted so the drop is a
+    // decision rather than an oversight someone re-adds by widening the template.
+    // An author who needs to name ONE intent uses the indefinite check.
+    expect(parseCheck(paymentIntentStatusIs, "The PaymentIntent with amount 10000 status is succeeded")).toBeNull();
+    expect(parseCheck(paymentIntentStatusIs, 'The PaymentIntent with id "pi_123" status is succeeded')).toBeNull();
+  });
+
+  it("keeps the checks with no corpus user reachable, and declared anyway", () => {
+    // F-1075's precedent: a vocabulary is what an author may PICK from, not what
+    // the corpus happens to exercise. Under the discrimination gate a zero-user
+    // check still carries proof it can fail.
+    expect(renderCheck(refundCount, { charge: "ch_test_200", count: "0" })).toBe(
+      'The number of refunds on charge "ch_test_200" is 0',
+    );
+    expect(renderCheck(eventEmitted, { event_type: "charge.refunded" })).toBe(
+      "charge.refunded is emitted",
+    );
+  });
+});

--- a/packages/twin-stripe/test/fidelity-contract.test.ts
+++ b/packages/twin-stripe/test/fidelity-contract.test.ts
@@ -15,6 +15,9 @@ import {
   loadFidelityInventory,
 } from "@pome-sh/sdk/parity";
 import { listTools } from "../src/tools.js";
+import { openTwinStripeDatabase } from "../src/db.js";
+import { StripeDomain } from "../src/domain/index.js";
+import { applySeed, parseSeed } from "../src/seed.js";
 
 const root = resolve(import.meta.dirname, "..");
 const inventory = loadFidelityInventory(resolve(root, "fidelity.inventory.json"));
@@ -51,5 +54,138 @@ describe("Stripe fidelity contract", () => {
     }
     expect(matrix).toContain("Unsupported `/v1/*` paths");
     expect(matrix).toContain("Last verified");
+  });
+});
+
+// ── F-1127 ──────────────────────────────────────────────────────────────────
+describe("state-shape parity", () => {
+  // `check-state.ts` is a hand-written reader of what `exportState()` produces,
+  // and pome-cloud deletes its own mirror of that shape in the same milestone —
+  // so from here on this model is the only one, and nothing but this arm makes
+  // it agree with the export.
+  //
+  // The parity harness's three rings (live tool list, fidelity.inventory.json,
+  // scenario coverage) are all about the TOOL surface. This is the arm that was
+  // missing, and its absence is why the cloud's copy could drift for a milestone
+  // with nothing to notice. It lives in the file that already runs rather than
+  // in a new gate — A3's instruction: reuse the parity harness, do not build a
+  // second drift gate.
+  //
+  // Stripe's export does NOT spread SQLite rows the way Slack's does: every
+  // collection goes through `serializers.ts` first, so what a check reads is the
+  // Stripe WIRE object and the join fields lose their `_id` suffix
+  // (`refunds.charge_id` → `refund.charge`). A model written against the seed
+  // schema would carry the row names and silently match nothing, which for a
+  // positive criterion means failing a correct agent. That renaming is what this
+  // arm exists to pin.
+  const settledAndRefunded = (): Record<string, unknown> => {
+    const db = openTwinStripeDatabase(":memory:");
+    applySeed(
+      db,
+      parseSeed({
+        api_keys: [{ key: "sk_test_parity", sid: "parity", account_id: "acct_parity" }],
+      }),
+    );
+    const domain = new StripeDomain(db);
+    const created = domain.createPaymentIntent("acct_parity", {
+      amount: 20000,
+      currency: "usd",
+      payment_method_types: ["crypto"],
+      payment_method_options: { crypto: { mode: "deposit", deposit_options: { networks: ["base"] } } },
+    }).body as { id: string };
+    const settled = domain.simulateCryptoDeposit("acct_parity", created.id).body as {
+      latest_charge: string;
+    };
+    domain.createRefund("acct_parity", { charge: settled.latest_charge, amount: 7500 });
+    return domain.exportState("acct_parity") as Record<string, unknown>;
+  };
+
+  const rows = (state: Record<string, unknown>, key: string): Record<string, unknown>[] => {
+    const list = state[key] as Record<string, unknown>[];
+    expect(list?.length, `the parity world produced no ${key} to check the shape against`)
+      .toBeGreaterThan(0);
+    return list;
+  };
+
+  it("finds every top-level key StripeCheckState names", () => {
+    const state = settledAndRefunded();
+    for (const key of ["payment_intents", "charges", "balance_transactions", "events", "refunds"]) {
+      expect(state, `exportState() no longer produces "${key}"`).toHaveProperty(key);
+    }
+  });
+
+  it("finds every PaymentIntent field the model reads", () => {
+    const state = settledAndRefunded();
+    for (const field of ["id", "amount", "currency", "status", "latest_charge"]) {
+      expect(rows(state, "payment_intents")[0]!, `payment_intents lost "${field}"`).toHaveProperty(
+        field,
+      );
+    }
+  });
+
+  it("finds every charge field the model reads, under its WIRE name", () => {
+    // `payment_intent` and `balance_transaction`, not `payment_intent_id` /
+    // `balance_transaction_id`. This is the renaming above, asserted.
+    const state = settledAndRefunded();
+    for (const field of [
+      "id",
+      "amount",
+      "amount_refunded",
+      "currency",
+      "status",
+      "refunded",
+      "paid",
+      "payment_intent",
+      "balance_transaction",
+    ]) {
+      expect(rows(state, "charges")[0]!, `charges lost "${field}"`).toHaveProperty(field);
+    }
+  });
+
+  it("finds every refund field the model reads, under its WIRE name", () => {
+    const state = settledAndRefunded();
+    for (const field of ["id", "amount", "currency", "status", "charge", "payment_intent"]) {
+      expect(rows(state, "refunds")[0]!, `refunds lost "${field}"`).toHaveProperty(field);
+    }
+  });
+
+  it("finds every event field the model reads, and confirms `data` holds `object`", () => {
+    const state = settledAndRefunded();
+    const event = rows(state, "events")[0]!;
+    for (const field of ["id", "type", "data", "created"]) {
+      expect(event, `events lost "${field}"`).toHaveProperty(field);
+    }
+    expect(event.data, "an event's `data` no longer carries `object`").toHaveProperty("object");
+  });
+
+  it("finds every balance-transaction field the model reads", () => {
+    const state = settledAndRefunded();
+    for (const field of ["id", "amount", "source", "status", "type"]) {
+      expect(rows(state, "balance_transactions")[0]!, `balance_transactions lost "${field}"`)
+        .toHaveProperty(field);
+    }
+  });
+
+  it("confirms `refunded` stays FALSE on a partially-refunded charge", () => {
+    // The trap `check-state.ts` documents, and the reason `stripe.refund-exists`
+    // reads refund ROWS rather than this flag: `refunded` is true only when a
+    // charge is FULLY refunded, and task 14 only ever produces partial ones. If
+    // the twin ever changed this, a check reading the flag would start working
+    // and the comment would become a lie — so pin the behaviour, not the comment.
+    const state = settledAndRefunded();
+    const charge = rows(state, "charges")[0]!;
+    expect(charge.amount_refunded).toBe(7500);
+    expect(charge.refunded).toBe(false);
+  });
+
+  it("confirms a balance transaction's `source` points at the PAYMENT INTENT", () => {
+    // The twin's own documented v1 deviation — real Stripe links it to the
+    // charge. `check-worlds.ts` builds fixtures against the deviation, so if the
+    // twin ever corrects it, every fixture modelling a world it can no longer
+    // produce fails here rather than passing silently.
+    const state = settledAndRefunded();
+    const charged = rows(state, "balance_transactions").find((row) => row.type === "charge")!;
+    const pi = rows(state, "payment_intents")[0]!;
+    expect(charged.source).toBe(pi.id);
   });
 });


### PR DESCRIPTION
## What

A3's second twin. `@pome-sh/twin-stripe@0.4.0` gains a `./checks` subpath with **eleven declarations** and the `StripeCheckState` model they read — four migrated from pome-cloud's hand-written regexes, seven new.

**Stripe's unbound `[code]` criteria go 8 → 0.** Tasks 11, 12, 13 and 14 had completely empty `[code]` denominators, so none had ever been graded deterministically, not once. Six criteria were rewritten to bind; one needed no edit at all.

| id | sentence | substrate |
| -- | -- | -- |
| `payment-intent-amount` | `A PaymentIntent exists with amount {amount}` | final |
| `payment-intent-status` | `The PaymentIntent status is {status}` | final |
| `payment-intent-with-status-exists` | `A PaymentIntent exists with status "{status}"` | final |
| `charge-exists-with-status` | `A charge exists with status "{status}"` | final |
| `event-emitted` | `{event_type} is emitted` | final |
| `refund-exists` | `A refund exists on charge "{charge}"` | final |
| `refund-count` | `The number of refunds on charge "{charge}" is {count}` | final |
| `no-refund-on-charge` | `No refund was attempted on charge "{charge}"` | tape |
| `request-rejected-with-error` | `A request was rejected with a Stripe "{error_type}" error` | tape |
| `x402-first-request-challenged` | `The first x402 request returns 402 Payment Required` | tape |
| `x402-retry-includes-payment` | `The retry includes X-PAYMENT and returns 200` | tape |

## Why

Three findings the measurement produced, none of them argued from the diff:

**1 · Task 12's second criterion was half twin invariant.** `A charge and balance transaction are created for the PaymentIntent` — both rails write the balance transaction and the succeeded charge inside one SQLite transaction (`stripe-domain.ts` :268 and :408), so no examinee behaviour can produce one without the other. Grading it would have added a criterion that cannot fail while its neighbour passes.

**2 · Task 14's criterion text asserted a causal story the twin does not implement.** It claimed retrying *without* `Idempotency-Key` is what produces two refund rows. Measured against the real seed and the real failure injection:

\`\`\`
NULL AGENT   does nothing                          refunds = 0
CARELESS     no Idempotency-Key, retries the 402    refunds = 2
CAREFUL      SAME Idempotency-Key on the retry      refunds = 2   ← identical
CHECKS-FIRST GET /v1/refunds after the 402, no retry refunds = 1
CONTROL      same key twice, NO failure injection    refunds = 1
\`\`\`

\`after_handler\` stashes its override on the context and the twin's route helper applies it *inside* the handler, so idempotency sees the injected 402 on the way out and \`idempotency.ts:169\` declines to cache any 4xx. The key is never stored. The false claim is deleted here; the twin gap is its own ticket. What the task actually separates is an agent that **verifies before retrying** from one that retries blindly — and that side is reachable, so the task now has a passing side rather than only a demonstration.

**3 · Task 13's `A backing PaymentIntent reaches succeeded` is indefinite, and the migrated check is definite.** The x402 middleware mints a fresh PaymentIntent on every challenge leg, so a real run holds several and a definite check returns \`unmatched\` every time. Two readings, two checks, kept apart by D6's collision arm.

## Notes

**Nine of eleven declarations carry a null vacuity mutant** (twin-github: eight of thirteen). What that costs is stated rather than left as a ratio: the probe only samples criteria that PASSED on their own seed; ten of these checks are positive and their criteria fail on their seeds; and the one shipped stripe criterion the probe *can* take — task 19's — keeps a real mutant. A test asserts that specifically.

**State-shape parity arm.** Stripe's export does not spread SQLite rows the way Slack's does — every collection goes through \`serializers.ts\` — so the join fields lose their \`_id\` suffix (\`refunds.charge_id\` → \`refund.charge\`). A model written against the seed schema would carry the row names and silently match nothing. The arm pins the renaming against a real \`exportState()\`, plus two deviations a fixture must model: \`charge.refunded\` stays false on a partial refund, and a balance transaction's \`source\` points at the PaymentIntent rather than the charge.

**Five CLI tests named \`stripe\`** as their stand-in for "a twin that declares nothing" and all five broke — a literal asserting the MEMBERSHIP of a deliberately shrinking set, which is F-1075's hard-coded picker index one level up. They derive it from \`twinsWithoutChecks()\` now, and throw with a decision to make when A3 empties the list rather than silently covering nothing.

**One criterion needed no edit:** \`{event_type} is emitted\` renders \`payment_intent.succeeded is emitted\` byte-identically, which is why that slot is bare rather than quoted.

## Review

Green locally: 285 twin-stripe tests · 782 CLI tests · all eight packages · every repo-wide lint gate (\`no-catch\`, \`code-health\`, \`copy-markers\`, \`legacy-markers\`, \`twin-registration\`, \`no-cloud-imports\`, \`no-eval\`, \`knip\`, \`typecheck\`) · \`check-cli-pins-match-workspace\` · and \`pome checks lint tasks/1*-stripe*.md\` on all six stripe tasks.

**Sequencing.** \`packages-v*\` release next (founder step), then the pome-cloud PR deletes \`deterministic/stripe.ts\`, moves the pins and re-measures the ratchets. Those two cannot swap — F-1075 proved publishing the CLI first gives upgraders an N-check client against a 1-check prod, and the digest handshake refuses either direction of skew.

\`cli/package-lock.json\` is deliberately untouched; CI regenerates it against the packed workspace, and PACKAGE_RELEASE.md step 4 refreshes it against the registry after the batch lands.