### PR TITLE
AgentSession uses field names Linear does not have (F-1172)

### DIFF
--- a/packages/twin-linear/CHANGELOG.md
+++ b/packages/twin-linear/CHANGELOG.md
@@ -56,7 +56,11 @@
   (`fixtures/linear-introspection.json`, refreshed by
   `node scripts/regen-linear-introspection.mjs`). The old drift only surfaced
   when a capture query happened to select the field; this fails at authoring
-  time instead.
+  time instead. Scope: the guard covers the output type and the one input
+  object the twin mirrors exactly. The mutation-input surface
+  (`AgentSessionUpdateInput`, `AgentSessionCreateOnIssue` / `OnComment`,
+  `AgentActivityCreateInput`) still diverges from Linear, predates this change,
+  and is tracked separately.
 - **Fixed: partial updates no longer wipe fields the caller never mentioned
   (F-1166).** Nullable fields on update mutations are tri-state — key absent
   and key present with `undefined` both mean "leave alone", `null` means

--- a/packages/twin-linear/CHANGELOG.md
+++ b/packages/twin-linear/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 ## Unreleased
 
+- **BREAKING — `AgentSession` now uses Linear's real field names and types
+  (F-1172).** The twin declared four fields Linear does not have, so an agent
+  written against real Linear read `undefined` from the twin and an agent
+  written against the twin broke in production. There is no alias and no
+  deprecation window: a twin carrying both the old and the new name would still
+  expose a field Linear does not declare, which is the defect itself.
+
+  | was | is now |
+  | --- | --- |
+  | `state: String!` | `status: AgentSessionStatus!` |
+  | `externalUrl: String` | `externalUrls: JSON!` |
+  | `agentUser: User!` | `appUser: User!` |
+  | `id: String!` | `id: ID!` |
+  | `createdAt` / `updatedAt: String!` | `createdAt` / `updatedAt: DateTime!` |
+  | `plan: String` | `plan: JSON` |
+
+  `AgentSessionStatus` is now a real enum carrying Linear's six members —
+  `pending`, `active`, `awaitingInput`, `complete`, `error`, `stale`. The twin
+  previously accepted `completed`, `failed` and `canceled`, which Linear does
+  not have; those are rejected now. Migrate `completed` → `complete` and
+  `failed` → `error`.
+
+  `externalUrls` is a collection, matching Linear: it replaces the single
+  nullable `externalUrl` string with a JSON array of `{ url, label }` objects,
+  and it is never null (an empty array when there are none). The mutation
+  inputs follow: `agentSessionCreateOnIssue` / `agentSessionCreateOnComment`
+  take `appUserId` and `externalUrls: [AgentSessionExternalUrlInput!]`, and
+  `agentSessionUpdate` takes `status` and `externalUrls`. F-1166's tri-state
+  contract is unchanged — key absent or `undefined` leaves a field alone, and
+  `null` clears it (`externalUrls: null` clears to `[]`).
+
+  The `/state` export and the `AgentSessionEvent` webhook payload rename with
+  the wire surface (`appUserId`, `status`, `externalUrls`).
+- **Added: a guard that fails when the twin invents a field Linear does not
+  have (F-1172).** `test/linear-schema-subset.test.ts` asserts the twin's
+  `AgentSession`, `AgentSessionStatus` and `AgentSessionExternalUrlInput`
+  members are a subset of Linear's, read from a committed, credential-free
+  slice of Linear's real introspection response
+  (`fixtures/linear-introspection.json`, refreshed by
+  `node scripts/regen-linear-introspection.mjs`). The old drift only surfaced
+  when a capture query happened to select the field; this fails at authoring
+  time instead.
 - **Fixed: partial updates no longer wipe fields the caller never mentioned
   (F-1166).** Nullable fields on update mutations are tri-state — key absent
   and key present with `undefined` both mean "leave alone", `null` means

--- a/packages/twin-linear/CHANGELOG.md
+++ b/packages/twin-linear/CHANGELOG.md
@@ -21,8 +21,21 @@
   `AgentSessionStatus` is now a real enum carrying Linear's six members —
   `pending`, `active`, `awaitingInput`, `complete`, `error`, `stale`. The twin
   previously accepted `completed`, `failed` and `canceled`, which Linear does
-  not have; those are rejected now. Migrate `completed` → `complete` and
-  `failed` → `error`.
+  not have; those are rejected now. All three are rewritten on open:
+  `completed` → `complete`, `failed` → `error`, and `canceled` → `stale`
+  (Linear has no cancellation state; `stale`, "no longer progressing", is its
+  closest neighbour).
+
+  **An existing `LINEAR_TWIN_DB` file migrates in place on open.**
+  `agent_sessions` renames `agent_user_id` → `app_user_id` and `state` →
+  `status`, adds `external_urls_json`, backfills a non-empty `external_url`
+  into a one-entry collection (`[{ url, label: "" }]` — Linear's label is
+  non-null and the old shape carried none), drops `external_url`, and maps the
+  three retired status values. It is idempotent and a no-op on a database
+  created by the current schema. Cloud's per-session databases are ephemeral
+  (ADR-012) and unaffected. A status that still cannot be mapped now fails at
+  the read boundary with a message naming the value and the cause, rather than
+  surviving to die at GraphQL enum serialisation.
 
   `externalUrls` is a collection, matching Linear: it replaces the single
   nullable `externalUrl` string with a JSON array of `{ url, label }` objects,

--- a/packages/twin-linear/fixtures/README.md
+++ b/packages/twin-linear/fixtures/README.md
@@ -6,5 +6,6 @@ Immutable upstream captures / freezes for `@pome-sh/twin-linear`.
 | --- | --- |
 | `mcp-tools-list.canonical.json` | Launch 22-tool MCP listing oracle (Gate-1 Wave 4) |
 | `graphql-surface.json` | Frozen GraphQL query/mutation operation inventory |
+| `linear-introspection.json` | Slice of Linear's real introspection; upstream truth for the subset guard (F-1172). Regenerate with `node scripts/regen-linear-introspection.mjs`, never by hand. A type absent from it is unguarded. |
 
 Normal tests must not require Linear credentials. Refresh MCP schemas only with a new Gate ruling.

--- a/packages/twin-linear/fixtures/linear-introspection.json
+++ b/packages/twin-linear/fixtures/linear-introspection.json
@@ -1,0 +1,66 @@
+{
+  "_readme": "Committed slice of Linear's real GraphQL introspection. A type absent here is UNGUARDED. Regenerate with `node scripts/regen-linear-introspection.mjs`; never hand-edit.",
+  "source": "https://api.linear.app/graphql",
+  "fetched_at": "2026-08-02T14:52:09.995Z",
+  "query_sha256": "6029c665c71a485e86c4524bfa6793eb6cb2f0f6ab48e6277bc4d5a62fbe1079",
+  "guarded_types": [
+    "AgentSession",
+    "AgentSessionExternalUrlInput",
+    "AgentSessionStatus"
+  ],
+  "types": {
+    "AgentSession": {
+      "kind": "OBJECT",
+      "fields": {
+        "activities": "AgentActivityConnection!",
+        "appUser": "User!",
+        "archivedAt": "DateTime",
+        "codingHarnessModelLabel": "String",
+        "comment": "Comment",
+        "context": "JSON!",
+        "createdAt": "DateTime!",
+        "creator": "User",
+        "dismissedAt": "DateTime",
+        "dismissedBy": "User",
+        "endedAt": "DateTime",
+        "externalLink": "String",
+        "externalLinks": "[AgentSessionExternalLink!]!",
+        "externalUrls": "JSON!",
+        "id": "ID!",
+        "issue": "Issue",
+        "plan": "JSON",
+        "pullRequest": "PullRequest",
+        "pullRequests": "AgentSessionToPullRequestConnection!",
+        "slugId": "String!",
+        "sourceComment": "Comment",
+        "sourceMetadata": "JSON",
+        "startedAt": "DateTime",
+        "status": "AgentSessionStatus!",
+        "summary": "String",
+        "type": "AgentSessionType",
+        "updatedAt": "DateTime!",
+        "url": "String",
+        "workspaceDiff": "JSON",
+        "workspaceDiffFiles": "[AgentSessionWorkspaceDiffFile!]"
+      }
+    },
+    "AgentSessionExternalUrlInput": {
+      "kind": "INPUT_OBJECT",
+      "inputFields": {
+        "label": "String!",
+        "url": "String!"
+      }
+    },
+    "AgentSessionStatus": {
+      "kind": "ENUM",
+      "enumValues": [
+        "active",
+        "awaitingInput",
+        "complete",
+        "error",
+        "pending",
+        "stale"
+      ]
+    }
+  }
+}

--- a/packages/twin-linear/package.json
+++ b/packages/twin-linear/package.json
@@ -39,7 +39,7 @@
     "dev": "tsx src/server.ts",
     "start": "node dist/src/server.js",
     "prepack": "npm run build",
-    "test": "node --test test/gate0-fixtures.test.mjs test/package-deps.test.mjs && vitest run test/domain.test.ts test/domain-wave4.test.ts test/graphql.test.ts test/mcp.test.ts test/mcp-graphql-parity.test.ts test/oauth.test.ts test/webhooks.test.ts test/webhook-policy.test.ts test/agent-path.test.ts test/partial-update-tristate.test.ts test/official-client.test.ts test/limits.test.ts test/concurrency.test.ts test/canary-matrix.test.ts test/auth-scopes.test.ts test/check-state.test.ts test/checks-contract.test.ts",
+    "test": "node --test test/gate0-fixtures.test.mjs test/package-deps.test.mjs && vitest run test/domain.test.ts test/domain-wave4.test.ts test/graphql.test.ts test/mcp.test.ts test/mcp-graphql-parity.test.ts test/oauth.test.ts test/webhooks.test.ts test/webhook-policy.test.ts test/agent-path.test.ts test/partial-update-tristate.test.ts test/linear-schema-subset.test.ts test/official-client.test.ts test/limits.test.ts test/concurrency.test.ts test/canary-matrix.test.ts test/auth-scopes.test.ts test/check-state.test.ts test/checks-contract.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "fidelity:parity": "tsx scripts/fidelity-parity.ts"
   },

--- a/packages/twin-linear/package.json
+++ b/packages/twin-linear/package.json
@@ -39,7 +39,7 @@
     "dev": "tsx src/server.ts",
     "start": "node dist/src/server.js",
     "prepack": "npm run build",
-    "test": "node --test test/gate0-fixtures.test.mjs test/package-deps.test.mjs && vitest run test/domain.test.ts test/domain-wave4.test.ts test/graphql.test.ts test/mcp.test.ts test/mcp-graphql-parity.test.ts test/oauth.test.ts test/webhooks.test.ts test/webhook-policy.test.ts test/agent-path.test.ts test/partial-update-tristate.test.ts test/linear-schema-subset.test.ts test/official-client.test.ts test/limits.test.ts test/concurrency.test.ts test/canary-matrix.test.ts test/auth-scopes.test.ts test/check-state.test.ts test/checks-contract.test.ts",
+    "test": "node --test test/gate0-fixtures.test.mjs test/package-deps.test.mjs && vitest run test/domain.test.ts test/domain-wave4.test.ts test/graphql.test.ts test/mcp.test.ts test/mcp-graphql-parity.test.ts test/oauth.test.ts test/webhooks.test.ts test/webhook-policy.test.ts test/agent-path.test.ts test/partial-update-tristate.test.ts test/linear-schema-subset.test.ts test/agent-session-migration.test.ts test/official-client.test.ts test/limits.test.ts test/concurrency.test.ts test/canary-matrix.test.ts test/auth-scopes.test.ts test/check-state.test.ts test/checks-contract.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "fidelity:parity": "tsx scripts/fidelity-parity.ts"
   },

--- a/packages/twin-linear/scripts/regen-linear-introspection.mjs
+++ b/packages/twin-linear/scripts/regen-linear-introspection.mjs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Refresh `fixtures/linear-introspection.json` — the committed slice of Linear's
+ * real GraphQL introspection that `test/linear-schema-subset.test.ts` checks the
+ * twin's SDL against (F-1172).
+ *
+ * WHY A SLICE. Linear's full introspection response is ~1.5 MB and 1,100+ types.
+ * The guard only needs the types the twin claims to emulate, so this vendors
+ * exactly those. A type that is ABSENT from the fixture is UNGUARDED — the guard
+ * cannot check what upstream truth it was never given. Add a name to
+ * `GUARDED_TYPES` to bring a type under the guard.
+ *
+ * NO CREDENTIALS. Linear answers introspection unauthenticated, which is what
+ * lets this stay a normal, offline-refreshable fixture:
+ *
+ *   curl -s -X POST https://api.linear.app/graphql -H 'Content-Type: application/json' \
+ *     -d '{"query":"{__schema{queryType{name}}}"}'
+ *
+ * Usage:
+ *   node scripts/regen-linear-introspection.mjs
+ */
+import { createHash } from "node:crypto";
+import { writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql";
+
+/**
+ * The upstream types the twin models and must not drift from. Extend this list
+ * (and re-run) when the twin starts emulating another Linear type.
+ */
+const GUARDED_TYPES = ["AgentSession", "AgentSessionStatus", "AgentSessionExternalUrlInput"];
+
+const QUERY = `query PomeTwinLinearIntrospection($name: String!) {
+  __type(name: $name) {
+    kind
+    name
+    fields(includeDeprecated: true) { name type { ...TypeRef } }
+    inputFields { name type { ...TypeRef } }
+    enumValues(includeDeprecated: true) { name }
+  }
+}
+fragment TypeRef on __Type {
+  kind name
+  ofType { kind name ofType { kind name ofType { kind name ofType { kind name } } } }
+}`;
+
+/** Render an introspected type reference as SDL (`String!`, `[Issue!]!`). */
+function sdl(ref) {
+  if (!ref) return "?";
+  if (ref.kind === "NON_NULL") return `${sdl(ref.ofType)}!`;
+  if (ref.kind === "LIST") return `[${sdl(ref.ofType)}]`;
+  return ref.name ?? "?";
+}
+
+function byName(entries) {
+  return Object.fromEntries(entries.sort((a, b) => a[0].localeCompare(b[0])));
+}
+
+async function introspect(name) {
+  const response = await fetch(LINEAR_GRAPHQL_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ query: QUERY, variables: { name } }),
+  });
+  if (!response.ok) throw new Error(`Linear introspection failed for ${name}: HTTP ${response.status}`);
+  const body = await response.json();
+  if (body.errors) throw new Error(`Linear introspection errored for ${name}: ${JSON.stringify(body.errors)}`);
+  const type = body.data?.__type;
+  if (!type) throw new Error(`Linear does not declare a type named ${name}`);
+  return type;
+}
+
+const types = {};
+for (const name of GUARDED_TYPES) {
+  const type = await introspect(name);
+  const entry = { kind: type.kind };
+  if (type.fields) entry.fields = byName(type.fields.map((f) => [f.name, sdl(f.type)]));
+  if (type.inputFields) entry.inputFields = byName(type.inputFields.map((f) => [f.name, sdl(f.type)]));
+  if (type.enumValues) entry.enumValues = type.enumValues.map((v) => v.name).sort();
+  types[name] = entry;
+}
+
+const artifact = {
+  _readme:
+    "Committed slice of Linear's real GraphQL introspection. A type absent here is UNGUARDED. " +
+    "Regenerate with `node scripts/regen-linear-introspection.mjs`; never hand-edit.",
+  source: LINEAR_GRAPHQL_URL,
+  fetched_at: new Date().toISOString(),
+  query_sha256: createHash("sha256").update(QUERY).digest("hex"),
+  guarded_types: GUARDED_TYPES.slice().sort(),
+  types: byName(Object.entries(types)),
+};
+
+const out = join(dirname(fileURLToPath(import.meta.url)), "..", "fixtures", "linear-introspection.json");
+writeFileSync(out, `${JSON.stringify(artifact, null, 2)}\n`);
+console.log(`wrote ${out} (${GUARDED_TYPES.length} types)`);

--- a/packages/twin-linear/scripts/regen-linear-introspection.mjs
+++ b/packages/twin-linear/scripts/regen-linear-introspection.mjs
@@ -29,6 +29,27 @@ const LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql";
 /**
  * The upstream types the twin models and must not drift from. Extend this list
  * (and re-run) when the twin starts emulating another Linear type.
+ *
+ * SCOPE — READ THIS BEFORE ASSUMING COVERAGE. These are the OUTPUT-side types
+ * plus the one input object the twin mirrors exactly. The twin's MUTATION INPUT
+ * types are deliberately NOT guarded yet, because they still diverge from
+ * Linear and adding them here would fail immediately:
+ *
+ *   - `AgentSessionUpdateInput` upstream declares externalLink, externalUrls,
+ *     addedExternalUrls, removedExternalUrls, plan, dismissedAt, userState —
+ *     no `status` and no `id`. Upstream, session status moves via agent
+ *     activities, not through `agentSessionUpdate` at all. The twin declares
+ *     id, status, plan, externalUrls.
+ *   - `AgentSessionCreateOnIssue` / `AgentSessionCreateOnComment` are not
+ *     Linear type names at all (upstream has `AgentSessionCreateInput`: id,
+ *     issueId, appUserId, context) and the twin adds `plan`.
+ *   - `AgentActivityCreateInput` — twin: sessionId, type, body, ephemeral;
+ *     Linear: id, agentSessionId, signal, signalMetadata, contextualMetadata,
+ *     content, ephemeral.
+ *
+ * These predate F-1172 (the old `state` / `agentUserId` were equally invented)
+ * and reconciling them is its own piece of work, tracked separately. Until
+ * then: the guard proves nothing about the mutation-input surface.
  */
 const GUARDED_TYPES = ["AgentSession", "AgentSessionStatus", "AgentSessionExternalUrlInput"];
 

--- a/packages/twin-linear/src/db.ts
+++ b/packages/twin-linear/src/db.ts
@@ -244,15 +244,15 @@ CREATE TABLE IF NOT EXISTS agent_sessions (
   id TEXT PRIMARY KEY,
   issue_id TEXT,
   comment_id TEXT,
-  agent_user_id TEXT NOT NULL,
-  state TEXT NOT NULL,
+  app_user_id TEXT NOT NULL,
+  status TEXT NOT NULL,
   plan TEXT,
-  external_url TEXT,
+  external_urls_json TEXT NOT NULL DEFAULT '[]',
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL,
   FOREIGN KEY (issue_id) REFERENCES issues(id) ON DELETE CASCADE,
   FOREIGN KEY (comment_id) REFERENCES comments(id) ON DELETE CASCADE,
-  FOREIGN KEY (agent_user_id) REFERENCES users(id) ON DELETE CASCADE
+  FOREIGN KEY (app_user_id) REFERENCES users(id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS agent_activities (

--- a/packages/twin-linear/src/db.ts
+++ b/packages/twin-linear/src/db.ts
@@ -322,11 +322,70 @@ export function openLinearTwinDatabase(
   return openTwinDatabase(path, { migrate });
 }
 
+/**
+ * Pre-F-1172 agent session states that Linear does not have, and the Linear
+ * member each one becomes. Linear has no cancellation state; `stale` ("no
+ * longer progressing") is its closest neighbour.
+ */
+export const RETIRED_AGENT_SESSION_STATUSES: ReadonlyArray<readonly [string, string]> = [
+  ["completed", "complete"],
+  ["failed", "error"],
+  ["canceled", "stale"],
+];
+
 export function migrate(db: LinearTwinDatabase): void {
   db.exec(MIGRATION_SQL);
   ensureColumn(db, "issues", "estimate", "INTEGER");
   ensureColumn(db, "issues", "parent_id", "TEXT");
   ensureColumn(db, "comments", "parent_id", "TEXT");
+  migrateAgentSessions(db);
+}
+
+/**
+ * F-1172 — carry a pre-rename `agent_sessions` table forward.
+ *
+ * `CREATE TABLE IF NOT EXISTS` is a no-op on a database that already has the
+ * table, so without this an existing `LINEAR_TWIN_DB` file opens clean on the
+ * OLD columns and then dies later with `"undefined" is not valid JSON` from
+ * `mapAgentSession`, nowhere near the cause. Reopening old files is supported
+ * (see the `ensureColumn` calls above); cloud's per-session databases are
+ * ephemeral, but local and self-host files are not.
+ *
+ * Every step is guarded on the current column set, so this is idempotent and a
+ * no-op on a database created by the current schema.
+ */
+function migrateAgentSessions(db: LinearTwinDatabase): void {
+  const columnNames = (): string[] =>
+    (db.prepare("PRAGMA table_info(agent_sessions)").all() as Array<{ name: string }>).map(
+      (column) => column.name
+    );
+
+  let columns = columnNames();
+  if (columns.includes("agent_user_id") && !columns.includes("app_user_id")) {
+    db.exec("ALTER TABLE agent_sessions RENAME COLUMN agent_user_id TO app_user_id");
+  }
+  if (columns.includes("state") && !columns.includes("status")) {
+    db.exec("ALTER TABLE agent_sessions RENAME COLUMN state TO status");
+  }
+
+  columns = columnNames();
+  if (!columns.includes("external_urls_json")) {
+    db.exec("ALTER TABLE agent_sessions ADD COLUMN external_urls_json TEXT NOT NULL DEFAULT '[]'");
+  }
+  if (columns.includes("external_url")) {
+    // The single URL becomes a one-entry collection. Linear's label is
+    // non-null and the old shape carried none, so it backfills as empty.
+    db.exec(
+      `UPDATE agent_sessions
+          SET external_urls_json = json_array(json_object('url', external_url, 'label', ''))
+        WHERE external_url IS NOT NULL AND external_url <> ''`
+    );
+    db.exec("ALTER TABLE agent_sessions DROP COLUMN external_url");
+  }
+
+  for (const [retired, replacement] of RETIRED_AGENT_SESSION_STATUSES) {
+    db.prepare("UPDATE agent_sessions SET status = ? WHERE status = ?").run(replacement, retired);
+  }
 }
 
 export function resetDatabase(db: LinearTwinDatabase): void {

--- a/packages/twin-linear/src/domain/agents.ts
+++ b/packages/twin-linear/src/domain/agents.ts
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import { notFound } from "../errors.js";
-import type { LinearAgentActivity, LinearAgentSession } from "../types.js";
-import { assertBody, normalizeActivityType, normalizeSessionState } from "./normalize.js";
+import type {
+  LinearAgentActivity,
+  LinearAgentSession,
+  LinearAgentSessionExternalUrl,
+} from "../types.js";
+import { assertBody, normalizeActivityType, normalizeSessionStatus } from "./normalize.js";
 import type { ActorContext, LinearDomain } from "./linear-domain.js";
 import { mapAgentActivity, mapAgentSession, type AgentActivityRow, type AgentSessionRow } from "./rows.js";
 import { emitWebhook } from "./webhooks.js";
@@ -19,31 +23,61 @@ export function getAgentSession(domain: LinearDomain, ref: string): LinearAgentS
   return row ? mapAgentSession(row) : null;
 }
 
+export type AgentSessionOnIssueInput = {
+  issueId: string;
+  appUserId?: string;
+  plan?: string | null;
+  externalUrls?: LinearAgentSessionExternalUrl[] | null;
+};
+
+export type AgentSessionOnCommentInput = {
+  commentId: string;
+  appUserId?: string;
+  plan?: string | null;
+  externalUrls?: LinearAgentSessionExternalUrl[] | null;
+};
+
+export type AgentSessionPatch = {
+  status?: string;
+  plan?: string | null;
+  externalUrls?: LinearAgentSessionExternalUrl[] | null;
+};
+
 export async function createAgentSessionOnIssue(
   domain: LinearDomain,
-  input: { issueId: string; agentUserId?: string; plan?: string | null; externalUrl?: string | null },
+  input: AgentSessionOnIssueInput,
   actor: ActorContext = {}
 ): Promise<LinearAgentSession> {
   domain.requireScopes(actor, ["write"]);
   const issue = domain.requireIssue(input.issueId);
   const viewer = domain.resolveViewer(actor);
   const agent =
-    (input.agentUserId ? domain.requireUser(input.agentUserId) : null) ??
+    (input.appUserId ? domain.requireUser(input.appUserId) : null) ??
     domain.listUsers().find((u) => u.app) ??
     viewer;
   const now = domain.tick();
   const id = domain.nextId("agent_session");
   domain.db
     .prepare(
-      `INSERT INTO agent_sessions(id, issue_id, comment_id, agent_user_id, state, plan, external_url, created_at, updated_at)
+      `INSERT INTO agent_sessions(id, issue_id, comment_id, app_user_id, status, plan, external_urls_json, created_at, updated_at)
          VALUES (?,?,?,?,?,?,?,?,?)`
     )
-    .run(id, issue.id, null, agent.id, "pending", input.plan ?? null, input.externalUrl ?? null, now, now);
+    .run(
+      id,
+      issue.id,
+      null,
+      agent.id,
+      "pending",
+      input.plan ?? null,
+      JSON.stringify(input.externalUrls ?? []),
+      now,
+      now
+    );
   const session = domain.requireAgentSession(id);
   await emitWebhook(domain, {
     type: "AgentSessionEvent",
     action: "created",
-    data: { id: session.id, issueId: issue.id, state: session.state },
+    data: { id: session.id, issueId: issue.id, status: session.status },
     actor: viewer,
     teamId: issue.teamId,
   });
@@ -52,7 +86,7 @@ export async function createAgentSessionOnIssue(
 
 export async function createAgentSessionOnComment(
   domain: LinearDomain,
-  input: { commentId: string; agentUserId?: string; plan?: string | null; externalUrl?: string | null },
+  input: AgentSessionOnCommentInput,
   actor: ActorContext = {}
 ): Promise<LinearAgentSession> {
   // comments:create covers mention-triggered sessions from createComment; write covers GraphQL.
@@ -61,24 +95,34 @@ export async function createAgentSessionOnComment(
   const issue = domain.requireIssue(comment.issueId);
   const viewer = domain.resolveViewer(actor);
   const agent =
-    (input.agentUserId ? domain.requireUser(input.agentUserId) : null) ??
+    (input.appUserId ? domain.requireUser(input.appUserId) : null) ??
     domain.listUsers().find((u) => u.app) ??
     viewer;
   const now = domain.tick();
   const id = domain.nextId("agent_session");
   domain.db
     .prepare(
-      `INSERT INTO agent_sessions(id, issue_id, comment_id, agent_user_id, state, plan, external_url, created_at, updated_at)
+      `INSERT INTO agent_sessions(id, issue_id, comment_id, app_user_id, status, plan, external_urls_json, created_at, updated_at)
          VALUES (?,?,?,?,?,?,?,?,?)`
     )
-    .run(id, issue.id, comment.id, agent.id, "pending", input.plan ?? null, input.externalUrl ?? null, now, now);
+    .run(
+      id,
+      issue.id,
+      comment.id,
+      agent.id,
+      "pending",
+      input.plan ?? null,
+      JSON.stringify(input.externalUrls ?? []),
+      now,
+      now
+    );
   return domain.requireAgentSession(id);
 }
 
 export function updateAgentSession(
   domain: LinearDomain,
   id: string,
-  input: { state?: string; plan?: string | null; externalUrl?: string | null },
+  input: AgentSessionPatch,
   actor: ActorContext = {}
 ): LinearAgentSession {
   domain.requireScopes(actor, ["write"]);
@@ -91,18 +135,18 @@ export function updateAgentSession(
   domain.db
     .prepare(
       `UPDATE agent_sessions SET
-          state = COALESCE(?, state),
+          status = COALESCE(?, status),
           plan = CASE WHEN ? THEN ? ELSE plan END,
-          external_url = CASE WHEN ? THEN ? ELSE external_url END,
+          external_urls_json = CASE WHEN ? THEN ? ELSE external_urls_json END,
           updated_at = ?
          WHERE id = ?`
     )
     .run(
-      input.state ? normalizeSessionState(input.state) : null,
+      input.status ? normalizeSessionStatus(input.status) : null,
       input.plan !== undefined ? 1 : 0,
       input.plan ?? null,
-      input.externalUrl !== undefined ? 1 : 0,
-      input.externalUrl ?? null,
+      input.externalUrls !== undefined ? 1 : 0,
+      JSON.stringify(input.externalUrls ?? []),
       now,
       session.id
     );
@@ -133,7 +177,7 @@ export async function createAgentActivity(
     await emitWebhook(domain, {
       type: "AgentSessionEvent",
       action: "prompted",
-      data: { id: session.id, state: session.state },
+      data: { id: session.id, status: session.status },
       actor: viewer,
       teamId: session.issueId ? domain.requireIssue(session.issueId).teamId : null,
     });

--- a/packages/twin-linear/src/domain/comments.ts
+++ b/packages/twin-linear/src/domain/comments.ts
@@ -76,7 +76,7 @@ export async function createComment(
   if (mentionsAppUser(comment.body)) {
     const appUser = domain.listUsers().find((u) => u.app && comment.body.includes(u.displayName));
     if (appUser) {
-      await domain.createAgentSessionOnComment({ commentId: comment.id, agentUserId: appUser.id }, actor);
+      await domain.createAgentSessionOnComment({ commentId: comment.id, appUserId: appUser.id }, actor);
     }
   }
   return comment;

--- a/packages/twin-linear/src/domain/issues.ts
+++ b/packages/twin-linear/src/domain/issues.ts
@@ -230,7 +230,7 @@ export async function createIssue(
     url: issue.url,
   });
   if (issue.delegateId) {
-    await domain.createAgentSessionOnIssue({ issueId: issue.id, agentUserId: issue.delegateId }, actor);
+    await domain.createAgentSessionOnIssue({ issueId: issue.id, appUserId: issue.delegateId }, actor);
   }
   return issue;
 }
@@ -391,7 +391,7 @@ export async function updateIssue(
     updatedFrom: before,
   });
   if (updated.delegateId && updated.delegateId !== issue.delegateId) {
-    await domain.createAgentSessionOnIssue({ issueId: updated.id, agentUserId: updated.delegateId }, actor);
+    await domain.createAgentSessionOnIssue({ issueId: updated.id, appUserId: updated.delegateId }, actor);
   }
   return updated;
 }

--- a/packages/twin-linear/src/domain/linear-domain.ts
+++ b/packages/twin-linear/src/domain/linear-domain.ts
@@ -361,14 +361,14 @@ export class LinearDomain {
   }
 
   createAgentSessionOnIssue(
-    input: { issueId: string; agentUserId?: string; plan?: string | null; externalUrl?: string | null },
+    input: agents.AgentSessionOnIssueInput,
     actor: ActorContext = {}
   ): Promise<LinearAgentSession> {
     return agents.createAgentSessionOnIssue(this, input, actor);
   }
 
   createAgentSessionOnComment(
-    input: { commentId: string; agentUserId?: string; plan?: string | null; externalUrl?: string | null },
+    input: agents.AgentSessionOnCommentInput,
     actor: ActorContext = {}
   ): Promise<LinearAgentSession> {
     return agents.createAgentSessionOnComment(this, input, actor);
@@ -376,7 +376,7 @@ export class LinearDomain {
 
   updateAgentSession(
     id: string,
-    input: { state?: string; plan?: string | null; externalUrl?: string | null },
+    input: agents.AgentSessionPatch,
     actor: ActorContext = {}
   ): LinearAgentSession {
     return agents.updateAgentSession(this, id, input, actor);

--- a/packages/twin-linear/src/domain/normalize.ts
+++ b/packages/twin-linear/src/domain/normalize.ts
@@ -5,7 +5,7 @@ import {
   BODY_MAX_BYTES,
   TITLE_MAX_BYTES,
   type LinearAgentActivityType,
-  type LinearAgentSessionState,
+  type LinearAgentSessionStatus,
   type LinearIssuePriority,
   type LinearWorkflowStateType,
 } from "../types.js";
@@ -44,10 +44,21 @@ export function inferStateType(name: string): LinearWorkflowStateType {
   return "unstarted";
 }
 
-export function normalizeSessionState(value: string): LinearAgentSessionState {
-  const allowed: LinearAgentSessionState[] = ["pending", "active", "completed", "failed", "canceled"];
-  if (!allowed.includes(value as LinearAgentSessionState)) badUserInput(`Invalid agent session state: ${value}`);
-  return value as LinearAgentSessionState;
+/** Linear's AgentSessionStatus members, verbatim (F-1172). */
+export const AGENT_SESSION_STATUSES: LinearAgentSessionStatus[] = [
+  "pending",
+  "active",
+  "awaitingInput",
+  "complete",
+  "error",
+  "stale",
+];
+
+export function normalizeSessionStatus(value: string): LinearAgentSessionStatus {
+  if (!AGENT_SESSION_STATUSES.includes(value as LinearAgentSessionStatus)) {
+    badUserInput(`Invalid agent session status: ${value}`);
+  }
+  return value as LinearAgentSessionStatus;
 }
 
 export function normalizeActivityType(value: string): LinearAgentActivityType {

--- a/packages/twin-linear/src/domain/normalize.ts
+++ b/packages/twin-linear/src/domain/normalize.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { badUserInput } from "../errors.js";
+import { LinearTwinError, badUserInput } from "../errors.js";
 import { byteLength } from "../ids.js";
 import {
   BODY_MAX_BYTES,
@@ -53,6 +53,25 @@ export const AGENT_SESSION_STATUSES: LinearAgentSessionStatus[] = [
   "error",
   "stale",
 ];
+
+/**
+ * A status read back OUT of storage. An unknown value here is a corrupt or
+ * unmigrated database, not bad caller input — and left unchecked it dies at
+ * GraphQL enum serialisation (`Enum "AgentSessionStatus" cannot represent
+ * value: "canceled"`), which names neither the row nor the cause. Fail at the
+ * boundary where the message can (F-1172).
+ */
+export function readSessionStatus(value: string): LinearAgentSessionStatus {
+  if (!AGENT_SESSION_STATUSES.includes(value as LinearAgentSessionStatus)) {
+    throw new LinearTwinError(
+      500,
+      "INTERNAL_SERVER_ERROR",
+      `Stored agent session status "${value}" is not one of Linear's AgentSessionStatus members ` +
+        `(${AGENT_SESSION_STATUSES.join(", ")}). This database predates the F-1172 rename and was not migrated.`
+    );
+  }
+  return value as LinearAgentSessionStatus;
+}
 
 export function normalizeSessionStatus(value: string): LinearAgentSessionStatus {
   if (!AGENT_SESSION_STATUSES.includes(value as LinearAgentSessionStatus)) {

--- a/packages/twin-linear/src/domain/rows.ts
+++ b/packages/twin-linear/src/domain/rows.ts
@@ -21,7 +21,8 @@ import type {
   LinearWebhook,
   LinearWorkflowState,
   LinearWorkflowStateType,
-  LinearAgentSessionState,
+  LinearAgentSessionExternalUrl,
+  LinearAgentSessionStatus,
 } from "../types.js";
 
 export type OrgRow = {
@@ -190,10 +191,10 @@ export type AgentSessionRow = {
   id: string;
   issue_id: string | null;
   comment_id: string | null;
-  agent_user_id: string;
-  state: string;
+  app_user_id: string;
+  status: string;
   plan: string | null;
-  external_url: string | null;
+  external_urls_json: string;
   created_at: string;
   updated_at: string;
 };
@@ -384,10 +385,10 @@ export function mapAgentSession(row: AgentSessionRow): LinearAgentSession {
     id: row.id,
     issueId: row.issue_id,
     commentId: row.comment_id,
-    agentUserId: row.agent_user_id,
-    state: row.state as LinearAgentSessionState,
+    appUserId: row.app_user_id,
+    status: row.status as LinearAgentSessionStatus,
     plan: row.plan,
-    externalUrl: row.external_url,
+    externalUrls: JSON.parse(row.external_urls_json) as LinearAgentSessionExternalUrl[],
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/packages/twin-linear/src/domain/rows.ts
+++ b/packages/twin-linear/src/domain/rows.ts
@@ -22,8 +22,8 @@ import type {
   LinearWorkflowState,
   LinearWorkflowStateType,
   LinearAgentSessionExternalUrl,
-  LinearAgentSessionStatus,
 } from "../types.js";
+import { readSessionStatus } from "./normalize.js";
 
 export type OrgRow = {
   id: string;
@@ -386,7 +386,7 @@ export function mapAgentSession(row: AgentSessionRow): LinearAgentSession {
     issueId: row.issue_id,
     commentId: row.comment_id,
     appUserId: row.app_user_id,
-    status: row.status as LinearAgentSessionStatus,
+    status: readSessionStatus(row.status),
     plan: row.plan,
     externalUrls: JSON.parse(row.external_urls_json) as LinearAgentSessionExternalUrl[],
     createdAt: row.created_at,

--- a/packages/twin-linear/src/graphql/formatters.ts
+++ b/packages/twin-linear/src/graphql/formatters.ts
@@ -299,14 +299,14 @@ export function createFormatters(commands: LinearDomain, actor: ActorContext): G
 
   const formatAgentSession = (session: LinearAgentSession) => ({
     id: session.id,
-    state: session.state,
+    status: session.status,
     plan: session.plan,
-    externalUrl: session.externalUrl,
+    externalUrls: session.externalUrls,
     createdAt: session.createdAt,
     updatedAt: session.updatedAt,
     issue: () => (session.issueId ? formatIssue(commands.requireIssue(session.issueId)) : null),
     comment: () => (session.commentId ? formatComment(commands.requireComment(session.commentId)) : null),
-    agentUser: () => formatUser(commands.requireUser(session.agentUserId)),
+    appUser: () => formatUser(commands.requireUser(session.appUserId)),
     activities: (args: ConnectionArgs) =>
       connect(
         commands.listAgentActivities(session.id),

--- a/packages/twin-linear/src/graphql/mutation-inputs.ts
+++ b/packages/twin-linear/src/graphql/mutation-inputs.ts
@@ -92,30 +92,36 @@ export const webhookCreateInputSchema = z
   })
   .strict();
 
+/** Mirrors Linear's `AgentSessionExternalUrlInput` field-for-field (F-1172). */
+const agentSessionExternalUrlSchema = z
+  .object({ url: z.string().min(1), label: z.string() })
+  .strict();
+const optionalExternalUrls = z.array(agentSessionExternalUrlSchema).nullish();
+
 export const agentSessionOnIssueInputSchema = z
   .object({
     issueId: z.string().min(1),
-    agentUserId: z.string().optional(),
+    appUserId: z.string().optional(),
     plan: optionalString,
-    externalUrl: optionalString,
+    externalUrls: optionalExternalUrls,
   })
   .strict();
 
 export const agentSessionOnCommentInputSchema = z
   .object({
     commentId: z.string().min(1),
-    agentUserId: z.string().optional(),
+    appUserId: z.string().optional(),
     plan: optionalString,
-    externalUrl: optionalString,
+    externalUrls: optionalExternalUrls,
   })
   .strict();
 
 export const agentSessionUpdateInputSchema = z
   .object({
     id: z.string().min(1).optional(),
-    state: z.string().optional(),
+    status: z.string().optional(),
     plan: optionalString,
-    externalUrl: optionalString,
+    externalUrls: optionalExternalUrls,
   })
   .strict();
 
@@ -229,9 +235,9 @@ export function parseAgentSessionOnIssueInput(input: unknown) {
   const raw = parseOrBadUserInput(agentSessionOnIssueInputSchema, input, "agentSessionCreateOnIssue input");
   return {
     issueId: raw.issueId,
-    agentUserId: raw.agentUserId,
+    appUserId: raw.appUserId,
     plan: raw.plan ?? null,
-    externalUrl: raw.externalUrl ?? null,
+    externalUrls: raw.externalUrls ?? null,
   };
 }
 
@@ -243,9 +249,9 @@ export function parseAgentSessionOnCommentInput(input: unknown) {
   );
   return {
     commentId: raw.commentId,
-    agentUserId: raw.agentUserId,
+    appUserId: raw.appUserId,
     plan: raw.plan ?? null,
-    externalUrl: raw.externalUrl ?? null,
+    externalUrls: raw.externalUrls ?? null,
   };
 }
 
@@ -253,9 +259,9 @@ export function parseAgentSessionUpdateInput(input: unknown) {
   const raw = parseOrBadUserInput(agentSessionUpdateInputSchema, input, "agentSessionUpdate input");
   return {
     id: raw.id,
-    state: raw.state,
+    status: raw.status,
     plan: raw.plan,
-    externalUrl: raw.externalUrl,
+    externalUrls: raw.externalUrls,
   };
 }
 

--- a/packages/twin-linear/src/graphql/resolvers.ts
+++ b/packages/twin-linear/src/graphql/resolvers.ts
@@ -204,9 +204,9 @@ export function createRootValue(ctx: GraphQLRuntimeContext): Record<string, unkn
       const session = commands.updateAgentSession(
         String(id ?? parsed.id),
         {
-          state: parsed.state,
+          status: parsed.status,
           plan: parsed.plan,
-          externalUrl: parsed.externalUrl,
+          externalUrls: parsed.externalUrls,
         },
         actor
       );

--- a/packages/twin-linear/src/graphql/schema.ts
+++ b/packages/twin-linear/src/graphql/schema.ts
@@ -7,6 +7,8 @@ import { buildSchema, type GraphQLSchema } from "graphql";
 export const linearGraphQLSchema: GraphQLSchema = buildSchema(`
   scalar TeamFilter
   scalar PaginationOrderBy
+  scalar DateTime
+  scalar JSON
 
   type Query {
     viewer: User!
@@ -299,16 +301,26 @@ export const linearGraphQLSchema: GraphQLSchema = buildSchema(`
     team: Team
   }
 
+  """Linear's AgentSessionStatus, member-for-member (F-1172)."""
+  enum AgentSessionStatus {
+    pending
+    active
+    awaitingInput
+    complete
+    error
+    stale
+  }
+
   type AgentSession {
-    id: String!
-    state: String!
-    plan: String
-    externalUrl: String
-    createdAt: String!
-    updatedAt: String!
+    id: ID!
+    status: AgentSessionStatus!
+    plan: JSON
+    externalUrls: JSON!
+    createdAt: DateTime!
+    updatedAt: DateTime!
     issue: Issue
     comment: Comment
-    agentUser: User!
+    appUser: User!
     activities(first: Int, after: String, last: Int, before: String): AgentActivityConnection!
   }
 
@@ -474,25 +486,31 @@ export const linearGraphQLSchema: GraphQLSchema = buildSchema(`
     enabled: Boolean
   }
 
+  """Linear's AgentSessionExternalUrlInput, field-for-field (F-1172)."""
+  input AgentSessionExternalUrlInput {
+    url: String!
+    label: String!
+  }
+
   input AgentSessionCreateOnIssue {
     issueId: String!
-    agentUserId: String
+    appUserId: String
     plan: String
-    externalUrl: String
+    externalUrls: [AgentSessionExternalUrlInput!]
   }
 
   input AgentSessionCreateOnComment {
     commentId: String!
-    agentUserId: String
+    appUserId: String
     plan: String
-    externalUrl: String
+    externalUrls: [AgentSessionExternalUrlInput!]
   }
 
   input AgentSessionUpdateInput {
     id: String
-    state: String
+    status: AgentSessionStatus
     plan: String
-    externalUrl: String
+    externalUrls: [AgentSessionExternalUrlInput!]
   }
 
   input AgentActivityCreateInput {

--- a/packages/twin-linear/src/state.ts
+++ b/packages/twin-linear/src/state.ts
@@ -238,13 +238,15 @@ export function exportLinearState(db: LinearTwinDatabase): LinearStateExport {
       resourceTypes: parseJson(wh.resourceTypes),
     })),
     webhookDeliveries,
-    agentSessions: db
-      .prepare(
-        `SELECT id, issue_id AS issueId, comment_id AS commentId, agent_user_id AS agentUserId,
-                state, plan, external_url AS externalUrl, created_at AS createdAt
-         FROM agent_sessions ORDER BY created_at`
-      )
-      .all(),
+    agentSessions: (
+      db
+        .prepare(
+          `SELECT id, issue_id AS issueId, comment_id AS commentId, app_user_id AS appUserId,
+                  status, plan, external_urls_json AS externalUrls, created_at AS createdAt
+           FROM agent_sessions ORDER BY created_at`
+        )
+        .all() as Array<Record<string, unknown>>
+    ).map((session) => ({ ...session, externalUrls: parseJson(session.externalUrls) })),
     agentActivities,
     exportBounds: { truncatedCollections },
   };

--- a/packages/twin-linear/src/types.ts
+++ b/packages/twin-linear/src/types.ts
@@ -20,7 +20,16 @@ export type LinearAgentActivityType =
   | "response"
   | "error"
   | "prompt";
-export type LinearAgentSessionState = "pending" | "active" | "completed" | "failed" | "canceled";
+/** Linear's `AgentSessionStatus` enum, member-for-member (F-1172). */
+export type LinearAgentSessionStatus =
+  | "pending"
+  | "active"
+  | "awaitingInput"
+  | "complete"
+  | "error"
+  | "stale";
+/** One entry of Linear's `AgentSession.externalUrls` JSON payload. */
+export type LinearAgentSessionExternalUrl = { url: string; label: string };
 export type LinearProjectState = "planned" | "started" | "completed" | "canceled";
 
 export type LinearOrganization = {
@@ -225,10 +234,10 @@ export type LinearAgentSession = {
   id: string;
   issueId: string | null;
   commentId: string | null;
-  agentUserId: string;
-  state: LinearAgentSessionState;
+  appUserId: string;
+  status: LinearAgentSessionStatus;
   plan: string | null;
-  externalUrl: string | null;
+  externalUrls: LinearAgentSessionExternalUrl[];
   createdAt: string;
   updatedAt: string;
 };

--- a/packages/twin-linear/test/agent-session-migration.test.ts
+++ b/packages/twin-linear/test/agent-session-migration.test.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-1172: `CREATE TABLE IF NOT EXISTS` is a no-op on a database that already
+// has the table, so a `LINEAR_TWIN_DB` file written before the AgentSession
+// rename used to open CLEAN on the old columns and then die later, far from the
+// cause, with `"undefined" is not valid JSON` out of `mapAgentSession`.
+// Reopening old files is a supported path (see db.ts's `ensureColumn` calls);
+// cloud's per-session databases are ephemeral, local and self-host files are
+// not.
+//
+// This builds a genuinely pre-rename `agent_sessions` table — asserting its
+// column set equals the frozen pre-rename list before going anywhere near the
+// migration — and then reopens it with the shipping code.
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { LinearDomain, openLinearTwinDatabase } from "../src/index.js";
+import { RETIRED_AGENT_SESSION_STATUSES } from "../src/db.js";
+import { testSeed } from "./_helpers.js";
+
+/** `agent_sessions` exactly as twin-linear 0.2.0 declared it. */
+const PRE_RENAME_COLUMNS = [
+  "id",
+  "issue_id",
+  "comment_id",
+  "agent_user_id",
+  "state",
+  "plan",
+  "external_url",
+  "created_at",
+  "updated_at",
+];
+
+const temporaries: string[] = [];
+
+afterEach(() => {
+  for (const dir of temporaries.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function columnsOf(db: { prepare: (sql: string) => { all: () => unknown[] } }): string[] {
+  return (db.prepare("PRAGMA table_info(agent_sessions)").all() as Array<{ name: string }>).map(
+    (column) => column.name
+  );
+}
+
+/**
+ * Write a database whose `agent_sessions` table is in the pre-rename shape,
+ * carrying one row per retired status plus a legacy `external_url`.
+ */
+function seedPreRenameDatabase(): string {
+  const dir = mkdtempSync(join(tmpdir(), "twin-linear-migration-"));
+  temporaries.push(dir);
+  const path = join(dir, "linear.db");
+
+  const db = openLinearTwinDatabase(path);
+  const commands = new LinearDomain(db);
+  commands.seed(testSeed());
+  const issue = commands.listIssues()[0]!;
+  const appUser = commands.listUsers().find((user) => user.app) ?? commands.listUsers()[0]!;
+
+  // Put the table back into the 0.2.0 shape, so what follows is the real old
+  // schema and not an approximation of it.
+  db.exec("ALTER TABLE agent_sessions RENAME COLUMN app_user_id TO agent_user_id");
+  db.exec("ALTER TABLE agent_sessions RENAME COLUMN status TO state");
+  db.exec("ALTER TABLE agent_sessions ADD COLUMN external_url TEXT");
+  db.exec("ALTER TABLE agent_sessions DROP COLUMN external_urls_json");
+  // Compared as a set: `ADD COLUMN` appends, so the rebuilt table's physical
+  // ordinals differ from 0.2.0's while every column name matches. Nothing here
+  // or in db.ts reads a column by position.
+  expect(columnsOf(db).sort()).toEqual([...PRE_RENAME_COLUMNS].sort());
+
+  const insert = db.prepare(
+    `INSERT INTO agent_sessions(id, issue_id, comment_id, agent_user_id, state, plan, external_url, created_at, updated_at)
+       VALUES (?,?,?,?,?,?,?,?,?)`
+  );
+  for (const [index, [retired]] of RETIRED_AGENT_SESSION_STATUSES.entries()) {
+    insert.run(
+      `legacy_${retired}`,
+      issue.id,
+      null,
+      appUser.id,
+      retired,
+      "OLD-PLAN",
+      index === 0 ? "https://old.example/run" : null,
+      "2026-07-21T00:00:00.000Z",
+      "2026-07-21T00:00:00.000Z"
+    );
+  }
+  db.close();
+  return path;
+}
+
+describe("a pre-rename agent_sessions table migrates on open (F-1172)", () => {
+  it("renames the columns instead of opening clean and crashing later", () => {
+    const path = seedPreRenameDatabase();
+
+    const db = openLinearTwinDatabase(path);
+
+    expect(columnsOf(db)).toEqual(
+      expect.arrayContaining(["app_user_id", "status", "external_urls_json"])
+    );
+    expect(columnsOf(db)).not.toContain("agent_user_id");
+    expect(columnsOf(db)).not.toContain("state");
+    expect(columnsOf(db)).not.toContain("external_url");
+    db.close();
+  });
+
+  it("maps every retired status onto a Linear member, canceled included", () => {
+    const path = seedPreRenameDatabase();
+
+    const db = openLinearTwinDatabase(path);
+    const sessions = new LinearDomain(db).listAgentSessions();
+
+    const byId = new Map(sessions.map((session) => [session.id, session.status]));
+    expect(byId.get("legacy_completed")).toBe("complete");
+    expect(byId.get("legacy_failed")).toBe("error");
+    // Linear has no cancellation state; `stale` is the closest neighbour.
+    expect(byId.get("legacy_canceled")).toBe("stale");
+    db.close();
+  });
+
+  it("carries the old single external_url into the externalUrls collection", () => {
+    const path = seedPreRenameDatabase();
+
+    const db = openLinearTwinDatabase(path);
+    const sessions = new LinearDomain(db).listAgentSessions();
+
+    expect(sessions.find((session) => session.id === "legacy_completed")?.externalUrls).toEqual([
+      { url: "https://old.example/run", label: "" },
+    ]);
+    expect(sessions.find((session) => session.id === "legacy_failed")?.externalUrls).toEqual([]);
+    db.close();
+  });
+
+  it("is idempotent — reopening a migrated database changes nothing", () => {
+    const path = seedPreRenameDatabase();
+
+    const first = openLinearTwinDatabase(path);
+    const before = new LinearDomain(first).listAgentSessions();
+    const columns = columnsOf(first);
+    first.close();
+
+    const second = openLinearTwinDatabase(path);
+    expect(columnsOf(second)).toEqual(columns);
+    expect(new LinearDomain(second).listAgentSessions()).toEqual(before);
+    second.close();
+  });
+
+  it("fails legibly if an unmigratable status somehow reaches the read boundary", () => {
+    const path = seedPreRenameDatabase();
+    const db = openLinearTwinDatabase(path);
+    db.prepare("UPDATE agent_sessions SET status = ? WHERE id = ?").run("wat", "legacy_failed");
+
+    expect(() => new LinearDomain(db).listAgentSessions()).toThrowError(
+      /Stored agent session status "wat" is not one of Linear's AgentSessionStatus members/
+    );
+    db.close();
+  });
+});

--- a/packages/twin-linear/test/linear-schema-subset.test.ts
+++ b/packages/twin-linear/test/linear-schema-subset.test.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * F-1172 guard: every field the twin declares on a Linear type must be a field
+ * Linear actually declares.
+ *
+ * This is a SUBSET check, not an equality check. The twin models a slice of
+ * Linear on purpose — missing fields are ordinary coverage scope. Inventing a
+ * field name (or an enum member) Linear does not have is a fidelity defect: an
+ * agent written against real Linear reads `undefined` from the twin, and an
+ * agent written against the twin breaks in production.
+ *
+ * Upstream truth is `fixtures/linear-introspection.json`, a committed slice of
+ * Linear's real introspection response. Refresh it with
+ * `node scripts/regen-linear-introspection.mjs`.
+ *
+ * A type ABSENT from the fixture is UNGUARDED, so this file also asserts that
+ * the types we expect to be guarded are actually present — otherwise an empty
+ * or truncated fixture would make the whole check pass vacuously.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  GraphQLEnumType,
+  GraphQLInputObjectType,
+  GraphQLObjectType,
+  type GraphQLNamedType,
+} from "graphql";
+import { describe, expect, it } from "vitest";
+import { linearGraphQLSchema } from "../src/graphql/schema.js";
+
+type UpstreamType = {
+  kind: string;
+  fields?: Record<string, string>;
+  inputFields?: Record<string, string>;
+  enumValues?: string[];
+};
+
+type UpstreamSlice = {
+  source: string;
+  fetched_at: string;
+  guarded_types: string[];
+  types: Record<string, UpstreamType>;
+};
+
+const upstream = JSON.parse(
+  readFileSync(join(import.meta.dirname, "..", "fixtures", "linear-introspection.json"), "utf8")
+) as UpstreamSlice;
+
+/**
+ * Types the guard must actually be checking. Kept here, not read off the
+ * fixture, so that deleting a type from the fixture fails loudly instead of
+ * silently removing coverage.
+ */
+const MUST_BE_GUARDED = ["AgentSession", "AgentSessionStatus", "AgentSessionExternalUrlInput"];
+
+/** Member names the twin declares for a named type, or null if it declares no such type. */
+function twinMembers(name: string): { kind: string; members: string[] } | null {
+  const type: GraphQLNamedType | undefined = linearGraphQLSchema.getType(name) ?? undefined;
+  if (!type) return null;
+  if (type instanceof GraphQLObjectType) return { kind: "OBJECT", members: Object.keys(type.getFields()) };
+  if (type instanceof GraphQLInputObjectType) {
+    return { kind: "INPUT_OBJECT", members: Object.keys(type.getFields()) };
+  }
+  if (type instanceof GraphQLEnumType) {
+    return { kind: "ENUM", members: type.getValues().map((value) => value.name) };
+  }
+  return { kind: "OTHER", members: [] };
+}
+
+/** Member names Linear declares for a fixture entry. */
+function upstreamMembers(entry: UpstreamType): string[] {
+  return Object.keys(entry.fields ?? entry.inputFields ?? {}).concat(entry.enumValues ?? []);
+}
+
+describe("twin GraphQL types stay a subset of Linear's real schema (F-1172)", () => {
+  it("guards the types it claims to guard", () => {
+    expect(upstream.source).toBe("https://api.linear.app/graphql");
+    for (const name of MUST_BE_GUARDED) {
+      const entry = upstream.types[name];
+      expect(entry, `${name} missing from linear-introspection.json — the guard would pass vacuously`)
+        .toBeDefined();
+      expect(
+        upstreamMembers(entry as UpstreamType).length,
+        `${name} has no members in linear-introspection.json`
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  for (const name of MUST_BE_GUARDED) {
+    it(`${name} declares no field Linear does not have`, () => {
+      const entry = upstream.types[name];
+      expect(entry).toBeDefined();
+      const twin = twinMembers(name);
+      // The twin is allowed not to model a type at all; it is not allowed to
+      // model one under names Linear does not use.
+      if (!twin) return;
+      expect(twin.kind).toBe((entry as UpstreamType).kind);
+      const declared = new Set(upstreamMembers(entry as UpstreamType));
+      const invented = twin.members.filter((member) => !declared.has(member)).sort();
+      expect(invented, `${name} declares members Linear does not: ${invented.join(", ")}`).toEqual([]);
+    });
+  }
+
+  it("AgentSession carries the fields the twin promises to model", () => {
+    const twin = twinMembers("AgentSession");
+    expect(twin?.members.slice().sort()).toEqual(
+      ["activities", "appUser", "comment", "createdAt", "externalUrls", "id", "issue", "plan", "status", "updatedAt"]
+    );
+  });
+});

--- a/packages/twin-linear/test/linear-schema-subset.test.ts
+++ b/packages/twin-linear/test/linear-schema-subset.test.ts
@@ -26,6 +26,7 @@ import {
   type GraphQLNamedType,
 } from "graphql";
 import { describe, expect, it } from "vitest";
+import { AGENT_SESSION_STATUSES } from "../src/domain/normalize.js";
 import { linearGraphQLSchema } from "../src/graphql/schema.js";
 
 type UpstreamType = {
@@ -100,6 +101,13 @@ describe("twin GraphQL types stay a subset of Linear's real schema (F-1172)", ()
       expect(invented, `${name} declares members Linear does not: ${invented.join(", ")}`).toEqual([]);
     });
   }
+
+  it("the status values the domain accepts are the ones the SDL declares", () => {
+    // Two declarations of the same enum (SDL + the TS union the writers validate
+    // against) can drift apart; a value the domain accepts but the SDL rejects
+    // would blow up at serialisation time, not at authoring time.
+    expect(AGENT_SESSION_STATUSES.slice().sort()).toEqual(twinMembers("AgentSessionStatus")?.members.sort());
+  });
 
   it("AgentSession carries the fields the twin promises to model", () => {
     const twin = twinMembers("AgentSession");

--- a/packages/twin-linear/test/linear-schema-subset.test.ts
+++ b/packages/twin-linear/test/linear-schema-subset.test.ts
@@ -51,6 +51,15 @@ const upstream = JSON.parse(
  * Types the guard must actually be checking. Kept here, not read off the
  * fixture, so that deleting a type from the fixture fails loudly instead of
  * silently removing coverage.
+ *
+ * SCOPE — this list is the OUTPUT-side surface plus the one input object the
+ * twin mirrors exactly. The twin's mutation INPUT types (`AgentSessionUpdateInput`,
+ * `AgentSessionCreateOnIssue` / `OnComment`, `AgentActivityCreateInput`) still
+ * declare fields Linear does not — `AgentSessionUpdateInput` upstream has no
+ * `status` and no `id` at all, for instance. That divergence predates F-1172
+ * and is tracked separately; see the SCOPE note on `GUARDED_TYPES` in
+ * `scripts/regen-linear-introspection.mjs`. Do not read this file as evidence
+ * about the input surface.
  */
 const MUST_BE_GUARDED = ["AgentSession", "AgentSessionStatus", "AgentSessionExternalUrlInput"];
 

--- a/packages/twin-linear/test/partial-update-tristate.test.ts
+++ b/packages/twin-linear/test/partial-update-tristate.test.ts
@@ -70,7 +70,11 @@ function callTool(commands: LinearDomain, name: string, args: Record<string, unk
 
 async function seededSession(commands: LinearDomain, plan: string) {
   const issue = commands.listIssues()[0]!;
-  return commands.createAgentSessionOnIssue({ issueId: issue.id, plan, externalUrl: null });
+  return commands.createAgentSessionOnIssue({
+    issueId: issue.id,
+    plan,
+    externalUrls: [{ url: "https://example.test/run/1", label: "run" }],
+  });
 }
 
 describe("agentSessionUpdate partial-update tri-state (F-1166)", () => {
@@ -79,22 +83,24 @@ describe("agentSessionUpdate partial-update tri-state (F-1166)", () => {
     const session = await seededSession(commands, "PLAN-RESIDUE");
 
     const updated = commands.updateAgentSession(session.id, {
-      state: "active",
+      status: "active",
       plan: undefined,
-      externalUrl: undefined,
+      externalUrls: undefined,
     });
 
     expect(updated.plan).toBe("PLAN-RESIDUE");
-    expect(updated.state).toBe("active");
+    expect(updated.externalUrls).toEqual([{ url: "https://example.test/run/1", label: "run" }]);
+    expect(updated.status).toBe("active");
   });
 
   it("leaves plan untouched when the key is absent", async () => {
     const commands = domain();
     const session = await seededSession(commands, "PLAN-RESIDUE");
 
-    const updated = commands.updateAgentSession(session.id, { state: "active" });
+    const updated = commands.updateAgentSession(session.id, { status: "active" });
 
     expect(updated.plan).toBe("PLAN-RESIDUE");
+    expect(updated.externalUrls).toEqual([{ url: "https://example.test/run/1", label: "run" }]);
   });
 
   it("clears plan when the key is present and null", async () => {
@@ -106,14 +112,28 @@ describe("agentSessionUpdate partial-update tri-state (F-1166)", () => {
     expect(updated.plan).toBeNull();
   });
 
-  it("parses a present-but-undefined plan as 'not provided', not as null", () => {
-    expect(parseAgentSessionUpdateInput({ id: "x", state: "active", plan: undefined }).plan).toBeUndefined();
-    expect(parseAgentSessionUpdateInput({ id: "x", state: "active" }).plan).toBeUndefined();
-    expect(parseAgentSessionUpdateInput({ id: "x", plan: null }).plan).toBeNull();
-    expect(parseAgentSessionUpdateInput({ id: "x", plan: "PLAN" }).plan).toBe("PLAN");
+  it("clears externalUrls when the key is present and null", async () => {
+    const commands = domain();
+    const session = await seededSession(commands, "PLAN-RESIDUE");
+
+    const updated = commands.updateAgentSession(session.id, { externalUrls: null });
+
+    expect(updated.externalUrls).toEqual([]);
+    expect(updated.plan).toBe("PLAN-RESIDUE");
   });
 
-  it("preserves plan across a GraphQL agentSessionUpdate that only sets state", async () => {
+  it("parses a present-but-undefined plan as 'not provided', not as null", () => {
+    expect(parseAgentSessionUpdateInput({ id: "x", status: "active", plan: undefined }).plan).toBeUndefined();
+    expect(parseAgentSessionUpdateInput({ id: "x", status: "active" }).plan).toBeUndefined();
+    expect(parseAgentSessionUpdateInput({ id: "x", plan: null }).plan).toBeNull();
+    expect(parseAgentSessionUpdateInput({ id: "x", plan: "PLAN" }).plan).toBe("PLAN");
+    expect(
+      parseAgentSessionUpdateInput({ id: "x", status: "active", externalUrls: undefined }).externalUrls
+    ).toBeUndefined();
+    expect(parseAgentSessionUpdateInput({ id: "x", externalUrls: null }).externalUrls).toBeNull();
+  });
+
+  it("preserves plan across a GraphQL agentSessionUpdate that only sets status", async () => {
     const instance = app();
     const issues = await graphql(instance, `query { issues(first: 1) { nodes { id } } }`);
     const issueId = issues.data?.issues.nodes[0].id as string;
@@ -121,25 +141,31 @@ describe("agentSessionUpdate partial-update tri-state (F-1166)", () => {
     const created = await graphql(
       instance,
       `mutation ($input: AgentSessionCreateOnIssue!) {
-         agentSessionCreateOnIssue(input: $input) { agentSession { id plan externalUrl } }
+         agentSessionCreateOnIssue(input: $input) { agentSession { id plan externalUrls } }
        }`,
-      { input: { issueId, plan: "PLAN-RESIDUE", externalUrl: "https://example.test/run/1" } }
+      {
+        input: {
+          issueId,
+          plan: "PLAN-RESIDUE",
+          externalUrls: [{ url: "https://example.test/run/1", label: "run" }],
+        },
+      }
     );
     const sessionId = created.data?.agentSessionCreateOnIssue.agentSession.id as string;
 
     const updated = await graphql(
       instance,
       `mutation ($id: String!, $input: AgentSessionUpdateInput!) {
-         agentSessionUpdate(id: $id, input: $input) { agentSession { id state plan externalUrl } }
+         agentSessionUpdate(id: $id, input: $input) { agentSession { id status plan externalUrls } }
        }`,
-      { id: sessionId, input: { state: "active" } }
+      { id: sessionId, input: { status: "active" } }
     );
 
     expect(updated.errors).toBeUndefined();
     expect(updated.data?.agentSessionUpdate.agentSession).toMatchObject({
-      state: "active",
+      status: "active",
       plan: "PLAN-RESIDUE",
-      externalUrl: "https://example.test/run/1",
+      externalUrls: [{ url: "https://example.test/run/1", label: "run" }],
     });
   });
 


### PR DESCRIPTION
<!-- Closes F-1172 -->

## What

`twin-linear`'s `AgentSession` **output type** now uses Linear's real field names and types; a pre-rename database migrates in place on open; and a new guard test fails whenever the twin declares an `AgentSession` field Linear does not have.

| was | is now |
| --- | --- |
| `state: String!` | `status: AgentSessionStatus!` |
| `externalUrl: String` | `externalUrls: JSON!` |
| `agentUser: User!` | `appUser: User!` |
| `id: String!` | `id: ID!` |
| `createdAt` / `updatedAt: String!` | `createdAt` / `updatedAt: DateTime!` |
| `plan: String` | `plan: JSON` |

`AgentSessionStatus` is a real enum carrying Linear's six members — `pending`, `active`, `awaitingInput`, `complete`, `error`, `stale`. The twin's invented `completed` / `failed` / `canceled` are rejected now and rewritten on open: `completed` → `complete`, `failed` → `error`, `canceled` → `stale` (Linear has no cancellation state; `stale`, "no longer progressing", is its closest neighbour). `externalUrls` is a collection of `{ url, label }` objects, matching Linear, and is never null. Mutation inputs (`appUserId`, `status`, `externalUrls: [AgentSessionExternalUrlInput!]`), the `/state` export and the `AgentSessionEvent` webhook payload follow the rename.

## Why

F-1172. An agent written against the real Linear API read `undefined` from the twin, and an agent written against the twin broke in production — the exact failure the twins exist to prevent. pome-cloud's declared lane found two of these (`state`, `externalUrl`) only because the capture query happened to select them; reading the SDL showed six.

Per the founder ruling on the ticket: fix the twin, do not register a divergence, and ship the rename straight as a breaking change. No alias and no deprecation window — a twin carrying both `state` and `status` would still expose a field Linear does not declare, so the shim would leave the gate red on the alias.

## Notes for reviewer

### Scope of the "no invented fields" claim — read this first

The claim in this PR is scoped to the **output type**. `GUARDED_TYPES` covers `AgentSession`, `AgentSessionStatus` and `AgentSessionExternalUrlInput` — the output surface plus the one input object the twin mirrors exactly.

**The mutation-input surface still diverges from Linear and this PR does not fix it.** Verified against `api.linear.app`:

- `AgentSessionUpdateInput` upstream declares exactly `externalLink, externalUrls, addedExternalUrls, removedExternalUrls, plan, dismissedAt, userState` — **no `status`, no `id`**. Upstream, session status moves via agent activities, not through `agentSessionUpdate` at all. The twin declares `id, status, plan, externalUrls`, so renaming `state` → `status` on that input replaced one invented field with another.
- `AgentSessionCreateOnIssue` / `AgentSessionCreateOnComment` are not Linear type names at all (upstream has `AgentSessionCreateInput { id, issueId, appUserId, context }`), and the twin adds `plan`.
- `AgentActivityCreateInput` — twin: `sessionId, type, body, ephemeral`; Linear: `id, agentSessionId, signal, signalMetadata, contextualMetadata, content, ephemeral`.

All of these predate F-1172 (the old `state` / `agentUserId` were equally invented) and are tracked separately. `status` stays on the input rather than reverting to `state`: both are invented, but `status` is at least consistent with the output type. The scope note is recorded at `GUARDED_TYPES` in `scripts/regen-linear-introspection.mjs`, on `MUST_BE_GUARDED` in the guard test, and in the CHANGELOG, so nobody reads the guard as evidence about the input surface.

### The guard

`test/linear-schema-subset.test.ts` asserts the twin's guarded members are a *subset* of Linear's, read from `fixtures/linear-introspection.json` — a committed, credential-free slice of Linear's real introspection response (Linear answers introspection unauthenticated). Refresh with `node scripts/regen-linear-introspection.mjs`. Subset, not equality: not modelling a field is ordinary coverage scope, inventing one is a defect. A type absent from the fixture is unguarded, so the test also asserts the types it claims to guard are present and non-empty — an empty fixture cannot make it pass vacuously.

**Proven it can fail.** Committed red first (`agentUser, externalUrl, state`), green after the rename, and separately verified green → red → green by adding and removing an invented `totallyRealLinearField`.

### The storage migration

An existing `LINEAR_TWIN_DB` file used to open **clean** on the old columns — `CREATE TABLE IF NOT EXISTS` is a no-op on an existing table — and then die later, far from the cause, with `"undefined" is not valid JSON` out of `mapAgentSession`. `migrate()` now renames `agent_user_id` → `app_user_id` and `state` → `status`, adds `external_urls_json`, backfills a non-empty `external_url` into a one-entry collection (`[{ url, label: "" }]` — Linear's label is non-null and the old shape carried none), drops `external_url`, and rewrites the three retired status values. Idempotent; a no-op on a database created by the current schema. Cloud's per-session databases are ephemeral (ADR-012) and unaffected; local and self-host files are not.

Verified by building a database with the pre-rename code and reopening it with this branch — before/after in the review thread. `test/agent-session-migration.test.ts` is the committed regression (5 cases: column rename, all three status mappings including `canceled`, the `external_url` backfill, idempotency, and the read-boundary failure); all 5 go red when the `migrateAgentSessions(db)` call is removed.

`mapAgentSession` no longer casts a stored status through unvalidated. An unmappable value now fails at the read boundary naming the value and the cause, instead of surviving to die at GraphQL enum serialisation with `Enum "AgentSessionStatus" cannot represent value: "canceled"`.

### Other

- **#277's tri-state contract survives.** `updateAgentSession` still tests presence with `!== undefined`, never `in`. `externalUrls` joins the contract: absent or `undefined` leaves it alone, `null` clears it to `[]`. `test/partial-update-tristate.test.ts` asserts that over `externalUrls` as well as `plan`.
- **Two findings beyond the ticket's table**, confirmed against introspection: `plan: String` is also a type Linear does not use (`plan: JSON`) — fixed here, same defect class, and a string is already valid JSON so nothing changes on the wire. And `externalUrls: JSON!` is itself deprecated upstream in favour of `externalLinks: [AgentSessionExternalLink!]!` (as is `externalLink: String`, the exact 1:1 match for the old `externalUrl`). Both are declared, so the gate is satisfied either way; adopting `externalLinks` is new-field scope and out of scope here.
- **No version bump.** `package.json` stays 0.2.0 and the entry sits under `## Unreleased`, matching how #277 landed; per `PACKAGE_RELEASE.md` the release batch owns the bump and the `cli/` pin. This is a `/state`-payload and on-disk-schema change, so it is a **minor** (0.3.0) when that batch runs. pome-cloud #479 needs that release plus a re-pin.

## Review required

Yes — twin fidelity contract, and a breaking change to observable twin behaviour (`AgentSession` field names, `AgentSessionStatus` values, on-disk `agent_sessions` schema, `/state` export, `AgentSessionEvent` webhook payload).
