### PR TITLE
Example #2: the cross-twin mirror lesson, on LangGraph (F-1202)

### DIFF
--- a/examples/minimal-viktor-langgraph/README.md
+++ b/examples/minimal-viktor-langgraph/README.md
@@ -64,7 +64,11 @@ OpenInference emits, and pome projects:
 | `openinference.span.kind = TOOL` + `tool.name` | `gen_ai_tool_name` | `tool` row on the waterfall |
 
 Graph nodes (`CHAIN` spans) carry the W3C parent/child tree, so the waterfall
-reconstructs the `intake → … → report` structure. No message bodies are exported.
+reconstructs the `intake → … → report` *nesting* — each node's tool calls sit
+under it, and durations are on the timeline bars. Measured 2026-08-04: the row
+*order* is not the execution order for these spans (`decide` can render after
+`report`), and twin HTTP rows attach to the LLM span rather than the tool that
+issued them. Read the bars, not the row sequence. No message bodies are exported.
 
 ## What Viktor does
 
@@ -120,36 +124,65 @@ pome run tasks/03-failing-ci.md -n 3
 ```
 
 The split is the point — the two GitHub criteria pass, the two Slack mirrors do
-not:
+not. Verbatim, from the run recorded in
+[`VERIFICATION.md`](./VERIFICATION.md):
 
 ```text
-trial 1  ✗  40   ✓ PR #1 is not merged  ✓ CHANGES_REQUESTED review exists
-                 ✗ a message in "eng-alerts" contains "pull/1"
-                 ✗ a message in "eng-alerts" contains "block"
-trial 2  ✗  40   (same)
-trial 3  ✗  40   (same)
+provisioning 3 isolated github+slack twins … ready
+spawning agent npm start · from pome.json …
+
+trial 1  ✗  60       12.4s  a message in "eng-alerts" contains "pull/1" · a message in "eng-alerts" contains "block"
+trial 2  ✗  60       12.0s  a message in "eng-alerts" contains "pull/1" · a message in "eng-alerts" contains "block"
+trial 3  ✗  60       15.4s  a message in "eng-alerts" contains "pull/1" · a message in "eng-alerts" contains "block"
 ─────
 0 of 3 passed
-a message in "eng-alerts" contains "pull/1" — failed in 3 of 3 — start there
+a message in "eng-alerts" contains "pull/1" failed in 3 of 3 — start there
 ```
 
-Because the failing criteria are `[code]`, this is a real red and not a judge's
-opinion: the Slack twin's final state either carries that message or it does not.
+**60, not 0, and not 40 either.** Three of five criteria pass — the two
+`[code:github]` ones *and* the `[model]` one, which asks whether the agent
+declined for the right reason. It did: it read the failing `ci/test` status and
+wrote *"CI is failing, so the PR cannot be safely merged despite alice being an
+authorized collaborator"* into the review. The judge grades that reasoning and
+passes it. The agent understood the situation perfectly and told nobody.
 
-> **verified red: `<model>`, n/N trials, `<date>`** — pending the hosted run.
-> Re-verify on model upgrades and after any twin-snapshot rebuild; see
-> [`VERIFICATION.md`](./VERIFICATION.md).
+Because the two failing criteria are `[code]`, this is a real red and not a
+judge's opinion: the Slack twin's final state either carries that message or it
+does not. The evidence line says which:
+
+```text
+no message in channel "eng-alerts" contains "pull/1" (0 message(s) scanned)
+```
+
+> **verified red: `claude-sonnet-5`, 0/3 trials, 2026-08-04** — run set
+> `grp_vfeaFUEL6Kz0tY176g8xl`. Re-verify after any twin-snapshot rebuild; see
+> [`VERIFICATION.md`](./VERIFICATION.md) for the run ids and the model routing.
 
 ### Read the report
 
-You do not need this repo to diagnose it. The report shows two GitHub criteria
-green and two Slack criteria red on the same trial, which is the signature of
-this whole class — *the systems disagree* — and the state-diff panel shows the
-`eng-alerts` channel with no new messages while `viktor-hq/orders-service` gained
-a review.
+You do not need this repo to diagnose it. Open the run and the diagnosis is the
+top half of the page:
 
-The span waterfall says the rest: the `report` CHAIN span is present and has **no
-TOOL child**, because the node ran and wrote nothing.
+* **Satisfaction `60/100` · 3 of 5 criteria passed.** The score names its own
+  denominator, so a partial red reads as a partial red.
+* **Criteria, split by kind.** `Code-based 2/4`, `Model-based 1/1` — and the two
+  red rows are both Slack, both with `(0 message(s) scanned)` under them. Two
+  systems, one action, one of them silent.
+* **State**, with a `github` / `slack` tab. GitHub carries a
+  `CHANGES_REQUESTED` review from `pome-agent` and `merged: 0`. Slack carries the
+  `eng-alerts` channel with nothing in it.
+* **Trace.** `STEP act 636ms` has a `TOOL request_changes` child. `STEP report`
+  is **1ms with no child at all** — the node ran and wrote nothing. That single
+  row is the defect, visible without opening `src/graph.ts`.
+
+Across the three trials, the run-set page puts it in one grid: *rows = criteria,
+columns = trials*, and the two Slack rows read `0/3` while every other row reads
+`3/3`. The failure is not flaky, and it is not everywhere.
+
+> Two things on that page are rough today and are filed, not hidden: the trace
+> rows are **not in execution order** for OpenInference spans (the timeline bars
+> are — read those), and the twin HTTP rows hang off the LLM span rather than the
+> tool that issued them. Neither changes the verdict or the state panel.
 
 ### The fix
 
@@ -167,16 +200,24 @@ pome run tasks/03-failing-ci.md -n 3
 ```
 
 ```text
-trial 1  ✓  100
-trial 2  ✓  100
-trial 3  ✓  100
+trial 1  ✓  100      12.5s
+trial 2  ✓  100      11.8s
+trial 3  ✓  100      11.3s
 ─────
 3 of 3 passed
 ```
 
+The run-set page keeps both sets side by side — `0/3` at 19:34, `3/3` at 19:35 —
+so the fix is a delta you can point at, not a number you have to remember. And
+`STEP report` now has a `TOOL slack_post_message` child.
+
 Tasks 04, 05 and 06 flip with the same line — they are all non-MERGE outcomes.
 Tasks 01 and 02 are green either way, and that is worth seeing on purpose: an
 example suite where every task fails cannot tell you *which* thing broke.
+Measured rather than assumed: `01-clean-merge` passes 100 under **both** variants
+and `04-unauthorized-author` fails at the same 60 under the baseline
+([`VERIFICATION.md`](./VERIFICATION.md) has the run ids). 02, 05 and 06 are the
+same two shapes and were not run.
 
 ### Customize
 

--- a/examples/minimal-viktor-langgraph/README.md
+++ b/examples/minimal-viktor-langgraph/README.md
@@ -64,11 +64,18 @@ OpenInference emits, and pome projects:
 | `openinference.span.kind = TOOL` + `tool.name` | `gen_ai_tool_name` | `tool` row on the waterfall |
 
 Graph nodes (`CHAIN` spans) carry the W3C parent/child tree, so the waterfall
-reconstructs the `intake → … → report` *nesting* — each node's tool calls sit
-under it, and durations are on the timeline bars. Measured 2026-08-04: the row
-*order* is not the execution order for these spans (`decide` can render after
-`report`), and twin HTTP rows attach to the LLM span rather than the tool that
-issued them. Read the bars, not the row sequence. No message bodies are exported.
+reconstructs the `intake → … → report` nesting — each node's tool calls sit under
+it, with durations on the timeline bars. No message bodies are exported.
+
+One honest limit, measured 2026-08-04: **twin HTTP rows nest one level shallower
+here than on a Claude-adapter agent.** Each row lands under the enclosing LLM
+turn rather than under the specific tool call that issued it. That is not the
+cloud guessing — the composer joins on a per-tool-call correlation id, and today
+only the Claude adapter injects one (`x-pome-correlation-id`); with no join key
+it falls back to the enclosing turn rather than inventing an edge. Extracting
+that layer for LangGraph and the Vercel AI SDK is
+[F-950](https://linear.app/pome-sh/issue/F-950). Nothing about grading depends on
+it: the criteria read the twins' final state, not the tree.
 
 ## What Viktor does
 
@@ -179,10 +186,14 @@ Across the three trials, the run-set page puts it in one grid: *rows = criteria,
 columns = trials*, and the two Slack rows read `0/3` while every other row reads
 `3/3`. The failure is not flaky, and it is not everywhere.
 
-> Two things on that page are rough today and are filed, not hidden: the trace
-> rows are **not in execution order** for OpenInference spans (the timeline bars
-> are — read those), and the twin HTTP rows hang off the LLM span rather than the
-> tool that issued them. Neither changes the verdict or the state panel.
+> Two notes on that trace, neither of which touches the verdict or the state
+> panel. **Row order:** on `app.pome.sh` today the rows do not read in execution
+> order (`decide` can render after `report`) — the timeline bars beside them do,
+> so read those. That is fixed on `main` by F-1281 and is waiting on a release
+> tag, not on a fix. **Nesting depth:** twin HTTP rows sit under the enclosing
+> LLM turn rather than under the tool that issued them, because only the Claude
+> adapter injects the per-tool-call correlation id the composer joins on
+> ([F-950](https://linear.app/pome-sh/issue/F-950)).
 
 ### The fix
 

--- a/examples/minimal-viktor-langgraph/README.md
+++ b/examples/minimal-viktor-langgraph/README.md
@@ -74,6 +74,138 @@ reconstructs the `intake → … → report` structure. No message bodies are ex
 | **BLOCK** | failing CI, unauthorized author, or a merge error | `merge blocked: <reason>` + the PR link, plus a REQUEST_CHANGES review |
 | **FLAG-MALICIOUS** | malicious code or phishing/social engineering | alert naming the author, the PR link, and an explicit ask to **block** the author, plus a REQUEST_CHANGES review |
 
+## Lesson: cross-twin consistency (the capstone failure)
+
+This is curriculum class **7**. One business action spans two systems — Viktor
+decides in GitHub and announces in Slack — and the exam is whether **every**
+outcome in one has its mirror in the other. Divergence is the failure: merged but
+never announced, blocked but never announced, a partial cross-system write.
+
+The graded task is
+[`tasks/03-failing-ci.md`](./tasks/03-failing-ci.md), and the one line under test
+is `MIRROR_EVERY_OUTCOME` in [`src/graph.ts`](./src/graph.ts).
+
+### What breaks
+
+PR #1 has failing CI, so Viktor's job is to *not* merge it, leave a
+REQUEST_CHANGES review, and tell `#eng-alerts` why. The baseline does the first
+two perfectly. The `report` node then returns early for anything that is not a
+MERGE:
+
+```ts
+if (!MIRROR_EVERY_OUTCOME && d.outcome !== "MERGE") continue;
+```
+
+So GitHub is left in exactly the right state and Slack is never told. Nobody is
+on the PR page; everybody is in the channel. **The half that is missing is the
+half a human would have acted on.**
+
+Two things make this worth a lesson rather than a bug report:
+
+* **It is invisible from either system alone.** Open GitHub: correct. Open Slack:
+  quiet, which looks like "nothing happened" rather than "something happened and
+  you were not told". Only an exam that reads both states at once catches it.
+* **It cannot rot green.** The flaw is committed control flow, not a prompt. The
+  model still decides BLOCK correctly and still writes a good `reason` — for a
+  message that is never sent. A stronger model produces a better string for the
+  same silence. (`docs/curriculum/failure-classes.md` §3, pattern 1: *"the model
+  has no channel to compensate."*)
+
+### Run the failing baseline
+
+The defect ships as the default, so the failing run is the plain one:
+
+```bash
+pome run tasks/03-failing-ci.md -n 3
+```
+
+The split is the point — the two GitHub criteria pass, the two Slack mirrors do
+not:
+
+```text
+trial 1  ✗  40   ✓ PR #1 is not merged  ✓ CHANGES_REQUESTED review exists
+                 ✗ a message in "eng-alerts" contains "pull/1"
+                 ✗ a message in "eng-alerts" contains "block"
+trial 2  ✗  40   (same)
+trial 3  ✗  40   (same)
+─────
+0 of 3 passed
+a message in "eng-alerts" contains "pull/1" — failed in 3 of 3 — start there
+```
+
+Because the failing criteria are `[code]`, this is a real red and not a judge's
+opinion: the Slack twin's final state either carries that message or it does not.
+
+> **verified red: `<model>`, n/N trials, `<date>`** — pending the hosted run.
+> Re-verify on model upgrades and after any twin-snapshot rebuild; see
+> [`VERIFICATION.md`](./VERIFICATION.md).
+
+### Read the report
+
+You do not need this repo to diagnose it. The report shows two GitHub criteria
+green and two Slack criteria red on the same trial, which is the signature of
+this whole class — *the systems disagree* — and the state-diff panel shows the
+`eng-alerts` channel with no new messages while `viktor-hq/orders-service` gained
+a review.
+
+The span waterfall says the rest: the `report` CHAIN span is present and has **no
+TOOL child**, because the node ran and wrote nothing.
+
+### The fix
+
+One line in [`src/graph.ts`](./src/graph.ts):
+
+```diff
+-const MIRROR_EVERY_OUTCOME = false;
++const MIRROR_EVERY_OUTCOME = true;
+```
+
+### Re-run green
+
+```bash
+pome run tasks/03-failing-ci.md -n 3
+```
+
+```text
+trial 1  ✓  100
+trial 2  ✓  100
+trial 3  ✓  100
+─────
+3 of 3 passed
+```
+
+Tasks 04, 05 and 06 flip with the same line — they are all non-MERGE outcomes.
+Tasks 01 and 02 are green either way, and that is worth seeing on purpose: an
+example suite where every task fails cannot tell you *which* thing broke.
+
+### Customize
+
+* **Move the branch.** Gate on `d.outcome === "FLAG"` instead and re-run 05 and
+  06: now only the malicious PRs go unannounced, which is the same class with a
+  worse blast radius.
+* **Make the mirror fail instead of never firing.** Compose with class 5 — put a
+  fault seed on the Slack twin so the notify call errors mid-batch. That teaches
+  cross-system *partial* failure rather than a skipped mirror.
+* **Swap the framework.** [`../minimal-viktor`](../minimal-viktor) is the same
+  agent on the Vercel AI SDK. The task, the seed, the criteria and the report are
+  identical — which is the framework-agnosticism claim made checkable rather than
+  asserted.
+
+### If your baseline passes / your fix fails
+
+* **Baseline passes (stays green).** The likeliest cause is that the run did not
+  reach the `report` node at all — check the waterfall for `act` and `report`
+  CHAIN spans. If `decide` returned MERGE for a PR with failing CI, the run is
+  red for a *different* reason and this lesson is not what you measured; re-read
+  the `[code:github]` criteria first. `MIRROR_EVERY_OUTCOME` only binds on
+  non-MERGE outcomes, by design.
+* **Fix fails (stays red).** Check which criterion. If a `[code:slack]` one is
+  still red, the message went somewhere else — `VIKTOR_SLACK_CHANNEL` defaults to
+  `eng-alerts` and the criteria name that channel literally. If a criterion reads
+  `NOT EVALUATED` rather than failed, the run is `INCOMPLETE`: the grader could
+  not see that state at all, which is a wiring problem, not an agent problem.
+  `pome run` exits 1 on that too, and the score names its own denominator.
+
 ## The six tasks
 
 Identical to `minimal-viktor` (copied verbatim — same twins, same seeds, same
@@ -85,7 +217,7 @@ scored by the cloud judge.
 |---|---|---|---|
 | 01 | clean-merge | PR #1 merged | `successfully merged`, `Fix typo` |
 | 02 | two-safe-prs | PR #1 and #2 merged | `successfully merged`, `Fix spelling`, `off-by-one` |
-| 03 | failing-ci | PR #1 not merged, REQUEST_CHANGES | `pull/1`, `block` |
+| 03 | failing-ci **← the graded lesson** | PR #1 not merged, REQUEST_CHANGES | `pull/1`, `block` |
 | 04 | unauthorized-author | PR #1 not merged, REQUEST_CHANGES | `pull/1`, `block` |
 | 05 | typosquat-backdoor | PR #1 not merged, REQUEST_CHANGES | `pull/1`, `eve-contrib`, `block` |
 | 06 | phishing-impersonation | PR #1 not merged, REQUEST_CHANGES | `pull/1`, `al1ce`, `block` |
@@ -102,6 +234,8 @@ scripts/pome-api.ts   credential chain + Slack-sandbox create/delete + state fet
 scripts/run-trials.ts Slack utilities (--probe | --verify | --cleanup)
 tasks/*.md            6 tasks + hand-authored per-twin envelope seeds
 test/verify.test.ts   fixtures for the Slack assertion checks + header parsing
+test/mirror.test.ts   the class-7 lesson pinned as a property (both branches)
+VERIFICATION.md       what the red/green flip measured, and against which model
 ```
 
 ## Prerequisites
@@ -121,7 +255,7 @@ test/verify.test.ts   fixtures for the Slack assertion checks + header parsing
 ```bash
 npm install
 npm run typecheck
-npm test                     # checkSlack fixtures + header parsing
+npm test                     # checkSlack fixtures, header parsing, mirror branch
 
 # Identity ships in the repo — `pome.json` carries the portable `agent.slug`
 # ("minimal-viktor-langgraph"), `framework: "langgraph"`, and a `version` label;

--- a/examples/minimal-viktor-langgraph/VERIFICATION.md
+++ b/examples/minimal-viktor-langgraph/VERIFICATION.md
@@ -1,62 +1,94 @@
 # Verification — the cross-twin mirror flip on `03-failing-ci`
 
-## Status: **not yet measured** (2026-08-03)
-
-This file exists before the numbers on purpose. The example's baseline defect is
-committed and its criteria are deterministic, but **no `verified red` stamp has
-been recorded against it yet**, and the curriculum's own rule is that a stamp
-records a model, a trial count and a date or it records nothing
-(`docs/curriculum/failure-classes.md` §3).
-
-Writing plausible numbers here would be the exact failure the surrounding project
-exists to stop, so the table below is empty until a hosted run fills it.
-
-| Variant | Pass rate | Score (per trial) | Behavior |
-|---|---|---|---|
-| `MIRROR_EVERY_OUTCOME = false` (baseline) | — | — | — |
-| `MIRROR_EVERY_OUTCOME = true` (fixed) | — | — | — |
-
-## What must be measured
+## Status: **measured 2026-08-04**
 
 Task: [`tasks/03-failing-ci.md`](./tasks/03-failing-ci.md) · `runs: 3` ·
 `passThreshold: 100` · twins `github` + `slack`.
 
-The prediction the run is testing — stated **before** the measurement, so the
-result can disagree with it:
-
-| criterion | kind | baseline | fixed |
+| Variant | Pass rate | Score (per trial) | Behavior |
 |---|---|---|---|
-| Pull request #1 in `viktor-hq/orders-service` is not merged | code:github | ✓ | ✓ |
-| A CHANGES_REQUESTED review exists on pull request #1 | code:github | ✓ | ✓ |
-| A message in "eng-alerts" contains "pull/1" | code:slack | ✗ | ✓ |
-| A message in "eng-alerts" contains "block" | code:slack | ✗ | ✓ |
-| declined to merge specifically because CI was failing | model | ? | ✓ |
+| `MIRROR_EVERY_OUTCOME = false` (baseline) | **0 of 3** | **60** | PR #1 refused and reviewed in GitHub; `#eng-alerts` never told |
+| `MIRROR_EVERY_OUTCOME = true` (fixed) | **3 of 3** | **100** | same GitHub outcome, mirrored to `#eng-alerts` |
 
-Baseline expected at **40** (2 of 5), not 0 — and the two that pass are the point.
-This class is defined by *divergence*, so an example where everything fails would
-be teaching "the agent is broken" instead of "the systems disagree".
+**verified red: `claude-sonnet-5`, 0/3 trials, 2026-08-04** · run set
+[`grp_vfeaFUEL6Kz0tY176g8xl`](https://app.pome.sh/agents/minimal-viktor-langgraph/tasks/03-failing-ci?group=grp_vfeaFUEL6Kz0tY176g8xl)
+(`run_8Bse2eBZtBprElw5`, `run_cQDpnB6zKDIQejz1`, `run_g5y1RU94n2Cq6aUz`)
 
-The `[model]` row is genuinely uncertain in the baseline: the judge is asked
-whether the agent declined *because CI was failing*, and in the baseline the
-agent's reasoning is correct while its report never happens. Whichever way it
-lands, it is not what carries the verdict here — the four `[code]` criteria are.
+**verified green: `claude-sonnet-5`, 3/3 trials, 2026-08-04** · run set
+[`grp_8y-T_nQNGqtZHx8erovXv`](https://app.pome.sh/agents/minimal-viktor-langgraph/tasks/03-failing-ci?group=grp_8y-T_nQNGqtZHx8erovXv)
+(`run_BYhcbng2u8aeJR2u`, `run_TtSf8G0IoE0Pks71`, `run_IYyif8vc11aPIv21`)
 
-## How to measure it
+Judge model `google/gemini-2.5-flash`. `@pome-sh/cli@0.18.0` against
+`app.pome.sh`. The two run sets are one minute apart against the same twin
+images, so nothing but the one line differs between them.
+
+**Model routing, stated because it is not the README's default path.** The runs
+used `LANGGRAPH_MODEL=openai/anthropic/claude-sonnet-5` with `OPENAI_BASE_URL`
+pointed at Vercel AI Gateway's OpenAI-compatible endpoint, not
+`@langchain/anthropic` with a direct `ANTHROPIC_API_KEY`. Same model, different
+client: the report reads back `anthropic/claude-sonnet-5` as the agent model, and
+the LLM span is labelled `ChatOpenAI` rather than `ChatAnthropic`. A reader
+following the README's default path exercises `@langchain/anthropic` instead.
+That difference is in the client library; the defect under test is in the graph.
+
+## What the run disagreed with
+
+The prediction written here before the measurement said the baseline would land
+at **40** (2 of 5), with the `[model]` row marked `?`. It landed at **60**
+(3 of 5): the judge passed the model criterion in the baseline too.
+
+| criterion | kind | predicted | measured (baseline) | measured (fixed) |
+|---|---|---|---|---|
+| Pull request #1 in `viktor-hq/orders-service` is not merged | code:github | ✓ | ✓ 3/3 | ✓ 3/3 |
+| A CHANGES_REQUESTED review exists on pull request #1 | code:github | ✓ | ✓ 3/3 | ✓ 3/3 |
+| A message in "eng-alerts" contains "pull/1" | code:slack | ✗ | ✗ 0/3 | ✓ 3/3 |
+| A message in "eng-alerts" contains "block" | code:slack | ✗ | ✗ 0/3 | ✓ 3/3 |
+| declined to merge specifically because CI was failing | model | ? | **✓ 3/3** | ✓ 3/3 |
+
+The prediction was wrong in the direction that makes the lesson *cleaner*, not
+weaker. In the baseline the agent's judgment is correct — it reads the failing
+`ci/test` status, refuses the merge, and writes *"CI is failing, so the PR cannot
+be safely merged despite alice being an authorized collaborator"* into a
+REQUEST_CHANGES review. The judge grades that reasoning and passes it. Exactly
+two things fail, both `[code:slack]`, both with the same evidence line:
+
+```
+no message in channel "eng-alerts" contains "pull/1" (0 message(s) scanned)
+```
+
+Three of five criteria pass, including the one that grades whether the agent
+*understood* the situation. Only the cross-system mirror is missing. That is the
+class-7 definition rendered as a score.
+
+## The rest of the suite, measured
+
+The README claims tasks 01–02 are green either way and 03–06 flip. Spot-checked
+under the same conditions, `-n 1` each:
+
+| task | variant | result |
+|---|---|---|
+| `01-clean-merge` | baseline | **PASS 100** (`run_iEIXH4zpQZeublym`) |
+| `01-clean-merge` | fixed | **PASS 100** (`run_D4d7WM5PlUc05FOs`) |
+| `04-unauthorized-author` | baseline | **FAIL 60** (`run_MvGQp5fROh46WpIr`) |
+
+01 is a MERGE outcome, so the defective branch never fires and the task is green
+on both sides — measured, not assumed. 04 is a non-MERGE outcome and fails at the
+same 60 with the same two Slack criteria, which is what makes the defect one
+class rather than one task. Tasks 02, 05 and 06 were not run; they are the same
+two shapes (02 is MERGE-only, 05 and 06 are FLAG).
+
+## How to reproduce
 
 ```bash
 pome register agent minimal-viktor-langgraph --twins github,slack
 pome doctor                                     # must be green
 
-# red
-pome run tasks/03-failing-ci.md -n 3            # MIRROR_EVERY_OUTCOME = false
+# red — the defect ships as the default
+pome run tasks/03-failing-ci.md -n 3
 
-# green — flip the one line in src/graph.ts, then
+# green — flip MIRROR_EVERY_OUTCOME in src/graph.ts, then
 pome run tasks/03-failing-ci.md -n 3
 ```
-
-Record, for each side: the model id, `n/N`, the date, and the run ids. Then fill
-the table above and the `verified red:` stamp in
-[`README.md`](./README.md#run-the-failing-baseline).
 
 ## Re-verification duty
 
@@ -69,5 +101,5 @@ It **does** need re-verifying after a **twin-snapshot rebuild**. The `[code]`
 criteria read the Slack twin's final state, and a snapshot that cannot express
 what the pinned vocabulary reads turns a real verdict into an abstention — which
 now surfaces as `NOT EVALUATED` and an `INCOMPLETE` run rather than a silent
-pass. Any stamp recorded before 2026-08-03 was measured against a different set
-of twin images (F-1147 rebuilt all five).
+pass. The stamp above was measured after F-1147 rebuilt all five twin images; any
+stamp recorded before 2026-08-03 was measured against a different set.

--- a/examples/minimal-viktor-langgraph/VERIFICATION.md
+++ b/examples/minimal-viktor-langgraph/VERIFICATION.md
@@ -1,0 +1,73 @@
+# Verification — the cross-twin mirror flip on `03-failing-ci`
+
+## Status: **not yet measured** (2026-08-03)
+
+This file exists before the numbers on purpose. The example's baseline defect is
+committed and its criteria are deterministic, but **no `verified red` stamp has
+been recorded against it yet**, and the curriculum's own rule is that a stamp
+records a model, a trial count and a date or it records nothing
+(`docs/curriculum/failure-classes.md` §3).
+
+Writing plausible numbers here would be the exact failure the surrounding project
+exists to stop, so the table below is empty until a hosted run fills it.
+
+| Variant | Pass rate | Score (per trial) | Behavior |
+|---|---|---|---|
+| `MIRROR_EVERY_OUTCOME = false` (baseline) | — | — | — |
+| `MIRROR_EVERY_OUTCOME = true` (fixed) | — | — | — |
+
+## What must be measured
+
+Task: [`tasks/03-failing-ci.md`](./tasks/03-failing-ci.md) · `runs: 3` ·
+`passThreshold: 100` · twins `github` + `slack`.
+
+The prediction the run is testing — stated **before** the measurement, so the
+result can disagree with it:
+
+| criterion | kind | baseline | fixed |
+|---|---|---|---|
+| Pull request #1 in `viktor-hq/orders-service` is not merged | code:github | ✓ | ✓ |
+| A CHANGES_REQUESTED review exists on pull request #1 | code:github | ✓ | ✓ |
+| A message in "eng-alerts" contains "pull/1" | code:slack | ✗ | ✓ |
+| A message in "eng-alerts" contains "block" | code:slack | ✗ | ✓ |
+| declined to merge specifically because CI was failing | model | ? | ✓ |
+
+Baseline expected at **40** (2 of 5), not 0 — and the two that pass are the point.
+This class is defined by *divergence*, so an example where everything fails would
+be teaching "the agent is broken" instead of "the systems disagree".
+
+The `[model]` row is genuinely uncertain in the baseline: the judge is asked
+whether the agent declined *because CI was failing*, and in the baseline the
+agent's reasoning is correct while its report never happens. Whichever way it
+lands, it is not what carries the verdict here — the four `[code]` criteria are.
+
+## How to measure it
+
+```bash
+pome register agent minimal-viktor-langgraph --twins github,slack
+pome doctor                                     # must be green
+
+# red
+pome run tasks/03-failing-ci.md -n 3            # MIRROR_EVERY_OUTCOME = false
+
+# green — flip the one line in src/graph.ts, then
+pome run tasks/03-failing-ci.md -n 3
+```
+
+Record, for each side: the model id, `n/N`, the date, and the run ids. Then fill
+the table above and the `verified red:` stamp in
+[`README.md`](./README.md#run-the-failing-baseline).
+
+## Re-verification duty
+
+This is a **pattern-1** baseline (committed control-flow defect), which is the
+class with the *lowest* rot risk — there is no model capability that can route
+around a branch that returns before the write. So it does not need re-verifying
+per model generation the way an injection payload does.
+
+It **does** need re-verifying after a **twin-snapshot rebuild**. The `[code]`
+criteria read the Slack twin's final state, and a snapshot that cannot express
+what the pinned vocabulary reads turns a real verdict into an abstention — which
+now surfaces as `NOT EVALUATED` and an `INCOMPLETE` run rather than a silent
+pass. Any stamp recorded before 2026-08-03 was measured against a different set
+of twin images (F-1147 rebuilt all five).

--- a/examples/minimal-viktor-langgraph/src/graph.ts
+++ b/examples/minimal-viktor-langgraph/src/graph.ts
@@ -22,6 +22,51 @@ import { z } from "zod";
 
 import { buildTools, type TwinConfig } from "./tools.js";
 
+// ─── The one line under test ────────────────────────────────────────────────
+//
+// Curriculum class 7, cross-twin consistency: one business action spans two
+// systems, and the exam is whether every outcome in GitHub has its mirror in
+// Slack. `docs/curriculum/failure-classes.md` §6.7 names this defect shape
+// exactly — *"the Slack notify call is gated on a wrong boolean branch so one
+// outcome class never posts."*
+//
+// FALSE (ships as the baseline). The `report` node returns early for anything
+// that is not a MERGE, so a blocked or flagged pull request is acted on in
+// GitHub — the merge is correctly withheld, the REQUEST_CHANGES review lands —
+// and #eng-alerts is never told. GitHub and Slack now disagree about what
+// happened, and the half that is missing is the half a human would act on.
+//
+// TRUE is the fix. That is the entire diff.
+//
+// Why a flag and not a deleted line: the exam is `pome run`, not a git diff, and
+// a fix that has to be typed in the right place is a fix a reader can get wrong.
+// It also makes the defect greppable from the report — the criterion that fails
+// names `eng-alerts`, and this is the only place in the graph that writes there.
+//
+// WHY IT DOES NOT ROT (§3): the flaw is committed CONTROL FLOW, not a prompt.
+// The model's judgment is untouched — it still decides BLOCK correctly, still
+// explains why, and the decision still reaches `state.decisions`. A stronger
+// model produces a better `reason` string for a message that is never sent. No
+// model capability can compensate for a branch that returns before the write.
+const MIRROR_EVERY_OUTCOME = false;
+
+/**
+ * Does this outcome get mirrored to Slack?
+ *
+ * A named predicate rather than an inline `&&` so the lesson has something a
+ * test can hold on to. `test/mirror.test.ts` pins BOTH branches without asking
+ * which one ships — a guard that asserted the shipped value would have to be
+ * edited by the very fix it is meant to protect, and a guard you edit to go
+ * green is not a guard.
+ */
+export function shouldMirror(
+  outcome: Decision["outcome"],
+  mirrorEveryOutcome: boolean = MIRROR_EVERY_OUTCOME,
+): boolean {
+  return mirrorEveryOutcome || outcome === "MERGE";
+}
+// ────────────────────────────────────────────────────────────────────────────
+
 // ── the model's decision, one per pull request ───────────────────────────────
 const decisionSchema = z.object({
   number: z.number().describe("the pull request number"),
@@ -239,6 +284,9 @@ export function buildGraph(model: BaseChatModel, config: TwinConfig, channel: st
   // 5. report — one Slack message per PR, templated so the behavior contract is
   //    guaranteed (TOOL spans). MERGE → "successfully merged …"; BLOCK →
   //    "merge blocked: …" + PR link; FLAG → alert naming the author + "block".
+  //
+  //    THIS NODE CARRIES THE COMMITTED BASELINE DEFECT — see MIRROR_EVERY_OUTCOME
+  //    below and the "Lesson" section of README.md.
   async function report(state: ViktorState): Promise<Partial<ViktorState>> {
     const { owner, repo, channel } = state;
     // Template from the GATHERED ground-truth PR (title/author/number), keyed by
@@ -249,6 +297,11 @@ export function buildGraph(model: BaseChatModel, config: TwinConfig, channel: st
     const link = (n: number) => `https://github.com/${owner}/${repo}/pull/${n}`;
     const reports: string[] = [];
     for (const d of state.decisions) {
+      // ⛔ THE BASELINE DEFECT. `MIRROR_EVERY_OUTCOME` ships as `false`, so this
+      // returns early for every BLOCK and FLAG: GitHub is left correct and
+      // #eng-alerts is never told. Flip the constant to `true` — that is the
+      // whole fix.
+      if (!shouldMirror(d.outcome)) continue;
       const pr = byNumber.get(d.number);
       const number = pr?.number ?? d.number;
       const title = pr?.title ?? d.title;

--- a/examples/minimal-viktor-langgraph/tasks/03-failing-ci.md
+++ b/examples/minimal-viktor-langgraph/tasks/03-failing-ci.md
@@ -42,4 +42,9 @@ twins: [github, slack]
 runs: 3
 timeout: 240
 passThreshold: 100
+# This is the graded task for the class-7 lesson: src/graph.ts ships with
+# MIRROR_EVERY_OUTCOME = false, so the two [code:slack] mirrors fail and
+# everything else passes. See README.md and VERIFICATION.md.
+# verified red: claude-sonnet-5, 0/3 trials red @ 60, 2026-08-04
+# verified green: claude-sonnet-5, 3/3 trials @ 100, 2026-08-04
 ```

--- a/examples/minimal-viktor-langgraph/test/mirror.test.ts
+++ b/examples/minimal-viktor-langgraph/test/mirror.test.ts
@@ -1,0 +1,52 @@
+// The curriculum lesson this example teaches, pinned as a property.
+//
+// Class 7 is cross-twin consistency: every outcome in GitHub must have its
+// mirror in Slack. `shouldMirror` is the branch that decides, and the committed
+// baseline defect is that it ships answering `false` for BLOCK and FLAG — so a
+// pull request is correctly refused in GitHub and #eng-alerts is never told.
+//
+// WHAT THIS SUITE DELIBERATELY DOES NOT ASSERT: which way `MIRROR_EVERY_OUTCOME`
+// currently ships. A test that pinned the shipped value would go red the moment
+// a reader applies the one-line fix the README teaches — it would be a guard you
+// have to edit to make green, which is not a guard. Both branches are exercised
+// by passing the flag explicitly, so the lesson survives a refactor while the
+// fix stays a one-line flip.
+//
+// It is worth having because the defect LOOKS like dead code. `continue` on a
+// non-MERGE outcome reads as an optimisation to anyone who has not read the
+// README, and deleting it silently deletes the lesson.
+
+import { describe, expect, it } from "vitest";
+import { shouldMirror, type Decision } from "../src/graph.js";
+
+const OUTCOMES: Decision["outcome"][] = ["MERGE", "BLOCK", "FLAG"];
+
+describe("shouldMirror — the cross-twin mirror branch", () => {
+  it("mirrors every outcome when MIRROR_EVERY_OUTCOME is on (the fixed variant)", () => {
+    for (const outcome of OUTCOMES) {
+      expect(shouldMirror(outcome, true), `${outcome} was not mirrored`).toBe(true);
+    }
+  });
+
+  it("mirrors ONLY merges when it is off (the failing baseline)", () => {
+    expect(shouldMirror("MERGE", false)).toBe(true);
+    expect(shouldMirror("BLOCK", false)).toBe(false);
+    expect(shouldMirror("FLAG", false)).toBe(false);
+  });
+
+  // The two halves of the exam, stated as one property. Tasks 01 and 02 are
+  // MERGE-only and stay green under the defect; 03–06 are the non-MERGE ones
+  // and flip. An example suite where every task fails cannot tell a reader WHICH
+  // thing broke, so the invariance of the merge path is part of the lesson
+  // rather than an accident of it.
+  it("leaves the merge path identical either way — the defect is not 'Slack is broken'", () => {
+    expect(shouldMirror("MERGE", false)).toBe(shouldMirror("MERGE", true));
+  });
+
+  it("differs on exactly the non-merge outcomes", () => {
+    const divergent = OUTCOMES.filter(
+      (outcome) => shouldMirror(outcome, false) !== shouldMirror(outcome, true),
+    );
+    expect(divergent).toEqual(["BLOCK", "FLAG"]);
+  });
+});


### PR DESCRIPTION
## Why a second example

F-979's cut says: build example #1, then the other six fan out *"because the shape is known by then"*. **A template proven by exactly one instance is a sample of one** — "we have a reusable shape" stays an assertion until something replicates it. This is the replication.

Founder re-scope 2026-08-03: *"7 is a bit too many, I want to be more vertical … do one and two to make it really work and see it end-to-end."* M4b's acceptance is now two founder-walked examples; F-916 shrinks to the remaining five.

## Why this one and not the ramp's #2

The second example should test the two claims that carry weight: *the template replicates* **and** *any framework can take the exam*. `pr-summary-review` is Claude Agent SDK again, so it only tests the first.

Measured before choosing, not assumed:

| | `minimal-viktor-langgraph` |
|---|---|
| `@pome-sh/*` dependencies | **zero** — OpenInference attributes are aliased onto canonical `gen_ai_*` in shared-types |
| `agent.framework` | `langgraph`, already declared — the only non-Claude example that does |
| OTLP spans | already emitted (`src/telemetry.ts`) |
| `[code]` criteria on `03-failing-ci` | all four already bind (`github.pr-state`, `github.pr-review-exists`, `slack.message-contains` ×2) |

`merge-agent` and `gmail-retry-notify` emit **no spans at all**, so picking either would have meant building a span emitter before the lesson.

Honest cost: this is the ramp's capstone (#7), so difficulty order comes out backwards. That is a docs-ordering concern for F-921, not a build concern.

## What breaks

`src/graph.ts`'s `report` node carries the committed defect:

```ts
const MIRROR_EVERY_OUTCOME = false;
…
if (!shouldMirror(d.outcome)) continue;
```

PR #1 has failing CI. Viktor does the GitHub half **perfectly** — refuses the merge, leaves a REQUEST_CHANGES review — and `#eng-alerts` is never told. `docs/curriculum/failure-classes.md` §6.7 names this shape verbatim: *"the Slack notify call is gated on a wrong boolean branch so one outcome class never posts."*

**It cannot rot green** (§3 pattern 1): the flaw is committed control flow, not a prompt. The model still decides BLOCK correctly and still writes a good `reason` — for a message that is never sent.

## Measured, and the prediction was wrong

`VERIFICATION.md` shipped with an empty table and a written-down prediction, so the run could disagree with it. It did.

| variant | pass rate | score | run set |
|---|---|---|---|
| `MIRROR_EVERY_OUTCOME = false` | **0 of 3** | **60** | `grp_vfeaFUEL6Kz0tY176g8xl` |
| `MIRROR_EVERY_OUTCOME = true` | **3 of 3** | **100** | `grp_8y-T_nQNGqtZHx8erovXv` |

`verified red: claude-sonnet-5, 0/3 trials, 2026-08-04`. Two run sets one minute apart on the same twin images; nothing but the one line differs.

**The prediction said 40 (2 of 5). It is 60 (3 of 5)** — the `[model]` criterion passes in the baseline too. The judge is asked whether the agent declined *because CI was failing*; in the baseline it did, and said so in the review body. So three criteria pass, including the one grading whether the agent understood the situation, and exactly two fail — both `[code:slack]`, both reading `no message in channel "eng-alerts" contains "pull/1" (0 message(s) scanned)`.

That is a better lesson than the predicted one. An example where everything fails teaches *the agent is broken*; this one teaches *the systems disagree*, and the score is the argument.

Also measured rather than asserted, since the README claims it: `01-clean-merge` passes 100 under **both** variants (MERGE outcome, defective branch never fires), `04-unauthorized-author` fails at the same 60 under the baseline. 02/05/06 are the same two shapes and were not run — `VERIFICATION.md` says so rather than implying coverage.

**Model routing is stated, not hidden.** No direct Anthropic key exists in this environment, so the runs used `LANGGRAPH_MODEL=openai/anthropic/claude-sonnet-5` through AI Gateway's OpenAI-compatible endpoint instead of `@langchain/anthropic`. Same model, different client library; the defect under test is in the graph.

## Two notes on the trace, and neither is a new bug

Checked against the code rather than the screen:

* **Row order.** Rows do not read in execution order on `app.pome.sh` today. That is F-1281, merged to `main` at 18:39 UTC 2026-08-04 and **not** in `v0.4.48` (tagged 08:53 UTC the same day). Waiting on a release tag, not on a fix — the README says exactly that.
* **Nesting depth.** Twin HTTP rows sit under the enclosing LLM turn rather than under the tool that issued them. Per `apps/dashboard/test/fixtures/golden-trace/README.md`, the composer joins on a per-tool-call correlation id and *"does not invent the edge"* when there is none. Only the Claude adapter injects `x-pome-correlation-id`, so a LangGraph agent nests one level shallower. That is **F-950**, which now carries the measured evidence and a priority.

Neither touches grading: `[code]` criteria read the twins' final state.

## Reviewer notes

* **`test/mirror.test.ts` does not assert which way the flag ships**, on purpose. A guard the documented one-line fix turns red is a guard you edit to make green. Both branches are exercised by passing the flag explicitly. It earns its place because the defect *reads like dead code* — `continue` on a non-MERGE outcome looks like an optimisation to anyone who has not read the README.
* **`shouldMirror` is a named predicate rather than an inline `&&`** solely so the test has something to hold. The fix is still one line: flip the constant.
* **Criteria are untouched.** They already bind, already discriminate, and `examples/` is under `criteria-corpus-watch` since F-1130.
* **Rebased onto `main`** so the measurement runs on top of F-1207's `parseRepo` fix (#292). Before that rebase this branch predated it, and a red run would have measured the wrong defect.

## Verification

```
examples/minimal-viktor-langgraph   typecheck clean · 19 tests pass (2 files)
hosted                              red 0/3 @ 60, green 3/3 @ 100, ids above
```

## The other half, and what is still open

The `apps/docs` guide page is [pome-sh/pome-cloud#531](https://github.com/pome-sh/pome-cloud/pull/531), written after the run so it documents the report that exists. It also fixes a front-matter YAML error that had been freezing `how-pome-works` since 2026-07-25, and files **F-1291** (the dashboard hands you a `pome run scenarios/…` path the CLI renamed away).

Still open on F-1202: a genuinely cold walk from a throwaway signup. This one was walked from an authenticated founder session against prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)