### PR TITLE
The third state is called INCOMPLETE, and pome run stops exiting 0 on it

### DIFF
--- a/cli/.changeset/the-third-state-is-called-incomplete.md
+++ b/cli/.changeset/the-third-state-is-called-incomplete.md
@@ -1,0 +1,46 @@
+---
+"@pome-sh/cli": minor
+---
+
+A run whose criteria did not all get graded is `INCOMPLETE`, and `pome run` no
+longer exits 0 on it.
+
+The old terminal output, from a real cold walk:
+
+```
+UNEVAL Task 01 — Bug, happy path
+  score: un-evaluated (cannot pass) — 2 passed, 0 failed, 2 skipped, 0 errored; cloud score: 100/100
+```
+
+Two of the four criteria never ran. The CLI was **right** to refuse to call that
+a pass — 100/100 over the other two is not a verified anything — and it said so
+in two broken ways. `cannot pass` reads as the agent's failure, when the gap was
+the grader's. And the state had no name the dashboard shared, so a first-run user
+saw a scary refusal sitting next to `cloud score: 100/100` with no way to know
+which one to believe.
+
+Now both surfaces say the same word:
+
+```
+INCOMPLETE Task 01 — Bug, happy path
+  score: incomplete — 2 of 4 criteria not evaluated; 2 passed, 0 failed, 2 skipped, 0 errored; cloud score: 100/100
+```
+
+**`pome run` exits 1 on an incomplete run.** It used to map the raw cloud score
+straight to an exit code, a divergence from `pome eval` justified by old cloud
+builds that emit no per-criterion results. That compatibility already lives one
+layer down — the score reader marks such a response gradable so the guard becomes
+a no-op for exactly those builds — so the divergence was protecting a case its
+own helper already protected. A run whose check never ran is not a green CI
+signal.
+
+**A trial group stops counting an ungradable trial as a loss.** Five trials with
+one abstention now read `3 of 4 passed · 1 incomplete, excluded from the
+fraction` — never `4 of 5`, which counted it as a pass, and never `3 of 5`, which
+counts it against the agent. The group cannot exit 0 while one of its trials was
+never graded.
+
+What did NOT change: the guard itself. `scoreStatus` and `can_pass` still refuse
+to inflate a partial run into a pass on **any** abstention, which is the same
+rule the dashboard applies to the same criteria. Only the name, the copy, and the
+exit code moved.

--- a/cli/src/cli/eval.ts
+++ b/cli/src/cli/eval.ts
@@ -485,7 +485,7 @@ export async function runEval(options: RunEvalOptions): Promise<RunEvalResult> {
     return client.finalize(sid, {
       stopReason: "eval_upload",
       // /finalize's schema requires an integer exit_code, so `null` (agent
-      // timed out, or meta.json lacked the field) cannot pass through.
+      // timed out, or meta.json lacked the field) is not a legal value.
       // Send -1 as the explicit "unknown" sentinel — never a fabricated 0,
       // which would report a clean agent exit the trace can't vouch for.
       exitCode: artifacts.meta.exitCode ?? -1,
@@ -530,14 +530,16 @@ export async function runEval(options: RunEvalOptions): Promise<RunEvalResult> {
   // score.json), and the verdict lives in the cloud (see the dashboard URL).
   const score = scoreFromFinalizeResponse(finalized);
 
-  // Exit-code policy — DELIBERATE DIVERGENCE from hosted `pome run`
-  // (FDRS-618): `pome run` maps the raw cloud score (score >= threshold →
-  // 0), because pre-FDRS-618 cloud builds don't emit criteria_results and
-  // the cloud exit decision is documented as score-only. `pome eval` is a
-  // NEW command with no such compatibility surface, so it adopts the full
-  // FDRS-591/611 A5 guard up front: exit 0 ONLY when the run was evaluated,
-  // every criterion was judged (can_pass), AND the score clears the
-  // threshold. An UNEVAL verdict (e.g. all criteria skipped) exits 1.
+  // Exit-code policy — the full FDRS-591/611 A5 guard: exit 0 ONLY when the run
+  // was evaluated, every criterion was judged (can_pass), AND the score clears
+  // the threshold. An INCOMPLETE verdict (any criterion not evaluated) exits 1.
+  //
+  // F-925 retired the divergence that used to be documented here. `pome run`
+  // mapped the raw cloud score because "pre-FDRS-618 cloud builds don't emit
+  // criteria_results" — but `scoreFromFinalizeResponse` already handles that
+  // case (`hasCriteriaResults ? … : true`), so the guard degrades to score-only
+  // for exactly those builds on its own. The divergence was protecting a case
+  // its own helper already protected, and the two commands now agree.
   const exitCode = scoreStatus(score, EVAL_PASS_THRESHOLD) === "pass" ? 0 : 1;
 
   return {
@@ -618,7 +620,7 @@ export async function runEvalCommand(
     // Same verdict shape as hosted `pome run`: LABEL, score line, cloud URL.
     const status = scoreStatus(result.score, EVAL_PASS_THRESHOLD);
     const label =
-      status === "pass" ? "PASS" : status === "fail" ? "FAIL" : "UNEVAL";
+      status === "pass" ? "PASS" : status === "fail" ? "FAIL" : "INCOMPLETE";
     console.error(`${label} ${result.taskName}`);
     console.error(`  ${runScoreLine(result.score, EVAL_PASS_THRESHOLD, "cloud score")}`);
     if (result.score.results.length > 0) {

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -941,7 +941,7 @@ export function createProgram() {
                 result.scenario.config.passThreshold,
               );
               const label =
-                status === "pass" ? "PASS" : status === "fail" ? "FAIL" : "UNEVAL";
+                status === "pass" ? "PASS" : status === "fail" ? "FAIL" : "INCOMPLETE";
               console.error(`${label} ${result.scenario.title}`);
               console.error(`  ${runScoreLine(result.score, result.scenario.config.passThreshold, "cloud score")}`);
               console.error(`  local: ${result.artifacts.runDir}`);

--- a/cli/src/hosted/evalResultView.ts
+++ b/cli/src/hosted/evalResultView.ts
@@ -38,7 +38,7 @@ type WireCriterion = z.infer<typeof criterionSchema>;
 //
 // `skipped` and `errored` are BOTH excluded from the satisfaction denominator
 // (only `passed`/`failed` count) but are surfaced as explicit counts so a run
-// that evaluated nothing renders as "un-evaluated", never as a hard 0%.
+// that evaluated nothing renders as "incomplete", never as a hard 0%.
 export type CriterionOutcome = "passed" | "failed" | "skipped" | "errored";
 
 export type CriterionResult = {
@@ -63,7 +63,7 @@ export type CriterionResult = {
 export type Score = {
   // passed / (passed + failed), rounded to 0-100. 0 when nothing was evaluated
   // — callers MUST consult `evaluated`/`can_pass` before reading this as a
-  // verdict, since a 0 here means "un-evaluated", not "hard fail".
+  // verdict, since a 0 here means "not evaluated", not "hard fail".
   satisfaction: number;
   passed: number;
   failed: number;
@@ -72,7 +72,7 @@ export type Score = {
   // = passed + failed. The satisfaction denominator.
   total_required: number;
   // false when total_required === 0 (nothing was evaluated). Renders as
-  // "un-evaluated" instead of 0%.
+  // "incomplete" instead of 0%.
   evaluated: boolean;
   // A5 inflation guard — a run may only PASS if every required criterion was
   // actually evaluated (passed or failed).
@@ -92,14 +92,25 @@ export function outcomeOf(result: CriterionResult): CriterionOutcome {
   return result.passed ? "passed" : "failed";
 }
 
-export type ScoreStatus = "pass" | "fail" | "unevaluated";
+export type ScoreStatus = "pass" | "fail" | "incomplete";
 
 // Single source of truth for "did this run pass?", applied to a CLOUD score.
 // Encodes the A5 guard: a run is only a PASS when it was evaluated, every
 // required criterion was evaluated (can_pass), AND satisfaction cleared the
 // threshold. PURE — no computation of the score itself.
+//
+// F-932 renamed the third state from `unevaluated` to `incomplete` and CHANGED
+// NOTHING ELSE HERE. The guard is the one place the CLI refuses to inflate a
+// partial run into a pass — the same refusal pome-cloud added server-side in
+// F-925 — so the rename must not become a loosening.
+//
+// One rule, two repos: `can_pass` is false for ANY abstention
+// (`uploadAndFinalize.ts`), and pome-cloud's `isRunIncomplete` says
+// `notEvaluated > 0` over the same `criteria_results`. Deliberately NOT read
+// from the wire's `all_skipped`, which is the narrower every-abstained
+// predicate and would loosen this guard.
 export function scoreStatus(score: Score, passThreshold: number): ScoreStatus {
-  if (!score.evaluated || !score.can_pass) return "unevaluated";
+  if (!score.evaluated || !score.can_pass) return "incomplete";
   return score.satisfaction >= passThreshold ? "pass" : "fail";
 }
 
@@ -124,7 +135,7 @@ export function markerFor(outcome: CriterionOutcome): string {
 // Multi-twin (M3): the per-criterion bracket for terminal display —
 // `[code]` / `[model]`, plus the `:<twin>` suffix when the criterion attributes
 // to a specific twin (so a `[code:slack]`/`[model:github]` marker survives into the
-// UNEVAL / criteria list). A bare (primary-twin) criterion renders `[code]`
+// INCOMPLETE / criteria list). A bare (primary-twin) criterion renders `[code]`
 // unchanged.
 export function criterionMarkerLabel(criterion: WireCriterion): string {
   return criterion.twin ? `[${criterion.type}:${criterion.twin}]` : `[${criterion.type}]`;
@@ -132,7 +143,7 @@ export function criterionMarkerLabel(criterion: WireCriterion): string {
 
 // Multi-twin (M3): when the cloud could not evaluate a criterion for a
 // twin-related reason (a twin-tagged criterion, or a `no_matching_predicate`
-// skip), name the twin inline so the UNEVAL line explains WHICH twin's timeline
+// skip), name the twin inline so the INCOMPLETE line explains WHICH twin's timeline
 // came up empty. Returns "" when there's nothing twin-specific to add.
 export function twinSkipSuffix(result: CriterionResult): string {
   const twin = result.criterion.twin;
@@ -155,8 +166,14 @@ export function runScoreLine(
   unevaluatedNumericLabel: string,
 ): string {
   const status = scoreStatus(score, passThreshold);
-  if (status === "unevaluated") {
-    return `score: un-evaluated (cannot pass) — ${scoreCountsSummary(score)}; ${unevaluatedNumericLabel}: ${score.satisfaction}/100`;
+  if (status === "incomplete") {
+    // Leads with the COUNT, which is the fact the reader needs and the same
+    // fact the cloud's own header now states. The old copy said "cannot pass",
+    // which is a verdict about the AGENT for a gap in the GRADER — the exact
+    // inversion F-925 exists to stop, one surface over.
+    const notEvaluated = score.skipped + score.errored;
+    const total = score.total_required + notEvaluated;
+    return `score: incomplete — ${notEvaluated} of ${total} criteria not evaluated; ${scoreCountsSummary(score)}; ${unevaluatedNumericLabel}: ${score.satisfaction}/100`;
   }
   return `score: ${score.satisfaction}/100`;
 }

--- a/cli/src/runner/groupRender.ts
+++ b/cli/src/runner/groupRender.ts
@@ -21,14 +21,24 @@
 // duration and are EXCLUDED from the fraction's denominator.
 
 import { criterionPhrase } from "../demo/render.js";
+import type { ScoreStatus } from "../hosted/evalResultView.js";
 
 export type TrialRow =
   | {
       kind: "completed";
       /** Cloud-authoritative satisfaction score, 0-100. */
       score: number;
-      /** Cleared the scenario's pass threshold. */
-      passed: boolean;
+      /**
+       * F-925 — three states, not a boolean. `incomplete` means the trial ran
+       * and finalized but at least one criterion never produced a verdict, so
+       * it is neither a pass nor the agent's failure. It was `passed: boolean`
+       * fed from `exitCode === 0`, which counted a 100/100 run with 3 of 4
+       * criteria skipped as a clean passing trial.
+       *
+       * Typed as the CLI's own `ScoreStatus` rather than a second enum, so the
+       * trial line and the single-run headline cannot drift apart.
+       */
+      verdict: ScoreStatus;
       seconds: number;
       /** Failing-criteria summary ("a · b"), absent when none were reported. */
       note?: string;
@@ -67,7 +77,11 @@ export function trialRowLine(n: number, row: TrialRow): string {
   if (row.kind === "errored") {
     return `trial ${n}  ⚠  ${"errored".padEnd(16)}${row.reason} — excluded`;
   }
-  const mark = row.passed ? "✓" : "✗";
+  // A dash for the ungradable trial: it ran, and it asserts nothing. Reusing
+  // ✗ would make a grader gap look like the agent's failure at a glance, which
+  // is the whole reading F-925 removes.
+  const mark =
+    row.verdict === "pass" ? "✓" : row.verdict === "incomplete" ? "–" : "✗";
   const base = `trial ${n}  ${mark}  ${String(row.score).padEnd(9)}${row.seconds.toFixed(1)}s`;
   return row.note ? `${base}  ${row.note}` : base;
 }
@@ -86,17 +100,32 @@ export function groupSummaryLines(input: GroupSummaryInput): string[] {
   const completed = input.rows.filter(
     (r): r is Extract<TrialRow, { kind: "completed" }> => r.kind === "completed",
   );
-  const passed = completed.filter((r) => r.passed).length;
+  const passed = completed.filter((r) => r.verdict === "pass").length;
+  const incomplete = completed.filter((r) => r.verdict === "incomplete").length;
+  // F-925 — the fraction's denominator is the GRADED trials. A trial that
+  // finalized but could not be fully graded leaves both the numerator and the
+  // denominator, so a 5-trial set with one of them reads "3 of 4", never the
+  // "4 of 5" that counted it as a pass.
+  const graded = completed.length - incomplete;
   const errored = input.rows.length - completed.length;
 
   const lines: string[] = ["─────"];
 
-  // The fraction counts COMPLETED trials only; errored trials are named and
-  // excluded, never silently folded into the denominator.
-  let fraction =
-    completed.length === 0
-      ? "no trials completed"
-      : `${passed} of ${completed.length} passed`;
+  // The fraction counts GRADED trials only; incomplete and errored trials are
+  // named and excluded, never silently folded into the denominator. They stay
+  // two clauses rather than one: "the trial died" is ours to retry, "the trial
+  // ran and could not be graded" is a grader gap, and a reader told the wrong
+  // one goes looking in the wrong place.
+  let fraction: string;
+  if (graded === 0) {
+    fraction =
+      completed.length === 0 ? "no trials completed" : "no trials could be graded";
+  } else {
+    fraction = `${passed} of ${graded} passed`;
+  }
+  if (incomplete > 0) {
+    fraction += ` · ${incomplete} incomplete, excluded from the fraction`;
+  }
   if (errored > 0) {
     fraction += ` · ${errored} errored, excluded from the fraction`;
   }
@@ -132,7 +161,11 @@ export function groupExitCode(rows: TrialRow[]): number {
     (r): r is Extract<TrialRow, { kind: "completed" }> => r.kind === "completed",
   );
   if (completed.length === 0) return 2;
-  return completed.every((r) => r.passed) ? 0 : 1;
+  // F-925 — an ungradable trial is not a pass, so a group holding one cannot
+  // exit 0: green here would tell CI the set was verified when part of it was
+  // never checked. It stays 1 rather than 2 even when EVERY trial was
+  // incomplete — `2` means nothing completed, and these completed.
+  return completed.every((r) => r.verdict === "pass") ? 0 : 1;
 }
 
 /** Modal failed-criterion text across the group's completed trials, as the

--- a/cli/src/runner/runTaskHosted.ts
+++ b/cli/src/runner/runTaskHosted.ts
@@ -31,7 +31,11 @@ import type {
 import type { CriterionDefWire } from "../hosted/client.js";
 import type { RecorderEvent as LegacyGithubRecorderEvent } from "@pome-sh/shared-types";
 import type { Task } from "../task/taskSchema.js";
-import type { Score } from "../hosted/evalResultView.js";
+import {
+  scoreStatus,
+  type Score,
+  type ScoreStatus,
+} from "../hosted/evalResultView.js";
 import type { RunArtifacts } from "../recorder/artifacts.js";
 
 export interface RunTaskHostedOptions {
@@ -73,6 +77,13 @@ export interface RunTaskHostedResult {
   cloudDashboardUrl: string;
   artifacts: RunArtifacts;
   score: Score;
+  /**
+   * F-925 — the run's own three-state verdict, computed ONCE here and carried
+   * out so a caller never re-derives it. `exitCode` cannot express it: 1 means
+   * both "failed" and "could not be graded", and a trial group needs to tell
+   * them apart to keep the ungradable one out of its fraction.
+   */
+  verdict: ScoreStatus;
   exitCode: number;
   /** Wall time from run start to post-agent state capture — the same value
    *  reported to /finalize as duration_ms. FDRS-636 renders it as the trial
@@ -645,8 +656,15 @@ export async function runTaskHosted(
     //     Pre-finalize agent failures (auth, quota, twin spawn, exec
     //     errors) take other code paths via thrown HostedAuthError /
     //     HostedQuotaError / HostedOrchError and never reach this line.
-    const exitCode =
-      finalized.score >= scenario.config.passThreshold ? 0 : 1;
+    //     F-925 — the score alone is not the verdict. A 100/100 run with a
+    //     criterion that never ran is `incomplete`, and exiting 0 on it is how
+    //     "the fix passed" came to mean "the check never ran". `scoreStatus`
+    //     applies the A5 guard `pome eval` has always applied; the FDRS-618
+    //     compat this used to preserve is already preserved inside
+    //     `scoreFromFinalizeResponse`, which sets can_pass true when the
+    //     response carries no criteria_results at all.
+    const verdict = scoreStatus(score, scenario.config.passThreshold);
+    const exitCode = verdict === "pass" ? 0 : 1;
 
     // 11. FDRS-644 — cache the CLOUD verdict payload next to the raw trace
     //     (verdict.json, provenance-labeled `source: "cloud-finalize"`).
@@ -688,6 +706,7 @@ export async function runTaskHosted(
       cloudDashboardUrl: finalized.dashboard_url,
       artifacts,
       score,
+      verdict,
       exitCode,
       durationMs,
     };

--- a/cli/src/runner/runTrialGroup.ts
+++ b/cli/src/runner/runTrialGroup.ts
@@ -250,7 +250,14 @@ export async function runTrialGroup(
       row = {
         kind: "completed",
         score: result.score.satisfaction,
-        passed: result.exitCode === 0,
+        // F-925 — the trial's own verdict, carried out of the run rather than
+        // re-derived here. It was `result.exitCode === 0`, which cannot express
+        // the third state (1 means both "failed" and "could not be graded"), so
+        // a 100/100 trial with 3 of 4 criteria skipped counted as a clean pass.
+        // Reusing the run's own value rather than calling `scoreStatus` again
+        // on the same inputs is what keeps the trial line and the single-run
+        // headline from ever disagreeing.
+        verdict: result.verdict,
         seconds: result.durationMs / 1000,
         note:
           failing.length > 0

--- a/cli/src/runner/runTrialGroup.ts
+++ b/cli/src/runner/runTrialGroup.ts
@@ -320,8 +320,14 @@ export async function runTrialGroup(
   // 4. FDRS-644 — the fix & green handoff, only when a COMPLETED trial
   // failed. Errored trials are sandbox noise: the answer there is re-run,
   // not a code fix, so an errored-only group gets no handoff.
+  //
+  // F-925 — `fail`, NOT "anything that isn't a pass". This was `!r.passed`,
+  // which now includes the incomplete trial, and pointing someone at
+  // `pome fix-prompt` for a criterion that never ran tells them to fix an agent
+  // that may be blameless. An abstention is a grader gap; the handoff is for
+  // agent defects.
   const failedCompleted = rows.filter(
-    (r) => r.kind === "completed" && !r.passed,
+    (r) => r.kind === "completed" && r.verdict === "fail",
   ).length;
   if (failedCompleted > 0) {
     const artifactsDir = options.artifactsDir ?? "runs";

--- a/cli/test/e2e/runTaskHosted.test.ts
+++ b/cli/test/e2e/runTaskHosted.test.ts
@@ -208,7 +208,7 @@ describe("pome run --hosted (e2e via spawn)", () => {
     );
   }, 90_000);
 
-  it("prints UNEVAL when cloud score is 100 but returned criteria were skipped", async () => {
+  it("prints INCOMPLETE and exits 1 when cloud score is 100 but a criterion was skipped", async () => {
     finalizeResponseOverrides = {
       criteria_results: [
         {
@@ -268,9 +268,19 @@ describe("pome run --hosted (e2e via spawn)", () => {
     child.stderr.on("data", (d) => (stderr += d.toString()));
     const code = await new Promise<number>((res) => child.on("close", res));
 
-    expect(code, `stderr was:\n${stderr}`).toBe(0);
-    expect(stderr).toMatch(/UNEVAL Trivial/);
-    expect(stderr).toContain("score: un-evaluated (cannot pass)");
+    // F-925 — `pome run` used to exit 0 here, a documented divergence from
+    // `pome eval` justified by pre-FDRS-618 cloud builds that emit no
+    // `criteria_results`. That compat lives in `scoreFromFinalizeResponse`
+    // (can_pass true when the field is absent), so the divergence was guarding
+    // a case its own helper already guarded. A run whose criterion never ran is
+    // not a green CI signal.
+    expect(code, `stderr was:\n${stderr}`).toBe(1);
+    // F-932 — the label and the copy. "cannot pass" was a verdict about the
+    // AGENT for a gap in the GRADER.
+    expect(stderr).toMatch(/INCOMPLETE Trivial/);
+    expect(stderr).toContain("score: incomplete —");
+    expect(stderr).toContain("1 of 1 criteria not evaluated");
+    expect(stderr).not.toContain("cannot pass");
     expect(stderr).toContain("cloud score: 100/100");
   }, 90_000);
 

--- a/cli/test/unit/eval-command.test.ts
+++ b/cli/test/unit/eval-command.test.ts
@@ -714,7 +714,7 @@ describe("pome eval review fixes (FDRS-656 follow-up)", () => {
     expect(result.reusedSession).toBe(true);
   });
 
-  it("UNEVAL verdict (all criteria skipped) exits 1 even at score 100", async () => {
+  it("INCOMPLETE verdict (all criteria skipped) exits 1 even at score 100", async () => {
     const runDir = await writeRunDir(tmp);
     const { client } = makeEvalClient({
       finalizeImpl: async () => ({

--- a/cli/test/unit/hosted/incompleteVerdict.test.ts
+++ b/cli/test/unit/hosted/incompleteVerdict.test.ts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-932 + F-925's CLI half — the CLI names the third state `incomplete` and
+// stops contradicting the cloud.
+//
+// The symptom, from the F-920 cold walk:
+//
+//   UNEVAL Task 01 — Bug, happy path
+//     score: un-evaluated (cannot pass) — 2 passed, 0 failed, 2 skipped, 0 errored; cloud score: 100/100
+//
+// Two of four criteria never ran. The CLI was RIGHT about that — 100/100 over
+// the other two is not a verified pass. It expressed a correct observation in
+// two broken ways: `cannot pass` reads as the agent's failure, and the state had
+// no name the cloud shared.
+//
+// What must NOT change, and why these tests guard it: `scoreStatus` and
+// `can_pass` are the A5 inflation guard. They are the one place the CLI refuses
+// to inflate a partial run into a pass, which is exactly what F-925 added
+// server-side. Renaming the state must not loosen it.
+
+import { describe, expect, it } from "vitest";
+import type { CriterionResult } from "@pome-sh/shared-types";
+import {
+  runScoreLine,
+  scoreStatus,
+  taskPassed,
+  type Score,
+} from "../../../src/hosted/evalResultView.js";
+
+const ok = (text: string): CriterionResult => ({
+  criterion: { type: "code", text },
+  passed: true,
+  skipped: false,
+  reason: "matched",
+});
+const abstained = (text: string): CriterionResult => ({
+  criterion: { type: "code", text },
+  passed: false,
+  skipped: true,
+  reason: "tool_not_recorded",
+});
+
+function score(results: CriterionResult[], satisfaction: number): Score {
+  const passed = results.filter((r) => !r.skipped && r.passed).length;
+  const failed = results.filter((r) => !r.skipped && !r.passed).length;
+  const skipped = results.filter((r) => r.skipped).length;
+  const totalRequired = passed + failed;
+  return {
+    satisfaction,
+    passed,
+    failed,
+    skipped,
+    errored: 0,
+    total_required: totalRequired,
+    evaluated: totalRequired > 0,
+    can_pass: totalRequired > 0 && skipped === 0,
+    results,
+    judge_model: null,
+    judge_tokens_in: null,
+    judge_tokens_out: null,
+  };
+}
+
+describe("scoreStatus — the third state is named `incomplete`", () => {
+  it("returns incomplete for a 100/100 run with ONE abstention", () => {
+    const s = score([ok("a"), ok("b"), ok("c"), abstained("d")], 100);
+    expect(scoreStatus(s, 100)).toBe("incomplete");
+    expect(taskPassed(s, 100)).toBe(false);
+  });
+
+  it("returns incomplete when nothing could be evaluated", () => {
+    expect(scoreStatus(score([abstained("a")], 0), 100)).toBe("incomplete");
+  });
+
+  it("leaves a fully-evaluated run exactly as it was", () => {
+    expect(scoreStatus(score([ok("a")], 100), 100)).toBe("pass");
+    expect(scoreStatus(score([ok("a")], 50), 100)).toBe("fail");
+  });
+
+  it("STILL refuses to inflate a partial run — the A5 guard survives the rename", () => {
+    // The rename must not become a loosening. One abstention is enough, which
+    // is the same rule pome-cloud's `isRunIncomplete` applies to the same
+    // `criteria_results`. If this ever flips to "every", the two surfaces
+    // disagree again and the CLI starts calling partial runs passes.
+    const oneSkipOfFour = score([ok("a"), ok("b"), ok("c"), abstained("d")], 100);
+    expect(oneSkipOfFour.can_pass).toBe(false);
+    expect(taskPassed(oneSkipOfFour, 100)).toBe(false);
+  });
+
+  it("degrades to score-only when the response carried no criteria_results", () => {
+    // Pre-FDRS-618 cloud builds omit the field; `scoreFromFinalizeResponse`
+    // sets can_pass/evaluated true for them, so the guard is a no-op and the
+    // verdict is the raw score. This is the compat the `pome run` divergence
+    // was written to protect — already protected here.
+    const legacy: Score = { ...score([], 100), evaluated: true, can_pass: true };
+    expect(scoreStatus(legacy, 100)).toBe("pass");
+  });
+});
+
+describe("runScoreLine — the copy stops blaming the agent", () => {
+  const s = score([ok("a"), ok("b"), abstained("c"), abstained("d")], 100);
+
+  it("names how many criteria were not evaluated", () => {
+    const line = runScoreLine(s, 100, "cloud score");
+    expect(line).toContain("incomplete");
+    expect(line).toContain("2 of 4 criteria not evaluated");
+  });
+
+  it("never says `cannot pass` — that is a verdict about the agent", () => {
+    expect(runScoreLine(s, 100, "cloud score")).not.toContain("cannot pass");
+  });
+
+  it("keeps the counts and the cloud score beside it", () => {
+    const line = runScoreLine(s, 100, "cloud score");
+    expect(line).toContain("2 passed, 0 failed, 2 skipped, 0 errored");
+    expect(line).toContain("cloud score: 100/100");
+  });
+
+  it("leaves the passing line untouched", () => {
+    expect(runScoreLine(score([ok("a")], 100), 100, "cloud score")).toBe(
+      "score: 100/100",
+    );
+  });
+});

--- a/cli/test/unit/inspect-command.test.ts
+++ b/cli/test/unit/inspect-command.test.ts
@@ -125,7 +125,7 @@ describe("pome inspect command", () => {
     expect(out).toContain("Events (2):");
     // No verdict rendered — capture-only.
     expect(out).not.toContain("Score");
-    expect(out).not.toMatch(/\bPASS\b|\bFAIL\b|\bUNEVAL\b/);
+    expect(out).not.toMatch(/\bPASS\b|\bFAIL\b|\bINCOMPLETE\b/);
   });
 
   it("shows only trace/audit content — never a verdict, even if a stray score.json exists", async () => {
@@ -171,6 +171,6 @@ describe("pome inspect command", () => {
     expect(out).toContain("Trace health:");
     expect(out).toContain("Events (1):");
     expect(out).not.toContain("Score");
-    expect(out).not.toMatch(/\bPASS\b|\bFAIL\b|\bUNEVAL\b/);
+    expect(out).not.toMatch(/\bPASS\b|\bFAIL\b|\bINCOMPLETE\b/);
   });
 });

--- a/cli/test/unit/runner/groupRender.test.ts
+++ b/cli/test/unit/runner/groupRender.test.ts
@@ -33,10 +33,10 @@ import {
 
 const completed = (
   score: number,
-  passed: boolean,
+  verdict: "pass" | "fail" | "incomplete",
   seconds: number,
   note?: string,
-): TrialRow => ({ kind: "completed", score, passed, seconds, note });
+): TrialRow => ({ kind: "completed", score, verdict, seconds, note });
 const errored = (reason: string): TrialRow => ({ kind: "errored", reason });
 
 describe("group header lines (moment 04)", () => {
@@ -77,22 +77,22 @@ describe("group header lines (moment 04)", () => {
 
 describe("trialRowLine (numeric scores, moment 04 column shape)", () => {
   it("renders a passing trial with score and duration", () => {
-    expect(trialRowLine(1, completed(100, true, 14.3))).toBe(
+    expect(trialRowLine(1, completed(100, "pass", 14.3))).toBe(
       "trial 1  ✓  100      14.3s",
     );
-    expect(trialRowLine(2, completed(96, true, 12.1))).toBe(
+    expect(trialRowLine(2, completed(96, "pass", 12.1))).toBe(
       "trial 2  ✓  96       12.1s",
     );
   });
 
   it("renders a failing trial with the failing criteria summary", () => {
     expect(
-      trialRowLine(3, completed(58, false, 15.9, "assignee never set · severity under-rated")),
+      trialRowLine(3, completed(58, "fail", 15.9, "assignee never set · severity under-rated")),
     ).toBe("trial 3  ✗  58       15.9s  assignee never set · severity under-rated");
   });
 
   it("renders a failing trial without a note when the cloud sent no criteria results", () => {
-    expect(trialRowLine(4, completed(74, false, 13.5))).toBe(
+    expect(trialRowLine(4, completed(74, "fail", 13.5))).toBe(
       "trial 4  ✗  74       13.5s",
     );
   });
@@ -109,10 +109,10 @@ describe("groupSummaryLines (errored trials excluded from the fraction)", () => 
 
   it("renders the moment-04 summary: fraction over completed trials only", () => {
     const rows = [
-      completed(100, true, 14.3),
-      completed(96, true, 12.1),
-      completed(58, false, 15.9, "n"),
-      completed(74, false, 13.5, "n"),
+      completed(100, "pass", 14.3),
+      completed(96, "pass", 12.1),
+      completed(58, "fail", 15.9, "n"),
+      completed(74, "fail", 13.5, "n"),
       errored("twin provision timeout"),
     ];
     expect(
@@ -133,7 +133,7 @@ describe("groupSummaryLines (errored trials excluded from the fraction)", () => 
   });
 
   it("omits the errored clause and start-there line when not applicable", () => {
-    const rows = [completed(100, true, 3), completed(100, true, 4)];
+    const rows = [completed(100, "pass", 3), completed(100, "pass", 4)];
     expect(groupSummaryLines({ rows, reliabilityUrl: url })).toEqual([
       "─────",
       "2 of 2 passed",
@@ -154,12 +154,12 @@ describe("groupSummaryLines (errored trials excluded from the fraction)", () => 
 
 describe("groupExitCode ([DECISION]: 0 iff ≥1 completed AND all completed passed)", () => {
   it("0 when every completed trial passed (errored rows don't block)", () => {
-    expect(groupExitCode([completed(100, true, 1), errored("x")])).toBe(0);
-    expect(groupExitCode([completed(100, true, 1), completed(96, true, 2)])).toBe(0);
+    expect(groupExitCode([completed(100, "pass", 1), errored("x")])).toBe(0);
+    expect(groupExitCode([completed(100, "pass", 1), completed(96, "pass", 2)])).toBe(0);
   });
 
   it("1 when any completed trial failed", () => {
-    expect(groupExitCode([completed(100, true, 1), completed(58, false, 2)])).toBe(1);
+    expect(groupExitCode([completed(100, "pass", 1), completed(58, "fail", 2)])).toBe(1);
   });
 
   it("2 when no trial completed at all", () => {
@@ -186,5 +186,93 @@ describe("failure aggregation helpers", () => {
   it("shortReason flattens whitespace and truncates long reasons", () => {
     expect(shortReason("boom\n  twice")).toBe("boom twice");
     expect(shortReason("x".repeat(100))).toBe(`${"x".repeat(69)}…`);
+  });
+});
+
+// ── F-925's CLI half ─────────────────────────────────────────────────────────
+//
+// A trial that could not be fully graded leaves the fraction — out of BOTH
+// numerator and denominator — and is always printed. Before this, the group
+// read `passed: result.exitCode === 0`, and `pome run` exited by raw score, so
+// a 100/100 trial with 3 of 4 criteria skipped counted as a clean pass.
+//
+// Same shape the cloud shipped in F-925: never a `4 of 5`.
+const incomplete = (score: number, seconds: number): TrialRow => ({
+  kind: "completed",
+  score,
+  verdict: "incomplete",
+  seconds,
+});
+
+describe("groupSummaryLines — incomplete trials leave the fraction (F-925)", () => {
+  const url = "https://app.pome.sh/runs/task/18-fabricate-green-ci";
+
+  it("counts 3 of 4, not 3 of 5 and not 4 of 5", () => {
+    const rows = [
+      completed(100, "pass", 14.3),
+      completed(100, "pass", 12.1),
+      completed(100, "pass", 13.0),
+      completed(58, "fail", 15.9, "n"),
+      incomplete(100, 11.2),
+    ];
+    expect(groupSummaryLines({ rows, reliabilityUrl: url })[1]).toBe(
+      "3 of 4 passed · 1 incomplete, excluded from the fraction",
+    );
+  });
+
+  it("names incomplete and errored separately — different findings", () => {
+    const rows = [
+      completed(100, "pass", 3),
+      incomplete(100, 4),
+      errored("twin provision timeout"),
+    ];
+    expect(groupSummaryLines({ rows, reliabilityUrl: url })[1]).toBe(
+      "1 of 1 passed · 1 incomplete, excluded from the fraction · 1 errored, excluded from the fraction",
+    );
+  });
+
+  it("says so honestly when every completed trial was ungradable", () => {
+    const rows = [incomplete(100, 3), incomplete(100, 4)];
+    expect(groupSummaryLines({ rows, reliabilityUrl: url })[1]).toBe(
+      "no trials could be graded · 2 incomplete, excluded from the fraction",
+    );
+  });
+
+  it("leaves a clean group's summary byte-identical", () => {
+    const rows = [completed(100, "pass", 3), completed(100, "pass", 4)];
+    expect(groupSummaryLines({ rows, reliabilityUrl: url })[1]).toBe(
+      "2 of 2 passed",
+    );
+  });
+});
+
+describe("trialRowLine — the incomplete trial is not visually a pass (F-925)", () => {
+  it("marks it with a dash, distinct from both ✓ and ✗", () => {
+    const line = trialRowLine(5, incomplete(100, 11.2));
+    expect(line).toContain("–");
+    expect(line).not.toContain("✓");
+    expect(line).not.toContain("✗");
+  });
+
+  it("still shows the score it did reach", () => {
+    expect(trialRowLine(5, incomplete(100, 11.2))).toContain("100");
+  });
+});
+
+describe("groupExitCode — an ungradable trial cannot buy a green group (F-925)", () => {
+  it("is 1 when a completed trial was incomplete, even if every graded one passed", () => {
+    expect(
+      groupExitCode([completed(100, "pass", 1), incomplete(100, 2)]),
+    ).toBe(1);
+  });
+
+  it("is 1 — not 2 — when every trial was incomplete; they DID complete", () => {
+    expect(groupExitCode([incomplete(100, 1), incomplete(100, 2)])).toBe(1);
+  });
+
+  it("keeps its documented contract otherwise", () => {
+    expect(groupExitCode([completed(100, "pass", 1), errored("x")])).toBe(0);
+    expect(groupExitCode([completed(58, "fail", 1)])).toBe(1);
+    expect(groupExitCode([errored("a")])).toBe(2);
   });
 });

--- a/cli/test/unit/runner/runTrialGroup.test.ts
+++ b/cli/test/unit/runner/runTrialGroup.test.ts
@@ -432,6 +432,11 @@ describe("runTrialGroup — errored trials (FDRS-636)", () => {
 
     const text = out.join("\n");
     expect(text).toContain("1 of 1 passed · 1 incomplete, excluded from the fraction");
+    // The fix-prompt handoff is for AGENT defects. An abstention is a grader
+    // gap, so pointing the reader at `pome fix-prompt` would tell them to fix
+    // an agent that may be blameless. (This predicate was `!r.passed`, which
+    // would have swept the incomplete trial in.)
+    expect(text).not.toContain("pome fix-prompt");
     // Never "1 of 2" (which would blame the agent) and never "2 of 2".
     expect(text).not.toContain("1 of 2 passed");
     expect(text).not.toContain("2 of 2 passed");

--- a/cli/test/unit/runner/runTrialGroup.test.ts
+++ b/cli/test/unit/runner/runTrialGroup.test.ts
@@ -32,7 +32,7 @@ import type {
   RunTaskHostedOptions,
   RunTaskHostedResult,
 } from "../../../src/runner/runTaskHosted.js";
-import type { Score } from "../../../src/hosted/evalResultView.js";
+import type { Score, ScoreStatus } from "../../../src/hosted/evalResultView.js";
 
 vi.mock("../../../src/hosted/client.js", async (importOriginal) => {
   const original = await importOriginal<typeof import("../../../src/hosted/client.js")>();
@@ -192,12 +192,20 @@ function trialResult(input: {
   exitCode: number;
   durationMs: number;
   failedTexts?: string[];
+  /**
+   * F-925 — the run's three-state verdict. Defaults from `exitCode` so every
+   * existing call site keeps meaning what it meant; pass it explicitly to
+   * simulate a trial that finalized but could not be fully graded, which is
+   * the state `exitCode` alone cannot express.
+   */
+  verdict?: ScoreStatus;
 }): RunTaskHostedResult {
   return {
     runId: input.sessionId,
     cloudRunId: `run_${input.sessionId}`,
     cloudDashboardUrl: `https://app.example/runs/run_${input.sessionId}`,
     score: scoreOf(input.satisfaction, input.failedTexts ?? []),
+    verdict: input.verdict ?? (input.exitCode === 0 ? "pass" : "fail"),
     exitCode: input.exitCode,
     durationMs: input.durationMs,
     scenario: undefined as never,
@@ -387,6 +395,48 @@ describe("runTrialGroup — errored trials (FDRS-636)", () => {
     expect(text).toContain("trial 1  ⚠  errored         twin pod restarted mid-run — excluded");
     expect(text).toContain("trial 2  ✓  96       12.1s");
     expect(result.exitCode).toBe(0);
+  });
+
+  // F-925 — the state `exitCode` alone could not express. A trial that
+  // finalized with a criterion that never ran is neither a pass nor the
+  // agent's failure; it leaves the fraction and cannot buy the group a 0.
+  it("keeps an ungradable trial out of the fraction and out of a green exit", async () => {
+    const taskPath = await scenarioFixture();
+    const cloud = makeFakeClient();
+    const out: string[] = [];
+
+    const result = await runTrialGroup({
+      taskPath,
+      agentCommand: "node agent.js",
+      trials: 2,
+      hosted: { baseUrl: "https://api.example", apiKey: "pme_k" },
+      dashboardBaseUrl: "https://app.pome.sh",
+      out: (line) => out.push(line),
+      client: cloud.client,
+      runTaskHostedFn: async (options) => {
+        const sid = options.premintedSession!.session_id;
+        // Trial 2 scored 100 over a shrunken denominator: exit 1, but NOT a
+        // failure. Before this it arrived as `passed: exitCode === 0` and
+        // simply counted as a loss.
+        return sid === "ses_1"
+          ? trialResult({ sessionId: sid, satisfaction: 100, exitCode: 0, durationMs: 1000 })
+          : trialResult({
+              sessionId: sid,
+              satisfaction: 100,
+              exitCode: 1,
+              durationMs: 1100,
+              verdict: "incomplete",
+            });
+      },
+    });
+
+    const text = out.join("\n");
+    expect(text).toContain("1 of 1 passed · 1 incomplete, excluded from the fraction");
+    // Never "1 of 2" (which would blame the agent) and never "2 of 2".
+    expect(text).not.toContain("1 of 2 passed");
+    expect(text).not.toContain("2 of 2 passed");
+    // Green here would tell CI the set was verified when half of it was not.
+    expect(result.exitCode).toBe(1);
   });
 
   it("exit 1 when a completed trial failed; failing criteria feed the start-there line", async () => {

--- a/docs/superpowers/specs/2026-08-03-cli-incomplete-verdict-design.md
+++ b/docs/superpowers/specs/2026-08-03-cli-incomplete-verdict-design.md
@@ -1,0 +1,183 @@
+# The CLI names the third state `INCOMPLETE`, and stops contradicting the cloud
+
+Covers **F-932 in full** and **F-925's CLI half**. They are one change: the same
+renderer, the same exit-code decision, and — per both tickets — the same
+`@pome-sh/cli` publish.
+
+F-925's cloud half merged as pome-cloud `870374b5`. F-931 (the per-criterion
+class) merged as `65439c0b`.
+
+---
+
+## The symptom
+
+```
+UNEVAL Task 01 — Bug, happy path
+  score: un-evaluated (cannot pass) — 2 passed, 0 failed, 2 skipped, 0 errored; cloud score: 100/100
+```
+
+Two of four criteria never ran. The CLI noticed, and said so in two broken ways:
+it called the state **`cannot pass`**, which reads as the agent's failure; and it
+**overrode** a verdict it is not authoritative over instead of naming a state
+the verdict itself now carries.
+
+---
+
+## Findings that shaped the design
+
+Measured on brisbane `4675826`, which is `origin/main`.
+
+**F1 — `can_pass` is ALREADY any-shaped. This is the finding that shrinks the
+work.** `uploadAndFinalize.ts`'s `scoreFromFinalizeResponse`:
+
+```ts
+can_pass: hasCriteriaResults
+  ? totalRequired > 0 && skipped === 0 && errored === 0
+  : true,
+```
+
+`skipped === 0` — **one abstention is enough**. The CLI's predicate is already
+F-925's ratified rule and has been all along, which is why the terminal output
+above exists at all. F-932 says it outright: *"The CLI was right."*
+
+So this is **not** a predicate change and **not** a new consumer. It is naming,
+authority, and an exit code.
+
+**F2 — `all_skipped` is the WRONG field to read, and reading it would re-open
+the hole F-932 warns about.** F-932's instruction is "render the cloud's
+`incomplete`", written when it looked as though F-925 would publish a run-level
+flag. F-925's cloud half deliberately publishes none — and that turns out to
+matter more than it did at the time:
+
+| | predicate |
+| -- | -- |
+| wire `all_skipped` | `isFullyUnevaluated` — **every** criterion abstained |
+| CLI `can_pass` | **any** criterion abstained |
+| cloud `deriveRunStatus` | **any** criterion abstained |
+
+`all_skipped` is strictly narrower. Wiring the CLI to it would *loosen* the A5
+guard — exactly the inflation F-932's own rewritten bullet 3 exists to prevent.
+Both surfaces already compute the same rule from the same `criteria_results`;
+what they lack is a written statement that it is one rule. That is a test and a
+pair of comments, not a field. No third place spans the two repos.
+
+**F3 — The FDRS-618 divergence's compat argument is already implemented, so
+retiring it costs nothing.** `eval.ts:532-540` documents why `pome run` maps the
+raw score while `pome eval` applies the A5 guard: *"pre-FDRS-618 cloud builds
+don't emit `criteria_results`."* But `scoreFromFinalizeResponse` already handles
+that — `hasCriteriaResults ? … : true` makes `can_pass` true when the field is
+absent, so `scoreStatus` degrades to score-only for exactly those builds. The
+divergence guards a case the shared helper already guards. Deleting it changes
+behaviour only for responses that DO carry `criteria_results`, which is the case
+the ticket wants changed.
+
+**F4 — The group already has a three-valued exit contract.**
+`groupRender.ts:126` documents `0` = every completed trial passed, `1` = a
+completed trial failed, `2` = nothing completed. So a third state is not
+unprecedented here; what is unprecedented is a fourth *code*.
+
+**F5 — One ticket coordinate is wrong.** F-932's "Repo / area" lists
+`cli/src/hosted/runTaskHosted.ts`; the file is `cli/src/runner/runTaskHosted.ts`.
+The line numbers (648-649) are right.
+
+**F6 — A known, unreachable corner, recorded so it is not mistaken for a bug.**
+`Score.evaluated` is `totalRequired > 0`, so a run with **zero** criteria reads
+`incomplete` in the CLI while the cloud's `total > 0` guard keeps it
+score-derived. The CLI's task parser requires a `## Success Criteria` section,
+so no CLI-run task reaches it. Not fixed; naming it costs a sentence and
+re-deriving it later would cost an afternoon.
+
+---
+
+## Design
+
+### 1. Rename the state; do not touch the guard
+
+`ScoreStatus`'s third value becomes `"incomplete"`. `scoreStatus` and `can_pass`
+keep their logic **exactly** — they are the A5 inflation guard, and F-932's
+rewritten bullet 3 is explicit that deleting them removes the one place the CLI
+refuses to inflate a partial run into a pass.
+
+| | before | after |
+| -- | -- | -- |
+| label | `UNEVAL` | `INCOMPLETE` |
+| line | `score: un-evaluated (cannot pass) — 2 passed, 0 failed, 2 skipped, 0 errored; cloud score: 100/100` | `score: incomplete — 2 of 4 criteria not evaluated; 2 passed, 0 failed, 2 skipped, 0 errored; cloud score: 100/100` |
+
+"cannot pass" goes because it is a verdict about the agent. The replacement
+leads with the count, which is the fact the reader needs and the thing the
+cloud's own header now says.
+
+### 2. `pome run` applies the A5 guard
+
+`runTaskHosted.ts:649` becomes `scoreStatus(score, passThreshold) === "pass" ? 0 : 1`,
+retiring the documented divergence on F3's grounds — the compatibility it
+protects is already protected one layer down.
+
+**`incomplete` exits 1, not a new code.** `pome eval` has shipped exactly that
+for the same state; two surfaces already agree on it; and `2` is documented as
+"nothing completed", so widening it would break a meaning something else
+depends on.
+
+The cost, stated rather than hidden: **a CI pipeline cannot distinguish "the
+agent regressed" from "we could not grade it".** F-932 raises the CI-signal
+question directly, and a distinct code would answer it better. It is declined
+here because CLI exit codes are a public contract and neither ticket asks to
+widen it — that is its own decision, not a side effect of this one.
+
+### 3. The run-set stops counting an ungradable trial as a failure
+
+`TrialRow`'s `passed: boolean` becomes a three-state verdict. `groupSummaryLines`
+prints the fraction over gradable trials with the incomplete count beside it,
+mirroring what `errored` already does and what F-925 shipped cloud-side:
+
+```
+3 of 4 passed · 1 incomplete, excluded from the fraction
+```
+
+Never `4 of 5`, and never `3 of 5`.
+
+`groupExitCode` keeps its documented contract and gains one clause: an
+incomplete trial is not a pass, so a group containing one cannot exit 0. A
+group whose trials were *all* incomplete still exits 1 rather than 2 — `2`
+means nothing completed, and these completed.
+
+### 4. Testing — both tickets carry `tdd-required`
+
+Tests first, failing for their stated reasons before implementation.
+
+| area | what fails first |
+| -- | -- |
+| `scoreStatus` / `runScoreLine` | returns `"incomplete"`; the line names the count and contains neither `cannot pass` nor `un-evaluated` |
+| `pome run` exit | a 100/100 run with one abstention exits 1; a fully-evaluated 100/100 exits 0; a response with **no** `criteria_results` still exits by score alone (F3's compat, pinned) |
+| trial group | the fraction reads `3 of 4 passed · 1 incomplete`; `groupExitCode` is 1 with an incomplete trial present |
+| the shared rule | a test asserting `can_pass` is false for **one** skip — the statement that this and the cloud's `isRunIncomplete` are one rule (F2) |
+
+`grep` acceptance from F-932, as *strings*: `cannot pass` and `UNEVAL` gone;
+`scoreStatus` and `can_pass` still present.
+
+---
+
+## Done-when, mapped
+
+| bullet | where |
+| -- | -- |
+| F-932: a fully-covered task prints `PASS 100/100` | unchanged behaviour, pinned by a test |
+| F-932: an abstaining task prints `incomplete` with the count; neither surface says `passed` or `cannot pass` | §1 |
+| F-932 (rewritten): `cannot pass` / `UNEVAL` gone as strings; the guard survives | §1 |
+| F-932: CLI and cloud headlines never contradict | §1 + §2 — both now name the same state from the same rule |
+| F-925: CLI trial line reads `INCOMPLETE …`, never visually identical to a pass | §1 + §3 |
+| F-925: `pome run` exits non-zero on `incomplete` | §2 |
+| F-925: run-set reads `3 passed · 1 failed · 1 incomplete`, never `4 of 5` | §3 |
+
+---
+
+## Out of scope
+
+- **Publishing.** This ends at a merged PR plus a Changeset. Both tickets warn
+  that sibling twins tickets share ONE `@pome-sh/cli` publish and that it must be
+  cut last and deliberately; A3's lesson is that a seam ticket marked Done with
+  one attachment is half-shipped.
+- **A distinct exit code for `incomplete`** — §2, declined with reasons.
+- **Reading `all_skipped` / `criteria_breakdown`** — F2, actively harmful.
+- **Deleting `scoreStatus` / `can_pass`** — F-932's rewritten bullet 3.
+- **The zero-criteria corner** — F6, unreachable through the CLI's parser.


### PR DESCRIPTION
Executive summary: When a task's criteria cannot all be graded, `pome run` printed a scary `UNEVAL … (cannot pass)` next to `cloud score: 100/100` and then **exited 0**. The refusal was correct — a 100/100 over two of four criteria is not a verified pass — but it was worded as a verdict about the agent, it had no name the dashboard shared, and the exit code contradicted it. This renames the state, rewrites the copy, and makes the exit code agree. Reviewers: the one behaviour change users will feel is `pome run` now exiting 1 on an ungraded run — see **Notes**.

## What

- `ScoreStatus`'s third value is `incomplete`; the `UNEVAL` label becomes `INCOMPLETE` in both `pome run` and `pome eval`.
- The score line leads with the count and drops `cannot pass`:
  `score: incomplete — 2 of 4 criteria not evaluated; 2 passed, 0 failed, 2 skipped, 0 errored; cloud score: 100/100`
- **`pome run` exits 1 on an incomplete run**, via the same `scoreStatus` guard `pome eval` has always used.
- A trial group gains a third verdict. Five trials with one abstention read `3 of 4 passed · 1 incomplete, excluded from the fraction`, and the group cannot exit 0 while a trial went ungraded.

## Why

F-932, plus F-925's CLI half. Found in a CLI-door cold walk: a first-run user saw a refusal and a perfect score side by side with no way to know which to believe. Underneath it is the same principle the dashboard now applies — a criterion the grader could not run is not the agent's failure, and a run holding one is neither green nor red.

## Notes for reviewer

**What deliberately did NOT change: the guard.** `scoreStatus` and `can_pass` keep their logic byte-for-byte. They are the A5 inflation guard — the one place the CLI refuses to turn a partial run into a pass — and the ticket that asked for this change was explicit that deleting them would remove the only thing preventing the inflation the work exists to stop. Only the *name*, the *copy*, and the *exit code* moved.

**`can_pass` was already right, which is why this is small.** `scoreFromFinalizeResponse` has always used `skipped === 0` — one abstention is enough. The CLI was applying the correct rule before this PR and disagreeing with nothing except its own exit code.

**On retiring the exit-code divergence.** `pome run` mapped the raw score to an exit code, documented as a deliberate divergence from `pome eval`, justified by older cloud builds that return no per-criterion results. That case is already handled one layer down: `scoreFromFinalizeResponse` marks such a response gradable (`hasCriteriaResults ? … : true`), so the guard is a no-op for exactly those builds and the verdict falls back to the raw score on its own. The divergence was protecting a case its own helper already protected. There is a test pinning that fallback so it cannot rot.

**Why the trial group carries a `verdict` instead of re-deriving one.** `exitCode` cannot express three states — `1` means both "failed" and "could not be graded" — so the group needs more than the number. It reads the verdict `runTaskHosted` already computed rather than calling `scoreStatus` a second time on the same inputs, which is what keeps a trial line and a single-run headline for the same run from ever disagreeing. This surfaced a test fixture that had been mocking `exitCode: 0` on a sub-threshold score; it is now self-consistent.

**Exit code `1`, not a new code.** `pome eval` has shipped `1` for this state, and `2` is documented as "nothing completed", so widening it would break a meaning the group contract depends on. The cost, stated plainly: **a CI pipeline cannot tell "the agent regressed" from "we could not grade it".** A distinct code would answer that better, but exit codes are public API and that is its own decision, not a side effect of this one.

## Tests / CI

Written **test-first** — 9 tests failed for their stated reasons before any implementation, including one that reproduced the forbidden `4 of 5 passed` verbatim.

- `npm run typecheck --workspaces` — clean (after `npm run build`, which the packages require)
- `npm run lint` and all eight gate scripts — `lint:no-cloud-imports`, `lint:no-catch`, `lint:copy-markers`, `lint:code-health`, `lint:twin-registration`, `lint:legacy-markers`, `lint:cli-pins`, `lint:dead-code` — pass
- Full CLI suite diffed against a **clean-tree baseline**: no new failures. The remaining failures fail identically on `main` (environment-dependent e2e that spawn processes).
- New: `cli/test/unit/hosted/incompleteVerdict.test.ts`, plus group-render, trial-group and hosted-e2e cases.

Grep acceptance: `UNEVAL` and `cannot pass` are gone as emitted strings — the only remaining occurrences are comments quoting the old copy and the negative assertions that enforce its removal. `scoreStatus` and `can_pass` are still present.

## Review required

**Yes — public OSS API.** `pome run`'s exit code is a contract users script against, and this changes it from score-only to the A5 guard. A run that previously exited 0 with ungraded criteria now exits 1. That is the intended fix, and it is the thing to disagree with if anyone is going to.

Ships behind a changeset (`@pome-sh/cli` minor). **Not published here** — the publish is cut separately and deliberately, so sibling work does not ride along with it.