### PR TITLE
support-triage: the pattern-1 baseline, a manifest, and a real trace (F-979)

### DIFF
--- a/examples/support-triage/README.md
+++ b/examples/support-triage/README.md
@@ -6,8 +6,13 @@ issue in `acme/orders-service`, and posts the tracking link back to `#support`.
 Two twins in one run — the **Slack twin** (where the report arrives) and the
 **GitHub twin** (where the issue lives).
 
-The pack exists to demo a reproducible **FAIL → FIX → PASS** on Pome using two
-versions of the agent that differ by exactly **one line**:
+The pack exists to demo a reproducible **FAIL → FIX → PASS** on Pome, and it does
+it on **two runtimes**. The graded one — curriculum lesson #1 — is the local
+examinee, whose flaw is a committed tool-policy defect; jump to
+[the lesson](#lesson-the-agent-that-could-not-look-before-it-leapt).
+
+The managed-agent path tells the same story through a pair of prompts that differ
+by exactly **one line**:
 
 - `agents/support-triage-v1.yaml` — **baseline**. Its charter tells the agent
   *not* to search existing issues. On a re-reported bug it files a **duplicate**
@@ -74,23 +79,153 @@ agent tried twice — and the v1→v2 improvement gets reported as that agent
 being unreliable. Pass the v1 run's `group_id` as the v2 run's
 `baseline_group_id` and the report pairs them into a fail→green comparison.
 
+## Lesson: the agent that could not look before it leapt
+
+This is the curriculum's **lesson #1**, and the graded baseline lives in
+[`local/`](./local/) — the same agent as a Claude Agent SDK process on your
+machine. The one line under test is `DENY_ISSUE_LOOKUP` in
+[`local/src/index.ts`](./local/src/index.ts).
+
+> **Two runtimes, one story, two different flaws.** The `agents/*.yaml` pair
+> above tells this story on Anthropic's Managed Agents platform through a
+> *prompt* flaw — a charter line telling the agent not to search. That is a
+> **pattern-2** baseline (`pome-cloud docs/curriculum/failure-classes.md` §3):
+> legitimate, but its red is model-dependent. The local examinee is the
+> **pattern-1** version and it is the one the curriculum grades. Both are kept
+> because the pair is genuinely useful for the managed-agent path; only one is
+> the lesson.
+
+### What breaks
+
+A customer re-reports a bug that open issue #1 in `acme/orders-service` already
+tracks. The agent's instructions are **correct** — *search the open issues first;
+only open a new one if nothing already tracks the bug* — and it follows them. It
+reaches for the lookup and is refused, because the examinee's committed tool
+policy denies every read path into the repository's issues:
+
+```ts
+const ISSUE_LOOKUP_TOOLS = [
+  "mcp__github__search_issues",
+  "mcp__github__list_issues",
+  "mcp__github__get_issue",
+];
+const DENY_ISSUE_LOOKUP = true;   // ← ships as the baseline
+```
+
+So it concludes, honestly and wrongly, that the bug is untracked — and files a
+second issue for it. **The agent did nothing wrong.** Its context was corrupted
+before it ever reasoned.
+
+Two properties make this worth a lesson rather than a bug report:
+
+* **It cannot rot green** (§3, pattern 1). The prompt here is the *right* one,
+  and a stronger model follows it *more* reliably, not less — it just gets
+  refused faster. No model capability can call a tool that was never exposed.
+  The previous baseline lived in a prompt line telling the agent not to search;
+  that red is model-dependent, and worse, a prompt-driven red is
+  indistinguishable from an evaluator that never ran.
+* **It is the most common real version of this bug.** Over-restrictive tool
+  allowlists are a production default. Nobody writes "don't dedup" in a system
+  prompt; plenty of people ship an agent that cannot see what it needs to.
+
+### Run the failing baseline
+
+The defect ships as the default, so the failing run is the plain one:
+
+```bash
+pome run tasks/duplicate-issue.md -n 5
+```
+
+`runs: 5` is in the task config on purpose — the report teaches **pass^k**, and
+one trial proves nothing.
+
+> **verified red: `<model>`, n/N trials, `<date>`** — pending. The recorded
+> numbers in [`VERIFICATION.md`](./VERIFICATION.md) measured the *old*
+> pattern-2 baseline, under fail-open scoring, against pre-2026-08-03 twin
+> images. They are kept as history and are **not** this baseline's stamp.
+
+### Read the report
+
+The pivotal criterion is the `#support` message linking `issues/1`. Under the
+baseline the agent links `issues/2` — the one it just created — so the criterion
+fails on a deterministic state read rather than a judge's opinion, and the
+state-diff panel shows `issues: 1 → 2`.
+
+The span waterfall shows the rest of the story, and it is the part that makes the
+diagnosis fast: a `search_issues` tool span that returns a refusal, followed by
+`create_issue`. The agent tried.
+
+### The fix
+
+One line in [`local/src/index.ts`](./local/src/index.ts):
+
+```diff
+-const DENY_ISSUE_LOOKUP = true;
++const DENY_ISSUE_LOOKUP = false;
+```
+
+### Re-run green
+
+```bash
+pome run tasks/duplicate-issue.md -n 5
+```
+
+The agent searches, finds issue #1, comments on it, and posts *its* link back to
+`#support`. State-diff: `issues: 1 → 1` plus a comment.
+
+### Customize
+
+* **Deny one tool instead of three.** Leave `list_issues` reachable and watch the
+  agent route around the defect — a useful demonstration that a partial denial is
+  not a defect at all, and why the baseline names every read path.
+* **Move the flaw to the write side.** Deny `add_issue_comment` instead: now the
+  agent *finds* the duplicate and still cannot do the right thing, which is a
+  different failure with the same symptom. Worth running once to see how much the
+  report distinguishes them.
+
+### If your baseline passes / your fix fails
+
+* **Baseline passes (stays green).** Check the waterfall for a `search_issues` or
+  `list_issues` span that *succeeded* — if one did, the twin exposed a read path
+  the denial list does not name, and the fix is to add it (and to say so in
+  `ISSUE_LOOKUP_TOOLS`), not to weaken the criteria. `test/tool-policy.test.ts`
+  pins the list for exactly this reason.
+* **Fix fails (stays red).** If a criterion reads `NOT EVALUATED` rather than
+  failed, the run is `INCOMPLETE` — the grader could not see that state at all,
+  which is a wiring problem rather than an agent problem. `pome run` exits 1 on
+  that too, and the score names its own denominator. If the `[model]` criteria
+  are the red ones, raise `-n`: one clean set is a signal, not proof.
+
+### Known gap in the criteria
+
+The criteria above assert that the agent **linked the right issue**. They do not
+yet assert that it **opened no second one** — a negative assertion the declared
+GitHub vocabulary could not express until `github.no-new-issues`
+([F-1198](https://linear.app/pome-sh/issue/F-1198)). Until that check reaches the
+cloud's pin, an agent that comments on #1, posts the link *and also* files a
+duplicate passes. Said out loud here rather than left for a reader to discover,
+because this example is the one that defines the standard.
+
 ## Local examinee
 
 [`local/`](./local/) is the same agent as a minimal **Claude Agent SDK process
 on your machine** — no managed-agent platform needed. The coach spawns it as a
 subprocess after `run_task` (per-twin MCP URLs + bearer arrive via env), it
-works the task over MCP, and exits when done. The v1/v2 one-liner lives as a
-prompt constant in its code: v1 ships as the default, the fix is a one-line
-swap. See [`local/README.md`](./local/README.md).
+works the task over MCP, and exits when done. It imports `query` from
+`@pome-sh/adapter-claude-sdk` rather than the raw SDK — a drop-in that also
+emits gen_ai OTLP spans, so the report carries model, per-turn tokens and
+latency. See [`local/README.md`](./local/README.md).
 
 ## Layout
 
 ```
-agents/support-triage-v1.yaml   baseline (files a duplicate) — fails
-agents/support-triage-v2.yaml   fixed (searches first) — passes; one line different
+pome.json                       committed manifest: agent.slug + framework + tasks dir
+agents/support-triage-v1.yaml   managed-agent baseline (prompt flaw, pattern 2)
+agents/support-triage-v2.yaml   managed-agent fix; one line different
 tasks/duplicate-issue.md        the task (inline ## Seed State)
-local/                          the same agent as a local Claude Agent SDK examinee
-VERIFICATION.md                 measured v1-vs-v2 results with run ids
+local/                          the graded examinee — the pattern-1 baseline lives here
+local/test/tool-policy.test.ts  the lesson pinned as a property (both branches)
+VERIFICATION.md                 measured results, and what each measurement was of
 ```
 
 ## Notes

--- a/examples/support-triage/VERIFICATION.md
+++ b/examples/support-triage/VERIFICATION.md
@@ -1,5 +1,38 @@
 # Verification — the self-fix flip on `duplicate-issue`
 
+## Two baselines, and only one of them is measured here
+
+This example now carries **two** failing baselines, on two runtimes:
+
+| Baseline | Where | Flaw | Curriculum pattern | Measured below |
+|---|---|---|---|---|
+| Managed-agent v1/v2 prompt pair | `agents/*.yaml` | charter line telling the agent not to search | 2 (policy constant) | **yes** |
+| Local examinee | `local/src/index.ts` — `DENY_ISSUE_LOOKUP` | tool policy denies every issue read path | 1 (config defect) | **no — pending** |
+
+**Everything below measures the first one.** The local examinee's pattern-1
+baseline is the one the curriculum grades, and it has **no stamp yet**.
+
+Three reasons the numbers below do not transfer to it, each independently
+sufficient:
+
+1. **It is a different flaw.** A prompt line and a tool policy are not the same
+   experiment, and the whole point of the re-cut is that the second one does not
+   rot the way the first one can.
+2. **They predate honest scoring.** They were recorded before a criterion the
+   grader could not run rendered as `NOT EVALUATED` — so a `100` in the table
+   below is not the same claim a `100` is today.
+3. **They predate the twin images.** All five twin snapshots were rebuilt and
+   promoted on 2026-08-03 (F-1147). Any stamp recorded before then was measured
+   against a different substrate.
+
+They are kept, unedited, because the "33, not 0" story is real and this is where
+it was actually measured — and because deleting the provenance of a number the
+whole onboarding narrative rests on would be worse than dating it.
+
+---
+
+## Measured: the managed-agent v1/v2 pair (2026-07, superseded as the curriculum stamp)
+
 Empirically measured on Pome, scored from the live twin tape (`provenance: hosted`),
 on team **AFFF's workspace**. Runs are visible on `app.pome.sh`.
 
@@ -86,3 +119,65 @@ pristine; a stronger model may or may not remove the last flake.
    agent_token)` immediately (tape is pulled from the still-live twin session).
 4. The two versions differ by one line — `agents/support-triage-v1.yaml` vs
    `agents/support-triage-v2.yaml`.
+
+---
+
+## Pending: the local examinee's pattern-1 baseline
+
+**Status: not yet measured** (2026-08-03). Deliberately empty — writing plausible
+numbers here is the exact failure the surrounding project exists to stop.
+
+| Variant | Pass rate | Score (per trial) | Behavior |
+|---|---|---|---|
+| `DENY_ISSUE_LOOKUP = true` (baseline) | — | — | — |
+| `DENY_ISSUE_LOOKUP = false` (fixed) | — | — | — |
+
+### The prediction, stated before the measurement
+
+So the run can disagree with it.
+
+| criterion | kind | baseline | fixed |
+|---|---|---|---|
+| A message in "support" contains "issues/1" | code:slack | ✗ | ✓ |
+| recognized the existing issue, opened no duplicate | model | ✗ | ✓ |
+| concrete repro steps | model | ✓ | ✓ |
+
+Baseline expected at **33**, for the same reason the managed-agent v1 scored 33
+and not 0: the agent does real work and its report is good. What it cannot do is
+look.
+
+### How to measure it
+
+```bash
+pome run tasks/duplicate-issue.md -n 5          # red   (DENY_ISSUE_LOOKUP = true)
+# flip the constant in local/src/index.ts, then
+pome run tasks/duplicate-issue.md -n 5          # green
+```
+
+Record the model id, `n/N`, the date and the run ids on both sides, then fill the
+table and the `verified red:` stamp in [`README.md`](./README.md).
+
+### The criteria are not finished
+
+The set above asserts that the agent **linked the right issue**. It does not
+assert that it **opened no second one** — the negative assertion
+`docs/curriculum/failure-classes.md` §4.2 asks for, and the one this example's
+lesson is actually named after. The declared GitHub vocabulary could not express
+it until `github.no-new-issues` ([F-1198](https://linear.app/pome-sh/issue/F-1198),
+digital-twins#283).
+
+Sequencing, because it is a cross-repo train and getting it wrong reddens the
+corpus gate: **twin-github 0.9.0 merges → publishes to npm → pome-cloud bumps its
+pin → only then** does a `no-new-issues` criterion belong in this task file. Added
+earlier, `criteria-corpus-watch` resolves it against the old pin and reports an
+unresolved phrase.
+
+### Re-verification duty
+
+Pattern-1 baselines carry the lowest rot risk — no model capability routes around
+a tool that was never exposed — so this does not need re-verifying per model
+generation. It **does** need re-verifying when the GitHub twin's tool surface
+changes: a new read path to an issue that `ISSUE_LOOKUP_TOOLS` does not name is a
+way around the defect, and the baseline would go green for the wrong reason.
+`local/test/tool-policy.test.ts` pins the list; it cannot know about a tool that
+does not exist yet.

--- a/examples/support-triage/local/README.md
+++ b/examples/support-triage/local/README.md
@@ -13,22 +13,53 @@ re-reports a bug that open issue #1 already tracks.
 
 ## The fix ("33, not 0")
 
-The whole product story is **one line** of the system prompt — `TRIAGE_RULE` in
-[`src/index.ts`](./src/index.ts):
+The whole product story is **one line** of committed configuration —
+`DENY_ISSUE_LOOKUP` in [`src/index.ts`](./src/index.ts):
 
-- **v1 (ships as the default — fails).** The baseline line tells the agent
-  *not* to search existing issues, so it files a **duplicate** issue for a bug
-  already tracked. It scores **33, not 0**: the agent does real work (its
-  report has concrete repro steps), but flunks both duplicate-detection
-  criteria — exactly the failure a happy-path demo never shows.
-- **v2 (the one-line fix — passes).** Swap `TRIAGE_RULE` to the commented
-  `TRIAGE_RULE_V2` right next to it (*search open issues first; comment on the
-  existing issue instead of opening a second one*), re-run, and the same exam
-  goes green.
+- **`true` (ships as the default — fails).** The agent's tool policy denies it
+  every read path into the repository's issues (`search_issues`, `list_issues`,
+  `get_issue`). Its system prompt is the *correct* one — search before filing —
+  so it reaches for the lookup, is refused, honestly concludes nothing tracks
+  the bug, and files a **duplicate**. It scores **33, not 0**: the agent does
+  real work (its report has concrete repro steps) and flunks the
+  duplicate-detection criteria — exactly the failure a happy-path demo never
+  shows.
+- **`false` (the one-line fix — passes).** Flip the constant, re-run, and the
+  same exam goes green: the agent searches, finds issue #1, comments on it, and
+  posts *its* link back.
 
-The two lines are verbatim from `../agents/support-triage-v1.yaml` and
-`…-v2.yaml` — this examinee and the managed-agent pair tell the same
-fail → fix → pass story on different runtimes.
+This is a **pattern-1** baseline in the curriculum's terms
+(`pome-cloud docs/curriculum/failure-classes.md` §3): the flaw is in the code
+and config layer, so a stronger model cannot rescue it — it follows the correct
+instruction *more* reliably and simply gets refused faster.
+
+The managed-agent pair next door (`../agents/support-triage-v1.yaml` vs
+`…-v2.yaml`) tells the same fail → fix → pass story through a *prompt* flaw, on
+a different runtime. That is a pattern-2 baseline and its red is
+model-dependent; it is kept for the managed-agent path, but this file is the one
+the curriculum grades.
+
+## Telemetry
+
+`query` is imported from `@pome-sh/adapter-claude-sdk`, not from
+`@anthropic-ai/claude-agent-sdk`. It is a drop-in — the message stream is
+byte-for-byte what the SDK yields — and it emits gen_ai OTLP spans (model,
+per-turn input/output tokens, latency) whenever a runner injects
+`POME_OTEL_EXPORTER_OTLP_ENDPOINT`, which both `pome run` and the coach do. With
+no endpoint set it is inert, so a standalone run is unaffected.
+
+Adopting it moved `@anthropic-ai/claude-agent-sdk` from a pinned `0.2.141` to
+`^0.3.215` — the adapter's peer range, and the range
+[`../../triage-agent`](../../triage-agent) already runs on. Nothing in this
+examinee's SDK surface changed with it.
+
+Using the adapter rather than hand-rolling the exporter is deliberate: per-turn
+token accounting has two non-obvious traps the adapter already fixed — one API
+turn arrives as several `assistant` messages that each repeat the same `usage`
+object (naive counting over-reported one run's input by 79%), and the true
+per-turn `output_tokens` only arrives on a `message_delta` stream event, not on
+the assistant message. An example that re-implemented this would be teaching the
+bug.
 
 ## How the coach launches it
 
@@ -90,8 +121,9 @@ per-session bearer the runner injects as `POME_AUTH_TOKEN`.
 ## Layout
 
 ```
-src/index.ts       the examinee — env wiring, the TRIAGE_RULE v1/v2 pair, the SDK loop
-test/env.test.ts   unit test for the launch env contract (npm test)
+src/index.ts             the examinee — env wiring, the DENY_ISSUE_LOOKUP defect, the SDK loop
+test/env.test.ts         unit test for the launch env contract (npm test)
+test/tool-policy.test.ts the lesson pinned as a property — both branches, neither shipped value
 ```
 
 `npm run typecheck` type-checks; `npm test` runs the env-contract test. This

--- a/examples/support-triage/local/package-lock.json
+++ b/examples/support-triage/local/package-lock.json
@@ -8,7 +8,8 @@
       "name": "@pome-sh/support-triage-local-example",
       "version": "0.1.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.2.141"
+        "@anthropic-ai/claude-agent-sdk": "^0.3.215",
+        "@pome-sh/adapter-claude-sdk": "0.2.5"
       },
       "devDependencies": {
         "@types/node": "^25.9.5",
@@ -21,35 +22,33 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.141.tgz",
-      "integrity": "sha512-AIBacMWGcZIUcXlUoObqjwJ6pmJI3BayAqPAFXuvSq3DHJXdiuZVs7l/zTB5l3nRhRv5cqSrI2XbiDeHgZWizw==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.220.tgz",
+      "integrity": "sha512-glc7SdwPkOkLw8oxwLo9PKTdLJGqW/PIR4urWXFoRtX9YllwozsEVc5Tc1+EvLSkfrsxPJqQWqOgpjUOQXf1oA==",
       "license": "SEE LICENSE IN README.md",
-      "dependencies": {
-        "@anthropic-ai/sdk": "^0.93.0",
-        "@modelcontextprotocol/sdk": "^1.29.0"
-      },
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.141",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.141",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.141",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.141",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.141",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.141",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.141",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.141"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.220"
       },
       "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.0.0"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.141.tgz",
-      "integrity": "sha512-9HZ0ot6+FwOfQ1aeMqQLH4IJGMm/DcP08SysDxscVjBm6l2JjqleHohxi3zid0DurfGweqT+4x9GScJffwg55g==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.220.tgz",
+      "integrity": "sha512-7VxlbEosK7DODiOnsjoVd0DSJzbnaPrM2jelMHI0y8zx1UnLS3WC6EFUXbvy74F2sXqEznh2tzn7EKWInaRN6Q==",
       "cpu": [
         "arm64"
       ],
@@ -60,9 +59,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.141.tgz",
-      "integrity": "sha512-4iAdarJaQ+2R58s6QJswZCzUdz2WQmL5lYG7Y+FLzWbRSROFfcH0QYpmOqSaPXd2KRQhIJwEacqecDZd/Q1XKQ==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.220.tgz",
+      "integrity": "sha512-X9RwDsSmbF6ultKZroaip+DL8WRgC64gHbrAwrRlAFSPNZV7zmJyP2ur8rW7KrxqmtuehdMMkw8+SAC/6hD2PA==",
       "cpu": [
         "x64"
       ],
@@ -73,9 +72,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.141.tgz",
-      "integrity": "sha512-Jdf0ZEwJzOP8sE6rPqdJN+SxMb0/L8sxJg4twCv/7S+Qzk0hJtls+wxSi+0Tjh6EEMaNxJqEGc7S3fx99Wi99Q==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.220.tgz",
+      "integrity": "sha512-WkROPwWskqhKR9XgnmseHQ6rLi9zM9qt57IWoToIjL/eXOqDWipp7JXZ1L5ud+LrA42dunHPZfBwD/vXZ+A7LA==",
       "cpu": [
         "arm64"
       ],
@@ -89,9 +88,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.141.tgz",
-      "integrity": "sha512-6H1AJ/AVaWNnV22kubUPkOTRzZFH0+qP9k7WlhriHMN9gtgZcVAsITMddDeGjQsQJMCAdhXFd6sgi7TM1LdeOQ==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.220.tgz",
+      "integrity": "sha512-OHoZOZ8Cf2TBr6oXIXPwyvUxj9jrq2w8E4poA8dMpacXszcPSPiCQCMuuOh4aWJzfeJE1+TtWxhKMVb2csXyZQ==",
       "cpu": [
         "arm64"
       ],
@@ -105,9 +104,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.141.tgz",
-      "integrity": "sha512-DVjp72f3HmrRYpbneWZZWIqkUht5kTZXS7wXGFiwzLz6eNYEgjjh+GcsnhIi8UOwZUtNiKUrjZnoP38ovFqV8A==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.220.tgz",
+      "integrity": "sha512-tkTJFnpR9VifvWX2fmkCAPkT6+8Wk/gVu8B5jsVekKZPiZoWRHmMXO30BnZn+f0TZhgYP+82PSX3S8crH1kn+w==",
       "cpu": [
         "x64"
       ],
@@ -121,9 +120,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.141.tgz",
-      "integrity": "sha512-fTI1YuM4cxOa4nSgsyMAdB5ELizkWp+w5Ispo4JnnYtcczMAL4D9GBNjWPW0sUzKvjsJOUVim68SmWLWhUOpXQ==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.220.tgz",
+      "integrity": "sha512-K+FWj+LcGhC1Z7wqeWoLxm1iemcba5xKpLLFVwYm4V6HyMx3ruYd/2r2TiQtjT+JWeNFWIys0ScHiItR6vWAiA==",
       "cpu": [
         "x64"
       ],
@@ -137,9 +136,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.141.tgz",
-      "integrity": "sha512-Wm10J6kfbufbPGFELokiJ/7Y5Oqug4Uag3HXFsV8g7TWCpaItx/oqVaJoiGptuAtXQB7xGLQVTuk082wER+Y5w==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.220.tgz",
+      "integrity": "sha512-rIwgq0UwQExWl6KrHUyC4w5KwpL9l6nd95aUTx6RitexaAuEw//xtfTVLnuE4hDDQZFkzEwpdKc3nxDWoGcUbA==",
       "cpu": [
         "arm64"
       ],
@@ -150,9 +149,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.141.tgz",
-      "integrity": "sha512-IXuP29YJuWbR5Q6xOHrjFVGG54V2s1FC61UVNwEN5fpxL09MwPnbwtQL6fqgzt/U1MP7vWAwpXZriYAklkH/mg==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.220.tgz",
+      "integrity": "sha512-MuOuXhbr66HlGaWXD2f3w0k2PsvmnbkwcUZ0dAe2poFLdl72GC2dapwwOBefxm9QmoNqk9+jmv/dSKGOVWyvLw==",
       "cpu": [
         "x64"
       ],
@@ -167,6 +166,7 @@
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.93.0.tgz",
       "integrity": "sha512-q9vaSZQVFx6B/gPxetGYfLXSJD5v0sOmh0OpZDq7yCrTSA+Rscvrtyol7JJTW40wEpQB4U1B4JXzxQitbQ3CAA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
       },
@@ -187,6 +187,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -672,6 +673,7 @@
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
       "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.14.1"
       },
@@ -691,6 +693,7 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -745,6 +748,318 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.220.0.tgz",
+      "integrity": "sha512-/+ExB3lRkf+erv4PnoywyL7RHKITidxtUpUTS55k7OQ0dB42S7gEF1gry7swb9MSm1hYLUhJg4QQh9W8SpwwqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/otlp-exporter-base": "0.220.0",
+        "@opentelemetry/otlp-transformer": "0.220.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/sdk-trace": "2.9.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.220.0.tgz",
+      "integrity": "sha512-CXYo8UD5Mn9YbgebO2EL4wejtA+gxLmLiu6HCk2KH2BR7XhFN6/6p1UlCb23DYCjeYkndevLHuejCCN1yx4+OQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/otlp-transformer": "0.220.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.220.0.tgz",
+      "integrity": "sha512-lXGrv7KXZ0gNH9SVNUaa6vv6phVYGvJxfXAlMbzbakiXru75f5MZl8Z7oqiMMQD77riVHJCFlQvbZs/VVN2/4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/sdk-logs": "0.220.0",
+        "@opentelemetry/sdk-metrics": "2.9.0",
+        "@opentelemetry/sdk-trace": "2.9.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.220.0.tgz",
+      "integrity": "sha512-WywcTkQtv2iNmt+6y5Kcd4rzvx9bLVsBa2Nwcmg01IUaBTkTow3W4d9KE5vNBpEDtb9tp21WcRBY/lANRrApYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.9.0.tgz",
+      "integrity": "sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
+      "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.139.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
@@ -753,6 +1068,37 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@pome-sh/adapter-claude-sdk": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@pome-sh/adapter-claude-sdk/-/adapter-claude-sdk-0.2.5.tgz",
+      "integrity": "sha512-gCztmJMPbQd9iXySzFIr4rEskZXpj4d8iF4u7jXSvVKZioEaoFfI96uITJ+MAez9qG4rSVorltPwl75IwpYTpA==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.220.0",
+        "@opentelemetry/resources": "^2.10.0",
+        "@opentelemetry/sdk-trace-base": "^2.0.0",
+        "@pome-sh/shared-types": "0.13.0"
+      },
+      "engines": {
+        "node": ">=24"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.3.215"
+      },
+      "peerDependenciesMeta": {
+        "@anthropic-ai/claude-agent-sdk": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@pome-sh/shared-types": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.13.0.tgz",
+      "integrity": "sha512-2PhyUXW0rehqa92fBOe0RTk6R4gJ5J/0lnPW+/x1I4+3xty0W4sQEb0BxJ1vuq66NExtcOAul5bQYlOqbNhnaA==",
+      "peerDependencies": {
+        "zod": "^4.1.13"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1208,6 +1554,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
@@ -1221,6 +1568,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1237,6 +1585,7 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -1264,6 +1613,7 @@
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
       "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^2.0.0",
@@ -1288,6 +1638,7 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1301,6 +1652,7 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1310,6 +1662,7 @@
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -1323,6 +1676,7 @@
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -1349,6 +1703,7 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1362,6 +1717,7 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1378,6 +1734,7 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1387,6 +1744,7 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.6.0"
       }
@@ -1396,6 +1754,7 @@
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -1413,6 +1772,7 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1427,6 +1787,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -1444,6 +1805,7 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1463,6 +1825,7 @@
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -1476,13 +1839,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1492,6 +1857,7 @@
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -1501,6 +1867,7 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -1517,6 +1884,7 @@
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -1570,7 +1938,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
@@ -1587,6 +1956,7 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1596,6 +1966,7 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
@@ -1608,6 +1979,7 @@
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
       "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -1627,6 +1999,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1670,6 +2043,7 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
       "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
         "ip-address": "^10.2.0"
@@ -1688,7 +2062,8 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-uri": {
       "version": "3.1.4",
@@ -1704,7 +2079,8 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1729,6 +2105,7 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "encodeurl": "^2.0.0",
@@ -1750,6 +2127,7 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1759,6 +2137,7 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1783,6 +2162,7 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -1792,6 +2172,7 @@
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -1816,6 +2197,7 @@
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -1829,6 +2211,7 @@
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -1841,6 +2224,7 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -1853,6 +2237,7 @@
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -1865,6 +2250,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
       "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1874,6 +2260,7 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "depd": "~2.0.0",
         "inherits": "~2.0.4",
@@ -1894,6 +2281,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
       "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -1909,13 +2297,15 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -1925,6 +2315,7 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -1933,19 +2324,22 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/jose": {
       "version": "6.2.4",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
       "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -1955,6 +2349,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "ts-algebra": "^2.0.0"
@@ -1967,13 +2362,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/lightningcss": {
       "version": "1.33.0",
@@ -2263,6 +2660,7 @@
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -2272,6 +2670,7 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2281,6 +2680,7 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2293,6 +2693,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2302,6 +2703,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -2317,7 +2719,8 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/nanoid": {
       "version": "3.3.16",
@@ -2343,6 +2746,7 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2352,6 +2756,7 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2361,6 +2766,7 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -2387,6 +2793,7 @@
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -2399,6 +2806,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -2408,6 +2816,7 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2417,6 +2826,7 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2426,6 +2836,7 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
@@ -2463,6 +2874,7 @@
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -2501,6 +2913,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -2514,6 +2927,7 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
       "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "es-define-property": "^1.0.1",
         "side-channel": "^1.1.1"
@@ -2530,6 +2944,7 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
       "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       },
@@ -2543,6 +2958,7 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes": "~3.1.2",
         "http-errors": "~2.0.1",
@@ -2558,6 +2974,7 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2601,6 +3018,7 @@
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "depd": "^2.0.0",
@@ -2616,13 +3034,15 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
@@ -2649,6 +3069,7 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
@@ -2667,13 +3088,15 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -2686,6 +3109,7 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2695,6 +3119,7 @@
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
       "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.4",
@@ -2714,6 +3139,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.4"
@@ -2730,6 +3156,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -2748,6 +3175,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -2791,6 +3219,7 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2851,6 +3280,7 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -2859,7 +3289,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -2893,6 +3324,7 @@
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
       "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
@@ -2911,6 +3343,7 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2945,6 +3378,7 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2954,6 +3388,7 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3131,6 +3566,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -3162,13 +3598,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/zod": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -3178,6 +3616,7 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }

--- a/examples/support-triage/local/package.json
+++ b/examples/support-triage/local/package.json
@@ -10,7 +10,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.2.141"
+    "@anthropic-ai/claude-agent-sdk": "^0.3.215",
+    "@pome-sh/adapter-claude-sdk": "0.2.5"
   },
   "devDependencies": {
     "@types/node": "^25.9.5",

--- a/examples/support-triage/local/src/index.ts
+++ b/examples/support-triage/local/src/index.ts
@@ -15,36 +15,78 @@
  * CLI injects on `pome run … --agent "npm run start"`, so both launchers
  * share this one code path.
  *
- * The product story lives in ONE line: TRIAGE_RULE below ships as the v1
- * baseline (files a fresh issue without searching → duplicates a bug that is
- * already tracked → fails the exam at 33/100). The v2 fix is the commented
- * one-liner next to it; swap, re-run, and the same exam goes green.
+ * The product story lives in ONE line: DENY_ISSUE_LOOKUP below ships as `true`,
+ * which strips the agent's read access to existing issues. It searches, as its
+ * instructions tell it to, is refused, and honestly concludes nothing tracks the
+ * bug — so it files a duplicate and fails the exam. Flip the constant, re-run,
+ * and the same exam goes green.
+ *
+ * `query` comes from `@pome-sh/adapter-claude-sdk` rather than the raw SDK. It
+ * is a drop-in — the message stream is byte-for-byte what the SDK yields — and
+ * it emits gen_ai OTLP spans (model, per-turn tokens, latency) when a runner
+ * injects POME_OTEL_EXPORTER_OTLP_ENDPOINT, which is what puts a real waterfall
+ * on this example's report instead of the shallowest trace in the catalog. It is
+ * inert with no endpoint set, so a standalone run is unaffected.
  */
 
-import { query } from "@anthropic-ai/claude-agent-sdk";
+import { query } from "@pome-sh/adapter-claude-sdk";
 
 // ─── The one line under test ───────────────────────────────────────────────
 //
-// v1 — BASELINE (the misconfiguration), verbatim from
-// ../../agents/support-triage-v1.yaml. Ships as the default so the first run
-// FAILS the duplicate-issue exam: the agent files a fresh issue for a bug
-// already tracked by issue #1.
-const TRIAGE_RULE_V1 =
-  "Don't spend time digging through existing issues — for each report you triage, file a fresh GitHub issue and post its link back so the reporter always gets a ticket.";
-
-// v2 — THE FIX, verbatim from ../../agents/support-triage-v2.yaml. Uncomment
-// this constant and assign it to TRIAGE_RULE below, then re-run: the agent
-// searches first, finds issue #1, comments on it instead of duplicating it,
-// and the exam passes.
+// Curriculum class 1/dedup, and a PATTERN-1 baseline: the flaw is committed
+// CONFIGURATION, not a prompt (`pome-cloud docs/curriculum/failure-classes.md`
+// §3). Read the rationale in ../README.md before changing either constant.
 //
-// const TRIAGE_RULE_V2 =
-//   "Your first action for any report is ALWAYS to search the open issues in acme/orders-service before doing anything else; only if no existing issue already tracks the bug may you open a new one — if one does, comment on that existing issue and post ITS link back, never opening a second issue for a bug that is already tracked.";
+// The agent's tool policy denies it every read path into the repository's
+// issues. It can create one and comment on one; it cannot look one up. So it
+// does exactly what its instructions say — search first — is refused, finds
+// nothing, and correctly concludes the bug is untracked. It then files a SECOND
+// issue for a bug issue #1 already tracks.
+//
+// WHY IT DOES NOT ROT. The system prompt below is the CORRECT one: it tells the
+// agent to search before filing, and a stronger model follows it more reliably,
+// not less. That is the whole point — perfect model behaviour is corrupted by
+// the committed config, and no amount of capability can call a tool that was
+// never exposed. This is what the earlier baseline could not promise: it lived
+// in a prompt line telling the agent NOT to search, which is a pattern-2 flaw
+// whose red is model-dependent and, worse, indistinguishable from an evaluator
+// that never ran.
+//
+// The three names are the Claude Agent SDK's MCP tool ids — `mcp__<server>__<tool>`,
+// where the server is the `github` key of `mcpServers` below. They are the GitHub
+// twin's ONLY read paths to an issue; leaving any one of them open lets the agent
+// route around the defect and the baseline goes green for the wrong reason.
+const ISSUE_LOOKUP_TOOLS = [
+  "mcp__github__search_issues",
+  "mcp__github__list_issues",
+  "mcp__github__get_issue",
+];
 
-const TRIAGE_RULE = TRIAGE_RULE_V1; // ← the one-line fix: swap in TRIAGE_RULE_V2
+// ⛔ Ships as `true` — the failing baseline. Set it to `false`; that is the fix.
+const DENY_ISSUE_LOOKUP = true;
+
+/**
+ * The tools this examinee refuses to expose.
+ *
+ * Named rather than inlined so `test/tool-policy.test.ts` can pin BOTH branches
+ * without asserting which one ships — a guard the documented fix turns red is a
+ * guard you edit to make green.
+ *
+ * `WebSearch`/`WebFetch` are unconditional and are NOT part of the lesson: the
+ * seeded twin world is the whole exam, so an agent that can reach the open web
+ * is taking a different test.
+ */
+export function deniedTools(denyIssueLookup: boolean = DENY_ISSUE_LOOKUP): string[] {
+  return ["WebSearch", "WebFetch", ...(denyIssueLookup ? ISSUE_LOOKUP_TOOLS : [])];
+}
 // ───────────────────────────────────────────────────────────────────────────
 
-// Identical to both YAMLs except for the TRIAGE_RULE line — the diff between
-// a failing and a passing agent is exactly that line.
+// The CORRECT triage rule, in both variants. It is verbatim
+// ../../agents/support-triage-v2.yaml's line, and it stays put: under a
+// pattern-1 baseline the prompt is not what is broken.
+const TRIAGE_RULE =
+  "Your first action for any report is ALWAYS to search the open issues in acme/orders-service before doing anything else; only if no existing issue already tracks the bug may you open a new one — if one does, comment on that existing issue and post ITS link back, never opening a second issue for a bug that is already tracked.";
+
 const SYSTEM_PROMPT = `You are a support-triage agent for the acme engineering org.
 
 Your job: watch the #support Slack channel for bug reports, reproduce and
@@ -151,9 +193,11 @@ async function main() {
       systemPrompt: SYSTEM_PROMPT,
       permissionMode: "bypassPermissions",
       maxTurns: 30,
-      // Allow every tool the two twins expose; keep the run closed-book (the
-      // seeded twin world is the whole exam — no web).
-      disallowedTools: ["WebSearch", "WebFetch"],
+      // Everything the two twins expose, minus `deniedTools()` — which is where
+      // the committed baseline defect lives. See the block at the top of this
+      // file; `WebSearch`/`WebFetch` are the unconditional closed-book clamp and
+      // are not part of the lesson.
+      disallowedTools: deniedTools(),
       mcpServers,
     },
   });

--- a/examples/support-triage/local/test/tool-policy.test.ts
+++ b/examples/support-triage/local/test/tool-policy.test.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The curriculum lesson this example teaches, pinned as a property.
+//
+// The baseline defect is committed CONFIGURATION: `deniedTools()` strips the
+// agent's read access to existing issues, so it searches (its prompt tells it
+// to), is refused, and files a duplicate for a bug issue #1 already tracks.
+//
+// WHAT THIS SUITE DELIBERATELY DOES NOT ASSERT: which way `DENY_ISSUE_LOOKUP`
+// currently ships. A test that pinned the shipped value would go red the moment
+// a reader applies the one-line fix the README teaches — a guard you have to
+// edit to make green is not a guard. Both branches are exercised by passing the
+// flag explicitly.
+//
+// It earns its place twice over. The denial list LOOKS like ordinary hardening —
+// a reader tidying up "unused" entries deletes the lesson — and the three names
+// are the twin's ONLY read paths to an issue, so a fourth one appearing upstream
+// would silently hand the baseline a way around its own defect.
+import { describe, expect, it } from "vitest";
+import { deniedTools } from "../src/index.ts";
+
+const ISSUE_LOOKUP = [
+  "mcp__github__search_issues",
+  "mcp__github__list_issues",
+  "mcp__github__get_issue",
+];
+
+describe("deniedTools — the committed baseline defect", () => {
+  it("denies every read path to an issue in the baseline", () => {
+    const denied = deniedTools(true);
+    for (const tool of ISSUE_LOOKUP) {
+      expect(denied, `${tool} was left reachable`).toContain(tool);
+    }
+  });
+
+  it("denies none of them once the fix is applied", () => {
+    const denied = deniedTools(false);
+    for (const tool of ISSUE_LOOKUP) {
+      expect(denied, `${tool} is still denied after the fix`).not.toContain(tool);
+    }
+  });
+
+  // The closed-book clamp is NOT the lesson and must survive the fix. An agent
+  // that can reach the open web is taking a different exam, and a fix that
+  // silently re-opened it would change what the green run even measured.
+  it("keeps the web tools denied on both sides — that clamp is not the lesson", () => {
+    for (const flag of [true, false]) {
+      expect(deniedTools(flag)).toContain("WebSearch");
+      expect(deniedTools(flag)).toContain("WebFetch");
+    }
+  });
+
+  // The write paths are what make the FIXED variant able to pass. If the defect
+  // ever grew to cover them, the green side would have no way through and the
+  // example would teach "the agent can do nothing" instead of "the agent could
+  // not look before it leapt".
+  it("never denies the write paths the fixed variant needs", () => {
+    for (const flag of [true, false]) {
+      const denied = deniedTools(flag);
+      expect(denied).not.toContain("mcp__github__add_issue_comment");
+      expect(denied).not.toContain("mcp__github__create_issue");
+      expect(denied).not.toContain("mcp__slack__post_message");
+    }
+  });
+
+  it("differs on exactly the issue-lookup tools", () => {
+    const extra = deniedTools(true).filter((tool) => !deniedTools(false).includes(tool));
+    expect(extra).toEqual(ISSUE_LOOKUP);
+  });
+});

--- a/examples/support-triage/pome.json
+++ b/examples/support-triage/pome.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://pome.sh/schemas/v1/pome.json",
+  "agent": {
+    "slug": "support-triage",
+    "name": "Support Triage",
+    "description": "Triages #support bug reports into GitHub issues, and is supposed to notice when one is already tracked",
+    "version": "v1",
+    "framework": "claude-agent-sdk"
+  },
+  "command": "npm --prefix local run start",
+  "twins": ["github", "slack"],
+  "tasks": "tasks",
+  "artifacts_dir": "runs",
+  "pass_threshold": 100
+}


### PR DESCRIPTION
Curriculum **lesson #1**, re-cut off its prompt flaw. This is three of F-979's five build sections; what is still owed is named at the bottom rather than implied.

## 1 · The baseline is now pattern-1

The flaw leaves the system prompt and becomes committed configuration:

```ts
const ISSUE_LOOKUP_TOOLS = [
  "mcp__github__search_issues",
  "mcp__github__list_issues",
  "mcp__github__get_issue",
];
const DENY_ISSUE_LOOKUP = true;   // ← ships as the baseline
```

The prompt it ships with is now the **correct** one — *search the open issues first; only open a new one if nothing already tracks the bug*. The agent follows it. It is refused. It honestly concludes the bug is untracked and files a duplicate.

**That inversion is the whole point.** A stronger model follows the correct instruction *more* reliably and gets refused faster, so the red cannot rot. The old baseline lived in a charter line telling the agent not to search — a pattern-2 flaw whose red is model-dependent and, worse, *indistinguishable from an evaluator that never ran*. That is F-979's own stated rationale, now true rather than planned.

It is also the most common real version of this bug: nobody writes "don't dedup" in a system prompt, and plenty of people ship an agent that cannot see what it needs to.

The managed-agent `v1/v2` YAML pair **stays**, relabelled as what it is — the same story on another runtime through a prompt flaw. Both READMEs say which of the two the curriculum grades.

## 2 · Telemetry

`query` now comes from `@pome-sh/adapter-claude-sdk` instead of the raw SDK. It is a drop-in (the message stream is byte-for-byte what the SDK yields) and it emits gen_ai OTLP spans when a runner injects `POME_OTEL_EXPORTER_OTLP_ENDPOINT` — which both `pome run` and the coach do. The hero example produced the shallowest trace in the catalog; it now carries model, per-turn tokens and latency.

Using the adapter rather than hand-rolling the exporter is deliberate. Per-turn token accounting has two non-obvious traps the adapter already fixed: one API turn arrives as several `assistant` messages that each repeat the same `usage` object (naive counting over-reported a live run's input by 79% — F-994), and the true per-turn `output_tokens` only arrives on a `message_delta` stream event (F-998). An example that re-implemented this would be teaching the bug.

**This moved `@anthropic-ai/claude-agent-sdk` from a pinned `0.2.141` to `^0.3.215`** — the adapter's peer range, and the range `examples/triage-agent` already runs on. Typecheck and tests are clean across the bump; nothing in this examinee's SDK surface changed.

## 3 · Manifest

`pome.json` with `agent.framework` set honestly. support-triage was the only example without one.

## Reviewer notes

* **`test/tool-policy.test.ts` does not assert which way `DENY_ISSUE_LOOKUP` ships**, on purpose — a guard the documented one-line fix turns red is a guard you edit to make green. It earns its place twice: a denial list *reads like ordinary hardening*, so a reader tidying "unused" entries deletes the lesson; and the three names are the twin's **only** read paths to an issue, so a fourth appearing upstream would silently hand the baseline a way around its own defect. There is also a test that the fix never denies the write paths the green side needs — a negative only "the agent did nothing" can satisfy is a trap, not a check.
* **`VERIFICATION.md` now says which baseline each number measured.** The 2026-07 v1/v2 figures are kept **unedited** and dated, with three independent reasons they do not transfer: different flaw, recorded before honest scoring, recorded against pre-2026-08-03 twin images. Deleting the provenance of the "33, not 0" number the whole onboarding narrative rests on would be worse than dating it. The pattern-1 table ships **empty**, with its prediction stated up front so the hosted run can disagree with it.
* **`typecheck:examples` does not cover this package.** It walks the 7 examples with a top-level `package.json`; `support-triage`'s code lives in `local/`. Typechecked manually here — worth a follow-up, not worth widening the script in this PR.

## Still owed — named, not implied

* **The criteria.** They assert the agent *linked the right issue*, not that it *opened no second one* — the negative `docs/curriculum/failure-classes.md` §4.2 asks for, and the one this lesson is named after. It needs `github.no-new-issues` (**F-1198**, #283) to reach the cloud's pin first: **twin-github 0.9.0 merges → publishes → pome-cloud bumps its pin → only then** does the criterion belong in the task file. Added earlier, `criteria-corpus-watch` resolves it against the old pin and reports an unresolved phrase. The README says this out loud rather than leaving a reader to find it.
* **The `verified red` stamp** and the hosted red/green run.
* **The `apps/docs` guide page**, which F-979 says to write *after* the walk so it documents reality.
* **The founder cold walk**, which is the ticket's actual acceptance.

## Verification

```
examples/support-triage/local   typecheck clean · 10 tests pass (2 files)
npm run typecheck:examples      all 7 workspace examples clean
lint:code-health / lint:legacy-markers / lint:copy-markers / lint:cli-pins   pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)