### PR TITLE
release: @pome-sh/twin-linear 0.3.0 (breaking AgentSession rename + tri-state partial updates)

### DIFF
--- a/cli/.changeset/repin-twin-linear-0-3-0.md
+++ b/cli/.changeset/repin-twin-linear-0-3-0.md
@@ -1,0 +1,35 @@
+---
+"@pome-sh/cli": minor
+---
+
+BREAKING: the bundled Linear twin moves to `@pome-sh/twin-linear` 0.3.0, whose
+`AgentSession` uses Linear's real field names.
+
+`@pome-sh/twin-linear` is a `bundleDependencies` entry, so the pin is baked into
+the CLI tarball and this re-pin is what actually delivers 0.3.0 to anyone running
+`pome`. The twin declared `state`, `externalUrl` and `agentUser` — three names
+Linear does not have — so an agent written against real Linear read `undefined`
+from the twin, and an agent written against the twin broke in production. They
+are now `status` (a real `AgentSessionStatus` enum), `externalUrls` (a collection
+of `{ url, label }`) and `appUser`, alongside `id: ID!`, `createdAt` /
+`updatedAt: DateTime!` and `plan: JSON`. There is no alias and no deprecation
+window: a twin carrying both names would still expose a field Linear does not
+declare, which is the defect.
+
+Two consequences for a CLI user. Any task, seed or check that names the old
+fields must be renamed — including in the `/_pome/state` export the checks read
+and in the `AgentSessionEvent` webhook payload. And an existing `LINEAR_TWIN_DB`
+file is migrated in place the first time this CLI opens it: `agent_sessions`
+renames `agent_user_id` → `app_user_id` and `state` → `status`, adds
+`external_urls_json` backfilled from `external_url`, and rewrites the three
+retired status values (`completed` → `complete`, `failed` → `error`,
+`canceled` → `stale`). The migration is idempotent, but there is no downgrade —
+an older CLI cannot read a migrated database.
+
+The same pin also carries F-1166: partial updates no longer wipe fields the
+caller never mentioned. Nullable fields are tri-state — key absent or present
+with `undefined` leaves the value alone, `null` clears it — which fixes
+`agentSessionUpdate`, `issueUpdate`, `issueLabelUpdate`, `updateProject`,
+`updateDocument` and the MCP `save_issue` / `save_project` / `save_document`
+tools, plus an `issueUpdate` with an explicit `stateId: null` erasing an issue's
+lifecycle timestamps.

--- a/cli/package.json
+++ b/cli/package.json
@@ -69,7 +69,7 @@
     "@pome-sh/shared-types": "0.13.0",
     "@pome-sh/twin-gmail": "0.3.0",
     "@pome-sh/twin-github": "0.8.0",
-    "@pome-sh/twin-linear": "0.2.0",
+    "@pome-sh/twin-linear": "0.3.0",
     "@pome-sh/twin-slack": "0.3.0",
     "@pome-sh/twin-stripe": "0.4.1",
     "ai": "^7.0.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5975,7 +5975,7 @@
     },
     "packages/twin-linear": {
       "name": "@pome-sh/twin-linear",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.10",

--- a/packages/twin-linear/CHANGELOG.md
+++ b/packages/twin-linear/CHANGELOG.md
@@ -1,6 +1,26 @@
 # @pome-sh/twin-linear — CHANGELOG
 
-## Unreleased
+## 0.3.0 — 2026-08-02
+
+**BREAKING RELEASE — read this before upgrading.** Two things a consumer must
+act on:
+
+1. **`AgentSession` is renamed to Linear's real field names (F-1172).** No
+   aliases, no deprecation window: `state` → `status` (now a real
+   `AgentSessionStatus` enum), `externalUrl` → `externalUrls` (a collection),
+   `agentUser` → `appUser`, plus `id: ID!`, `createdAt` / `updatedAt: DateTime!`
+   and `plan: JSON`. Queries, mutation inputs, the `/_pome/state` export and the
+   `AgentSessionEvent` webhook payload all change shape. Any agent, task or
+   check that names the old fields must be updated.
+2. **An existing `LINEAR_TWIN_DB` file is migrated in place on open.** The
+   `agent_sessions` table is rewritten (`agent_user_id` → `app_user_id`,
+   `state` → `status`, `external_url` → `external_urls_json`), and the three
+   retired status values are remapped: **`completed` → `complete`,
+   `failed` → `error`, `canceled` → `stale`.** The migration is idempotent and
+   there is no downgrade path — a 0.2.x twin cannot read a migrated database.
+
+Also in this release: partial updates stop wiping fields the caller never
+mentioned (F-1166), across `agentSessionUpdate` and six sibling mutations.
 
 - **BREAKING — `AgentSession` now uses Linear's real field names and types
   (F-1172).** The twin declared four fields Linear does not have, so an agent

--- a/packages/twin-linear/package.json
+++ b/packages/twin-linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-linear",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Deterministic Linear-shaped twin for agent testing \u2014 SQLite-backed GraphQL + MCP + OAuth.",
   "private": false,
   "type": "module",


### PR DESCRIPTION
<!-- Closes F-1166 / F-1172 (release) -->

## What

Cuts `@pome-sh/twin-linear` **0.2.0 → 0.3.0**, converts its `## Unreleased`
changelog section into a `0.3.0 — 2026-08-02` entry, moves `cli/package.json`'s
pin to `0.3.0`, and adds the changeset that ships that re-pin.

`twin-linear` is the only package whose source changed since `packages-v27`
(#277 and #278, both today). `twin-stripe` 0.4.1 also rides the next publish
batch, but it bumped itself in #275 and needs nothing here. `sdk`,
`shared-types`, `adapter-claude-sdk`, `twin-github`, `twin-slack` and
`twin-gmail` are untouched and keep their versions.

## Why

**Minor, not patch.** `PACKAGE_RELEASE.md` reserves minor for "anything a
consumer must act on: a change to the frozen runtime contract (`CONTRACT.md`,
`/_pome/state` payloads)…". Both merged PRs change observable twin behaviour and
F-1172 changes the `/_pome/state` payload outright. Every `@pome-sh/*` package is
pre-1.0, so `^0.2.x` never resolves to `0.3.0` — minor plays the major role,
which is exactly the fence a breaking rename needs.

- **#278 (F-1172)** — `AgentSession` renamed to Linear's real field names:
  `state` → `status` (a real `AgentSessionStatus` enum), `externalUrl` →
  `externalUrls` (a collection of `{ url, label }`), `agentUser` → `appUser`,
  plus `id: ID!`, `createdAt`/`updatedAt: DateTime!` and `plan: JSON`. No alias,
  no deprecation window. Carries a real storage migration: `agent_user_id` →
  `app_user_id`, `state` → `status`, `external_url` → `external_urls_json` with
  backfill, and the three retired statuses remapped — `completed` → `complete`,
  `failed` → `error`, `canceled` → `stale`.
- **#277 (F-1166)** — partial updates stop wiping unmentioned fields. Tri-state:
  key absent → untouched, `null` → cleared, `undefined` → untouched. Plus the
  `stateId: null` fix that was wiping `started_at`/`completed_at`/`canceled_at`.

`cli/package.json`'s pin has to move in this same PR or
`scripts/check-cli-pins-match-workspace.mjs` (F-1135) fails CI. Pinning a version
that is not on npm yet is expected — `cli-ci` packs it from `packages/`. The
changeset is required too: `@pome-sh/twin-linear` is a `bundleDependencies`
entry, so the pin is baked into the CLI tarball and without a changeset the
re-pin never reaches users.

## Notes for reviewer

**One place `PACKAGE_RELEASE.md` does not match the repo.** The Versioning
section says `npm run test:contract` "is the arbiter: green means the contract
surface did not change and no minor is required." It is green on this branch —
but the contract harness freezes the *cross-twin SDK* surface (healthz shape,
`/_pome/state` key set, auth matrix, MCP envelopes), not the per-twin contents of
a `/_pome/state` payload, so it structurally cannot see an `AgentSession` field
rename. Read literally the sentence argues for a patch here, and it is wrong.
The explicit "`/_pome/state` payloads" bullet directly above it is the criterion
that governs. Worth softening that line to "green is necessary, not sufficient"
in a follow-up.

Two other observations, neither blocking and neither in scope for a release PR:

- `cli/package-lock.json` still resolves `@pome-sh/twin-linear` at `0.1.0`,
  already behind the `0.2.0` pin before this PR. That is the lag
  `PACKAGE_RELEASE.md` step 4 says to refresh against the registry *after* the
  batch publishes, so it is left alone.
- `packages/adapter-claude-sdk/CHANGELOG.md` carries an empty `## Unreleased`
  heading and `packages/shared-types/CHANGELOG.md` an unreleased M1 OTel section.
  Both predate today and neither package changed since `packages-v27`, so neither
  bumps here.

The root `package-lock.json` is refreshed via `npm install --package-lock-only`;
the diff is the single `packages/twin-linear` version line.

### Verification (all run locally on this branch)

- `node scripts/pack-publishable.mjs --out dist-tarballs` → 8 tarballs,
  `pome-sh-twin-linear-0.3.0.tgz` among them
- clean-room smoke replicated from `.github/workflows/sdk-publish.yml` (manifest
  guard + tarball-only install + import and bin-resolution checks) → PASS,
  installed twin-linear reports `0.3.0`
- `npm run lint:cli-pins` → `✅ CLI pin parity OK: 7 @pome-sh/* pin(s) match packages/.`
- `npm run typecheck` → clean
- `npm test` → 8 workspaces, 2027 tests, 0 failures
- `npm run test:contract` → 104 pass / 5 skip / 0 fail

## Review required

Yes — public OSS API and twin fidelity contract. This publishes a breaking
`AgentSession` rename and an on-open storage migration with no downgrade path.

---

### Next step for a human (not done here, deliberately)

No tag and no GitHub Release were created — publishing is the founder's call.
After this merges:

1. Create a **GitHub Release whose tag starts with `packages-v`** (next in
   sequence: `packages-v28`). That triggers the `package publish` workflow, which
   publishes with npm OIDC provenance and skips the packages whose versions are
   already on npm — so only `@pome-sh/twin-linear@0.3.0` and
   `@pome-sh/twin-stripe@0.4.1` actually publish.
2. Nothing else to sequence. `cli-release.yml` waits for this batch on its own:
   it reads the pins from `cli/package.json` and probes npm, skipping with a
   named reason until `0.3.0` is live. Rerun it after the batch lands and refresh
   the committed `cli/package-lock.json` against the registry.
