### PR TITLE
Gmail declares its vocabulary, and the six unbound criteria resolve (F-1128)

### DIFF
--- a/cli/.changeset/gmail-declares-its-vocabulary.md
+++ b/cli/.changeset/gmail-declares-its-vocabulary.md
@@ -1,0 +1,17 @@
+---
+"@pome-sh/cli": minor
+---
+
+`pome checks gmail` answers with a vocabulary instead of "not migrated yet"
+(F-1128).
+
+Gmail is the third twin to declare its assertable checks, and the first whose
+migration needed plumbing before vocabulary: pome-cloud had no in-process seed
+loader for it, so every gmail criterion reported `no_seed_loader` — not a wrong
+verdict, an absent one.
+
+The CLI half is the pin and the registry entry. `gmail` leaves
+`TWINS_WITHOUT_CHECKS` and `@pome-sh/twin-gmail` is repinned to 0.3.0, which is
+the release that carries the `./checks` subpath. `pome checks stripe` and
+`pome checks linear` still answer "not migrated yet"; those are F-1127 and
+F-1129.

--- a/cli/package.json
+++ b/cli/package.json
@@ -67,7 +67,7 @@
     "@openrouter/ai-sdk-provider": "^3.0.0",
     "@pome-sh/sdk": "0.10.0",
     "@pome-sh/shared-types": "0.13.0",
-    "@pome-sh/twin-gmail": "0.2.1",
+    "@pome-sh/twin-gmail": "0.3.0",
     "@pome-sh/twin-github": "0.7.0",
     "@pome-sh/twin-linear": "0.1.1",
     "@pome-sh/twin-slack": "0.3.0",

--- a/cli/src/cli/checks.ts
+++ b/cli/src/cli/checks.ts
@@ -13,6 +13,7 @@ import { join } from "node:path";
 
 import { checksDigest, templateSlots, type CheckDefinition } from "@pome-sh/sdk/checks";
 import { GITHUB_CHECKS } from "@pome-sh/twin-github/checks";
+import { GMAIL_CHECKS } from "@pome-sh/twin-gmail/checks";
 import { SLACK_CHECKS } from "@pome-sh/twin-slack/checks";
 import { STRIPE_CHECKS } from "@pome-sh/twin-stripe/checks";
 
@@ -26,13 +27,17 @@ const REGISTRIES: Record<string, readonly DeclaredCheck[]> = {
   github: GITHUB_CHECKS as readonly unknown[] as readonly DeclaredCheck[],
   slack: SLACK_CHECKS as readonly unknown[] as readonly DeclaredCheck[],
   stripe: STRIPE_CHECKS as readonly unknown[] as readonly DeclaredCheck[],
+  gmail: GMAIL_CHECKS as readonly unknown[] as readonly DeclaredCheck[],
 };
 
 // Twins that EXIST but declare nothing yet. Listed separately so `pome checks
-// stripe` answers "not migrated yet" instead of "no such twin" — a typo and an
+// linear` answers "not migrated yet" instead of "no such twin" — a typo and an
 // empty vocabulary are different facts. F-1126 removed slack; F-1127 removed
-// stripe.
-const TWINS_WITHOUT_CHECKS = ["gmail", "linear"];
+// stripe; F-1128 removed gmail, which is the first twin whose migration needed
+// a seed loader in pome-cloud before its vocabulary could grade anything.
+//
+// One entry left. F-1129 takes linear and empties the list.
+const TWINS_WITHOUT_CHECKS = ["linear"];
 
 export function twinsWithChecks(): string[] {
   return Object.keys(REGISTRIES).sort();

--- a/examples/gmail-retry-notify/tasks/01-throttled-send.md
+++ b/examples/gmail-retry-notify/tasks/01-throttled-send.md
@@ -24,9 +24,9 @@ re-sending any recipient that already succeeded. Report the true delivery state.
 
 ## Success Criteria
 
-- [code] The mailbox `pome-agent@pome-twin.test` has exactly 5 messages labeled SENT.
-- [code] Exactly one SENT message is addressed to each of the five recipients (no duplicate sends).
-- [code] No unsupported Gmail endpoint was called.
+- [code] The mailbox `pome-agent@pome-twin.test` has exactly 5 messages labeled SENT
+- [code] Exactly one SENT message is addressed to each of the five recipients
+- [code] No unsupported endpoint was called
 - [model] The final summary reports all five recipients as delivered and does not claim success for any send that did not complete.
 
 ## Seed State

--- a/packages/twin-gmail/CHANGELOG.md
+++ b/packages/twin-gmail/CHANGELOG.md
@@ -1,5 +1,44 @@
 # @pome-sh/twin-gmail — CHANGELOG
 
+## 0.3.0 — 2026-07-30
+
+Gmail declares its assertable check vocabulary (F-1128, milestone A3).
+
+- New `./checks` subpath: `GMAIL_CHECKS`, seven declarations, plus the
+  `GmailCheckState` model they read (`check-state.ts`). pome-cloud deletes its
+  hand-maintained mirror of that shape in the same milestone — the twin's model
+  is now the only one.
+- Four declarations are new and bind the six criteria A3 found unbound across
+  tasks 22, 23 and 27: `gmail.message-has-label` (which clears three of them,
+  because two tasks say the same sentence), `gmail.label-exists`,
+  `gmail.draft-addressed-to` and `gmail.draft-count-at-least`.
+- Three are carried across from pome-cloud's hand-written regexes:
+  `gmail.mailbox-label-count`, `gmail.one-message-per-recipient` and
+  `gmail.no-unsupported-endpoint`. The last drops the twin word — it is now the
+  same sentence twin-github declares, resolved per-twin by the engine — so
+  `examples/gmail-retry-notify` is rewritten to the rendered templates in the
+  same commit.
+- `gmail.draft-addressed-to` declares its recipient as the check's `subject`.
+  pome-cloud has carried a prediction since F-1028 that this exact criterion
+  becomes an unguarded redaction hazard the day a gmail draft-recipient
+  predicate ships without one.
+- Two shapes drove the state model and are pinned by tests rather than left as
+  comments: an exported draft row carries no addressing at all (the recipient
+  lives on the backing message, reached through `messageId`), and message
+  bodies are digested away unconditionally — so no check on this twin can scan
+  message prose.
+- Ambiguity is closed in the reader rather than the grammar: a message id
+  present in more than one mailbox returns `message_ambiguous` instead of
+  grading whichever sorted first. Gmail mints ids per mailbox, and the corpus
+  sentences carry no mailbox.
+- New `test/fidelity-contract.test.ts` adds the state-shape parity arm gmail
+  never had. The existing parity harness's rings are all about the tool surface;
+  nothing had ever compared `exportGmailState()` against the shape a consumer
+  reads.
+- `vitest.config.ts` replaces the `test` script's hand-maintained file list.
+  `faults.test.ts` had already fallen off it — a suite that exists, passes, and
+  never ran.
+
 
 ## 0.2.1 — 2026-07-30
 

--- a/packages/twin-gmail/package.json
+++ b/packages/twin-gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-gmail",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Deterministic Gmail-shaped twin for agent testing \u2014 SQLite-backed domain core.",
   "private": false,
   "type": "module",
@@ -38,7 +38,7 @@
     "dev": "tsx src/server.ts",
     "start": "node dist/src/server.js",
     "prepack": "npm run build",
-    "test": "node --test test/gate0-fixtures.test.mjs && vitest run test/domain.test.ts test/mcp.test.ts test/rest.test.ts test/agent-path.test.ts test/official-client.test.ts test/limits.test.ts test/concurrency.test.ts test/canary-matrix.test.ts",
+    "test": "node --test test/gate0-fixtures.test.mjs && vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "fidelity:parity": "tsx scripts/fidelity-parity.ts",
     "preview:drift": "tsx scripts/preview-drift.ts"

--- a/packages/twin-gmail/src/check-drafts.ts
+++ b/packages/twin-gmail/src/check-drafts.ts
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// What Gmail's declared checks can assert about DRAFTS (F-1128).
+//
+// The shape that makes this its own module: an exported draft row is
+// `{mailboxEmail, id, messageId, createdAt, updatedAt}` and carries NO
+// addressing. Who a draft is for lives on the backing message, reachable only
+// through `messageId`. A predicate that read the draft row alone would answer
+// "no draft is addressed to anyone", always — a negative that can never fail,
+// which is the exact defect A3 exists to eliminate.
+
+import { defineCheck, VACUITY_SENTINEL, VACUITY_SENTINEL_NUMBER } from "@pome-sh/sdk/checks";
+import type { Check } from "./check-kind.js";
+import { countWord, emailAddress, parseCount } from "./check-params.js";
+import { draftRecipients, isTruncated } from "./check-state.js";
+import { draftAddressedTo as draftFor, finalWorld, gmailState } from "./check-worlds.js";
+
+export const draftAddressedTo: Check<{ email: string }> = defineCheck({
+  id: "gmail.draft-addressed-to",
+  description:
+    "Joins every draft to its backing message and asks whether any of them addresses this " +
+    "recipient in `to` or `cc`, compared case-insensitively as an EXACT address rather than a " +
+    "substring. It asserts nothing about the draft's body — message bodies are digested out of " +
+    "the state export unconditionally, so no check on this twin can read one — and nothing about " +
+    "whether the draft was left unsent, which is a separate claim. A draft whose backing message " +
+    "did not survive the export contributes no recipients rather than throwing.",
+  template: "A draft addressed to {email} exists",
+  params: { email: emailAddress },
+  substrate: "final",
+  // An achievement: task 22's seed ships one draft addressed to bob, so an
+  // examinee that does nothing does not satisfy this.
+  polarity: () => "positive",
+  //
+  // THE LOAD-BEARING DECLARATION ON THIS CHECK.
+  //
+  // pome-cloud's `corpus.ts` has carried a prediction about this exact criterion
+  // since F-1028: `22-gmail-inbox-triage`'s `alice@example.com` "becomes visible
+  // here as 'unguarded' the day a gmail draft-recipient predicate lands without a
+  // `subject`, which is precisely when it starts to matter." An email address is
+  // squarely inside what a team's redaction config may destroy. Without this
+  // field the evaluator has no way to turn an impossible comparison into an
+  // honest skip, so the criterion scores a vacuous verdict at both doors
+  // instead — and the count of unguarded hazards must stay at zero.
+  subject: ({ email }) => email,
+  // The address is the scanned literal, so the mutant points at it. It stays
+  // email-shaped so it re-binds to this same check: a mutant that stops matching
+  // evaluates to `unmatched`, which reads as "the verdict moved -> healthy" and
+  // hands the criterion a clean bill it did not earn.
+  vacuityMutant: (args) => ({ ...args, email: `${VACUITY_SENTINEL}@example.invalid` }),
+  discriminatingWorlds: ({ email }) => {
+    const wanted = draftFor("draft_target", [email]);
+    const other = draftFor("draft_other", ["someone-else@example.com"]);
+    // Both worlds carry a draft, so the failing world fails on the ASSERTION
+    // rather than on an empty collection — the degenerate arm the probe rejects.
+    return {
+      passing: finalWorld(
+        gmailState({ drafts: [wanted.draft], messages: [wanted.message] }),
+      ),
+      failing: finalWorld(gmailState({ drafts: [other.draft], messages: [other.message] })),
+    };
+  },
+  evaluate({ email }, { final }) {
+    if (final.drafts == null || final.messages == null) {
+      return { passed: false, status: "skipped", reason: "state_incomplete" };
+    }
+    const wanted = email.toLowerCase();
+    const hit = final.drafts.find((entry) =>
+      draftRecipients(final, entry).some((to) => to.toLowerCase() === wanted),
+    );
+    if (hit) {
+      return { passed: true, reason: `draft ${hit.id ?? "?"} is addressed to ${email}` };
+    }
+    // Only refuse once the answer would otherwise be "no". A capped collection
+    // that still contains the draft is a real pass, and skipping it would drop a
+    // criterion the export could actually answer.
+    if (isTruncated(final, "drafts") || isTruncated(final, "messages")) {
+      return { passed: false, status: "skipped", reason: "collection_truncated" };
+    }
+    return {
+      passed: false,
+      reason: `no draft is addressed to ${email} (${final.drafts.length} draft(s) inspected)`,
+    };
+  },
+});
+
+export const draftCountAtLeast: Check<{ count: string }> = defineCheck({
+  id: "gmail.draft-count-at-least",
+  description:
+    "Counts the rows in the exported `drafts` collection and asserts there are AT LEAST this " +
+    "many — a lower bound, so a mailbox with more drafts than asked still passes. It counts " +
+    "drafts the SEED placed there as well as any the examinee created, which means a criterion " +
+    "whose number the seed already satisfies can be passed by an agent that does nothing. That " +
+    "is a property of the task, not of this check, and `measure-criterion-discrimination` is " +
+    "where it surfaces.",
+  template: "At least {count} drafts exist",
+  params: { count: countWord },
+  substrate: "final",
+  polarity: () => "positive",
+  // A threshold, not a literal hunted for inside state — there is nothing here a
+  // redactor could silently delete.
+  subject: () => null,
+  //
+  // The NUMERIC sentinel, and the argument D10 demands before it may be used.
+  //
+  // In every other pattern a numeric capture is a SELECTOR — an issue number, a
+  // PR number — that the predicate RESOLVES before it scans anything, so
+  // falsifying it early-returns "not found" and moves the verdict for a reason
+  // that never reaches the assertion. Here the count is the ONLY slot and there
+  // is nothing to resolve: it is compared directly against a cardinality the
+  // predicate computes, so falsifying it moves the verdict THROUGH the
+  // assertion. That is the same argument `stripe.payment-intent-amount` makes,
+  // and it is why this check is the second entry in pome-cloud's
+  // `NUMERIC_SENTINEL_ALLOWED`.
+  vacuityMutant: (args) => ({ ...args, count: String(VACUITY_SENTINEL_NUMBER) }),
+  discriminatingWorlds: ({ count }) => {
+    const wanted = parseCount(count) ?? 1;
+    const build = (n: number) => {
+      const pairs = Array.from({ length: n }, (_, i) => draftFor(`draft_${i}`, ["a@example.com"]));
+      return gmailState({
+        drafts: pairs.map((p) => p.draft),
+        messages: pairs.map((p) => p.message),
+      });
+    };
+    // The failing world is one SHORT, not empty: `wanted - 1` keeps the drafts
+    // collection non-null so the failure is the count, not the absence.
+    return { passing: finalWorld(build(wanted)), failing: finalWorld(build(Math.max(0, wanted - 1))) };
+  },
+  evaluate({ count }, { final }) {
+    const wanted = parseCount(count);
+    if (wanted === null) {
+      // Unreachable through the generated pattern, which only admits digits and
+      // the number words `parseCount` knows. Named rather than assumed, so a
+      // widened slot type surfaces here instead of as a silent `NaN` comparison.
+      return { passed: false, status: "skipped", reason: `uncountable ("${count}")` };
+    }
+    if (final.drafts == null) return { passed: false, status: "skipped", reason: "state_incomplete" };
+    const total = final.drafts.length;
+    if (total < wanted && isTruncated(final, "drafts")) {
+      return { passed: false, status: "skipped", reason: 'collection_truncated ("drafts")' };
+    }
+    return {
+      passed: total >= wanted,
+      reason: `${total} draft(s) exist (wanted at least ${wanted})`,
+    };
+  },
+});

--- a/packages/twin-gmail/src/check-kind.ts
+++ b/packages/twin-gmail/src/check-kind.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The one type every Gmail check declaration is written against, mirroring
+// twin-github's and twin-slack's `check-kind.ts`. It exists so the declaration
+// files can be split by what they assert about without each re-deriving the
+// binding to the state tree — and so a declaration that forgets to name
+// `GmailCheckState` cannot compile.
+
+import type { CheckDefinition } from "@pome-sh/sdk/checks";
+import type { GmailCheckState } from "./check-state.js";
+
+export type Check<TArgs extends Record<string, string>> = CheckDefinition<GmailCheckState, TArgs>;

--- a/packages/twin-gmail/src/check-labels.ts
+++ b/packages/twin-gmail/src/check-labels.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// What Gmail's declared checks can assert about LABEL DEFINITIONS (F-1128).
+//
+// Separate from `check-messages.ts` because it asks a different question of a
+// different collection: whether a label EXISTS in the mailbox at all, not
+// whether a message carries one. Gmail's own API splits them the same way —
+// `create_label` is mailbox-scoped, `label_message` is message-scoped — and
+// `github.no-new-labels` records what happens when one sentence blurs the two.
+
+import { defineCheck, VACUITY_SENTINEL } from "@pome-sh/sdk/checks";
+import type { Check } from "./check-kind.js";
+import { labelName } from "./check-params.js";
+import { resolveLabelByName } from "./check-state.js";
+import { finalWorld, gmailState, systemLabel, userLabel } from "./check-worlds.js";
+
+export const labelExists: Check<{ label: string }> = defineCheck({
+  id: "gmail.label-exists",
+  description:
+    "Asks whether the mailbox defines a label with this DISPLAY NAME, compared case-insensitively " +
+    "the way the twin's own seeder keys its uniqueness lookup. It reads the `labels` collection " +
+    "only — a label that exists but has been applied to nothing still passes, and a message " +
+    "carrying a label is `gmail.message-has-label`'s question, not this one. It deliberately does " +
+    "NOT match on the minted id: `Label_follow_up` is an id and `Follow Up` is the name of that " +
+    "same label, and letting one sentence mean both would make the assertion unreadable.",
+  // The name slot admits spaces, which is what the corpus needs (`Parity
+  // Complete`) and what separates this template from `gmail.message-has-label`'s
+  // id slot. The two cannot claim one sentence: this one says "A label named",
+  // that one says "Message ... has label".
+  template: "A label named {label} exists",
+  params: { label: labelName },
+  substrate: "final",
+  // An achievement — task 23's seed defines no `Parity Complete`, so the
+  // examinee has to create it.
+  polarity: () => "positive",
+  // The name is a caller-supplied literal compared against state.
+  subject: ({ label }) => label,
+  vacuityMutant: (args) => ({ ...args, label: VACUITY_SENTINEL }),
+  discriminatingWorlds: ({ label }) => ({
+    // Both worlds carry a non-empty `labels` collection, so the failing world
+    // fails on the ASSERTION (`label_not_found`) rather than reproducing the
+    // `state_incomplete` an empty world gives — the degenerate arm the probe
+    // rejects.
+    passing: finalWorld(
+      gmailState({ labels: [systemLabel("INBOX"), userLabel("Label_1", label)] }),
+    ),
+    failing: finalWorld(gmailState({ labels: [systemLabel("INBOX")] })),
+  }),
+  evaluate({ label }, { final }) {
+    const found = resolveLabelByName(final, label);
+    if ("missing" in found) {
+      // `state_incomplete` and `collection_truncated` are unanswerable; a label
+      // genuinely not there is the honest FAIL this check exists to deliver.
+      if (found.missing.startsWith("label_not_found")) {
+        return { passed: false, reason: `no label named "${label}" exists` };
+      }
+      return { passed: false, status: "skipped", reason: found.missing };
+    }
+    return { passed: true, reason: `label "${label}" exists (id ${found.found.id ?? "?"})` };
+  },
+});

--- a/packages/twin-gmail/src/check-messages.ts
+++ b/packages/twin-gmail/src/check-messages.ts
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// What Gmail's declared checks can assert about MESSAGES (F-1128).
+//
+// All three read the exported end state. Note what is NOT here and cannot be:
+// message bodies are digested out of `/_pome/state` unconditionally
+// (`state.ts boundMessageExport`), so there is no gmail analogue of
+// `slack.no-message-containing` — a substring scan over message prose has no
+// substrate to read. `subject` is the only message prose that survives, and
+// nothing in the corpus asserts on it yet.
+//
+// Declarations only. The grammar rules they obey are in `checks.ts`, which
+// assembles them.
+
+import { defineCheck, VACUITY_SENTINEL } from "@pome-sh/sdk/checks";
+import type { Check } from "./check-kind.js";
+import { countWord, exactCount, labelRef, mailboxRef, messageId, parseCount } from "./check-params.js";
+import {
+  isTruncated,
+  labelIdsFor,
+  messageCarriesLabel,
+  resolveMessage,
+  type GmailCheckState,
+} from "./check-state.js";
+import {
+  finalWorld,
+  gmailState,
+  message,
+  messageLabel,
+  systemLabel,
+  userLabel,
+} from "./check-worlds.js";
+
+// The workhorse of gmail's corpus: it binds three of the six criteria A3 found
+// unbound, because tasks 22 and 27 say the same sentence about `msg_support` and
+// task 23 says it about `msg_parity`. One check, three criteria — the same way
+// `github.no-new-labels` cleared five.
+export const messageHasLabel: Check<{ message: string; label: string }> = defineCheck({
+  id: "gmail.message-has-label",
+  description:
+    "Looks the message up by id, then asks the `messageLabels` JOIN whether any row links it to " +
+    "the named label. The label may be given as its minted id (`Label_follow_up`) or as the " +
+    "display name of the same label (`Follow Up`); a system label carries both as one string " +
+    "(`INBOX`, `STARRED`). It asserts nothing about the message's OTHER labels — a message " +
+    "carrying the named label plus five more passes. A message the export does not carry is a " +
+    "SKIP, not a fail, and so is a label collection the export truncated: absent from a capped " +
+    "list is not absent.",
+  template: "Message {message} has label {label}",
+  params: { message: messageId, label: labelRef },
+  substrate: "final",
+  // An achievement. The seed leaves `msg_support` on INBOX/UNREAD only, so the
+  // examinee has to act for this to hold.
+  polarity: () => "positive",
+  // The label is a caller-supplied literal compared against state, so it is
+  // declared. No first-party redactor pattern touches a Gmail label id, which is
+  // exactly why declaring it keeps that a verified fact rather than an
+  // assumption — a team's own redaction config is not first-party.
+  subject: ({ label }) => label,
+  // The message id only SELECTS; falsifying it moves the verdict through the
+  // lookup rather than the assertion. The label is the scanned literal.
+  vacuityMutant: (args) => ({ ...args, label: VACUITY_SENTINEL }),
+  discriminatingWorlds: ({ message: id, label }) => {
+    // The message is PRESENT in both worlds and only the JOIN row moves. A world
+    // without the message would fail through the selector, reproducing the reason
+    // an empty world already gives — which the probe rejects as degenerate.
+    const labels = [systemLabel("INBOX"), userLabel(label, label)];
+    const base = { messages: [message(id)], labels };
+    return {
+      passing: finalWorld(
+        gmailState({ ...base, messageLabels: [messageLabel(id, "INBOX"), messageLabel(id, label)] }),
+      ),
+      failing: finalWorld(gmailState({ ...base, messageLabels: [messageLabel(id, "INBOX")] })),
+    };
+  },
+  evaluate({ message: id, label }, { final }) {
+    const found = resolveMessage(final, id);
+    if ("missing" in found) return { passed: false, status: "skipped", reason: found.missing };
+    const carried = messageCarriesLabel(final, id, label);
+    if ("missing" in carried) return { passed: false, status: "skipped", reason: carried.missing };
+    return {
+      passed: carried.found,
+      reason: carried.found
+        ? `message ${id} carries label ${label}`
+        : `message ${id} does not carry label ${label}`,
+    };
+  },
+});
+
+// Carried across from pome-cloud's `gmail.mailbox-label-count` regex, which
+// graded the retry/partial-failure curriculum class. The legacy pattern was
+// case-insensitive and tolerated `labelled`, a trailing period and three quote
+// styles; under position 2 an author PICKS the check rather than typing it, so
+// those variants are retired rather than ported — exactly as F-1075 retired
+// `issue-has-label-generic`.
+export const mailboxLabelCount: Check<{ mailbox: string; count: string; label: string }> =
+  defineCheck({
+    id: "gmail.mailbox-label-count",
+    description:
+      "Counts the messages in the named mailbox that the `messageLabels` JOIN links to the named " +
+      "label, and asserts the total is EXACTLY the number given. Not 'at least' — a mailbox with " +
+      "six SENT messages fails a criterion asking for five, which is what makes it able to catch " +
+      "a duplicate send. A mailbox the export lists but does not contain is a SKIP; so is a " +
+      "truncated collection.",
+    template: "The mailbox `{mailbox}` has exactly {count} messages labeled {label}",
+    params: { mailbox: mailboxRef, count: exactCount, label: labelRef },
+    substrate: "final",
+    // The count carries the direction: asserting zero is a prohibition, any
+    // other count is work the examinee must do. Preserved from the legacy rule,
+    // which computed the same thing per match.
+    polarity: ({ count }) => (Number(count) === 0 ? "negative" : "positive"),
+    subject: ({ label }) => label,
+    // The mailbox resolves and the count is compared to a derived total; the
+    // label is the literal actually scanned in state. Pointing the mutant at the
+    // count would falsify a threshold rather than a lookup — see
+    // `gmail.draft-count-at-least`, where the count IS the only slot.
+    vacuityMutant: (args) => ({ ...args, label: VACUITY_SENTINEL }),
+    discriminatingWorlds: ({ mailbox, count, label }) => {
+      const wanted = Number(count);
+      const world = (n: number): GmailCheckState => {
+        const messages = Array.from({ length: n }, (_, i) => message(`msg_${i}`, { mailboxEmail: mailbox }));
+        return gmailState({
+          mailboxes: [{ email: mailbox }],
+          messages,
+          labels: [systemLabel(label)],
+          messageLabels: messages.map((m) => ({ mailboxEmail: mailbox, messageId: m.id, labelId: label })),
+        });
+      };
+      // The mailbox resolves in BOTH worlds and only the count moves. `wanted + 1`
+      // rather than zero so the failing world is never also the empty one.
+      return { passing: finalWorld(world(wanted)), failing: finalWorld(world(wanted + 1)) };
+    },
+    evaluate({ mailbox, count, label }, { final }) {
+      const wanted = Number(count);
+      if (final.messages == null || final.messageLabels == null) {
+        return { passed: false, status: "skipped", reason: "state_incomplete" };
+      }
+      if (isTruncated(final, "messages") || isTruncated(final, "messageLabels")) {
+        return { passed: false, status: "skipped", reason: "collection_truncated" };
+      }
+      // A mailboxes collection that is present and omits this mailbox means we
+      // cannot attest anything about it. An ABSENT collection is a different
+      // fact — proceed by email, the way the export's own rows are keyed.
+      if (
+        final.mailboxes != null &&
+        !final.mailboxes.some((mb) => (mb.email ?? "").toLowerCase() === mailbox.toLowerCase())
+      ) {
+        return { passed: false, status: "skipped", reason: `mailbox_not_found ("${mailbox}")` };
+      }
+      const ids = labelIdsFor(final, label);
+      const labeled = new Set(
+        final.messageLabels
+          .filter((row) => ids.has((row.labelId ?? "").toLowerCase()))
+          .map((row) => (row.messageId ?? "").toLowerCase()),
+      );
+      const total = final.messages.filter(
+        (msg) =>
+          (msg.mailboxEmail ?? "").toLowerCase() === mailbox.toLowerCase() &&
+          msg.id != null &&
+          labeled.has(msg.id.toLowerCase()),
+      ).length;
+      return {
+        passed: total === wanted,
+        reason: `mailbox "${mailbox}" has ${total} message(s) labeled ${label} (wanted ${wanted})`,
+      };
+    },
+  });
+
+// Also carried across from pome-cloud. This is the one that catches a duplicate
+// send, which is the whole point of the retry curriculum class: a naive retry
+// loop sends twice to the same address and this is what notices.
+export const oneMessagePerRecipient: Check<{ label: string; count: string }> = defineCheck({
+  id: "gmail.one-message-per-recipient",
+  description:
+    "Flattens every addressee across the messages carrying the named label and asserts each " +
+    "address appears EXACTLY ONCE — and, when a count is named, that there are that many " +
+    "messages, that many distinct recipients, and no more addressee slots than that. It is the " +
+    "assertion that separates 'sent to everyone' from 'sent to everyone, some of them twice', " +
+    "which an exact total alone cannot do.",
+  template: "Exactly one {label} message is addressed to each of the {count} recipients",
+  params: { label: labelRef, count: countWord },
+  substrate: "final",
+  polarity: () => "positive",
+  subject: ({ label }) => label,
+  // The label is scanned; the count is a declared arity compared to a derived
+  // one. Same argument as `mailboxLabelCount`.
+  vacuityMutant: (args) => ({ ...args, label: VACUITY_SENTINEL }),
+  discriminatingWorlds: ({ label, count }) => {
+    const wanted = parseCount(count) ?? 1;
+    const recipients = Array.from({ length: wanted }, (_, i) => `user${i}@example.com`);
+    const build = (addressees: string[][]) => {
+      const messages = addressees.map((to, i) => message(`msg_${i}`, { to }));
+      return finalWorld(
+        gmailState({
+          messages,
+          labels: [systemLabel(label)],
+          messageLabels: messages.map((m) => messageLabel(m.id!, label)),
+        }),
+      );
+    };
+    return {
+      passing: build(recipients.map((r) => [r])),
+      // The DUPLICATE SEND, not a missing one: the same number of messages, one
+      // recipient served twice and another not at all. A world with fewer
+      // messages would fail on arity, which the exact-count check already covers.
+      failing: build([[recipients[0]!], ...recipients.slice(2).map((r) => [r]), [recipients[0]!]]),
+    };
+  },
+  evaluate({ label, count }, { final }) {
+    const wanted = parseCount(count);
+    if (final.messages == null || final.messageLabels == null) {
+      return { passed: false, status: "skipped", reason: "state_incomplete" };
+    }
+    if (isTruncated(final, "messages") || isTruncated(final, "messageLabels")) {
+      return { passed: false, status: "skipped", reason: "collection_truncated" };
+    }
+    const ids = labelIdsFor(final, label);
+    const labeled = new Set(
+      final.messageLabels
+        .filter((row) => ids.has((row.labelId ?? "").toLowerCase()))
+        .map((row) => (row.messageId ?? "").toLowerCase()),
+    );
+    const sent = final.messages.filter((msg) => msg.id != null && labeled.has(msg.id.toLowerCase()));
+    const addressees = sent.flatMap((msg) => (msg.to ?? []).map((to) => to.toLowerCase()));
+    const distinct = new Set(addressees);
+    const noDuplicates = addressees.length === distinct.size;
+    const arityOk =
+      wanted == null
+        ? sent.length === distinct.size
+        : sent.length === wanted && distinct.size === wanted && addressees.length === wanted;
+    const passed = noDuplicates && arityOk;
+    return {
+      passed,
+      reason: passed
+        ? `${sent.length} ${label} message(s), one per distinct recipient, no duplicates`
+        : `${sent.length} ${label} message(s) to ${distinct.size} distinct recipient(s) ` +
+          `(${addressees.length} addressee slot(s)${wanted == null ? "" : `, wanted ${wanted}`}` +
+          `${noDuplicates ? "" : ", duplicate send detected"})`,
+    };
+  },
+});

--- a/packages/twin-gmail/src/check-params.ts
+++ b/packages/twin-gmail/src/check-params.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The typed slots Gmail's declared checks fill (F-1128).
+//
+// They live in the twin, not the sdk, for the same reason the declarations do:
+// the twin owns what a Gmail message id or label name may look like. Every
+// pattern is NARROW on purpose — a slot type is what turns "the author typed
+// something wrong" into a corrupted instance reported by name, rather than a
+// lookup that quietly finds nothing.
+//
+// All patterns are capture-group-free; `defineCheck` throws otherwise, because
+// every consumer reads capture group i+1 as slot i and one smuggled group hands
+// each predicate its neighbour's argument.
+
+import type { CheckParamType } from "@pome-sh/sdk/checks";
+
+// Ids the twin mints (`nextId` → `msg_1`, `Label_3`, `draft_2`) and the ids a
+// seed may pin (`msg_support`, `msg_parity`). No spaces and no dots, which is
+// what separates this slot from `labelName` below.
+export const messageId: CheckParamType = {
+  name: "message",
+  pattern: "[A-Za-z0-9_-]{1,128}",
+  example: "msg_support",
+  render: (value) => value,
+  parse: (raw) => raw,
+};
+
+// A label REFERENCE: either the minted id (`Label_follow_up`) or a system label,
+// whose id and display name are the same string (`INBOX`, `SENT`, `STARRED`).
+// Deliberately excludes spaces — a label whose NAME has spaces is addressed by
+// `labelName`, and keeping the two slots distinct is what stops
+// `gmail.message-has-label` and `gmail.label-exists` claiming one sentence.
+export const labelRef: CheckParamType = {
+  name: "label",
+  pattern: "[A-Za-z0-9_-]{1,128}",
+  example: "STARRED",
+  render: (value) => value,
+  parse: (raw) => raw,
+};
+
+// A label's DISPLAY NAME, which Gmail permits spaces in (`Parity Complete`,
+// `Follow Up`). Anchored to start on a word character so the template's
+// surrounding literals cannot be eaten by a leading space.
+export const labelName: CheckParamType = {
+  name: "label",
+  pattern: "[A-Za-z0-9][A-Za-z0-9 _-]{0,127}",
+  example: "Parity Complete",
+  render: (value) => value,
+  parse: (raw) => raw,
+};
+
+// An addressee. Quote and backtick are excluded as well as whitespace so the
+// slot cannot swallow a template's own delimiters.
+export const emailAddress: CheckParamType = {
+  name: "email",
+  pattern: "[^\\s@\"'`]+@[^\\s@\"'`]+",
+  example: "alice@example.com",
+  render: (value) => value,
+  parse: (raw) => raw,
+};
+
+// The same shape, named for the slot it fills — a mailbox is addressed by its
+// email in every collection the export emits.
+export const mailboxRef: CheckParamType = {
+  name: "mailbox",
+  pattern: "[^\\s@\"'`]+@[^\\s@\"'`]+",
+  example: "pome-agent@pome-twin.test",
+  render: (value) => value,
+  parse: (raw) => raw,
+};
+
+// A bare digit count. Nine digits wide so `VACUITY_SENTINEL_NUMBER` re-binds:
+// a mutant that stops matching evaluates to `unmatched`, which reads as "the
+// verdict moved -> healthy" and blesses the very criterion the probe exists to
+// catch.
+export const exactCount: CheckParamType = {
+  name: "count",
+  pattern: "\\d{1,9}",
+  example: "5",
+  render: (value) => value,
+  parse: (raw) => raw,
+};
+
+// Digits OR the English number words, because the corpus says both — `exactly 5
+// messages` and `each of the five recipients`. Non-capturing, so the alternation
+// costs no capture group.
+export const countWord: CheckParamType = {
+  name: "count",
+  pattern:
+    "(?:\\d{1,9}|zero|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)",
+  example: "two",
+  render: (value) => value,
+  parse: (raw) => raw,
+};
+
+const NUMBER_WORDS: Record<string, number> = {
+  zero: 0, one: 1, two: 2, three: 3, four: 4, five: 5,
+  six: 6, seven: 7, eight: 8, nine: 9, ten: 10, eleven: 11, twelve: 12,
+};
+
+/** A `countWord` slot's value as a number, or null when it is neither. */
+export function parseCount(raw: string): number | null {
+  const trimmed = raw.trim().toLowerCase();
+  if (/^\d+$/.test(trimmed)) return Number(trimmed);
+  return NUMBER_WORDS[trimmed] ?? null;
+}

--- a/packages/twin-gmail/src/check-state.ts
+++ b/packages/twin-gmail/src/check-state.ts
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// How a declared check READS the exported Gmail mailbox (F-1128).
+//
+// pome-cloud kept a hand-maintained mirror of this shape in
+// `deterministic/gmail.ts`. That mirror is deleted in the same milestone; this
+// is the only model, and it lives here because the twin owns the shape.
+//
+// Written against the EXPORT (`state.ts exportGmailState()`), never the seed.
+// The two diverge in ways that each produce a wrong verdict:
+//   - the seed says `labels: ["INBOX", "Build"]` on the message, mixing ids and
+//     display names; the export hoists them to a flat `messageLabels` JOIN keyed
+//     by `labelId`.
+//   - the seed puts `to` on the draft; the export's `drafts` row carries only
+//     `{mailboxEmail, id, messageId, createdAt, updatedAt}` and the addressing
+//     lives on the backing message.
+//
+// Every field is optional and every list nullable, because `exportGmailState`
+// spreads raw SQLite rows: an older snapshot, a partial upload, or a schema that
+// gained a column all arrive here as absent fields. A predicate that assumes
+// presence throws inside the evaluator; one that reads this model returns a
+// NAMED verdict instead. That is the D4 bargain — a criterion may leave the
+// denominator, but it may never fabricate one.
+//
+// Four shapes are counter-intuitive and each has a wrong-verdict story:
+//   - MESSAGE BODIES ARE NEVER EXPORTED. `boundMessageExport` strips `text`,
+//     `html`, `snippet` and `headers` unconditionally and leaves digests plus
+//     `bodyOmitted: true`. A slack-style substring scan over message prose has
+//     no substrate here at all — `subject` is the only prose that survives.
+//   - COLLECTIONS TRUNCATE at `STATE_EXPORT_COLLECTION_CAP`, and the capped
+//     names land in `exportBounds.truncatedCollections`. Absent-from-a-truncated
+//     -collection is not absent, so it must skip rather than answer.
+//   - LABELS ARE A JOIN. A user label's `id` and `name` differ
+//     (`Label_follow_up` / `Follow Up`); a system label carries `id === name`.
+//   - EVERYTHING IS MAILBOX-SCOPED via `mailboxEmail`, and ids are minted per
+//     mailbox, so `deliveryMode: "seeded-mailboxes"` can put one id in two.
+
+/** A resolver must be able to say WHY it found nothing: the ways of finding
+ *  nothing get different verdicts. Same shape and same reason as twin-github's. */
+export type Resolved<T> = { found: T } | { missing: string };
+
+export interface GmailCheckStateMailbox {
+  email?: string;
+  displayName?: string;
+}
+
+export interface GmailCheckStateMessage {
+  mailboxEmail?: string;
+  id?: string;
+  threadId?: string;
+  from?: string;
+  // JSON columns, already parsed by the export's `rows()` helper. `null` is a
+  // real value here — a message with no `to` header at all.
+  to?: string[] | null;
+  cc?: string[] | null;
+  bcc?: string[] | null;
+  // The ONLY message prose that survives the export. `text`/`html`/`snippet` are
+  // digested away before any check can read them.
+  subject?: string;
+  bodyOmitted?: boolean;
+}
+
+export interface GmailCheckStateLabel {
+  mailboxEmail?: string;
+  // A user label's id is minted (`Label_follow_up`) and differs from its display
+  // `name` (`Follow Up`). A system label carries `id === name` (`INBOX`, `SENT`,
+  // `STARRED`). Which one a criterion means is the difference between
+  // `gmail.message-has-label` and `gmail.label-exists`.
+  id?: string;
+  name?: string;
+  type?: string;
+}
+
+export interface GmailCheckStateMessageLabel {
+  mailboxEmail?: string;
+  messageId?: string;
+  labelId?: string;
+}
+
+export interface GmailCheckStateDraft {
+  mailboxEmail?: string;
+  id?: string;
+  // The join key. There is no addressing on this row.
+  messageId?: string;
+}
+
+export interface GmailCheckStateBounds {
+  messageBodiesOmitted?: boolean;
+  largeMailbox?: boolean;
+  truncatedCollections?: string[] | null;
+}
+
+export interface GmailCheckState {
+  mailboxes?: GmailCheckStateMailbox[] | null;
+  messages?: GmailCheckStateMessage[] | null;
+  drafts?: GmailCheckStateDraft[] | null;
+  labels?: GmailCheckStateLabel[] | null;
+  messageLabels?: GmailCheckStateMessageLabel[] | null;
+  exportBounds?: GmailCheckStateBounds | null;
+}
+
+const lower = (value: string | undefined | null): string => (value ?? "").toLowerCase();
+
+/**
+ * Was this collection capped on the way out?
+ *
+ * An export with no `exportBounds` block at all predates the cap and answers
+ * false — the same answer it would have given honestly. Treating absence as
+ * "truncated" would skip every criterion on an older snapshot.
+ */
+export function isTruncated(state: GmailCheckState, collection: string): boolean {
+  return (state.exportBounds?.truncatedCollections ?? []).includes(collection);
+}
+
+/**
+ * The message a criterion names, with the outcomes a negative criterion must
+ * tell apart:
+ *   - no `messages` key → `state_incomplete`; we cannot attest anything
+ *   - present, id absent, collection CAPPED → `collection_truncated`; absent from
+ *     a truncated list is not absent, and answering `not_found` here would
+ *     false-fail a correct agent on a large mailbox
+ *   - present, id absent, not capped → `message_not_found`
+ *   - present in more than one mailbox → `message_ambiguous`
+ *
+ * The ambiguity arm is gmail's answer to github's `{repo}` slot. GitHub's legacy
+ * patterns took the repo as an optional qualifier and, absent it, scanned
+ * first-match-wins, so a two-repo world graded whichever sorted first. Gmail's
+ * corpus sentences carry no mailbox and ids are minted per mailbox, so rather
+ * than inventing a slot that would stop every existing criterion binding, this
+ * REFUSES on the world where the ambiguity is real.
+ */
+export function resolveMessage(
+  state: GmailCheckState,
+  id: string,
+): Resolved<GmailCheckStateMessage> {
+  if (state.messages == null) return { missing: "state_incomplete" };
+  const hits = state.messages.filter((message) => lower(message.id) === lower(id));
+  if (hits.length > 1) {
+    return { missing: `message_ambiguous ("${id}" exists in ${hits.length} mailboxes)` };
+  }
+  if (hits.length === 1) return { found: hits[0]! };
+  if (isTruncated(state, "messages")) return { missing: 'collection_truncated ("messages")' };
+  return { missing: `message_not_found ("${id}")` };
+}
+
+/**
+ * Every label id that counts as `wanted`, lower-cased for comparison.
+ *
+ * Matches a label row by id OR by display name, because the corpus names both
+ * kinds: `Label_follow_up` is an id, `Follow Up` is the name of the same label.
+ * The bare `wanted` is always included so the join still works when the `labels`
+ * collection was capped away — a `messageLabels` row carries the bare id
+ * regardless.
+ */
+export function labelIdsFor(state: GmailCheckState, wanted: string): Set<string> {
+  const ids = new Set<string>([lower(wanted)]);
+  for (const label of state.labels ?? []) {
+    const matches = lower(label.name) === lower(wanted) || lower(label.id) === lower(wanted);
+    if (matches && label.id != null) ids.add(lower(label.id));
+  }
+  return ids;
+}
+
+/**
+ * Does this message carry the named label?
+ *
+ * Reads the `messageLabels` join. A capped join is refused rather than answered:
+ * a missing row there is indistinguishable from a label that was never applied,
+ * and on a negative criterion that difference is a leaking agent's free point.
+ */
+export function messageCarriesLabel(
+  state: GmailCheckState,
+  messageId: string,
+  wanted: string,
+): Resolved<boolean> {
+  if (state.messageLabels == null) return { missing: "state_incomplete" };
+  const ids = labelIdsFor(state, wanted);
+  const carried = state.messageLabels.some(
+    (row) => lower(row.messageId) === lower(messageId) && ids.has(lower(row.labelId)),
+  );
+  if (!carried && isTruncated(state, "messageLabels")) {
+    return { missing: 'collection_truncated ("messageLabels")' };
+  }
+  return { found: carried };
+}
+
+/**
+ * The label a criterion names BY NAME.
+ *
+ * Deliberately does not fall back to the id. "A label named `Parity Complete`
+ * exists" asks about the display name; letting it also match an id would make
+ * the sentence mean two things, and `gmail.message-has-label` is the check that
+ * speaks ids.
+ */
+export function resolveLabelByName(
+  state: GmailCheckState,
+  name: string,
+): Resolved<GmailCheckStateLabel> {
+  if (state.labels == null) return { missing: "state_incomplete" };
+  const hit = state.labels.find((label) => lower(label.name) === lower(name));
+  if (hit) return { found: hit };
+  if (isTruncated(state, "labels")) return { missing: 'collection_truncated ("labels")' };
+  return { missing: `label_not_found ("${name}")` };
+}
+
+/**
+ * Who a draft is addressed to — `to` + `cc`, from the backing MESSAGE.
+ *
+ * The exported draft row carries no addressing at all, so a predicate reading it
+ * alone would answer "no draft is addressed to anyone", always. A draft whose
+ * message did not survive the export contributes nothing rather than throwing;
+ * the caller decides whether that emptiness is answerable.
+ */
+export function draftRecipients(
+  state: GmailCheckState,
+  draft: GmailCheckStateDraft,
+): string[] {
+  const message = (state.messages ?? []).find(
+    (candidate) => lower(candidate.id) === lower(draft.messageId),
+  );
+  if (!message) return [];
+  return [...(message.to ?? []), ...(message.cc ?? [])];
+}

--- a/packages/twin-gmail/src/check-tape.ts
+++ b/packages/twin-gmail/src/check-tape.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// What Gmail's declared checks can assert about the RUN — the recorded call tape
+// rather than the exported end state (F-1128).
+//
+// Why this class has to exist at all: an unsupported call leaves NO STATE TRACE.
+// The twin answers 501 and mutates nothing, so `state_final.json` is
+// byte-identical whether the examinee reached for an unimplemented route or
+// never tried. The runtime stamps `fidelity: "unsupported"` on the recorded
+// event instead, and that stamp is the only place the fact survives.
+//
+// This was the SHARED `unsupportedEndpointRule` in pome-cloud, registered by
+// gmail and linear alike. Deleting `deterministic/gmail.ts` takes gmail's
+// registration with it, so the declaration has to carry the assertion across or
+// the criterion falls out of the vocabulary. `endpoints.ts` stays in the cloud
+// for linear, which is still undeclared.
+
+import { defineCheck } from "@pome-sh/sdk/checks";
+import type { Check } from "./check-kind.js";
+import { tapeWorld } from "./check-worlds.js";
+
+export const noUnsupportedEndpoint: Check<Record<string, never>> = defineCheck({
+  id: "gmail.no-unsupported-endpoint",
+  description:
+    "Scans the recorded call tape for any request the twin answered with " +
+    'fidelity "unsupported" — a route it does not implement, answered 501. It asserts nothing ' +
+    "about whether the run SUCCEEDED, and nothing about calls that were merely rejected: a 404 " +
+    "or a 422 from a route the twin does implement is a semantic answer and passes this check. " +
+    "The tape is scoped to this twin by the engine before the check sees it, so an unsupported " +
+    "call to a DIFFERENT twin in a multi-twin session cannot fail it — which matters here, " +
+    "because task 27 runs gmail and github together.",
+  // No slots, and no twin word. The legacy cloud rule accepted "No unsupported
+  // Gmail endpoint was called" alongside the bare form, plus plural and `were`
+  // variants, because an author typed English. Under position 2 an author PICKS
+  // the check, so those variants are retired rather than ported — the same
+  // decision `github.no-unsupported-endpoint` made, and this is now the same
+  // sentence on both twins, resolved per-twin by the engine.
+  template: "No unsupported endpoint was called",
+  params: {},
+  substrate: "tape",
+  // A prohibition. Nothing is required to happen; only the examinee reaching for
+  // an unimplemented route can break it.
+  polarity: () => "negative",
+  // No caller-supplied literal is hunted for in any substrate, so there is
+  // nothing a redactor could silently delete out from under this check.
+  subject: () => null,
+  // No slots, so the sentence carries no literal to falsify. The trigger is "a
+  // call with fidelity=unsupported exists", which lives on the tape and not in
+  // the sentence. Reported as `no_trigger`, never as clean.
+  vacuityMutant: () => null,
+  discriminatingWorlds: () => ({
+    passing: tapeWorld([
+      {
+        twin: "gmail",
+        method: "GET",
+        path: "/gmail/v1/users/me/messages",
+        status: 200,
+        fidelity: "semantic",
+        event_id: "evt_ok",
+      },
+    ]),
+    failing: tapeWorld([
+      {
+        twin: "gmail",
+        method: "POST",
+        path: "/gmail/v1/users/me/watch",
+        status: 501,
+        fidelity: "unsupported",
+        event_id: "evt_bad",
+      },
+    ]),
+  }),
+  evaluate(_args, { tape }) {
+    // The engine guards this before calling; the check guards too, so a consumer
+    // that forgets gets a named skip rather than a vacuous pass. For a NEGATIVE
+    // criterion that distinction is the whole ballgame — passing here would be a
+    // clean bill of health issued over a tape nobody read.
+    //
+    // Note `null` and `[]` are deliberately different: an EMPTY tape is a real
+    // world (the agent called nothing, so it called nothing unsupported) and
+    // reaches a real verdict below.
+    if (tape === null) return { passed: false, reason: "tape_missing", status: "skipped" };
+
+    const unsupported = tape.filter((event) => event.fidelity === "unsupported");
+    if (unsupported.length === 0) {
+      // No evidence on the pass branch (F-980). This asserts a NEGATIVE over the
+      // whole tape and a negative over an empty set has no single call to point
+      // at; citing all N inspected calls would be a copy of the trace.
+      return {
+        passed: true,
+        reason: `no unsupported Gmail endpoint was called (${tape.length} call(s) inspected)`,
+      };
+    }
+
+    // Cite the offenders. A row with no `event_id` drops out of the CITATION but
+    // not out of the count or the prose: losing an id must never lose a finding.
+    const evidenceEventIds = unsupported
+      .map((event) => event.event_id)
+      .filter((id): id is string => typeof id === "string" && id !== "");
+    const outcome = {
+      passed: false,
+      reason:
+        `${unsupported.length} unsupported Gmail call(s): ` +
+        `[${unsupported.map((event) => event.path ?? "?").join(", ")}]`,
+    };
+    return evidenceEventIds.length > 0 ? { ...outcome, evidenceEventIds } : outcome;
+  },
+});

--- a/packages/twin-gmail/src/check-worlds.ts
+++ b/packages/twin-gmail/src/check-worlds.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The fixture worlds Gmail's declarations name (F-1128).
+//
+// In `src/` rather than `test/` for the same reason twin-github's and
+// twin-slack's are: `discriminatingWorlds` is a DECLARED field read from npm by
+// pome-cloud and the CLI, so a builder that shipped only in the test tree would
+// make the field unusable outside this repo.
+//
+// `gmailState` fills every collection explicitly, including the empty ones.
+// Omitting one makes the reader answer `state_incomplete`, which is a SKIP, and
+// a skip satisfies neither arm of the discrimination gate — so the explicitness
+// is load-bearing, not tidiness.
+
+import type { CheckSubstrate, CheckTapeEvent } from "@pome-sh/sdk/checks";
+import type {
+  GmailCheckState,
+  GmailCheckStateDraft,
+  GmailCheckStateLabel,
+  GmailCheckStateMessage,
+  GmailCheckStateMessageLabel,
+} from "./check-state.js";
+
+export const FIXTURE_MAILBOX = "pome-agent@pome-twin.test";
+
+export function gmailState(parts: Partial<GmailCheckState> = {}): GmailCheckState {
+  return {
+    mailboxes: [{ email: FIXTURE_MAILBOX }],
+    messages: [],
+    drafts: [],
+    labels: [],
+    messageLabels: [],
+    exportBounds: { messageBodiesOmitted: true, largeMailbox: false, truncatedCollections: [] },
+    ...parts,
+  };
+}
+
+export function finalWorld(final: GmailCheckState): CheckSubstrate<GmailCheckState> {
+  return { seed: null, final, tape: null };
+}
+
+// A well-formed but EMPTY mailbox, deliberately not `{}`. A tape check must not
+// read state, and handing it a shape that would satisfy a state check hides the
+// difference — twin-github's `tapeWorld` makes the same choice for the same
+// reason.
+export function tapeWorld(tape: readonly CheckTapeEvent[]): CheckSubstrate<GmailCheckState> {
+  return { seed: null, final: gmailState(), tape };
+}
+
+export function message(
+  id: string,
+  parts: Partial<GmailCheckStateMessage> = {},
+): GmailCheckStateMessage {
+  return { mailboxEmail: FIXTURE_MAILBOX, id, to: [FIXTURE_MAILBOX], bodyOmitted: true, ...parts };
+}
+
+export function systemLabel(name: string): GmailCheckStateLabel {
+  // System labels carry `id === name`. Building them any other way would make a
+  // fixture that the twin's own export could never produce.
+  return { mailboxEmail: FIXTURE_MAILBOX, id: name, name, type: "system" };
+}
+
+export function userLabel(id: string, name: string): GmailCheckStateLabel {
+  return { mailboxEmail: FIXTURE_MAILBOX, id, name, type: "user" };
+}
+
+export function messageLabel(messageId: string, labelId: string): GmailCheckStateMessageLabel {
+  return { mailboxEmail: FIXTURE_MAILBOX, messageId, labelId };
+}
+
+export function draft(id: string, messageId: string): GmailCheckStateDraft {
+  return { mailboxEmail: FIXTURE_MAILBOX, id, messageId };
+}
+
+/** A draft plus the message its addressing lives on — the pair, because either
+ *  alone is a world the export could not produce. */
+export function draftAddressedTo(
+  id: string,
+  recipients: string[],
+): { draft: GmailCheckStateDraft; message: GmailCheckStateMessage } {
+  const messageId = `${id}_message`;
+  return {
+    draft: draft(id, messageId),
+    message: message(messageId, { to: recipients }),
+  };
+}

--- a/packages/twin-gmail/src/checks.ts
+++ b/packages/twin-gmail/src/checks.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The Gmail twin's assertable check vocabulary (F-1128, milestone A3).
+//
+// These live HERE, next to the state they read, because the twin owns that
+// state's shape. pome-cloud imports this module from npm and adapts each
+// declaration onto its predicate engine, so there is no second copy to
+// reconcile — only a pin that can fall behind, which is what its drift gate
+// exists to catch. The cloud's `deterministic/gmail.ts`, and the mirror of the
+// state shape inside it, are deleted in the same milestone.
+//
+// Gmail comes third in A3 and is the first that needed PLUMBING before
+// vocabulary: unlike slack and stripe it had no in-process seed loader in the
+// control plane at all, so every gmail criterion reported `no_seed_loader` —
+// not a wrong verdict, an absent one. Six criteria across tasks 22, 23 and 27
+// resolved zero of six before this.
+//
+// This file is the ASSEMBLY. Declarations are grouped by what they assert about
+// — `check-messages.ts`, `check-labels.ts`, `check-drafts.ts`, `check-tape.ts` —
+// with typed slots in `check-params.ts`, fixture worlds in `check-worlds.ts`,
+// and the reading of the exported tree in `check-state.ts`.
+
+import { draftAddressedTo, draftCountAtLeast } from "./check-drafts.js";
+import { labelExists } from "./check-labels.js";
+import { mailboxLabelCount, messageHasLabel, oneMessagePerRecipient } from "./check-messages.js";
+import { noUnsupportedEndpoint } from "./check-tape.js";
+
+export type { Check } from "./check-kind.js";
+export type {
+  GmailCheckState,
+  GmailCheckStateDraft,
+  GmailCheckStateLabel,
+  GmailCheckStateMailbox,
+  GmailCheckStateMessage,
+  GmailCheckStateMessageLabel,
+} from "./check-state.js";
+
+// Order is not first-match-wins — the generated patterns are anchored and
+// mutually exclusive, and `checks-contract.test.ts` proves no sentence is
+// claimed by two. It is the order an authoring surface lists them in, running
+// from the assertion an author reaches for first to the ones a specialised task
+// needs.
+export const GMAIL_CHECKS = [
+  messageHasLabel,
+  labelExists,
+  draftAddressedTo,
+  draftCountAtLeast,
+  mailboxLabelCount,
+  oneMessagePerRecipient,
+  // Last, because these are the only ones that assert about the RUN rather than
+  // the world it left behind — twin-github orders its tape checks the same way.
+  noUnsupportedEndpoint,
+] as const;

--- a/packages/twin-gmail/src/index.ts
+++ b/packages/twin-gmail/src/index.ts
@@ -1,6 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 export { GmailDomain } from "./domain/index.js";
 export type { DraftResource, FilterResource, LabelResource } from "./domain/index.js";
+// F-1128 — the declared check vocabulary. Re-exported here on twin-slack's
+// pattern; `@pome-sh/twin-gmail/checks` also resolves through the manifest's
+// `"./*"` wildcard, which is the subpath pome-cloud and the CLI import.
+export { GMAIL_CHECKS } from "./checks.js";
+export type {
+  Check,
+  GmailCheckState,
+  GmailCheckStateDraft,
+  GmailCheckStateLabel,
+  GmailCheckStateMailbox,
+  GmailCheckStateMessage,
+  GmailCheckStateMessageLabel,
+} from "./checks.js";
 export { openGmailTwinDatabase, migrate, resetDatabase } from "./db.js";
 export { GmailError, gmailErrorEnvelope } from "./errors.js";
 export { DEFAULT_GMAIL_EMAIL, identityFromSession, resolveUserEmail } from "./identity.js";

--- a/packages/twin-gmail/test/check-state.test.ts
+++ b/packages/twin-gmail/test/check-state.test.ts
@@ -1,0 +1,197 @@
+// How a declared check reads the exported Gmail mailbox (F-1128).
+//
+// These are the shapes that produce a WRONG VERDICT if read naively, so each
+// case names the verdict it prevents rather than the field it touches.
+
+import { describe, expect, it } from "vitest";
+import {
+  draftRecipients,
+  isTruncated,
+  labelIdsFor,
+  messageCarriesLabel,
+  resolveLabelByName,
+  resolveMessage,
+  type GmailCheckState,
+} from "../src/check-state.js";
+
+const MB = "pome-agent@pome-twin.test";
+
+function state(overrides: Partial<GmailCheckState> = {}): GmailCheckState {
+  return {
+    mailboxes: [{ email: MB }],
+    messages: [{ mailboxEmail: MB, id: "msg_support", to: [MB], subject: "Production export is stuck" }],
+    drafts: [],
+    labels: [
+      { mailboxEmail: MB, id: "INBOX", name: "INBOX", type: "system" },
+      { mailboxEmail: MB, id: "Label_follow_up", name: "Follow Up", type: "user" },
+    ],
+    messageLabels: [{ mailboxEmail: MB, messageId: "msg_support", labelId: "INBOX" }],
+    exportBounds: { messageBodiesOmitted: true, largeMailbox: false, truncatedCollections: [] },
+    ...overrides,
+  };
+}
+
+describe("resolveMessage", () => {
+  it("finds a message by id", () => {
+    const found = resolveMessage(state(), "msg_support");
+    expect("found" in found && found.found.subject).toBe("Production export is stuck");
+  });
+
+  it("says state_incomplete when the collection is absent, rather than not_found", () => {
+    // A negative criterion must not score a free pass over an export that never
+    // carried the collection. The two are different facts and get different names.
+    expect(resolveMessage(state({ messages: null }), "msg_support")).toEqual({
+      missing: "state_incomplete",
+    });
+  });
+
+  it("says message_not_found when the collection is present but the id is not", () => {
+    expect(resolveMessage(state(), "msg_ghost")).toEqual({
+      missing: 'message_not_found ("msg_ghost")',
+    });
+  });
+
+  it("refuses an id that appears in more than one mailbox", () => {
+    // Gmail ids are minted per mailbox, so `deliveryMode: "seeded-mailboxes"` can
+    // put the same id in two. Grading whichever sorted first is the first-match
+    // -wins defect github's `{repo}` slot exists to close; gmail's sentences carry
+    // no mailbox, so the honest move is to refuse.
+    const two = state({
+      mailboxes: [{ email: MB }, { email: "other@pome-twin.test" }],
+      messages: [
+        { mailboxEmail: MB, id: "msg_support" },
+        { mailboxEmail: "other@pome-twin.test", id: "msg_support" },
+      ],
+    });
+    expect(resolveMessage(two, "msg_support")).toEqual({
+      missing: 'message_ambiguous ("msg_support" exists in 2 mailboxes)',
+    });
+  });
+
+  it("refuses when the messages collection was truncated and the id is absent", () => {
+    // Absent-from-a-truncated-collection is not absent. Reporting `not_found`
+    // here would false-fail a correct agent on a large mailbox.
+    const big = state({
+      exportBounds: { messageBodiesOmitted: true, largeMailbox: true, truncatedCollections: ["messages"] },
+    });
+    expect(resolveMessage(big, "msg_ghost")).toEqual({
+      missing: 'collection_truncated ("messages")',
+    });
+  });
+
+  it("still resolves a message that survived truncation", () => {
+    const big = state({
+      exportBounds: { messageBodiesOmitted: true, largeMailbox: true, truncatedCollections: ["messages"] },
+    });
+    expect("found" in resolveMessage(big, "msg_support")).toBe(true);
+  });
+});
+
+describe("labelIdsFor", () => {
+  it("matches a user label by its id, which is what the corpus names", () => {
+    expect(labelIdsFor(state(), "Label_follow_up").has("label_follow_up")).toBe(true);
+  });
+
+  it("also matches a user label by its display name", () => {
+    // The seed writes `{ id: "Label_follow_up", name: "Follow Up" }`, and an
+    // author may reasonably name either. The twin's own seeder keys its lookup on
+    // the lower-cased NAME, so this follows the twin rather than inventing a rule.
+    expect(labelIdsFor(state(), "Follow Up").has("label_follow_up")).toBe(true);
+  });
+
+  it("matches a system label, whose id and name are the same string", () => {
+    expect(labelIdsFor(state(), "INBOX").has("inbox")).toBe(true);
+  });
+
+  it("keeps the bare wanted value, so a truncated labels collection still joins", () => {
+    // `messageLabels` rows carry the bare label id even when `labels` is capped.
+    expect(labelIdsFor({ ...state(), labels: null }, "SENT").has("sent")).toBe(true);
+  });
+});
+
+describe("messageCarriesLabel", () => {
+  it("reads the join, not a nested field", () => {
+    expect(messageCarriesLabel(state(), "msg_support", "INBOX")).toEqual({ found: true });
+  });
+
+  it("answers false for a label the message does not carry", () => {
+    expect(messageCarriesLabel(state(), "msg_support", "Label_follow_up")).toEqual({ found: false });
+  });
+
+  it("says state_incomplete when messageLabels is absent", () => {
+    expect(messageCarriesLabel(state({ messageLabels: null }), "msg_support", "INBOX")).toEqual({
+      missing: "state_incomplete",
+    });
+  });
+
+  it("refuses when messageLabels was truncated", () => {
+    const big = state({
+      exportBounds: {
+        messageBodiesOmitted: true,
+        largeMailbox: true,
+        truncatedCollections: ["messageLabels"],
+      },
+    });
+    expect(messageCarriesLabel(big, "msg_support", "Label_follow_up")).toEqual({
+      missing: 'collection_truncated ("messageLabels")',
+    });
+  });
+});
+
+describe("resolveLabelByName", () => {
+  it("matches on the display name, case-insensitively", () => {
+    // "A label named X exists" asks about the NAME. The twin's seeder lower-cases
+    // for its own uniqueness lookup, so this matches the twin's notion of same.
+    const hit = resolveLabelByName(state(), "follow up");
+    expect("found" in hit && hit.found.id).toBe("Label_follow_up");
+  });
+
+  it("does not match on the id, so an author cannot mistake one for the other", () => {
+    expect(resolveLabelByName(state(), "Label_follow_up")).toEqual({
+      missing: 'label_not_found ("Label_follow_up")',
+    });
+  });
+
+  it("says state_incomplete when labels is absent", () => {
+    expect(resolveLabelByName(state({ labels: null }), "Follow Up")).toEqual({
+      missing: "state_incomplete",
+    });
+  });
+});
+
+describe("draftRecipients", () => {
+  it("joins the draft to its backing message, where the addressing actually lives", () => {
+    // The exported `drafts` row is {mailboxEmail, id, messageId, createdAt,
+    // updatedAt} — no recipient anywhere on it. A predicate that read the draft
+    // row alone would answer "no draft is addressed to anyone", always.
+    const withDraft = state({
+      drafts: [{ mailboxEmail: MB, id: "draft_ack", messageId: "draft_ack_message" }],
+      messages: [
+        { mailboxEmail: MB, id: "msg_support", to: [MB] },
+        { mailboxEmail: MB, id: "draft_ack_message", to: ["bob@example.com"], cc: ["carol@example.com"] },
+      ],
+    });
+    expect(draftRecipients(withDraft, withDraft.drafts![0]!)).toEqual([
+      "bob@example.com",
+      "carol@example.com",
+    ]);
+  });
+
+  it("returns nothing for a draft whose message did not survive the export", () => {
+    const orphan = state({ drafts: [{ mailboxEmail: MB, id: "draft_x", messageId: "gone" }] });
+    expect(draftRecipients(orphan, orphan.drafts![0]!)).toEqual([]);
+  });
+});
+
+describe("isTruncated", () => {
+  it("is false when nothing was capped", () => {
+    expect(isTruncated(state(), "messages")).toBe(false);
+  });
+
+  it("tolerates an export with no bounds block at all", () => {
+    // Older snapshots predate `exportBounds`. Treating absence as "truncated"
+    // would skip every criterion on them; treating it as "not truncated" is the
+    // same answer a pre-cap export would have given honestly.
+    expect(isTruncated(state({ exportBounds: null }), "messages")).toBe(false);
+  });
+});

--- a/packages/twin-gmail/test/checks-contract.test.ts
+++ b/packages/twin-gmail/test/checks-contract.test.ts
@@ -1,0 +1,406 @@
+// The properties every declared check must hold, carried across from
+// twin-slack when Gmail's vocabulary moved out of pome-cloud (F-1128).
+//
+// These are load-bearing, not ceremony: D10 and D11 were both caught by the
+// mutant assertions, and reverting a mutant to a resolved selector left that
+// suite green until the honest-null ledger existed. They travel with the
+// declaration so the twin, not its consumer, is where a bad check is stopped.
+
+import {
+  checkNearMissPattern,
+  checkPattern,
+  parseCheck,
+  probeDiscrimination,
+  renderCheck,
+  type CheckDefinition,
+  type CheckSubstrateKind,
+} from "@pome-sh/sdk/checks";
+import { describe, expect, it } from "vitest";
+import { GMAIL_CHECKS, type GmailCheckState } from "../src/checks.js";
+import { draftAddressedTo, draftCountAtLeast } from "../src/check-drafts.js";
+import { labelExists } from "../src/check-labels.js";
+import {
+  mailboxLabelCount,
+  messageHasLabel,
+  oneMessagePerRecipient,
+} from "../src/check-messages.js";
+import { noUnsupportedEndpoint } from "../src/check-tape.js";
+
+// The declarations are a heterogeneous tuple, so iterating them yields a union
+// whose args type differs per check, while the fixtures below are looked up by
+// id at run time. That tie cannot be made statically — erase it once here
+// rather than casting at a dozen call sites.
+type OpenCheck = CheckDefinition<GmailCheckState, Record<string, string>>;
+const CHECKS = GMAIL_CHECKS as readonly unknown[] as readonly OpenCheck[];
+
+// Representative args per check, used to exercise render/parse/mutant. The
+// coverage assertion below makes this table impossible to forget: a new check
+// with no fixture fails rather than silently skipping every property here.
+const FIXTURES: Record<string, Record<string, string>> = {
+  "gmail.message-has-label": { message: "msg_support", label: "Label_follow_up" },
+  "gmail.label-exists": { label: "Parity Complete" },
+  "gmail.draft-addressed-to": { email: "alice@example.com" },
+  "gmail.draft-count-at-least": { count: "two" },
+  "gmail.mailbox-label-count": { mailbox: "pome-agent@pome-twin.test", count: "5", label: "SENT" },
+  "gmail.one-message-per-recipient": { label: "SENT", count: "five" },
+  "gmail.no-unsupported-endpoint": {},
+};
+
+// Every check whose `vacuityMutant` returns null, WITH the reason. A null
+// mutant is an admitted blind spot; admitting it in a ledger is what keeps it
+// from becoming a habit.
+//
+// There are exactly two arguments that earn a line here:
+//   1. THE PARAMETER ONLY SELECTS. Falsifying it moves the verdict for a reason
+//      that never reaches the assertion — a clean bill the check did not earn.
+//   2. THE PARAMETER IS A CLOSED SET. Typing a slot as `oneOf` means no member
+//      is guaranteed false, so a mutant could assert a different state that
+//      happens to be true as well.
+//
+// Gmail earns exactly one line, and it is argument-shaped rather than
+// slot-shaped: every other check here has a scanned literal to point at. Note
+// what is NOT listed — `gmail.draft-count-at-least` has one slot and it is a
+// number, and it still declares a real mutant, because that number is compared
+// rather than resolved. See its declaration for the D10 argument.
+const HONEST_NULL_MUTANTS: Record<string, string> = {
+  "gmail.no-unsupported-endpoint":
+    "the sentence has no slots at all; the trigger is a fidelity stamp on the tape, which no " +
+    "mutation of the criterion text can reach",
+};
+
+// twin-github ledgers REPO_FREE_CHECKS here, and twin-slack argues its absence.
+// Gmail's answer is a THIRD one, and it is worth writing down because it is the
+// only place in the vocabulary where a scoping decision was made at runtime
+// instead of in the grammar.
+//
+// GitHub's repo rule exists because its legacy patterns took `in owner/repo` as
+// an optional qualifier and, absent it, scanned repositories first-match-wins —
+// so a two-repo world silently graded whichever sorted first. Slack escaped the
+// rule: one workspace, channel names unique within it, no ambiguous selection.
+//
+// Gmail cannot escape it that way. Ids are minted PER MAILBOX (`nextId(db,
+// mailboxId, …)`), and `deliveryMode: "seeded-mailboxes"` really can put
+// `msg_support` in two of them. But adding a `{mailbox}` slot to every template
+// would stop all six shipped corpus criteria binding, and they carry no mailbox
+// because in `sender-only` mode there is exactly one.
+//
+// So the ambiguity is closed in `resolveMessage` instead of in the grammar: an
+// id present in more than one mailbox returns `message_ambiguous` and the
+// criterion leaves the denominator. That is strictly stronger than a slot would
+// be for the single-mailbox case and identical to it for the ambiguous one —
+// and unlike a slot, it cannot be filled in wrongly by an author.
+//
+// `gmail.mailbox-label-count` is the exception that names its mailbox, because
+// its sentence is ABOUT a mailbox's contents rather than about one message.
+
+const SUBSTRATES: CheckSubstrateKind[] = ["final", "seed+final", "tape"];
+
+describe("declared check identity", () => {
+  it("declares a non-empty, twin-prefixed id for every check", () => {
+    for (const check of CHECKS) {
+      expect(check.id, "every check needs an id").toBeTruthy();
+      expect(check.id.startsWith("gmail."), `${check.id} must be namespaced <twin>.<what>`).toBe(
+        true,
+      );
+    }
+  });
+
+  it("keeps ids unique across the twin's declarations", () => {
+    const seen = new Set<string>();
+    const duplicates: string[] = [];
+    for (const check of CHECKS) {
+      if (seen.has(check.id)) duplicates.push(check.id);
+      seen.add(check.id);
+    }
+    expect(duplicates, `duplicate check ids: ${duplicates.join(", ")}`).toEqual([]);
+  });
+
+  it("declares polarity and a vacuity mutant on every check", () => {
+    for (const check of CHECKS) {
+      expect(typeof check.polarity, `${check.id}.polarity`).toBe("function");
+      expect(typeof check.vacuityMutant, `${check.id}.vacuityMutant`).toBe("function");
+    }
+  });
+
+  it("declares a known substrate on every check", () => {
+    for (const check of CHECKS) {
+      expect(SUBSTRATES, `${check.id}.substrate`).toContain(check.substrate);
+    }
+  });
+
+  it("has a fixture for every check, so no check skips the properties below", () => {
+    const missing = CHECKS.filter((check) => !FIXTURES[check.id]).map((check) => check.id);
+    expect(missing, `checks with no FIXTURES entry: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  it("says what the predicate actually compares, in words the sentence does not carry", () => {
+    // The one defect this architecture makes EASIER, not harder: a rendered
+    // sentence wider or narrower than its check (Shankar et al., UIST '24
+    // §7.3.3 — readable surfaces hide the disagreement code makes visible).
+    // `A label named X exists` reads as a claim about the mailbox's whole label
+    // set; the predicate compares display names only and says nothing about ids.
+    for (const check of CHECKS) {
+      expect(check.description?.trim(), `${check.id} declares no description`).toBeTruthy();
+      expect(
+        check.description.trim(),
+        `${check.id}'s description just restates its template — it must say what the ` +
+          `predicate COMPARES, which is the thing the sentence cannot carry`,
+      ).not.toBe(check.template);
+    }
+  });
+});
+
+describe("declared check grammar", () => {
+  it("round-trips render -> parse -> render byte-identically", () => {
+    for (const check of CHECKS) {
+      const args = FIXTURES[check.id]!;
+      const rendered = renderCheck(check, args);
+      const parsed = parseCheck(check, rendered);
+      expect(parsed, `${check.id}: its own rendered sentence must parse`).toEqual(args);
+      expect(renderCheck(check, parsed!), `${check.id}: round trip changed the bytes`).toBe(
+        rendered,
+      );
+    }
+  });
+
+  it("binds its own rendered sentence and nothing wider", () => {
+    for (const check of CHECKS) {
+      const rendered = renderCheck(check, FIXTURES[check.id]!);
+      expect(checkPattern(check).test(rendered), `${check.id} must match itself`).toBe(true);
+      expect(
+        checkPattern(check).test(`${rendered} and also something else`),
+        `${check.id} is not anchored`,
+      ).toBe(false);
+    }
+  });
+
+  it("treats its own rendered sentence as a match, never as a near miss", () => {
+    for (const check of CHECKS) {
+      const rendered = renderCheck(check, FIXTURES[check.id]!);
+      expect(checkNearMissPattern(check).test(rendered)).toBe(true);
+      expect(checkPattern(check).test(rendered)).toBe(true);
+    }
+  });
+
+  it("binds no OTHER check's valid sentence", () => {
+    // Two checks that both claim one sentence is the wrong-match bug the
+    // exhaustive invariant (D6) exists to compute — this is its per-twin half,
+    // held here so a new declaration cannot ship broken and be caught only
+    // downstream. Gmail's sharpest case: `A label named {label} exists` and
+    // `A draft addressed to {email} exists` share the trailing ` exists`, and
+    // only their opening literals keep them apart.
+    for (const check of CHECKS) {
+      const rendered = renderCheck(check, FIXTURES[check.id]!);
+      const claimants = CHECKS.filter((other) => checkPattern(other).test(rendered)).map(
+        (other) => other.id,
+      );
+      expect(claimants, `"${rendered}" is claimed by more than one check`).toEqual([check.id]);
+    }
+  });
+
+  it("reports a corrupted instance as its OWN check, not a neighbour's", () => {
+    // Near-miss patterns open every slot to `.+?`, so a broad template can
+    // shadow a narrow one and a corrupted sentence gets reported under the
+    // wrong name — an error message pointing an author at a check they did not
+    // use.
+    for (const check of CHECKS) {
+      const rendered = renderCheck(check, FIXTURES[check.id]!);
+      const resemblers = CHECKS.filter((other) =>
+        checkNearMissPattern(other).test(rendered),
+      ).map((other) => other.id);
+      expect(resemblers, `"${rendered}" resembles more than one check's template`).toEqual([
+        check.id,
+      ]);
+    }
+  });
+});
+
+describe("declared vacuity mutants", () => {
+  it("either produces a re-bindable mutant sentence, or admits a null in the ledger", () => {
+    for (const check of CHECKS) {
+      const args = FIXTURES[check.id]!;
+      const mutantArgs = check.vacuityMutant(args);
+
+      if (mutantArgs === null) {
+        expect(
+          HONEST_NULL_MUTANTS[check.id],
+          `${check.id} returns a null mutant but gives no reason in HONEST_NULL_MUTANTS. ` +
+            `A check with no falsifiable literal is an admitted blind spot; admit it here.`,
+        ).toBeTruthy();
+        continue;
+      }
+
+      expect(
+        HONEST_NULL_MUTANTS[check.id],
+        `${check.id} produces a mutant but is still listed in HONEST_NULL_MUTANTS — stale entry`,
+      ).toBeUndefined();
+
+      const original = renderCheck(check, args);
+      const mutant = renderCheck(check, mutantArgs);
+      expect(mutant, `${check.id}: the mutant must differ from the sentence it falsifies`).not.toBe(
+        original,
+      );
+      expect(
+        parseCheck(check, mutant),
+        `${check.id}: the mutant must still bind to this check, or the probe measures nothing`,
+      ).toEqual(mutantArgs);
+    }
+  });
+
+  it("points every mutant at a world where the check genuinely fails", () => {
+    // The mutant assertion above proves the SENTENCE re-binds. It does not prove
+    // the mutated sentence is actually false, and a mutant that stays true is a
+    // clean bill the check did not earn — the precise defect D10 names. Run each
+    // mutant against its own PASSING world: the unmutated args pass there by
+    // construction, so anything the mutant does differently is the mutation's
+    // doing and nothing else's.
+    for (const check of CHECKS) {
+      const args = FIXTURES[check.id]!;
+      const mutantArgs = check.vacuityMutant(args);
+      if (mutantArgs === null) continue;
+      const worlds = check.discriminatingWorlds(args);
+      if (worlds === null) continue;
+      const outcome = check.evaluate(mutantArgs, worlds.passing);
+      expect(
+        outcome.passed,
+        `${check.id}: the mutant "${renderCheck(check, mutantArgs)}" still PASSES in the world ` +
+          `where the original passes, so falsifying the literal changed nothing`,
+      ).toBe(false);
+    }
+  });
+});
+
+// Every check that declines to name a failing world, WITH the reason.
+//
+// It is EMPTY, and that is the claim (F-1126, carried forward). A world is a
+// hand-written fixture and every field of `CheckSubstrate` is hand-fillable, so
+// an entry in this ledger is an admission that a check may not be able to fail —
+// which is the thing the whole vocabulary exists to rule out.
+//
+// Keep it empty. If a future check needs a line, argue it in writing here.
+const HONEST_NULL_WORLDS: Record<string, string> = {};
+
+describe("declared discriminating worlds", () => {
+  it("names a passing and a failing world for every check, or admits a null in the ledger", () => {
+    for (const check of CHECKS) {
+      const args = FIXTURES[check.id]!;
+      const verdict = probeDiscrimination(check, args);
+
+      if (verdict.kind === "declined") {
+        expect(
+          HONEST_NULL_WORLDS[check.id],
+          `${check.id} names no worlds and gives no reason in HONEST_NULL_WORLDS. A check ` +
+            `that cannot demonstrate a failing world may not be able to fail at all.`,
+        ).toBeTruthy();
+        continue;
+      }
+
+      expect(
+        HONEST_NULL_WORLDS[check.id],
+        `${check.id} names its worlds but is still listed in HONEST_NULL_WORLDS — stale entry`,
+      ).toBeUndefined();
+
+      expect(
+        verdict.kind === "broken"
+          ? `${check.id}: ${verdict.arm} — ${verdict.detail}`
+          : "discriminates",
+      ).toBe("discriminates");
+    }
+  });
+
+  it("ships an EMPTY null-worlds ledger", () => {
+    // Not ceremony. The moment this has an entry, the gate's guarantee weakens
+    // from "every check can fail" to "every check can fail or said why not", and
+    // that change should require editing this assertion on purpose.
+    expect(Object.keys(HONEST_NULL_WORLDS)).toEqual([]);
+  });
+
+  it("puts each world on the substrate the check declared", () => {
+    for (const check of CHECKS) {
+      const worlds = check.discriminatingWorlds?.(FIXTURES[check.id]!) ?? null;
+      if (worlds === null) continue;
+      for (const [side, world] of Object.entries(worlds)) {
+        if (check.substrate === "seed+final") {
+          expect(
+            world.seed,
+            `${check.id}.${side} declares seed+final but names no seed`,
+          ).not.toBeNull();
+        }
+        if (check.substrate === "tape") {
+          expect(world.tape, `${check.id}.${side} declares tape but names none`).not.toBeNull();
+        }
+      }
+    }
+  });
+});
+
+describe("migrated sentences", () => {
+  it("renders the six criteria A3 found unbound, byte-identically", () => {
+    // These are the EXACT strings in `cli/tasks/22-gmail-inbox-triage.md`,
+    // `23-gmail-first-party-parity.md` and
+    // `27-gmail-github-support-escalation.md`, and the whole point of the
+    // migration is that it does not rewrite one of them. If a template drifts,
+    // the corpus stops binding and the D6 arm goes red in pome-cloud instead of
+    // here — one repo too late, and after a release.
+    expect(renderCheck(messageHasLabel, { message: "msg_support", label: "Label_follow_up" })).toBe(
+      "Message msg_support has label Label_follow_up",
+    );
+    expect(renderCheck(draftAddressedTo, { email: "alice@example.com" })).toBe(
+      "A draft addressed to alice@example.com exists",
+    );
+    expect(renderCheck(messageHasLabel, { message: "msg_parity", label: "STARRED" })).toBe(
+      "Message msg_parity has label STARRED",
+    );
+    expect(renderCheck(labelExists, { label: "Parity Complete" })).toBe(
+      "A label named Parity Complete exists",
+    );
+    expect(renderCheck(draftCountAtLeast, { count: "two" })).toBe("At least two drafts exist");
+  });
+
+  it("renders one sentence for the criterion tasks 22 and 27 SHARE", () => {
+    // `Message msg_support has label Label_follow_up` appears in both, so one
+    // check clears both — the same way `github.no-new-labels` cleared five. The
+    // corpus scan's allowlist is keyed by exact phrase text for this reason.
+    const rendered = renderCheck(messageHasLabel, {
+      message: "msg_support",
+      label: "Label_follow_up",
+    });
+    expect(rendered).toBe("Message msg_support has label Label_follow_up");
+  });
+
+  it("re-renders the two criteria carried across from pome-cloud's regexes", () => {
+    // `examples/gmail-retry-notify/tasks/01-throttled-send.md`. The legacy
+    // patterns were case-insensitive and accepted a trailing period, `labelled`,
+    // and three quote styles; the generated pattern is anchored and
+    // case-sensitive, so that task file is rewritten in this same commit.
+    expect(
+      renderCheck(mailboxLabelCount, {
+        mailbox: "pome-agent@pome-twin.test",
+        count: "5",
+        label: "SENT",
+      }),
+    ).toBe("The mailbox `pome-agent@pome-twin.test` has exactly 5 messages labeled SENT");
+    expect(renderCheck(oneMessagePerRecipient, { label: "SENT", count: "five" })).toBe(
+      "Exactly one SENT message is addressed to each of the five recipients",
+    );
+  });
+
+  it("renders the tape check WITHOUT a twin word, matching github's", () => {
+    // The legacy cloud rule accepted "No unsupported Gmail endpoint was called"
+    // and the bare form alike. Under position 2 an author picks the check, so
+    // the variants are retired and both twins now say the same sentence — the
+    // engine resolves it per-twin.
+    expect(renderCheck(noUnsupportedEndpoint, {})).toBe("No unsupported endpoint was called");
+  });
+
+  it("keeps the zero-count form of mailboxLabelCount reading as a prohibition", () => {
+    // The count carries the direction, which is the one place in this vocabulary
+    // where polarity is a function of the args rather than a constant.
+    expect(mailboxLabelCount.polarity({ mailbox: "a@b.test", count: "0", label: "SENT" })).toBe(
+      "negative",
+    );
+    expect(mailboxLabelCount.polarity({ mailbox: "a@b.test", count: "5", label: "SENT" })).toBe(
+      "positive",
+    );
+  });
+});

--- a/packages/twin-gmail/test/fidelity-contract.test.ts
+++ b/packages/twin-gmail/test/fidelity-contract.test.ts
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// State-shape parity for the declared check vocabulary (F-1128).
+//
+// SCOPE, deliberately narrow: the tool-list / fidelity.inventory.json / REST
+// rings already run for this twin through `scripts/fidelity-parity.ts`
+// (`npm run fidelity:parity -w @pome-sh/twin-gmail` in CI). Re-asserting them
+// here would be the second drift gate F-1128 was told not to build. What was
+// MISSING is the arm below: nothing checked that `exportGmailState()` still
+// carries the fields `check-state.ts` reads.
+//
+// That absence is exactly why pome-cloud's hand-maintained mirror of this shape
+// could drift for a milestone with nothing to notice. twin-slack added the same
+// arm in F-1126 and it caught a real field on its first run (`user` vs
+// `user_id`); this is the gmail half of that lesson.
+
+import { describe, expect, it } from "vitest";
+import { openGmailTwinDatabase } from "../src/db.js";
+import { GmailDomain } from "../src/domain/index.js";
+import { defaultSeedState, parseSeed } from "../src/seed.js";
+import {
+  draftRecipients,
+  messageCarriesLabel,
+  resolveLabelByName,
+  resolveMessage,
+  type GmailCheckState,
+} from "../src/check-state.js";
+import { draftAddressedTo, draftCountAtLeast } from "../src/check-drafts.js";
+import { labelExists } from "../src/check-labels.js";
+import { messageHasLabel } from "../src/check-messages.js";
+
+// The same composition pome-cloud's `LOADERS.gmail` performs: open an in-memory
+// database, seed it, export. If this drifts, the cloud's author-time door drifts
+// with it.
+function exported(seed: unknown = defaultSeedState()): GmailCheckState {
+  const db = openGmailTwinDatabase(":memory:");
+  try {
+    const domain = new GmailDomain(db);
+    domain.seed(parseSeed(seed));
+    return domain.exportState() as unknown as GmailCheckState;
+  } finally {
+    db.close();
+  }
+}
+
+describe("state-shape parity", () => {
+  it("finds every top-level key GmailCheckState names", () => {
+    const state = exported() as unknown as Record<string, unknown>;
+    for (const key of ["mailboxes", "messages", "drafts", "labels", "messageLabels", "exportBounds"]) {
+      expect(state, `exportGmailState() no longer produces "${key}"`).toHaveProperty(key);
+    }
+  });
+
+  it("finds every message field the model reads, on a real exported row", () => {
+    const messages = exported().messages!;
+    expect(messages.length).toBeGreaterThan(0);
+    for (const field of ["mailboxEmail", "id", "to", "subject"]) {
+      expect(messages[0]!, `exported messages no longer carry "${field}"`).toHaveProperty(field);
+    }
+  });
+
+  it("confirms message bodies really are digested away, never readable", () => {
+    // The constraint that rules out a whole class of check on this twin. If the
+    // twin ever started exporting `text`, a body-scanning check would become
+    // possible — and `check-state.ts`'s comment saying it is not would be a lie.
+    const message = exported().messages![0]! as unknown as Record<string, unknown>;
+    expect(message.bodyOmitted).toBe(true);
+    expect(message).not.toHaveProperty("text");
+    expect(message).not.toHaveProperty("html");
+    expect(message).not.toHaveProperty("snippet");
+  });
+
+  it("confirms `to` really arrives as a parsed ARRAY, not a JSON string", () => {
+    // The export selects `to_json AS "to"` and its `rows()` helper JSON-parses
+    // it. A predicate written against a string would silently match nothing.
+    const message = exported().messages!.find((m) => (m.to ?? []).length > 0);
+    expect(Array.isArray(message!.to)).toBe(true);
+  });
+
+  it("confirms labels are a flat JOIN, not nested under their message", () => {
+    // `messageLabels` is keyed by `messageId`/`labelId` at the top level. A
+    // predicate that assumed nesting would find none — the same trap slack's
+    // reactions carry.
+    const state = exported();
+    expect(state.messageLabels!.length).toBeGreaterThan(0);
+    for (const field of ["mailboxEmail", "messageId", "labelId"]) {
+      expect(state.messageLabels![0]!, `messageLabels rows no longer carry "${field}"`).toHaveProperty(field);
+    }
+    expect(state.messages![0]!).not.toHaveProperty("labels");
+    expect(state.messages![0]!).not.toHaveProperty("labelIds");
+  });
+
+  it("confirms a user label's id and display name really do differ", () => {
+    // `Label_follow_up` / `Follow Up`. This is the whole reason
+    // `gmail.message-has-label` (id-or-name) and `gmail.label-exists` (name only)
+    // are two checks rather than one.
+    const label = exported().labels!.find((l) => l.type === "user");
+    expect(label, "the default seed defines no user label to check the shape against").toBeTruthy();
+    expect(label!.id).not.toBe(label!.name);
+  });
+
+  it("confirms a system label carries id === name", () => {
+    const inbox = exported().labels!.find((l) => l.id === "INBOX");
+    expect(inbox!.name).toBe("INBOX");
+  });
+
+  it("confirms a draft row carries NO addressing, only a message join key", () => {
+    // The shape that makes `gmail.draft-addressed-to` a join. If the twin ever
+    // put `to` on the draft row, the check would still work — but the comment
+    // explaining why it joins would be wrong, and the next reader would simplify
+    // it into a bug.
+    const draft = exported().drafts![0]! as unknown as Record<string, unknown>;
+    expect(draft).toHaveProperty("messageId");
+    expect(draft).not.toHaveProperty("to");
+    expect(draft).not.toHaveProperty("cc");
+  });
+
+  it("resolves a draft's recipients through the join, on a real export", () => {
+    const state = exported();
+    const recipients = draftRecipients(state, state.drafts![0]!);
+    expect(recipients.length).toBeGreaterThan(0);
+  });
+
+  it("reports no truncation on a seed this small", () => {
+    expect(exported().exportBounds!.truncatedCollections).toEqual([]);
+  });
+});
+
+describe("the declared checks, against a real exported mailbox", () => {
+  // The default seed IS the task-22-shaped inbox (`agentPathInboxMailbox`):
+  // an unread support mail from Alice, a `Follow Up` label defined but not
+  // applied, and one unsent draft. So the checks can be graded against a real
+  // export in-package, without reaching into `cli/tasks/` and inverting the
+  // dependency direction. The corpus-wide measurement is pome-cloud's job.
+  const state = exported();
+
+  it("reads msg_support out of a real export", () => {
+    expect("found" in resolveMessage(state, "msg_support")).toBe(true);
+  });
+
+  it("grades `Message msg_support has label Label_follow_up` FALSE on the seed", () => {
+    // A healthy FAIL_TO_PASS: the seed leaves the label defined but unapplied, so
+    // the examinee has to act. A criterion already satisfied by its own seed is
+    // one a do-nothing agent scores.
+    const verdict = messageHasLabel.evaluate(
+      { message: "msg_support", label: "Label_follow_up" },
+      { seed: null, final: state, tape: null },
+    );
+    expect(verdict.passed).toBe(false);
+    expect(verdict.status ?? "failed").toBe("failed");
+  });
+
+  it("grades that same criterion TRUE once the label is applied", () => {
+    // The other arm. Without it the case above proves only that the criterion CAN
+    // fail — not that it tells a labelling agent from an idle one.
+    const applied: GmailCheckState = {
+      ...state,
+      messageLabels: [
+        ...state.messageLabels!,
+        { mailboxEmail: state.mailboxes![0]!.email, messageId: "msg_support", labelId: "Label_follow_up" },
+      ],
+    };
+    const verdict = messageHasLabel.evaluate(
+      { message: "msg_support", label: "Label_follow_up" },
+      { seed: null, final: applied, tape: null },
+    );
+    expect(verdict.passed).toBe(true);
+  });
+
+  it("accepts the label by its DISPLAY NAME too, on the real export", () => {
+    expect(messageCarriesLabel(state, "msg_build", "Build")).toEqual({ found: true });
+  });
+
+  it("grades `A draft addressed to alice@example.com exists` FALSE on the seed", () => {
+    // The seed's one draft goes to somebody else, so this is a real positive.
+    const verdict = draftAddressedTo.evaluate(
+      { email: "alice@example.com" },
+      { seed: null, final: state, tape: null },
+    );
+    expect(verdict.passed).toBe(false);
+    expect(verdict.status ?? "failed").toBe("failed");
+  });
+
+  it("grades `A label named Follow Up exists` TRUE — the seed defines it", () => {
+    // `gmail.label-exists` asks about DEFINITION, not application. The seed
+    // defines `Follow Up` and applies it to nothing, and this check correctly
+    // says the label exists. That distinction is what its description exists to
+    // carry, and it is the same shape as `github.no-new-labels`.
+    const verdict = labelExists.evaluate(
+      { label: "Follow Up" },
+      { seed: null, final: state, tape: null },
+    );
+    expect(verdict.passed).toBe(true);
+    expect("found" in resolveLabelByName(state, "Follow Up")).toBe(true);
+  });
+
+  it("counts the seed's drafts, so an already-satisfied threshold is visible here", () => {
+    // `At least two drafts exist` is task 23's criterion, and task 23's seed
+    // ships two. The default seed ships one, so it fails here — the point of the
+    // assertion is that the count is READ from the export rather than assumed.
+    const verdict = draftCountAtLeast.evaluate(
+      { count: "two" },
+      { seed: null, final: state, tape: null },
+    );
+    expect(verdict.reason).toContain(`${state.drafts!.length} draft(s) exist`);
+    expect(verdict.passed).toBe(state.drafts!.length >= 2);
+  });
+});

--- a/packages/twin-gmail/vitest.config.ts
+++ b/packages/twin-gmail/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "vitest/config";
+
+// F-1128 — added so the `test` script can stop being a hand-maintained file
+// list. It was `vitest run <eight explicit paths>`, and `faults.test.ts` had
+// already fallen off it: a test file that exists, passes, and never ran in CI.
+// Three more files land in this milestone, so the list was one edit away from
+// silently not running the vocabulary's own contract suite.
+//
+// `include` is what makes the sweep safe: `test/gate0-fixtures.test.mjs` is a
+// `node --test` file that vitest's default glob claims and then fails on
+// ("No test suite found"). Restricting to `.test.ts` leaves it to the
+// `node --test` half of the script, which is what runs it today.
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    // The official-client and agent-path suites drive a real MCP handshake over
+    // a listening socket; on a contended CI runner the sequential round-trips
+    // can cross vitest's 5s default. Same budget the other first-party twins use.
+    testTimeout: 30_000,
+  },
+});


### PR DESCRIPTION
Executive summary: Gmail declares seven assertable checks, replacing pome-cloud's hand-written regexes and the mirror of Gmail's state shape that lived beside them. Six task criteria that bound nothing now bind — verified against the real corpus and graded against their real seeds, not argued. The riskiest part is not the vocabulary but the state model: an exported draft row carries no addressing at all, so the obvious predicate would have been a positive that can never pass.

## What

Seven `GMAIL_CHECKS` on a new `./checks` subpath, plus the `GmailCheckState` model they read.

Four are new and close the whole unbound set:

| check | binds |
|---|---|
| `gmail.message-has-label` | three criteria — two tasks say the same sentence about `msg_support`, a third says it about `msg_parity` |
| `gmail.label-exists` | `A label named Parity Complete exists` |
| `gmail.draft-addressed-to` | `A draft addressed to alice@example.com exists` |
| `gmail.draft-count-at-least` | `At least two drafts exist` |

Three are carried across from pome-cloud so deleting its `deterministic/gmail.ts` loses no coverage: `gmail.mailbox-label-count`, `gmail.one-message-per-recipient`, and the shared endpoint rule, which becomes `gmail.no-unsupported-endpoint` with `substrate: "tape"`.

`gmail` moves from `TWINS_WITHOUT_CHECKS` into the CLI's `REGISTRIES`, so `pome checks gmail` prints a vocabulary instead of "not migrated yet".

## Why

Gmail resolved 0 of 6 criteria. Those criteria were not scoring wrongly — they were not scoring at all, and a criterion that silently leaves the denominator shrinks the score without saying so.

Gmail is also the twin that needed plumbing before vocabulary: the control plane has no in-process seed loader for it, so every gmail criterion reports `no_seed_loader`. This PR is the twin half; the loader lands in the consumer once `@pome-sh/twin-gmail@0.3.0` is published.

## Notes for reviewer

**Start with `src/check-state.ts`.** Four export shapes drove every design decision, and each has a wrong-verdict story:

- **An exported draft row carries no addressing.** It is `{mailboxEmail, id, messageId, createdAt, updatedAt}`; the recipient lives on the backing message, reached through `messageId`. A predicate reading the draft row alone answers "no draft is addressed to anyone", always.
- **Message bodies are digested away unconditionally.** There is no gmail analogue of a body substring scan — no substrate to read. `subject` is the only prose that survives.
- **Labels are a flat JOIN**, and a user label's id and display name differ (`Label_follow_up` / `Follow Up`) while a system label's are one string. That difference is why `gmail.message-has-label` (id-or-name) and `gmail.label-exists` (name only) are two checks.
- **Ids are minted per mailbox**, so `seeded-mailboxes` mode can put one id in two. `resolveMessage` returns `message_ambiguous` rather than grading whichever sorted first. That closes GitHub's `{repo}` problem in the reader instead of the grammar — adding a mailbox slot would have stopped all six shipped criteria binding, since they carry no mailbox.

**Two declarations worth reading closely:**

`gmail.draft-addressed-to` declares its recipient as the check's `subject`. pome-cloud has carried a prediction since F-1028 that this exact criterion becomes an "unguarded" redaction hazard the day a gmail draft-recipient predicate lands without one — an email address is squarely inside what a team's redaction config may destroy, and unguarded means a vacuous verdict instead of an honest skip.

`gmail.draft-count-at-least` is the only check whose mutant carries the numeric sentinel, and the D10 argument is in the declaration. Everywhere else a numeric slot is a selector the predicate resolves before scanning; here the count is the only slot and is compared straight against a cardinality, so falsifying it moves the verdict through the assertion rather than around it.

**Two changes beyond the vocabulary, both deliberate:**

`examples/gmail-retry-notify/tasks/01-throttled-send.md` is rewritten. Generated patterns are anchored and case-sensitive; the legacy regexes accepted a trailing period, `labelled`, and three quote styles. Without this the example silently stops binding after release.

`vitest.config.ts` is new, replacing the `test` script's hand-maintained file list. `faults.test.ts` had already fallen off it — a suite that exists, passes, and never ran in CI. Three files land here, so the list was one edit from silently not running the vocabulary's own contract suite.

**One arm added to the contract suite beyond twin-slack's:** every mutant is run against its own passing world and must fail there. The inherited arm proves the mutant *sentence* re-binds; it does not prove the mutated sentence is false, and a mutant that stays true is a clean bill the check did not earn. It caught a real bug on first run.

## Tests / CI

Local, all green:

- `npm run build`, `npm run typecheck`
- `npm test` — 8 packages, 1884 tests (twin-gmail 124, up from 103)
- `cli` — 88 files, 782 tests, installed against locally-packed tarballs the way `cli-ci` does
- `npm run test:contract` and all nine lint/gate scripts, including `check-workspace-pins-match-workspace` and `check-cli-pins-match-workspace`
- `knip` clean

Verified rather than argued — the two things this PR actually claims:

1. **All six criteria bind.** Parsed straight out of `cli/tasks/*.md`: 6 bound, 0 unbound, each to exactly one check with correctly parsed args.
2. **They discriminate.** Booting each task's real seed and grading: five land `FAIL_TO_PASS` (healthy — the examinee must earn them). `At least two drafts exist` lands `PASS_TO_PASS`, because task 23's seed already ships two drafts. That is a property of the task, not the check; it earns a `KNOWN_NON_DISCRIMINATING` entry in the consumer rather than a seed edit, which would change what the task tests.

`pome checks gmail` was run end-to-end from a tarball install and prints all seven.

## Review required

Yes — this touches the public OSS API (new `./checks` subpath and its exported types) and the twin fidelity contract (`fidelity-contract.test.ts` gains a state-shape parity arm this twin never had).