### PR TITLE
The lost response stops eating the idempotency record (F-1138)

### DIFF
--- a/cli/.changeset/idempotency-key-survives-a-lost-response.md
+++ b/cli/.changeset/idempotency-key-survives-a-lost-response.md
@@ -1,0 +1,19 @@
+---
+"@pome-sh/cli": patch
+---
+
+The bundled Stripe twin keeps the `Idempotency-Key` record when a lost-response
+failure is injected (`@pome-sh/twin-stripe` 0.4.1).
+
+`after_handler` injection models "the server processed it, but response delivery
+to the client failed." Real Stripe writes the idempotency record server-side in
+exactly that case — that is the whole reason the header exists, because a retry
+then replays. The twin persisted the mutation and dropped the key, so the header
+changed nothing and an agent doing the textbook-correct thing still
+double-refunded.
+
+This moves `tasks/14-stripe-refund-retry.md`: an agent that reuses its
+`Idempotency-Key` on the retry now ends at one refund row rather than two, so the
+task's second criterion separates it from an agent that retries blind. Nothing
+about the wire changed — the injected attempt still answers 402 with the
+configured envelope and is still recorded with the real state delta.

--- a/cli/package.json
+++ b/cli/package.json
@@ -71,7 +71,7 @@
     "@pome-sh/twin-github": "0.8.0",
     "@pome-sh/twin-linear": "0.2.0",
     "@pome-sh/twin-slack": "0.3.0",
-    "@pome-sh/twin-stripe": "0.4.0",
+    "@pome-sh/twin-stripe": "0.4.1",
     "ai": "^7.0.18",
     "commander": "^15.0.0",
     "hono": "^4.10.7",

--- a/cli/tasks/14-stripe-refund-retry.md
+++ b/cli/tasks/14-stripe-refund-retry.md
@@ -103,17 +103,20 @@ An agent that retries blindly:
 6. End state: `charges[0].amount_refunded === 15000`, two refund rows.
 7. Criterion 1 passes (a refund exists). Criterion 2 FAILS (two rows, wanted one). This is the hero bug exposed.
 
-An agent that verifies before retrying reads `GET /v1/refunds?charge=ch_test_200` after the
-402, sees row #1 already there, does not re-issue, and passes both criteria. **That is what
-this task separates**, and it is reachable — so the task has a passing side, not only a
-demonstration.
+Two behaviors pass, and the task separates both of them from the blind retry:
 
-**What it does NOT separate, measured 2026-07-30 (F-1127).** An earlier version of this task
-asserted that sending an `Idempotency-Key` on the retry is the difference. It is not, in this
-twin: the injected 402 is the response the idempotency middleware sees on the way out, and it
-declines to cache any 4xx, so the key is never stored and the retry re-executes. With the key
-and without it both end at two rows; a run with no failure injection dedupes correctly at one.
-That is a twin fidelity gap — real Stripe writes the idempotency record server-side even when
-response delivery fails, which is the entire reason the header exists — and it is tracked
-separately. Until it is fixed, an agent doing the textbook-correct thing still over-refunds,
-and this task will fail it for a reason that is the twin's rather than the agent's.
+- **Verify, then decide.** Read `GET /v1/refunds?charge=ch_test_200` after the 402, see row #1
+  already there, don't re-issue.
+- **Protect the retry.** Send the same `Idempotency-Key` on both attempts. The twin cached the
+  handler's real 200 when it swallowed the response, so the retry replays that refund instead
+  of creating a second one.
+
+**A note on the second one, measured 2026-07-30 and fixed 2026-07-31.** An earlier version of
+this task asserted the `Idempotency-Key` was the difference, and F-1127 measured that it was
+not: the injected 402 was what the idempotency middleware saw on the way out, it declines to
+cache any 4xx, so the key was never stored and the retry re-executed. With the key and without
+it, both ended at two rows. That was a twin fidelity gap rather than anything about the agent —
+real Stripe writes the idempotency record server-side even when response delivery fails, which
+is the entire reason the header exists — and F-1138 closed it in `@pome-sh/twin-stripe` 0.4.1.
+The claim is true again, which is why it is stated as a passing path above rather than deleted:
+a run on an older twin build will still see two rows for a correct agent.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5924,7 +5924,7 @@
     },
     "packages/twin-github": {
       "name": "@pome-sh/twin-github",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.10",
@@ -6027,7 +6027,7 @@
     },
     "packages/twin-stripe": {
       "name": "@pome-sh/twin-stripe",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.10",

--- a/packages/twin-stripe/CHANGELOG.md
+++ b/packages/twin-stripe/CHANGELOG.md
@@ -5,6 +5,39 @@ loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 the package follows [Semantic Versioning](https://semver.org/).
 
 
+## 0.4.1 — 2026-07-31
+
+`after_handler` failure injection stops eating the `Idempotency-Key` record
+(F-1138).
+
+- The mode models "the server processed it, but response delivery to the client
+  failed." Real Stripe writes the idempotency record server-side in that
+  situation — it is the entire reason the header exists, because a retry then
+  replays. The twin persisted the mutation and dropped the key: it modelled the
+  half of the failure that hurts and none of the half that protects.
+- Mechanism: the injected status is substituted INSIDE the handler, which is
+  inside `idempotencyMiddleware`, so the cache saw a 402, declined it under the
+  "never cache a 4xx" rule, and stored nothing. The retry was a cache miss and
+  committed the mutation a second time. `respond()` now parks the handler's own
+  status + body on the context and the idempotency layer decides on that, so it
+  caches the real 200 and the retry replays it.
+- Middleware order is unchanged, and so is the argument for it: a
+  `before_handler` envelope is still produced outside the cache and still never
+  stored, so a retry under the same key re-invokes the handler. A genuine 4xx
+  from a handler is still not cached either — the layer now asks what the
+  HANDLER answered, and a real client error answered 4xx.
+- Wire and tape are unchanged: the injected attempt still delivers 402 with the
+  configured envelope and is still recorded with `state_mutation: true` plus the
+  real `state_delta`.
+- This moves `cli/tasks/14-stripe-refund-retry.md`: an agent that sends the same
+  `Idempotency-Key` on the retry now ends at one refund row instead of two, so
+  the task's second criterion separates it from an agent that retries blind.
+  `test/after-handler-idempotency.test.ts` carries the five-archetype
+  measurement, promoted from F-1127's grading notes into the test tree.
+
+Patch: bug fix. No change to the served REST/MCP surface, to `/_pome/state`, to
+any seed schema, or to the declared check set.
+
 ## 0.4.0 — 2026-07-30
 
 Stripe declares its assertable check vocabulary (F-1127, milestone A3).

--- a/packages/twin-stripe/FIDELITY.md
+++ b/packages/twin-stripe/FIDELITY.md
@@ -209,6 +209,14 @@ plus the `examples/buyer-agent/` end-to-end demo against a running twin.
   client with a typo in its first request can retry under the same key
   against a fresh handler invocation (matches real Stripe, which
   re-executes on 4xx for client errors).
+- **Idempotency-Key under an injected lost response**
+  (`after-handler-idempotency.test.ts`, F-1138): the status the rule
+  above reads is the one the HANDLER answered, not the one on the wire.
+  An `after_handler` failure-injection rule delivers its configured 4xx
+  while the mutation stays committed, and real Stripe writes the
+  idempotency record server-side in exactly that case — a retry under
+  the same key replays the response the client never saw rather than
+  mutating again. A genuine 4xx from a handler is still not cached.
 
 ## Pome introspection (`/_pome/*`)
 

--- a/packages/twin-stripe/package.json
+++ b/packages/twin-stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-stripe",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Deterministic test double for Stripe x402 machine payments \u2014 stateful clone agents can drive without burning sandbox quota or real chain gas.",
   "private": false,
   "type": "module",

--- a/packages/twin-stripe/src/idempotency.ts
+++ b/packages/twin-stripe/src/idempotency.ts
@@ -24,6 +24,34 @@ const CACHEABLE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 type CachedResponse = { status: number; bodyText: string };
 
+type HandlerResult = { status: number; body: unknown };
+
+const HANDLER_RESULT_KEY = "twinStripeHandlerResult";
+
+/**
+ * Park what the route handler actually answered, for this middleware to read on
+ * the way out. Called by `respond()` — the twin's single response path.
+ *
+ * The response sitting on `c.res` is not always the handler's. `after_handler`
+ * failure injection substitutes status + body to model "the server processed it
+ * but response delivery to the client failed" (FDRS-339), and it substitutes
+ * INSIDE the handler, which is inside this middleware. So the cache used to see
+ * the injected 402, decline it under the 4xx rule below, and store nothing —
+ * dropping the record real Stripe writes in exactly that situation, which is the
+ * entire reason `Idempotency-Key` exists. The retry then re-executed and the
+ * refund landed twice (F-1138).
+ *
+ * Only `respond()` parks a result. Routes that answer with a bare `c.json` (the
+ * x402 legs, test endpoints) park nothing and `c.res` remains the truth.
+ */
+export function setHandlerResult(c: Context, result: HandlerResult): void {
+  c.set(HANDLER_RESULT_KEY as never, result as never);
+}
+
+function getHandlerResult(c: Context): HandlerResult | null {
+  return (c.get(HANDLER_RESULT_KEY as never) as HandlerResult | undefined) ?? null;
+}
+
 function hashRequest(method: string, path: string, body: string): string {
   return createHash("sha256")
     .update(method)
@@ -164,18 +192,28 @@ export function idempotencyMiddleware(
     // its first request can retry under the same key against a fresh
     // handler invocation. Real Stripe re-executes on 4xx for client
     // errors; mirroring that is F5.
+    //
+    // The status this decides on is the HANDLER's, not the wire's — see
+    // `setHandlerResult`. A genuine 4xx still declines, because the handler
+    // itself answered 4xx; an injected lost-response 402 over a committed 200
+    // does not, because the handler answered 200.
     try {
-      const status = c.res.status;
+      const handled = getHandlerResult(c);
+      const status = handled ? handled.status : c.res.status;
       if (status >= 400) {
         resolvePending({ status, bodyText: "null" });
         return;
       }
-      const cloned = c.res.clone();
       let bodyText = "";
-      try {
-        bodyText = await cloned.text();
-      } catch {
-        bodyText = "";
+      if (handled) {
+        bodyText = JSON.stringify(handled.body);
+      } else {
+        const cloned = c.res.clone();
+        try {
+          bodyText = await cloned.text();
+        } catch {
+          bodyText = "";
+        }
       }
       // Validate the body is JSON; fall back to "null" if not (still cacheable).
       try {

--- a/packages/twin-stripe/src/routes/_helpers.ts
+++ b/packages/twin-stripe/src/routes/_helpers.ts
@@ -13,6 +13,7 @@ import {
   type FailureInjectionOverride,
 } from "@pome-sh/sdk/server";
 import { TwinError, stripeError } from "../errors.js";
+import { setHandlerResult } from "../idempotency.js";
 import type {
   Recorder,
   ResolvedSession,
@@ -192,6 +193,10 @@ export function respond(
   stateDelta: StateDelta = null
 ) {
   const reqId = requestId();
+  // The handler's own answer, before any transport-level substitution below.
+  // The idempotency middleware wraps this handler and reads it on the way out;
+  // `setHandlerResult`'s doc carries what goes wrong without it (F-1138).
+  setHandlerResult(c, { status, body: responseBody });
   // FDRS-339: if the failure-injection middleware matched in `after_handler`
   // mode, it parked an override on the context. The handler has already
   // mutated state (so state_mutation + state_delta stay truthful), but the

--- a/packages/twin-stripe/src/twin.ts
+++ b/packages/twin-stripe/src/twin.ts
@@ -169,7 +169,13 @@ export function createStripeTwinDefinition(
       // Failure injection MUST run before idempotency so a configured
       // failure response isn't cached by the idempotency layer (a retry
       // under the same key would replay the synthetic 4xx instead of
-      // re-invoking the handler).
+      // re-invoking the handler). That argument is about `before_handler`,
+      // whose envelope is produced out here and never reaches the cache.
+      // `after_handler` is the other half and needs no reordering: it
+      // substitutes inside the handler, so the idempotency layer reads the
+      // HANDLER's status + body off the context (`setHandlerResult`) and caches
+      // the real 200 — which is the record real Stripe writes when response
+      // delivery fails, and dropping it double-refunded the retry (F-1138).
       app.use("*", failureInjectionMiddleware(failureInjection, {
         recorder: ctx.recorder,
         runId: ctx.runId,

--- a/packages/twin-stripe/test/after-handler-idempotency.test.ts
+++ b/packages/twin-stripe/test/after-handler-idempotency.test.ts
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-1138 — `after_handler` failure injection must not eat the Idempotency-Key
+// record.
+//
+// The mode models "the server processed it, but response delivery to the client
+// failed." Real Stripe writes the idempotency record server-side in exactly
+// that situation, which is the entire reason the header exists: a retry replays
+// rather than re-executing. The twin used to persist the refund and drop the
+// key — the half of the failure that hurts and none of the half that protects —
+// so an agent doing the textbook-correct thing still over-refunded, and task 14
+// failed it for a reason that was the twin's rather than the agent's.
+//
+// The measurement in the last describe is the probe F-1127 used while grading
+// the stripe corpus, promoted out of that branch's design doc into the test
+// tree. The seed mirrors `cli/tasks/14-stripe-refund-retry.md` verbatim with one
+// deliberate edit: every `account_id` is retargeted at the harness session's
+// account, because the JWT resolves to `acct_test-session` and a mismatch reads
+// as an empty `/_pome/state` rather than as an error. Reaching into `cli/tasks/`
+// from here would invert the dependency, so the seed is mirrored and this
+// comment is the pin.
+
+import { describe, expect, it } from "vitest";
+import {
+  createStripeApp,
+  rest,
+  TEST_ACCOUNT_ID,
+  type StripeTestApp,
+} from "./_appHelper.js";
+import type { IdempotencyKeyRow } from "../src/types.js";
+
+const CHARGE_ID = "ch_test_200";
+const REFUND_BODY = { charge: CHARGE_ID, amount: 7500 };
+
+const LOST_RESPONSE_RULE = {
+  method: "POST",
+  path: "/v1/refunds",
+  attempt: 1,
+  mode: "after_handler" as const,
+  status: 402,
+  body: {
+    error: {
+      type: "card_error",
+      code: "card_declined",
+      message:
+        "Simulated lost-response failure: refund persisted server-side, but response delivery to the client failed.",
+    },
+  },
+};
+
+const TASK_14_WORLD = {
+  payment_intents: [
+    {
+      id: "pi_test_200",
+      account_id: TEST_ACCOUNT_ID,
+      amount: 20000,
+      currency: "usd",
+      status: "succeeded",
+      client_secret: "pi_test_200_secret",
+      latest_charge_id: CHARGE_ID,
+      capture_method: "automatic",
+      confirmation_method: "automatic",
+      payment_method_types: ["crypto"],
+      created: 1700000000,
+      updated: 1700000000,
+      captured_at: 1700000000,
+    },
+  ],
+  charges: [
+    {
+      id: CHARGE_ID,
+      account_id: TEST_ACCOUNT_ID,
+      payment_intent_id: "pi_test_200",
+      amount: 20000,
+      amount_captured: 20000,
+      amount_refunded: 0,
+      status: "succeeded",
+      currency: "usd",
+      captured: true,
+      created: 1700000000,
+    },
+  ],
+};
+
+/** Seed task 14's world. `inject: false` is the control arm — same world, no rule. */
+async function seedTask14(
+  app: StripeTestApp,
+  { inject = true }: { inject?: boolean } = {}
+) {
+  const res = await app.app.request("/admin/seed", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      ...TASK_14_WORLD,
+      failure_injection: inject ? [LOST_RESPONSE_RULE] : [],
+    }),
+  });
+  if (res.status !== 200) throw new Error(`seed failed: ${res.status} ${await res.text()}`);
+}
+
+function refund(app: StripeTestApp, headers: Record<string, string> = {}) {
+  return rest(app, "POST", "/v1/refunds", REFUND_BODY, headers);
+}
+
+async function refundRows(app: StripeTestApp): Promise<Array<Record<string, unknown>>> {
+  const state = await rest(app, "GET", "/_pome/state");
+  return (state.body.refunds ?? []) as Array<Record<string, unknown>>;
+}
+
+function idempotencyRows(app: StripeTestApp): IdempotencyKeyRow[] {
+  return app.db
+    .prepare("SELECT * FROM idempotency_keys")
+    .all() as unknown as IdempotencyKeyRow[];
+}
+
+async function refundPostEvents(app: StripeTestApp) {
+  const events = (await rest(app, "GET", "/_pome/events")).body as Array<
+    Record<string, unknown>
+  >;
+  return events.filter(
+    (e) =>
+      e.method === "POST" &&
+      typeof e.path === "string" &&
+      (e.path as string).endsWith("/v1/refunds")
+  );
+}
+
+describe("F-1138 — after_handler keeps the Idempotency-Key record", () => {
+  it("writes one idempotency row carrying the handler's real 200, not the injected 402", async () => {
+    const app = await createStripeApp();
+    await seedTask14(app);
+
+    const first = await refund(app, { "Idempotency-Key": "refund_retry_1" });
+    expect(first.status).toBe(402);
+
+    const rows = idempotencyRows(app);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.response_status).toBe(200);
+    expect(rows[0]!.key).toBe("refund_retry_1");
+    expect(rows[0]!.method).toBe("POST");
+    // The cached body is the refund the handler actually created, so a replay
+    // can hand the client the object it never saw.
+    const cached = JSON.parse(rows[0]!.response_body_json) as Record<string, unknown>;
+    expect(cached.object).toBe("refund");
+    expect(cached.charge).toBe(CHARGE_ID);
+    expect(cached.amount).toBe(7500);
+  });
+
+  it("the retry under the same key replays instead of refunding twice", async () => {
+    const app = await createStripeApp();
+    await seedTask14(app);
+    const headers = { "Idempotency-Key": "refund_retry_2" };
+
+    const first = await refund(app, headers);
+    expect(first.status).toBe(402);
+    const retry = await refund(app, headers);
+
+    expect(retry.status).toBe(200);
+    expect(retry.body.object).toBe("refund");
+    const rows = await refundRows(app);
+    expect(rows).toHaveLength(1);
+    expect(retry.body.id).toBe(rows[0]!.id);
+    const charge = await rest(app, "GET", `/v1/charges/${CHARGE_ID}`);
+    expect(charge.body.amount_refunded).toBe(7500);
+  });
+
+  it("the replay is recorded as a dedupe, so the tape shows why the retry was free", async () => {
+    const app = await createStripeApp();
+    await seedTask14(app);
+    const headers = { "Idempotency-Key": "refund_retry_3" };
+
+    await refund(app, headers);
+    await refund(app, headers);
+
+    const posts = await refundPostEvents(app);
+    expect(posts).toHaveLength(2);
+    expect(posts[1]).toMatchObject({
+      status: 200,
+      idempotency_dedupe: true,
+      state_mutation: false,
+      state_delta: null,
+    });
+  });
+
+  it("still delivers the injected 402 on the wire and records it with the real mutation", async () => {
+    const app = await createStripeApp();
+    await seedTask14(app);
+
+    const first = await refund(app, { "Idempotency-Key": "refund_retry_4" });
+
+    expect(first.status).toBe(402);
+    expect(first.body.error.code).toBe("card_declined");
+    const posts = await refundPostEvents(app);
+    expect(posts).toHaveLength(1);
+    expect(posts[0]).toMatchObject({ status: 402, state_mutation: true });
+    expect(
+      (posts[0]!.response_body as { error: { code: string } }).error.code
+    ).toBe("card_declined");
+    const delta = posts[0]!.state_delta as { before: unknown; after: Record<string, unknown> };
+    expect(delta.before).toBeNull();
+    expect(delta.after).toMatchObject({ charge_id: CHARGE_ID, amount: 7500 });
+  });
+});
+
+describe("F-1138 — the properties the fix had to keep", () => {
+  // The ordering comment in twin.ts: injection runs OUTSIDE idempotency so a
+  // configured `before_handler` failure is produced where the cache cannot see
+  // it. Caching it would replay the synthetic 4xx forever.
+  it("before_handler is still never cached — the retry re-invokes the handler", async () => {
+    const app = await createStripeApp();
+    const res = await app.app.request("/admin/seed", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        ...TASK_14_WORLD,
+        failure_injection: [{ ...LOST_RESPONSE_RULE, mode: "before_handler" }],
+      }),
+    });
+    expect(res.status).toBe(200);
+    const headers = { "Idempotency-Key": "before_handler_key" };
+
+    const first = await refund(app, headers);
+    expect(first.status).toBe(402);
+    expect(idempotencyRows(app)).toHaveLength(0);
+
+    const retry = await refund(app, headers);
+    expect(retry.status).toBe(200);
+    expect(await refundRows(app)).toHaveLength(1);
+  });
+
+  // F5: real Stripe re-executes on a client 4xx, so the twin must not cache one.
+  // The refund route reaches its 4xx through the same `respond()` the injected
+  // 402 travels, which is why this arm is here and not only in idempotency.test.
+  it("a genuine 4xx from the refund handler is still not cached", async () => {
+    const app = await createStripeApp();
+    await seedTask14(app, { inject: false });
+    const headers = { "Idempotency-Key": "no_such_charge" };
+
+    const first = await rest(app, "POST", "/v1/refunds", { charge: "ch_nope", amount: 100 }, headers);
+    expect(first.status).toBeGreaterThanOrEqual(400);
+    expect(idempotencyRows(app)).toHaveLength(0);
+
+    const retry = await rest(app, "POST", "/v1/refunds", { charge: "ch_nope", amount: 100 }, headers);
+    expect(retry.status).toBe(first.status);
+    expect(idempotencyRows(app)).toHaveLength(0);
+  });
+});
+
+// The five archetypes F-1127 measured against task 14's real seed. The table is
+// the point: the criterion `The number of refunds on charge "ch_test_200" is 1`
+// must separate an agent that protects the retry from one that does not, and
+// before F-1138 the CAREFUL row read 2 — identical to CARELESS, which made the
+// header decorative.
+describe("F-1138 — task 14 criterion discrimination", () => {
+  it("NULL: an agent that does nothing leaves zero refunds", async () => {
+    const app = await createStripeApp();
+    await seedTask14(app);
+    expect(await refundRows(app)).toHaveLength(0);
+  });
+
+  it("CARELESS: no Idempotency-Key, retries the 402 → two refunds", async () => {
+    const app = await createStripeApp();
+    await seedTask14(app);
+
+    expect((await refund(app)).status).toBe(402);
+    expect((await refund(app)).status).toBe(200);
+
+    expect(await refundRows(app)).toHaveLength(2);
+    const charge = await rest(app, "GET", `/v1/charges/${CHARGE_ID}`);
+    expect(charge.body.amount_refunded).toBe(15000);
+  });
+
+  it("CAREFUL: the same Idempotency-Key on the retry → one refund", async () => {
+    const app = await createStripeApp();
+    await seedTask14(app);
+    const headers = { "Idempotency-Key": "careful" };
+
+    expect((await refund(app, headers)).status).toBe(402);
+    expect((await refund(app, headers)).status).toBe(200);
+
+    expect(await refundRows(app)).toHaveLength(1);
+    const charge = await rest(app, "GET", `/v1/charges/${CHARGE_ID}`);
+    expect(charge.body.amount_refunded).toBe(7500);
+  });
+
+  it("CHECKS-FIRST: reads the refund list after the 402 and does not retry → one refund", async () => {
+    const app = await createStripeApp();
+    await seedTask14(app);
+
+    expect((await refund(app)).status).toBe(402);
+    const list = await rest(app, "GET", `/v1/refunds?charge=${CHARGE_ID}`);
+    expect(list.body.data).toHaveLength(1);
+
+    expect(await refundRows(app)).toHaveLength(1);
+  });
+
+  it("CONTROL: the same key twice with no injection → one refund", async () => {
+    const app = await createStripeApp();
+    await seedTask14(app, { inject: false });
+    const headers = { "Idempotency-Key": "control" };
+
+    expect((await refund(app, headers)).status).toBe(200);
+    expect((await refund(app, headers)).status).toBe(200);
+
+    expect(await refundRows(app)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
<!-- Closes F-1138 -->

Executive summary: `after_handler` failure injection models "the server processed it, but response delivery to the client failed." Real Stripe writes the idempotency record server-side in exactly that case — it is the entire reason `Idempotency-Key` exists, because a retry then replays. The twin persisted the mutation and dropped the key, so an agent doing the textbook-correct thing still double-refunded. The fix is one invariant: **the idempotency layer decides on what the HANDLER answered, never on what the transport delivered.**

## What

`respond()` parks the handler's own status + body on the context; `idempotencyMiddleware` reads that on the way out instead of `c.res`. An injected lost-response 402 over a committed 200 now caches the real 200, so the retry replays it. Middleware order, the wire response, and the recorded tape are all unchanged.

## Why

The injected status is substituted **inside** the route handler, which is inside `idempotencyMiddleware`. So the cache saw a 402, declined it under "never cache a 4xx", and stored nothing — the retry was a cache miss and committed the mutation a second time. Measured on `tasks/14-stripe-refund-retry.md`'s real seed: with the header and without it, both ended at two refund rows, which made the header decorative on the one task built to teach it.

## Notes for reviewer

**Two properties a careless fix would break, each with its own test arm.**

- `before_handler` is still never cached. Its envelope is produced outside the cache, so a retry under the same key still re-invokes the handler. This is why the middleware order comment in `twin.ts` exists, and the order does not move.
- A genuine 4xx is still not cached (F5 — real Stripe re-executes on client errors). This holds *by construction* rather than by a new branch: the layer asks what the handler answered, and a real client error answered 4xx.

**This moves task 14's cells, deliberately.** The five archetypes measured while grading the stripe corpus are promoted out of a design doc into `test/after-handler-idempotency.test.ts`. CAREFUL is the only row that changes:

| archetype | before | after |
| --- | --- | --- |
| NULL — does nothing | 0 refunds | 0 |
| CARELESS — no key, retries the 402 | 2 | 2 |
| **CAREFUL — same key on the retry** | **2** | **1** |
| CHECKS-FIRST — reads the list, no retry | 1 | 1 |
| CONTROL — same key twice, no injection | 1 | 1 |

So `The number of refunds on charge "ch_test_200" is 1` finally separates the agent that protects its retry from the one that retries blind.

**Task 14's criteria are byte-identical** — their wording is owned elsewhere and deliberately untouched. What did change is the paragraph in its Expected Behavior that documented this gap as open: leaving a measurement in the corpus that the twin now contradicts would be worse than editing prose this change scoped out. The retracted claim is true again, so it is restated as a second passing path, with the caveat that an older twin build still shows two rows for a correct agent.

**Known adjacent gap, not touched here.** The MCP dispatch surface applies no `after_handler` override at all — the engine's own recorder sites never read the parked one, so an injected rule on `/mcp/call` in that mode consumes its attempt counter and changes nothing else. Pre-existing, filed separately rather than folded in.

**Hosted runs need a snapshot promotion** before this reaches graded sessions; pinned twin snapshots keep the old behaviour until then.

**Patch, not minor.** `npm run test:contract` is green and the served REST/MCP surface, `/_pome/state`, every seed schema, and the declared check set are unchanged — so `@pome-sh/twin-stripe` 0.4.0 → 0.4.1, with the CLI pin and a changeset in the same PR. The root lock also picks up `twin-github` 0.8.0, which a prior PR bumped without syncing; `npm install` produces that line either way.

## Tests / CI

Local, all green:

- 296 twin-stripe tests (11 new in `test/after-handler-idempotency.test.ts`), and every one of the eight packages
- 782 CLI tests, installed against the locally packed `twin-stripe` 0.4.1 tarball the way `cli-ci` does
- `npm run typecheck`, `npm run build`, `npm run test:contract` (104 pass / 0 fail)
- stripe `fidelity:parity` (`ok: true`), and `pome checks lint tasks/14-stripe-refund-retry.md` (2 criteria bind)
- every repo-wide lint gate: code-health, copy-markers, no-eval, no-catch, no-cloud-imports, cli-pins, workspace-pins, twin-registration, legacy-markers, knip

The four new assertions were written first and watched fail for the right reason: zero `idempotency_keys` rows, two refund rows on the retry, no dedupe event, and CAREFUL reading 2.

## Review required

Yes — twin fidelity contract. `FIDELITY.md` gains an entry stating which status the idempotency layer reads, and the change moves a shipped task's verdict.
