### PR TITLE
Linear declares its vocabulary, and a rendered sentence names its subject (F-1129)

### DIFF
--- a/cli/.changeset/linear-declares-its-vocabulary.md
+++ b/cli/.changeset/linear-declares-its-vocabulary.md
@@ -1,0 +1,17 @@
+---
+"@pome-sh/cli": minor
+---
+
+`pome checks linear` answers with a vocabulary instead of "not migrated yet" —
+eight declared checks covering issue state, labels, estimate, assignee,
+comments, threaded replies, existence, and unsupported endpoint calls.
+
+Tasks 24, 25 and 26 are rewritten so every criterion names its own subject. A
+rendered sentence cannot say "that issue": under a picked check the author fills
+parameters, and a check only ever sees its own arguments. Each Linear check now
+names both the issue title and its team, because Linear validates title
+uniqueness per team rather than per workspace.
+
+Task 26 loses one criterion rather than gaining a subject: `linear.issue-state`
+fails when the issue is absent, so it already subsumes `An issue titled "..."
+exists`.

--- a/cli/package.json
+++ b/cli/package.json
@@ -69,7 +69,7 @@
     "@pome-sh/shared-types": "0.13.0",
     "@pome-sh/twin-gmail": "0.3.0",
     "@pome-sh/twin-github": "0.7.0",
-    "@pome-sh/twin-linear": "0.1.1",
+    "@pome-sh/twin-linear": "0.2.0",
     "@pome-sh/twin-slack": "0.3.0",
     "@pome-sh/twin-stripe": "0.4.0",
     "ai": "^7.0.18",

--- a/cli/src/cli/checks.ts
+++ b/cli/src/cli/checks.ts
@@ -45,7 +45,11 @@ const REGISTRIES: Record<string, readonly DeclaredCheck[]> = {
 // acceptance criterion. The day a sixth twin mounts, it repopulates itself and
 // the "not migrated yet" path comes back live without anyone remembering to add
 // a literal — which is the failure this project is named for, one level down.
-const TWINS_WITHOUT_CHECKS = MOUNTED_TWINS.filter((twin) => !(twin in REGISTRIES));
+// Annotated `string[]` on purpose: `MOUNTED_TWINS` is a literal-union tuple, so
+// the filtered result keeps that union and `isKnownTwin` cannot ask it about an
+// arbitrary string. Widening here is what keeps the caller's question — "is this
+// user-typed word a twin?" — expressible.
+const TWINS_WITHOUT_CHECKS: string[] = MOUNTED_TWINS.filter((twin) => !(twin in REGISTRIES));
 
 export function twinsWithChecks(): string[] {
   return Object.keys(REGISTRIES).sort();

--- a/cli/src/cli/checks.ts
+++ b/cli/src/cli/checks.ts
@@ -12,8 +12,10 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { checksDigest, templateSlots, type CheckDefinition } from "@pome-sh/sdk/checks";
+import { MOUNTED_TWINS } from "@pome-sh/shared-types";
 import { GITHUB_CHECKS } from "@pome-sh/twin-github/checks";
 import { GMAIL_CHECKS } from "@pome-sh/twin-gmail/checks";
+import { LINEAR_CHECKS } from "@pome-sh/twin-linear/checks";
 import { SLACK_CHECKS } from "@pome-sh/twin-slack/checks";
 import { STRIPE_CHECKS } from "@pome-sh/twin-stripe/checks";
 
@@ -28,16 +30,22 @@ const REGISTRIES: Record<string, readonly DeclaredCheck[]> = {
   slack: SLACK_CHECKS as readonly unknown[] as readonly DeclaredCheck[],
   stripe: STRIPE_CHECKS as readonly unknown[] as readonly DeclaredCheck[],
   gmail: GMAIL_CHECKS as readonly unknown[] as readonly DeclaredCheck[],
+  linear: LINEAR_CHECKS as readonly unknown[] as readonly DeclaredCheck[],
 };
 
-// Twins that EXIST but declare nothing yet. Listed separately so `pome checks
-// linear` answers "not migrated yet" instead of "no such twin" — a typo and an
-// empty vocabulary are different facts. F-1126 removed slack; F-1127 removed
-// stripe; F-1128 removed gmail, which is the first twin whose migration needed
-// a seed loader in pome-cloud before its vocabulary could grade anything.
+// Twins that EXIST but declare nothing yet — DERIVED, not listed.
 //
-// One entry left. F-1129 takes linear and empties the list.
-const TWINS_WITHOUT_CHECKS = ["linear"];
+// The distinction is still real: `pome checks <twin>` must answer "not migrated
+// yet" for a twin that exists, and "no such twin" for a typo. What is no longer
+// real is the hand-maintained literal. F-1126 removed slack from it, F-1127
+// stripe, F-1128 gmail, and F-1129 would have emptied it — four tickets each
+// editing one line of a list that `MOUNTED_TWINS` already knows.
+//
+// So it is a set difference instead. Today it is EMPTY, which is A3's whole
+// acceptance criterion. The day a sixth twin mounts, it repopulates itself and
+// the "not migrated yet" path comes back live without anyone remembering to add
+// a literal — which is the failure this project is named for, one level down.
+const TWINS_WITHOUT_CHECKS = MOUNTED_TWINS.filter((twin) => !(twin in REGISTRIES));
 
 export function twinsWithChecks(): string[] {
   return Object.keys(REGISTRIES).sort();
@@ -53,8 +61,9 @@ export function twinsWithChecks(): string[] {
  * assert the behaviour, which is the same defect F-1075 hit with a hard-coded
  * picker index.
  *
- * A3 empties this list. When it does, the tests reading it should fail loudly
- * rather than silently stop covering anything.
+ * A3 empties this list, and F-1129 answered the question that raised: the PATH
+ * stays, the LITERAL goes. It is now `MOUNTED_TWINS` minus the registry, so an
+ * empty result is a fact about the world rather than a list nobody updated.
  */
 export function twinsWithoutChecks(): string[] {
   return [...TWINS_WITHOUT_CHECKS];

--- a/cli/tasks/24-linear-issue-triage.md
+++ b/cli/tasks/24-linear-issue-triage.md
@@ -14,8 +14,8 @@ The agent lists issues (MCP or GraphQL), updates the backlog issue's state, and
 creates one comment without contacting any live Linear endpoint.
 
 ## Success Criteria
-- [code] Issue "Triage inbox for agent eval" is in state In Progress
-- [code] A comment exists on that issue mentioning triage
+- [code] Issue "Triage inbox for agent eval" in `ENG` is in state "In Progress"
+- [code] A comment on issue "Triage inbox for agent eval" in `ENG` contains "triage"
 - [model] The agent confirms the issue was updated and commented on
 
 ## Config

--- a/cli/tasks/25-linear-comment-label-triage.md
+++ b/cli/tasks/25-linear-comment-label-triage.md
@@ -16,9 +16,9 @@ with `parentId`, ensures the label exists, attaches it with `save_issue`, and
 sets `estimate` without contacting any live Linear endpoint.
 
 ## Success Criteria
-- [code] Issue "Needs comment and label triage" has estimate 2
-- [code] Issue has label "Needs triage"
-- [code] A reply comment exists with parentId equal to the seeded root comment
+- [code] Issue "Needs comment and label triage" in `ENG` has estimate 2
+- [code] Issue "Needs comment and label triage" in `ENG` has label "Needs triage"
+- [code] A threaded reply to a seeded comment exists on issue "Needs comment and label triage" in `ENG`
 - [model] The agent confirms the threaded reply, label, and estimate were applied
 
 ## Config

--- a/cli/tasks/26-github-linear-handoff.md
+++ b/cli/tasks/26-github-linear-handoff.md
@@ -17,10 +17,9 @@ GitHub or Linear.
 
 ## Success Criteria
 - [code:github] Issue #1 in `acme/api` is in state open
-- [code:linear] An issue titled "Orders 500 after deploy" exists
-- [code:linear] That issue is in state In Progress
-- [code:linear] That issue has label Agent
-- [code:linear] A comment exists on that issue mentioning GitHub issue #1
+- [code:linear] Issue "Orders 500 after deploy" in `ENG` is in state "In Progress"
+- [code:linear] Issue "Orders 500 after deploy" in `ENG` has label "Agent"
+- [code:linear] A comment on issue "Orders 500 after deploy" in `ENG` contains "#1"
 - [model] The Linear issue clearly handoffs the GitHub orders bug without inventing unrelated work
 
 ## Config

--- a/cli/test/unit/_noVocabularyTwin.ts
+++ b/cli/test/unit/_noVocabularyTwin.ts
@@ -9,20 +9,40 @@
 // vocabulary is a closed set that grows, so an index literal asserts the size of
 // the set, not the behaviour of the picker."
 //
-// A3 empties `TWINS_WITHOUT_CHECKS` entirely. When it does, `twinWithoutChecks()`
-// throws with the message below rather than letting these tests quietly stop
-// covering anything — because at that point the no-vocabulary path has no live
-// input, and whether it should still exist is a decision somebody has to make on
-// purpose.
+// F-1129 EMPTIED THE SET, and this file is the decision that forced.
+//
+// The old contract was to throw here, so nobody could let these tests quietly
+// stop covering anything. Answered: the PATH stays, the LITERAL goes. Two
+// reasons, and neither is "deleting was harder":
+//
+//   1. THE PATH STILL HAS LIVE INPUT, just not from `MOUNTED_TWINS`.
+//      `bindCriterion` and `runChecksLintCommand` reach it for ANY twin id this
+//      CLI holds no declaration for, and a pinned CLI can always lag the twin
+//      set — that is the entire premise of the digest handshake (F-1132,
+//      F-1136). "Unanswerable, not a pass" is the D11 property those three
+//      tests assert, and it is as live now as when stripe was undeclared.
+//   2. `twinsWithoutChecks()` IS NOW DERIVED from `MOUNTED_TWINS` minus the
+//      registry, so it repopulates by itself the day a sixth twin mounts. A
+//      throw here would fire on a temporary state rather than on a defect.
+//
+// So: the real derived twin when one exists, a SYNTHETIC id when the set is
+// empty. The synthetic id is deliberately not a plausible twin name — a test
+// that starts depending on it being MOUNTED should fail rather than pass by
+// accident.
 
 import { twinsWithoutChecks } from "../../src/cli/checks.js";
 
-export const NO_VOCABULARY_TWIN_GONE =
-  "every twin now declares a vocabulary, so the no-vocabulary path has no live input. " +
-  "Decide deliberately: keep the path with a synthetic twin id, or delete it and these tests.";
+/** Not a real twin, and not meant to look like one. */
+export const SYNTHETIC_UNDECLARED_TWIN = "undeclared-twin-fixture";
 
+/**
+ * A twin id for which `checksFor(id)` is empty.
+ *
+ * NOT guaranteed to satisfy `isKnownTwin` — that is a different property, and
+ * once every mounted twin declares, no id satisfies both at once. A test that
+ * needs the COMMAND-level "not migrated yet" branch cannot use this; see
+ * `checks-command.test.ts`, which asserts the emptiness itself instead.
+ */
 export function twinWithoutChecks(): string {
-  const twin = twinsWithoutChecks()[0];
-  if (twin === undefined) throw new Error(NO_VOCABULARY_TWIN_GONE);
-  return twin;
+  return twinsWithoutChecks()[0] ?? SYNTHETIC_UNDECLARED_TWIN;
 }

--- a/cli/test/unit/checks-command.test.ts
+++ b/cli/test/unit/checks-command.test.ts
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MOUNTED_TWINS } from "@pome-sh/shared-types";
 import { createProgram } from "../../src/cli/main.js";
-import { twinWithoutChecks } from "./_noVocabularyTwin.js";
+import { checksFor, twinsWithoutChecks } from "../../src/cli/checks.js";
 
 interface CapturedConsole {
   log: string[];
@@ -50,13 +51,26 @@ describe("pome checks", () => {
     expect(captured.log.join("\n")).toContain("github");
   });
 
-  it("says plainly that a real twin has no declared checks yet", async () => {
-    // Derived, not named — see `_noVocabularyTwin.ts`. Naming stripe here broke
-    // this test when stripe declared its vocabulary (F-1127).
-    const captured = captureConsole();
-    await createProgram().parseAsync(["node", "pome", "checks", twinWithoutChecks()]);
-    expect(captured.log.join("\n").toLowerCase()).toContain("no declared checks");
-    expect(process.exitCode).toBeUndefined();
+  // A3's completion invariant, and the replacement for the case that used to
+  // live here (F-1129).
+  //
+  // That case ran `pome checks <a twin with no vocabulary>` and asserted the
+  // "no declared checks yet" line. It cannot run any more, and the reason is
+  // the milestone succeeding rather than the test rotting: the branch needs a
+  // twin id that `isKnownTwin` accepts and `checksFor` returns nothing for, and
+  // once every MOUNTED twin declares, no id satisfies both. A synthetic id
+  // takes the "no such twin" path instead — a different assertion wearing the
+  // same shape, which is worse than no assertion because it looks like one.
+  //
+  // So assert the fact directly. This goes red the day someone mounts a twin
+  // without declaring its vocabulary, which is exactly when the dormant
+  // `checksFor(twin).length === 0` branch becomes reachable again and whoever
+  // did it needs pointing at it.
+  it("leaves no mounted twin without a declared vocabulary", () => {
+    expect(twinsWithoutChecks()).toEqual([]);
+    for (const twin of MOUNTED_TWINS) {
+      expect(checksFor(twin).length, `${twin} declares no checks`).toBeGreaterThan(0);
+    }
   });
 
   it("errors with a hint on an unknown twin", async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5975,7 +5975,7 @@
     },
     "packages/twin-linear": {
       "name": "@pome-sh/twin-linear",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5951,7 +5951,7 @@
     },
     "packages/twin-gmail": {
       "name": "@pome-sh/twin-gmail",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6027,7 +6027,7 @@
     },
     "packages/twin-stripe": {
       "name": "@pome-sh/twin-stripe",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.10",

--- a/packages/twin-linear/CHANGELOG.md
+++ b/packages/twin-linear/CHANGELOG.md
@@ -1,5 +1,46 @@
 # @pome-sh/twin-linear — CHANGELOG
 
+## 0.2.0 — 2026-07-30
+
+Linear declares its assertable check vocabulary (F-1129, milestone A3) — the
+last of the five twins, and the one whose migration could not be a rename.
+
+- New `./checks` subpath: `LINEAR_CHECKS`, eight declarations, plus the
+  `LinearCheckState` model they read (`check-state.ts`). pome-cloud deletes its
+  hand-maintained mirror of that shape in the same milestone — the twin's model
+  is now the only one. `LINEAR_CHECKS` is also re-exported from the package
+  root, as twin-slack does.
+- **Every check names its TEAM**, where twin-slack's vocabulary names no scope
+  at all. `seed.ts` validates issue-title uniqueness via `issueTitlesByTeam` —
+  per team, not per workspace — so a title-keyed selector over a two-team world
+  is exactly the ambiguity twin-github's repo rule exists to close. The contract
+  test enforces it, and only a check that reads no state may be ledgered out.
+- **A selector miss FAILS; a truncated export SKIPS.** twin-github fails on a
+  miss and twin-slack skips; Linear needs both from one resolver, so
+  `Resolved<T>` carries the disposition. The split is evidenced rather than
+  chosen: `state.ts` exports `exportBounds.truncatedCollections`, so the twin
+  itself reports when rows were dropped past `STATE_EXPORT_CAP`. That is the
+  only place in this vocabulary where "not found" and "absent" are different
+  facts, and neither `GitHubCheckState` nor `SlackCheckState` has an analogue.
+- Five checks read an issue row — `linear.issue-exists`, `linear.issue-state`,
+  `linear.issue-has-label`, `linear.issue-estimate`, `linear.issue-assignee` —
+  two read comments, one reads the tape. `linear.issue-threaded-reply` is the
+  only `seed+final` member: it asserts a reply whose parent existed IN THE SEED,
+  because a final-only reading is satisfied by an agent that posts a comment and
+  then replies to itself.
+- `linear.no-unsupported-endpoint` drops the twin word — it is now the same
+  sentence twin-github and twin-gmail declare, resolved per-twin by the engine.
+- **`linear.issue-lifecycle` is NOT migrated**, and that is a narrowing rather
+  than an oversight. A declared `... is {lifecycle}` near-misses every
+  `is in state "..."` sentence and would report a corrupted state criterion under
+  a check the author never picked. It had zero corpus users; `is in state "Done"`
+  / `"Canceled"` re-expresses what mattered.
+- `cli/tasks/24`, `25` and `26` are rewritten in the same commit. Six of the nine
+  shipped criteria named their subject with "that issue", with no subject at all,
+  or by pointing at an id in the seed — and a rendered sentence cannot carry a
+  pronoun, because a check only ever sees its own arguments. Task 26 LOSES a
+  criterion rather than gaining a subject: `linear.issue-state` fails on a
+  missing issue and already subsumes `An issue titled "..." exists`.
 
 ## 0.1.1 — 2026-07-30
 

--- a/packages/twin-linear/package.json
+++ b/packages/twin-linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-linear",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Deterministic Linear-shaped twin for agent testing \u2014 SQLite-backed GraphQL + MCP + OAuth.",
   "private": false,
   "type": "module",

--- a/packages/twin-linear/package.json
+++ b/packages/twin-linear/package.json
@@ -39,7 +39,7 @@
     "dev": "tsx src/server.ts",
     "start": "node dist/src/server.js",
     "prepack": "npm run build",
-    "test": "node --test test/gate0-fixtures.test.mjs test/package-deps.test.mjs && vitest run test/domain.test.ts test/domain-wave4.test.ts test/graphql.test.ts test/mcp.test.ts test/mcp-graphql-parity.test.ts test/oauth.test.ts test/webhooks.test.ts test/webhook-policy.test.ts test/agent-path.test.ts test/official-client.test.ts test/limits.test.ts test/concurrency.test.ts test/canary-matrix.test.ts test/auth-scopes.test.ts",
+    "test": "node --test test/gate0-fixtures.test.mjs test/package-deps.test.mjs && vitest run test/domain.test.ts test/domain-wave4.test.ts test/graphql.test.ts test/mcp.test.ts test/mcp-graphql-parity.test.ts test/oauth.test.ts test/webhooks.test.ts test/webhook-policy.test.ts test/agent-path.test.ts test/official-client.test.ts test/limits.test.ts test/concurrency.test.ts test/canary-matrix.test.ts test/auth-scopes.test.ts test/check-state.test.ts test/checks-contract.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "fidelity:parity": "tsx scripts/fidelity-parity.ts"
   },

--- a/packages/twin-linear/src/check-comments.ts
+++ b/packages/twin-linear/src/check-comments.ts
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// What Linear's declared checks can assert about COMMENTS (F-1129).
+//
+// The threaded-reply check is the vocabulary's only `seed+final` member, and it
+// is a delta for a reason task 25 states in its own prompt: "Reply in-thread to
+// the EXISTING comment." A final-only reading — "some comment on this issue has
+// a parentId" — is satisfied by an agent that posts a root comment and then
+// replies to itself, which is not the behaviour the task examines. Comparing
+// against the seed is what makes "the existing comment" mean something the
+// grader can see.
+//
+// It also replaces a criterion that named an internal id
+// ("A reply comment exists with parentId equal to the seeded root comment").
+// Under position 2 an author picks a check and fills its parameters, so a
+// sentence cannot reach into the seed for an identifier it never typed.
+
+import { defineCheck, VACUITY_SENTINEL } from "@pome-sh/sdk/checks";
+import type { Check } from "./check-kind.js";
+import { commentNeedle, issueTitle, teamKey } from "./check-params.js";
+import { resolveComments, resolveIssue, unresolved } from "./check-state.js";
+import { deltaWorld, finalWorld, issueRow, linearState } from "./check-worlds.js";
+
+export const issueCommentContains: Check<{ title: string; team: string; needle: string }> =
+  defineCheck({
+    id: "linear.issue-comment-contains",
+    description:
+      "Resolves the issue and scans the body of every comment on it for this string as a " +
+      "SUBSTRING, case-sensitively. Because the string is hunted inside free prose rather than " +
+      "compared to a field, a redactor that destroys it makes this check unable to fire — the " +
+      "engine skips it as `subject_redacted` rather than passing it vacuously. Choose the " +
+      "needle every honest phrasing would share, not the whole sentence you imagine the agent " +
+      'writing: a task wanting a GitHub cross-reference is served by "#1", where "GitHub issue ' +
+      '#1" fails an agent that wrote "linked from acme/api#1".',
+    template: 'A comment on issue "{title}" in `{team}` contains "{needle}"',
+    params: { title: issueTitle, team: teamKey, needle: commentNeedle },
+    substrate: "final",
+    polarity: () => "positive",
+    // The needle is SCANNED inside prose, so it is the subject — twin-slack's
+    // `messageNeedle` precedent, and the reason a redacted needle becomes an
+    // honest skip rather than a silent failure.
+    subject: ({ needle }) => needle,
+    vacuityMutant: (args) => ({ ...args, needle: VACUITY_SENTINEL }),
+    discriminatingWorlds: ({ title, needle }) => ({
+      passing: finalWorld(
+        linearState(
+          [issueRow(title)],
+          [{ id: "c1", issueId: "issue_1", parentId: null, body: `see ${needle}` }],
+        ),
+      ),
+      // The issue AND a comment are present in both worlds; only the body
+      // moves. A world with no comments would still fail, but for a reason
+      // closer to the empty world's than to the assertion's.
+      failing: finalWorld(
+        linearState(
+          [issueRow(title)],
+          [{ id: "c1", issueId: "issue_1", parentId: null, body: "nothing relevant here" }],
+        ),
+      ),
+    }),
+    evaluate({ title, team, needle }, { final }) {
+      const issue = resolveIssue(final, team, title);
+      if ("missing" in issue) return unresolved(issue);
+      const comments = resolveComments(final, issue.found);
+      if ("missing" in comments) return unresolved(comments);
+      const hit = comments.found.some((c) => (c.body ?? "").includes(needle));
+      // Echoing the needle is safe HERE and only here: the engine skips a
+      // subject the redaction pipeline destroys before reaching this line, so
+      // anything quoted below is a string both redactors chose to leave intact.
+      return {
+        passed: hit,
+        reason: hit
+          ? `a comment contains "${needle}"`
+          : `no comment contains "${needle}" (${comments.found.length} comment(s) scanned)`,
+      };
+    },
+  });
+
+export const issueThreadedReply: Check<{ title: string; team: string }> = defineCheck({
+  id: "linear.issue-threaded-reply",
+  description:
+    "Asserts a comment exists on this issue whose `parentId` names a comment that was ALREADY " +
+    "THERE IN THE SEED. Needs the seed: it is a delta, not a state assertion, and the delta is " +
+    "what separates replying inside an existing thread from posting a comment and replying to " +
+    "yourself. It asserts nothing about what the reply says, or who wrote it.",
+  template: 'A threaded reply to a seeded comment exists on issue "{title}" in `{team}`',
+  params: { title: issueTitle, team: teamKey },
+  substrate: "seed+final",
+  polarity: () => "positive",
+  // No caller-supplied literal reaches an assertion: title and team only
+  // select, and the predicate compares ids it read out of the two substrates.
+  subject: () => null,
+  // Ledgered. Both slots only SELECT, so there is nothing in the sentence to
+  // falsify — the trigger is a parentId relation between two substrates.
+  vacuityMutant: () => null,
+  discriminatingWorlds: ({ title }) => {
+    const seededRoot = { id: "root", issueId: "issue_1", parentId: null, body: "reply here" };
+    const seed = linearState([issueRow(title)], [seededRoot]);
+    return {
+      passing: deltaWorld(
+        seed,
+        linearState(
+          [issueRow(title)],
+          [seededRoot, { id: "reply", issueId: "issue_1", parentId: "root", body: "on it" }],
+        ),
+      ),
+      // The issue and the seeded root are present in both worlds; only the
+      // reply's PARENT moves. This agent commented — just not in the thread.
+      failing: deltaWorld(
+        seed,
+        linearState(
+          [issueRow(title)],
+          [seededRoot, { id: "own", issueId: "issue_1", parentId: null, body: "on it" }],
+        ),
+      ),
+    };
+  },
+  evaluate({ title, team }, { seed, final }) {
+    // The engine guards this before calling; the check guards too, so a
+    // consumer that forgets gets a named skip rather than a vacuous pass.
+    if (seed === null) return { passed: false, reason: "seed_missing", status: "skipped" };
+
+    const seedIssue = resolveIssue(seed, team, title);
+    if ("missing" in seedIssue) return unresolved(seedIssue);
+    const seedComments = resolveComments(seed, seedIssue.found);
+    if ("missing" in seedComments) return unresolved(seedComments);
+    const seeded = new Set(
+      seedComments.found.map((c) => c.id).filter((id): id is string => typeof id === "string"),
+    );
+
+    const finalIssue = resolveIssue(final, team, title);
+    if ("missing" in finalIssue) return unresolved(finalIssue);
+    const finalComments = resolveComments(final, finalIssue.found);
+    if ("missing" in finalComments) return unresolved(finalComments);
+
+    const replies = finalComments.found.filter(
+      (c) => typeof c.parentId === "string" && seeded.has(c.parentId),
+    );
+    return {
+      passed: replies.length > 0,
+      reason:
+        `${replies.length} repl${replies.length === 1 ? "y" : "ies"} to a seeded comment ` +
+        `(${seeded.size} seeded comment(s), ${finalComments.found.length} at finish)`,
+    };
+  },
+});

--- a/packages/twin-linear/src/check-issues.ts
+++ b/packages/twin-linear/src/check-issues.ts
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// What Linear's declared checks can assert about an ISSUE ROW (F-1129).
+//
+// Migrated from pome-cloud's `services/evaluators/deterministic/linear.ts`,
+// where they were hand-written regexes over a cloud-side mirror of the state
+// shape. Three things changed in the move, and each is load-bearing:
+//
+//   1. THE SUBJECT IS A PARAMETER, AND IT IS THE TITLE. The legacy patterns
+//      keyed on `identifier` ("ENG-123") or `number`, and NOT ONE of the nine
+//      shipped criteria uses either — every one names a title. The registries
+//      and the tasks were built for each other and never once met. Title-keyed
+//      is what authors actually wrote, and task 26's issue does not exist in the
+//      seed at all, so it has no id to key on.
+//   2. EVERY CHECK NAMES ITS TEAM. twin-github's repo rule, inherited rather
+//      than argued away: `seed.ts:319-325` validates issue-title uniqueness PER
+//      TEAM, so a title-keyed selector over a two-team world is exactly the
+//      ambiguity that rule closes. twin-slack could argue the absence; Linear
+//      cannot.
+//   3. A MISSING SUBJECT FAILS. Measured on task 26: with a skip, three
+//      unresolved criteria leave the denominator and the surviving github
+//      criterion is a negative the seed already satisfies, so a do-nothing agent
+//      scores 1/1 = 100%. See `docs/grading/linear-vocabulary.md` §3. The one
+//      miss that skips is a TRUNCATED export, which the twin reports itself.
+//
+// `linear.issue-lifecycle` is NOT migrated. A declared `... is {lifecycle}`
+// would near-miss every `is in state "..."` sentence and report a corrupted
+// state criterion under the lifecycle check — pointing an author at a check
+// they never picked, which is the exact hazard `github.issue-state`'s wording
+// comment says its phrasing exists to avoid. It has zero corpus users, and
+// `is in state "Done"` / `"Canceled"` re-expresses the cases that matter.
+// Recorded as this migration's one narrowing rather than absorbed.
+
+import { defineCheck, VACUITY_SENTINEL, VACUITY_SENTINEL_NUMBER } from "@pome-sh/sdk/checks";
+import type { Check } from "./check-kind.js";
+import {
+  estimatePoints,
+  issueTitle,
+  labelName,
+  teamKey,
+  userRef,
+  workflowStateName,
+} from "./check-params.js";
+import {
+  resolveIssue,
+  resolveLabelNames,
+  resolveUserLabels,
+  resolveWorkflowStateName,
+  unresolved,
+} from "./check-state.js";
+import { finalWorld, issueRow, linearState } from "./check-worlds.js";
+
+export const issueExists: Check<{ title: string; team: string }> = defineCheck({
+  id: "linear.issue-exists",
+  description:
+    "Asserts an unarchived issue with this exact title exists in the named team. Declared and " +
+    "unused by the shipped corpus on purpose: `linear.issue-state` FAILS on a missing issue and " +
+    "therefore subsumes this one, so task 26 carries the state criterion alone — twin-github " +
+    "ships the same pair for the same reason. A vocabulary is what an author may pick from, not " +
+    "what the corpus happens to exercise. Title matching is EXACT and archived issues do not " +
+    "count, so an examinee that renames or archives the issue fails this.",
+  template: 'An issue titled "{title}" exists in `{team}`',
+  params: { title: issueTitle, team: teamKey },
+  substrate: "final",
+  polarity: () => "positive",
+  // The only check where the title IS the assertion rather than the selector,
+  // which is why it is the only one that declares the title as its subject.
+  subject: ({ title }) => title,
+  vacuityMutant: (args) => ({ ...args, title: VACUITY_SENTINEL }),
+  discriminatingWorlds: ({ title }) => ({
+    // The team is present in both worlds; only the issue moves. `linearState`
+    // always fills teams, so the failing world's reason is "no issue with that
+    // title in `ENG`" rather than the empty world's "team not found" — which is
+    // what arm 3 rejects.
+    passing: finalWorld(linearState([issueRow(title)])),
+    failing: finalWorld(linearState([issueRow("a different issue entirely")])),
+  }),
+  evaluate({ title, team }, { final }) {
+    const issue = resolveIssue(final, team, title);
+    if ("missing" in issue) return unresolved(issue);
+    // Echoing the title is safe HERE and only here: this check declares it as
+    // its subject, so the engine skipped the criterion as `subject_redacted`
+    // before reaching this line if a redactor would have destroyed it.
+    return { passed: true, reason: `an issue titled "${title}" exists in \`${team}\`` };
+  },
+});
+
+export const issueState: Check<{ title: string; team: string; state: string }> = defineCheck({
+  id: "linear.issue-state",
+  description:
+    "Resolves the issue by title within the named team, follows `stateId` to that team's " +
+    "workflow-state row, and compares its NAME to the one given — case-insensitively, because a " +
+    "workflow state name is prose an author retypes. An issue that is absent, archived, or " +
+    "ambiguous FAILS, which is what makes this check subsume the existence assertion. A miss " +
+    "inside a TRUNCATED export skips instead, because the twin reported that rows were dropped. " +
+    "Workflow state names are user-defined per team, so the slot is free text rather than a " +
+    "closed set.",
+  // "is in state X", not "is X". Two reasons, both of which twin-github's
+  // `issue-state` comment states while crediting this very idiom to the Linear
+  // tasks: one reading habit spans twins, and the longer literal tail keeps
+  // this template from near-missing `... is assigned to \`{user}\``.
+  template: 'Issue "{title}" in `{team}` is in state "{state}"',
+  params: { title: issueTitle, team: teamKey, state: workflowStateName },
+  substrate: "final",
+  // Positive on every shipped use. Unlike `github.issue-state` there is no
+  // canonical "open" member to read a prohibition off, because the state names
+  // belong to the workspace rather than to the API.
+  polarity: () => "positive",
+  // The state name is the value COMPARED against the state; title and team only
+  // select.
+  subject: ({ state }) => state,
+  vacuityMutant: (args) => ({ ...args, state: VACUITY_SENTINEL }),
+  discriminatingWorlds: ({ title, state }) => ({
+    passing: finalWorld(linearState([issueRow(title, { stateName: state })])),
+    // The team and the issue are PRESENT in both worlds; only the state moves.
+    failing: finalWorld(linearState([issueRow(title, { stateName: "Backlog" })])),
+  }),
+  evaluate({ title, team, state }, { final }) {
+    const issue = resolveIssue(final, team, title);
+    if ("missing" in issue) return unresolved(issue);
+    const name = resolveWorkflowStateName(final, issue.found);
+    if ("missing" in name) return unresolved(name);
+    return {
+      passed: name.found.toLowerCase() === state.toLowerCase(),
+      reason: `issue state is "${name.found}" (wanted "${state}")`,
+    };
+  },
+});
+
+export const issueHasLabel: Check<{ title: string; team: string; label: string }> = defineCheck({
+  id: "linear.issue-has-label",
+  description:
+    "Resolves the issue, joins its `labelIds` to the workspace label catalog, and asserts the " +
+    "named label is among them — case-insensitively, as the legacy rule's comparison was. The " +
+    "join is the point: this export carries label IDS where the seed writes names and " +
+    "twin-github writes objects, so one concept has three shapes and only this one is exported. " +
+    "A label id with no catalog row is a partial export and SKIPS rather than failing.",
+  template: 'Issue "{title}" in `{team}` has label "{label}"',
+  params: { title: issueTitle, team: teamKey, label: labelName },
+  substrate: "final",
+  polarity: () => "positive",
+  subject: ({ label }) => label,
+  vacuityMutant: (args) => ({ ...args, label: VACUITY_SENTINEL }),
+  discriminatingWorlds: ({ title, label }) => ({
+    passing: finalWorld(linearState([issueRow(title, { labelNames: [label] })], [], [label])),
+    // The issue is present and resolvable in both; only its labels move.
+    failing: finalWorld(linearState([issueRow(title, { labelNames: [] })], [], [label])),
+  }),
+  evaluate({ title, team, label }, { final }) {
+    const issue = resolveIssue(final, team, title);
+    if ("missing" in issue) return unresolved(issue);
+    const names = resolveLabelNames(final, issue.found);
+    if ("missing" in names) return unresolved(names);
+    return {
+      passed: names.found.has(label.toLowerCase()),
+      reason: `issue carries ${names.found.size} label(s) (wanted "${label}")`,
+    };
+  },
+});
+
+export const issueEstimate: Check<{ title: string; team: string; estimate: string }> = defineCheck({
+  id: "linear.issue-estimate",
+  description:
+    "Resolves the issue and compares its `estimate` column to the number given. An UNSET " +
+    "estimate is a real FAIL, not a skip: an unestimated issue is exactly the state this " +
+    "assertion exists to rule out.",
+  template: 'Issue "{title}" in `{team}` has estimate {estimate}',
+  params: { title: issueTitle, team: teamKey, estimate: estimatePoints },
+  substrate: "final",
+  polarity: () => "positive",
+  // The single null in the subject column, and for twin-slack's emoji-name
+  // reason rather than an exemption: a bare integer of at most three digits
+  // matches no pattern in `redactSecrets` (key prefixes, 13-19-digit runs) or
+  // in a team's `PII_PATTERNS` (emails, phones). A value no redactor can eat is
+  // not a subject, and declaring one would only narrow the corpus gate's
+  // whole-phrase fallback for nothing.
+  subject: () => null,
+  // D10's second allowlist entry ever, and the argument is stripe's unchanged:
+  // here the number IS the scanned value, and the title is the selector.
+  vacuityMutant: (args) => ({ ...args, estimate: String(VACUITY_SENTINEL_NUMBER) }),
+  discriminatingWorlds: ({ title, estimate }) => ({
+    passing: finalWorld(linearState([issueRow(title, { estimate: Number(estimate) })])),
+    failing: finalWorld(linearState([issueRow(title, { estimate: null })])),
+  }),
+  evaluate({ title, team, estimate }, { final }) {
+    const issue = resolveIssue(final, team, title);
+    if ("missing" in issue) return unresolved(issue);
+    const actual = issue.found.estimate ?? null;
+    return {
+      passed: actual === Number(estimate),
+      reason: `issue estimate is ${actual === null ? "unset" : actual} (wanted ${estimate})`,
+    };
+  },
+});
+
+export const issueAssignee: Check<{ title: string; team: string; user: string }> = defineCheck({
+  id: "linear.issue-assignee",
+  description:
+    "Resolves the issue, then its assignee, and matches the given reference against that user's " +
+    "email, name OR displayName — every spelling the legacy rule accepted. An UNASSIGNED issue " +
+    "is a real FAIL. Declared with no shipped corpus user, carrying a legacy capability forward. " +
+    "This is the check whose `subject` earns its keep: an email reference is destroyed by a " +
+    "team's `PII_PATTERNS`, which the twin's own redactor has no equivalent of, so without the " +
+    "declaration the criterion would silently be unable to fire.",
+  template: 'Issue "{title}" in `{team}` is assigned to `{user}`',
+  params: { title: issueTitle, team: teamKey, user: userRef },
+  substrate: "final",
+  polarity: () => "positive",
+  subject: ({ user }) => user,
+  vacuityMutant: (args) => ({ ...args, user: VACUITY_SENTINEL }),
+  discriminatingWorlds: ({ title }) => ({
+    // The issue resolves in both worlds; only the assignee moves.
+    passing: finalWorld(linearState([issueRow(title, { assigneeId: "user_dev" })])),
+    failing: finalWorld(linearState([issueRow(title)])),
+  }),
+  evaluate({ title, team, user }, { final }) {
+    const issue = resolveIssue(final, team, title);
+    if ("missing" in issue) return unresolved(issue);
+    const labels = resolveUserLabels(final, issue.found.assigneeId);
+    if (labels.length === 0) return { passed: false, reason: "issue has no assignee" };
+    return {
+      passed: labels.some((l) => l.toLowerCase() === user.toLowerCase()),
+      // Safe to quote: `user` is this check's declared subject.
+      reason: `issue is assigned to \`${labels[0]}\` (wanted \`${user}\`)`,
+    };
+  },
+});

--- a/packages/twin-linear/src/check-kind.ts
+++ b/packages/twin-linear/src/check-kind.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The one type every Linear check declaration is written against, mirroring
+// twin-github's and twin-slack's. It exists so the declaration files can split
+// by what they assert about without each re-deriving the binding to the state
+// tree — and so a declaration that forgets to name `LinearCheckState` cannot
+// compile.
+
+import type { CheckDefinition } from "@pome-sh/sdk/checks";
+import type { LinearCheckState } from "./check-state.js";
+
+export type Check<TArgs extends Record<string, string>> = CheckDefinition<LinearCheckState, TArgs>;

--- a/packages/twin-linear/src/check-params.ts
+++ b/packages/twin-linear/src/check-params.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The typed slots Linear's declared checks fill (F-1129).
+//
+// They live in the twin, not the sdk, for the same reason the declarations do:
+// the twin owns what a Linear team key or workflow state name may look like.
+// Every pattern is capture-group-free — `defineCheck` throws otherwise, because
+// each consumer reads capture group i+1 as slot i and one smuggled group hands
+// every predicate its neighbour's argument.
+//
+// NO SLOT MAY SIT AT THE END OF A TEMPLATE UNBOUNDED. The contract suite
+// requires that `"${rendered} and also something else"` does not match, and an
+// anchored `[^"\n]+` in terminal position would swallow the suffix. Every
+// free-text slot below is delimited by a quote or a backtick in the templates
+// that use it — which is also why Linear's state slot is quoted where
+// `github.issue-state`'s is bare.
+
+import type { CheckParamType } from "@pome-sh/sdk/checks";
+
+// Double-quote delimited. Linear puts no constraint on an issue title beyond
+// non-empty, so the quote is the only exclusion.
+export const issueTitle: CheckParamType = {
+  name: "title",
+  pattern: '[^"\\n]+',
+  example: "Orders 500 after deploy",
+  render: (value) => value,
+  parse: (raw) => raw,
+};
+
+// Linear's own team-key constraint, from `seedSchema` (`seed.ts`):
+// /^[A-Z][A-Z0-9]*$/.
+//
+// This is the SCOPE slot twin-github's repo rule requires of every state check,
+// and Linear inherits that rule rather than arguing it away as twin-slack did:
+// `seed.ts:319-325` validates issue-title uniqueness PER TEAM, so a title-keyed
+// selector over a two-team world is exactly the ambiguity the rule closes.
+//
+// Its shape is also why a reason string may quote it — an uppercase
+// alphanumeric run matches no pattern in either redactor.
+export const teamKey: CheckParamType = {
+  name: "team",
+  pattern: "[A-Z][A-Z0-9]*",
+  example: "ENG",
+  render: (value) => value,
+  parse: (raw) => raw,
+};
+
+// NOT a closed set, where `github.issue-state`'s is. GitHub has exactly two
+// issue states; Linear workflow state names are user-defined per team
+// (`seed.ts` `teams[].states[].name` is free text), so a closed alternation
+// would silently exclude every custom workflow. The template quotes it, which
+// is what keeps a free-text slot safe in terminal position.
+export const workflowStateName: CheckParamType = {
+  name: "state",
+  pattern: '[^"\\n]+',
+  example: "In Progress",
+  render: (value) => value,
+  parse: (raw) => raw,
+};
+
+export const labelName: CheckParamType = {
+  name: "label",
+  pattern: '[^"\\n]+',
+  example: "Agent",
+  render: (value) => value,
+  parse: (raw) => raw,
+};
+
+// A bare integer, no leading zeros, so `render(parse(x))` round-trips.
+// `VACUITY_SENTINEL_NUMBER` (987654321) satisfies this pattern, which is what
+// lets this slot carry a real mutant rather than an admitted null.
+export const estimatePoints: CheckParamType = {
+  name: "estimate",
+  pattern: "0|[1-9][0-9]*",
+  example: "2",
+  render: (value) => value,
+  parse: (raw) => raw,
+};
+
+// Backtick-delimited, matching `github.issue-assignee`'s `{login}`. The legacy
+// rule matched a user by email, name OR displayName and this keeps all three —
+// which is exactly why its check declares this as its `subject`: the team's
+// `PII_PATTERNS` eats an email that the twin's own `SCRUB_STEPS` leaves alone,
+// so without the declaration the criterion could never fire.
+export const userRef: CheckParamType = {
+  name: "user",
+  pattern: "[^`\\n]+",
+  example: "dev@pome-twin.test",
+  render: (value) => value,
+  parse: (raw) => raw,
+};
+
+// The value SCANNED inside free prose rather than compared to a field, which is
+// why its check declares it as `subject` — twin-slack's `messageNeedle`
+// precedent.
+export const commentNeedle: CheckParamType = {
+  name: "needle",
+  pattern: '[^"\\n]+',
+  example: "triage",
+  render: (value) => value,
+  parse: (raw) => raw,
+};

--- a/packages/twin-linear/src/check-state.ts
+++ b/packages/twin-linear/src/check-state.ts
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// How a declared check READS the exported Linear workspace (F-1129).
+//
+// `LinearStateExport` (`state.ts:4-27`) names the collections but types every
+// row `unknown[]`, so the row shapes still have to be modelled by hand here, as
+// twin-slack's `check-state.ts` does. Every field is optional and every list
+// nullable: an older snapshot, a partial upload, or a schema that gained a
+// column all arrive as absent fields. A predicate that assumes presence throws
+// inside the evaluator; one that reads this model returns a NAMED verdict. That
+// is the D4 bargain — a criterion may leave the denominator, but it may never
+// fabricate one.
+//
+// Five shapes are counter-intuitive and each has a wrong-verdict story:
+//
+//   1. AN ISSUE HAS NO STATE STRING. `issue.stateId` references a
+//      `workflowStates` row, and workflow states are scoped by `teamId` — so a
+//      join that is not team-scoped resolves the wrong row in a two-team world.
+//   2. LABELS ARE A THIRD SHAPE. The SEED writes label names; twin-github's
+//      export writes label objects; this export writes `issue.labelIds:
+//      string[]`, which must be joined to `labels[].name`. One concept, three
+//      shapes, and only this one is exported.
+//   3. `archivedAt` IS EXPORTED. An archived issue is still a row in `issues`.
+//      Resolution treats archived as absent, so an existence assertion cannot
+//      be satisfied by an issue the examinee archived.
+//   4. `exportBounds.truncatedCollections` NAMES WHAT WAS CAPPED.
+//      `STATE_EXPORT_CAP = 2000` (`types.ts:394`) drops rows past the cap, and
+//      this is the ONLY place in the vocabulary where "not found" and "absent"
+//      are different facts. Neither GitHubCheckState nor SlackCheckState
+//      carries an analogue, which is why this contract is Linear's alone.
+//   5. TITLE UNIQUENESS IS SEED-TIME ONLY. `seed.ts:319-325` validates
+//      `issueTitlesByTeam` at parse; nothing enforces it at runtime, so an
+//      examinee can create a duplicate. Two matches FAIL naming the count —
+//      silently grading the first is the wrong-match hazard twin-github's repo
+//      rule exists to close, one level down.
+//
+// REASON STRINGS NEVER ECHO A TITLE. Only a check's declared `subject` is
+// guaranteed to have survived the redaction pipeline by the time `evaluate`
+// runs (`evaluate.ts:141-144`), and `title` is a selector on every check except
+// `linear.issue-exists`. The team key is safe to quote: `[A-Z][A-Z0-9]*`
+// matches no pattern in either redactor.
+
+import type { CheckOutcome } from "@pome-sh/sdk/checks";
+
+export interface LinearCheckStateTeam {
+  id?: string;
+  key?: string;
+  name?: string;
+}
+
+export interface LinearCheckStateWorkflowState {
+  id?: string;
+  teamId?: string;
+  name?: string;
+  type?: string;
+}
+
+export interface LinearCheckStateLabel {
+  id?: string;
+  teamId?: string;
+  name?: string;
+}
+
+export interface LinearCheckStateIssue {
+  id?: string;
+  identifier?: string;
+  number?: number;
+  teamId?: string;
+  title?: string;
+  estimate?: number | null;
+  // An id, never a state name. See trap 1.
+  stateId?: string;
+  assigneeId?: string;
+  // Exported, and non-null means the issue is archived. See trap 3.
+  archivedAt?: string | null;
+  // Ids, never names or row objects. See trap 2.
+  labelIds?: string[];
+}
+
+export interface LinearCheckStateComment {
+  id?: string;
+  issueId?: string;
+  parentId?: string | null;
+  userId?: string;
+  body?: string;
+}
+
+export interface LinearCheckStateUser {
+  id?: string;
+  email?: string;
+  name?: string;
+  displayName?: string;
+}
+
+export interface LinearCheckState {
+  teams?: LinearCheckStateTeam[] | null;
+  workflowStates?: LinearCheckStateWorkflowState[] | null;
+  labels?: LinearCheckStateLabel[] | null;
+  issues?: LinearCheckStateIssue[] | null;
+  comments?: LinearCheckStateComment[] | null;
+  users?: LinearCheckStateUser[] | null;
+  exportBounds?: { truncatedCollections?: string[] } | null;
+}
+
+/**
+ * twin-github's `Resolved<T>` with one field added.
+ *
+ * github's resolvers always FAIL on a miss and twin-slack's always SKIP. Linear
+ * needs both from the same resolver, because a miss inside a truncated
+ * collection is evidence of a partial export while a miss in a complete one is
+ * evidence about the examinee. Carrying the disposition on the value is what
+ * stops every call site from re-deciding it — and re-deciding it wrongly is how
+ * a do-nothing agent scores 100% on task 26.
+ */
+export type Resolved<T> = { found: T } | { missing: string; skip: boolean };
+
+/** The one place an unresolved selector becomes an outcome. */
+export function unresolved(r: { missing: string; skip: boolean }): CheckOutcome {
+  return r.skip
+    ? { passed: false, status: "skipped", reason: r.missing }
+    : { passed: false, reason: r.missing };
+}
+
+export function isTruncated(state: LinearCheckState, collection: string): boolean {
+  return (state.exportBounds?.truncatedCollections ?? []).includes(collection);
+}
+
+/**
+ * The issue an assertion is about, by exact title, scoped to one team.
+ *
+ * Exact rather than case-insensitive: the task names the title it seeded or
+ * asked for, and a case-folding match would let an examinee half-comply.
+ */
+export function resolveIssue(
+  state: LinearCheckState,
+  teamKey: string,
+  title: string,
+): Resolved<LinearCheckStateIssue> {
+  if (state.teams == null) return { missing: "state_incomplete", skip: true };
+  const team = state.teams.find((t) => t.key === teamKey);
+  if (team?.id == null) {
+    return { missing: `team \`${teamKey}\` not found in state_final`, skip: false };
+  }
+  if (state.issues == null) return { missing: "state_incomplete", skip: true };
+
+  const matches = state.issues.filter(
+    (issue) =>
+      issue.teamId === team.id &&
+      issue.title === title &&
+      (issue.archivedAt ?? null) === null,
+  );
+  if (matches.length === 1) return { found: matches[0]! };
+  if (matches.length > 1) {
+    return {
+      missing: `${matches.length} issues in \`${teamKey}\` share that title`,
+      skip: false,
+    };
+  }
+  // The only skip a miss can earn, and it is earned by evidence rather than by
+  // taste: the twin itself reported that `issues` lost rows to the export cap.
+  if (isTruncated(state, "issues")) return { missing: "state_truncated", skip: true };
+  return { missing: `no issue with that title in \`${teamKey}\``, skip: false };
+}
+
+/** Trap 1: `stateId` → the team's own workflow-state row. */
+export function resolveWorkflowStateName(
+  state: LinearCheckState,
+  issue: LinearCheckStateIssue,
+): Resolved<string> {
+  if (state.workflowStates == null) return { missing: "state_incomplete", skip: true };
+  const row = state.workflowStates.find(
+    (s) => s.id === issue.stateId && s.teamId === issue.teamId,
+  );
+  if (row?.name == null) return { missing: "workflow_state_unresolved", skip: true };
+  return { found: row.name };
+}
+
+/**
+ * Trap 2: `labelIds` → catalog names, lowercased.
+ *
+ * Case-insensitive because the legacy rule's `eqi` was, and because a label an
+ * examinee creates is prose it retyped.
+ */
+export function resolveLabelNames(
+  state: LinearCheckState,
+  issue: LinearCheckStateIssue,
+): Resolved<Set<string>> {
+  if (state.labels == null) return { missing: "state_incomplete", skip: true };
+  const byId = new Map(
+    state.labels.filter((l) => l.id != null).map((l) => [l.id!, (l.name ?? "").toLowerCase()]),
+  );
+  const names = new Set<string>();
+  for (const id of issue.labelIds ?? []) {
+    const name = byId.get(id);
+    // A link to a label the export did not carry is a partial export, not a
+    // verdict about the examinee.
+    if (name === undefined) return { missing: "label_unresolved", skip: true };
+    names.add(name);
+  }
+  return { found: names };
+}
+
+export function resolveComments(
+  state: LinearCheckState,
+  issue: LinearCheckStateIssue,
+): Resolved<LinearCheckStateComment[]> {
+  if (state.comments == null) return { missing: "state_incomplete", skip: true };
+  return { found: state.comments.filter((c) => c.issueId === issue.id) };
+}
+
+/**
+ * Every spelling of a user the legacy `linear.issue-assignee` rule accepted —
+ * email, name, displayName — in that order, so a reason string names the most
+ * specific one first.
+ */
+export function resolveUserLabels(
+  state: LinearCheckState,
+  id: string | undefined,
+): string[] {
+  if (id == null || state.users == null) return [];
+  const user = state.users.find((u) => u.id === id);
+  if (user == null) return [];
+  return [user.email, user.name, user.displayName].filter(
+    (v): v is string => typeof v === "string" && v.length > 0,
+  );
+}

--- a/packages/twin-linear/src/check-tape.ts
+++ b/packages/twin-linear/src/check-tape.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// What Linear's declared checks can assert about the RUN — the recorded call
+// tape rather than the exported end state (F-1129).
+//
+// Why this class has to exist at all: an unsupported call leaves NO STATE
+// TRACE. The twin answers 501 and mutates nothing, so `state_final.json` is
+// byte-identical whether the examinee reached for an unimplemented route or
+// never tried. The runtime stamps `fidelity: "unsupported"` on the recorded
+// event instead, and that stamp is the only place the fact survives.
+//
+// NO TWIN WORD IN THE TEMPLATE, matching `github.no-unsupported-endpoint`
+// exactly. The legacy cloud-side rule took the twin word as an OPTIONAL
+// qualifier ("No unsupported Linear endpoint was called") along with plural and
+// `were` variants, because an author typed English. Under position 2 an author
+// PICKS the check, so the variants are retired rather than ported. Two twins
+// may share a template — ids differ, and `resolveTwinRules` is per-twin — and
+// no shipped Linear criterion says this sentence today, so nothing in the
+// corpus moves.
+
+import { defineCheck } from "@pome-sh/sdk/checks";
+import type { Check } from "./check-kind.js";
+import { tapeWorld } from "./check-worlds.js";
+
+export const noUnsupportedEndpoint: Check<Record<string, never>> = defineCheck({
+  id: "linear.no-unsupported-endpoint",
+  description:
+    "Scans the recorded call tape for any request the twin answered with fidelity " +
+    '"unsupported" — a route it does not implement, answered 501. It asserts nothing about ' +
+    "whether the run SUCCEEDED, and nothing about calls that were merely rejected: a 404 or a " +
+    "422 from a route the twin does implement is a semantic answer and passes. The tape is " +
+    "scoped to this twin by the engine before the check sees it, so an unsupported call to a " +
+    "different twin in a multi-twin session cannot fail it.",
+  template: "No unsupported endpoint was called",
+  params: {},
+  substrate: "tape",
+  // A prohibition. Nothing is required to happen; only the examinee reaching
+  // for an unimplemented route can break it.
+  polarity: () => "negative",
+  // No caller-supplied literal is hunted for in any substrate, so there is
+  // nothing a redactor could silently delete out from under this check.
+  subject: () => null,
+  // Ledgered. No slots, so the sentence carries no literal to falsify — the
+  // trigger is a fidelity stamp on the tape, which no mutation of the criterion
+  // text can reach.
+  vacuityMutant: () => null,
+  discriminatingWorlds: () => ({
+    passing: tapeWorld([
+      {
+        twin: "linear",
+        method: "POST",
+        path: "/graphql",
+        status: 200,
+        fidelity: "semantic",
+        event_id: "evt_ok",
+      },
+    ]),
+    failing: tapeWorld([
+      {
+        twin: "linear",
+        method: "POST",
+        path: "/graphql",
+        status: 501,
+        fidelity: "unsupported",
+        event_id: "evt_bad",
+      },
+    ]),
+  }),
+  evaluate(_args, { tape }) {
+    // The engine guards this before calling; the check guards too, so a
+    // consumer that forgets gets a named skip rather than a vacuous pass. For a
+    // NEGATIVE criterion that distinction is the whole ballgame — passing here
+    // would be a clean bill of health issued over a tape nobody read.
+    //
+    // `null` and `[]` are deliberately different: an EMPTY tape is a real world
+    // (the agent called nothing, so it called nothing unsupported).
+    if (tape === null) return { passed: false, reason: "tape_missing", status: "skipped" };
+
+    const unsupported = tape.filter((event) => event.fidelity === "unsupported");
+    if (unsupported.length === 0) {
+      // No evidence on the pass branch (F-980). This asserts a NEGATIVE over
+      // the whole tape, and a negative over an empty set has no single call to
+      // point at; citing all N inspected calls would be a copy of the trace.
+      return {
+        passed: true,
+        reason: `no unsupported endpoint was called (${tape.length} call(s) inspected)`,
+      };
+    }
+
+    // Cite the offenders. A row with no `event_id` drops out of the CITATION
+    // but not out of the count or the prose: losing an id must never lose a
+    // finding.
+    const evidenceEventIds = unsupported
+      .map((event) => event.event_id)
+      .filter((id): id is string => typeof id === "string" && id !== "");
+    return {
+      passed: false,
+      reason: `${unsupported.length} unsupported call(s): ${unsupported
+        .map((e) => `${e.method ?? "?"} ${e.path ?? "?"}`)
+        .join(", ")}`,
+      ...(evidenceEventIds.length > 0 ? { evidenceEventIds } : {}),
+    };
+  },
+});

--- a/packages/twin-linear/src/check-worlds.ts
+++ b/packages/twin-linear/src/check-worlds.ts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The fixture worlds Linear's declarations name (F-1129).
+//
+// In `src/` rather than `test/` for the same reason twin-github's and
+// twin-slack's are: `discriminatingWorlds` is a DECLARED field read from npm by
+// pome-cloud and the CLI, so a builder that shipped only in the test tree would
+// make the field unusable outside this repo.
+//
+// EVERY FAILING WORLD KEEPS ITS SELECTOR RESOLVABLE. Arm 3 of
+// `probeDiscrimination` rejects a failing world whose `reason` matches the one
+// an EMPTY world produces — measured on 11 of twin-github's 13 checks before
+// that arm existed. So a world built by omitting the team or the issue fails
+// through its selector rather than its assertion and is thrown out. Which is
+// why `linearState` always fills teams, workflowStates and labels, and why the
+// declarations move only the asserted value between their two worlds.
+//
+// The id derivations are shared rather than written twice. A fixture whose
+// `stateId` did not match a row in the same world would skip
+// `workflow_state_unresolved`, and a skip satisfies NEITHER arm — so a drifting
+// literal would look like a broken check rather than a broken fixture.
+
+import type { CheckSubstrate, CheckTapeEvent } from "@pome-sh/sdk/checks";
+import type {
+  LinearCheckState,
+  LinearCheckStateComment,
+  LinearCheckStateIssue,
+} from "./check-state.js";
+
+export const FIXTURE_TEAM_ID = "team_eng";
+export const FIXTURE_TEAM_KEY = "ENG";
+
+/** The one derivation, used by both the catalog and the rows that reference it. */
+export function fixtureStateId(name: string): string {
+  return `state_${name.toLowerCase().replace(/[^a-z0-9]+/g, "_")}`;
+}
+
+/** Ditto for labels. */
+export function fixtureLabelId(name: string): string {
+  return `label_${name.toLowerCase().replace(/[^a-z0-9]+/g, "_")}`;
+}
+
+/** Linear's default workflow, the five states `defaultSeedState()` seeds. */
+export const FIXTURE_STATES = [
+  { name: "Backlog", type: "backlog" },
+  { name: "Todo", type: "unstarted" },
+  { name: "In Progress", type: "started" },
+  { name: "Done", type: "completed" },
+  { name: "Canceled", type: "canceled" },
+] as const;
+
+export function finalWorld(final: LinearCheckState): CheckSubstrate<LinearCheckState> {
+  return { seed: null, final, tape: null };
+}
+
+export function deltaWorld(
+  seed: LinearCheckState,
+  final: LinearCheckState,
+): CheckSubstrate<LinearCheckState> {
+  return { seed, final, tape: null };
+}
+
+export function tapeWorld(tape: readonly CheckTapeEvent[]): CheckSubstrate<LinearCheckState> {
+  return { seed: null, final: { issues: [] }, tape };
+}
+
+/**
+ * A one-team workspace with Linear's five default workflow states.
+ *
+ * `labelNames` is the workspace label CATALOG, not the labels on any issue —
+ * `issueRow` attaches ids, and an id with no catalog row resolves to
+ * `label_unresolved`, a skip. Pass every label the issues reference.
+ */
+export function linearState(
+  issues: LinearCheckStateIssue[],
+  comments: LinearCheckStateComment[] = [],
+  labelNames: readonly string[] = ["Agent"],
+): LinearCheckState {
+  return {
+    teams: [{ id: FIXTURE_TEAM_ID, key: FIXTURE_TEAM_KEY, name: "Engineering" }],
+    workflowStates: FIXTURE_STATES.map((s) => ({
+      id: fixtureStateId(s.name),
+      teamId: FIXTURE_TEAM_ID,
+      name: s.name,
+      type: s.type,
+    })),
+    labels: labelNames.map((name) => ({
+      id: fixtureLabelId(name),
+      teamId: FIXTURE_TEAM_ID,
+      name,
+    })),
+    issues,
+    comments,
+    users: [
+      { id: "user_dev", email: "dev@pome-twin.test", name: "Developer", displayName: "Dev" },
+    ],
+    exportBounds: { truncatedCollections: [] },
+  };
+}
+
+/** A resolvable issue row, with `stateId` and `labelIds` derived the way the export emits them. */
+export function issueRow(
+  title: string,
+  over: {
+    id?: string;
+    stateName?: string;
+    labelNames?: readonly string[];
+    estimate?: number | null;
+    assigneeId?: string;
+  } = {},
+): LinearCheckStateIssue {
+  return {
+    id: over.id ?? "issue_1",
+    identifier: "ENG-1",
+    number: 1,
+    teamId: FIXTURE_TEAM_ID,
+    title,
+    stateId: fixtureStateId(over.stateName ?? "In Progress"),
+    estimate: over.estimate ?? null,
+    ...(over.assigneeId === undefined ? {} : { assigneeId: over.assigneeId }),
+    archivedAt: null,
+    labelIds: (over.labelNames ?? []).map(fixtureLabelId),
+  };
+}

--- a/packages/twin-linear/src/checks.ts
+++ b/packages/twin-linear/src/checks.ts
@@ -29,6 +29,7 @@
 // `check-params.ts`, fixture worlds in `check-worlds.ts`, and the reading of the
 // exported tree in `check-state.ts`.
 
+import { issueCommentContains, issueThreadedReply } from "./check-comments.js";
 import {
   issueAssignee,
   issueEstimate,
@@ -36,6 +37,7 @@ import {
   issueHasLabel,
   issueState,
 } from "./check-issues.js";
+import { noUnsupportedEndpoint } from "./check-tape.js";
 
 export type { Check } from "./check-kind.js";
 export type {
@@ -59,4 +61,10 @@ export const LINEAR_CHECKS = [
   issueHasLabel,
   issueEstimate,
   issueAssignee,
+  issueCommentContains,
+  issueThreadedReply,
+  // Last, because the listing order runs from the assertion an author reaches
+  // for first to the ones a specialised task needs — and this is the only one
+  // that reads the run rather than the world it left behind.
+  noUnsupportedEndpoint,
 ] as const;

--- a/packages/twin-linear/src/checks.ts
+++ b/packages/twin-linear/src/checks.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The Linear twin's assertable check vocabulary (F-1129, milestone A3).
+//
+// These live HERE, next to the state they read, because the twin owns that
+// state's shape. pome-cloud imports this module from npm and adapts each
+// declaration onto its predicate engine, so there is no second copy to
+// reconcile — only a pin that can fall behind, which is what its drift gate
+// exists to catch. The cloud's `deterministic/linear.ts`, including its
+// hand-maintained mirror of the state shape whose header records a manual
+// audit "verified against source, 2026-07-25", is deleted in the same
+// milestone. That audit is the artifact this file retires.
+//
+// Linear is the LAST of A3's four vocabularies, and the one that answered the
+// two questions the earlier three left open:
+//
+//   * A rendered sentence cannot carry a pronoun. Six of the nine shipped
+//     criteria named their subject with "that issue", with no subject at all,
+//     or by pointing at the seed. Under position 2 an author picks a check and
+//     fills its parameters, and `evaluate(args, substrate)` receives only its
+//     own args — so there is no mechanism by which "that issue" could resolve.
+//     Every check therefore takes an explicit title, and the three task files
+//     were rewritten to say so.
+//   * twin-github FAILS on a selector miss and twin-slack SKIPS. Linear does
+//     both, split by evidence rather than by taste — see `check-state.ts`.
+//
+// This file is the ASSEMBLY. Declarations group by what they assert about
+// (`check-issues.ts`, `check-comments.ts`, `check-tape.ts`), with typed slots in
+// `check-params.ts`, fixture worlds in `check-worlds.ts`, and the reading of the
+// exported tree in `check-state.ts`.
+
+import {
+  issueAssignee,
+  issueEstimate,
+  issueExists,
+  issueHasLabel,
+  issueState,
+} from "./check-issues.js";
+
+export type { Check } from "./check-kind.js";
+export type {
+  LinearCheckState,
+  LinearCheckStateComment,
+  LinearCheckStateIssue,
+  LinearCheckStateLabel,
+  LinearCheckStateTeam,
+  LinearCheckStateUser,
+  LinearCheckStateWorkflowState,
+} from "./check-state.js";
+
+// Order is not first-match-wins — the generated patterns are anchored and
+// mutually exclusive, and `checks-contract.test.ts` proves no sentence is
+// claimed by two. It is the order an authoring surface lists them in, running
+// from the assertion an author reaches for first to the ones a specialised task
+// needs.
+export const LINEAR_CHECKS = [
+  issueExists,
+  issueState,
+  issueHasLabel,
+  issueEstimate,
+  issueAssignee,
+] as const;

--- a/packages/twin-linear/src/index.ts
+++ b/packages/twin-linear/src/index.ts
@@ -27,6 +27,23 @@ export {
   withPublicOAuth,
 } from "./twin.js";
 export { registerLinearRoutes } from "./routes.js";
+// The declared check vocabulary (F-1129). Re-exported from the root as
+// twin-slack does, alongside the `@pome-sh/twin-linear/checks` subpath that
+// pome-cloud and the CLI both import. The `LinearCheckState*` types are a
+// CHECK's reading of the exported tree, and are deliberately distinct from the
+// `LinearIssue` / `LinearUser` / `LinearComment` row types below: the export
+// carries `stateId` and `labelIds` where those carry names.
+export { LINEAR_CHECKS } from "./checks.js";
+export type {
+  Check,
+  LinearCheckState,
+  LinearCheckStateComment,
+  LinearCheckStateIssue,
+  LinearCheckStateLabel,
+  LinearCheckStateTeam,
+  LinearCheckStateUser,
+  LinearCheckStateWorkflowState,
+} from "./checks.js";
 export type {
   LinearStateSeed,
   LinearTwinDatabase,

--- a/packages/twin-linear/test/check-state.test.ts
+++ b/packages/twin-linear/test/check-state.test.ts
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The four outcomes of resolving a Linear issue by title (F-1129).
+//
+// twin-github's resolvers always FAIL on a miss and twin-slack's always SKIP.
+// Linear needs both from the same resolver, and this file is where that
+// distinction is pinned: a miss inside a TRUNCATED export is evidence of a
+// partial snapshot, while a miss in a complete one is evidence about the
+// examinee. Getting it backwards hands a do-nothing agent a pass on task 26.
+
+import { describe, expect, it } from "vitest";
+import {
+  isTruncated,
+  resolveComments,
+  resolveIssue,
+  resolveLabelNames,
+  resolveUserLabels,
+  resolveWorkflowStateName,
+  type LinearCheckState,
+  type LinearCheckStateIssue,
+} from "../src/check-state.js";
+
+const TEAM = { id: "team_eng", key: "ENG", name: "Engineering" };
+const STATE_PROGRESS = {
+  id: "state_progress",
+  teamId: "team_eng",
+  name: "In Progress",
+  type: "started",
+};
+const LABEL_AGENT = { id: "label_agent", teamId: "team_eng", name: "Agent" };
+
+function world(over: Partial<LinearCheckState> = {}): LinearCheckState {
+  return {
+    teams: [TEAM],
+    workflowStates: [STATE_PROGRESS],
+    labels: [LABEL_AGENT],
+    issues: [
+      {
+        id: "issue_1",
+        teamId: "team_eng",
+        title: "Orders 500 after deploy",
+        stateId: "state_progress",
+        estimate: 2,
+        labelIds: ["label_agent"],
+        archivedAt: null,
+      },
+    ],
+    comments: [{ id: "c1", issueId: "issue_1", parentId: null, body: "opened" }],
+    users: [{ id: "user_dev", email: "dev@pome-twin.test", name: "Developer" }],
+    exportBounds: { truncatedCollections: [] },
+    ...over,
+  };
+}
+
+/** The resolved issue, or an explicit failure — never `as never`. */
+function issueIn(state: LinearCheckState, team = "ENG", title = "Orders 500 after deploy") {
+  const r = resolveIssue(state, team, title);
+  if ("missing" in r) throw new Error(`expected a resolved issue, got: ${r.missing}`);
+  return r.found;
+}
+
+describe("resolveIssue — the four outcomes", () => {
+  it("finds the issue by title within its team", () => {
+    expect(issueIn(world()).id).toBe("issue_1");
+  });
+
+  it("FAILS, does not skip, when the title is absent and the collection is complete", () => {
+    const r = resolveIssue(world(), "ENG", "Never created");
+    expect("missing" in r && r.skip).toBe(false);
+    expect("missing" in r && r.missing).toContain("`ENG`");
+    // The title is a selector, not a declared subject, so it may not have
+    // survived redaction — it must never be echoed into a reason string.
+    expect("missing" in r && r.missing).not.toContain("Never created");
+  });
+
+  it("SKIPS when the issues collection was truncated by STATE_EXPORT_CAP", () => {
+    const r = resolveIssue(
+      world({ exportBounds: { truncatedCollections: ["issues"] } }),
+      "ENG",
+      "Never created",
+    );
+    expect("missing" in r && r.skip).toBe(true);
+    expect("missing" in r && r.missing).toBe("state_truncated");
+  });
+
+  it("still resolves a PRESENT issue even when the collection was truncated", () => {
+    // Truncation only excuses a MISS. A hit is a hit.
+    const truncated = world({ exportBounds: { truncatedCollections: ["issues"] } });
+    expect(issueIn(truncated).id).toBe("issue_1");
+  });
+
+  it("SKIPS when the issues collection is absent entirely", () => {
+    const r = resolveIssue(world({ issues: null }), "ENG", "Orders 500 after deploy");
+    expect("missing" in r && r.missing).toBe("state_incomplete");
+    expect("missing" in r && r.skip).toBe(true);
+  });
+
+  it("SKIPS when the teams collection is absent entirely", () => {
+    const r = resolveIssue(world({ teams: null }), "ENG", "Orders 500 after deploy");
+    expect("missing" in r && r.missing).toBe("state_incomplete");
+    expect("missing" in r && r.skip).toBe(true);
+  });
+
+  it("FAILS on an ambiguous title, naming the count and not the title", () => {
+    const dup = world();
+    dup.issues = [...dup.issues!, { ...dup.issues![0]!, id: "issue_2" }];
+    const r = resolveIssue(dup, "ENG", "Orders 500 after deploy");
+    expect("missing" in r && r.skip).toBe(false);
+    expect("missing" in r && r.missing).toContain("2 issues");
+    expect("missing" in r && r.missing).not.toContain("Orders 500 after deploy");
+  });
+
+  it("FAILS when the team key is absent", () => {
+    const r = resolveIssue(world(), "OPS", "Orders 500 after deploy");
+    expect("missing" in r && r.skip).toBe(false);
+    // The team key is `[A-Z][A-Z0-9]*` — no redactor pattern matches it, so it
+    // is the one selector a reason string may quote.
+    expect("missing" in r && r.missing).toContain("`OPS`");
+  });
+
+  it("treats an archived issue as absent", () => {
+    const archived = world();
+    archived.issues = [{ ...archived.issues![0]!, archivedAt: "2026-07-30T00:00:00.000Z" }];
+    const r = resolveIssue(archived, "ENG", "Orders 500 after deploy");
+    expect("missing" in r).toBe(true);
+  });
+
+  it("scopes the title search to the named team", () => {
+    const twoTeams = world();
+    twoTeams.teams = [TEAM, { id: "team_ops", key: "OPS", name: "Ops" }];
+    twoTeams.issues = [
+      ...twoTeams.issues!,
+      {
+        id: "issue_ops",
+        teamId: "team_ops",
+        title: "Orders 500 after deploy",
+        archivedAt: null,
+      },
+    ];
+    // Title uniqueness is validated PER TEAM (`seed.ts:319-325`), so this world
+    // is legal and an unscoped search would grade whichever sorted first.
+    expect(issueIn(twoTeams, "ENG").id).toBe("issue_1");
+    expect(issueIn(twoTeams, "OPS").id).toBe("issue_ops");
+  });
+
+  it("matches the title exactly, not case-insensitively", () => {
+    const r = resolveIssue(world(), "ENG", "orders 500 after deploy");
+    expect("missing" in r).toBe(true);
+  });
+});
+
+describe("the indirect joins", () => {
+  it("resolves the workflow state NAME through stateId, team-scoped", () => {
+    expect(resolveWorkflowStateName(world(), issueIn(world()))).toEqual({ found: "In Progress" });
+  });
+
+  it("skips workflow_state_unresolved when the state row belongs to another team", () => {
+    const w = world({ workflowStates: [{ ...STATE_PROGRESS, teamId: "team_ops" }] });
+    expect(resolveWorkflowStateName(w, issueIn(w))).toEqual({
+      missing: "workflow_state_unresolved",
+      skip: true,
+    });
+  });
+
+  it("skips state_incomplete when workflowStates is absent", () => {
+    const w = world({ workflowStates: null });
+    expect(resolveWorkflowStateName(w, issueIn(w))).toEqual({
+      missing: "state_incomplete",
+      skip: true,
+    });
+  });
+
+  it("resolves label NAMES through labelIds, lowercased", () => {
+    expect(resolveLabelNames(world(), issueIn(world()))).toEqual({ found: new Set(["agent"]) });
+  });
+
+  it("skips label_unresolved when a linked label has no catalog row", () => {
+    const w = world();
+    w.issues = [{ ...w.issues![0]!, labelIds: ["label_agent", "label_ghost"] }];
+    expect(resolveLabelNames(w, issueIn(w))).toEqual({ missing: "label_unresolved", skip: true });
+  });
+
+  it("returns an empty set for an issue with no labels", () => {
+    const w = world();
+    w.issues = [{ ...w.issues![0]!, labelIds: [] }];
+    expect(resolveLabelNames(w, issueIn(w))).toEqual({ found: new Set() });
+  });
+
+  it("returns only the comments on the given issue", () => {
+    const w = world();
+    w.comments = [...w.comments!, { id: "c2", issueId: "issue_other", body: "elsewhere" }];
+    const r = resolveComments(w, issueIn(w));
+    expect("found" in r && r.found.map((c) => c.id)).toEqual(["c1"]);
+  });
+
+  it("skips state_incomplete when comments is absent", () => {
+    const w = world({ comments: null });
+    expect(resolveComments(w, issueIn(w))).toEqual({ missing: "state_incomplete", skip: true });
+  });
+
+  it("offers every spelling of a user the legacy assignee rule accepted", () => {
+    const w = world();
+    w.users = [
+      { id: "user_dev", email: "dev@pome-twin.test", name: "Developer", displayName: "Dev" },
+    ];
+    expect(resolveUserLabels(w, "user_dev")).toEqual([
+      "dev@pome-twin.test",
+      "Developer",
+      "Dev",
+    ]);
+  });
+
+  it("returns no user labels for an unassigned issue", () => {
+    expect(resolveUserLabels(world(), undefined)).toEqual([]);
+    expect(resolveUserLabels(world(), "user_missing")).toEqual([]);
+  });
+
+  it("reports a truncated collection by name", () => {
+    expect(
+      isTruncated(world({ exportBounds: { truncatedCollections: ["comments"] } }), "comments"),
+    ).toBe(true);
+    expect(isTruncated(world(), "comments")).toBe(false);
+    expect(isTruncated(world({ exportBounds: null }), "issues")).toBe(false);
+  });
+});
+
+describe("the model tolerates a partial export rather than throwing", () => {
+  it("survives an issue row missing every optional field", () => {
+    const bare: LinearCheckStateIssue = { id: "i", teamId: "team_eng", title: "bare" };
+    const w = world({ issues: [bare] });
+    const r = resolveIssue(w, "ENG", "bare");
+    expect("found" in r).toBe(true);
+    // No stateId to follow, so the state join names itself rather than throwing.
+    expect(resolveWorkflowStateName(w, bare)).toEqual({
+      missing: "workflow_state_unresolved",
+      skip: true,
+    });
+    expect(resolveLabelNames(w, bare)).toEqual({ found: new Set() });
+  });
+
+  it("survives an entirely empty state object", () => {
+    const r = resolveIssue({}, "ENG", "anything");
+    expect("missing" in r && r.missing).toBe("state_incomplete");
+  });
+});

--- a/packages/twin-linear/test/checks-contract.test.ts
+++ b/packages/twin-linear/test/checks-contract.test.ts
@@ -44,6 +44,13 @@ const FIXTURES: Record<string, Record<string, string>> = {
     team: "ENG",
     user: "dev@pome-twin.test",
   },
+  "linear.issue-comment-contains": {
+    title: "Orders 500 after deploy",
+    team: "ENG",
+    needle: "#1",
+  },
+  "linear.issue-threaded-reply": { title: "Needs comment and label triage", team: "ENG" },
+  "linear.no-unsupported-endpoint": {},
 };
 
 // Every check whose `vacuityMutant` returns null, WITH the reason. A null
@@ -56,14 +63,28 @@ const FIXTURES: Record<string, Record<string, string>> = {
 //   2. THE PARAMETER IS A CLOSED SET. Typing a slot as `oneOf` means no member
 //      is guaranteed false, so a mutant could assert a different state that
 //      happens to be true as well.
-const HONEST_NULL_MUTANTS: Record<string, string> = {};
+const HONEST_NULL_MUTANTS: Record<string, string> = {
+  "linear.issue-threaded-reply":
+    "both slots only SELECT the issue; the trigger is a parentId relation between the seed and " +
+    "the final state, which no mutation of the criterion text can reach",
+  // The sharpest form of the argument, and the reason `discriminatingWorlds`
+  // exists: with no slots there is no sentence to falsify, so the vacuity probe
+  // is STRUCTURALLY blind to this check and its declared failing world is the
+  // only evidence it can fail at all.
+  "linear.no-unsupported-endpoint":
+    "the sentence has no slots; the trigger is a fidelity stamp on the tape, which lives in the " +
+    "recording and not in the criterion text",
+};
 
 // twin-github ledgers REPO_FREE_CHECKS; this is Linear's analogue, and unlike
 // twin-slack Linear does NOT argue the rule away — `seed.ts:319-325` validates
 // issue-title uniqueness per team, so the ambiguity a scope slot closes is real
 // here. Only a check that reads no state at all may be ledgered, and the second
 // assertion below enforces that by requiring `substrate: "tape"`.
-const TEAM_FREE_CHECKS: Record<string, string> = {};
+const TEAM_FREE_CHECKS: Record<string, string> = {
+  "linear.no-unsupported-endpoint":
+    "reads the tape and no state at all, so there is no issue to disambiguate between teams",
+};
 
 // Ships EMPTY and stays empty. Unlike `vacuityMutant` there is no structural
 // excuse — a closed set genuinely has no guaranteed-false member, but every

--- a/packages/twin-linear/test/checks-contract.test.ts
+++ b/packages/twin-linear/test/checks-contract.test.ts
@@ -1,0 +1,386 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The properties every declared check must hold, carried across from twin-slack
+// when Linear's vocabulary moved out of pome-cloud (F-1129).
+//
+// Load-bearing, not ceremony: D10 and D11 were both caught by the mutant
+// assertions in twin-github's copy of this file, and reverting a mutant to a
+// resolved selector left that suite green until the honest-null ledger existed.
+// They travel with the declaration so the twin, not its consumer, is where a
+// bad check is stopped.
+
+import {
+  checkNearMissPattern,
+  checkPattern,
+  parseCheck,
+  probeDiscrimination,
+  renderCheck,
+  VACUITY_SENTINEL,
+  VACUITY_SENTINEL_NUMBER,
+  type CheckDefinition,
+  type CheckSubstrateKind,
+} from "@pome-sh/sdk/checks";
+import { describe, expect, it } from "vitest";
+import { LINEAR_CHECKS } from "../src/checks.js";
+import { resolveIssue, type LinearCheckState } from "../src/check-state.js";
+
+// The declarations are a heterogeneous tuple, so iterating them yields a union
+// whose args type differs per check, while the fixtures below are looked up by
+// id at run time. That tie cannot be made statically — erase it once here
+// rather than casting at a dozen call sites.
+type OpenCheck = CheckDefinition<LinearCheckState, Record<string, string>>;
+const CHECKS = LINEAR_CHECKS as readonly unknown[] as readonly OpenCheck[];
+
+// Representative args per check, used to exercise render/parse/mutant/worlds.
+// The coverage arm below makes this table impossible to forget: a check with no
+// fixture FAILS rather than silently skipping every property here.
+const FIXTURES: Record<string, Record<string, string>> = {
+  "linear.issue-exists": { title: "Orders 500 after deploy", team: "ENG" },
+  "linear.issue-state": { title: "Orders 500 after deploy", team: "ENG", state: "In Progress" },
+  "linear.issue-has-label": { title: "Orders 500 after deploy", team: "ENG", label: "Agent" },
+  "linear.issue-estimate": { title: "Orders 500 after deploy", team: "ENG", estimate: "2" },
+  "linear.issue-assignee": {
+    title: "Orders 500 after deploy",
+    team: "ENG",
+    user: "dev@pome-twin.test",
+  },
+};
+
+// Every check whose `vacuityMutant` returns null, WITH the reason. A null
+// mutant is an admitted blind spot; admitting it in a ledger is what keeps it
+// from becoming a habit.
+//
+// Exactly two arguments earn a line here:
+//   1. THE PARAMETER ONLY SELECTS. Falsifying it moves the verdict for a reason
+//      that never reaches the assertion — a clean bill the check did not earn.
+//   2. THE PARAMETER IS A CLOSED SET. Typing a slot as `oneOf` means no member
+//      is guaranteed false, so a mutant could assert a different state that
+//      happens to be true as well.
+const HONEST_NULL_MUTANTS: Record<string, string> = {};
+
+// twin-github ledgers REPO_FREE_CHECKS; this is Linear's analogue, and unlike
+// twin-slack Linear does NOT argue the rule away — `seed.ts:319-325` validates
+// issue-title uniqueness per team, so the ambiguity a scope slot closes is real
+// here. Only a check that reads no state at all may be ledgered, and the second
+// assertion below enforces that by requiring `substrate: "tape"`.
+const TEAM_FREE_CHECKS: Record<string, string> = {};
+
+// Ships EMPTY and stays empty. Unlike `vacuityMutant` there is no structural
+// excuse — a closed set genuinely has no guaranteed-false member, but every
+// field of `CheckSubstrate<LinearCheckState>` is hand-fillable.
+const HONEST_NULL_WORLDS: Record<string, string> = {};
+
+const SUBSTRATES: CheckSubstrateKind[] = ["final", "seed+final", "tape"];
+
+describe("declared check identity", () => {
+  it("gives every check a fixture, and carries no stale fixture", () => {
+    for (const check of CHECKS) {
+      expect(FIXTURES[check.id], `${check.id} has no FIXTURES entry`).toBeDefined();
+    }
+    for (const id of Object.keys(FIXTURES)) {
+      expect(
+        CHECKS.some((c) => c.id === id),
+        `stale FIXTURES entry: ${id}`,
+      ).toBe(true);
+    }
+  });
+
+  it("declares a non-empty, twin-prefixed, unique id", () => {
+    const seen = new Set<string>();
+    for (const check of CHECKS) {
+      expect(check.id, "every check needs an id").toBeTruthy();
+      expect(check.id.startsWith("linear."), `${check.id} is not twin-prefixed`).toBe(true);
+      expect(seen.has(check.id), `duplicate id ${check.id}`).toBe(false);
+      seen.add(check.id);
+    }
+  });
+
+  it("declares a description that is not just the template", () => {
+    // Shankar et al., UIST '24 §7.3.3: a picker can only show what is declared,
+    // and a description that restates the sentence teaches an author nothing.
+    for (const check of CHECKS) {
+      expect(check.description, `${check.id} has no description`).toBeTruthy();
+      expect(check.description).not.toBe(check.template);
+    }
+  });
+
+  it("declares a known substrate and function-valued polarity/vacuityMutant", () => {
+    for (const check of CHECKS) {
+      expect(SUBSTRATES, `${check.id} declares an unknown substrate`).toContain(check.substrate);
+      expect(typeof check.polarity).toBe("function");
+      expect(typeof check.vacuityMutant).toBe("function");
+      expect(typeof check.discriminatingWorlds).toBe("function");
+    }
+  });
+
+  it("names its team unless ledgered, and a ledgered check reads no state", () => {
+    for (const check of CHECKS) {
+      if (TEAM_FREE_CHECKS[check.id] !== undefined) {
+        expect(check.substrate, `${check.id} is team-free but reads state`).toBe("tape");
+        continue;
+      }
+      expect(
+        Object.keys(check.params),
+        `${check.id} does not name its team — a title-keyed selector is ambiguous across teams`,
+      ).toContain("team");
+    }
+    for (const id of Object.keys(TEAM_FREE_CHECKS)) {
+      expect(
+        CHECKS.some((c) => c.id === id),
+        `stale TEAM_FREE_CHECKS entry: ${id}`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe("declared check grammar", () => {
+  it("round-trips render -> parse -> render byte-identically", () => {
+    for (const check of CHECKS) {
+      const rendered = renderCheck(check, FIXTURES[check.id]!);
+      const parsed = parseCheck(check, rendered);
+      expect(parsed, `${check.id}: its own sentence did not parse`).not.toBeNull();
+      expect(renderCheck(check, parsed!)).toBe(rendered);
+    }
+  });
+
+  it("binds its own sentence and is anchored", () => {
+    for (const check of CHECKS) {
+      const rendered = renderCheck(check, FIXTURES[check.id]!);
+      expect(checkPattern(check).test(rendered), `${check.id} does not bind itself`).toBe(true);
+      expect(
+        checkPattern(check).test(`${rendered} and also something else`),
+        `${check.id} is not anchored — a terminal free-text slot swallows the suffix`,
+      ).toBe(false);
+    }
+  });
+
+  it("binds no OTHER check's valid sentence", () => {
+    for (const check of CHECKS) {
+      const rendered = renderCheck(check, FIXTURES[check.id]!);
+      for (const other of CHECKS) {
+        if (other.id === check.id) continue;
+        expect(
+          checkPattern(other).test(rendered),
+          `${other.id} claims ${check.id}'s sentence`,
+        ).toBe(false);
+      }
+    }
+  });
+
+  it("near-misses only its own template", () => {
+    // A near-miss pattern opens every slot to `.+?` while keeping the literals,
+    // so two templates whose literal skeletons overlap would report a corrupted
+    // instance under a check the author never picked. This is the arm that
+    // makes `is in state "{state}"` the wording rather than `is {state}`.
+    for (const check of CHECKS) {
+      const rendered = renderCheck(check, FIXTURES[check.id]!);
+      for (const other of CHECKS) {
+        if (other.id === check.id) continue;
+        expect(
+          checkNearMissPattern(other).test(rendered),
+          `${other.id} near-misses ${check.id}'s sentence`,
+        ).toBe(false);
+      }
+    }
+  });
+});
+
+describe("declared vacuity mutants", () => {
+  it("produces a sentinel-bearing mutant that re-binds to the same check, or is ledgered", () => {
+    for (const check of CHECKS) {
+      const args = FIXTURES[check.id]!;
+      const mutant = check.vacuityMutant(args);
+      if (mutant === null) {
+        expect(
+          HONEST_NULL_MUTANTS[check.id],
+          `${check.id} declared a null mutant with no ledger entry`,
+        ).toBeTruthy();
+        continue;
+      }
+      const rendered = renderCheck(check, mutant);
+      // A "mutation" to a value that could actually exist proves nothing.
+      expect(rendered, `${check.id}: mutant is identical to the original`).not.toBe(
+        renderCheck(check, args),
+      );
+      expect(
+        rendered.includes(VACUITY_SENTINEL) || rendered.includes(String(VACUITY_SENTINEL_NUMBER)),
+        `${check.id}: mutant "${rendered}" carries no sentinel`,
+      ).toBe(true);
+      // The load-bearing one: a mutant that stops matching evaluates to
+      // `unmatched`, which differs from `passed`, which reads as "the verdict
+      // moved -> healthy". It must re-bind.
+      expect(
+        checkPattern(check).test(rendered),
+        `${check.id}: mutant "${rendered}" does not re-bind`,
+      ).toBe(true);
+      // Re-binding is necessary but not sufficient: a mutant may not silently
+      // change a slot it never set out to falsify.
+      for (const [slot, value] of Object.entries(mutant)) {
+        if (value === args[slot]) continue;
+        expect(
+          value.includes(VACUITY_SENTINEL) || value === String(VACUITY_SENTINEL_NUMBER),
+          `${check.id}: mutant changed slot "${slot}" from ${JSON.stringify(
+            args[slot],
+          )} to ${JSON.stringify(value)} without falsifying it`,
+        ).toBe(true);
+      }
+    }
+    for (const id of Object.keys(HONEST_NULL_MUTANTS)) {
+      expect(
+        CHECKS.some((c) => c.id === id),
+        `stale HONEST_NULL_MUTANTS entry: ${id}`,
+      ).toBe(true);
+    }
+  });
+
+  it("carries the NUMERIC sentinel only where the number is the scanned value (D10)", () => {
+    // In these patterns a numeric capture is a SELECTOR unless you can argue
+    // the number IS what the predicate scans for. `linear.issue-estimate` can:
+    // the estimate is compared to the column, and the title is the selector —
+    // stripe's `payment-intent-amount` argument, unchanged.
+    const NUMERIC_ALLOWED = new Set(["linear.issue-estimate"]);
+    for (const check of CHECKS) {
+      const mutant = check.vacuityMutant(FIXTURES[check.id]!);
+      if (mutant === null) continue;
+      if (!renderCheck(check, mutant).includes(String(VACUITY_SENTINEL_NUMBER))) continue;
+      expect(
+        NUMERIC_ALLOWED.has(check.id),
+        `${check.id}: mutant carries the NUMERIC sentinel. Falsifying a selector moves the ` +
+          `verdict on every seed for a reason that never reaches the trigger clause, so the ` +
+          `criterion always reads as "discriminates" and can never be flagged vacuous. Point ` +
+          `the mutant at the literal the predicate SCANS for instead.`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe("declared discriminating worlds", () => {
+  it("names a passing and a failing world for every check, or admits a null in the ledger", () => {
+    for (const check of CHECKS) {
+      const verdict = probeDiscrimination(check, FIXTURES[check.id]!);
+      if (verdict.kind === "declined") {
+        expect(
+          HONEST_NULL_WORLDS[check.id],
+          `${check.id} declined to declare worlds with no ledger entry`,
+        ).toBeTruthy();
+        continue;
+      }
+      expect(
+        verdict.kind === "broken"
+          ? `${check.id}: ${verdict.arm} — ${verdict.detail}`
+          : "discriminates",
+      ).toBe("discriminates");
+    }
+    for (const id of Object.keys(HONEST_NULL_WORLDS)) {
+      expect(
+        CHECKS.some((c) => c.id === id),
+        `stale HONEST_NULL_WORLDS entry: ${id}`,
+      ).toBe(true);
+    }
+  });
+
+  it("ships an EMPTY null-worlds ledger", () => {
+    // A failing world is a hand-written fixture and every field of
+    // CheckSubstrate is hand-fillable, so unlike a vacuity mutant there is no
+    // structural excuse for absence.
+    expect(Object.keys(HONEST_NULL_WORLDS)).toEqual([]);
+  });
+
+  it("puts each world on the substrate the check declared", () => {
+    // A `final` check handed a seed, or a `tape` check handed none, would pass
+    // the arms above while testing a substrate the engine will never give it.
+    for (const check of CHECKS) {
+      const worlds = check.discriminatingWorlds(FIXTURES[check.id]!);
+      if (worlds === null) continue;
+      for (const [arm, world] of [
+        ["passing", worlds.passing],
+        ["failing", worlds.failing],
+      ] as const) {
+        if (check.substrate === "tape") {
+          expect(world.tape, `${check.id} ${arm}: a tape check was handed no tape`).not.toBeNull();
+        } else {
+          expect(world.tape, `${check.id} ${arm}: a state check was handed a tape`).toBeNull();
+        }
+        if (check.substrate === "seed+final") {
+          expect(world.seed, `${check.id} ${arm}: a delta check was handed no seed`).not.toBeNull();
+        } else {
+          expect(world.seed, `${check.id} ${arm}: a final-only check was handed a seed`).toBeNull();
+        }
+      }
+    }
+  });
+});
+
+describe("state-shape parity", () => {
+  // `LinearCheckState` is a HAND-WRITTEN reader of raw SQLite rows, so nothing
+  // but this arm stops it drifting from what `exportLinearState` actually
+  // emits. twin-slack put its equivalent in `fidelity-contract.test.ts`; Linear
+  // has no such vitest suite — its parity harness is a standalone tsx script —
+  // so the arm goes in the file that already runs, and the repo gains one test
+  // file rather than a second drift gate.
+  async function realExport(): Promise<LinearCheckState> {
+    const { LinearDomain, defaultSeedState, openLinearTwinDatabase, parseSeed } = await import(
+      "../src/index.js"
+    );
+    const db = openLinearTwinDatabase(":memory:");
+    try {
+      const domain = new LinearDomain(db);
+      domain.seed(parseSeed(defaultSeedState()));
+      return domain.exportState() as unknown as LinearCheckState;
+    } finally {
+      db.close();
+    }
+  }
+
+  it("emits every collection the check state model reads", async () => {
+    const state = await realExport();
+    for (const key of ["teams", "workflowStates", "labels", "issues", "comments", "users"] as const) {
+      expect(Array.isArray(state[key]), `export has no ${key} array`).toBe(true);
+    }
+    expect(Array.isArray(state.exportBounds?.truncatedCollections)).toBe(true);
+  });
+
+  it("emits every issue field the model reads, with the types it assumes", async () => {
+    const issue = (await realExport()).issues!.find((i) => i.title === "Triage inbox for agent eval");
+    expect(issue, "the default seed no longer carries that issue").toBeDefined();
+    expect(typeof issue!.id).toBe("string");
+    expect(typeof issue!.teamId).toBe("string");
+    expect(typeof issue!.title).toBe("string");
+    // stateId, NOT a state name — trap 1, and the reason
+    // `resolveWorkflowStateName` exists at all.
+    expect(typeof issue!.stateId).toBe("string");
+    expect("state" in issue!, "the export gained a state NAME; the join may be redundant").toBe(
+      false,
+    );
+    // labelIds, NOT label objects and NOT names — trap 2.
+    expect(Array.isArray(issue!.labelIds)).toBe(true);
+    // Trap 3: resolution filters on this, so it must be a declared column.
+    expect("archivedAt" in issue!).toBe(true);
+    expect("estimate" in issue!).toBe(true);
+  });
+
+  it("scopes workflow states and labels by teamId", async () => {
+    const state = await realExport();
+    expect(typeof state.workflowStates![0]!.teamId).toBe("string");
+    expect(typeof state.workflowStates![0]!.name).toBe("string");
+    expect(typeof state.labels![0]!.teamId).toBe("string");
+    expect(typeof state.labels![0]!.name).toBe("string");
+  });
+
+  it("exports comment threading", async () => {
+    const comments = (await realExport()).comments!;
+    expect(Array.isArray(comments)).toBe(true);
+    // `parentId` must be a declared column even when every seeded comment is a
+    // root, or `linear.issue-threaded-reply` is unanswerable.
+    if (comments.length > 0) expect("parentId" in comments[0]!).toBe(true);
+  });
+
+  it("resolves a real seeded issue end to end", async () => {
+    const state = await realExport();
+    const r = resolveIssue(state, "ENG", "Triage inbox for agent eval");
+    expect(
+      "found" in r,
+      `resolveIssue failed on a REAL export: ${JSON.stringify(r)}`,
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- Closes F-1129 -->

## What

The Linear twin declares an assertable check vocabulary — **eight checks**, a state model, fixture worlds, and a contract suite — and tasks 24, 25 and 26 are rewritten so every criterion names its own subject. `pome checks linear` answers with a vocabulary instead of "not migrated yet".

## Why

F-1129, milestone A3. Linear resolved **0 of 9** shipped `[code]` criteria — the joint-largest gap in the corpus. Its five cloud-side regexes keyed on `identifier` ("ENG-123") or issue number, and **not one** of the nine criteria uses either; every one names a title. The registries and the tasks were built for each other and had never once met.

Design of record: `pome-cloud docs/grading/linear-vocabulary.md`.

## Notes for reviewer

**Three findings changed the shape the ticket proposed. All measured, not argued.**

**1 · The anaphora count is six, not four — and the repair is nine rewrites.**
The ticket counted the four `that issue` pronouns; it missed `Issue has label "Needs triage"` (no subject at all) and `A reply comment exists with parentId equal to the seeded root comment` (points at an id in the seed). And all nine change, not six, because Linear inherits twin-github's scope rule rather than twin-slack's exemption: `packages/twin-linear/src/seed.ts:319-325` validates issue-title uniqueness via `issueTitlesByTeam` — **per team**. A title-keyed selector over a two-team world is exactly the ambiguity that rule closes, so slack's "there is nothing to disambiguate" argument is not available to borrow. Every state check names its team.

**2 · A selector miss FAILS, and task 26 is why.**
twin-github fails on a miss, twin-slack skips, and A2b never said which a third twin inherits. Slack's argument is about *negatives*; all seven Linear state checks are positive, where a skip is the unsafe direction. Measured on task 26 with slack's discipline:

```
[code:github] Issue #1 ... is in state open   negative, seed satisfies  -> PASSED
[code:linear] x3, issue never created          -> skipped, leaves denominator
                                                  1/1 = 100%, threshold 100 -> PASS
```

That reproduces the `KNOWN_NULL_AGENT_TASKS` entry this milestone exists to clear. With FAIL it is 25%.

**3 · The honest named skip is truncation, not renaming — and Linear is the only twin that can evidence it.**
`src/state.ts:24` exports `exportBounds.truncatedCollections`, so the twin itself reports when rows were dropped past `STATE_EXPORT_CAP = 2000`. Neither `GitHubCheckState` nor `SlackCheckState` carries an analogue. Four-outcome resolution in `check-state.ts`: collection absent → `state_incomplete` (skip); truncated + miss → `state_truncated` (skip); miss in a complete collection → **fail**; >1 match → **fail** naming the count.

**One capability is narrowed, recorded rather than absorbed.** `linear.issue-lifecycle` (`is open/closed/done`) is not migrated: a declared `... is {lifecycle}` near-misses every `is in state "..."` sentence and would report a corrupted state criterion under the lifecycle check — the exact hazard `github.issue-state`'s wording comment says its phrasing exists to avoid. Zero corpus users; `is in state "Done"` / `"Canceled"` re-expresses what matters.

**Task 26 loses a criterion rather than gaining a subject.** `linear.issue-state` fails on a missing issue, so it subsumes `An issue titled "..." exists` — F-1075's collapse, applied on the side the ticket asked us to look for it. Corpus goes 70 → 69 `[code]` criteria.

**Evidence, all run:**

- All 8 checks `discriminate` through their **assertion**, not their selector. The threaded-reply failing world reads `0 replies to a seeded comment (1 seeded comment(s), 2 at finish)` — the agent commented, just not in the thread.
- `HONEST_NULL_WORLDS` ships **empty**. `HONEST_NULL_MUTANTS` holds two, `TEAM_FREE_CHECKS` one (and its own rule forces `substrate: "tape"`).
- All 8 rewritten criteria bind **exactly one** check, verified offline against the built declarations — D6's invariant before CI sees it.
- State-shape parity arm boots a real twin over the default seed and passed first run, including that an exported issue carries `stateId` and **not** a state name.
- Full repo: 8 packages green. twin-linear 16 files / 95 tests. CLI 88 files / 782 tests. Gates green: CLI pin parity, workspace pin parity, first-party twin registration, copy-markers, legacy-markers, no-cloud-imports.

**Two traps worth knowing.** `packages/twin-linear/package.json`'s `test` script names every file explicitly (twin-slack runs bare `vitest run`), so both new test files are added to that list — a contract suite that silently never runs is the worst outcome here. And the state-shape parity arm lives in `checks-contract.test.ts` rather than a `fidelity-contract.test.ts`, because twin-linear has no such vitest suite; that is the honest reading of "reuse the harness, do not add a second drift gate".

## Review required

**Yes — twin fidelity contract.** `src/check-state.ts` is a new hand-written reader of `exportLinearState()`'s raw rows, and the state-shape parity arm is what holds it to the real export.

**Release ordering.** `@pome-sh/twin-linear` 0.1.1 → **0.2.0** (new `./checks` subpath and state model); `cli/package.json` pin moves in this PR per `PACKAGE_RELEASE.md` step 1. A `packages-v*` release must land before the pome-cloud PR, and the CLI publish must come **after** the prod tag — F-1075 proved publishing the CLI first gives upgraders an 8-check client against a 1-check prod, and the digest handshake refuses either direction of skew.
