### PR TITLE
A pull request can be commented on, and the sentence that says so binds (F-1151)

### DIFF
--- a/cli/.changeset/github-pull-requests-take-comments.md
+++ b/cli/.changeset/github-pull-requests-take-comments.md
@@ -1,0 +1,25 @@
+---
+"@pome-sh/cli": minor
+---
+
+`pome checks github` gains a fourteenth check, and the GitHub twin can finally
+record the thing it grades. `github.pr-comment-exists` binds
+`` Pull request #N in `<repo>` has at least one comment ``, the sentence six
+bundled `pr-summary-*` criteria have carried unbound since the vocabulary was
+declared.
+
+The sentence was unbound because "comment" has three readings on a pull request —
+a conversation comment, a review's body, or an inline review comment — and
+guessing between them ships a check that lies. This one grades the CONVERSATION
+timeline, its `description` says so, and says the other two are not it: assert a
+review with `github.pr-review-exists`, and an inline comment has no declaration
+yet.
+
+Underneath, `add_issue_comment` and `list_issue_comments` now accept a PULL
+REQUEST number, which is how real GitHub documents commenting on a PR. They used
+to answer `404 Issue not found` for every PR, so an agent whose job is to leave a
+summary had no working way to leave one.
+
+Bundled twin pins: `@pome-sh/twin-github` 0.7.0 → 0.8.0. github's checks digest
+moves with the new declaration, so `pome checks add --twin github` requires a
+control plane on the matching pin.

--- a/cli/package.json
+++ b/cli/package.json
@@ -68,7 +68,7 @@
     "@pome-sh/sdk": "0.10.0",
     "@pome-sh/shared-types": "0.13.0",
     "@pome-sh/twin-gmail": "0.3.0",
-    "@pome-sh/twin-github": "0.7.0",
+    "@pome-sh/twin-github": "0.8.0",
     "@pome-sh/twin-linear": "0.2.0",
     "@pome-sh/twin-slack": "0.3.0",
     "@pome-sh/twin-stripe": "0.4.0",

--- a/packages/twin-github/CHANGELOG.md
+++ b/packages/twin-github/CHANGELOG.md
@@ -1,6 +1,44 @@
 # @pome-sh/twin-github — CHANGELOG
 
 
+## 0.8.0 — 2026-07-31
+
+`Pull request #N in \`<repo>\` has at least one comment` binds a declaration, and
+the write path it grades exists for the first time (F-1151).
+
+- **A comment may hang off a PULL REQUEST.**
+  `GET|POST /repos/:o/:r/issues/:number/comments` (`add_issue_comment`,
+  `list_issue_comments`) accept a PR number, which is how real GitHub documents
+  commenting on a PR's conversation. They used to answer `404 Issue not found`:
+  `issue_comments` carried a foreign key to `issues(repo_id, number)` and a pull
+  request has no row there. The FK is now repo-level, which is what the migration
+  `ensureCommentsAllowPullRequests` rebuilds an existing database for. One table
+  and one id space, so `PATCH|DELETE /issues/comments/:comment_id` still addresses
+  either kind unambiguously.
+- **`exportState()` gives each pull request `comments`.** Three surfaces on a PR
+  can be called a comment and the export keeps them apart: `comments[]` is the
+  conversation, `reviews[].body` is a review's prose, `review_comments[]` are
+  inline. `GitHubCheckStatePullRequest` models the new field nullable, so an older
+  snapshot SKIPS rather than reporting a false zero.
+- **`github.pr-comment-exists`** — template
+  `` Pull request #{pr} in `{repo}` has at least one comment ``, substrate `final`,
+  positive polarity. It grades the CONVERSATION reading and its `description` says
+  so, and says the other two are not it. F-1075 declined to bind this sentence
+  because "comment" had three meanings; the reading picked is the one GitHub's own
+  API means and the one a summarising agent produces.
+- `html_url` on a PR's comment is `/pull/N#issuecomment-…`, matching GitHub;
+  `issue_url` stays on the issues path for both kinds, also matching GitHub.
+- New `test/db-migrations.test.ts` — the first coverage of this package's
+  `migrate()` upgrade path, which no `:memory:` test exercises.
+
+Minor, and the exported tuple grows, so **`checksDigest` for github moves**:
+`sha256:5282…4424` → `sha256:cbf9…6782`. Every consumer pin must catch up or the
+`pome checks add` handshake refuses the write — the CLI pin moves in the same
+commit, and pome-cloud's must move when it takes this release.
+
+The `GET /issues` COLLECTION still excludes pull requests (FIDELITY.md
+divergence 16); only the comment routes honour the PR-is-an-issue rule so far.
+
 ## 0.7.0 — 2026-07-30
 
 Every declared check names its discriminating worlds (F-1126).

--- a/packages/twin-github/FIDELITY.md
+++ b/packages/twin-github/FIDELITY.md
@@ -287,6 +287,20 @@ upstream so a divergence that upstream "heals" becomes a tier-upgrade signal.
     out of scope, but the array-aware oracle (FDRS-455) now SEES the item-count
     divergence: registered as accepted on the collection root so this L1 read surface is
     INFO, not drift, and flagged as a genuine twin-fidelity gap for follow-up.
+
+    **Narrowed by F-1151: the COMMENT routes now honour the rule.**
+    `GET|POST /repos/:o/:r/issues/:number/comments` accept a pull-request number, which is
+    how real GitHub documents commenting on a PR's conversation. Until F-1151 they did
+    not — `issue_comments` carried a foreign key to `issues(repo_id, number)` and a PR has
+    no row there, so every PR comment failed the constraint and the route answered
+    `404 Issue not found`. That was this bullet's write-side face, and it was recorded
+    nowhere: the matrix listed the route as `hot`/`semantic` with no caveat, and the only
+    comment tool the bundled `pr-summary-*` examples expose 404'd on every run. What
+    remains open is the READ half above — the `/issues` COLLECTION still lists issues
+    only, and PRs still carry no `pull_request` member — so the divergence stands and
+    keeps its registry entry. The number space was never the obstacle: `nextNumber()`
+    already draws issue and PR numbers from one per-repo counter, so a number names one
+    entity or the other, never both.
 17. **Issue `assignees`/`labels` arrays reflect the controlled-sandbox seed, not real GitHub.**
     The plural `assignees` and the `labels` arrays are non-empty on the twin (its seeded
     fictional assignee/label) but empty on real GitHub for the seeded sandbox — the same

--- a/packages/twin-github/FIDELITY_MATRIX.md
+++ b/packages/twin-github/FIDELITY_MATRIX.md
@@ -12,9 +12,9 @@ Last verified: 2026-07-12
 | `POST /repos/:owner/:repo/issues` | hot | semantic | Creates persistent issues with GitHub-shaped labels and assignees. |
 | `GET /repos/:owner/:repo/issues/:number` | hot | semantic | Reads persisted issue state and returns GitHub-style 404. |
 | `PATCH /repos/:owner/:repo/issues/:number` | hot | semantic | Mutates title/body/state/labels/assignees and records state mutation. |
-| `GET /repos/:owner/:repo/issues/:number/comments` | hot | semantic | Lists persisted issue comments with pagination. |
-| `POST /repos/:owner/:repo/issues/:number/comments` | hot | semantic | Creates persistent issue comments. |
-| `PATCH /repos/:owner/:repo/issues/comments/:comment_id` | hot | semantic | Updates issue comment body and `updated_at`. |
+| `GET /repos/:owner/:repo/issues/:number/comments` | hot | semantic | Lists persisted conversation comments with pagination. `:number` may name an ISSUE or a PULL REQUEST (F-1151), as on real GitHub. |
+| `POST /repos/:owner/:repo/issues/:number/comments` | hot | semantic | Creates persistent conversation comments. `:number` may name an ISSUE or a PULL REQUEST (F-1151) — this is how a PR's conversation is commented on; `pulls/:number/comments` is the inline review-comment surface instead. |
+| `PATCH /repos/:owner/:repo/issues/comments/:comment_id` | hot | semantic | Updates issue comment body and `updated_at`. One id space across both target kinds, so this addresses a PR's comment too. |
 | `DELETE /repos/:owner/:repo/issues/comments/:comment_id` | hot | semantic | Deletes issue comment; 404 for unknown id. |
 | `GET /repos/:owner/:repo/labels` | hot | semantic | Lists repository labels with deterministic local IDs. |
 | `POST /repos/:owner/:repo/labels` | warm | semantic | Creates labels; color validation is intentionally permissive. |

--- a/packages/twin-github/package.json
+++ b/packages/twin-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-github",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Deterministic GitHub-shaped twin for agent testing \u2014 REST + MCP, SQLite-backed state.",
   "private": false,
   "type": "module",

--- a/packages/twin-github/src/check-pulls.ts
+++ b/packages/twin-github/src/check-pulls.ts
@@ -133,9 +133,11 @@ export const pullRequestCommentExists: Check<{ pr: string; repo: string }> = def
     "reader may call a comment on a PR: a review's body is not one (assert that with " +
     "`github.pr-review-exists`), and an inline review comment anchored to a file and line is " +
     "not one either. It says nothing about who commented, how many did, or what any of them " +
-    "say — `github.issue-comment-contains` is the assertion that reads a body. A pull request " +
-    "whose export carries no comments section at all is SKIPPED, because absent is not the " +
-    "same as none.",
+    "say — and no declaration reads the TEXT of a pull request's comment yet. " +
+    "`github.issue-comment-contains` is the issue-side counterpart and does NOT reach a pull " +
+    "request: it resolves its subject among the repository's issues, so pointing it at a PR " +
+    "number fails as `issue #N not found`. A pull request whose export carries no comments " +
+    "section at all is SKIPPED, because absent is not the same as none.",
   template: "Pull request #{pr} in `{repo}` has at least one comment",
   params: { pr: prNumber, repo: repoRef },
   substrate: "final",

--- a/packages/twin-github/src/check-pulls.ts
+++ b/packages/twin-github/src/check-pulls.ts
@@ -92,6 +92,101 @@ export const pullRequestStateCheck: Check<{ pr: string; repo: string; state: str
   },
 });
 
+// F-1151 — the fourteenth declaration, and the one whose whole difficulty was
+// deciding WHICH question it answers.
+//
+// Three things on a pull request can be called "a comment", the twin exports all
+// three separately, and F-1075 declined to bind this sentence rather than guess
+// between them:
+//
+//   1. a CONVERSATION comment — `pull_requests[].comments[]`  ← this check
+//   2. a REVIEW BODY          — `pull_requests[].reviews[].body`
+//   3. an INLINE REVIEW COMMENT — `pull_requests[].review_comments[]`
+//
+// Reading 1, for three reasons that agree. It is what GitHub itself means by a
+// comment on a pull request: its API routes these through the Issue Comments
+// endpoints and names the other two "review comments" and "a review". It is what
+// a summarising agent produces — the `pr-summary-*` tasks that ship these six
+// criteria post a summary to the conversation, they do not open a review to carry
+// it. And it is the only reading whose sentence needs no qualifier: the other two
+// have to say "review" out loud to be true, so they belong in templates that do.
+//
+// The other two are NOT covered here and are not silently folded in. Reading 2
+// already has a neighbour — `github.pr-review-exists` with `COMMENTED` asserts a
+// review exists, and a body check would be a strictly narrower sibling of it.
+// Reading 3 has no declaration at all yet; when something asserts it, it gets its
+// own sentence naming the file it is anchored to.
+//
+// The sentence is deliberately UNCHANGED from the six criteria already written
+// in `examples/pr-summary-agent` and `examples/pr-summary-review`. It could have
+// been re-rendered to say "conversation comment" and remove all doubt from the
+// sentence itself, and that was weighed: the words "a comment on pull request #1" are
+// GitHub's own for this surface, so a template that says them is accurate, and
+// keeping it byte-identical means the corpus binds without six file edits and
+// without moving `CORPUS_SHAPE_BASELINE`. What carries the disambiguation is the
+// `description`, which is what an author reads before picking.
+export const pullRequestCommentExists: Check<{ pr: string; repo: string }> = defineCheck({
+  id: "github.pr-comment-exists",
+  description:
+    "Asserts the pull request's CONVERSATION timeline carries at least one comment — the " +
+    "surface GitHub's issue-comment endpoints write to. It is not the other two things a " +
+    "reader may call a comment on a PR: a review's body is not one (assert that with " +
+    "`github.pr-review-exists`), and an inline review comment anchored to a file and line is " +
+    "not one either. It says nothing about who commented, how many did, or what any of them " +
+    "say — `github.issue-comment-contains` is the assertion that reads a body. A pull request " +
+    "whose export carries no comments section at all is SKIPPED, because absent is not the " +
+    "same as none.",
+  template: "Pull request #{pr} in `{repo}` has at least one comment",
+  params: { pr: prNumber, repo: repoRef },
+  substrate: "final",
+  polarity: () => "positive",
+  // A count, not a literal hunted inside prose: no redaction rule can destroy
+  // the thing this check compares, so there is no subject to declare.
+  subject: () => null,
+  // No falsifiable trigger. The PR number only RESOLVES — mutating it
+  // early-returns "not found", which moves the verdict on every seed for a reason
+  // that never reaches the comment count — and there is no second slot to
+  // falsify. Same shape as `pr-review-exists`, and admitted as `no_trigger`
+  // rather than buying a false clean bill.
+  vacuityMutant: () => null,
+  // The failing world names `comments: []`, NOT an absent section: absent SKIPS,
+  // because absent is not none — and a skip satisfies no arm.
+  discriminatingWorlds: ({ pr }) => ({
+    passing: finalWorld(
+      repoState({
+        pull_requests: [{ number: Number(pr), comments: [{ body: "Summary: adds an optional discount." }] }],
+      }),
+    ),
+    failing: finalWorld(repoState({ pull_requests: [{ number: Number(pr), comments: [] }] })),
+  }),
+  evaluate({ pr, repo }, { final }) {
+    const found = resolvePullRequest(final, repo, pr);
+    if ("missing" in found) return { passed: false, reason: found.missing };
+    // Comments section absent — a snapshot predating PR-comment export. We
+    // cannot tell "nobody commented" from "not captured", so safe-skip rather
+    // than failing an agent that did comment. An empty array is a real zero and
+    // falls through to failed.
+    if (found.found.comments == null) {
+      return {
+        passed: false,
+        status: "skipped",
+        reason: `pull request #${pr} has no comments section in state_final (state_incomplete)`,
+      };
+    }
+    const count = found.found.comments.length;
+    return {
+      passed: count > 0,
+      // Names the surface, so a failure cannot be misread as "the agent left a
+      // review body and this check refused to see it" — which is exactly the
+      // wrong-match complaint the three readings invite.
+      reason:
+        count > 0
+          ? `pull request #${pr} has ${count} conversation comment(s)`
+          : `pull request #${pr} has no conversation comments (reviews and inline review comments are not counted)`,
+    };
+  },
+});
+
 export const pullRequestReviewExists: Check<{ review: string; pr: string; repo: string }> = defineCheck({
   id: "github.pr-review-exists",
   description:

--- a/packages/twin-github/src/check-state.ts
+++ b/packages/twin-github/src/check-state.ts
@@ -64,6 +64,14 @@ export interface GitHubCheckStatePullRequest {
   // empty array. The predicate has to tell those apart or it fails a correct
   // agent for a gap in the recording.
   reviews?: GitHubCheckStateReview[] | null;
+  // The CONVERSATION timeline (F-1151) — the same shape as `issue.comments`
+  // because it is the same table, which is what GitHub does too. Not
+  // `reviews[].body` and not `review_comments[]`: those are two other things a
+  // reader could reasonably call "a comment on the PR", and the whole point of
+  // modelling this field separately is that a predicate can name which one it
+  // read. Nullable for the same reason `reviews` is — absent means a snapshot
+  // that predates PR-comment export, and absent is not none.
+  comments?: GitHubCheckStateComment[] | null;
 }
 
 export interface GitHubCheckStateCommitStatus {

--- a/packages/twin-github/src/checks.ts
+++ b/packages/twin-github/src/checks.ts
@@ -53,7 +53,11 @@ import {
   issueHasLabel,
   issueStateCheck,
 } from "./check-issues.js";
-import { pullRequestReviewExists, pullRequestStateCheck } from "./check-pulls.js";
+import {
+  pullRequestCommentExists,
+  pullRequestReviewExists,
+  pullRequestStateCheck,
+} from "./check-pulls.js";
 import { commitStatus, fileExists, noNewLabels } from "./check-repos.js";
 import { noUnsupportedEndpoint, toolNeverCalled } from "./check-tape.js";
 
@@ -84,6 +88,7 @@ export const GITHUB_CHECKS = [
   issueCommentContains,
   noNewLabels,
   pullRequestStateCheck,
+  pullRequestCommentExists,
   pullRequestReviewExists,
   fileExists,
   commitStatus,

--- a/packages/twin-github/src/db.ts
+++ b/packages/twin-github/src/db.ts
@@ -181,6 +181,8 @@ CREATE TABLE IF NOT EXISTS issue_labels (
   FOREIGN KEY (repo_id, label_name) REFERENCES labels(repo_id, name) ON DELETE CASCADE
 );
 
+-- issue_number names an issue OR a pull request, so no FK to issues — see
+-- ensureCommentsAllowPullRequests below (F-1151).
 CREATE TABLE IF NOT EXISTS issue_comments (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   repo_id INTEGER NOT NULL,
@@ -189,7 +191,7 @@ CREATE TABLE IF NOT EXISTS issue_comments (
   user_login TEXT NOT NULL,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL,
-  FOREIGN KEY (repo_id, issue_number) REFERENCES issues(repo_id, number) ON UPDATE CASCADE ON DELETE CASCADE
+  FOREIGN KEY (repo_id) REFERENCES repositories(id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS pull_requests (
@@ -325,6 +327,7 @@ export function migrate(db: GitHubCloneDatabase) {
   ensureColumn(db, "pull_request_review_comments", "in_reply_to_id", "INTEGER");
   ensureColumn(db, "collaborators", "invitation_state", "TEXT NOT NULL DEFAULT 'accepted'");
   ensureIssueNumberCascade(db);
+  ensureCommentsAllowPullRequests(db);
   hydrateDerivedColumns(db);
 }
 
@@ -340,7 +343,11 @@ function ensureColumn(db: GitHubCloneDatabase, table: string, column: string, de
 }
 
 function ensureIssueNumberCascade(db: GitHubCloneDatabase) {
-  const tables = ["issue_assignees", "issue_labels", "issue_comments"];
+  // `issue_comments` used to be rebuilt here too. It is not any more: F-1151
+  // removed its `issues` FK outright, so it has no cascade to fix, and leaving
+  // it in this list would have this function put the constraint back on every
+  // boot of an older database. `ensureCommentsAllowPullRequests` owns it now.
+  const tables = ["issue_assignees", "issue_labels"];
   const needsRebuild = tables.some((table) => {
     const foreignKeys = db.prepare(`PRAGMA foreign_key_list(${table})`).all() as Array<{ table: string; on_update: string }>;
     return foreignKeys.some((key) => key.table === "issues" && key.on_update !== "CASCADE");
@@ -373,7 +380,45 @@ CREATE TABLE issue_labels (
 INSERT INTO issue_labels (repo_id, issue_number, label_name)
   SELECT repo_id, issue_number, label_name FROM issue_labels_old;
 DROP TABLE issue_labels_old;
+`);
+  db.pragma("foreign_keys = ON");
+}
 
+// F-1151 — a comment may hang off a PULL REQUEST, not only an issue.
+//
+// Real GitHub models every pull request as an issue and documents the Issue
+// Comments endpoints as the way to comment on a PR's conversation. The twin's
+// `add_issue_comment` therefore has to accept a PR number, and until this
+// migration it could not: `issue_comments` carried an FK to `issues(repo_id,
+// number)`, and a PR has no row there (`createPullRequest` writes no companion
+// issue — that is divergence #16 in FIDELITY.md, whose read side is still open).
+// So the insert failed the constraint before any predicate could read it, and
+// the only comment tool the bundled `pr-summary-*` examples expose 404'd on
+// every run.
+//
+// The pair stays unambiguous without the constraint because `nextNumber()` hands
+// issues and pull requests numbers out of ONE per-repo `entity_counter`: within
+// a repo a number names an issue or a PR, never both.
+//
+// What the FK was also buying, and where each half went:
+//   - ON DELETE CASCADE from `repositories` — replaced by a direct repo FK, so
+//     dropping a repository still takes its comments.
+//   - ON UPDATE CASCADE on issue renumbering — dropped. The seed path already
+//     renumbers `issue_comments` itself (`domain/github-domain.ts`), belt-and-
+//     braces with the cascade that is now the only belt.
+//
+// One table rather than a second `pull_request_comments`, because
+// `PATCH|DELETE /repos/:o/:r/issues/comments/:comment_id` addresses a comment by
+// id alone. Two AUTOINCREMENT tables behind one route is two id spaces behind
+// one address — a wrong-target write waiting for the first collision.
+function ensureCommentsAllowPullRequests(db: GitHubCloneDatabase) {
+  const foreignKeys = db.prepare("PRAGMA foreign_key_list(issue_comments)").all() as Array<{
+    table: string;
+  }>;
+  if (!foreignKeys.some((key) => key.table === "issues")) return;
+
+  db.pragma("foreign_keys = OFF");
+  db.exec(`
 ALTER TABLE issue_comments RENAME TO issue_comments_old;
 CREATE TABLE issue_comments (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -383,7 +428,7 @@ CREATE TABLE issue_comments (
   user_login TEXT NOT NULL,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL,
-  FOREIGN KEY (repo_id, issue_number) REFERENCES issues(repo_id, number) ON UPDATE CASCADE ON DELETE CASCADE
+  FOREIGN KEY (repo_id) REFERENCES repositories(id) ON DELETE CASCADE
 );
 INSERT INTO issue_comments (id, repo_id, issue_number, body, user_login, created_at, updated_at)
   SELECT id, repo_id, issue_number, body, user_login, created_at, updated_at FROM issue_comments_old;

--- a/packages/twin-github/src/domain/github-domain.ts
+++ b/packages/twin-github/src/domain/github-domain.ts
@@ -218,7 +218,18 @@ export class GitHubDomain {
           ...pull,
           files: this.listPullRequestFileRows(repo.id, pull.number),
           reviews: this.listPullRequestReviewRows(repo.id, pull.number),
-          review_comments: this.listPullRequestReviewCommentRows(repo.id, pull.number)
+          review_comments: this.listPullRequestReviewCommentRows(repo.id, pull.number),
+          // F-1151. THREE distinct comment surfaces reach a pull request and this
+          // is the third, so the export keeps them apart rather than merging them
+          // into one count a predicate could not attribute:
+          //   `reviews[].body`     — the prose attached to a review verdict
+          //   `review_comments[]`  — inline comments anchored to a file and line
+          //   `comments[]`         — the conversation timeline, THIS one
+          // Read from `issue_comments` because that is where GitHub puts them:
+          // conversation comments on a PR go through the issue-comment endpoints,
+          // and the number space is shared, so a PR's number selects its own rows
+          // and no issue's.
+          comments: this.listIssueCommentRows(repo.id, pull.number)
         })),
         commit_statuses: this.db.prepare("SELECT * FROM commit_statuses WHERE repo_id = ? ORDER BY id ASC").all(repo.id),
         check_runs: this.db.prepare("SELECT * FROM check_runs WHERE repo_id = ? ORDER BY id ASC").all(repo.id)
@@ -1065,6 +1076,47 @@ export class GitHubDomain {
 
   requireIssue(repoId: number, number: number) {
     return (this.db.prepare("SELECT * FROM issues WHERE repo_id = ? AND number = ?").get(repoId, number) as IssueRow | undefined) ?? notFound("Issue not found");
+  }
+
+
+  // F-1151 — what the ISSUE COMMENT endpoints may address.
+  //
+  // Real GitHub models every pull request as an issue and documents
+  // `/repos/:o/:r/issues/:number/comments` as the way to comment on a PR's
+  // conversation; `pulls/:number/comments` is the inline REVIEW comment surface,
+  // which is a different thing. So a comment target is an issue OR a pull
+  // request, and `requireIssue` is too narrow for these two routes — it 404'd
+  // every PR comment, including the only one the bundled `pr-summary-*` examples
+  // know how to write.
+  //
+  // Deliberately NOT widened past the comment routes. Everything else reached
+  // through `requireIssue` (labels, assignees, state) really is issue-only in
+  // this twin, and making a PR answer those would be divergence #16's read half
+  // — a bigger change than a comment target, and still out of scope.
+  //
+  // The lookup order does not matter: `nextNumber()` draws issue and PR numbers
+  // from one per-repo counter, so at most one of the two can match.
+  //
+  // The KIND is returned rather than a boolean because the serializer needs it:
+  // GitHub's `html_url` for a comment on a PR is `/pull/N#issuecomment-…`, not
+  // `/issues/N#…`, and the twin would otherwise ship a divergence nothing had
+  // recorded.
+  commentTargetKind(repoId: number, number: number): "issue" | "pull_request" | null {
+    if (this.db.prepare("SELECT 1 FROM issues WHERE repo_id = ? AND number = ?").get(repoId, number)) {
+      return "issue";
+    }
+    if (this.db.prepare("SELECT 1 FROM pull_requests WHERE repo_id = ? AND number = ?").get(repoId, number)) {
+      return "pull_request";
+    }
+    return null;
+  }
+
+
+  requireCommentTarget(repoId: number, number: number): "issue" | "pull_request" {
+    // Same sentence `requireIssue` raises: this IS the issues endpoint, and an
+    // agent that named a number belonging to neither entity has made the same
+    // mistake either way.
+    return this.commentTargetKind(repoId, number) ?? notFound("Issue not found");
   }
 
 

--- a/packages/twin-github/src/domain/issues.ts
+++ b/packages/twin-github/src/domain/issues.ts
@@ -163,8 +163,12 @@ export function updateIssue(domain: GitHubDomain, input: { owner: string; repo: 
 
 export function addIssueComment(domain: GitHubDomain, input: { owner: string; repo: string; issue_number: number; body: string }, onDelta?: StateDeltaCallback) {
   const repo = domain.requireRepo(input.owner, input.repo);
+  // Issue OR pull request (F-1151) — see `requireCommentTarget`. Resolved once,
+  // outside the transaction's return value, because the serializer below needs
+  // the kind too.
+  let target: "issue" | "pull_request" = "issue";
   const comment = domain.transaction(() => {
-    domain.requireIssue(repo.id, input.issue_number);
+    target = domain.requireCommentTarget(repo.id, input.issue_number);
     if (!input.body.trim()) validationFailed("body", "missing");
     const now = nowIso();
     const result = domain.db.prepare("INSERT INTO issue_comments (repo_id, issue_number, body, user_login, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)").run(
@@ -179,15 +183,17 @@ export function addIssueComment(domain: GitHubDomain, input: { owner: string; re
   });
   domain.audit("add_issue_comment", repo.full_name, input);
   onDelta?.({ before: null, after: issueCommentState(comment, repo) });
-  return issueCommentJson(comment, repo);
+  return issueCommentJson(comment, repo, target);
 }
 
 
 export function listIssueComments(domain: GitHubDomain, input: { owner: string; repo: string; issue_number: number } & PageOptions) {
   const repo = domain.requireRepo(input.owner, input.repo);
-  domain.requireIssue(repo.id, input.issue_number);
+  // Reads the same targets the write path accepts (F-1151). Widening only the
+  // POST would let an agent leave a comment it could not then read back.
+  const target = domain.requireCommentTarget(repo.id, input.issue_number);
   const rows = domain.listIssueCommentRows(repo.id, input.issue_number);
-  return paginate(rows, input.page, input.per_page ?? input.perPage).map((comment) => issueCommentJson(comment, repo));
+  return paginate(rows, input.page, input.per_page ?? input.perPage).map((comment) => issueCommentJson(comment, repo, target));
 }
 
 
@@ -279,7 +285,11 @@ export function updateIssueComment(domain: GitHubDomain, input: { owner: string;
   });
   domain.audit("update_issue_comment", repo.full_name, input);
   onDelta?.({ before, after: issueCommentState(comment, repo) });
-  return issueCommentJson(comment, repo);
+  // Addressed by comment id, so the kind has to be looked up from the row rather
+  // than taken from the request (F-1151). `commentTargetKind` — not the throwing
+  // form: the comment exists, so an unresolvable target is a corrupt row, and
+  // 404ing an update that already succeeded would be the worse answer.
+  return issueCommentJson(comment, repo, domain.commentTargetKind(repo.id, comment.issue_number) ?? "issue");
 }
 
 

--- a/packages/twin-github/src/serializers.ts
+++ b/packages/twin-github/src/serializers.ts
@@ -362,13 +362,23 @@ export function issueJson(issue: IssueRow, repo: RepoRow, labels: LabelRow[] = [
   } satisfies DeepPartial<Issue>;
 }
 
-export function issueCommentJson(comment: IssueCommentRow, repo: RepoRow) {
+// `target` is what the comment hangs off (F-1151). Only `html_url` turns on it,
+// and it does so the way GitHub's does: a comment on a pull request is browsed at
+// `/pull/N`, while `issue_url` stays `/repos/:o/:r/issues/N` for BOTH — GitHub
+// keeps that one on the issues path even for a PR, because a PR is an issue.
+// Defaulted to `"issue"`, so the only callers that must think about it are the
+// comment routes.
+export function issueCommentJson(
+  comment: IssueCommentRow,
+  repo: RepoRow,
+  target: "issue" | "pull_request" = "issue"
+) {
   return {
     id: comment.id,
     node_id: `IC_${comment.id}`,
     body: comment.body,
     user: userJson(comment.user_login),
-    html_url: `https://github.com/${repo.full_name}/issues/${comment.issue_number}#issuecomment-${comment.id}`,
+    html_url: `https://github.com/${repo.full_name}/${target === "pull_request" ? "pull" : "issues"}/${comment.issue_number}#issuecomment-${comment.id}`,
     issue_url: `https://api.github.com/repos/${repo.full_name}/issues/${comment.issue_number}`,
     created_at: comment.created_at,
     updated_at: comment.updated_at

--- a/packages/twin-github/test/checks-contract.test.ts
+++ b/packages/twin-github/test/checks-contract.test.ts
@@ -37,6 +37,7 @@ const FIXTURES: Record<string, Record<string, string>> = {
   "github.issue-assignee": { issue: "1", repo: "acme/api", login: "alice" },
   "github.issue-comment-contains": { needle: "Deploy blocked", issue: "1", repo: "acme/api" },
   "github.pr-state": { pr: "1", repo: "acme/api", state: "not merged" },
+  "github.pr-comment-exists": { pr: "1", repo: "acme/api" },
   "github.pr-review-exists": { review: "APPROVED", pr: "1", repo: "acme/api" },
   "github.file-exists": { path: "src/index.ts", repo: "acme/api" },
   "github.commit-status": { context: "ci/build", repo: "acme/api", state: "success" },
@@ -63,6 +64,14 @@ const HONEST_NULL_MUTANTS: Record<string, string> = {
   "github.issue-state": "the state is a closed set; the issue number only selects",
   "github.pr-state": "the state is a closed set; the PR number only selects",
   "github.pr-review-exists": "the review state is a closed set; the PR number only selects",
+  // F-1151, and this is argument 1 with nothing to soften it: the PR number is
+  // the check's ONLY slot and it purely selects. Falsifying it early-returns
+  // "pull request not found" on every seed, which moves the verdict without the
+  // comment count ever being read — a clean bill the check did not earn. There is
+  // no second slot to falsify because the assertion is a count, not a literal.
+  "github.pr-comment-exists":
+    "the PR number is the only slot and it only selects; the assertion is a count, " +
+    "so there is no scanned literal to falsify",
   "github.commit-status":
     "the status state is a closed set, and the context only filters the candidate rows",
   "github.no-unsupported-endpoint":

--- a/packages/twin-github/test/checks-predicates.test.ts
+++ b/packages/twin-github/test/checks-predicates.test.ts
@@ -295,6 +295,76 @@ describe("github.pr-state", () => {
   });
 });
 
+// F-1151. The properties worth pinning here are the ones the three readings put
+// at risk: this check must count the CONVERSATION timeline and must not be
+// satisfied by either of its neighbours.
+describe("github.pr-comment-exists", () => {
+  const subject = check("github.pr-comment-exists");
+  const args = { pr: "1", repo: REPO };
+
+  it("renders and binds the sentence the corpus already carries", () => {
+    // Byte-identical to the six criteria in `examples/pr-summary-agent` and
+    // `examples/pr-summary-review`. If this string ever changes, those six stop
+    // binding and pome-cloud's exhaustive arm goes red — which is the intended
+    // alarm, not a nuisance.
+    const sentence = "Pull request #1 in `acme/api` has at least one comment";
+    expect(renderCheck(subject, args)).toBe(sentence);
+    expect(parseCheck(subject, sentence)).toEqual(args);
+  });
+
+  it("passes on one conversation comment", () => {
+    const final = world({ pull_requests: [{ number: 1, comments: [{ body: "Summary: adds a discount." }] }] });
+    expect(subject.evaluate(args, { seed: null, tape: null, final }).passed).toBe(true);
+  });
+
+  it("is NOT satisfied by a review body — that is reading 2, and a different check", () => {
+    const final = world({
+      pull_requests: [{ number: 1, comments: [], reviews: [{ state: "COMMENTED" }] }],
+    });
+    const outcome = subject.evaluate(args, { seed: null, tape: null, final });
+    expect(outcome.passed).toBe(false);
+    expect(outcome.reason).toContain("no conversation comments");
+  });
+
+  it("is NOT satisfied by an inline review comment — that is reading 3", () => {
+    // `review_comments` is not even in the read model, so this is really a
+    // statement about the shape: an extra exported field must not leak into this
+    // count. Written as a cast because a predicate that could see it would be
+    // the bug.
+    const final = world({
+      pull_requests: [
+        { number: 1, comments: [], review_comments: [{ path: "a.py", body: "nit" }] } as never,
+      ],
+    });
+    expect(subject.evaluate(args, { seed: null, tape: null, final }).passed).toBe(false);
+  });
+
+  it("fails on an empty comments array — that is a real `nobody commented`", () => {
+    const final = world({ pull_requests: [{ number: 1, comments: [] }] });
+    const outcome = subject.evaluate(args, { seed: null, tape: null, final });
+    expect(outcome.passed).toBe(false);
+    expect(outcome.status).toBeUndefined();
+  });
+
+  it("SKIPS on an absent comments section — absent is not the same as none", () => {
+    const final = world({ pull_requests: [{ number: 1 }] });
+    const outcome = subject.evaluate(args, { seed: null, tape: null, final });
+    expect(outcome.status).toBe("skipped");
+    expect(outcome.reason).toContain("state_incomplete");
+  });
+
+  it("does not read the ISSUE with the same number", () => {
+    // The number space is shared, so a world can hold an issue #1 and a PR #1
+    // only if the twin misnumbered something — but the predicate must select by
+    // entity regardless, or a commented issue would pass a PR's criterion.
+    const final = world({
+      issues: [{ number: 1, comments: [{ body: "on the issue" }] }],
+      pull_requests: [{ number: 1, comments: [] }],
+    });
+    expect(subject.evaluate(args, { seed: null, tape: null, final }).passed).toBe(false);
+  });
+});
+
 describe("github.pr-review-exists", () => {
   const subject = check("github.pr-review-exists");
   const args = { review: "CHANGES_REQUESTED", pr: "1", repo: REPO };
@@ -406,6 +476,7 @@ describe("every check, against a repo that is not in the state", () => {
       "github.issue-comment-contains": { needle: "x", issue: "1", repo: "acme/missing" },
       "github.no-new-labels": { repo: "acme/missing" },
       "github.pr-state": { pr: "1", repo: "acme/missing", state: "merged" },
+      "github.pr-comment-exists": { pr: "1", repo: "acme/missing" },
       "github.pr-review-exists": { review: "APPROVED", pr: "1", repo: "acme/missing" },
       "github.file-exists": { path: "a.ts", repo: "acme/missing" },
       "github.commit-status": { context: "ci/build", repo: "acme/missing", state: "success" },

--- a/packages/twin-github/test/checks-predicates.test.ts
+++ b/packages/twin-github/test/checks-predicates.test.ts
@@ -353,6 +353,23 @@ describe("github.pr-comment-exists", () => {
     expect(outcome.reason).toContain("state_incomplete");
   });
 
+  it("is the ONLY declaration that reaches a PR's comments — the issue-side needle does not", () => {
+    // This is what the description promises, and the promise is load-bearing: it
+    // tells an author where to go for the comment's TEXT. `issue-comment-contains`
+    // resolves its subject among the repository's ISSUES, so aiming it at a PR
+    // number fails at the lookup — the author must not be sent there. If that
+    // check ever learns to read a PR, this test fails and the description is
+    // wrong; fix both together.
+    const needle = check("github.issue-comment-contains");
+    const final = world({
+      issues: [],
+      pull_requests: [{ number: 1, comments: [{ body: "Summary: adds a discount." }] }],
+    });
+    const outcome = needle.evaluate({ needle: "discount", issue: "1", repo: REPO }, { seed: null, tape: null, final });
+    expect(outcome.passed).toBe(false);
+    expect(outcome.reason).toContain("issue #1 not found");
+  });
+
   it("does not read the ISSUE with the same number", () => {
     // The number space is shared, so a world can hold an issue #1 and a PR #1
     // only if the twin misnumbered something — but the predicate must select by

--- a/packages/twin-github/test/db-migrations.test.ts
+++ b/packages/twin-github/test/db-migrations.test.ts
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-1151 — the schema upgrade an EXISTING database file gets.
+//
+// `migrate()` runs on every open, so a twin whose db predates a change is
+// repaired in place rather than rebuilt. That makes the ensure* functions the one
+// place where a wrong condition is invisible: a fresh `:memory:` db is created
+// from `MIGRATION_SQL` and never exercises them, so the whole package could stay
+// green while every persisted db kept the old shape. This file opens the door the
+// other tests do not.
+//
+// It also guards the specific hazard in this change. `issue_comments` used to be
+// rebuilt by BOTH `ensureIssueNumberCascade` (adding the `issues` FK) and now
+// `ensureCommentsAllowPullRequests` (removing it). Leaving it in the first list
+// would have the two fight on every boot of an older db, and whichever ran last
+// would decide whether PR comments worked — silently, and differently for a
+// persisted db than for the in-memory ones the suite uses.
+
+import { describe, expect, it } from "vitest";
+import { migrate, openGitHubCloneDatabase } from "../src/db.js";
+import { GitHubDomain } from "../src/domain/index.js";
+import type { GitHubCloneDatabase } from "../src/types.js";
+
+const LEGACY_ISSUE_COMMENTS = `
+DROP TABLE issue_comments;
+CREATE TABLE issue_comments (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  repo_id INTEGER NOT NULL,
+  issue_number INTEGER NOT NULL,
+  body TEXT NOT NULL,
+  user_login TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY (repo_id, issue_number) REFERENCES issues(repo_id, number) ON UPDATE CASCADE ON DELETE CASCADE
+);
+`;
+
+function foreignKeyTargets(db: GitHubCloneDatabase, table: string): string[] {
+  const rows = db.prepare(`PRAGMA foreign_key_list(${table})`).all() as Array<{ table: string }>;
+  return rows.map((row) => row.table);
+}
+
+/** A db carrying the pre-F-1151 `issue_comments` shape, with one comment in it. */
+function legacyDatabase() {
+  const db = openGitHubCloneDatabase(":memory:");
+  const domain = new GitHubDomain(db);
+  domain.seed();
+  domain.addIssueComment({ owner: "acme", repo: "api", issue_number: 1, body: "from before the migration" });
+
+  // Roll the table back to the old DDL, carrying the row across the way a real
+  // older file would already hold it.
+  const existing = db.prepare("SELECT * FROM issue_comments").all() as Array<Record<string, unknown>>;
+  db.pragma("foreign_keys = OFF");
+  db.exec(LEGACY_ISSUE_COMMENTS);
+  for (const row of existing) {
+    db.prepare(
+      "INSERT INTO issue_comments (id, repo_id, issue_number, body, user_login, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    ).run(row.id, row.repo_id, row.issue_number, row.body, row.user_login, row.created_at, row.updated_at);
+  }
+  db.pragma("foreign_keys = ON");
+  return { db, domain };
+}
+
+describe("issue_comments migration (F-1151)", () => {
+  it("starts from a db that really does carry the old constraint", () => {
+    // Guards the fixture itself: if this assertion ever fails, the tests below
+    // are proving nothing because they never had an old schema to upgrade.
+    const { db } = legacyDatabase();
+    expect(foreignKeyTargets(db, "issue_comments")).toContain("issues");
+  });
+
+  it("drops the issues FK, keeps a repositories FK, and preserves existing rows", () => {
+    const { db } = legacyDatabase();
+    migrate(db);
+
+    const targets = foreignKeyTargets(db, "issue_comments");
+    expect(targets).not.toContain("issues");
+    expect(targets).toContain("repositories");
+    expect(db.prepare("SELECT body FROM issue_comments").all()).toEqual([
+      { body: "from before the migration" },
+    ]);
+  });
+
+  it("lets a pull-request comment land once the migration has run", () => {
+    const { db, domain } = legacyDatabase();
+    domain.createBranch({ owner: "acme", repo: "api", branch: "migrated" });
+    domain.pushFiles({
+      owner: "acme",
+      repo: "api",
+      branch: "migrated",
+      message: "Change",
+      files: [{ path: "migrated.txt", content: "x\n" }],
+    });
+    const pr = domain.createPullRequest({ owner: "acme", repo: "api", title: "PR", head: "migrated", base: "main" }) as {
+      number: number;
+    };
+
+    // Before: the constraint rejects it — this is the 404 the pr-summary examples hit.
+    expect(() => domain.addIssueComment({ owner: "acme", repo: "api", issue_number: pr.number, body: "nope" })).toThrow();
+
+    migrate(db);
+
+    domain.addIssueComment({ owner: "acme", repo: "api", issue_number: pr.number, body: "Summary." });
+    const repo = domain.exportState().repositories.find((item) => item.full_name === "acme/api");
+    expect(repo?.pull_requests.find((item) => item.number === pr.number)?.comments).toEqual([
+      expect.objectContaining({ body: "Summary." }),
+    ]);
+  });
+
+  it("is idempotent — a second migrate leaves the shape and the rows alone", () => {
+    const { db } = legacyDatabase();
+    migrate(db);
+    const afterFirst = db.prepare("SELECT sql FROM sqlite_master WHERE name = 'issue_comments'").get();
+    migrate(db);
+    expect(db.prepare("SELECT sql FROM sqlite_master WHERE name = 'issue_comments'").get()).toEqual(afterFirst);
+    expect(db.prepare("SELECT COUNT(*) AS count FROM issue_comments").get()).toEqual({ count: 1 });
+  });
+
+  it("does not put the issues FK back on a db already migrated", () => {
+    // The regression this change could cause: `ensureIssueNumberCascade` rebuilds
+    // `issue_assignees` / `issue_labels` when their cascade is missing, and it
+    // used to rebuild `issue_comments` in the same pass. If it still did,
+    // upgrading an old db would restore the constraint that has just been removed.
+    const { db } = legacyDatabase();
+    db.pragma("foreign_keys = OFF");
+    db.exec(`
+DROP TABLE issue_assignees;
+CREATE TABLE issue_assignees (
+  repo_id INTEGER NOT NULL,
+  issue_number INTEGER NOT NULL,
+  login TEXT NOT NULL,
+  PRIMARY KEY (repo_id, issue_number, login),
+  FOREIGN KEY (repo_id, issue_number) REFERENCES issues(repo_id, number) ON DELETE CASCADE
+);
+`);
+    db.pragma("foreign_keys = ON");
+
+    migrate(db);
+
+    // The cascade repair ran on its own table…
+    const assignees = db.prepare("PRAGMA foreign_key_list(issue_assignees)").all() as Array<{
+      table: string;
+      on_update: string;
+    }>;
+    expect(assignees.find((row) => row.table === "issues")?.on_update).toBe("CASCADE");
+    // …and left the comments table's new shape intact.
+    expect(foreignKeyTargets(db, "issue_comments")).not.toContain("issues");
+  });
+
+  it("still cascades a repository delete to its comments", () => {
+    // What the repo-level FK is replacing. Without it, dropping a repository
+    // would orphan comments the issues FK used to take with it.
+    const { db, domain } = legacyDatabase();
+    migrate(db);
+    expect(db.prepare("SELECT COUNT(*) AS count FROM issue_comments").get()).toEqual({ count: 1 });
+
+    const repo = domain.requireRepo("acme", "api");
+    db.prepare("DELETE FROM repositories WHERE id = ?").run(repo.id);
+    expect(db.prepare("SELECT COUNT(*) AS count FROM issue_comments").get()).toEqual({ count: 0 });
+  });
+});

--- a/packages/twin-github/test/domain.test.ts
+++ b/packages/twin-github/test/domain.test.ts
@@ -118,6 +118,80 @@ describe("GitHubDomain edge cases", () => {
     expect(domain.getIssue({ owner: "acme", repo: "api", issue_number: 1 }).comments).toBe(1);
   });
 
+  // F-1151 — the issue-comment endpoints address an issue OR a pull request,
+  // because real GitHub models every PR as an issue and documents these routes as
+  // the way to comment on one.
+  describe("comments on a pull request", () => {
+    const seeded = () => {
+      const domain = new GitHubDomain(openGitHubCloneDatabase());
+      domain.seed();
+      domain.createBranch({ owner: "acme", repo: "api", branch: "pr-comment" });
+      domain.pushFiles({
+        owner: "acme",
+        repo: "api",
+        branch: "pr-comment",
+        message: "Change",
+        files: [{ path: "pr-comment.txt", content: "x\n" }]
+      });
+      const pr = domain.createPullRequest({ owner: "acme", repo: "api", title: "PR", head: "pr-comment", base: "main" });
+      return { domain, pr: (pr as { number: number }).number };
+    };
+
+    it("accepts a comment addressed to a PR number and reads it back", () => {
+      const { domain, pr } = seeded();
+      // The default seed has issue #1 and this PR is #2, so the number really is
+      // selecting the PR rather than falling back to an issue.
+      expect(pr).not.toBe(1);
+      domain.addIssueComment({ owner: "acme", repo: "api", issue_number: pr, body: "Summary of this PR." });
+      const listed = domain.listIssueComments({ owner: "acme", repo: "api", issue_number: pr }) as Array<{ body: string }>;
+      expect(listed).toEqual([expect.objectContaining({ body: "Summary of this PR." })]);
+      // …and it did NOT land on the issue that shares the endpoint.
+      expect(domain.listIssueComments({ owner: "acme", repo: "api", issue_number: 1 })).toEqual([]);
+    });
+
+    it("browses at /pull/N while keeping issue_url on the issues path, as GitHub does", () => {
+      const { domain, pr } = seeded();
+      const created = domain.addIssueComment({ owner: "acme", repo: "api", issue_number: pr, body: "Summary." }) as {
+        html_url: string;
+        issue_url: string;
+      };
+      expect(created.html_url).toContain(`/acme/api/pull/${pr}#issuecomment-`);
+      expect(created.issue_url).toBe(`https://api.github.com/repos/acme/api/issues/${pr}`);
+
+      // Same shape when read back by id, where the kind has to come from the row.
+      const updated = domain.updateIssueComment({ owner: "acme", repo: "api", comment_id: 1, body: "Revised." }) as {
+        html_url: string;
+      };
+      expect(updated.html_url).toContain(`/acme/api/pull/${pr}#issuecomment-`);
+    });
+
+    it("keeps html_url on /issues/N for a comment on a real issue", () => {
+      const { domain } = seeded();
+      const created = domain.addIssueComment({ owner: "acme", repo: "api", issue_number: 1, body: "On the issue." }) as {
+        html_url: string;
+      };
+      expect(created.html_url).toContain("/acme/api/issues/1#issuecomment-");
+    });
+
+    it("still 404s a number that names neither an issue nor a pull request", () => {
+      const { domain } = seeded();
+      expect(() => domain.addIssueComment({ owner: "acme", repo: "api", issue_number: 999, body: "nobody" })).toThrow(
+        "Issue not found"
+      );
+      expect(() => domain.listIssueComments({ owner: "acme", repo: "api", issue_number: 999 })).toThrow("Issue not found");
+    });
+
+    it("does not widen the issue-only surfaces to pull requests", () => {
+      // The comment routes moved; labels/assignees/state did not. Widening those
+      // would be divergence #16's read half, which is still out of scope.
+      const { domain, pr } = seeded();
+      expect(() => domain.getIssue({ owner: "acme", repo: "api", issue_number: pr })).toThrow("Issue not found");
+      expect(() => domain.updateIssue({ owner: "acme", repo: "api", issue_number: pr, state: "closed" })).toThrow(
+        "Issue not found"
+      );
+    });
+  });
+
   it("populates pull request head and base SHAs", () => {
     const domain = new GitHubDomain(openGitHubCloneDatabase());
     domain.seed();

--- a/packages/twin-github/test/state-export.test.ts
+++ b/packages/twin-github/test/state-export.test.ts
@@ -39,6 +39,56 @@ describe("state export", () => {
     });
   });
 
+  // F-1151 — the third comment surface on a pull request, and the one the twin
+  // could not record at all before: `add_issue_comment` on a PR number failed the
+  // `issue_comments` FK, so a summarising agent's only write path 404'd.
+  it("exports a pull request's conversation comments separately from its reviews and inline comments", () => {
+    const domain = new GitHubDomain(openGitHubCloneDatabase());
+    domain.seed({
+      users: [{ login: "alice", type: "User", name: "Alice" }],
+      repositories: [
+        {
+          owner: "acme",
+          name: "widgets",
+          default_branch: "main",
+          collaborators: ["alice"],
+          files: [
+            { path: "widget.py", content: "def total():\n    return 1\n", branch: "main" },
+            { path: "widget.py", content: "def total(discount=0):\n    return 1\n", branch: "add-discount" }
+          ],
+          // No `issues` at all — exactly the shape the pr-summary seeds carry, and
+          // the shape that used to make a PR comment impossible.
+          pull_requests: [{ number: 1, title: "Add discount", head: "add-discount", base: "main" }]
+        }
+      ]
+    });
+
+    domain.addIssueComment({ owner: "acme", repo: "widgets", issue_number: 1, body: "Summary: adds an optional discount." });
+    domain.createPullRequestReview({ owner: "acme", repo: "widgets", pull_number: 1, event: "COMMENT", body: "a review body" });
+    domain.createPullRequestReviewComment({
+      owner: "acme",
+      repo: "widgets",
+      pull_number: 1,
+      path: "widget.py",
+      line: 1,
+      body: "an inline comment"
+    });
+
+    const repo = domain.exportState().repositories.find((item) => item.full_name === "acme/widgets");
+    const pull = repo?.pull_requests.find((item) => item.number === 1);
+    // All three surfaces present and DISTINCT: `github.pr-comment-exists` reads
+    // only the first, and the point of exporting them apart is that a predicate
+    // can say which one it read.
+    expect(pull?.comments).toEqual([
+      expect.objectContaining({ body: "Summary: adds an optional discount." })
+    ]);
+    expect(pull?.reviews).toEqual([expect.objectContaining({ body: "a review body" })]);
+    expect(pull?.review_comments).toEqual([expect.objectContaining({ body: "an inline comment" })]);
+    // The comment hangs off the PR and nothing else — there is no issue #1 to
+    // have absorbed it.
+    expect(repo?.issues).toEqual([]);
+  });
+
   it("preserves the seeded pull request author as user_login on export", () => {
     const domain = new GitHubDomain(openGitHubCloneDatabase());
     const seed = parseSeed({


### PR DESCRIPTION
<!-- Part of F-1151. Deliberately NOT `Closes` — see "Why this does not close the ticket" below. -->

Executive summary: `` Pull request #N in `<repo>` has at least one comment `` binds a declaration, emptying the last four entries of the corpus's deferral list. The decision the ticket asked for — which of three meanings of "comment" to grade — is the **conversation timeline**, and the check's `description` says so and says the other two are not it. Measuring the three readings first changed the shape of the work: all three are exported separately, but the one the six criteria were written for had **no reachable write path**, so binding it alone would have converted six visible unmatched criteria into six permanent reds blaming the agent for a 404.

## What

- **`github.pr-comment-exists`**, github's fourteenth declaration. Template renders the corpus sentence byte-identically, so the six criteria bind with **no task-file edit** and no `CORPUS_SHAPE_BASELINE` movement.
- **A comment may hang off a pull request.** `GET|POST /repos/:o/:r/issues/:number/comments` accept a PR number, which is how real GitHub documents commenting on a PR. `issue_comments`' foreign key moves from `issues(repo_id, number)` to `repositories(id)`; migration `ensureCommentsAllowPullRequests` upgrades an existing database.
- **`exportState()` gives each pull request `comments`**, kept apart from `reviews[].body` and `review_comments[]` so a predicate can name which surface it read. Modelled nullable, so an older snapshot SKIPS rather than reporting a false zero.
- `html_url` for a PR's comment is `/pull/N#issuecomment-…` as GitHub's is; `issue_url` stays on the issues path for both kinds, also as GitHub's does.
- `@pome-sh/twin-github` 0.7.0 → 0.8.0, CLI pin carried in the same commit, changeset added.

## Why

Milestone A3. These four sentences at six subjects were the entire gap between the corpus's `inScope` (143) and `boundExactlyOnce` (137). F-1075 declined to bind them and wrote down why — "comment" could mean a review comment, a review body, or an issue comment on the PR, and guessing ships a check that lies — and F-1130 could not resolve it from pome-cloud, because adding a declaration is a twins release.

## Notes for reviewer

**The finding that changed the ticket, measured before deciding.** The ticket asked which reading to pick and warned that "a meaning the state cannot distinguish is a fourth option: decline again". The state distinguishes all three — `issues[].comments[]`, `reviews[].body`, `review_comments[]` are three separate places. What it could not do was let an agent *write* the first one:

| reading | write path | before | after |
| --- | --- | --- | --- |
| conversation comment | `add_issue_comment` | **404 Issue not found**, all four subjects | ✅ |
| review body | `create_pull_request_review` | ✅ | ✅ |
| inline review comment | `create_pull_request_review_comment` | ✅ | ✅ |

Both bundled examples expose exactly one comment tool — `comment_on_pull_request` (`pr-summary-agent/src/index.ts:250`, `pr-summary-review/src/index.ts:248`) — it wraps `add_issue_comment`, and its own description already asserted the rule the twin did not implement: *"A PR shares the issue-number space, so this comments via the issue endpoint."* Every one of those calls 404'd, on every subject, for as long as the examples have existed. That is the write-side face of a divergence the repo already conceded on the read side (`FIDELITY.md` #16), recorded nowhere: `FIDELITY_MATRIX.md` listed the route as `hot`/`semantic` with no caveat.

**Why conversation, and not one of the other two.** Three reasons that agree. It is what GitHub's own API means by a comment on a pull request — it names the others "review comments" and "a review". It is what a summarising agent produces; the `pr-summary-*` tasks post a summary, they do not open a review to carry one. And it is the only reading whose sentence needs no qualifier — the other two must say "review" out loud to be true, so they belong in templates that do. Reading 2 already has a neighbour in `github.pr-review-exists`; reading 3 gets its own sentence if anything ever asserts it.

**Please look hardest at three things.**

1. **`packages/twin-github/src/db.ts`** — dropping an FK is the riskiest edit here. Both halves it was buying are accounted for: repo-level `ON DELETE CASCADE` replaces it (tested), and `ON UPDATE CASCADE` on issue renumbering is dropped because the seed path already renumbers `issue_comments` itself. The pair stays unambiguous because `nextNumber()` draws issue and PR numbers from one per-repo counter. `test/db-migrations.test.ts` is new and is this package's **first** coverage of `migrate()` — no `:memory:` test had ever exercised the upgrade path.
2. **`ensureIssueNumberCascade` lost `issue_comments` from its table list.** Left in, it would have restored the constraint on every boot of an older database, and the two migrations would fight with whichever ran last deciding whether PR comments worked. There is a regression test for exactly that.
3. **One table, not a second `pull_request_comments`.** `PATCH|DELETE /repos/:o/:r/issues/comments/:comment_id` addresses a comment by id alone; two `AUTOINCREMENT` tables behind one route is two id spaces behind one address.

**Consumer pins must catch up.** The exported tuple grows, so github's `checksDigest` moves `sha256:5282…4424` → `sha256:cbf9…6782`. The `pome checks add` handshake refuses a write when the CLI's pin and the control plane's disagree, so the cloud pin has to move when it takes this release. The CLI pin moves in this commit.

**Two follow-ups filed rather than folded in.** F-1152 — nothing catches a bundled example whose twin tool always fails; `typecheck:examples` passes on well-typed arguments and `smoke:examples` returns before any tool fires, so this went unnoticed for the examples' whole lifetime. F-1153 — a seeded pull request's `number` is silently ignored (`seedSchema` accepts it, the applier never reads it; a seed asking for PR #7 gets #2). Every shipped task is safe only by coincidence, and it directly threatens criteria that name a PR number.

**Out of scope, deliberately:** the `/issues` **collection** still excludes pull requests and PRs still carry no `pull_request` member. Divergence 16 keeps its registry entry (`GH-DIV-017`); the bullet's bold title is unchanged, so pome-cloud's 1:1 known-divergences lint stays green without a same-PR cloud edit.

## Why this does not close the ticket

F-1151's three "Done when" bullets span both repos, and this PR can only satisfy the middle one:

- ✅ **"read the new check's `description`"** — it names the conversation reading and says the other two are not it.
- ⏳ **"`DECLARED_DEFERRALS` is EMPTY, and the exhaustive pins read `143 of 143`"** — `apps/control-plane/scripts/resolve-criteria-corpus.ts` is in pome-cloud, and it resolves declarations from the **npm pin**. It cannot see this declaration until `@pome-sh/twin-github` 0.8.0 publishes.
- ⏳ **"delete a deferral line without binding it → the gate goes red"** — same file, same repo, same dependency.

So the chain is: merge this → `packages-v*` release publishes 0.8.0 → pome-cloud bumps its pin, empties the deferral list, and moves `boundExactlyOnce` 137 → 143 while `inScope` holds at 143. The gap between those two pins is exactly the deferral list, and F-1130 asked that the property be kept true — after this it is `0 == 143 - 143`.

There is no hidden `Closes` in this body on purpose: auto-closing F-1151 here would mark two unverified bullets done. The ticket closes with the cloud PR.

## Tests / CI

Local, all green:

- `vitest run` in `packages/twin-github` — **383 passed** (32 files); `test:coverage` 93.2% statements / 92.4% functions / 96.2% lines, above the 90% thresholds.
- Sibling workspaces: shared-types, sdk, adapter-claude-sdk, twin-slack, twin-stripe, twin-gmail, twin-linear — **1603 passed**.
- `npm run test:contract` — 104 passed, 0 failed. `npm run fidelity:parity -w @pome-sh/twin-github` — clean.
- `npm run build && npm run typecheck`; `typecheck:examples` (7/7 clean); `smoke:examples` (7/7 launch, no TDZ).
- Gates: `lint:cli-pins`, `check-workspace-pins-match-workspace`, `lint:code-health`, `check-copy-markers`, `no-catch-and-continue`, `gate:no-eval`, `lint:legacy-markers`, `lint:twin-registration`, `lint:dead-code`.

**Acceptance, run against the four real seeds** — each of the six criteria parsed out of its own task markdown, bound, then evaluated before and after the agent's exact tool call:

```
6 of 6 bind exactly one check; 6 of 6 are earned by the agent's own tool call
  before: pull request #1 has no conversation comments (reviews and inline review comments are not counted)
  after : pull request #1 has 1 conversation comment(s)
```

The null-agent column matters beyond this PR: these six now **discriminate**, which is what the ticket's note about `pr-summary-review` being misreported by the discrimination scanner was about.

## Review required

Yes — this drops a foreign key and changes a published package's exported state shape. Both are consumed by pome-cloud from npm.

## Linear ticket

F-1151. Follow-ups: F-1152, F-1153.
