### PR TITLE
docs(cli): exit 1 now also means INCOMPLETE, and the group rule moved with it

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -64,22 +64,30 @@ code is the verdict**. Gate CI on it directly.
 | Exit code | Meaning |
 | --- | --- |
 | `0` | pass (hosted/scored run), or trace captured (`--local`, not scored) |
-| `1` | ran and scored **below** the pass threshold |
+| `1` | ran and scored **below** the pass threshold, **or ran `INCOMPLETE`** |
 | `2` | twin / orchestration error (network, 5xx, twin spawn failed) |
 | `3` | auth error (401/403) — `pome login` again, or set `POME_API_KEY` in CI |
 | `4` | quota exceeded (402/429) |
 | `5` | usage error (bad flags, missing task file) |
 
-Two rules CI must honor:
+Three rules CI must honor:
 
 - **`--local` is not a verdict.** A `--local` run captures a raw trace and never
   scores, so its exit `0` means "trace captured," not "passed." Never gate CI on
   a `--local` exit code — score it later with `pome eval <run-dir>`.
+- **`INCOMPLETE` shares exit `1`, and it is not the agent's failure.** A run
+  whose criteria could not all be graded exits `1` rather than mapping its
+  partial score to a code — a run whose checks never ran is not a green CI
+  signal. The cost is stated rather than hidden: **`1` cannot tell "the agent
+  regressed" from "we could not grade it."** Read the verdict word printed
+  beside the score (`INCOMPLETE` vs a sub-threshold number) to separate them.
 - **Trial groups map as a whole.** `pome run -n k` (k>1) collapses the whole
   group to one code: `0` = at least one trial completed and every completed
-  trial passed; `1` = at least one completed trial failed its threshold; `2` =
-  no trial completed. Errored trials are excluded from the verdict fraction and
-  never drag a passing group below `0` on their own.
+  trial passed; `1` = at least one completed trial failed its threshold **or was
+  incomplete**; `2` = no trial completed. Errored and incomplete trials are
+  excluded from the verdict fraction (`3 of 4 passed · 1 incomplete`) so neither
+  is counted as a pass nor charged to the agent as a loss — but a group holding
+  one cannot exit `0`.
 
 ## Development
 


### PR DESCRIPTION
Executive summary: #280 changed what `pome run`'s exit code means and the published exit-code contract did not move with it. `cli/README.md` is the **npm package README**, so this has to land before #281 merges or `@pome-sh/cli@0.18.0` ships to npm carrying the pre-#280 contract on its package page.

## What

`cli/README.md` — "CI one-shot — the exit-code contract":

- Row `1` gains `, **or ran `INCOMPLETE`**`.
- A new rule between the two existing ones, naming the cost rather than hiding it: **exit `1` cannot tell "the agent regressed" from "we could not grade it"** — read the verdict word beside the score to separate them. #280's own PR body states this cost; nothing user-facing said it.
- The trial-group rule gains the case #280 added: `1` = a completed trial failed its threshold **or was incomplete**; incomplete trials are excluded from the fraction (`3 of 4 passed · 1 incomplete`) but a group holding one cannot exit `0`.

Verified against the shipped code, not the PR prose — `groupRender.ts:159-169` (`completed.every(r => r.verdict === "pass") ? 0 : 1`, with `2` reserved for "nothing completed") and `runTrialGroup.ts:253-260` (the trial carries the verdict out rather than re-deriving it from `exitCode`).

## Why

Milestone B3 — *the report doesn't overstate what it checked*. F-1029 repaired three shipped surfaces that claimed more grading coverage than they had; F-932 then shipped a behaviour change that opened a fourth of the same shape on the way out. The sibling copy in pome-cloud (`apps/docs/docs/cli/index.mdx`, which is what `docs.pome.sh` serves) is fixed in pome-cloud in the same window.

## Notes for reviewer

- **No changeset, deliberately.** This documents a behaviour change that already carries one (`cli/.changeset/the-third-state-is-called-incomplete.md`). Adding a second would split one user-visible change across two release notes.
- **The version-bump gate does not fire.** `check-cli-version-bump.sh` triggers on `cli/src/**`, `cli/vendor/**`, or a moved `@pome-sh/*` bundled pin. This touches none of them — confirmed by reading the guard, not by assuming.
- **Merge order matters and is the point of the PR.** This → then #281. Merging it after would leave 0.18.0's npm page wrong until 0.19.0.

## Tests / CI

Documentation only; no source, no test, no pin. CI's own checks apply unchanged.

Refs F-932, F-925.