### PR TITLE
The digest refusal names what moved (F-1137)

### DIFF
--- a/cli/.changeset/digest-refusal-names-what-moved.md
+++ b/cli/.changeset/digest-refusal-names-what-moved.md
@@ -1,0 +1,23 @@
+---
+"@pome-sh/cli": patch
+---
+
+The digest refusal now names what moved in every case, including the two it used
+to refuse over in silence.
+
+`pome checks add` compares its own vocabulary digest against the one the control
+plane grades with, and refuses to write a sentence when they differ. That refusal
+built its "which check moved" list from `id` and `template`, while `checksDigest`
+hashes `id`, `substrate` and the COMPILED pattern. So a skew that moved only a
+`substrate`, or only `buildPattern`'s output while every template stayed
+byte-identical, printed the headline and then an empty bullet list — a named
+refusal that named nothing, in exactly the two cases the digest was widened to
+catch.
+
+The comparison is now a taxonomy with no silent branch: ids on one side only, a
+moved sentence, a moved substrate, moved parameter patterns, and — because
+`GET /v1/checks` publishes the compiled pattern too — a check whose declaration
+matches ours yet compiles differently, which is reported as the `@pome-sh/sdk`
+`buildPattern` difference it is, with this CLI's sdk pin named. A control plane
+that publishes no compiled pattern leaves nothing to localise, and that case is
+reported as its own class rather than as a blank list.

--- a/cli/src/cli/checks-add.ts
+++ b/cli/src/cli/checks-add.ts
@@ -8,7 +8,9 @@
  * the cloud resolves them from a different one. Before writing, ask the cloud
  * for the vocabulary it GRADES against and compare digests.
  *   equal        → write, silently
- *   different    → REFUSE, and name which check moved
+ *   different    → REFUSE, and name what moved (`vocabulary-skew.ts`, F-1137 —
+ *                  a check, a field of one, or the sdk that compiled it, but
+ *                  never an empty list)
  *   unreachable  → write from the local pin with a named note on stderr
  * Offline authoring is real, and the degraded path's worst case is bounded: a
  * stale sentence that keeps a template's literal segments fails at finalize as
@@ -37,11 +39,10 @@ import {
 } from "./checks.js";
 import { resolveCredentials, type ResolvedCredentials } from "./credentials.js";
 import { auditCodeCriteria, formatBindingReport } from "./criterion-binding.js";
+import { explainSkew, formatSkewRefusal, type RemoteVocabulary } from "./vocabulary-skew.js";
 
-export interface RemoteChecks {
+export interface RemoteChecks extends RemoteVocabulary {
   twin: string;
-  digest: string;
-  checks: Array<{ id: string; template: string; substrate: string }>;
 }
 
 export type HandshakeResult =
@@ -78,31 +79,12 @@ export async function handshake(
 
   if (localDigest(twin) === remote.digest) return { kind: "match" };
 
-  const here = new Map(checksFor(twin).map((check) => [check.id, check.template]));
-  const there = new Map(remote.checks.map((check) => [check.id, check.template]));
-  const moved: string[] = [];
-  for (const [id, template] of here) {
-    if (!there.has(id)) moved.push(`${id} — this CLI has it, the cloud does not`);
-    else if (there.get(id) !== template) {
-      moved.push(
-        `${id} — the sentence differs\n        here:  ${template}\n        cloud: ${there.get(id)}`,
-      );
-    }
-  }
-  for (const id of there.keys()) {
-    if (!here.has(id)) moved.push(`${id} — the cloud has it, this CLI does not`);
-  }
-
-  return {
-    kind: "skew",
-    message:
-      `Refusing to write: this CLI and the cloud disagree about ${twin}'s vocabulary, so a ` +
-      `sentence written here might not be graded there.\n` +
-      moved.map((line) => `      - ${line}`).join("\n") +
-      `\n\n  local @pome-sh/twin-${twin} ${pin}` +
-      `\n  Update with \`npm i -g @pome-sh/cli@latest\`. If this CLI is already current, the ` +
-      `cloud is behind — that is a deploy, not something you can fix here.`,
-  };
+  // F-1137 — the taxonomy lives in `vocabulary-skew.ts` and is NON-EMPTY by
+  // construction, so this refusal cannot name the disagreement and then list
+  // nothing. Which is what it did whenever the skew was in `substrate` or in the
+  // compiled pattern: the two fields `checksDigest` hashes that the old
+  // id-and-template diff never looked at.
+  return { kind: "skew", message: formatSkewRefusal(twin, explainSkew(twin, remote)) };
 }
 
 async function liveFetch(creds: ResolvedCredentials, twin: string): Promise<RemoteChecks> {

--- a/cli/src/cli/vocabulary-skew.ts
+++ b/cli/src/cli/vocabulary-skew.ts
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * F-1137 — WHY do this CLI and the cloud disagree about a twin's vocabulary?
+ *
+ * `checksDigest` hashes three fields per check: `id`, `substrate`, and the
+ * COMPILED pattern (`packages/sdk/src/checks.ts`). The refusal in `checks-add.ts`
+ * used to build its "which check moved" list from `id` and `template` — so a skew
+ * that moved only `substrate`, or only `buildPattern`'s output while every
+ * template was byte-identical, refused correctly and then named NOTHING. A named
+ * refusal that names nothing, in exactly the two cases the digest was widened to
+ * catch, during a situation that already blocks the author.
+ *
+ * The fix is a taxonomy with no silent branch: `explainSkew` returns a NON-EMPTY
+ * list by construction, and the type says so. The class names are pome-cloud's
+ * (`apps/control-plane/src/services/vocabulary-parity.ts`, F-1136) so the two
+ * surfaces that explain the same disagreement stay greppable against each other.
+ *
+ * This side can say more than the cloud-side monitor can. `GET /v1/checks`
+ * publishes the compiled `pattern` and the parameter patterns (F-1074 Phase 3),
+ * which the CLI's own `checks --json` does not — so a generator-only skew is
+ * localisable to a check HERE, and only falls back to the unlocalised
+ * `pattern_generation` class when the control plane published nothing to diff.
+ *
+ * `description` and `params[].example` are compared by nothing here on purpose:
+ * `checksDigest` does not hash them, so a difference in either cannot be what
+ * moved the digest, and comparing them could only manufacture false findings.
+ */
+import { checkPattern, templateSlots } from "@pome-sh/sdk/checks";
+
+import { checksFor, localDigest, pinnedVersion, type DeclaredCheck } from "./checks.js";
+
+/** One check as `GET /v1/checks` publishes it. */
+export interface RemoteCheck {
+  id: string;
+  template: string;
+  substrate: string;
+  /** The compiled regex source. Optional because a control plane that does not
+   *  publish it must degrade to a named class, never to a crash or to silence. */
+  pattern?: string;
+  /** Ordered as the template names them — the compiled pattern wraps one group
+   *  per slot in that order, so the ORDER is part of what the digest sees. */
+  params?: Array<{ name: string; pattern: string }>;
+}
+
+export interface RemoteVocabulary {
+  digest: string;
+  checks: RemoteCheck[];
+}
+
+export type SkewFinding =
+  | { kind: "only_here"; check: string }
+  | { kind: "only_there"; check: string }
+  | { kind: "template"; check: string; here: string; there: string }
+  | { kind: "substrate"; check: string; here: string; there: string }
+  | { kind: "params"; check: string; here: string; there: string }
+  // Same declaration, different compiled pattern: the two sides' `@pome-sh/sdk`
+  // turn one declaration into different regexes. `paramsCompared` records whether
+  // the cloud published the parameter patterns — without them, a parameter type
+  // is the other thing this could be, and the report has to say so.
+  | { kind: "pattern"; check: string; here: string; there: string; paramsCompared: boolean }
+  // Nothing above fired and the digests still differ. Carries the digest pair
+  // rather than a check, because the difference is not localisable to one.
+  | { kind: "pattern_generation"; check: null; here: string; there: string };
+
+function paramsHere(def: DeclaredCheck): string {
+  return templateSlots(def.template)
+    .params.map((name) => `${name}=${def.params[name]!.pattern}`)
+    .join(", ");
+}
+
+function paramsThere(check: RemoteCheck): string {
+  return (check.params ?? []).map((p) => `${p.name}=${p.pattern}`).join(", ");
+}
+
+/** The fields BOTH sides always publish. Returns empty when the declarations
+ *  agree — which is the precondition for reading anything into the compiled
+ *  pattern, since a moved template moves the pattern too and reporting both
+ *  would bury the cause under its own consequence. */
+function declarationSkew(def: DeclaredCheck, check: RemoteCheck): SkewFinding[] {
+  const findings: SkewFinding[] = [];
+  if (def.template !== check.template) {
+    findings.push({ kind: "template", check: def.id, here: def.template, there: check.template });
+  }
+  if (def.substrate !== check.substrate) {
+    findings.push({
+      kind: "substrate",
+      check: def.id,
+      here: def.substrate,
+      there: check.substrate,
+    });
+  }
+  if (check.params !== undefined && paramsHere(def) !== paramsThere(check)) {
+    findings.push({
+      kind: "params",
+      check: def.id,
+      here: paramsHere(def),
+      there: paramsThere(check),
+    });
+  }
+  return findings;
+}
+
+/**
+ * Every way this CLI's vocabulary for `twin` differs from the one the cloud
+ * published, as at least one named finding.
+ *
+ * Ordered by check id, so the readout is a property of the difference rather
+ * than of either side's declaration order.
+ */
+export function explainSkew(
+  twin: string,
+  remote: RemoteVocabulary,
+): [SkewFinding, ...SkewFinding[]] {
+  const here = new Map(checksFor(twin).map((def) => [def.id, def]));
+  const there = new Map(remote.checks.map((check) => [check.id, check]));
+  const findings: SkewFinding[] = [];
+
+  for (const id of [...new Set([...here.keys(), ...there.keys()])].sort()) {
+    const def = here.get(id);
+    const check = there.get(id);
+    if (!check) {
+      findings.push({ kind: "only_here", check: id });
+      continue;
+    }
+    if (!def) {
+      findings.push({ kind: "only_there", check: id });
+      continue;
+    }
+
+    const declaration = declarationSkew(def, check);
+    if (declaration.length > 0) {
+      findings.push(...declaration);
+      continue;
+    }
+
+    const compiled = checkPattern(def).source;
+    if (check.pattern !== undefined && check.pattern !== compiled) {
+      findings.push({
+        kind: "pattern",
+        check: id,
+        here: compiled,
+        there: check.pattern,
+        paramsCompared: check.params !== undefined,
+      });
+    }
+  }
+
+  const [first, ...rest] = findings;
+  if (!first) {
+    return [
+      {
+        kind: "pattern_generation",
+        check: null,
+        here: localDigest(twin),
+        there: remote.digest,
+      },
+    ];
+  }
+  return [first, ...rest];
+}
+
+function pair(here: string, there: string): string[] {
+  return [`        here:  ${here}`, `        cloud: ${there}`];
+}
+
+// One bullet per class, and the compiler holds the line: the annotated return
+// type plus an exhaustive switch means a class added without a bullet is
+// `error TS2366`, not a line that renders `undefined`. Do NOT add a `default:` —
+// it would buy back the silence this module exists to remove.
+function bullet(finding: SkewFinding): string[] {
+  switch (finding.kind) {
+    case "only_here":
+      return [`      - ${finding.check} — this CLI has it, the cloud does not`];
+    case "only_there":
+      return [`      - ${finding.check} — the cloud has it, this CLI does not`];
+    case "template":
+      return [
+        `      - ${finding.check} — the sentence differs`,
+        ...pair(finding.here, finding.there),
+      ];
+    case "substrate":
+      return [
+        `      - ${finding.check} — the substrate differs, so the two sides grade it against`,
+        `        different evidence`,
+        ...pair(finding.here, finding.there),
+      ];
+    case "params":
+      return [
+        `      - ${finding.check} — the parameters differ`,
+        ...pair(`[${finding.here}]`, `[${finding.there}]`),
+      ];
+    case "pattern":
+      return [
+        ...(finding.paramsCompared
+          ? [
+              `      - ${finding.check} — same sentence and parameters, different compiled`,
+              `        pattern: the two sides' @pome-sh/sdk compile one declaration differently,`,
+              `        which is a buildPattern change and not a vocabulary change`,
+            ]
+          : [
+              `      - ${finding.check} — same sentence, different compiled pattern, and no`,
+              `        parameter patterns published: either a parameter type or @pome-sh/sdk`,
+              `        buildPattern moved`,
+            ]),
+        ...pair(finding.here, finding.there),
+      ];
+    case "pattern_generation":
+      return [
+        `      - the digests differ, but every field the cloud published matches this CLI's`,
+        `        declarations. That makes it an @pome-sh/sdk difference — buildPattern, or what`,
+        `        checksDigest hashes — rather than a vocabulary change`,
+        ...pair(finding.here, finding.there),
+      ];
+  }
+}
+
+/** The refusal an author reads. Names the twin pin always, and the sdk pin only
+ *  when the sdk is what the findings implicate — a pin nobody needs is noise in a
+ *  message someone is reading because they are already blocked. */
+export function formatSkewRefusal(twin: string, findings: readonly SkewFinding[]): string {
+  const sdkImplicated = findings.some(
+    (f) => f.kind === "pattern" || f.kind === "pattern_generation",
+  );
+  return [
+    `Refusing to write: this CLI and the cloud disagree about ${twin}'s vocabulary, so a ` +
+      `sentence written here might not be graded there.`,
+    ...findings.flatMap(bullet),
+    "",
+    `  local @pome-sh/twin-${twin} ${pinnedVersion(`@pome-sh/twin-${twin}`)}` +
+      (sdkImplicated ? `, @pome-sh/sdk ${pinnedVersion("@pome-sh/sdk")}` : ""),
+    ...(sdkImplicated
+      ? [`  The cloud publishes no sdk version here, so that is the only pin this CLI can name.`]
+      : []),
+    `  Update with \`npm i -g @pome-sh/cli@latest\`. If this CLI is already current, the ` +
+      `cloud is behind — that is a deploy, not something you can fix here.`,
+  ].join("\n");
+}

--- a/cli/test/unit/checks-add.test.ts
+++ b/cli/test/unit/checks-add.test.ts
@@ -2,9 +2,10 @@
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { checkPattern, templateSlots } from "@pome-sh/sdk/checks";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { handshake, runChecksAddCommand } from "../../src/cli/checks-add.js";
-import { checksFor, localDigest } from "../../src/cli/checks.js";
+import { checksFor, localDigest, pinnedVersion } from "../../src/cli/checks.js";
 import { twinWithoutChecks } from "./_noVocabularyTwin.js";
 
 // The menu position of the check these tests pick. Derived, never hard-coded:
@@ -50,6 +51,32 @@ const agreeing = async (twin: string) => ({
   digest: localDigest(twin),
   checks: [],
 });
+
+/** Everything `GET /v1/checks` publishes, mirrored from this CLI's own pin — the
+ *  compiled `pattern` and the parameter patterns included, because prod serves
+ *  both. Derived rather than written out: the vocabulary is a closed set that
+ *  grows, so a literal fixture would assert its size, not the behaviour. */
+function mirrorOfLocal(twin: string) {
+  return checksFor(twin).map((def) => ({
+    id: def.id,
+    template: def.template,
+    substrate: def.substrate,
+    pattern: checkPattern(def).source,
+    params: templateSlots(def.template).params.map((name) => ({
+      name,
+      pattern: def.params[name]!.pattern,
+    })),
+  }));
+}
+
+/** The bullet list the refusal renders. The F-1137 defect was that this came back
+ *  empty while the refusal claimed to name what moved. */
+function bulletsIn(message: string): string[] {
+  return message
+    .split("\n")
+    .filter((line) => line.trimStart().startsWith("- "))
+    .map((line) => line.replace(/^\s*-\s*/, ""));
+}
 
 beforeEach(() => {
   process.exitCode = undefined;
@@ -188,6 +215,67 @@ describe("the digest handshake", () => {
     expect(result.message).toContain("github.no-new-labels");
     expect(result.message).toContain("No labels were created");
     expect(result.message).toContain("@pome-sh/cli@latest");
+  });
+
+  // F-1137 — the refusal is correct, but it used to build its bullet list from
+  // `id` and `template` while `checksDigest` hashes `id`, `substrate` and the
+  // COMPILED pattern. A skew in either of the two it did not compare refused with
+  // an empty bullet list: a named refusal that names nothing, in exactly the
+  // situation the digest was widened to catch.
+  it("names the check and both substrates when only the substrate moved", async () => {
+    const result = await handshake("github", async (twin) => ({
+      twin,
+      digest: "sha256:the-cloud-hashed-a-different-substrate",
+      checks: mirrorOfLocal("github").map((check, index) =>
+        index === 0 ? { ...check, substrate: "tape" } : check,
+      ),
+    }));
+
+    expect(result.kind).toBe("skew");
+    if (result.kind !== "skew") throw new Error("unreachable");
+    const first = checksFor("github")[0]!;
+    expect(result.message).toContain(first.id);
+    expect(result.message).toContain(first.substrate);
+    expect(result.message).toContain("tape");
+    expect(bulletsIn(result.message).length).toBeGreaterThan(0);
+  });
+
+  it("names the sdk generator when only the compiled pattern moved", async () => {
+    const result = await handshake("github", async (twin) => ({
+      twin,
+      digest: "sha256:a-different-sdk-compiled-these",
+      // Every field the cloud publishes is byte-identical to ours EXCEPT the
+      // compiled pattern — what a `buildPattern` change looks like on the wire.
+      checks: mirrorOfLocal("github").map((check) => ({
+        ...check,
+        pattern: check.pattern!.replace("^", "^(?:)"),
+      })),
+    }));
+
+    expect(result.kind).toBe("skew");
+    if (result.kind !== "skew") throw new Error("unreachable");
+    expect(result.message).toContain("buildPattern");
+    expect(result.message).toContain(`@pome-sh/sdk ${pinnedVersion("@pome-sh/sdk")}`);
+    expect(bulletsIn(result.message).length).toBeGreaterThan(0);
+  });
+
+  it("still names a class when the cloud publishes nothing this CLI can diff", async () => {
+    const result = await handshake("github", async (twin) => ({
+      twin,
+      digest: "sha256:a-control-plane-that-publishes-no-pattern",
+      checks: checksFor("github").map((def) => ({
+        id: def.id,
+        template: def.template,
+        substrate: def.substrate,
+      })),
+    }));
+
+    expect(result.kind).toBe("skew");
+    if (result.kind !== "skew") throw new Error("unreachable");
+    const bullets = bulletsIn(result.message);
+    expect(bullets.length).toBeGreaterThan(0);
+    for (const bullet of bullets) expect(bullet).not.toBe("");
+    expect(result.message).toContain("buildPattern");
   });
 
   it("degrades with a NAMED note when the cloud is unreachable", async () => {

--- a/cli/test/unit/vocabulary-skew.test.ts
+++ b/cli/test/unit/vocabulary-skew.test.ts
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: Apache-2.0
+import { checkPattern, templateSlots } from "@pome-sh/sdk/checks";
+import { describe, expect, it } from "vitest";
+import { checksFor, pinnedVersion } from "../../src/cli/checks.js";
+import {
+  explainSkew,
+  formatSkewRefusal,
+  type RemoteVocabulary,
+} from "../../src/cli/vocabulary-skew.js";
+
+// A digest the cloud published that is not ours. The handshake only ever compares
+// digests for EQUALITY, so a sentinel is the honest fixture here: what is under
+// test is the explanation, never the hash arithmetic.
+const MOVED = "sha256:the-cloud-published-a-different-digest";
+
+/**
+ * The cloud's payload, mirrored from this CLI's own declarations.
+ *
+ * Derived, never a literal list — the vocabulary is a CLOSED SET THAT GROWS
+ * (F-1075, F-1151), so a hand-written fixture would assert the size of the set
+ * where these tests mean to assert the classification of a difference. Every
+ * field `GET /v1/checks` serves is mirrored, including the compiled `pattern`
+ * and the parameter patterns, because prod really does serve both.
+ */
+function mirror(twin: string): RemoteVocabulary {
+  return {
+    digest: MOVED,
+    checks: checksFor(twin).map((def) => ({
+      id: def.id,
+      template: def.template,
+      substrate: def.substrate,
+      pattern: checkPattern(def).source,
+      params: templateSlots(def.template).params.map((name) => ({
+        name,
+        pattern: def.params[name]!.pattern,
+      })),
+    })),
+  };
+}
+
+/** The first declaration that takes at least one parameter — derived, so no test
+ *  below names a check that a later ticket may reorder or rename. */
+function withParams(twin: string): string {
+  const def = checksFor(twin).find((c) => templateSlots(c.template).params.length > 0);
+  if (!def) throw new Error(`${twin} declares no parameterised check`);
+  return def.id;
+}
+
+function findingFor(remote: RemoteVocabulary, id: string) {
+  const hit = remote.checks.find((c) => c.id === id);
+  if (!hit) throw new Error(`fixture lost ${id}`);
+  return hit;
+}
+
+describe("explainSkew", () => {
+  it("names a check this CLI has and the cloud does not", () => {
+    const remote = mirror("github");
+    const dropped = remote.checks[0]!.id;
+    remote.checks = remote.checks.filter((c) => c.id !== dropped);
+
+    expect(explainSkew("github", remote)).toEqual([{ kind: "only_here", check: dropped }]);
+  });
+
+  it("names a check the cloud has and this CLI does not", () => {
+    const remote = mirror("github");
+    remote.checks = [
+      ...remote.checks,
+      { id: "github.invented-later", template: "Something new", substrate: "final" },
+    ];
+
+    expect(explainSkew("github", remote)).toEqual([
+      { kind: "only_there", check: "github.invented-later" },
+    ]);
+  });
+
+  it("names the check and both sentences when a template moved", () => {
+    const remote = mirror("github");
+    const id = remote.checks[0]!.id;
+    const here = findingFor(remote, id).template;
+    findingFor(remote, id).template = `${here} (reworded)`;
+
+    expect(explainSkew("github", remote)).toEqual([
+      { kind: "template", check: id, here, there: `${here} (reworded)` },
+    ]);
+  });
+
+  // F-1137's first Done-when bullet. `substrate` is hashed by `checksDigest` and
+  // was not compared by the refusal, so this skew refused while naming nothing.
+  it("names the check and both substrates when only the substrate moved", () => {
+    const remote = mirror("github");
+    const id = remote.checks[0]!.id;
+    const here = findingFor(remote, id).substrate;
+    findingFor(remote, id).substrate = here === "tape" ? "final" : "tape";
+
+    expect(explainSkew("github", remote)).toEqual([
+      { kind: "substrate", check: id, here, there: findingFor(remote, id).substrate },
+    ]);
+  });
+
+  it("names the check and both parameter signatures when a slot's pattern moved", () => {
+    const remote = mirror("github");
+    const id = withParams("github");
+    const check = findingFor(remote, id);
+    const here = check.params!.map((p) => `${p.name}=${p.pattern}`).join(", ");
+    check.params = check.params!.map((p, i) =>
+      i === 0 ? { ...p, pattern: "CHANGED-BY-THE-CLOUD" } : p,
+    );
+
+    expect(explainSkew("github", remote)).toEqual([
+      {
+        kind: "params",
+        check: id,
+        here,
+        there: check.params!.map((p) => `${p.name}=${p.pattern}`).join(", "),
+      },
+    ]);
+  });
+
+  // F-1137's second Done-when bullet, localised. The compiled pattern IS on the
+  // `GET /v1/checks` wire (F-1074 Phase 3, verified against prod), so a
+  // generator-only skew can name the check rather than only its class.
+  it("names the check when the compiled pattern moved under an identical declaration", () => {
+    const remote = mirror("github");
+    const id = remote.checks[0]!.id;
+    const check = findingFor(remote, id);
+    const here = check.pattern!;
+    // Same declaration, different compiled source: what a `buildPattern` change
+    // in the two sides' `@pome-sh/sdk` looks like on the wire.
+    check.pattern = here.replace("^", "^(?:)");
+
+    expect(explainSkew("github", remote)).toEqual([
+      { kind: "pattern", check: id, here, there: check.pattern, paramsCompared: true },
+    ]);
+  });
+
+  it("reports the sentence, not the compiled pattern, when the template moved too", () => {
+    const remote = mirror("github");
+    const id = remote.checks[0]!.id;
+    const check = findingFor(remote, id);
+    check.template = `${check.template} (reworded)`;
+    check.pattern = `${check.pattern}(?:)`;
+
+    expect(explainSkew("github", remote).map((f) => f.kind)).toEqual(["template"]);
+  });
+
+  // F-1137's second Done-when bullet, unlocalised: the class the ticket asks for.
+  // A control plane that publishes no compiled pattern leaves nothing to diff
+  // field-by-field, and this is the branch that used to render as the empty string.
+  it("names the generator as its own class when the cloud published nothing to diff", () => {
+    const remote = mirror("github");
+    remote.checks = remote.checks.map(({ id, template, substrate }) => ({
+      id,
+      template,
+      substrate,
+    }));
+
+    expect(explainSkew("github", remote)).toEqual([
+      { kind: "pattern_generation", check: null, here: expect.any(String), there: MOVED },
+    ]);
+  });
+
+  it("never explains a skew with an empty list", () => {
+    const twin = "github";
+    const payloads: RemoteVocabulary[] = [
+      // Byte-identical to ours in every published field, yet a different digest.
+      mirror(twin),
+      { digest: MOVED, checks: [] },
+      {
+        digest: MOVED,
+        checks: mirror(twin).checks.map(({ id, template, substrate }) => ({
+          id,
+          template,
+          substrate,
+        })),
+      },
+    ];
+    for (const remote of payloads) {
+      expect(explainSkew(twin, remote).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("orders findings by check id, so the readout does not depend on declaration order", () => {
+    const remote = mirror("github");
+    for (const check of remote.checks) {
+      check.substrate = check.substrate === "tape" ? "final" : "tape";
+    }
+    const named = explainSkew("github", remote).map((f) => f.check);
+
+    expect(named.length).toBe(remote.checks.length);
+    expect(named).toEqual([...named].sort());
+  });
+});
+
+describe("formatSkewRefusal", () => {
+  it("renders one bullet per finding, and never a blank one", () => {
+    const remote = mirror("github");
+    const id = remote.checks[0]!.id;
+    findingFor(remote, id).substrate = "tape";
+    const message = formatSkewRefusal("github", explainSkew("github", remote));
+
+    const bullets = message.split("\n").filter((line) => line.trimStart().startsWith("- "));
+    expect(bullets.length).toBeGreaterThan(0);
+    for (const bullet of bullets) expect(bullet.replace(/^\s*-\s*/, "")).not.toBe("");
+  });
+
+  it("names the local @pome-sh/sdk pin when the generator is what moved", () => {
+    const remote = mirror("github");
+    remote.checks = remote.checks.map(({ id, template, substrate }) => ({
+      id,
+      template,
+      substrate,
+    }));
+    const message = formatSkewRefusal("github", explainSkew("github", remote));
+
+    expect(message).toContain(`@pome-sh/sdk ${pinnedVersion("@pome-sh/sdk")}`);
+    expect(message).toContain("buildPattern");
+  });
+
+  it("leaves the sdk pin out when the vocabulary itself is what moved", () => {
+    const remote = mirror("github");
+    findingFor(remote, remote.checks[0]!.id).substrate = "tape";
+    const message = formatSkewRefusal("github", explainSkew("github", remote));
+
+    expect(message).not.toContain("@pome-sh/sdk");
+    expect(message).toContain(`@pome-sh/twin-github ${pinnedVersion("@pome-sh/twin-github")}`);
+  });
+});


### PR DESCRIPTION
## What

`pome checks add`'s digest refusal now names what moved in every case, including the two it used to refuse over in silence. The comparison moves out of `handshake()` into `cli/src/cli/vocabulary-skew.ts` as a taxonomy that is non-empty by construction.

## Why

`checksDigest` hashes three fields per check — `id`, `substrate`, and the **compiled** pattern (`packages/sdk/src/checks.ts`, whose comment says the compiled source is deliberate: "this also catches a change in `buildPattern` itself"). The refusal built its list from `id` and `template`:

```ts
const here  = new Map(checksFor(twin).map((check) => [check.id, check.template]));
const there = new Map(remote.checks.map((check) => [check.id, check.template]));
```

So a skew that moved only a `substrate`, or only `buildPattern`'s output while every template stayed byte-identical, rendered

```ts
moved.map((line) => `      - ${line}`).join("\n")
```

as the empty string. Reproduced on unpatched `main` — headline, two blank lines, footer:

```
Refusing to write: this CLI and the cloud disagree about github's vocabulary, so a sentence written here might not be graded there.


  local @pome-sh/twin-github 0.8.0
  Update with `npm i -g @pome-sh/cli@latest`. …
```

A named refusal that names nothing, in exactly the two cases the digest was widened to catch, while the author is already blocked. F-1132 measured what an uninformative refusal costs: six hours.

## Measured

Verified end-to-end through the real HTTP path with the built CLI — live prod first, then a stub serving prod's own payload shape with one field moved. All four exit `2` and leave the task file untouched.

| skew | what the refusal now says |
| --- | --- |
| **live prod** (this CLI 14 checks / `cbf9…`, prod 13 / `5282…`) | `github.pr-comment-exists — this CLI has it, the cloud does not` |
| **substrate only** | `github.issue-exists — the substrate differs, so the two sides grade it against different evidence` · `here: final` / `cloud: tape` |
| **compiled pattern only** | `github.issue-exists — same sentence and parameters, different compiled pattern: the two sides' @pome-sh/sdk compile one declaration differently` · both sources · `@pome-sh/sdk 0.10.0` |
| **cloud publishes no pattern** | `the digests differ, but every field the cloud published matches this CLI's declarations. That makes it an @pome-sh/sdk difference — buildPattern, or what checksDigest hashes` · both digests |

The live row is a real skew, not a fixture: prod has not been promoted to the pin carrying F-1151's fourteenth declaration. Every one of the 13 shared checks is byte-identical across template, substrate, parameter patterns and compiled pattern.

## Notes for reviewer

**The ticket's second bullet had a wrong premise, and the fix is better for it.** It states the compiled `pattern` is not on the `GET /v1/checks` → CLI wire, so a `buildPattern` skew "has to be named as its own class". It *is* on that wire, and has been since F-1074 Phase 3 — `checksPayload` serves `pattern` and `params[].pattern`, confirmed against live `api.pome.sh`. What omits `pattern` is the CLI's **own** `checks --json`, which is the side pome-cloud's monitor reads, which is why that module needs an unlocalised class. So this side names the check whose declaration matches ours yet compiles differently, and keeps the unlocalised class only for a control plane that published nothing to diff — reachable, so it is tested.

**What this cannot do is name both sdk pins.** Prod publishes no sdk version: not in the payload, not in a response header, and `GET /v1/version` is `no_route`. So the refusal names this CLI's pin and says plainly that the other is not on the wire, rather than implying a comparison the reader cannot make. Naming both needs an additive `sdk` field in the control plane's `checksPayload` — a different repo, and worth its own ticket if we want it.

**No `default:` in `bullet()`, on purpose.** With the annotated return type, a class added without a bullet is `error TS2366` rather than a line that renders `undefined`. Proven by temporarily adding an eighth class and watching `tsc` reject it; a `default:` would buy the silence back.

**Class names are pome-cloud's `vocabulary-parity.ts` on purpose** (`only_here`/`only_there` for its `only_left`/`only_right`, then `template`, `substrate`, `params`, `pattern_generation`) so the two surfaces that explain one disagreement stay greppable against each other. Not hoisted into `@pome-sh/sdk`: the two sides compare different information sets — this one has the compiled pattern from both sides and can localise, the cloud's cannot — so a shared function would be a lowest common denominator, not one implementation of one fact.

**`description` and `params[].example` are compared by nothing here**, matching the digest: `checksDigest` does not hash them, so a difference in either cannot be what moved the digest, and comparing them could only manufacture false findings.

## Tests / CI

- `cd cli && npm test` — **798 passed** (89 files), including 13 new in `test/unit/vocabulary-skew.test.ts` and 3 new handshake cases. Written first; the three failed against unpatched `main` for the right reason (0 bullets, no id, no `buildPattern`).
- `npm run typecheck` clean. Root gates green: `lint:code-health`, `lint:no-catch`, `gate:no-eval`, `lint:dead-code` (knip), `lint:cli-pins`, `lint:copy-markers`.
- Changeset: `patch`. No `packages/*` version moved, so no pin to carry.

## Linear ticket

F-1137.

<!-- Closes F-1137 -->
