### PR TITLE
`github.no-new-issues` — the curriculum's hero lesson becomes gradable (F-1198)

### DIFF
--- a/cli/.changeset/curly-moons-grin.md
+++ b/cli/.changeset/curly-moons-grin.md
@@ -1,0 +1,9 @@
+---
+"@pome-sh/cli": minor
+---
+
+`pome checks github` lists `github.no-new-issues`, so `pome checks add --check github.no-new-issues --arg repo=<owner>/<name>` can write the sentence.
+
+The pin carries `@pome-sh/twin-github` 0.8.0 → 0.9.0. Without this half the CLI would know one fewer check than prod serves, which is F-1132 exactly: for six hours every `pome checks add --check github.*` refused with exit 2 while cli-ci was green on the commit that caused it.
+
+What the new check says: *No new issues were created in `<repo>`* — a seed→final delta over issue NUMBERS. It is what `github.issue-exists` cannot say, and the curriculum's hero lesson ("do not open a duplicate for a bug already tracked") had no deterministic way to be graded without it.

--- a/cli/package.json
+++ b/cli/package.json
@@ -68,7 +68,7 @@
     "@pome-sh/sdk": "0.11.0",
     "@pome-sh/shared-types": "0.14.0",
     "@pome-sh/twin-gmail": "0.3.2",
-    "@pome-sh/twin-github": "0.8.2",
+    "@pome-sh/twin-github": "0.9.0",
     "@pome-sh/twin-linear": "0.3.2",
     "@pome-sh/twin-slack": "0.3.2",
     "@pome-sh/twin-stripe": "0.4.3",

--- a/packages/twin-github/CHANGELOG.md
+++ b/packages/twin-github/CHANGELOG.md
@@ -1,6 +1,41 @@
 # @pome-sh/twin-github — CHANGELOG
 
 
+## 0.9.0 — 2026-08-04
+
+`No new issues were created in \`<repo>\`` is declarable, and the curriculum's
+hero lesson can be graded deterministically for the first time (F-1198).
+
+- **`github.no-new-issues`.** A `seed+final` delta over issue NUMBERS, negative
+  polarity, no subject, no vacuity mutant — the exact sibling of
+  `github.no-new-labels`, down to the "the repo is a selector" entry in the
+  honest-null ledger. It fails when the final state carries an issue number the
+  seed did not.
+- **Why it exists.** `examples/support-triage` teaches *"do not open a second
+  issue for a bug that is already tracked"* and, until this, the vocabulary had
+  no way to say that: `github.issue-exists` is positive-only and
+  `github.issue-state` FAILS on a missing issue, so neither can be turned around
+  into an absence. The lesson was graded by `[model]`, which meant an agent that
+  commented on the right issue, posted the right link **and also filed a
+  duplicate** scored 100. That is τ-bench's necessary-but-not-sufficient caveat,
+  which `docs/curriculum/failure-classes.md` §4.2 names as a rule we follow.
+- **Numbers, not titles.** A duplicate issue is the one that looks most like what
+  it duplicates — same title, same body, same labels. The number is the only
+  field an examinee cannot choose, so it is the only honest key for the delta. A
+  row carrying no usable number is dropped rather than counted: `NaN` compares
+  unequal to itself and would read as a newly created issue on every run.
+- **What it does NOT assert.** Anything about the seeded issues themselves.
+  Closing one, relabelling one and commenting on one all PASS — pair it with
+  `github.issue-state` or `github.issue-comment-contains` when those matter. The
+  green half of the hero lesson (comment on #1 instead of opening #2) has its own
+  test for exactly this reason: a negative that only "the agent did nothing" can
+  satisfy is not a check, it is a trap.
+- **It cites, on both arms** (F-1197's rule, so `HONEST_UNCITED_CHECKS` stays
+  empty): the pointer is the FINAL issue list, the collection a reader can count
+  for themselves, and the reason carries the comparison. Like `no-new-labels`, a
+  seed-side repo miss cites nothing — a pointer addresses `final`, and one walked
+  in the seed would send a reader into a tree no report renders.
+
 ## 0.8.2 — 2026-08-04
 
 - Re-pinned to `@pome-sh/sdk@0.11.0` / `@pome-sh/shared-types@0.14.0` for the F-1200 parent-vocabulary

--- a/packages/twin-github/package.json
+++ b/packages/twin-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-github",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Deterministic GitHub-shaped twin for agent testing \u2014 REST + MCP, SQLite-backed state.",
   "private": false,
   "type": "module",

--- a/packages/twin-github/src/check-repos.ts
+++ b/packages/twin-github/src/check-repos.ts
@@ -8,7 +8,7 @@
 
 import { childStatePath, defineCheck, repoRef, VACUITY_SENTINEL } from "@pome-sh/sdk/checks";
 import { commitStatusState, filePath, statusContext } from "./check-params.js";
-import { labelNames, missOutcome, resolveRepo } from "./check-state.js";
+import { issueNumbers, labelNames, missOutcome, resolveRepo } from "./check-state.js";
 import { deltaWorld, finalWorld, repoState } from "./check-worlds.js";
 import type { Check } from "./check-kind.js";
 
@@ -90,6 +90,98 @@ export const noNewLabels: Check<{ repo: string }> = defineCheck({
       passed: false,
       reason: `labels created in ${repo}: ${created.map((name) => `\`${name}\``).join(", ")}`,
       evidenceStatePaths: definitions,
+    };
+  },
+});
+
+// F-1198. The sibling of `noNewLabels`, and it exists because the curriculum's
+// hero lesson could not be graded without it: `support-triage` teaches "do not
+// open a second issue for a bug that is already tracked", and until this check
+// the only way to say that was `[model]`. An agent that comments on the right
+// issue, posts the right link, AND ALSO files a duplicate scored 100 — which is
+// τ-bench's necessary-but-not-sufficient caveat arriving in our own catalog
+// (`docs/curriculum/failure-classes.md` §4.2, which names the rule we were
+// breaking).
+//
+// Modelled on `noNewLabels` rather than invented: same delta substrate, same
+// negative polarity, same "the repo is a selector" mutant argument. The one
+// difference worth stating is WHAT is compared. Labels compare NAMES because a
+// label is identified by its name; issues compare NUMBERS, because the number is
+// the only field an examinee cannot choose — a duplicate issue may carry the
+// same title, body and labels as the one it duplicates, and comparing any of
+// those would let a duplicate hide behind its own likeness.
+export const noNewIssues: Check<{ repo: string }> = defineCheck({
+  id: "github.no-new-issues",
+  description:
+    "Compares the issue NUMBERS present in the seed against the final state, and fails when " +
+    "finish carries one the seed did not. Numbers, not titles: a duplicate issue usually " +
+    "carries the same title as the one it duplicates. It says nothing about what happened to " +
+    "the seeded issues — closing, relabelling or commenting on one all PASS this check, so " +
+    "pair it with `github.issue-state` or `github.issue-comment-contains` when those matter. " +
+    "Its natural use is the inverse of `github.issue-exists`: a task whose examinee must " +
+    "recognise that an issue already exists and NOT open another. Needs the seed: it is a " +
+    "delta, not a state assertion.",
+  // The repo is named for `noNewLabels`'s reason, one step stronger: without it
+  // the sentence reads as a claim about the whole world, and issue numbers are
+  // per-repository — `#2` in one repo has nothing to do with `#2` in another.
+  template: "No new issues were created in `{repo}`",
+  params: { repo: repoRef },
+  substrate: "seed+final",
+  // Passes on the untouched seed; only the examinee acting can break it.
+  polarity: () => "negative",
+  // Nothing is hunted inside free text, so there is nothing a redactor could
+  // delete out from under this check.
+  subject: () => null,
+  // Same admission `noNewLabels` makes: the repo SELECTS, it is not a scanned
+  // literal. Falsifying it moves the verdict to "repo not found" for a reason
+  // that never reaches the comparison — a clean bill this check did not earn.
+  vacuityMutant: () => null,
+  discriminatingWorlds: () => ({
+    passing: deltaWorld(
+      repoState({ issues: [{ number: 1 }] }),
+      repoState({ issues: [{ number: 1 }] }),
+    ),
+    failing: deltaWorld(
+      repoState({ issues: [{ number: 1 }] }),
+      repoState({ issues: [{ number: 1 }, { number: 2 }] }),
+    ),
+  }),
+  evaluate({ repo }, { seed, final }) {
+    // The engine guards this before calling; guarding here too means a consumer
+    // that forgets gets a named skip rather than a vacuous pass.
+    if (seed === null) return { passed: false, reason: "seed_missing", status: "skipped" };
+
+    // The seed-side refusal cites nothing, for the reason `noNewLabels` states
+    // at the same line: a pointer always addresses `final`, so handing back one
+    // the lookup walked in the SEED would send a reader into a tree the report
+    // never renders. The reason still names the miss.
+    const seedRepo = resolveRepo(seed, repo, "the seed state");
+    if ("missing" in seedRepo) return missOutcome({ ...seedRepo, searched: undefined });
+    const finalRepo = resolveRepo(final, repo, "state_final");
+    if ("missing" in finalRepo) return missOutcome(finalRepo);
+
+    const before = issueNumbers(seedRepo.found);
+    const created = [...issueNumbers(finalRepo.found)]
+      .filter((number) => !before.has(number))
+      .sort((a, b) => a - b);
+    // The final issue LIST, not the rows that broke it — the same citation
+    // `noNewLabels` makes and for the same reason. The delta is computed from
+    // two trees and the reader has one on screen, so the honest pointer is the
+    // collection they can count for themselves; the reason carries the
+    // comparison. On a failure it is also the only pointer that resolves: the
+    // numbers named in the reason are exactly the rows the seed does not have.
+    const issues = [childStatePath(finalRepo.path, "issues")];
+    if (created.length === 0) {
+      return {
+        passed: true,
+        reason: `no issues were created in ${repo} (${before.size} at seed, unchanged at finish)`,
+        evidenceStatePaths: issues,
+      };
+    }
+    return {
+      passed: false,
+      reason: `issues created in ${repo}: ${created.map((number) => `#${number}`).join(", ")}`,
+      evidenceStatePaths: issues,
     };
   },
 });

--- a/packages/twin-github/src/check-state.ts
+++ b/packages/twin-github/src/check-state.ts
@@ -136,6 +136,21 @@ export function findRepo(
   return null;
 }
 
+// The issue NUMBERS a repository export carries. `github.no-new-issues` compares
+// these across the seed/final delta, and it compares numbers rather than titles
+// for the reason its own description states: a duplicate issue usually carries
+// the same title as the one it duplicates, so any human-authored field would let
+// the duplicate hide behind its own likeness. A row with no usable number is
+// dropped rather than counted as `NaN`, which would compare unequal to itself
+// and read as a newly created issue on every run.
+export function issueNumbers(repo: GitHubCheckStateRepo): Set<number> {
+  const numbers = new Set<number>();
+  for (const issue of repo.issues ?? []) {
+    if (typeof issue.number === "number" && Number.isFinite(issue.number)) numbers.add(issue.number);
+  }
+  return numbers;
+}
+
 export function labelNames(repo: GitHubCheckStateRepo): Set<string> {
   const names = new Set<string>();
   for (const label of repo.labels ?? []) {

--- a/packages/twin-github/src/checks.ts
+++ b/packages/twin-github/src/checks.ts
@@ -58,7 +58,7 @@ import {
   pullRequestReviewExists,
   pullRequestStateCheck,
 } from "./check-pulls.js";
-import { commitStatus, fileExists, noNewLabels } from "./check-repos.js";
+import { commitStatus, fileExists, noNewIssues, noNewLabels } from "./check-repos.js";
 import { noUnsupportedEndpoint, toolNeverCalled } from "./check-tape.js";
 
 export type { Check } from "./check-kind.js";
@@ -86,6 +86,10 @@ export const GITHUB_CHECKS = [
   issueExactlyOneLabel,
   issueAssignee,
   issueCommentContains,
+  // The two repo-scoped deltas sit together, right after the issue assertions
+  // they are the negatives of: `no-new-issues` is what `issue-exists` cannot
+  // say, and an author reaching for one usually wants to see the other.
+  noNewIssues,
   noNewLabels,
   pullRequestStateCheck,
   pullRequestCommentExists,

--- a/packages/twin-github/test/checks-contract.test.ts
+++ b/packages/twin-github/test/checks-contract.test.ts
@@ -31,6 +31,7 @@ const CHECKS = GITHUB_CHECKS as readonly unknown[] as readonly OpenCheck[];
 // with no fixture fails rather than silently skipping every property here.
 const FIXTURES: Record<string, Record<string, string>> = {
   "github.no-new-labels": { repo: "acme/api" },
+  "github.no-new-issues": { repo: "acme/api" },
   "github.issue-exists": { issue: "1", repo: "acme/api" },
   "github.issue-state": { issue: "1", repo: "acme/api", state: "closed" },
   "github.issue-has-label": { issue: "1", repo: "acme/api", label: "bug" },
@@ -62,6 +63,12 @@ const FIXTURES: Record<string, Record<string, string>> = {
 //      is worth paying — but it must be admitted, not hidden.
 const HONEST_NULL_MUTANTS: Record<string, string> = {
   "github.no-new-labels": "the repo is a selector, not a scanned literal",
+  // F-1198, and it is argument 1 verbatim — same shape as its sibling above.
+  // The repo is the only slot and it purely selects; falsifying it early-returns
+  // "repo not found" on every seed, so the number comparison never runs. There is
+  // no second slot to falsify because the assertion is a set difference, not a
+  // literal hunted inside state.
+  "github.no-new-issues": "the repo is a selector, not a scanned literal",
   "github.issue-state": "the state is a closed set; the issue number only selects",
   "github.pr-state": "the state is a closed set; the PR number only selects",
   "github.pr-review-exists": "the review state is a closed set; the PR number only selects",

--- a/packages/twin-github/test/checks-predicates.test.ts
+++ b/packages/twin-github/test/checks-predicates.test.ts
@@ -492,6 +492,7 @@ describe("every check, against a repo that is not in the state", () => {
       "github.issue-assignee": { issue: "1", repo: "acme/missing", login: "alice" },
       "github.issue-comment-contains": { needle: "x", issue: "1", repo: "acme/missing" },
       "github.no-new-labels": { repo: "acme/missing" },
+      "github.no-new-issues": { repo: "acme/missing" },
       "github.pr-state": { pr: "1", repo: "acme/missing", state: "merged" },
       "github.pr-comment-exists": { pr: "1", repo: "acme/missing" },
       "github.pr-review-exists": { review: "APPROVED", pr: "1", repo: "acme/missing" },

--- a/packages/twin-github/test/checks.test.ts
+++ b/packages/twin-github/test/checks.test.ts
@@ -11,6 +11,9 @@ type OpenCheck = CheckDefinition<GitHubCheckState, Record<string, string>>;
 const noNewLabels = (GITHUB_CHECKS as readonly unknown[] as readonly OpenCheck[]).find(
   (check) => check.id === "github.no-new-labels",
 )!;
+const noNewIssues = (GITHUB_CHECKS as readonly unknown[] as readonly OpenCheck[]).find(
+  (check) => check.id === "github.no-new-issues",
+)!;
 
 function state(labels: string[]): GitHubCheckState {
   return {
@@ -20,6 +23,28 @@ function state(labels: string[]): GitHubCheckState {
         name: "api",
         full_name: "acme/api",
         labels: labels.map((name) => ({ name })),
+      },
+    ],
+  };
+}
+
+// The issue-side counterpart. Rows carry the extra fields a real export does, so
+// a predicate that reached for `title` or `state` would compile here and then
+// disagree with production — the same trap the fixture comment in
+// `checks-predicates.test.ts` names.
+function issueState(numbers: number[]): GitHubCheckState {
+  return {
+    repositories: [
+      {
+        owner: "acme",
+        name: "api",
+        full_name: "acme/api",
+        issues: numbers.map((number) => ({
+          number,
+          state: "open",
+          labels: [{ name: "bug" }],
+          assignees: [],
+        })),
       },
     ],
   };
@@ -123,5 +148,146 @@ describe("github.no-new-labels — predicate", () => {
   it("tolerates a state export with no labels key at all", () => {
     const bare: GitHubCheckState = { repositories: [{ full_name: "acme/api" }] };
     expect(noNewLabels.evaluate(ARGS, { seed: bare, tape: null, final: bare }).passed).toBe(true);
+  });
+});
+
+// F-1198 — the sibling. It exists because `support-triage` teaches "do not open
+// a duplicate" and, until it, the only way to grade that was `[model]`. The
+// tests below are its counterpart to the block above, plus the two that are
+// specific to issues rather than labels: the duplicate-with-the-same-title case
+// (which is why the comparison is on numbers) and the case where the examinee
+// does the RIGHT thing to a seeded issue.
+describe("github.no-new-issues — declaration", () => {
+  it("renders the sentence an author will pick", () => {
+    expect(renderCheck(noNewIssues, ARGS)).toBe("No new issues were created in `acme/api`");
+  });
+
+  it("binds that sentence back to its args", () => {
+    expect(parseCheck(noNewIssues, "No new issues were created in `acme/api`")).toEqual(ARGS);
+  });
+
+  it("declares negative polarity — it can only be broken by the examinee", () => {
+    expect(noNewIssues.polarity(ARGS)).toBe("negative");
+  });
+
+  it("declares that it needs the seed — it is a delta, not a state assertion", () => {
+    expect(noNewIssues.substrate).toBe("seed+final");
+  });
+
+  it("declares no vacuity mutant: the repo is a selector, not a scanned literal", () => {
+    expect(noNewIssues.vacuityMutant(ARGS)).toBeNull();
+  });
+
+  it("declares no subject: nothing here is a literal a redactor could delete", () => {
+    expect(noNewIssues.subject?.(ARGS) ?? null).toBeNull();
+  });
+
+  it("does not claim the sentence `github.issue-exists` owns", () => {
+    expect(parseCheck(noNewIssues, "Issue #1 exists in `acme/api`")).toBeNull();
+  });
+});
+
+describe("github.no-new-issues — predicate", () => {
+  it("passes when the issue set is untouched", () => {
+    const outcome = noNewIssues.evaluate(ARGS, {
+      seed: issueState([1]),
+      tape: null,
+      final: issueState([1]),
+    });
+    expect(outcome.passed).toBe(true);
+  });
+
+  // Also THE reason this check compares numbers. A duplicate issue is, by
+  // definition, the one that looks most like what it duplicates — same state,
+  // same labels, and in the hero example the same title too.
+  // `GitHubCheckStateIssue` does not even model `title`, which is itself the
+  // point: every field a reader might reach for is one the examinee chose, and
+  // the number is the only one it cannot. `issueState` builds both issues
+  // identically on every modelled field, so this fails on the number alone — and
+  // the reason names only what was created, never the issue that was always there.
+  it("fails, naming only the created issue, on a duplicate identical on every modelled field", () => {
+    const outcome = noNewIssues.evaluate(ARGS, {
+      seed: issueState([1]),
+      tape: null,
+      final: issueState([1, 2]),
+    });
+    expect(outcome.passed).toBe(false);
+    expect(outcome.reason).toContain("#2");
+    expect(outcome.reason).not.toContain("#1");
+  });
+
+  // The green half of the hero lesson: the agent comments on the seeded issue
+  // instead of opening a second one. That MUST pass, or the check would grade
+  // "the agent did nothing" as the only way through.
+  it("passes when the examinee comments on a seeded issue instead of opening a new one", () => {
+    const final = issueState([1]);
+    final.repositories![0]!.issues![0]!.comments = [{ body: "Same bug re-reported in #support." }];
+    expect(noNewIssues.evaluate(ARGS, { seed: issueState([1]), tape: null, final }).passed).toBe(
+      true,
+    );
+  });
+
+  it("does not fail when an issue is CLOSED — the sentence says `new`", () => {
+    const final = issueState([1]);
+    final.repositories![0]!.issues![0]!.state = "closed";
+    expect(noNewIssues.evaluate(ARGS, { seed: issueState([1]), tape: null, final }).passed).toBe(
+      true,
+    );
+  });
+
+  it("does not fail when an issue DISAPPEARS — the sentence says `new`", () => {
+    const outcome = noNewIssues.evaluate(ARGS, {
+      seed: issueState([1, 2]),
+      tape: null,
+      final: issueState([1]),
+    });
+    expect(outcome.passed).toBe(true);
+  });
+
+  it("skips, named, when the seed is unavailable rather than passing vacuously", () => {
+    const outcome = noNewIssues.evaluate(ARGS, {
+      seed: null,
+      tape: null,
+      final: issueState([1]),
+    });
+    expect(outcome.status).toBe("skipped");
+    expect(outcome.reason).toBe("seed_missing");
+  });
+
+  it("fails when the named repo is absent from the state", () => {
+    const outcome = noNewIssues.evaluate(
+      { repo: "acme/other" },
+      { seed: issueState([1]), tape: null, final: issueState([1]) },
+    );
+    expect(outcome.passed).toBe(false);
+    expect(outcome.reason).toContain("acme/other");
+  });
+
+  // A seed with no issues at all is the ordinary case for a "the agent must not
+  // file anything" task, and the empty-set delta has to behave — an empty
+  // `before` must not make every final issue invisible or every final issue new
+  // by accident.
+  it("passes on a repo with no issues on either side", () => {
+    const bare: GitHubCheckState = { repositories: [{ full_name: "acme/api" }] };
+    expect(noNewIssues.evaluate(ARGS, { seed: bare, tape: null, final: bare }).passed).toBe(true);
+  });
+
+  it("fails when the examinee files the first issue into an empty repo", () => {
+    const bare: GitHubCheckState = { repositories: [{ full_name: "acme/api" }] };
+    const outcome = noNewIssues.evaluate(ARGS, { seed: bare, tape: null, final: issueState([1]) });
+    expect(outcome.passed).toBe(false);
+    expect(outcome.reason).toContain("#1");
+  });
+
+  // A row with no usable number is DROPPED, not counted. Counting it would add
+  // `NaN` to the set, and `NaN !== NaN`, so a malformed row in the final state
+  // would read as a newly created issue on every single run — a false red that
+  // no examinee could ever clear.
+  it("ignores a malformed issue row rather than reading it as a new issue", () => {
+    const final = issueState([1]);
+    final.repositories![0]!.issues!.push({ state: "open" });
+    expect(noNewIssues.evaluate(ARGS, { seed: issueState([1]), tape: null, final }).passed).toBe(
+      true,
+    );
   });
 });


### PR DESCRIPTION
## What this fixes

`examples/support-triage` is the M0/M1 hero — the paste-prompt runs it, so it is the first report a new user ever sees. Its lesson is one sentence: **do not open a second issue for a bug that is already tracked.**

Until this PR the declared vocabulary could not say that. `list_checks(twin="github")` returned 14 checks, and the only negatives among them were `no-new-labels` (label definitions), `tool-never-called` (slot typed to `create_commit_status | create_check_run`) and `no-unsupported-endpoint`. `github.issue-exists` is positive-only, and `github.issue-state` **fails** on a missing issue, so neither can be turned around into an absence.

So the lesson was graded by `[model]`, and the example's only `[code]` criterion was `slack.message-contains "issues/1"`. **An agent that comments on the right issue, posts the right link and also files a duplicate scores 100.** Not hypothetical — `examples/support-triage/VERIFICATION.md` records v2 doing exactly that on 1 of 5 trials.

That is τ-bench's necessary-but-not-sufficient caveat, which `docs/curriculum/failure-classes.md` §4.2 names as a rule we follow: *"Assert the absence of forbidden writes, not just the presence of required ones."*

## What landed

`github.no-new-issues` — *"No new issues were created in \`{repo}\`"*, `substrate: "seed+final"`, negative polarity, no subject, no vacuity mutant. Built as the exact sibling of `github.no-new-labels`, down to its line in `HONEST_NULL_MUTANTS` ("the repo is a selector, not a scanned literal").

**Numbers, not titles.** A duplicate issue is by definition the one that looks most like what it duplicates — same title, same body, same labels. The number is the only field an examinee cannot choose. `GitHubCheckStateIssue` does not model `title` at all, which is the same argument from the other side. A row carrying no usable number is *dropped* rather than counted: `NaN !== NaN`, so counting it would read as a newly created issue on every single run — a false red no examinee could clear.

**What it deliberately does not assert:** anything about the seeded issues themselves. Closing one, relabelling one, commenting on one all PASS. Pair it with `github.issue-state` or `github.issue-comment-contains` when those matter. There is a test for exactly this — the green half of the hero lesson is "comment on #1 instead of opening #2", and a negative that only *"the agent did nothing"* can satisfy is a trap, not a check.

## Reviewer notes

* **The CLI pin travels in this PR on purpose.** `lint:cli-pins` requires it and its own message explains why: F-1132 left prod serving 12 GitHub checks while the published CLI knew 11, and every `pome checks add --check github.*` refused with exit 2 for six hours while cli-ci was green on the commit that caused it. The changeset is what makes the re-pin actually reach users.
* **pome-cloud needs a pin bump and no code change.** `bind.ts` binds against the declaration itself since F-1131, so `apps/control-plane/package.json`'s `@pome-sh/twin-github` `0.8.0` → `0.9.0` is the whole integration. That is a separate PR; nothing here depends on it.
* `packages/twin-github` 0.8.0 → **0.9.0** — a vocabulary addition, matching how 0.4.0 (F-1075's ten checks) and 0.8.0 (F-1151's one) were cut.
* `test/checks-predicates.test.ts` has a **second, local** fixtures table (the missing-repo loop) with no coverage assertion of its own — a new check silently gets `{}`. It caught mine anyway, because `repo undefined` fails the "names the missing repo" assertion. Worth a coverage assertion someday; not this PR.

## Verification

```
packages/twin-github    32 files, 401 tests   pass
npm run typecheck       clean
npm run test:contract   9 suites, 104 pass, 0 fail
lint:cli-pins           7 pins match
lint:code-health / lint:twin-registration / lint:legacy-markers   pass
```

Found by the M4a/M4b ticket audit — it was in no ticket before today, and it is now M4b's stated blocker on F-979's `verified red` stamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)