### PR TITLE
fix(twin-linear): partial updates stop wiping unmentioned fields (F-1166)

### DIFF
--- a/packages/twin-linear/CHANGELOG.md
+++ b/packages/twin-linear/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @pome-sh/twin-linear — CHANGELOG
 
+## Unreleased
+
+- **Fixed: partial updates no longer wipe fields the caller never mentioned
+  (F-1166).** Nullable fields on update mutations are tri-state — key absent
+  and key present with `undefined` both mean "leave alone", `null` means
+  "clear". The twin tested presence with the `in` operator, but every caller
+  builds its patch as an object literal with all keys present, so an
+  `agentSessionUpdate` that only set `state` silently erased `plan` and
+  `externalUrl`. The same shape bug affected `issueUpdate`, `issueLabelUpdate`,
+  `updateProject`, `updateDocument`, and the MCP `save_issue`, `save_project`,
+  and `save_document` tools; `save_document` with only a title additionally
+  failed outright with a spurious reparenting error. Presence is now tested as
+  `!== undefined` at both the input-parsing and domain layers.
+
 ## 0.2.0 — 2026-07-30
 
 Linear declares its assertable check vocabulary (F-1129, milestone A3) — the

--- a/packages/twin-linear/CHANGELOG.md
+++ b/packages/twin-linear/CHANGELOG.md
@@ -13,6 +13,14 @@
   and `save_document` tools; `save_document` with only a title additionally
   failed outright with a spurious reparenting error. Presence is now tested as
   `!== undefined` at both the input-parsing and domain layers.
+- **Fixed: `issueUpdate` with an explicit `stateId: null` no longer erases an
+  issue's lifecycle timestamps (F-1166).** The block that derives
+  `started_at` / `completed_at` / `canceled_at` was gated on `stateId != null`,
+  but the flags that wrote them were gated on `stateId !== undefined`, so a
+  rename sent alongside `stateId: null` wrote the uncomputed nulls while
+  `COALESCE` correctly held `state_id` — leaving a Done issue with no
+  completion timestamp. The flags now match the guard. A real transition still
+  clears the stamps.
 
 ## 0.2.0 — 2026-07-30
 

--- a/packages/twin-linear/package.json
+++ b/packages/twin-linear/package.json
@@ -39,7 +39,7 @@
     "dev": "tsx src/server.ts",
     "start": "node dist/src/server.js",
     "prepack": "npm run build",
-    "test": "node --test test/gate0-fixtures.test.mjs test/package-deps.test.mjs && vitest run test/domain.test.ts test/domain-wave4.test.ts test/graphql.test.ts test/mcp.test.ts test/mcp-graphql-parity.test.ts test/oauth.test.ts test/webhooks.test.ts test/webhook-policy.test.ts test/agent-path.test.ts test/official-client.test.ts test/limits.test.ts test/concurrency.test.ts test/canary-matrix.test.ts test/auth-scopes.test.ts test/check-state.test.ts test/checks-contract.test.ts",
+    "test": "node --test test/gate0-fixtures.test.mjs test/package-deps.test.mjs && vitest run test/domain.test.ts test/domain-wave4.test.ts test/graphql.test.ts test/mcp.test.ts test/mcp-graphql-parity.test.ts test/oauth.test.ts test/webhooks.test.ts test/webhook-policy.test.ts test/agent-path.test.ts test/partial-update-tristate.test.ts test/official-client.test.ts test/limits.test.ts test/concurrency.test.ts test/canary-matrix.test.ts test/auth-scopes.test.ts test/check-state.test.ts test/checks-contract.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "fidelity:parity": "tsx scripts/fidelity-parity.ts"
   },

--- a/packages/twin-linear/src/domain/agents.ts
+++ b/packages/twin-linear/src/domain/agents.ts
@@ -84,6 +84,10 @@ export function updateAgentSession(
   domain.requireScopes(actor, ["write"]);
   const session = domain.requireAgentSession(id);
   const now = domain.tick();
+  // Nullable fields are tri-state: `undefined` (absent, or explicitly passed as undefined)
+  // means "leave alone", `null` means "clear". Never test presence with `in` here — callers
+  // build this patch as an object literal with every key present, so `in` would clear
+  // every field the caller did not mention (F-1166).
   domain.db
     .prepare(
       `UPDATE agent_sessions SET
@@ -95,9 +99,9 @@ export function updateAgentSession(
     )
     .run(
       input.state ? normalizeSessionState(input.state) : null,
-      "plan" in input ? 1 : 0,
+      input.plan !== undefined ? 1 : 0,
       input.plan ?? null,
-      "externalUrl" in input ? 1 : 0,
+      input.externalUrl !== undefined ? 1 : 0,
       input.externalUrl ?? null,
       now,
       session.id

--- a/packages/twin-linear/src/domain/documents.ts
+++ b/packages/twin-linear/src/domain/documents.ts
@@ -117,15 +117,15 @@ export function updateDocument(
 ): LinearDocument {
   domain.requireScopes(actor, ["write"]);
   const doc = domain.requireDocument(id);
-  if ("title" in input && input.title !== undefined) assertTitle(input.title);
-  if ("content" in input && input.content != null) assertBody(input.content);
+  if (input.title !== undefined) assertTitle(input.title);
+  if (input.content != null) assertBody(input.content);
   const parents =
-    "project" in input || "team" in input || "issue" in input || "cycle" in input
+    input.project !== undefined || input.team !== undefined || input.issue !== undefined || input.cycle !== undefined
       ? resolveParents(domain, {
-          project: "project" in input ? input.project : undefined,
-          team: "team" in input ? input.team : undefined,
-          issue: "issue" in input ? input.issue : undefined,
-          cycle: "cycle" in input ? input.cycle : undefined,
+          project: input.project,
+          team: input.team,
+          issue: input.issue,
+          cycle: input.cycle,
         })
       : null;
   if (parents && parents.count !== 1) {
@@ -148,7 +148,7 @@ export function updateDocument(
     )
     .run(
       input.title ?? null,
-      "content" in input ? 1 : 0,
+      input.content !== undefined ? 1 : 0,
       input.content ?? null,
       parents ? 1 : 0,
       parents?.projectId ?? null,
@@ -158,9 +158,9 @@ export function updateDocument(
       parents?.issueId ?? null,
       parents ? 1 : 0,
       parents?.cycleId ?? null,
-      "icon" in input ? 1 : 0,
+      input.icon !== undefined ? 1 : 0,
       input.icon ?? null,
-      "color" in input ? 1 : 0,
+      input.color !== undefined ? 1 : 0,
       input.color ?? null,
       now,
       doc.id

--- a/packages/twin-linear/src/domain/issues.ts
+++ b/packages/twin-linear/src/domain/issues.ts
@@ -360,11 +360,14 @@ export async function updateIssue(
       input.archivedAt !== undefined ? 1 : 0,
       patch.archived_at ?? null,
       // Must CASE-clear timestamps on reopen — COALESCE(null, completed_at) would keep Done stamps.
-      input.stateId !== undefined ? 1 : 0,
+      // Gated on `!= null` to match the guard that computes them: the timestamps are derived from a
+      // target state, so a null stateId (no transition, and state_id itself held by COALESCE) leaves
+      // them alone rather than writing the uncomputed nulls over a Done issue's stamps.
+      input.stateId != null ? 1 : 0,
       patch.canceled_at ?? null,
-      input.stateId !== undefined ? 1 : 0,
+      input.stateId != null ? 1 : 0,
       patch.completed_at ?? null,
-      input.stateId !== undefined ? 1 : 0,
+      input.stateId != null ? 1 : 0,
       patch.started_at ?? null,
       input.dueDate !== undefined ? 1 : 0,
       patch.due_date ?? null,

--- a/packages/twin-linear/src/domain/issues.ts
+++ b/packages/twin-linear/src/domain/issues.ts
@@ -246,30 +246,30 @@ export async function updateIssue(
   const before = issueWebhookPayload(issue);
   const patch: Partial<IssueRow> = {};
   let changed = false;
-  if ("title" in input && input.title !== undefined) {
+  if (input.title !== undefined) {
     assertTitle(input.title);
     patch.title = input.title;
     if (input.title !== issue.title) changed = true;
   }
-  if ("description" in input) {
+  if (input.description !== undefined) {
     if (input.description != null) assertBody(input.description);
     patch.description = input.description ?? null;
     if ((input.description ?? null) !== issue.description) changed = true;
   }
-  if ("priority" in input) {
+  if (input.priority !== undefined) {
     patch.priority = normalizePriority(input.priority);
     if (patch.priority !== issue.priority) changed = true;
   }
-  if ("estimate" in input) {
+  if (input.estimate !== undefined) {
     patch.estimate = normalizeEstimate(input.estimate);
     if (patch.estimate !== issue.estimate) changed = true;
   }
-  if ("parentId" in input) {
+  if (input.parentId !== undefined) {
     patch.parent_id = input.parentId ? domain.requireIssue(input.parentId).id : null;
     if (patch.parent_id) assertNoParentCycle(domain, issue.id, patch.parent_id);
     if (patch.parent_id !== issue.parentId) changed = true;
   }
-  if ("stateId" in input && input.stateId != null) {
+  if (input.stateId != null) {
     const state = domain.requireState(input.stateId, issue.teamId);
     const now = domain.now();
     patch.state_id = state.id;
@@ -279,33 +279,33 @@ export async function updateIssue(
     patch.canceled_at = state.type === "canceled" ? (issue.canceledAt ?? now) : null;
     if (state.id !== issue.stateId) changed = true;
   }
-  if ("assigneeId" in input) {
+  if (input.assigneeId !== undefined) {
     patch.assignee_id = input.assigneeId ? domain.requireUser(input.assigneeId).id : null;
     if (patch.assignee_id !== issue.assigneeId) changed = true;
   }
-  if ("delegateId" in input) {
+  if (input.delegateId !== undefined) {
     patch.delegate_id = input.delegateId ? domain.requireUser(input.delegateId).id : null;
     if (patch.delegate_id !== issue.delegateId) changed = true;
   }
-  if ("projectId" in input) {
+  if (input.projectId !== undefined) {
     patch.project_id = input.projectId ? domain.requireProject(input.projectId, issue.teamId).id : null;
     if (patch.project_id !== issue.projectId) changed = true;
   }
-  if ("cycleId" in input) {
+  if (input.cycleId !== undefined) {
     patch.cycle_id = input.cycleId ? domain.requireCycle(input.cycleId, issue.teamId).id : null;
     if (patch.cycle_id !== issue.cycleId) changed = true;
   }
-  if ("archivedAt" in input) {
+  if (input.archivedAt !== undefined) {
     patch.archived_at = input.archivedAt ?? null;
     if ((input.archivedAt ?? null) !== issue.archivedAt) changed = true;
   }
-  if ("dueDate" in input) {
+  if (input.dueDate !== undefined) {
     patch.due_date = input.dueDate ?? null;
     if ((input.dueDate ?? null) !== issue.dueDate) changed = true;
   }
 
   let nextLabelIds: string[] | undefined;
-  if ("labelIds" in input && input.labelIds !== undefined && input.labelIds !== null) {
+  if (input.labelIds != null) {
     nextLabelIds = input.labelIds.map((ref) => domain.requireLabel(ref, issue.teamId).id);
     const beforeLabels = [...issue.labelIds].sort().join("\0");
     const afterLabels = [...nextLabelIds].sort().join("\0");
@@ -341,32 +341,32 @@ export async function updateIssue(
     )
     .run(
       patch.title ?? null,
-      "description" in input ? 1 : 0,
+      input.description !== undefined ? 1 : 0,
       patch.description ?? null,
       patch.priority ?? null,
-      "estimate" in input ? 1 : 0,
+      input.estimate !== undefined ? 1 : 0,
       patch.estimate ?? null,
       patch.state_id ?? null,
-      "assigneeId" in input ? 1 : 0,
+      input.assigneeId !== undefined ? 1 : 0,
       patch.assignee_id ?? null,
-      "delegateId" in input ? 1 : 0,
+      input.delegateId !== undefined ? 1 : 0,
       patch.delegate_id ?? null,
-      "projectId" in input ? 1 : 0,
+      input.projectId !== undefined ? 1 : 0,
       patch.project_id ?? null,
-      "cycleId" in input ? 1 : 0,
+      input.cycleId !== undefined ? 1 : 0,
       patch.cycle_id ?? null,
-      "parentId" in input ? 1 : 0,
+      input.parentId !== undefined ? 1 : 0,
       patch.parent_id ?? null,
-      "archivedAt" in input ? 1 : 0,
+      input.archivedAt !== undefined ? 1 : 0,
       patch.archived_at ?? null,
       // Must CASE-clear timestamps on reopen — COALESCE(null, completed_at) would keep Done stamps.
-      "stateId" in input ? 1 : 0,
+      input.stateId !== undefined ? 1 : 0,
       patch.canceled_at ?? null,
-      "stateId" in input ? 1 : 0,
+      input.stateId !== undefined ? 1 : 0,
       patch.completed_at ?? null,
-      "stateId" in input ? 1 : 0,
+      input.stateId !== undefined ? 1 : 0,
       patch.started_at ?? null,
-      "dueDate" in input ? 1 : 0,
+      input.dueDate !== undefined ? 1 : 0,
       patch.due_date ?? null,
       now,
       issue.id

--- a/packages/twin-linear/src/domain/labels.ts
+++ b/packages/twin-linear/src/domain/labels.ts
@@ -64,7 +64,7 @@ export async function updateLabel(
     .run(
       input.name ?? null,
       input.color ?? null,
-      "description" in input ? 1 : 0,
+      input.description !== undefined ? 1 : 0,
       input.description ?? null,
       now,
       label.id

--- a/packages/twin-linear/src/domain/projects-cycles.ts
+++ b/packages/twin-linear/src/domain/projects-cycles.ts
@@ -60,7 +60,7 @@ export function updateProject(
     )
     .run(
       input.name ?? null,
-      "description" in input ? 1 : 0,
+      input.description !== undefined ? 1 : 0,
       input.description ?? null,
       input.state ?? null,
       now,

--- a/packages/twin-linear/src/graphql/mutation-inputs.ts
+++ b/packages/twin-linear/src/graphql/mutation-inputs.ts
@@ -144,7 +144,7 @@ export function parseIssueCreateInput(input: unknown): IssueCreateInput {
     title: raw.title,
     description: raw.description ?? null,
     priority: raw.priority ?? undefined,
-    estimate: "estimate" in raw ? (raw.estimate ?? null) : undefined,
+    estimate: raw.estimate,
     stateId: raw.stateId ?? null,
     assigneeId: raw.assigneeId ?? null,
     delegateId: raw.delegateId ?? null,
@@ -161,19 +161,19 @@ export function parseIssueCreateInput(input: unknown): IssueCreateInput {
 export function parseIssueUpdateInput(input: unknown): { id?: string; patch: IssueUpdateInput } {
   const raw = parseOrBadUserInput(issueUpdateInputSchema, input, "issueUpdate input");
   const patch: IssueUpdateInput = {};
-  if ("title" in raw && raw.title !== undefined) patch.title = raw.title;
-  if ("description" in raw) patch.description = raw.description ?? null;
-  if ("priority" in raw) patch.priority = raw.priority ?? null;
-  if ("estimate" in raw) patch.estimate = raw.estimate ?? null;
-  if ("stateId" in raw) patch.stateId = raw.stateId ?? null;
-  if ("assigneeId" in raw) patch.assigneeId = raw.assigneeId ?? null;
-  if ("delegateId" in raw) patch.delegateId = raw.delegateId ?? null;
-  if ("labelIds" in raw) patch.labelIds = raw.labelIds ?? [];
-  if ("projectId" in raw) patch.projectId = raw.projectId ?? null;
-  if ("cycleId" in raw) patch.cycleId = raw.cycleId ?? null;
-  if ("parentId" in raw) patch.parentId = raw.parentId ?? null;
-  if ("archivedAt" in raw) patch.archivedAt = raw.archivedAt ?? null;
-  if ("dueDate" in raw) patch.dueDate = raw.dueDate ?? null;
+  if (raw.title !== undefined) patch.title = raw.title;
+  if (raw.description !== undefined) patch.description = raw.description ?? null;
+  if (raw.priority !== undefined) patch.priority = raw.priority ?? null;
+  if (raw.estimate !== undefined) patch.estimate = raw.estimate ?? null;
+  if (raw.stateId !== undefined) patch.stateId = raw.stateId ?? null;
+  if (raw.assigneeId !== undefined) patch.assigneeId = raw.assigneeId ?? null;
+  if (raw.delegateId !== undefined) patch.delegateId = raw.delegateId ?? null;
+  if (raw.labelIds !== undefined) patch.labelIds = raw.labelIds ?? [];
+  if (raw.projectId !== undefined) patch.projectId = raw.projectId ?? null;
+  if (raw.cycleId !== undefined) patch.cycleId = raw.cycleId ?? null;
+  if (raw.parentId !== undefined) patch.parentId = raw.parentId ?? null;
+  if (raw.archivedAt !== undefined) patch.archivedAt = raw.archivedAt ?? null;
+  if (raw.dueDate !== undefined) patch.dueDate = raw.dueDate ?? null;
   return { id: raw.id, patch };
 }
 
@@ -208,7 +208,7 @@ export function parseIssueLabelUpdateInput(input: unknown) {
     id: raw.id,
     name: raw.name,
     color: raw.color,
-    description: "description" in raw ? (raw.description ?? null) : undefined,
+    description: raw.description,
   };
 }
 
@@ -254,8 +254,8 @@ export function parseAgentSessionUpdateInput(input: unknown) {
   return {
     id: raw.id,
     state: raw.state,
-    plan: "plan" in raw ? (raw.plan ?? null) : undefined,
-    externalUrl: "externalUrl" in raw ? (raw.externalUrl ?? null) : undefined,
+    plan: raw.plan,
+    externalUrl: raw.externalUrl,
   };
 }
 

--- a/packages/twin-linear/test/partial-update-tristate.test.ts
+++ b/packages/twin-linear/test/partial-update-tristate.test.ts
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-1166: partial updates must honour the three-way distinction that GraphQL
+// partial-update inputs require:
+//
+//   * key absent entirely        -> leave the stored value alone
+//   * key present, value `null`  -> clear the stored value
+//   * key present, value `undefined` -> leave the stored value alone
+//     (`undefined` is the absence of a value, not a value)
+//
+// The twin used to conflate the last two by testing key presence with the `in`
+// operator, so any caller that built a patch object literal with every key
+// always present silently wiped every field it did not mention.
+import { describe, expect, it } from "vitest";
+import { createRecorderStore } from "@pome-sh/sdk/server";
+import {
+  DEFAULT_LINEAR_TOKEN,
+  LinearDomain,
+  createLinearTwinApp,
+  linearTools,
+  openLinearTwinDatabase,
+} from "../src/index.js";
+import { parseAgentSessionUpdateInput } from "../src/graphql/mutation-inputs.js";
+import { testSeed } from "./_helpers.js";
+
+const SECRET = "linear-tristate-test-secret-32chars!";
+
+function domain() {
+  const db = openLinearTwinDatabase(":memory:");
+  const commands = new LinearDomain(db);
+  commands.seed(testSeed());
+  return commands;
+}
+
+function app() {
+  process.env.TWIN_AUTH_SECRET = SECRET;
+  const db = openLinearTwinDatabase(":memory:");
+  return createLinearTwinApp({
+    db,
+    seed: testSeed(),
+    recorder: createRecorderStore(),
+    runId: "tristate-test",
+  });
+}
+
+async function graphql(
+  instance: ReturnType<typeof createLinearTwinApp>,
+  query: string,
+  variables?: Record<string, unknown>
+) {
+  const response = await instance.request("/graphql", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${DEFAULT_LINEAR_TOKEN}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  return (await response.json()) as {
+    data?: Record<string, any>;
+    errors?: Array<{ message: string }>;
+  };
+}
+
+function callTool(commands: LinearDomain, name: string, args: Record<string, unknown>) {
+  const tool = linearTools.find((candidate) => candidate.name === name);
+  if (!tool) throw new Error(`Unknown MCP tool: ${name}`);
+  return tool.handler(commands, args, { reportDelta: () => {} } as never);
+}
+
+async function seededSession(commands: LinearDomain, plan: string) {
+  const issue = commands.listIssues()[0]!;
+  return commands.createAgentSessionOnIssue({ issueId: issue.id, plan, externalUrl: null });
+}
+
+describe("agentSessionUpdate partial-update tri-state (F-1166)", () => {
+  it("leaves plan untouched when the key is present but undefined", async () => {
+    const commands = domain();
+    const session = await seededSession(commands, "PLAN-RESIDUE");
+
+    const updated = commands.updateAgentSession(session.id, {
+      state: "active",
+      plan: undefined,
+      externalUrl: undefined,
+    });
+
+    expect(updated.plan).toBe("PLAN-RESIDUE");
+    expect(updated.state).toBe("active");
+  });
+
+  it("leaves plan untouched when the key is absent", async () => {
+    const commands = domain();
+    const session = await seededSession(commands, "PLAN-RESIDUE");
+
+    const updated = commands.updateAgentSession(session.id, { state: "active" });
+
+    expect(updated.plan).toBe("PLAN-RESIDUE");
+  });
+
+  it("clears plan when the key is present and null", async () => {
+    const commands = domain();
+    const session = await seededSession(commands, "PLAN-RESIDUE");
+
+    const updated = commands.updateAgentSession(session.id, { plan: null });
+
+    expect(updated.plan).toBeNull();
+  });
+
+  it("parses a present-but-undefined plan as 'not provided', not as null", () => {
+    expect(parseAgentSessionUpdateInput({ id: "x", state: "active", plan: undefined }).plan).toBeUndefined();
+    expect(parseAgentSessionUpdateInput({ id: "x", state: "active" }).plan).toBeUndefined();
+    expect(parseAgentSessionUpdateInput({ id: "x", plan: null }).plan).toBeNull();
+    expect(parseAgentSessionUpdateInput({ id: "x", plan: "PLAN" }).plan).toBe("PLAN");
+  });
+
+  it("preserves plan across a GraphQL agentSessionUpdate that only sets state", async () => {
+    const instance = app();
+    const issues = await graphql(instance, `query { issues(first: 1) { nodes { id } } }`);
+    const issueId = issues.data?.issues.nodes[0].id as string;
+
+    const created = await graphql(
+      instance,
+      `mutation ($input: AgentSessionCreateOnIssue!) {
+         agentSessionCreateOnIssue(input: $input) { agentSession { id plan externalUrl } }
+       }`,
+      { input: { issueId, plan: "PLAN-RESIDUE", externalUrl: "https://example.test/run/1" } }
+    );
+    const sessionId = created.data?.agentSessionCreateOnIssue.agentSession.id as string;
+
+    const updated = await graphql(
+      instance,
+      `mutation ($id: String!, $input: AgentSessionUpdateInput!) {
+         agentSessionUpdate(id: $id, input: $input) { agentSession { id state plan externalUrl } }
+       }`,
+      { id: sessionId, input: { state: "active" } }
+    );
+
+    expect(updated.errors).toBeUndefined();
+    expect(updated.data?.agentSessionUpdate.agentSession).toMatchObject({
+      state: "active",
+      plan: "PLAN-RESIDUE",
+      externalUrl: "https://example.test/run/1",
+    });
+  });
+
+  it("still clears plan through GraphQL when null is sent explicitly", async () => {
+    const instance = app();
+    const issues = await graphql(instance, `query { issues(first: 1) { nodes { id } } }`);
+    const issueId = issues.data?.issues.nodes[0].id as string;
+    const created = await graphql(
+      instance,
+      `mutation ($input: AgentSessionCreateOnIssue!) {
+         agentSessionCreateOnIssue(input: $input) { agentSession { id } }
+       }`,
+      { input: { issueId, plan: "PLAN-RESIDUE" } }
+    );
+    const sessionId = created.data?.agentSessionCreateOnIssue.agentSession.id as string;
+
+    const updated = await graphql(
+      instance,
+      `mutation ($id: String!, $input: AgentSessionUpdateInput!) {
+         agentSessionUpdate(id: $id, input: $input) { agentSession { plan } }
+       }`,
+      { id: sessionId, input: { plan: null } }
+    );
+
+    expect(updated.data?.agentSessionUpdate.agentSession.plan).toBeNull();
+  });
+});
+
+describe("sibling mutations share the tri-state contract (F-1166)", () => {
+  it("issueUpdate leaves description untouched when the key is present but undefined", async () => {
+    const commands = domain();
+    const team = commands.listTeams()[0]!;
+    const issue = await commands.createIssue({ teamId: team.id, title: "Tri", description: "KEEP-ME" });
+
+    const updated = await commands.updateIssue(issue.id, { title: "Tri 2", description: undefined });
+
+    expect(updated.description).toBe("KEEP-ME");
+    expect((await commands.updateIssue(issue.id, { description: null })).description).toBeNull();
+  });
+
+  it("updateLabel leaves description untouched when the key is present but undefined", async () => {
+    const commands = domain();
+    const label = commands.requireLabel("Bug");
+
+    const updated = await commands.updateLabel(label.id, { name: "Bug 2", description: undefined });
+
+    expect(updated.description).toBe("Defect");
+    expect((await commands.updateLabel(label.id, { description: null })).description).toBeNull();
+  });
+
+  it("issueLabelUpdate over GraphQL preserves description when the input omits it", async () => {
+    const instance = app();
+    const labels = await graphql(
+      instance,
+      `query { issueLabels(first: 50) { nodes { id name description } } }`
+    );
+    const label = (labels.data?.issueLabels.nodes as Array<any>).find((l) => l.description);
+
+    const updated = await graphql(
+      instance,
+      `mutation ($id: String!, $input: IssueLabelUpdateInput!) {
+         issueLabelUpdate(id: $id, input: $input) { issueLabel { id name description } }
+       }`,
+      { id: label.id, input: { name: `${label.name} renamed` } }
+    );
+
+    expect(updated.errors).toBeUndefined();
+    expect(updated.data?.issueLabelUpdate.issueLabel.description).toBe(label.description);
+  });
+
+  it("updateProject leaves description untouched when the key is present but undefined", () => {
+    const commands = domain();
+    const team = commands.listTeams()[0]!;
+    const project = commands.createProject({
+      teamId: team.id,
+      name: "Tri project",
+      description: "KEEP-ME",
+    });
+
+    const updated = commands.updateProject(project.id, { name: "Tri project 2", description: undefined });
+
+    expect(updated.description).toBe("KEEP-ME");
+    expect(commands.updateProject(project.id, { description: null }).description).toBeNull();
+  });
+
+  it("updateDocument leaves content untouched when the key is present but undefined", () => {
+    const commands = domain();
+    const team = commands.listTeams()[0]!;
+    const doc = commands.createDocument({ title: "Tri doc", content: "KEEP-ME", team: team.id });
+
+    const updated = commands.updateDocument(doc.id, { title: "Tri doc 2", content: undefined });
+
+    expect(updated.content).toBe("KEEP-ME");
+    expect(commands.updateDocument(doc.id, { content: null }).content).toBeNull();
+  });
+
+  it("MCP save_issue preserves description when the caller does not mention it", async () => {
+    const commands = domain();
+    const team = commands.listTeams()[0]!;
+    const issue = await commands.createIssue({ teamId: team.id, title: "MCP tri", description: "KEEP-ME" });
+
+    await callTool(commands, "save_issue", { id: issue.id, title: "MCP tri 2" });
+
+    expect(commands.requireIssue(issue.id).description).toBe("KEEP-ME");
+  });
+
+  it("MCP save_document preserves content when the caller does not mention it", async () => {
+    const commands = domain();
+    const team = commands.listTeams()[0]!;
+    const doc = commands.createDocument({ title: "MCP doc", content: "KEEP-ME", team: team.id });
+
+    await callTool(commands, "save_document", { id: doc.id, title: "MCP doc 2" });
+
+    expect(commands.requireDocument(doc.id).content).toBe("KEEP-ME");
+  });
+});

--- a/packages/twin-linear/test/partial-update-tristate.test.ts
+++ b/packages/twin-linear/test/partial-update-tristate.test.ts
@@ -256,3 +256,105 @@ describe("sibling mutations share the tri-state contract (F-1166)", () => {
     expect(commands.requireDocument(doc.id).content).toBe("KEEP-ME");
   });
 });
+
+// The lifecycle timestamps (started_at / completed_at / canceled_at) are not
+// set directly by the caller — they are derived from the state transition. So
+// `stateId: null` cannot mean "clear the timestamps" the way `description: null`
+// means "clear the description": with no target state there is no transition to
+// derive them from, and `state_id` itself is left alone by its COALESCE. The
+// guard that computes the timestamps and the flags that write them must agree
+// on `!= null`, or an unrelated sibling edit sent alongside `stateId: null`
+// wipes a Done issue's completedAt while leaving it in the Done state.
+describe("issueUpdate lifecycle timestamps ignore a null stateId (F-1166)", () => {
+  async function doneIssue(commands: LinearDomain) {
+    const team = commands.listTeams()[0]!;
+    const done = commands.getWorkflowState("Done", "ENG")!;
+    const issue = await commands.createIssue({ teamId: team.id, title: "Lifecycle" });
+    const completed = await commands.updateIssue(issue.id, { stateId: done.id });
+    expect(completed.completedAt).toBeTruthy();
+    return { completed, done };
+  }
+
+  it("keeps completedAt when a sibling field is edited alongside stateId: null", async () => {
+    const commands = domain();
+    const { completed, done } = await doneIssue(commands);
+
+    const updated = await commands.updateIssue(completed.id, {
+      stateId: null,
+      title: "Lifecycle renamed",
+    });
+
+    expect(updated.title).toBe("Lifecycle renamed");
+    expect(updated.stateId).toBe(done.id);
+    expect(updated.completedAt).toBe(completed.completedAt);
+    expect(updated.canceledAt).toBe(completed.canceledAt);
+    expect(updated.startedAt).toBe(completed.startedAt);
+  });
+
+  it("keeps startedAt when a sibling field is edited alongside stateId: null", async () => {
+    const commands = domain();
+    const team = commands.listTeams()[0]!;
+    const started = commands.getWorkflowState("In Progress", "ENG")!;
+    const issue = await commands.createIssue({ teamId: team.id, title: "Lifecycle started" });
+    const inProgress = await commands.updateIssue(issue.id, { stateId: started.id });
+    expect(inProgress.startedAt).toBeTruthy();
+
+    const updated = await commands.updateIssue(inProgress.id, {
+      stateId: null,
+      title: "Lifecycle started renamed",
+    });
+
+    expect(updated.stateId).toBe(started.id);
+    expect(updated.startedAt).toBe(inProgress.startedAt);
+  });
+
+  it("keeps completedAt through a GraphQL issueUpdate that sends stateId: null with a title", async () => {
+    const instance = app();
+    const states = await graphql(
+      instance,
+      `query { workflowStates(first: 50) { nodes { id name } } }`
+    );
+    const done = (states.data?.workflowStates.nodes as Array<any>).find((s) => s.name === "Done");
+    const issues = await graphql(instance, `query { issues(first: 1) { nodes { id } } }`);
+    const issueId = issues.data?.issues.nodes[0].id as string;
+
+    const mutation = `mutation ($id: String!, $input: IssueUpdateInput!) {
+      issueUpdate(id: $id, input: $input) {
+        issue { id title completedAt canceledAt state { id name } }
+      }
+    }`;
+
+    const completed = await graphql(instance, mutation, {
+      id: issueId,
+      input: { stateId: done.id },
+    });
+    expect(completed.errors).toBeUndefined();
+    const completedAt = completed.data?.issueUpdate.issue.completedAt as string;
+    expect(completedAt).toBeTruthy();
+
+    const renamed = await graphql(instance, mutation, {
+      id: issueId,
+      input: { stateId: null, title: "Renamed via GraphQL" },
+    });
+
+    expect(renamed.errors).toBeUndefined();
+    expect(renamed.data?.issueUpdate.issue).toMatchObject({
+      title: "Renamed via GraphQL",
+      completedAt,
+    });
+    expect(renamed.data?.issueUpdate.issue.state.name).toBe("Done");
+  });
+
+  it("still clears completedAt on a real transition out of Done", async () => {
+    const commands = domain();
+    const { completed } = await doneIssue(commands);
+    const todo = commands.getWorkflowState("Todo", "ENG")!;
+
+    const reopened = await commands.updateIssue(completed.id, { stateId: todo.id });
+
+    expect(reopened.stateId).toBe(todo.id);
+    expect(reopened.completedAt).toBeNull();
+    expect(reopened.canceledAt).toBeNull();
+    expect(reopened.startedAt).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- Closes F-1166 -->

## What

Partial updates in `twin-linear` now honour the three-way distinction GraphQL partial-update inputs require: key **absent** and key present with **`undefined`** both mean "leave this field alone"; key present with **`null`** means "clear it". Presence used to be tested with the `in` operator, which cannot tell `undefined` from a real value, so `agentSessionUpdate` silently erased `plan` and `externalUrl` on any update that did not re-send them.

## Why

F-1166. Found while building the Linear fidelity harness's Level-2 write round trip (F-1165, pome-cloud#479): the harness set a residue marker on `plan`, a later `agentSessionUpdate` returned success, and the marker was gone. Real Linear does not behave this way, so a task exercising partial updates scores differently against the twin than against upstream — and the response shape is correct, so no surface-level comparison catches it. Only a write round trip that reads back the *unmentioned* fields sees it.

## Notes for reviewer

**The bug was worse than "present-but-undefined".** Every caller builds its patch as an object literal with all keys always present (`{ state, plan, externalUrl }` in `resolvers.ts`, and the same in the MCP handlers), so `"plan" in input` was **always** true. `agentSessionUpdate` wiped `plan` even when the GraphQL input omitted the field entirely. Both the absent case and the present-but-undefined case are pinned by the new tests.

**Sibling audit — the ticket's third acceptance criterion.** This is a shape bug, not a one-field typo, and the same `in`-operator idiom appears throughout. Audited and fixed in the same shape:

| Site | Before | Now |
| --- | --- | --- |
| `agents.updateAgentSession` | wiped `plan`, `externalUrl` | fixed |
| `issues.updateIssue` | wiped `description`, `estimate`, `assigneeId`, `delegateId`, `projectId`, `cycleId`, `parentId`, `archivedAt`, `dueDate`; also CASE-cleared `started_at`/`completed_at`/`canceled_at` on any MCP update | fixed |
| `labels.updateLabel` | wiped `description` | fixed |
| `projects-cycles.updateProject` | wiped `description` | fixed |
| `documents.updateDocument` | wiped `content`, `icon`, `color`; **`save_document` with only a title failed outright** with a spurious "exactly one parent is required", because all four parent keys were "present" | fixed |
| `mutation-inputs.ts` (`parseIssueUpdateInput`, `parseIssueLabelUpdateInput`, `parseAgentSessionUpdateInput`, `parseIssueCreateInput.estimate`) | zod v4 keeps an explicitly-passed `undefined` key, so `"x" in raw` was true | fixed |

**Deliberately not changed: `src/mcp.ts`.** Its `"key" in args` checks read MCP tool arguments that came from parsed JSON, where a present-but-undefined value cannot exist — key presence is the correct test at that boundary. The bug was that those handlers then *emit* object literals with every key present; that is now read correctly by the domain layer.

**Where the existing suite was blind.** `test/mcp.test.ts` already did a `save_issue` update sending only `title` and asserted only the title came back — it never looked at `description`, so it passed while the description was being erased. The new file asserts the unmentioned field survives.

**TDD (ticket is `tdd-required`).** The red test is commit `ac0c4fb`, the fix is `3367bd3`. At red, 10 of 13 assertions failed; the 3 that passed were the `null`-clears-the-field cases, which were never broken. Full `npm test` for the workspace is green (8 packages, all suites), as are `npm run typecheck`, `npm run build`, and the repo lint gates (`lint:no-catch`, `lint:code-health`, `lint:dead-code`).

**Follow-up not done here.** `pome-cloud` has a workaround in the fidelity harness that re-sends `plan` to dodge this defect (F-1165). It is harmless now but can be simplified once a twin release carrying this fix is pinned.

## Review required

Yes — twin fidelity contract. This changes observable twin behaviour on six mutations plus three MCP tools. Any recorded tape whose expected state depended on the old wipe-on-omit behaviour would now differ; the workspace suites and the Gate-0/Gate-1 fixture freezes all pass unchanged, but this is worth a second pair of eyes before a release.
