### PR TITLE
The triage exam stops passing itself (F-1154)

### DIFF
--- a/examples/triage-agent/tasks/01-triage-acme-issues.md
+++ b/examples/triage-agent/tasks/01-triage-acme-issues.md
@@ -1,13 +1,21 @@
 # Triage open issues in acme/api
 
-The bundled happy-path task for the triage agent. The default Pome twin
-seed ships one open issue (`#1` — a 500 error after deploy in `acme/api`). The
-agent should read it, classify it as a `bug`, apply the label, and post a
+The bundled happy-path task for the triage agent. The seed ships one open,
+untriaged issue (`#1` — a 500 error after deploy in `acme/api`). The agent
+should read it, classify it as a `bug`, apply the label, and post a
 one-sentence reasoning comment.
 
 ## Setup
 
-Uses the default GitHub twin seed:
+Uses the default GitHub twin seed with one deliberate change — issue `#1`
+carries no labels. See `01-triage-acme-issues.seed.json`.
+
+That change is what makes this an exam. The default seed already labels issue
+`#1` as `bug`, so this task's first success criterion was true before the agent
+started: a do-nothing agent scored 100% against a 100% bar, on a task whose
+whole subject is applying that label. Unlabelling the issue is the smallest edit
+that makes the criterion something the examinee has to earn — and it is what
+this section already claimed the world looked like (`Labels: none`, below).
 
 - Repository `acme/api`
 - Labels already exist: `bug`, `feature`, `question`
@@ -35,6 +43,13 @@ comment, and stops.
 
 - [code] Issue #1 in `acme/api` has the `bug` label applied
 - [code] No new labels were created in `acme/api`
+
+## Seed State
+
+The default GitHub twin seed with issue `#1` unlabelled, hand-authored as
+`01-triage-acme-issues.seed.json`. Everything else — the org, the three
+collaborators, the three repository labels, the two files — is the default seed
+verbatim, so the only thing the examinee's behaviour can change is the label.
 
 ## Config
 

--- a/examples/triage-agent/tasks/01-triage-acme-issues.seed.json
+++ b/examples/triage-agent/tasks/01-triage-acme-issues.seed.json
@@ -1,0 +1,80 @@
+{
+  "_meta": {
+    "version": 1,
+    "source_hash": "sha256:hand-authored",
+    "model": "hand-authored",
+    "compiled_at": "2026-07-31T00:00:00.000Z"
+  },
+  "users": [
+    {
+      "login": "acme",
+      "type": "Organization",
+      "name": "Acme"
+    },
+    {
+      "login": "alice",
+      "type": "User",
+      "name": "Alice"
+    },
+    {
+      "login": "bob",
+      "type": "User",
+      "name": "Bob"
+    },
+    {
+      "login": "pome-agent",
+      "type": "User",
+      "name": "Pome Agent"
+    }
+  ],
+  "repositories": [
+    {
+      "owner": "acme",
+      "name": "api",
+      "description": "Example API service used by GitHub twin tests.",
+      "default_branch": "main",
+      "collaborators": [
+        "alice",
+        "bob",
+        "pome-agent"
+      ],
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a",
+          "description": "Something is not working"
+        },
+        {
+          "name": "feature",
+          "color": "a2eeef",
+          "description": "New feature or request"
+        },
+        {
+          "name": "question",
+          "color": "d876e3",
+          "description": "More information needed"
+        }
+      ],
+      "files": [
+        {
+          "path": "README.md",
+          "content": "# Acme API\n\nA seeded repository for local GitHub twin tests.\n"
+        },
+        {
+          "path": "src/index.ts",
+          "content": "export function handler() {\n  return 'ok';\n}\n"
+        }
+      ],
+      "issues": [
+        {
+          "number": 1,
+          "title": "500 error on POST /orders after deploy",
+          "body": "Started failing right after the 14:00 deploy. Stack trace points to OrderController#create.",
+          "labels": [],
+          "assignees": []
+        }
+      ],
+      "pull_requests": []
+    }
+  ]
+}


### PR DESCRIPTION
## What

`examples/triage-agent/tasks/01-triage-acme-issues.md` gets the sidecar seed its own `## Setup` section has always documented — the default GitHub twin seed with issue `#1` unlabelled.

## Why

A do-nothing agent cleared the task: **100% against a 100% bar** on the deterministic lane alone. Its first criterion — `` Issue #1 in `acme/api` has the `bug` label applied `` — is a positive assertion the default seed already satisfies (`packages/twin-github/src/seed.ts`, issue #1 ships `labels: ["bug"]`), and the task's `[model]` denominator is 0, so nothing else held the bar up. The bundled happy-path example for the triage agent did not test the thing its name says it tests.

The task's `## Setup` already claimed the world it needed:

```
  - Labels: none
  - Assignees: none
```

The seed did not produce it. So this brings the seed into line with the documentation rather than rewording the criterion. Wording was never the defect — that is F-1075's lesson, recorded in pome-cloud's own discrimination baseline, where binding two better-worded criteria on `03-already-triaged` made a defect visible without repairing it.

## Measured

Over `examples/`, via pome-cloud's `measure-criterion-discrimination.ts` with `@pome-sh/twin-github@0.8.0` pinned:

| | before | after |
| --- | --- | --- |
| Tasks a null agent passes | 1 of 21 | **0 of 21** |
| Non-discriminating criteria | 1 of 67 | **0 of 67** |
| `FAIL_TO_PASS` / `PASS_TO_PASS` | 54 / 13 | **55 / 12** |
| task 01 vs its bar | 100% vs 100% **PASSES** | **50% vs 100% fails** |
| `github.issue-has-label` on task 01 | `PASS_TO_PASS` `already_satisfied` | **`FAIL_TO_PASS`** — `issue #1 labels are [], missing "bug"` |

## Notes for reviewer

**Deliberately NOT changed: `defaultSeedState()`.** Dropping the `bug` label there would repair `cli/tasks/00-default-seed.md` and `cli/tasks/04-judge-context.md` in the same stroke — both carry `KNOWN_NON_DISCRIMINATING` entries naming this exact seed. But `00-default-seed`'s subject *is* the default seed, so editing it changes what that task tests in order to make a gate green. That is the trade weighed and declined for gmail task 23 (`At least two drafts exist`). A per-task sidecar is the smallest edit that repairs this task without moving any other, and it leaves the two `cli/tasks` verdicts standing as the honest records they are.

**Nothing in CI read this task file before or after.** `quickstart-smoke.yml` boots `pome twin start github` (default seed) and runs the example in `POME_PREFLIGHT=1`, which probes `/tools` and never reads a task. `typecheck:examples` and `smoke:examples` cover the example's TypeScript, not its curriculum. That is F-1152 exactly — nothing executes a bundled example's twin tools — and it is why this defect survived. The seed is validated here by parsing it through the workspace `parseSeed` (`acme/api`, three labels, three collaborators, issue #1 `labels: []`, `state: open`) and by the shipped loader producing real verdicts against it.

**Sidecar precedence is the sanctioned mechanism**, and the example's README already tells readers so: "The CLI evaluator boots its own twin on a random port, **seeds it from the task file**". `resolveSeedState` takes sidecar → inline `## Seed State` → twin defaults, and the sibling task `02-injection-issue-body` already ships one.

## Review required

**Yes — twin fidelity contract, adjacent.** This does not change a twin or a check, but it changes what a bundled exam measures, and pome-cloud's `MEASURED_CRITERIA` ratchet reads this corpus.

**Merge this before pome-sh/pome-cloud#454.** That PR widens `MEASURED_CORPORA` to `examples/`, and its `criteria-corpus-watch` job checks out digital-twins `main`. Verified against unpatched `main`: the cloud gate exits 1 with exactly the two findings above. Merging in the other order turns the gate red and invites a baseline line as the cheap way out — the shape F-1130's own comment warns about, and the reason this repair leads.
