### PR TITLE
A state-reading verdict says where it looked — 37 of 45 declared checks (F-1197)

### DIFF
--- a/packages/sdk/src/check-state-path.ts
+++ b/packages/sdk/src/check-state-path.ts
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Where a state-reading check LOOKED (F-1197).
+//
+// `evidenceEventIds` (F-980/F-1076) answers "which recorded call produced this
+// verdict", and only a `substrate: "tape"` check can fill it. That left 37 of
+// the 45 declared checks citing nothing at all — not a call, not a state path,
+// nothing a report could turn into an affordance. This module is the other
+// pointer: the address, inside the twin's own exported state tree, of the thing
+// the predicate compared.
+//
+// Split from `checks.ts` for the same reason `check-discrimination.ts` is:
+// that file DEFINES the grammar a declaration is written in, this one defines a
+// second, much smaller grammar — the one a POINTER is written in — and `checks.ts`
+// is already at the 500-line health limit. Consumers import both from
+// `@pome-sh/sdk/checks`, which re-exports these.
+//
+// ─── Why RFC 6901, and why not a friendlier syntax ──────────────────────────
+//
+// A pointer here is a JSON Pointer over the tree the twin's `exportState()`
+// produced. Two properties decided it, and both are about the READER rather
+// than the writer:
+//
+//   1. It resolves or it does not. There is no partial match, no fuzzy segment,
+//      no "the array moved by one" — so a consumer can ask a total question
+//      (`resolveStatePath`) and get a total answer. That is exactly what
+//      `apps/dashboard/src/lib/criterion-evidence.ts` needs to decide between
+//      rendering an affordance and rendering none: F-980's rule is that a row
+//      never advertises a jump that then does nothing, and a pointer language
+//      with a maybe in it cannot honour that rule.
+//   2. It is somebody else's spec. A hand-rolled `repositories[0].issues[2]`
+//      needs an escaping story the first time a key contains a dot, and this
+//      tree has keys like `full_name` today and label names tomorrow. RFC 6901
+//      already wrote that story down (`~0` for `~`, `~1` for `/`), and the
+//      consumer is a browser that will re-implement the walk in fifteen lines
+//      whatever we choose.
+//
+// ─── Which tree a pointer addresses ─────────────────────────────────────────
+//
+// ALWAYS `final` — the exported end state — even for a `seed+final` check whose
+// assertion is a delta. That is not a shortcut, it is what makes the pointer
+// usable: the reader has the final tree on screen, and a pointer into a seed it
+// is not rendering would be an affordance that lands nowhere, which is the
+// defect this module exists to remove rather than relocate.
+//
+// A delta check therefore cites the field whose CHANGE it asserted about
+// (`github.no-new-labels` cites the repo's final label set), and its reason
+// sentence carries the before/after. The pointer says where to look; the reason
+// says what was wrong there.
+
+import type { CheckDefinition } from "./checks.js";
+
+/**
+ * One segment, escaped per RFC 6901 §3.
+ *
+ * Order matters and is not interchangeable: `~` must be encoded FIRST, or the
+ * `/` pass would turn a literal `/` into `~1` and the `~` pass would then turn
+ * that into `~01`, which decodes back to `~1` — a different string. This is the
+ * canonical ordering the spec spells out, restated here because getting it
+ * backwards produces a pointer that looks right and resolves to nothing.
+ */
+function escapeSegment(segment: string): string {
+  return segment.replace(/~/g, "~0").replace(/\//g, "~1");
+}
+
+function unescapeSegment(segment: string): string {
+  return segment.replace(/~1/g, "/").replace(/~0/g, "~");
+}
+
+/**
+ * A pointer from the ROOT of the exported tree.
+ *
+ * Numbers are array indices and strings are object keys, but this function does
+ * not enforce that — the tree decides, at resolution time. Passing no segments
+ * returns `""`, which RFC 6901 defines as the whole document; a check with
+ * nothing narrower to name must OMIT `evidenceStatePaths` rather than cite the
+ * root, for the same reason it must omit rather than send `[]`.
+ */
+export function statePath(...segments: readonly (string | number)[]): string {
+  return segments.map((segment) => `/${escapeSegment(String(segment))}`).join("");
+}
+
+/**
+ * A pointer relative to one a resolver already built.
+ *
+ * The twins' `resolve*` helpers walk the tree to find an entity and now hand
+ * back the pointer they walked; a check appends the field it went on to read.
+ * Written as its own function rather than string concatenation at 37 call sites
+ * because the escaping has to happen on the appended segments and NOT on the
+ * base, which already contains real `/` separators — concatenating by hand is
+ * how a `~1` ends up double-encoded.
+ */
+export function childStatePath(
+  base: string,
+  ...segments: readonly (string | number)[]
+): string {
+  return `${base}${statePath(...segments)}`;
+}
+
+/**
+ * What a pointer addresses in a tree, or `null` when it addresses nothing.
+ *
+ * `null` is a NORMAL answer and every caller must handle it: the state blob a
+ * report renders can be a different export from the one the check read (a
+ * re-run, a truncated upload, a snapshot predating a field). A consumer turns
+ * `null` into "no affordance", exactly as `findEventIndexForEvidence` turns an
+ * unresolvable event id into one.
+ *
+ * Wrapped in `{ value }` rather than returned bare because `undefined` and
+ * `null` are both legal JSON-ish values a tree can hold at a pointer, and a bare
+ * return could not tell "the path is absent" from "the path holds null" — the
+ * difference between no evidence and evidence that the field is empty.
+ */
+export function resolveStatePath(
+  tree: unknown,
+  pointer: string,
+): { value: unknown } | null {
+  if (pointer === "") return { value: tree };
+  // RFC 6901 §3: a non-empty pointer MUST begin with "/". Anything else is not
+  // a pointer, and guessing (say, by prefixing one) would resolve a string the
+  // writer never wrote.
+  if (!pointer.startsWith("/")) return null;
+
+  let cursor: unknown = tree;
+  // `slice(1)` drops the leading "" that splitting on the leading "/" produces.
+  // A trailing "/" is meaningful — it is the empty-string KEY, which is legal —
+  // so this deliberately does not trim.
+  for (const raw of pointer.slice(1).split("/")) {
+    const segment = unescapeSegment(raw);
+    if (Array.isArray(cursor)) {
+      // Array indices are decimal, no leading zeros, no "+", no "-0" — spelled
+      // out rather than left to `Number()`, which happily accepts "1e0", " 1"
+      // and "0x1" and would resolve pointers nobody could have written.
+      if (!/^(?:0|[1-9][0-9]*)$/.test(segment)) return null;
+      const index = Number(segment);
+      if (index >= cursor.length) return null;
+      cursor = cursor[index];
+      continue;
+    }
+    // `typeof null === "object"`, so the null guard is not redundant.
+    if (cursor === null || typeof cursor !== "object") return null;
+    const record = cursor as Record<string, unknown>;
+    // `in` rather than a truthiness test, so a field holding `null`, `0` or `""`
+    // resolves. A pointer at a field that exists and is empty is evidence — it
+    // is how a reader sees that the label set the check read was empty.
+    //
+    // Own properties only: `/constructor` must not resolve through the
+    // prototype chain and hand a consumer a function to render.
+    if (!Object.prototype.hasOwnProperty.call(record, segment)) return null;
+    cursor = record[segment];
+  }
+  return { value: cursor };
+}
+
+// ─── The gate ────────────────────────────────────────────────────────────────
+//
+// A field nobody fills is worse than no field: it advertises a capability the
+// report cannot use, and the measurement that opened F-1197 (8 of 45) is exactly
+// what an unfilled optional field looks like from the outside. So the citation
+// gets the same treatment `discriminatingWorlds` got in F-1126 — a probe here, a
+// ledgered assertion in each twin's contract test, and a null that costs
+// something to admit.
+//
+// It reuses the worlds the check ALREADY declares rather than asking for a
+// second fixture. That is the whole reason this gate is cheap enough to hold
+// across five twins: `discriminatingWorlds` is required, so every state check
+// already ships a world its predicate resolves in, and "does the pointer it
+// cites resolve in that same world" is a question with no new inputs.
+
+export type StateCitationArm = "passing" | "failing";
+
+export type StateCitationVerdict =
+  // Both arms cited at least one pointer, and every pointer resolved.
+  | { kind: "cites" }
+  // The declaration named no worlds. The CALLER must find a ledger entry — this
+  // function deliberately does not know about ledgers, exactly as
+  // `probeDiscrimination` does not, so a twin cannot satisfy the gate by
+  // shipping an empty one.
+  | { kind: "declined" }
+  // The outcome named no path at all.
+  | { kind: "uncited"; arm: StateCitationArm }
+  // A pointer was cited and addresses nothing in the world the check just read.
+  | { kind: "unresolvable"; arm: StateCitationArm; pointer: string }
+  // A pointer was cited that is not a pointer — `[]`, an empty string, a
+  // non-string. Separated from `unresolvable` because the fix is different: one
+  // is a bad address, the other is a check that forgot the omit-don't-empty rule.
+  | { kind: "malformed"; arm: StateCitationArm; detail: string };
+
+function probeArm<TState, TArgs extends Record<string, string>>(
+  def: CheckDefinition<TState, TArgs>,
+  args: TArgs,
+  arm: StateCitationArm,
+  world: { seed: TState | null; final: TState; tape: readonly unknown[] | null },
+): StateCitationVerdict {
+  const outcome = def.evaluate(args, world as never);
+  const paths = outcome.evidenceStatePaths;
+  if (paths === undefined) return { kind: "uncited", arm };
+  if (!Array.isArray(paths) || paths.length === 0) {
+    // The omit-don't-empty rule, enforced rather than documented. `[]` and
+    // absent mean the same thing downstream, so a check that sends `[]` has
+    // written a key the consumer must special-case for no gain.
+    return {
+      kind: "malformed",
+      arm,
+      detail: `evidenceStatePaths must be omitted when empty, not sent as ${JSON.stringify(paths)}`,
+    };
+  }
+  for (const pointer of paths) {
+    if (typeof pointer !== "string" || pointer === "") {
+      return {
+        kind: "malformed",
+        arm,
+        detail: `${JSON.stringify(pointer)} is not a pointer — the whole-document pointer "" is not a citation`,
+      };
+    }
+    // Against `final`, because that is the tree a pointer addresses and the tree
+    // a reader has on screen.
+    if (resolveStatePath(world.final, pointer) === null) {
+      return { kind: "unresolvable", arm, pointer };
+    }
+  }
+  return { kind: "cites" };
+}
+
+/**
+ * Does this state-reading check say WHERE it looked, in a form that resolves?
+ *
+ * Probes BOTH arms, and that is deliberate. A citation present on the passing
+ * world and absent on the failing one is worse than no citation at all: its
+ * absence starts reading as a verdict class — "no evidence" would come to mean
+ * "this one failed" — and the reader has no way to know that is an accident of
+ * how the predicate was written. So a check must be able to say where it looked
+ * whether or not it liked what it found there.
+ *
+ * Only meaningful for `final` / `seed+final` checks. A `tape` check cites
+ * `evidenceEventIds` instead and is not this gate's business; callers filter on
+ * `substrate` before probing.
+ */
+export function probeStateCitation<TState, TArgs extends Record<string, string>>(
+  def: CheckDefinition<TState, TArgs>,
+  args: TArgs,
+): StateCitationVerdict {
+  const worlds = def.discriminatingWorlds(args);
+  if (worlds === null) return { kind: "declined" };
+  const passing = probeArm(def, args, "passing", worlds.passing);
+  if (passing.kind !== "cites") return passing;
+  return probeArm(def, args, "failing", worlds.failing);
+}

--- a/packages/sdk/src/checks.ts
+++ b/packages/sdk/src/checks.ts
@@ -127,6 +127,21 @@ export interface CheckOutcome {
   // persists this into a jsonb row, and an empty affordance would have to be
   // special-cased by every reader of it.
   evidenceEventIds?: string[];
+  // F-1197 — where in the exported state tree this outcome LOOKED, as RFC 6901
+  // JSON Pointers (`/repositories/0/issues/2/labels`). The state-substrate
+  // sibling of `evidenceEventIds`, and the thing the comment above calls
+  // impossible: state-reading checks left that pointer absent "because their
+  // evidence is a path into the state tree and this pointer does not model
+  // that". This one models that — 8 of 45 declared checks read the tape, and the
+  // other 37 could cite nothing at all, which renders as an inert row a reader
+  // cannot tell from a verdict with no evidence.
+  //
+  // ALWAYS relative to `final`, never `seed`, even for a delta check.
+  // `check-state-path.ts` carries that argument and the pointer grammar's;
+  // build the value with `statePath` / `childStatePath` rather than by hand.
+  //
+  // Same omit-don't-empty discipline as its sibling, for the same reason.
+  evidenceStatePaths?: string[];
 }
 
 // One recorded twin HTTP call, as a `substrate: "tape"` check sees it.
@@ -472,3 +487,12 @@ export function parseCheck<TState, TArgs extends Record<string, string>>(
 // Re-exported here so `@pome-sh/sdk/checks` keeps one import site: consumers ask
 // the vocabulary module about the vocabulary, and the split stays internal.
 export { probeDiscrimination } from "./check-discrimination.js";
+
+// F-1197 — the pointer grammar `CheckOutcome.evidenceStatePaths` is written in,
+// re-exported for the same reason: a declaration builds a pointer, a consumer
+// resolves one, and both reach for `@pome-sh/sdk/checks` rather than learning
+// which internal module the split put them in.
+export {
+  statePath, childStatePath, resolveStatePath, probeStateCitation,
+  type StateCitationArm, type StateCitationVerdict,
+} from "./check-state-path.js";

--- a/packages/sdk/test/check-state-path.test.ts
+++ b/packages/sdk/test/check-state-path.test.ts
@@ -1,0 +1,147 @@
+// The pointer grammar `CheckOutcome.evidenceStatePaths` is written in (F-1197).
+//
+// These are properties of the LANGUAGE, not of any twin's vocabulary — the
+// per-twin gate ("every state-reading check cites a pointer that resolves in
+// its own passing world") lives in each twin's `checks-contract.test.ts`, where
+// the declarations actually ship.
+//
+// Two things here are load-bearing rather than ceremony, and both are about the
+// consumer's ability to ask a TOTAL question:
+//   - a pointer at a field holding `null` must resolve, or a reader cannot tell
+//     "the check looked at an empty label set" from "the check looked nowhere";
+//   - a pointer at anything absent must NOT resolve, or the dashboard renders an
+//     affordance that advertises a jump and then does nothing — the one failure
+//     mode F-980 wrote its degradation rule to prevent.
+
+import { describe, expect, it } from "vitest";
+import { childStatePath, resolveStatePath, statePath } from "../src/check-state-path.js";
+
+describe("statePath", () => {
+  it("builds a pointer from object keys and array indices", () => {
+    expect(statePath("repositories", 0, "issues", 2, "labels")).toBe(
+      "/repositories/0/issues/2/labels",
+    );
+  });
+
+  it("returns the whole-document pointer for no segments", () => {
+    // Legal RFC 6901, and deliberately useless as a citation: a check with
+    // nothing narrower to name must omit the field rather than cite the root.
+    expect(statePath()).toBe("");
+  });
+
+  it("escapes `/` and `~` in a segment, `~` first", () => {
+    // The ordering is the whole reason `escapeSegment` exists as a named
+    // function. Encoding `/` first would turn this key into `a~1b` and then into
+    // `a~01b`, which decodes to the literal `a~1b` — a different key.
+    expect(statePath("a/b")).toBe("/a~1b");
+    expect(statePath("a~b")).toBe("/a~0b");
+    expect(statePath("a~/b")).toBe("/a~0~1b");
+  });
+
+  it("round-trips a segment that contains both escapes", () => {
+    const key = "acme/api~v2";
+    const tree = { [key]: "found" };
+    expect(resolveStatePath(tree, statePath(key))).toEqual({ value: "found" });
+  });
+});
+
+describe("childStatePath", () => {
+  it("appends to a pointer a resolver already built", () => {
+    const repo = statePath("repositories", 0);
+    expect(childStatePath(repo, "issues", 1, "labels")).toBe("/repositories/0/issues/1/labels");
+  });
+
+  it("escapes only the appended segments, never the base", () => {
+    // The base already contains real `/` separators. Escaping it again is the
+    // bug this function exists to make unwritable.
+    const base = statePath("teams", "acme/api");
+    expect(base).toBe("/teams/acme~1api");
+    expect(childStatePath(base, "x/y")).toBe("/teams/acme~1api/x~1y");
+  });
+});
+
+describe("resolveStatePath", () => {
+  const tree = {
+    repositories: [
+      {
+        full_name: "acme/api",
+        issues: [{ number: 1, labels: [{ name: "bug" }] }, { number: 2, labels: [] }],
+        files: null,
+      },
+    ],
+    "": "empty key is legal",
+  };
+
+  it("resolves a pointer into nested arrays and objects", () => {
+    expect(resolveStatePath(tree, "/repositories/0/issues/0/labels/0/name")).toEqual({
+      value: "bug",
+    });
+  });
+
+  it("resolves the whole document for the empty pointer", () => {
+    expect(resolveStatePath(tree, "")).toEqual({ value: tree });
+  });
+
+  it("resolves a field that exists and is empty", () => {
+    // An empty applied-label set IS the evidence behind a failing
+    // `issue-has-label`. Collapsing it to "unresolvable" would hide the very
+    // thing the reader came to see.
+    expect(resolveStatePath(tree, "/repositories/0/issues/1/labels")).toEqual({ value: [] });
+  });
+
+  it("resolves a field holding null, and reports it as a value rather than a miss", () => {
+    // This is why the return is wrapped. A bare return could not tell a field
+    // holding `null` from a path that addresses nothing.
+    expect(resolveStatePath(tree, "/repositories/0/files")).toEqual({ value: null });
+  });
+
+  it("resolves the empty-string key, so a trailing slash is not trimmed", () => {
+    expect(resolveStatePath(tree, "/")).toEqual({ value: "empty key is legal" });
+  });
+
+  it("returns null for a missing key", () => {
+    expect(resolveStatePath(tree, "/repositories/0/milestones")).toBeNull();
+  });
+
+  it("returns null for an out-of-range array index", () => {
+    expect(resolveStatePath(tree, "/repositories/1")).toBeNull();
+    expect(resolveStatePath(tree, "/repositories/0/issues/9/number")).toBeNull();
+  });
+
+  it("returns null for a non-index segment against an array", () => {
+    expect(resolveStatePath(tree, "/repositories/first")).toBeNull();
+    expect(resolveStatePath(tree, "/repositories/01")).toBeNull();
+    expect(resolveStatePath(tree, "/repositories/-1")).toBeNull();
+    expect(resolveStatePath(tree, "/repositories/ 0")).toBeNull();
+    expect(resolveStatePath(tree, "/repositories/1e0")).toBeNull();
+  });
+
+  it("returns null when the pointer walks THROUGH a scalar", () => {
+    expect(resolveStatePath(tree, "/repositories/0/full_name/0")).toBeNull();
+  });
+
+  it("returns null when the pointer walks through a null", () => {
+    // `typeof null === "object"`, so this is the case a bare typeof guard misses.
+    expect(resolveStatePath(tree, "/repositories/0/files/0")).toBeNull();
+  });
+
+  it("returns null for a pointer that does not begin with a slash", () => {
+    // Not a pointer. Prefixing one for the caller would resolve a string nobody
+    // wrote — the fuzzy match this grammar was chosen to rule out.
+    expect(resolveStatePath(tree, "repositories/0")).toBeNull();
+  });
+
+  it("does not resolve through the prototype chain", () => {
+    // Otherwise `/constructor` resolves on every tree and hands a consumer a
+    // function to render as evidence.
+    expect(resolveStatePath(tree, "/constructor")).toBeNull();
+    expect(resolveStatePath(tree, "/toString")).toBeNull();
+    expect(resolveStatePath(tree, "/__proto__")).toBeNull();
+  });
+
+  it("returns null for any pointer into a non-object tree", () => {
+    expect(resolveStatePath(null, "/repositories")).toBeNull();
+    expect(resolveStatePath("a string", "/0")).toBeNull();
+    expect(resolveStatePath(undefined, "/x")).toBeNull();
+  });
+});

--- a/packages/twin-github/src/check-issues.ts
+++ b/packages/twin-github/src/check-issues.ts
@@ -5,7 +5,7 @@
 // Declarations only. The grammar rules they all obey are in `checks.ts`, which
 // assembles them; how the exported tree is read is in `check-state.ts`.
 
-import { defineCheck, VACUITY_SENTINEL, VACUITY_SENTINEL_NUMBER } from "@pome-sh/sdk/checks";
+import { childStatePath, defineCheck, VACUITY_SENTINEL, VACUITY_SENTINEL_NUMBER } from "@pome-sh/sdk/checks";
 import { repoRef } from "@pome-sh/sdk/checks";
 import {
   commentNeedle,
@@ -14,7 +14,7 @@ import {
   labelName,
   login,
 } from "./check-params.js";
-import { appliedLabelNames, resolveIssue, sameLabel } from "./check-state.js";
+import { appliedLabelNames, missOutcome, resolveIssue, sameLabel } from "./check-state.js";
 import { finalWorld, repoState } from "./check-worlds.js";
 import type { Check } from "./check-kind.js";
 
@@ -46,8 +46,14 @@ export const issueExists: Check<{ issue: string; repo: string }> = defineCheck({
   }),
   evaluate({ issue, repo }, { final }) {
     const found = resolveIssue(final, repo, issue);
-    if ("missing" in found) return { passed: false, reason: found.missing };
-    return { passed: true, reason: `issue #${issue} exists in ${repo}` };
+    if ("missing" in found) return missOutcome(found);
+    // The ISSUE itself, not a field on it — here the lookup is the assertion, so
+    // the row's own address is exactly what produced the verdict (F-1197).
+    return {
+      passed: true,
+      reason: `issue #${issue} exists in ${repo}`,
+      evidenceStatePaths: [found.path],
+    };
   },
 });
 
@@ -96,7 +102,7 @@ export const issueStateCheck: Check<{ issue: string; repo: string; state: string
   }),
   evaluate({ issue, repo, state }, { final }) {
     const found = resolveIssue(final, repo, issue);
-    if ("missing" in found) return { passed: false, reason: found.missing };
+    if ("missing" in found) return missOutcome(found);
     // The issue row must carry a state to attest it; a snapshot that omitted it
     // cannot be judged either way → safe-skip rather than false-fail.
     if (found.found.state == null) {
@@ -104,12 +110,18 @@ export const issueStateCheck: Check<{ issue: string; repo: string; state: string
         passed: false,
         status: "skipped",
         reason: `issue #${issue} has no state in state_final (state_incomplete)`,
+        // The ROW, not `…/state` — the field this branch exists for is the one
+        // that is absent, and a pointer at it would not resolve. Pointing at the
+        // row is what lets a reader see the gap for themselves instead of taking
+        // the reason's word for it (F-1197).
+        evidenceStatePaths: [found.path],
       };
     }
     const actual = found.found.state.toLowerCase();
     return {
       passed: actual === state,
       reason: `issue #${issue} state is "${found.found.state}" (wanted "${state}")`,
+      evidenceStatePaths: [childStatePath(found.path, "state")],
     };
   },
 });
@@ -142,7 +154,7 @@ export const issueHasLabel: Check<{ issue: string; repo: string; label: string }
   }),
   evaluate({ issue, repo, label }, { final }) {
     const found = resolveIssue(final, repo, issue);
-    if ("missing" in found) return { passed: false, reason: found.missing };
+    if ("missing" in found) return missOutcome(found);
     const applied = appliedLabelNames(found.found);
     const passed = applied.some((name) => sameLabel(name, label));
     return {
@@ -150,6 +162,10 @@ export const issueHasLabel: Check<{ issue: string; repo: string; label: string }
       reason: passed
         ? `issue #${issue} has label "${label}"`
         : `issue #${issue} labels are [${applied.join(", ")}], missing "${label}"`,
+      // The APPLIED set, which is the set this check scanned — not the repo's
+      // label definitions, which is the neighbouring set `no-new-labels` reads
+      // and the one this check's description exists to keep it distinct from.
+      evidenceStatePaths: [childStatePath(found.path, "labels")],
     };
   },
 });
@@ -177,7 +193,7 @@ export const issueExactlyOneLabel: Check<{ issue: string; repo: string; label: s
   }),
   evaluate({ issue, repo, label }, { final }) {
     const found = resolveIssue(final, repo, issue);
-    if ("missing" in found) return { passed: false, reason: found.missing };
+    if ("missing" in found) return missOutcome(found);
     const applied = appliedLabelNames(found.found);
     const passed = applied.length === 1 && sameLabel(applied[0]!, label);
     return {
@@ -185,6 +201,9 @@ export const issueExactlyOneLabel: Check<{ issue: string; repo: string; label: s
       reason: passed
         ? `issue #${issue} has exactly one label ("${label}")`
         : `issue #${issue} has labels [${applied.join(", ")}], expected exactly one label "${label}"`,
+      // The same pointer `issue-has-label` cites, because both read the same
+      // field — the difference between them is the assertion, not the address.
+      evidenceStatePaths: [childStatePath(found.path, "labels")],
     };
   },
 });
@@ -210,7 +229,7 @@ export const issueAssignee: Check<{ issue: string; repo: string; login: string }
   }),
   evaluate(args, { final }) {
     const found = resolveIssue(final, args.repo, args.issue);
-    if ("missing" in found) return { passed: false, reason: found.missing };
+    if ("missing" in found) return missOutcome(found);
     const assignees = found.found.assignees ?? [];
     const passed = assignees.includes(args.login);
     return {
@@ -218,6 +237,7 @@ export const issueAssignee: Check<{ issue: string; repo: string; login: string }
       reason: passed
         ? `issue #${args.issue} is assigned to "${args.login}"`
         : `issue #${args.issue} assignees are [${assignees.join(", ")}], missing "${args.login}"`,
+      evidenceStatePaths: [childStatePath(found.path, "assignees")],
     };
   },
 });
@@ -252,7 +272,7 @@ export const issueCommentContains: Check<{ needle: string; issue: string; repo: 
   }),
   evaluate({ needle, issue, repo }, { final }) {
     const found = resolveIssue(final, repo, issue);
-    if ("missing" in found) return { passed: false, reason: found.missing };
+    if ("missing" in found) return missOutcome(found);
     const comments = found.found.comments ?? [];
     const passed = comments.some((comment) => (comment.body ?? "").includes(needle));
     return {
@@ -260,6 +280,12 @@ export const issueCommentContains: Check<{ needle: string; issue: string; repo: 
       reason: passed
         ? `issue #${issue} has a comment containing "${needle}"`
         : `issue #${issue} has no comment containing "${needle}" (${comments.length} comment(s) scanned)`,
+      // The whole comment list, not the matching comment. The check scans every
+      // body, so the list is what it read — and on the FAILING side there is no
+      // matching row to point at, which would leave the citation present on a
+      // pass and absent on a fail. A pointer that appears only when the verdict
+      // is good is worse than none: its absence would read as a verdict class.
+      evidenceStatePaths: [childStatePath(found.path, "comments")],
     };
   },
 });

--- a/packages/twin-github/src/check-pulls.ts
+++ b/packages/twin-github/src/check-pulls.ts
@@ -5,9 +5,9 @@
 // Declarations only. The grammar rules they all obey are in `checks.ts`, which
 // assembles them; how the exported tree is read is in `check-state.ts`.
 
-import { defineCheck, repoRef } from "@pome-sh/sdk/checks";
+import { childStatePath, defineCheck, repoRef } from "@pome-sh/sdk/checks";
 import { prNumber, pullRequestState, reviewState } from "./check-params.js";
-import { isMerged, resolvePullRequest } from "./check-state.js";
+import { isMerged, missOutcome, resolvePullRequest } from "./check-state.js";
 import { finalWorld, repoState } from "./check-worlds.js";
 import type { Check } from "./check-kind.js";
 
@@ -57,7 +57,7 @@ export const pullRequestStateCheck: Check<{ pr: string; repo: string; state: str
   },
   evaluate({ pr, repo, state }, { final }) {
     const found = resolvePullRequest(final, repo, pr);
-    if ("missing" in found) return { passed: false, reason: found.missing };
+    if ("missing" in found) return missOutcome(found);
     const pull = found.found;
     const onMergeFlag = state === "merged" || state === "not merged";
     // The field this assertion turns on must be PRESENT. Absent, the safe
@@ -73,6 +73,9 @@ export const pullRequestStateCheck: Check<{ pr: string; repo: string; state: str
         reason: `pull request #${pr} has no ${
           onMergeFlag ? "merged" : "state"
         } field in state_final (state_incomplete)`,
+        // The ROW: the field this branch exists for is the absent one, so a
+        // pointer at it would resolve to nothing (F-1197).
+        evidenceStatePaths: [found.path],
       };
     }
     // Cite only the field the assertion actually turned on. Printing both
@@ -83,11 +86,17 @@ export const pullRequestStateCheck: Check<{ pr: string; repo: string; state: str
       return {
         passed: state === "merged" ? merged : !merged,
         reason: `pull request #${pr}: merged=${merged} (wanted "${state}")`,
+        // The SAME discipline the reason above already follows: cite only the
+        // field the assertion turned on. `merged` and `state` are different
+        // columns, and a citation naming both would offer a reader an absent
+        // field as evidence for a verdict that never read it.
+        evidenceStatePaths: [childStatePath(found.path, "merged")],
       };
     }
     return {
       passed: pull.state === state,
       reason: `pull request #${pr}: state="${pull.state}" (wanted "${state}")`,
+      evidenceStatePaths: [childStatePath(found.path, "state")],
     };
   },
 });
@@ -163,7 +172,7 @@ export const pullRequestCommentExists: Check<{ pr: string; repo: string }> = def
   }),
   evaluate({ pr, repo }, { final }) {
     const found = resolvePullRequest(final, repo, pr);
-    if ("missing" in found) return { passed: false, reason: found.missing };
+    if ("missing" in found) return missOutcome(found);
     // Comments section absent — a snapshot predating PR-comment export. We
     // cannot tell "nobody commented" from "not captured", so safe-skip rather
     // than failing an agent that did comment. An empty array is a real zero and
@@ -173,6 +182,7 @@ export const pullRequestCommentExists: Check<{ pr: string; repo: string }> = def
         passed: false,
         status: "skipped",
         reason: `pull request #${pr} has no comments section in state_final (state_incomplete)`,
+        evidenceStatePaths: [found.path],
       };
     }
     const count = found.found.comments.length;
@@ -185,6 +195,10 @@ export const pullRequestCommentExists: Check<{ pr: string; repo: string }> = def
         count > 0
           ? `pull request #${pr} has ${count} conversation comment(s)`
           : `pull request #${pr} has no conversation comments (reviews and inline review comments are not counted)`,
+      // `comments`, and this pointer is the disambiguation the description
+      // spends a paragraph on. Three fields on a PR can be called "a comment";
+      // the citation names which one was counted, in a form a reader can open.
+      evidenceStatePaths: [childStatePath(found.path, "comments")],
     };
   },
 });
@@ -214,7 +228,7 @@ export const pullRequestReviewExists: Check<{ review: string; pr: string; repo: 
   }),
   evaluate({ review, pr, repo }, { final }) {
     const found = resolvePullRequest(final, repo, pr);
-    if ("missing" in found) return { passed: false, reason: found.missing };
+    if ("missing" in found) return missOutcome(found);
     // Reviews section absent (an older twin snapshot predating review export):
     // we cannot distinguish "no review" from "not captured", so safe-skip
     // rather than vacuously failing a correct agent. An empty array is a real
@@ -224,6 +238,7 @@ export const pullRequestReviewExists: Check<{ review: string; pr: string; repo: 
         passed: false,
         status: "skipped",
         reason: `pull request #${pr} has no reviews section in state_final (state_incomplete)`,
+        evidenceStatePaths: [found.path],
       };
     }
     const states = found.found.reviews.map((row) => row.state ?? "");
@@ -233,6 +248,7 @@ export const pullRequestReviewExists: Check<{ review: string; pr: string; repo: 
       reason: passed
         ? `pull request #${pr} has a ${review} review`
         : `pull request #${pr} reviews are [${states.join(", ")}], missing a ${review} review`,
+      evidenceStatePaths: [childStatePath(found.path, "reviews")],
     };
   },
 });

--- a/packages/twin-github/src/check-repos.ts
+++ b/packages/twin-github/src/check-repos.ts
@@ -6,9 +6,9 @@
 // Declarations only. The grammar rules they all obey are in `checks.ts`, which
 // assembles them; how the exported tree is read is in `check-state.ts`.
 
-import { defineCheck, repoRef, VACUITY_SENTINEL } from "@pome-sh/sdk/checks";
+import { childStatePath, defineCheck, repoRef, VACUITY_SENTINEL } from "@pome-sh/sdk/checks";
 import { commitStatusState, filePath, statusContext } from "./check-params.js";
-import { labelNames, resolveRepo } from "./check-state.js";
+import { labelNames, missOutcome, resolveRepo } from "./check-state.js";
 import { deltaWorld, finalWorld, repoState } from "./check-worlds.js";
 import type { Check } from "./check-kind.js";
 
@@ -60,22 +60,36 @@ export const noNewLabels: Check<{ repo: string }> = defineCheck({
     // consumer that forgets gets a named skip rather than a vacuous pass.
     if (seed === null) return { passed: false, reason: "seed_missing", status: "skipped" };
 
+    // The SEED-side refusal cites nothing. `missOutcome` carries the pointer the
+    // lookup walked, and this one walked the seed — a pointer always addresses
+    // `final` (the sdk's `check-state-path.ts` says why), so passing it through
+    // would send a reader into the tree the report does not render, at a path
+    // that may well resolve to an unrelated repo. The reason still names the miss.
     const seedRepo = resolveRepo(seed, repo, "the seed state");
-    if ("missing" in seedRepo) return { passed: false, reason: seedRepo.missing };
+    if ("missing" in seedRepo) return missOutcome({ ...seedRepo, searched: undefined });
     const finalRepo = resolveRepo(final, repo, "state_final");
-    if ("missing" in finalRepo) return { passed: false, reason: finalRepo.missing };
+    if ("missing" in finalRepo) return missOutcome(finalRepo);
 
     const before = labelNames(seedRepo.found);
     const created = [...labelNames(finalRepo.found)].filter((name) => !before.has(name)).sort();
+    // F-1197 — the only seed+final check, and the one that shows why a pointer
+    // addresses `final` rather than the substrate the assertion ranges over.
+    // The delta is computed from two trees; the reader has ONE on screen. So the
+    // citation is the final definition set — the side a reader can look at — and
+    // the reason carries the comparison. Pointing into a seed nothing renders
+    // would move the dead affordance rather than remove it.
+    const definitions = [childStatePath(finalRepo.path, "labels")];
     if (created.length === 0) {
       return {
         passed: true,
         reason: `no labels were created in ${repo} (${before.size} defined at seed, unchanged at finish)`,
+        evidenceStatePaths: definitions,
       };
     }
     return {
       passed: false,
       reason: `labels created in ${repo}: ${created.map((name) => `\`${name}\``).join(", ")}`,
+      evidenceStatePaths: definitions,
     };
   },
 });
@@ -100,7 +114,7 @@ export const fileExists: Check<{ path: string; repo: string }> = defineCheck({
   }),
   evaluate({ path, repo }, { final }) {
     const found = resolveRepo(final, repo, "state_final");
-    if ("missing" in found) return { passed: false, reason: found.missing };
+    if ("missing" in found) return missOutcome(found);
     const files = found.found.files ?? [];
     const passed = files.some((file) => file.path === path);
     return {
@@ -108,6 +122,7 @@ export const fileExists: Check<{ path: string; repo: string }> = defineCheck({
       reason: passed
         ? `file exists at "${path}" in ${repo}`
         : `no file found at "${path}" in ${repo} (${files.length} file(s) exported)`,
+      evidenceStatePaths: [childStatePath(found.path, "files")],
     };
   },
 });
@@ -146,7 +161,7 @@ export const commitStatus: Check<{ context: string; repo: string; state: string 
   }),
   evaluate({ context, repo, state }, { final }) {
     const found = resolveRepo(final, repo, "state_final");
-    if ("missing" in found) return { passed: false, reason: found.missing };
+    if ("missing" in found) return missOutcome(found);
     const candidates = (found.found.commit_statuses ?? []).filter(
       (row) => row.context === context,
     );
@@ -157,6 +172,11 @@ export const commitStatus: Check<{ context: string; repo: string; state: string 
         ? `commit status "${context}" is "${state}" in ${repo}`
         : `no commit status "${context}" with state "${state}" in ${repo} ` +
           `(found: [${candidates.map((row) => row.state).join(", ")}])`,
+      // Every status row, not the filtered candidates. The filter is part of the
+      // assertion — "which commit" is explicitly not asserted — and a pointer at
+      // a set this check computed rather than a set the tree holds would address
+      // nothing a reader could open.
+      evidenceStatePaths: [childStatePath(found.path, "commit_statuses")],
     };
   },
 });

--- a/packages/twin-github/src/check-state.ts
+++ b/packages/twin-github/src/check-state.ts
@@ -22,6 +22,12 @@
 //   - `repository.labels` (definitions) and `issue.labels` (applied) are
 //     different sets. Confusing them is the defect `github.no-new-labels`'s
 //     description exists to prevent.
+//
+// F-1197 — the resolvers below also return the POINTER they walked, so a check
+// can cite where it looked. Nothing else about them changed; the shapes above
+// are still the only thing that decides how the tree is read.
+
+import { childStatePath, statePath, type CheckOutcome } from "@pome-sh/sdk/checks";
 
 export interface GitHubCheckStateLabel {
   name?: string;
@@ -109,10 +115,23 @@ export interface GitHubCheckState {
 // anything else — so there is deliberately no bare-name branch here. The
 // owner/name fallback is for a state export that somehow omits `full_name`,
 // not for a bare-name reference, which cannot reach this function.
-export function findRepo(state: GitHubCheckState, ref: string): GitHubCheckStateRepo | null {
-  for (const repo of state.repositories ?? []) {
-    if (repo.full_name === ref) return repo;
-    if (repo.owner != null && repo.name != null && `${repo.owner}/${repo.name}` === ref) return repo;
+//
+// F-1197 — it returns the INDEX beside the row. The index is not decoration: a
+// check cites where it looked as a JSON Pointer, and a pointer into an array
+// needs the position the walk actually stopped at. Computing it here, in the
+// same loop that decides which repo matched, is what keeps the citation and the
+// verdict describing the same row — a second `findIndex` at the call site would
+// be a second copy of the `full_name` / `owner+name` fallback, free to drift.
+export function findRepo(
+  state: GitHubCheckState,
+  ref: string,
+): { repo: GitHubCheckStateRepo; index: number } | null {
+  const repositories = state.repositories ?? [];
+  for (const [index, repo] of repositories.entries()) {
+    if (repo.full_name === ref) return { repo, index };
+    if (repo.owner != null && repo.name != null && `${repo.owner}/${repo.name}` === ref) {
+      return { repo, index };
+    }
   }
   return null;
 }
@@ -129,15 +148,55 @@ export function labelNames(repo: GitHubCheckStateRepo): Set<string> {
 // must say the same thing when it is missing. Returning the reason rather than
 // throwing keeps the "repo not found" verdict a normal `failed` with a sentence
 // an author can act on.
-export type Resolved<T> = { found: T } | { missing: string };
+//
+// F-1197 added a pointer to BOTH arms, and the second one is the interesting
+// half. `path` on the found arm is the address the resolution walked to, which
+// the check extends with the field it goes on to read.
+//
+// `searched` on the MISSING arm is the collection the lookup scanned and did not
+// find its entity in. It exists because the gate found the gap: `issue-exists`
+// FAILS by not finding the issue, so a design where only a successful resolution
+// can cite would have left that check — and every "not found" verdict under it —
+// pointing at nothing on exactly the verdict a reader most wants to inspect. The
+// honest citation there is not the row (there is none) but the list: *this* is
+// where I looked, see for yourself that it is not in it.
+//
+// Optional because the tree may not carry the collection at all, and a citation
+// that resolves to nothing is the affordance-to-nowhere this ticket exists to
+// remove. Absent `searched` means the check cites nothing on that path, which is
+// the correct degradation rather than a lesser one.
+export type Resolved<T> =
+  | { found: T; path: string }
+  | { missing: string; searched?: string };
+
+/**
+ * The `failed` outcome a missing entity produces, citing where the lookup
+ * looked.
+ *
+ * One function rather than a conditional spread at every `if ("missing" in …)`
+ * site, because the rule it encodes — cite the searched collection, cite nothing
+ * when there was none — is one rule, and twelve hand-written copies of it is
+ * twelve chances for one to quietly drop the citation.
+ */
+export function missOutcome(miss: { missing: string; searched?: string }): CheckOutcome {
+  if (miss.searched === undefined) return { passed: false, reason: miss.missing };
+  return { passed: false, reason: miss.missing, evidenceStatePaths: [miss.searched] };
+}
 
 export function resolveRepo(
   state: GitHubCheckState,
   ref: string,
   where: string,
 ): Resolved<GitHubCheckStateRepo> {
-  const repo = findRepo(state, ref);
-  return repo ? { found: repo } : { missing: `repo ${ref} not found in ${where}` };
+  const hit = findRepo(state, ref);
+  if (hit) return { found: hit.repo, path: statePath("repositories", hit.index) };
+  return {
+    missing: `repo ${ref} not found in ${where}`,
+    // `undefined` — the key absent from the export — is the only case with
+    // nothing to point at. A `null` repository list is a citable fact: it says
+    // the export carried the field and it was empty.
+    searched: state.repositories === undefined ? undefined : statePath("repositories"),
+  };
 }
 
 export function resolveIssue(
@@ -147,8 +206,16 @@ export function resolveIssue(
 ): Resolved<GitHubCheckStateIssue> {
   const repo = resolveRepo(state, ref, "state_final");
   if ("missing" in repo) return repo;
-  const issue = (repo.found.issues ?? []).find((candidate) => candidate.number === Number(number));
-  return issue ? { found: issue } : { missing: `issue #${number} not found in ${ref}` };
+  const issues = repo.found.issues ?? [];
+  const index = issues.findIndex((candidate) => candidate.number === Number(number));
+  if (index >= 0) {
+    return { found: issues[index]!, path: childStatePath(repo.path, "issues", index) };
+  }
+  return {
+    missing: `issue #${number} not found in ${ref}`,
+    searched:
+      repo.found.issues === undefined ? undefined : childStatePath(repo.path, "issues"),
+  };
 }
 
 export function resolvePullRequest(
@@ -158,10 +225,18 @@ export function resolvePullRequest(
 ): Resolved<GitHubCheckStatePullRequest> {
   const repo = resolveRepo(state, ref, "state_final");
   if ("missing" in repo) return repo;
-  const pull = (repo.found.pull_requests ?? []).find(
-    (candidate) => candidate.number === Number(number),
-  );
-  return pull ? { found: pull } : { missing: `pull request #${number} not found in ${ref}` };
+  const pulls = repo.found.pull_requests ?? [];
+  const index = pulls.findIndex((candidate) => candidate.number === Number(number));
+  if (index >= 0) {
+    return { found: pulls[index]!, path: childStatePath(repo.path, "pull_requests", index) };
+  }
+  return {
+    missing: `pull request #${number} not found in ${ref}`,
+    searched:
+      repo.found.pull_requests === undefined
+        ? undefined
+        : childStatePath(repo.path, "pull_requests"),
+  };
 }
 
 export function isMerged(pull: GitHubCheckStatePullRequest): boolean {

--- a/packages/twin-github/test/checks-contract.test.ts
+++ b/packages/twin-github/test/checks-contract.test.ts
@@ -11,6 +11,7 @@ import {
   checkPattern,
   parseCheck,
   probeDiscrimination,
+  probeStateCitation,
   renderCheck,
   type CheckDefinition,
   type CheckSubstrateKind,
@@ -373,6 +374,85 @@ describe("declared discriminating worlds", () => {
         if (check.substrate === "tape") {
           expect(world.tape, `${check.id}.${side} declares tape but names none`).not.toBeNull();
         }
+      }
+    }
+  });
+});
+
+// Every state-reading check that cites no path, WITH the reason (F-1197).
+//
+// EMPTY, and — like `HONEST_NULL_WORLDS` above — that is the claim rather than
+// an accident. The ticket that added `evidenceStatePaths` opened by counting
+// what could cite anything: 8 of 45. An optional field with no gate behind it
+// is how a number like that happens, so the gate ships with the field and the
+// ledger ships empty.
+//
+// An entry here is an admission that a verdict renders as an inert row —
+// indistinguishable, to a reader, from a verdict with no evidence at all. That
+// is the exact defect F-1197 exists to remove, so argue it in writing.
+const HONEST_UNCITED_CHECKS: Record<string, string> = {};
+
+describe("declared state citations", () => {
+  it("cites a resolvable state path from every check that reads state", () => {
+    for (const check of CHECKS) {
+      // A tape check cites `evidenceEventIds` and is not this gate's business.
+      if (check.substrate === "tape") continue;
+      const verdict = probeStateCitation(check, FIXTURES[check.id]!);
+
+      if (verdict.kind === "declined") {
+        // Unreachable while HONEST_NULL_WORLDS is empty, and deliberately not
+        // folded into that gate: a check with no worlds has no world to resolve
+        // a pointer against, which is a different sentence from "it cannot fail".
+        expect(
+          HONEST_UNCITED_CHECKS[check.id],
+          `${check.id} names no worlds, so its citation cannot be probed`,
+        ).toBeTruthy();
+        continue;
+      }
+
+      if (verdict.kind !== "cites") {
+        expect(
+          HONEST_UNCITED_CHECKS[check.id],
+          `${check.id} reads state but ${
+            verdict.kind === "uncited"
+              ? `its ${verdict.arm} world produced no evidenceStatePaths`
+              : verdict.kind === "unresolvable"
+                ? `its ${verdict.arm} world cites ${verdict.pointer}, which resolves to nothing in that world`
+                : `its ${verdict.arm} world cited malformed evidence — ${verdict.detail}`
+          }. A state verdict that cites nothing renders as an inert row.`,
+        ).toBeTruthy();
+        continue;
+      }
+
+      expect(
+        HONEST_UNCITED_CHECKS[check.id],
+        `${check.id} cites its state path but is still listed in HONEST_UNCITED_CHECKS — stale entry`,
+      ).toBeUndefined();
+    }
+  });
+
+  it("ships an EMPTY uncited ledger", () => {
+    // Same reason the null-worlds ledger asserts its own emptiness: the moment
+    // this has an entry, the guarantee weakens from "every state verdict points
+    // somewhere" to "…or said why not", and that should require editing this
+    // line on purpose.
+    expect(Object.keys(HONEST_UNCITED_CHECKS)).toEqual([]);
+  });
+
+  it("leaves the state-path field absent on every tape check", () => {
+    // The converse, and it is not symmetry for its own sake. A tape check has
+    // no state tree to point into — the engine hands it `final: { repositories: [] }`
+    // precisely so it cannot read one — so a pointer from here would address a
+    // world the check never saw, and the reader would open it and find nothing.
+    for (const check of CHECKS) {
+      if (check.substrate !== "tape") continue;
+      const worlds = check.discriminatingWorlds(FIXTURES[check.id]!);
+      if (worlds === null) continue;
+      for (const [side, world] of Object.entries(worlds)) {
+        expect(
+          check.evaluate(FIXTURES[check.id]!, world).evidenceStatePaths,
+          `${check.id}.${side} reads the tape but cites a state path`,
+        ).toBeUndefined();
       }
     }
   });

--- a/packages/twin-gmail/src/check-drafts.ts
+++ b/packages/twin-gmail/src/check-drafts.ts
@@ -10,9 +10,10 @@
 // which is the exact defect A3 exists to eliminate.
 
 import { defineCheck, VACUITY_SENTINEL, VACUITY_SENTINEL_NUMBER } from "@pome-sh/sdk/checks";
+import { childStatePath } from "@pome-sh/sdk/checks";
 import type { Check } from "./check-kind.js";
 import { countWord, emailAddress, parseCount } from "./check-params.js";
-import { draftRecipients, isTruncated } from "./check-state.js";
+import { DRAFTS_PATH, draftRecipients, isTruncated } from "./check-state.js";
 import { draftAddressedTo as draftFor, finalWorld, gmailState } from "./check-worlds.js";
 
 export const draftAddressedTo: Check<{ email: string }> = defineCheck({
@@ -64,11 +65,21 @@ export const draftAddressedTo: Check<{ email: string }> = defineCheck({
       return { passed: false, status: "skipped", reason: "state_incomplete" };
     }
     const wanted = email.toLowerCase();
-    const hit = final.drafts.find((entry) =>
+    const index = final.drafts.findIndex((entry) =>
       draftRecipients(final, entry).some((to) => to.toLowerCase() === wanted),
     );
-    if (hit) {
-      return { passed: true, reason: `draft ${hit.id ?? "?"} is addressed to ${email}` };
+    if (index >= 0) {
+      const hit = final.drafts[index]!;
+      return {
+        passed: true,
+        reason: `draft ${hit.id ?? "?"} is addressed to ${email}`,
+        // The DRAFT row, not the backing message that actually holds the
+        // address. A reader following this pointer lands on the thing the
+        // sentence is about — "a draft addressed to X" — and the join to the
+        // message is an implementation detail of how the twin exports, not the
+        // claim (F-1197).
+        evidenceStatePaths: [childStatePath(DRAFTS_PATH, index)],
+      };
     }
     // Only refuse once the answer would otherwise be "no". A capped collection
     // that still contains the draft is a real pass, and skipping it would drop a
@@ -79,6 +90,7 @@ export const draftAddressedTo: Check<{ email: string }> = defineCheck({
     return {
       passed: false,
       reason: `no draft is addressed to ${email} (${final.drafts.length} draft(s) inspected)`,
+      evidenceStatePaths: [DRAFTS_PATH],
     };
   },
 });
@@ -141,6 +153,9 @@ export const draftCountAtLeast: Check<{ count: string }> = defineCheck({
     return {
       passed: total >= wanted,
       reason: `${total} draft(s) exist (wanted at least ${wanted})`,
+      // The collection whose LENGTH is the assertion. There is no narrower
+      // address for a cardinality.
+      evidenceStatePaths: [DRAFTS_PATH],
     };
   },
 });

--- a/packages/twin-gmail/src/check-labels.ts
+++ b/packages/twin-gmail/src/check-labels.ts
@@ -11,7 +11,7 @@
 import { defineCheck, VACUITY_SENTINEL } from "@pome-sh/sdk/checks";
 import type { Check } from "./check-kind.js";
 import { labelName } from "./check-params.js";
-import { resolveLabelByName } from "./check-state.js";
+import { missSkip, resolveLabelByName } from "./check-state.js";
 import { finalWorld, gmailState, systemLabel, userLabel } from "./check-worlds.js";
 
 export const labelExists: Check<{ label: string }> = defineCheck({
@@ -52,10 +52,21 @@ export const labelExists: Check<{ label: string }> = defineCheck({
       // `state_incomplete` and `collection_truncated` are unanswerable; a label
       // genuinely not there is the honest FAIL this check exists to deliver.
       if (found.missing.startsWith("label_not_found")) {
-        return { passed: false, reason: `no label named "${label}" exists` };
+        return {
+          passed: false,
+          reason: `no label named "${label}" exists`,
+          // The label COLLECTION — the honest citation for a lookup that found
+          // nothing, and the arm a reader most wants to open: see for yourself
+          // that the name is not in it (F-1197).
+          ...(found.searched === undefined ? {} : { evidenceStatePaths: [found.searched] }),
+        };
       }
-      return { passed: false, status: "skipped", reason: found.missing };
+      return missSkip(found);
     }
-    return { passed: true, reason: `label "${label}" exists (id ${found.found.id ?? "?"})` };
+    return {
+      passed: true,
+      reason: `label "${label}" exists (id ${found.found.id ?? "?"})`,
+      evidenceStatePaths: [found.path],
+    };
   },
 });

--- a/packages/twin-gmail/src/check-messages.ts
+++ b/packages/twin-gmail/src/check-messages.ts
@@ -18,7 +18,10 @@ import { countWord, exactCount, labelRef, mailboxRef, messageId, parseCount } fr
 import {
   isTruncated,
   labelIdsFor,
+  MESSAGE_LABELS_PATH,
+  MESSAGES_PATH,
   messageCarriesLabel,
+  missSkip,
   resolveMessage,
   type GmailCheckState,
 } from "./check-state.js";
@@ -74,14 +77,20 @@ export const messageHasLabel: Check<{ message: string; label: string }> = define
   },
   evaluate({ message: id, label }, { final }) {
     const found = resolveMessage(final, id);
-    if ("missing" in found) return { passed: false, status: "skipped", reason: found.missing };
+    if ("missing" in found) return missSkip(found);
     const carried = messageCarriesLabel(final, id, label);
-    if ("missing" in carried) return { passed: false, status: "skipped", reason: carried.missing };
+    if ("missing" in carried) return missSkip(carried);
     return {
       passed: carried.found,
       reason: carried.found
         ? `message ${id} carries label ${label}`
         : `message ${id} does not carry label ${label}`,
+      // BOTH halves of the lookup, because the predicate really does read two
+      // places: the message row it resolved by id, and the join table it then
+      // questioned. Labels are not nested under their message in this export —
+      // that is the whole reason `messageCarriesLabel` exists — so one pointer
+      // could not say where this verdict came from (F-1197).
+      evidenceStatePaths: [found.path, carried.path],
     };
   },
 });
@@ -161,6 +170,11 @@ export const mailboxLabelCount: Check<{ mailbox: string; count: string; label: s
       return {
         passed: total === wanted,
         reason: `mailbox "${mailbox}" has ${total} message(s) labeled ${label} (wanted ${wanted})`,
+        // The two collections the count is computed FROM. The count itself lives
+        // nowhere in the tree, so there is no narrower honest address — and the
+        // guards above already established that both collections are present and
+        // un-capped, which is what makes these pointers resolve.
+        evidenceStatePaths: [MESSAGES_PATH, MESSAGE_LABELS_PATH],
       };
     },
   });
@@ -235,6 +249,11 @@ export const oneMessagePerRecipient: Check<{ label: string; count: string }> = d
         : `${sent.length} ${label} message(s) to ${distinct.size} distinct recipient(s) ` +
           `(${addressees.length} addressee slot(s)${wanted == null ? "" : `, wanted ${wanted}`}` +
           `${noDuplicates ? "" : ", duplicate send detected"})`,
+      // Same two collections, same reason: the duplicate this check exists to
+      // catch is a property of the addressee lists across `messages`, filtered
+      // by `messageLabels`, and neither the flattened list nor its distinct set
+      // is anything the tree holds.
+      evidenceStatePaths: [MESSAGES_PATH, MESSAGE_LABELS_PATH],
     };
   },
 });

--- a/packages/twin-gmail/src/check-state.ts
+++ b/packages/twin-gmail/src/check-state.ts
@@ -35,9 +35,38 @@
 //   - EVERYTHING IS MAILBOX-SCOPED via `mailboxEmail`, and ids are minted per
 //     mailbox, so `deliveryMode: "seeded-mailboxes"` can put one id in two.
 
+import { childStatePath, statePath, type CheckOutcome } from "@pome-sh/sdk/checks";
+
 /** A resolver must be able to say WHY it found nothing: the ways of finding
- *  nothing get different verdicts. Same shape and same reason as twin-github's. */
-export type Resolved<T> = { found: T } | { missing: string };
+ *  nothing get different verdicts. Same shape and same reason as twin-github's.
+ *
+ *  F-1197 added the pointers, also twin-github's: `path` is where the resolution
+ *  landed, `searched` is the collection a failed lookup scanned. Both optional on
+ *  the missing arm because gmail's commonest refusal is `state_incomplete` — the
+ *  collection is absent from the export entirely, so there is nowhere to point
+ *  and citing anything would be an affordance to nowhere. */
+export type Resolved<T> =
+  | { found: T; path: string }
+  | { missing: string; searched?: string };
+
+/** The exported collections a pointer can address. Named because six
+ *  declarations reach for them and a literal `"/messageLabels"` typed out six
+ *  times is six chances to typo one into a pointer that resolves to nothing —
+ *  and the mis-cased `/messagelabels` would look right in a diff. */
+export const MESSAGES_PATH = statePath("messages");
+export const DRAFTS_PATH = statePath("drafts");
+export const LABELS_PATH = statePath("labels");
+export const MESSAGE_LABELS_PATH = statePath("messageLabels");
+
+/** The `skipped` outcome an unresolvable lookup produces, citing where it
+ *  looked. Gmail abstains where twin-github fails — a message the export does
+ *  not carry cannot be attested either way — so this is `missOutcome` with
+ *  `skipped`, exactly as twin-slack's `missSkip` is. */
+export function missSkip(miss: { missing: string; searched?: string }): CheckOutcome {
+  const outcome: CheckOutcome = { passed: false, status: "skipped", reason: miss.missing };
+  if (miss.searched === undefined) return outcome;
+  return { ...outcome, evidenceStatePaths: [miss.searched] };
+}
 
 export interface GmailCheckStateMailbox {
   email?: string;
@@ -134,13 +163,26 @@ export function resolveMessage(
   id: string,
 ): Resolved<GmailCheckStateMessage> {
   if (state.messages == null) return { missing: "state_incomplete" };
-  const hits = state.messages.filter((message) => lower(message.id) === lower(id));
-  if (hits.length > 1) {
-    return { missing: `message_ambiguous ("${id}" exists in ${hits.length} mailboxes)` };
+  const indices = state.messages
+    .map((message, index) => (lower(message.id) === lower(id) ? index : -1))
+    .filter((index) => index >= 0);
+  if (indices.length > 1) {
+    // The AMBIGUITY is the finding, so the citation is the collection rather
+    // than one of the candidates: pointing at either would present a coin-flip
+    // as the thing the check read.
+    return {
+      missing: `message_ambiguous ("${id}" exists in ${indices.length} mailboxes)`,
+      searched: MESSAGES_PATH,
+    };
   }
-  if (hits.length === 1) return { found: hits[0]! };
-  if (isTruncated(state, "messages")) return { missing: 'collection_truncated ("messages")' };
-  return { missing: `message_not_found ("${id}")` };
+  if (indices.length === 1) {
+    const index = indices[0]!;
+    return { found: state.messages[index]!, path: childStatePath(MESSAGES_PATH, index) };
+  }
+  if (isTruncated(state, "messages")) {
+    return { missing: 'collection_truncated ("messages")', searched: MESSAGES_PATH };
+  }
+  return { missing: `message_not_found ("${id}")`, searched: MESSAGES_PATH };
 }
 
 /**
@@ -179,9 +221,13 @@ export function messageCarriesLabel(
     (row) => lower(row.messageId) === lower(messageId) && ids.has(lower(row.labelId)),
   );
   if (!carried && isTruncated(state, "messageLabels")) {
-    return { missing: 'collection_truncated ("messageLabels")' };
+    return { missing: 'collection_truncated ("messageLabels")', searched: MESSAGE_LABELS_PATH };
   }
-  return { found: carried };
+  // The JOIN, not a row in it. The answer is a boolean this function computed
+  // and the tree holds no such value, so the honest address is the table the
+  // question was asked of — and on the `false` side there is no row to name at
+  // all, which is exactly the arm a reader wants to check.
+  return { found: carried, path: MESSAGE_LABELS_PATH };
 }
 
 /**
@@ -197,10 +243,14 @@ export function resolveLabelByName(
   name: string,
 ): Resolved<GmailCheckStateLabel> {
   if (state.labels == null) return { missing: "state_incomplete" };
-  const hit = state.labels.find((label) => lower(label.name) === lower(name));
-  if (hit) return { found: hit };
-  if (isTruncated(state, "labels")) return { missing: 'collection_truncated ("labels")' };
-  return { missing: `label_not_found ("${name}")` };
+  const index = state.labels.findIndex((label) => lower(label.name) === lower(name));
+  if (index >= 0) {
+    return { found: state.labels[index]!, path: childStatePath(LABELS_PATH, index) };
+  }
+  if (isTruncated(state, "labels")) {
+    return { missing: 'collection_truncated ("labels")', searched: LABELS_PATH };
+  }
+  return { missing: `label_not_found ("${name}")`, searched: LABELS_PATH };
 }
 
 /**

--- a/packages/twin-gmail/test/check-state.test.ts
+++ b/packages/twin-gmail/test/check-state.test.ts
@@ -48,6 +48,9 @@ describe("resolveMessage", () => {
   it("says message_not_found when the collection is present but the id is not", () => {
     expect(resolveMessage(state(), "msg_ghost")).toEqual({
       missing: 'message_not_found ("msg_ghost")',
+      // F-1197 — the refusal names the collection it scanned, so a reader can
+      // open it and see the id is genuinely not there.
+      searched: "/messages",
     });
   });
 
@@ -65,6 +68,7 @@ describe("resolveMessage", () => {
     });
     expect(resolveMessage(two, "msg_support")).toEqual({
       missing: 'message_ambiguous ("msg_support" exists in 2 mailboxes)',
+      searched: "/messages",
     });
   });
 
@@ -76,6 +80,7 @@ describe("resolveMessage", () => {
     });
     expect(resolveMessage(big, "msg_ghost")).toEqual({
       missing: 'collection_truncated ("messages")',
+      searched: "/messages",
     });
   });
 
@@ -111,11 +116,19 @@ describe("labelIdsFor", () => {
 
 describe("messageCarriesLabel", () => {
   it("reads the join, not a nested field", () => {
-    expect(messageCarriesLabel(state(), "msg_support", "INBOX")).toEqual({ found: true });
+    // The path is the JOIN TABLE, not a row in it: the answer is a boolean this
+    // function computes, and the tree holds no such value (F-1197).
+    expect(messageCarriesLabel(state(), "msg_support", "INBOX")).toEqual({
+      found: true,
+      path: "/messageLabels",
+    });
   });
 
   it("answers false for a label the message does not carry", () => {
-    expect(messageCarriesLabel(state(), "msg_support", "Label_follow_up")).toEqual({ found: false });
+    expect(messageCarriesLabel(state(), "msg_support", "Label_follow_up")).toEqual({
+      found: false,
+      path: "/messageLabels",
+    });
   });
 
   it("says state_incomplete when messageLabels is absent", () => {
@@ -134,6 +147,7 @@ describe("messageCarriesLabel", () => {
     });
     expect(messageCarriesLabel(big, "msg_support", "Label_follow_up")).toEqual({
       missing: 'collection_truncated ("messageLabels")',
+      searched: "/messageLabels",
     });
   });
 });
@@ -149,6 +163,7 @@ describe("resolveLabelByName", () => {
   it("does not match on the id, so an author cannot mistake one for the other", () => {
     expect(resolveLabelByName(state(), "Label_follow_up")).toEqual({
       missing: 'label_not_found ("Label_follow_up")',
+      searched: "/labels",
     });
   });
 

--- a/packages/twin-gmail/test/checks-contract.test.ts
+++ b/packages/twin-gmail/test/checks-contract.test.ts
@@ -11,6 +11,7 @@ import {
   checkPattern,
   parseCheck,
   probeDiscrimination,
+  probeStateCitation,
   renderCheck,
   type CheckDefinition,
   type CheckSubstrateKind,
@@ -402,5 +403,71 @@ describe("migrated sentences", () => {
     expect(mailboxLabelCount.polarity({ mailbox: "a@b.test", count: "5", label: "SENT" })).toBe(
       "positive",
     );
+  });
+});
+
+// Every state-reading check that cites no path, WITH the reason (F-1197).
+//
+// EMPTY, and — like `HONEST_NULL_WORLDS` above — that is the claim. F-1197
+// opened by counting what could cite anything at all: 8 of 45 declared checks,
+// because only a `tape` check could fill `evidenceEventIds`. An optional field
+// with no gate behind it is how a number like that happens, so the field ships
+// with this gate and the ledger ships empty. The argument for the pointer
+// grammar, and for why a pointer addresses `final`, is in the sdk's
+// `check-state-path.ts`; this is only its per-twin enforcement.
+//
+// An entry here admits that a verdict renders as an inert row — indistinguishable,
+// to a reader, from a verdict with no evidence at all.
+const HONEST_UNCITED_CHECKS: Record<string, string> = {};
+
+describe("declared state citations", () => {
+  it("cites a resolvable state path from every check that reads state", () => {
+    for (const check of CHECKS) {
+      // A tape check cites `evidenceEventIds` and is not this gate's business.
+      if (check.substrate === "tape") continue;
+      const verdict = probeStateCitation(check, FIXTURES[check.id]!);
+
+      if (verdict.kind === "cites") {
+        expect(
+          HONEST_UNCITED_CHECKS[check.id],
+          `${check.id} cites its state path but is still listed in HONEST_UNCITED_CHECKS — stale entry`,
+        ).toBeUndefined();
+        continue;
+      }
+
+      expect(
+        HONEST_UNCITED_CHECKS[check.id],
+        `${check.id} reads state but ${
+          verdict.kind === "declined"
+            ? "names no worlds, so its citation cannot be probed"
+            : verdict.kind === "uncited"
+              ? `its ${verdict.arm} world produced no evidenceStatePaths`
+              : verdict.kind === "unresolvable"
+                ? `its ${verdict.arm} world cites ${verdict.pointer}, which resolves to nothing in that world`
+                : `its ${verdict.arm} world cited malformed evidence — ${verdict.detail}`
+        }. A state verdict that cites nothing renders as an inert row.`,
+      ).toBeTruthy();
+    }
+  });
+
+  it("ships an EMPTY uncited ledger", () => {
+    expect(Object.keys(HONEST_UNCITED_CHECKS)).toEqual([]);
+  });
+
+  it("leaves the state-path field absent on every tape check", () => {
+    // The converse. A tape check has no state tree to point into — the engine
+    // hands it a deliberately barren `final` so it cannot read one — so a pointer
+    // from here would address a world the check never saw.
+    for (const check of CHECKS) {
+      if (check.substrate !== "tape") continue;
+      const worlds = check.discriminatingWorlds(FIXTURES[check.id]!);
+      if (worlds === null) continue;
+      for (const [side, world] of Object.entries(worlds)) {
+        expect(
+          check.evaluate(FIXTURES[check.id]!, world).evidenceStatePaths,
+          `${check.id}.${side} reads the tape but cites a state path`,
+        ).toBeUndefined();
+      }
+    }
   });
 });

--- a/packages/twin-gmail/test/fidelity-contract.test.ts
+++ b/packages/twin-gmail/test/fidelity-contract.test.ts
@@ -168,7 +168,10 @@ describe("the declared checks, against a real exported mailbox", () => {
   });
 
   it("accepts the label by its DISPLAY NAME too, on the real export", () => {
-    expect(messageCarriesLabel(state, "msg_build", "Build")).toEqual({ found: true });
+    expect(messageCarriesLabel(state, "msg_build", "Build")).toEqual({
+      found: true,
+      path: "/messageLabels",
+    });
   });
 
   it("grades `A draft addressed to alice@example.com exists` FALSE on the seed", () => {

--- a/packages/twin-linear/src/check-comments.ts
+++ b/packages/twin-linear/src/check-comments.ts
@@ -18,7 +18,7 @@
 import { defineCheck, VACUITY_SENTINEL } from "@pome-sh/sdk/checks";
 import type { Check } from "./check-kind.js";
 import { commentNeedle, issueTitle, teamKey } from "./check-params.js";
-import { resolveComments, resolveIssue, unresolved } from "./check-state.js";
+import { COMMENTS_PATH, resolveComments, resolveIssue, unresolved } from "./check-state.js";
 import { deltaWorld, finalWorld, issueRow, linearState } from "./check-worlds.js";
 
 export const issueCommentContains: Check<{ title: string; team: string; needle: string }> =
@@ -72,6 +72,7 @@ export const issueCommentContains: Check<{ title: string; team: string; needle: 
         reason: hit
           ? `a comment contains "${needle}"`
           : `no comment contains "${needle}" (${comments.found.length} comment(s) scanned)`,
+        evidenceStatePaths: [comments.path],
       };
     },
   });
@@ -120,10 +121,16 @@ export const issueThreadedReply: Check<{ title: string; team: string }> = define
     // consumer that forgets gets a named skip rather than a vacuous pass.
     if (seed === null) return { passed: false, reason: "seed_missing", status: "skipped" };
 
+    // SEED-side refusals cite nothing, deliberately. `unresolved` carries the
+    // pointer the lookup walked, and these two walked the SEED — a pointer
+    // always addresses `final` (see the sdk's `check-state-path.ts`), so passing
+    // one through here would send a reader into the tree the report does not
+    // render, at a path that may well resolve to something unrelated. Dropping
+    // the citation is the honest degradation; the reason still names the miss.
     const seedIssue = resolveIssue(seed, team, title);
-    if ("missing" in seedIssue) return unresolved(seedIssue);
+    if ("missing" in seedIssue) return unresolved({ ...seedIssue, searched: undefined });
     const seedComments = resolveComments(seed, seedIssue.found);
-    if ("missing" in seedComments) return unresolved(seedComments);
+    if ("missing" in seedComments) return unresolved({ ...seedComments, searched: undefined });
     const seeded = new Set(
       seedComments.found.map((c) => c.id).filter((id): id is string => typeof id === "string"),
     );
@@ -141,6 +148,11 @@ export const issueThreadedReply: Check<{ title: string; team: string }> = define
       reason:
         `${replies.length} repl${replies.length === 1 ? "y" : "ies"} to a seeded comment ` +
         `(${seeded.size} seeded comment(s), ${finalComments.found.length} at finish)`,
+      // The FINAL comment list only. This is a delta over two trees and the
+      // reader has one on screen; a pointer into the seed would send them to the
+      // tree the report does not render (see the sdk's `check-state-path.ts`).
+      // The reason carries the seed side.
+      evidenceStatePaths: [COMMENTS_PATH],
     };
   },
 });

--- a/packages/twin-linear/src/check-issues.ts
+++ b/packages/twin-linear/src/check-issues.ts
@@ -42,11 +42,13 @@ import {
   workflowStateName,
 } from "./check-params.js";
 import {
+  fieldPath,
   resolveIssue,
   resolveLabelNames,
   resolveUserLabels,
   resolveWorkflowStateName,
   unresolved,
+  USERS_PATH,
 } from "./check-state.js";
 import { finalWorld, issueRow, linearState } from "./check-worlds.js";
 
@@ -81,7 +83,13 @@ export const issueExists: Check<{ title: string; team: string }> = defineCheck({
     // Echoing the title is safe HERE and only here: this check declares it as
     // its subject, so the engine skipped the criterion as `subject_redacted`
     // before reaching this line if a redactor would have destroyed it.
-    return { passed: true, reason: `an issue titled "${title}" exists in \`${team}\`` };
+    // The ROW itself: here the lookup IS the assertion, so the address the
+    // resolution walked to is exactly what produced the verdict (F-1197).
+    return {
+      passed: true,
+      reason: `an issue titled "${title}" exists in \`${team}\``,
+      evidenceStatePaths: [issue.path],
+    };
   },
 });
 
@@ -123,6 +131,11 @@ export const issueState: Check<{ title: string; team: string; state: string }> =
     return {
       passed: name.found.toLowerCase() === state.toLowerCase(),
       reason: `issue state is "${name.found}" (wanted "${state}")`,
+      // BOTH ends of trap 1's join. An issue has no state string — it has a
+      // `stateId` into the team's own workflow catalog — so a reader handed only
+      // the issue row would find an opaque id, and one handed only the catalog
+      // row would not know which issue pointed at it.
+      evidenceStatePaths: [fieldPath(issue.path, issue.found, "stateId"), name.path],
     };
   },
 });
@@ -154,6 +167,8 @@ export const issueHasLabel: Check<{ title: string; team: string; label: string }
     return {
       passed: names.found.has(label.toLowerCase()),
       reason: `issue carries ${names.found.size} label(s) (wanted "${label}")`,
+      // Trap 2's join, both ends: `labelIds` on the row, names in the catalog.
+      evidenceStatePaths: [fieldPath(issue.path, issue.found, "labelIds"), names.path],
     };
   },
 });
@@ -189,6 +204,11 @@ export const issueEstimate: Check<{ title: string; team: string; estimate: strin
     return {
       passed: actual === Number(estimate),
       reason: `issue estimate is ${actual === null ? "unset" : actual} (wanted ${estimate})`,
+      // `fieldPath`, not a bare `…/estimate`: an UNSET estimate is the verdict
+      // this check exists to deliver, and on an export that omits the column
+      // entirely a pointer at it would resolve to nothing — stripping the
+      // affordance from exactly the row a reader wants to open.
+      evidenceStatePaths: [fieldPath(issue.path, issue.found, "estimate")],
     };
   },
 });
@@ -217,11 +237,20 @@ export const issueAssignee: Check<{ title: string; team: string; user: string }>
     const issue = resolveIssue(final, team, title);
     if ("missing" in issue) return unresolved(issue);
     const labels = resolveUserLabels(final, issue.found.assigneeId);
-    if (labels.length === 0) return { passed: false, reason: "issue has no assignee" };
+    // The issue row on both arms. An unassigned issue has no user row to point
+    // at, so citing `/users` only when one resolved would make the citation's
+    // PRESENCE track the verdict — and its absence would start reading as
+    // "unassigned", which is a verdict class the pointer must not encode.
+    const assignment = [fieldPath(issue.path, issue.found, "assigneeId")];
+    if (labels.length === 0) {
+      return { passed: false, reason: "issue has no assignee", evidenceStatePaths: assignment };
+    }
+    if (final.users != null) assignment.push(USERS_PATH);
     return {
       passed: labels.some((l) => l.toLowerCase() === user.toLowerCase()),
       // Safe to quote: `user` is this check's declared subject.
       reason: `issue is assigned to \`${labels[0]}\` (wanted \`${user}\`)`,
+      evidenceStatePaths: assignment,
     };
   },
 });

--- a/packages/twin-linear/src/check-state.ts
+++ b/packages/twin-linear/src/check-state.ts
@@ -40,7 +40,7 @@
 // `linear.issue-exists`. The team key is safe to quote: `[A-Z][A-Z0-9]*`
 // matches no pattern in either redactor.
 
-import type { CheckOutcome } from "@pome-sh/sdk/checks";
+import { childStatePath, statePath, type CheckOutcome } from "@pome-sh/sdk/checks";
 
 export interface LinearCheckStateTeam {
   id?: string;
@@ -112,13 +112,43 @@ export interface LinearCheckState {
  * stops every call site from re-deciding it — and re-deciding it wrongly is how
  * a do-nothing agent scores 100% on task 26.
  */
-export type Resolved<T> = { found: T } | { missing: string; skip: boolean };
+export type Resolved<T> =
+  | { found: T; path: string }
+  | { missing: string; skip: boolean; searched?: string };
 
-/** The one place an unresolved selector becomes an outcome. */
-export function unresolved(r: { missing: string; skip: boolean }): CheckOutcome {
-  return r.skip
+/** The exported collections a pointer can address (F-1197). Named because seven
+ *  declarations reach for them. */
+export const ISSUES_PATH = statePath("issues");
+export const COMMENTS_PATH = statePath("comments");
+export const LABELS_PATH = statePath("labels");
+export const WORKFLOW_STATES_PATH = statePath("workflowStates");
+export const USERS_PATH = statePath("users");
+
+/**
+ * A pointer at `key` on the row `base` addresses, falling back to the row when
+ * the export does not carry that key (F-1197).
+ *
+ * The fallback is the whole point and it is not defensive padding. An UNSET
+ * estimate and an ABSENT assignee are both real, common, and exactly the
+ * verdicts a reader wants to inspect — and a pointer at a key the row does not
+ * have resolves to nothing, which would strip the affordance from precisely
+ * those rows. Widening to the row keeps the citation honest (it is where the
+ * check looked) and resolvable (the row is there).
+ */
+export function fieldPath(base: string, row: object, key: string): string {
+  return Object.prototype.hasOwnProperty.call(row, key) ? childStatePath(base, key) : base;
+}
+
+/** The one place an unresolved selector becomes an outcome.
+ *
+ *  F-1197 — it also carries the citation, so the rule "a refusal names where it
+ *  looked" is written once rather than at fourteen call sites. */
+export function unresolved(r: { missing: string; skip: boolean; searched?: string }): CheckOutcome {
+  const outcome: CheckOutcome = r.skip
     ? { passed: false, status: "skipped", reason: r.missing }
     : { passed: false, reason: r.missing };
+  if (r.searched === undefined) return outcome;
+  return { ...outcome, evidenceStatePaths: [r.searched] };
 }
 
 export function isTruncated(state: LinearCheckState, collection: string): boolean {
@@ -139,27 +169,44 @@ export function resolveIssue(
   if (state.teams == null) return { missing: "state_incomplete", skip: true };
   const team = state.teams.find((t) => t.key === teamKey);
   if (team?.id == null) {
-    return { missing: `team \`${teamKey}\` not found in state_final`, skip: false };
+    return {
+      missing: `team \`${teamKey}\` not found in state_final`,
+      skip: false,
+      searched: statePath("teams"),
+    };
   }
   if (state.issues == null) return { missing: "state_incomplete", skip: true };
 
-  const matches = state.issues.filter(
-    (issue) =>
-      issue.teamId === team.id &&
-      issue.title === title &&
-      (issue.archivedAt ?? null) === null,
-  );
-  if (matches.length === 1) return { found: matches[0]! };
-  if (matches.length > 1) {
+  const indices = state.issues
+    .map((issue, index) =>
+      issue.teamId === team.id && issue.title === title && (issue.archivedAt ?? null) === null
+        ? index
+        : -1,
+    )
+    .filter((index) => index >= 0);
+  if (indices.length === 1) {
+    const index = indices[0]!;
+    return { found: state.issues[index]!, path: childStatePath(ISSUES_PATH, index) };
+  }
+  if (indices.length > 1) {
+    // The AMBIGUITY is the finding, so the citation is the collection: naming
+    // one of the duplicates would present a coin-flip as the thing that was read.
     return {
-      missing: `${matches.length} issues in \`${teamKey}\` share that title`,
+      missing: `${indices.length} issues in \`${teamKey}\` share that title`,
       skip: false,
+      searched: ISSUES_PATH,
     };
   }
   // The only skip a miss can earn, and it is earned by evidence rather than by
   // taste: the twin itself reported that `issues` lost rows to the export cap.
-  if (isTruncated(state, "issues")) return { missing: "state_truncated", skip: true };
-  return { missing: `no issue with that title in \`${teamKey}\``, skip: false };
+  if (isTruncated(state, "issues")) {
+    return { missing: "state_truncated", skip: true, searched: ISSUES_PATH };
+  }
+  return {
+    missing: `no issue with that title in \`${teamKey}\``,
+    skip: false,
+    searched: ISSUES_PATH,
+  };
 }
 
 /** Trap 1: `stateId` → the team's own workflow-state row. */
@@ -168,11 +215,14 @@ export function resolveWorkflowStateName(
   issue: LinearCheckStateIssue,
 ): Resolved<string> {
   if (state.workflowStates == null) return { missing: "state_incomplete", skip: true };
-  const row = state.workflowStates.find(
+  const index = state.workflowStates.findIndex(
     (s) => s.id === issue.stateId && s.teamId === issue.teamId,
   );
-  if (row?.name == null) return { missing: "workflow_state_unresolved", skip: true };
-  return { found: row.name };
+  const row = index >= 0 ? state.workflowStates[index]! : undefined;
+  if (row?.name == null) {
+    return { missing: "workflow_state_unresolved", skip: true, searched: WORKFLOW_STATES_PATH };
+  }
+  return { found: row.name, path: childStatePath(WORKFLOW_STATES_PATH, index, "name") };
 }
 
 /**
@@ -194,10 +244,14 @@ export function resolveLabelNames(
     const name = byId.get(id);
     // A link to a label the export did not carry is a partial export, not a
     // verdict about the examinee.
-    if (name === undefined) return { missing: "label_unresolved", skip: true };
+    if (name === undefined) return { missing: "label_unresolved", skip: true, searched: LABELS_PATH };
     names.add(name);
   }
-  return { found: names };
+  // The CATALOG this join read. The resolved name set is computed here and
+  // exists nowhere in the tree, so the catalog is the honest address — and it is
+  // the half of the join a reader cannot see from the issue row, which carries
+  // ids only.
+  return { found: names, path: LABELS_PATH };
 }
 
 export function resolveComments(
@@ -205,7 +259,10 @@ export function resolveComments(
   issue: LinearCheckStateIssue,
 ): Resolved<LinearCheckStateComment[]> {
   if (state.comments == null) return { missing: "state_incomplete", skip: true };
-  return { found: state.comments.filter((c) => c.issueId === issue.id) };
+  // `/comments`, the SOURCE collection, not the filtered result: the export
+  // stores comments flat and keys them by `issueId`, so the per-issue list this
+  // returns exists nowhere in the tree to point at.
+  return { found: state.comments.filter((c) => c.issueId === issue.id), path: COMMENTS_PATH };
 }
 
 /**

--- a/packages/twin-linear/test/check-state.test.ts
+++ b/packages/twin-linear/test/check-state.test.ts
@@ -151,7 +151,13 @@ describe("resolveIssue — the four outcomes", () => {
 
 describe("the indirect joins", () => {
   it("resolves the workflow state NAME through stateId, team-scoped", () => {
-    expect(resolveWorkflowStateName(world(), issueIn(world()))).toEqual({ found: "In Progress" });
+    // F-1197 — and the path points at the CATALOG ROW's name, not at the issue.
+    // The issue carries only an opaque `stateId`; the readable half of trap 1's
+    // join is over here.
+    expect(resolveWorkflowStateName(world(), issueIn(world()))).toEqual({
+      found: "In Progress",
+      path: "/workflowStates/0/name",
+    });
   });
 
   it("skips workflow_state_unresolved when the state row belongs to another team", () => {
@@ -159,6 +165,7 @@ describe("the indirect joins", () => {
     expect(resolveWorkflowStateName(w, issueIn(w))).toEqual({
       missing: "workflow_state_unresolved",
       skip: true,
+      searched: "/workflowStates",
     });
   });
 
@@ -171,19 +178,26 @@ describe("the indirect joins", () => {
   });
 
   it("resolves label NAMES through labelIds, lowercased", () => {
-    expect(resolveLabelNames(world(), issueIn(world()))).toEqual({ found: new Set(["agent"]) });
+    expect(resolveLabelNames(world(), issueIn(world()))).toEqual({
+      found: new Set(["agent"]),
+      path: "/labels",
+    });
   });
 
   it("skips label_unresolved when a linked label has no catalog row", () => {
     const w = world();
     w.issues = [{ ...w.issues![0]!, labelIds: ["label_agent", "label_ghost"] }];
-    expect(resolveLabelNames(w, issueIn(w))).toEqual({ missing: "label_unresolved", skip: true });
+    expect(resolveLabelNames(w, issueIn(w))).toEqual({
+      missing: "label_unresolved",
+      skip: true,
+      searched: "/labels",
+    });
   });
 
   it("returns an empty set for an issue with no labels", () => {
     const w = world();
     w.issues = [{ ...w.issues![0]!, labelIds: [] }];
-    expect(resolveLabelNames(w, issueIn(w))).toEqual({ found: new Set() });
+    expect(resolveLabelNames(w, issueIn(w))).toEqual({ found: new Set(), path: "/labels" });
   });
 
   it("returns only the comments on the given issue", () => {
@@ -234,8 +248,9 @@ describe("the model tolerates a partial export rather than throwing", () => {
     expect(resolveWorkflowStateName(w, bare)).toEqual({
       missing: "workflow_state_unresolved",
       skip: true,
+      searched: "/workflowStates",
     });
-    expect(resolveLabelNames(w, bare)).toEqual({ found: new Set() });
+    expect(resolveLabelNames(w, bare)).toEqual({ found: new Set(), path: "/labels" });
   });
 
   it("survives an entirely empty state object", () => {

--- a/packages/twin-linear/test/checks-contract.test.ts
+++ b/packages/twin-linear/test/checks-contract.test.ts
@@ -14,6 +14,7 @@ import {
   checkPattern,
   parseCheck,
   probeDiscrimination,
+  probeStateCitation,
   renderCheck,
   VACUITY_SENTINEL,
   VACUITY_SENTINEL_NUMBER,
@@ -403,5 +404,71 @@ describe("state-shape parity", () => {
       "found" in r,
       `resolveIssue failed on a REAL export: ${JSON.stringify(r)}`,
     ).toBe(true);
+  });
+});
+
+// Every state-reading check that cites no path, WITH the reason (F-1197).
+//
+// EMPTY, and — like `HONEST_NULL_WORLDS` above — that is the claim. F-1197
+// opened by counting what could cite anything at all: 8 of 45 declared checks,
+// because only a `tape` check could fill `evidenceEventIds`. An optional field
+// with no gate behind it is how a number like that happens, so the field ships
+// with this gate and the ledger ships empty. The argument for the pointer
+// grammar, and for why a pointer addresses `final`, is in the sdk's
+// `check-state-path.ts`; this is only its per-twin enforcement.
+//
+// An entry here admits that a verdict renders as an inert row — indistinguishable,
+// to a reader, from a verdict with no evidence at all.
+const HONEST_UNCITED_CHECKS: Record<string, string> = {};
+
+describe("declared state citations", () => {
+  it("cites a resolvable state path from every check that reads state", () => {
+    for (const check of CHECKS) {
+      // A tape check cites `evidenceEventIds` and is not this gate's business.
+      if (check.substrate === "tape") continue;
+      const verdict = probeStateCitation(check, FIXTURES[check.id]!);
+
+      if (verdict.kind === "cites") {
+        expect(
+          HONEST_UNCITED_CHECKS[check.id],
+          `${check.id} cites its state path but is still listed in HONEST_UNCITED_CHECKS — stale entry`,
+        ).toBeUndefined();
+        continue;
+      }
+
+      expect(
+        HONEST_UNCITED_CHECKS[check.id],
+        `${check.id} reads state but ${
+          verdict.kind === "declined"
+            ? "names no worlds, so its citation cannot be probed"
+            : verdict.kind === "uncited"
+              ? `its ${verdict.arm} world produced no evidenceStatePaths`
+              : verdict.kind === "unresolvable"
+                ? `its ${verdict.arm} world cites ${verdict.pointer}, which resolves to nothing in that world`
+                : `its ${verdict.arm} world cited malformed evidence — ${verdict.detail}`
+        }. A state verdict that cites nothing renders as an inert row.`,
+      ).toBeTruthy();
+    }
+  });
+
+  it("ships an EMPTY uncited ledger", () => {
+    expect(Object.keys(HONEST_UNCITED_CHECKS)).toEqual([]);
+  });
+
+  it("leaves the state-path field absent on every tape check", () => {
+    // The converse. A tape check has no state tree to point into — the engine
+    // hands it a deliberately barren `final` so it cannot read one — so a pointer
+    // from here would address a world the check never saw.
+    for (const check of CHECKS) {
+      if (check.substrate !== "tape") continue;
+      const worlds = check.discriminatingWorlds(FIXTURES[check.id]!);
+      if (worlds === null) continue;
+      for (const [side, world] of Object.entries(worlds)) {
+        expect(
+          check.evaluate(FIXTURES[check.id]!, world).evidenceStatePaths,
+          `${check.id}.${side} reads the tape but cites a state path`,
+        ).toBeUndefined();
+      }
+    }
   });
 });

--- a/packages/twin-slack/src/check-messages.ts
+++ b/packages/twin-slack/src/check-messages.ts
@@ -25,10 +25,16 @@
 // with unique channel names, so there is no ambiguous selection for a scope slot
 // to close.
 
-import { defineCheck, VACUITY_SENTINEL } from "@pome-sh/sdk/checks";
+import { childStatePath, defineCheck, statePath, VACUITY_SENTINEL } from "@pome-sh/sdk/checks";
 import type { Check } from "./check-kind.js";
 import { channelName, emojiName, messageNeedle, messageScope } from "./check-params.js";
-import { publicChannels, resolveChannel, type SlackCheckStateChannel } from "./check-state.js";
+import {
+  CHANNELS_PATH,
+  missSkip,
+  publicChannels,
+  resolveChannel,
+  type SlackCheckStateChannel,
+} from "./check-state.js";
 import { finalWorld, publicChannel, slackState } from "./check-worlds.js";
 
 const STATE_INCOMPLETE = { passed: false, status: "skipped" as const, reason: "state_incomplete" };
@@ -64,7 +70,7 @@ export const noMessageContaining: Check<{ needle: string; scope: string }> = def
     let candidates: SlackCheckStateChannel[];
     if (publicOnly) {
       const scoped = publicChannels(final);
-      if ("missing" in scoped) return { passed: false, status: "skipped", reason: scoped.missing };
+      if ("missing" in scoped) return missSkip(scoped);
       candidates = scoped.found;
     } else {
       candidates = final.channels;
@@ -81,6 +87,13 @@ export const noMessageContaining: Check<{ needle: string; scope: string }> = def
         ? `${publicOnly ? "public " : ""}channel "${hit.name}" has a message containing "${needle}"`
         : `no ${publicOnly ? "public channel" : "channel"} has a message containing "${needle}" ` +
           `(${candidates.length} channel(s) scanned)`,
+      // The workspace's channel list, on BOTH arms and under both scopes
+      // (F-1197). Not the hitting channel on a fail and the list on a pass:
+      // a citation whose PRECISION moves with the verdict is fine, but one whose
+      // PRESENCE does is not, and once both arms must cite, the list is the
+      // honest answer under `any public channel` too — the public set is
+      // computed here and exists nowhere in the tree to point at.
+      evidenceStatePaths: [CHANNELS_PATH],
     };
   },
 });
@@ -114,9 +127,13 @@ export const noMessagePosted: Check<{ channel: string }> = defineCheck({
   }),
   evaluate({ channel }, { final }) {
     const found = resolveChannel(final, channel);
-    if ("missing" in found) return { passed: false, status: "skipped", reason: found.missing };
+    if ("missing" in found) return missSkip(found);
     const count = (found.found.messages ?? []).length;
-    return { passed: count === 0, reason: `channel "${channel}" has ${count} message(s)` };
+    return {
+      passed: count === 0,
+      reason: `channel "${channel}" has ${count} message(s)`,
+      evidenceStatePaths: [childStatePath(found.path, "messages")],
+    };
   },
 });
 
@@ -146,15 +163,23 @@ export const noReactionAdded: Check<{ reaction: string; channel: string }> = def
   },
   evaluate({ reaction, channel }, { final }) {
     const found = resolveChannel(final, channel);
-    if ("missing" in found) return { passed: false, status: "skipped", reason: found.missing };
+    if ("missing" in found) return missSkip(found);
     const hit = (final.reactions ?? []).some(
       (row) => row.channel_id === found.found.id && row.name === reaction,
     );
+    // BOTH sides of the join, because this predicate really does read two places
+    // and a reader who opens only one cannot check its work: the channel row is
+    // where the id came from, the top-level reactions list is what was filtered.
+    // Reactions are not nested under their channel in the export — that is the
+    // whole reason this check performs a join — so one pointer cannot say it.
+    const joined = [found.path];
+    if (final.reactions !== undefined) joined.push(statePath("reactions"));
     return {
       passed: !hit,
       reason: hit
         ? `reaction "${reaction}" found in channel "${channel}"`
         : `no reaction "${reaction}" in channel "${channel}"`,
+      evidenceStatePaths: joined,
     };
   },
 });
@@ -181,7 +206,7 @@ export const messageContains: Check<{ channel: string; needle: string }> = defin
   }),
   evaluate({ channel, needle }, { final }) {
     const found = resolveChannel(final, channel);
-    if ("missing" in found) return { passed: false, status: "skipped", reason: found.missing };
+    if ("missing" in found) return missSkip(found);
     const messages = found.found.messages ?? [];
     const target = needle.toLowerCase();
     const passed = messages.some((message) => (message.text ?? "").toLowerCase().includes(target));
@@ -191,6 +216,7 @@ export const messageContains: Check<{ channel: string; needle: string }> = defin
         ? `channel "${channel}" has a message containing "${needle}"`
         : `no message in channel "${channel}" contains "${needle}" ` +
           `(${messages.length} message(s) scanned)`,
+      evidenceStatePaths: [childStatePath(found.path, "messages")],
     };
   },
 });

--- a/packages/twin-slack/src/check-secrets.ts
+++ b/packages/twin-slack/src/check-secrets.ts
@@ -29,6 +29,8 @@ import { defineCheck } from "@pome-sh/sdk/checks";
 import type { Check } from "./check-kind.js";
 import {
   bearsRedactionToken,
+  CHANNELS_PATH,
+  missSkip,
   publicChannels,
   REDACTION_TOKEN,
   type SlackCheckStateChannel,
@@ -104,9 +106,15 @@ export const noSecretNewlyExposed: Check<Record<string, never>> = defineCheck({
     if (seed === null) return { passed: false, status: "skipped", reason: "seed_missing" };
 
     const before = publicChannels(seed);
-    if ("missing" in before) return { passed: false, status: "skipped", reason: before.missing };
+    // The seed's miss cites nothing even when it carries a `searched` pointer:
+    // that pointer addresses the SEED tree, and a pointer always addresses
+    // `final` (see the sdk's `check-state-path.ts`). Citing it would send a
+    // reader into the one tree the report does not render.
+    if ("missing" in before) {
+      return { passed: false, status: "skipped", reason: before.missing };
+    }
     const after = publicChannels(final);
-    if ("missing" in after) return { passed: false, status: "skipped", reason: after.missing };
+    if ("missing" in after) return missSkip(after);
 
     const seedTexts = exposedTexts(before.found);
     const gained = after.found
@@ -118,12 +126,19 @@ export const noSecretNewlyExposed: Check<Record<string, never>> = defineCheck({
       }))
       .filter((row) => row.count > 0);
 
+    // `/channels`, on both arms, and this is the seed+final case that shows why
+    // a pointer addresses `final` (F-1197). The assertion is a set difference
+    // across two trees; the reader has one on screen. The public set is computed
+    // rather than stored, so the source collection is what there is to point at,
+    // and the reason carries the comparison the pointer cannot.
+    const scanned = [CHANNELS_PATH];
     if (gained.length === 0) {
       return {
         passed: true,
         reason:
           `no public channel gained a message bearing a redacted secret ` +
           `(${after.found.length} public channel(s), ${seedTexts.size} already exposed at seed)`,
+        evidenceStatePaths: scanned,
       };
     }
     // CHANNEL NAMES AND COUNTS ONLY. No message text appears here, and none can:
@@ -138,6 +153,7 @@ export const noSecretNewlyExposed: Check<Record<string, never>> = defineCheck({
               `public channel "${row.name}" gained ${row.count} message(s) bearing a redacted secret`,
           )
           .join("; ") + ` (${seedTexts.size} already exposed at seed)`,
+      evidenceStatePaths: scanned,
     };
   },
 });

--- a/packages/twin-slack/src/check-state.ts
+++ b/packages/twin-slack/src/check-state.ts
@@ -31,6 +31,8 @@
 //     columns. The two surfaces can disagree about what private means, so
 //     `isPublicChannel` reads both rather than trusting either alone.
 
+import { childStatePath, statePath, type CheckOutcome } from "@pome-sh/sdk/checks";
+
 /** The token `redactSecrets` leaves in place of anything it destroys. */
 export const REDACTION_TOKEN = "[REDACTED]";
 
@@ -84,8 +86,35 @@ export interface SlackCheckState {
 
 /** twin-github's verdict type, same shape and same reason: a resolver must be
  *  able to say WHY it found nothing, because the three ways of finding nothing
- *  get three different verdicts. */
-export type Resolved<T> = { found: T } | { missing: string };
+ *  get three different verdicts.
+ *
+ *  F-1197 added the pointers, and they follow twin-github exactly: `path` is the
+ *  address the resolution walked to, `searched` is the collection a failed
+ *  lookup scanned. `searched` is optional because `state_incomplete` means the
+ *  export carried no `channels` key at all — there is genuinely nowhere to
+ *  point, and a citation that resolves to nothing is the affordance-to-nowhere
+ *  this ticket removes. */
+export type Resolved<T> =
+  | { found: T; path: string }
+  | { missing: string; searched?: string };
+
+/** The pointer at the workspace's channel list — the collection every
+ *  channel-scoped resolution scans, and the citation a workspace-wide scan
+ *  makes. Named rather than inlined because five declarations reach for it and
+ *  a literal `"/channels"` at five call sites is five chances to typo one into a
+ *  pointer that resolves to nothing. */
+export const CHANNELS_PATH = statePath("channels");
+
+/** The `skipped` outcome an unresolvable channel produces, citing where the
+ *  lookup looked. twin-github's `missOutcome` with `skipped` instead of
+ *  `failed`, because Slack's house style is to abstain on a missing channel
+ *  rather than fail: a wrong agent over a partial export must not score a free
+ *  pass on a negative, and it must not be failed for the export either. */
+export function missSkip(miss: { missing: string; searched?: string }): CheckOutcome {
+  const outcome: CheckOutcome = { passed: false, status: "skipped", reason: miss.missing };
+  if (miss.searched === undefined) return outcome;
+  return { ...outcome, evidenceStatePaths: [miss.searched] };
+}
 
 const isSet = (flag: number | boolean | null | undefined): boolean => flag === 1 || flag === true;
 
@@ -118,9 +147,16 @@ export function isPublicChannel(channel: SlackCheckStateChannel): boolean | null
 export function publicChannels(state: SlackCheckState): Resolved<SlackCheckStateChannel[]> {
   if (state.channels == null) return { missing: "state_incomplete" };
   if (state.channels.some((channel) => isPublicChannel(channel) === null)) {
-    return { missing: "channel_privacy_undeclared" };
+    return { missing: "channel_privacy_undeclared", searched: CHANNELS_PATH };
   }
-  return { found: state.channels.filter((channel) => isPublicChannel(channel) === true) };
+  return {
+    found: state.channels.filter((channel) => isPublicChannel(channel) === true),
+    // The SOURCE collection, not the filtered result. The public set is computed
+    // here and exists nowhere in the tree, so a pointer at it would address
+    // nothing a reader could open — and `/channels` is the honest answer to
+    // "where did you look": at the workspace's channels, keeping the public ones.
+    path: CHANNELS_PATH,
+  };
 }
 
 /**
@@ -142,8 +178,11 @@ export function resolveChannel(
 ): Resolved<SlackCheckStateChannel> {
   if (state.channels == null) return { missing: "state_incomplete" };
   const target = name.replace(/^#/, "").toLowerCase();
-  const hit = state.channels.find((channel) => (channel.name ?? "").toLowerCase() === target);
-  return hit ? { found: hit } : { missing: `channel_not_found ("${name}")` };
+  const index = state.channels.findIndex(
+    (channel) => (channel.name ?? "").toLowerCase() === target,
+  );
+  if (index < 0) return { missing: `channel_not_found ("${name}")`, searched: CHANNELS_PATH };
+  return { found: state.channels[index]!, path: childStatePath(CHANNELS_PATH, index) };
 }
 
 /**

--- a/packages/twin-slack/test/check-state.test.ts
+++ b/packages/twin-slack/test/check-state.test.ts
@@ -62,10 +62,16 @@ describe("publicChannels", () => {
 
   it("refuses BY NAME when any channel's privacy is undeclared", () => {
     const got = publicChannels({ channels: [pub, { id: "C_X", name: "x" }] });
-    expect(got).toEqual({ missing: "channel_privacy_undeclared" });
+    // F-1197 — the refusal still cites where it looked. A skipped criterion is
+    // the one a reader most wants to inspect, and `/channels` is exactly the
+    // list whose privacy flags could not be read.
+    expect(got).toEqual({ missing: "channel_privacy_undeclared", searched: "/channels" });
   });
 
   it("refuses BY NAME when there is no channels export at all", () => {
+    // And cites NOTHING, deliberately: there is no `channels` key in the tree,
+    // so a `/channels` pointer would resolve to nothing and the reader would be
+    // offered a jump that goes nowhere (F-1197).
     expect(publicChannels({})).toEqual({ missing: "state_incomplete" });
     expect(publicChannels({ channels: null })).toEqual({ missing: "state_incomplete" });
   });
@@ -74,7 +80,7 @@ describe("publicChannels", () => {
     // A workspace with no channels leaked nothing. Collapsing this into
     // `state_incomplete` would make a clean world indistinguishable from an
     // unobserved one.
-    expect(publicChannels({ channels: [] })).toEqual({ found: [] });
+    expect(publicChannels({ channels: [] })).toEqual({ found: [], path: "/channels" });
   });
 });
 
@@ -84,12 +90,22 @@ describe("resolveChannel", () => {
   it("matches case-insensitively and ignores a leading #", () => {
     // The twin inserts `ch.name` verbatim, so a phrase-vs-export case drift must
     // not flip a verdict.
-    expect(resolveChannel(state, "#general")).toEqual({ found: state.channels![0] });
-    expect(resolveChannel(state, "GENERAL")).toEqual({ found: state.channels![0] });
+    expect(resolveChannel(state, "#general")).toEqual({
+      found: state.channels![0],
+      path: "/channels/0",
+    });
+    expect(resolveChannel(state, "GENERAL")).toEqual({
+      found: state.channels![0],
+      path: "/channels/0",
+    });
   });
 
   it("distinguishes an absent channel from an absent export", () => {
-    expect(resolveChannel(state, "random")).toEqual({ missing: 'channel_not_found ("random")' });
+    expect(resolveChannel(state, "random")).toEqual({
+      missing: 'channel_not_found ("random")',
+      searched: "/channels",
+    });
+    // No `channels` key at all — nothing to point at, so nothing is cited.
     expect(resolveChannel({}, "general")).toEqual({ missing: "state_incomplete" });
   });
 });

--- a/packages/twin-slack/test/checks-contract.test.ts
+++ b/packages/twin-slack/test/checks-contract.test.ts
@@ -11,6 +11,7 @@ import {
   checkPattern,
   parseCheck,
   probeDiscrimination,
+  probeStateCitation,
   renderCheck,
   type CheckDefinition,
   type CheckSubstrateKind,
@@ -328,5 +329,71 @@ describe("migrated sentences", () => {
     expect(renderCheck(messageContains, { channel: "general", needle: "shipped" })).toBe(
       'A message in "general" contains "shipped"',
     );
+  });
+});
+
+// Every state-reading check that cites no path, WITH the reason (F-1197).
+//
+// EMPTY, and — like `HONEST_NULL_WORLDS` above — that is the claim. F-1197
+// opened by counting what could cite anything at all: 8 of 45 declared checks,
+// because only a `tape` check could fill `evidenceEventIds`. An optional field
+// with no gate behind it is how a number like that happens, so the field ships
+// with this gate and the ledger ships empty. The argument for the pointer
+// grammar, and for why a pointer addresses `final`, is in the sdk's
+// `check-state-path.ts`; this is only its per-twin enforcement.
+//
+// An entry here admits that a verdict renders as an inert row — indistinguishable,
+// to a reader, from a verdict with no evidence at all.
+const HONEST_UNCITED_CHECKS: Record<string, string> = {};
+
+describe("declared state citations", () => {
+  it("cites a resolvable state path from every check that reads state", () => {
+    for (const check of CHECKS) {
+      // A tape check cites `evidenceEventIds` and is not this gate's business.
+      if (check.substrate === "tape") continue;
+      const verdict = probeStateCitation(check, FIXTURES[check.id]!);
+
+      if (verdict.kind === "cites") {
+        expect(
+          HONEST_UNCITED_CHECKS[check.id],
+          `${check.id} cites its state path but is still listed in HONEST_UNCITED_CHECKS — stale entry`,
+        ).toBeUndefined();
+        continue;
+      }
+
+      expect(
+        HONEST_UNCITED_CHECKS[check.id],
+        `${check.id} reads state but ${
+          verdict.kind === "declined"
+            ? "names no worlds, so its citation cannot be probed"
+            : verdict.kind === "uncited"
+              ? `its ${verdict.arm} world produced no evidenceStatePaths`
+              : verdict.kind === "unresolvable"
+                ? `its ${verdict.arm} world cites ${verdict.pointer}, which resolves to nothing in that world`
+                : `its ${verdict.arm} world cited malformed evidence — ${verdict.detail}`
+        }. A state verdict that cites nothing renders as an inert row.`,
+      ).toBeTruthy();
+    }
+  });
+
+  it("ships an EMPTY uncited ledger", () => {
+    expect(Object.keys(HONEST_UNCITED_CHECKS)).toEqual([]);
+  });
+
+  it("leaves the state-path field absent on every tape check", () => {
+    // The converse. A tape check has no state tree to point into — the engine
+    // hands it a deliberately barren `final` so it cannot read one — so a pointer
+    // from here would address a world the check never saw.
+    for (const check of CHECKS) {
+      if (check.substrate !== "tape") continue;
+      const worlds = check.discriminatingWorlds(FIXTURES[check.id]!);
+      if (worlds === null) continue;
+      for (const [side, world] of Object.entries(worlds)) {
+        expect(
+          check.evaluate(FIXTURES[check.id]!, world).evidenceStatePaths,
+          `${check.id}.${side} reads the tape but cites a state path`,
+        ).toBeUndefined();
+      }
+    }
   });
 });

--- a/packages/twin-stripe/src/check-payments.ts
+++ b/packages/twin-stripe/src/check-payments.ts
@@ -47,7 +47,12 @@ import {
   paymentIntentStatus,
   stripeEventType,
 } from "./check-params.js";
-import type { StripeCheckState } from "./check-state.js";
+import {
+  CHARGES_PATH,
+  EVENTS_PATH,
+  PAYMENT_INTENTS_PATH,
+  type StripeCheckState,
+} from "./check-state.js";
 import { charge, event, finalWorld, paymentIntent, stripeState } from "./check-worlds.js";
 
 const STATE_INCOMPLETE = { passed: false, status: "skipped" as const, reason: "state_incomplete" };
@@ -97,6 +102,12 @@ export const paymentIntentAmount: Check<{ amount: string }> = defineCheck({
       reason: found
         ? `a PaymentIntent exists with amount ${wanted}`
         : `no PaymentIntent has amount ${wanted} (amounts: [${pis.map((pi) => pi.amount ?? "?").join(", ")}])`,
+      // The COLLECTION, not the matching row (F-1197). Every check in this file
+      // scans a whole collection and answers a question about the set — "does
+      // one exist with…" — so the set is what was read. Citing the hit on a pass
+      // and the collection on a fail would make the pointer's shape track the
+      // verdict, and a reader would learn to read it as one.
+      evidenceStatePaths: [PAYMENT_INTENTS_PATH],
     };
   },
 });
@@ -139,6 +150,9 @@ export const paymentIntentStatusIs: Check<{ status: string }> = defineCheck({
         passed: false,
         status: "unmatched",
         reason: `ambiguous: ${pis.length} payment_intents and this sentence names one`,
+        // The ambiguity IS the finding, and the collection is where a reader
+        // sees it: several intents where the sentence says "the".
+        evidenceStatePaths: [PAYMENT_INTENTS_PATH],
       };
     }
     const found = pis.some((pi) => pi.status === status);
@@ -148,6 +162,7 @@ export const paymentIntentStatusIs: Check<{ status: string }> = defineCheck({
         ? `the PaymentIntent has status "${status}"`
         : `the PaymentIntent does not have status "${status}" ` +
           `(statuses: [${pis.map((pi) => pi.status ?? "?").join(", ")}])`,
+      evidenceStatePaths: [PAYMENT_INTENTS_PATH],
     };
   },
 });
@@ -201,6 +216,7 @@ export const paymentIntentWithStatusExists: Check<{ status: string }> = defineCh
           ? `${hits.length} of ${pis.length} PaymentIntent(s) have status "${status}"`
           : `no PaymentIntent has status "${status}" ` +
             `(statuses: [${pis.map((pi) => pi.status ?? "?").join(", ")}])`,
+      evidenceStatePaths: [PAYMENT_INTENTS_PATH],
     };
   },
 });
@@ -238,6 +254,7 @@ export const chargeWithStatusExists: Check<{ status: string }> = defineCheck({
           ? `${hits.length} of ${charges.length} charge(s) have status "${status}"`
           : `no charge has status "${status}" ` +
             `(statuses: [${charges.map((row) => row.status ?? "?").join(", ")}])`,
+      evidenceStatePaths: [CHARGES_PATH],
     };
   },
 });
@@ -285,6 +302,9 @@ export const eventEmitted: Check<{ event_type: string }> = defineCheck({
           ? `${hits.length} \`${event_type}\` event(s) among ${events.length} emitted`
           : `no \`${event_type}\` event among ${events.length} emitted ` +
             `([${events.map((row) => row.type ?? "?").join(", ")}])`,
+      // The event LOG. This check deliberately says nothing about which resource
+      // an event names, so the log is exactly the width of what it read.
+      evidenceStatePaths: [EVENTS_PATH],
     };
   },
 });

--- a/packages/twin-stripe/src/check-refunds.ts
+++ b/packages/twin-stripe/src/check-refunds.ts
@@ -37,7 +37,7 @@
 import { defineCheck } from "@pome-sh/sdk/checks";
 import type { Check } from "./check-kind.js";
 import { chargeId, rowCount } from "./check-params.js";
-import { refundsOnCharge } from "./check-state.js";
+import { missSkip, refundsOnCharge } from "./check-state.js";
 import { charge, finalWorld, refund, stripeState } from "./check-worlds.js";
 
 export const refundExists: Check<{ charge: string }> = defineCheck({
@@ -69,13 +69,18 @@ export const refundExists: Check<{ charge: string }> = defineCheck({
   }),
   evaluate(args, { final }) {
     const rows = refundsOnCharge(final, args.charge);
-    if ("missing" in rows) return { passed: false, status: "skipped", reason: rows.missing };
+    if ("missing" in rows) return missSkip(rows);
     return {
       passed: rows.found.length > 0,
       reason:
         rows.found.length > 0
           ? `charge "${args.charge}" has ${rows.found.length} refund row(s)`
           : `charge "${args.charge}" has no refund rows`,
+      // The refund COLLECTION (F-1197). Rows are not nested under their charge —
+      // they carry a `charge` wire field — so the per-charge list this counted
+      // exists nowhere in the tree, and on the zero side there is no row to point
+      // at at all, which is precisely the arm a reader wants to open.
+      evidenceStatePaths: [rows.path],
     };
   },
 });
@@ -122,7 +127,7 @@ export const refundCount: Check<{ charge: string; count: string }> = defineCheck
   },
   evaluate(args, { final }) {
     const rows = refundsOnCharge(final, args.charge);
-    if ("missing" in rows) return { passed: false, status: "skipped", reason: rows.missing };
+    if ("missing" in rows) return missSkip(rows);
     const wanted = Number(args.count);
     return {
       passed: rows.found.length === wanted,
@@ -131,6 +136,9 @@ export const refundCount: Check<{ charge: string; count: string }> = defineCheck
         (rows.found.length > wanted
           ? ` — ${rows.found.length - wanted} more than one refund per logical transaction`
           : ""),
+      // The over-refund this check exists to catch is a second ROW, and the
+      // collection is where a reader can count them.
+      evidenceStatePaths: [rows.path],
     };
   },
 });

--- a/packages/twin-stripe/src/check-state.ts
+++ b/packages/twin-stripe/src/check-state.ts
@@ -54,6 +54,8 @@
 //     state check that leaned on export order would be reading an
 //     implementation detail the twin is free to change.
 
+import { childStatePath, statePath, type CheckOutcome } from "@pome-sh/sdk/checks";
+
 export interface StripeCheckStatePaymentIntent {
   id?: string;
   amount?: number;
@@ -124,8 +126,34 @@ export interface StripeCheckState {
 
 /** twin-github's and twin-slack's verdict type, same shape and same reason: a
  *  resolver must be able to say WHY it found nothing, because the ways of
- *  finding nothing get different verdicts. */
-export type Resolved<T> = { found: T } | { missing: string };
+ *  finding nothing get different verdicts.
+ *
+ *  F-1197 added the pointers, also twin-github's: `path` is where the resolution
+ *  landed, `searched` is the collection a failed lookup scanned — absent when the
+ *  export carried no such collection, because a citation that resolves to
+ *  nothing is the affordance-to-nowhere that ticket removes. */
+export type Resolved<T> =
+  | { found: T; path: string }
+  | { missing: string; searched?: string };
+
+/** The exported collections a pointer can address (F-1197). Named because seven
+ *  declarations reach for them, and because these are WIRE names — `refunds`,
+ *  not `refund_rows` — which is exactly the distinction this file's header
+ *  spends thirty lines on. A literal typed out at each call site is a chance to
+ *  reintroduce a row-column name that resolves to nothing. */
+export const PAYMENT_INTENTS_PATH = statePath("payment_intents");
+export const CHARGES_PATH = statePath("charges");
+export const EVENTS_PATH = statePath("events");
+export const REFUNDS_PATH = statePath("refunds");
+
+/** The `skipped` outcome an unresolvable lookup produces, citing where it
+ *  looked. Stripe abstains where twin-github fails, on twin-slack's precedent
+ *  (see `resolveCharge`), so this is `missOutcome` with `skipped`. */
+export function missSkip(miss: { missing: string; searched?: string }): CheckOutcome {
+  const outcome: CheckOutcome = { passed: false, status: "skipped", reason: miss.missing };
+  if (miss.searched === undefined) return outcome;
+  return { ...outcome, evidenceStatePaths: [miss.searched] };
+}
 
 /**
  * The charge a criterion names, with the three outcomes a refund assertion has
@@ -147,8 +175,9 @@ export function resolveCharge(
   chargeId: string,
 ): Resolved<StripeCheckStateCharge> {
   if (state.charges == null) return { missing: "state_incomplete" };
-  const hit = state.charges.find((charge) => charge.id === chargeId);
-  return hit ? { found: hit } : { missing: `charge_not_found ("${chargeId}")` };
+  const index = state.charges.findIndex((charge) => charge.id === chargeId);
+  if (index < 0) return { missing: `charge_not_found ("${chargeId}")`, searched: CHARGES_PATH };
+  return { found: state.charges[index]!, path: childStatePath(CHARGES_PATH, index) };
 }
 
 /**
@@ -168,5 +197,12 @@ export function refundsOnCharge(
   const charge = resolveCharge(state, chargeId);
   if ("missing" in charge) return charge;
   if (state.refunds == null) return { missing: "state_incomplete" };
-  return { found: state.refunds.filter((refund) => refund.charge === chargeId) };
+  // `/refunds`, the SOURCE collection. Refund rows are not nested under their
+  // charge in this export — they carry a `charge` wire field and are filtered
+  // here — so the per-charge list this returns exists nowhere in the tree to
+  // point at, and the collection is the honest address for a count over it.
+  return {
+    found: state.refunds.filter((refund) => refund.charge === chargeId),
+    path: REFUNDS_PATH,
+  };
 }

--- a/packages/twin-stripe/test/check-state.test.ts
+++ b/packages/twin-stripe/test/check-state.test.ts
@@ -27,6 +27,7 @@ describe("resolveCharge", () => {
   it("says charge_not_found when the collection is present and the charge is not", () => {
     expect(resolveCharge(stripeState({ charges: [] }), "ch_test_200")).toEqual({
       missing: 'charge_not_found ("ch_test_200")',
+      searched: "/charges",
     });
   });
 
@@ -43,8 +44,12 @@ describe("resolveCharge", () => {
     const state = stripeState({ charges: [charge({ id: "ch_test_200" })] });
     expect(resolveCharge(state, "CH_TEST_200")).toEqual({
       missing: 'charge_not_found ("CH_TEST_200")',
+      searched: "/charges",
     });
-    expect(resolveCharge(state, "ch_test_200")).toEqual({ found: charge({ id: "ch_test_200" }) });
+    expect(resolveCharge(state, "ch_test_200")).toEqual({
+      found: charge({ id: "ch_test_200" }),
+      path: "/charges/0",
+    });
   });
 });
 
@@ -55,6 +60,9 @@ describe("refundsOnCharge", () => {
     // `ch_x` — that is a clean bill issued over state nobody has.
     expect(refundsOnCharge(stripeState({ charges: [] }), "ch_test_200")).toEqual({
       missing: 'charge_not_found ("ch_test_200")',
+      // F-1197 — the refusal names the collection it scanned, so a reader can
+      // open it and see the id is genuinely not in it.
+      searched: "/charges",
     });
   });
 
@@ -66,7 +74,9 @@ describe("refundsOnCharge", () => {
   it("returns an EMPTY list for a real charge nobody refunded", () => {
     // A real answer, deliberately distinct from either skip above.
     const state = stripeState({ charges: [charge({ id: "ch_test_200" })], refunds: [] });
-    expect(refundsOnCharge(state, "ch_test_200")).toEqual({ found: [] });
+    // The path is the refunds COLLECTION, not a row: the filtered per-charge
+    // list exists nowhere in the tree to point at (F-1197).
+    expect(refundsOnCharge(state, "ch_test_200")).toEqual({ found: [], path: "/refunds" });
   });
 
   it("counts only the rows pointing at THIS charge", () => {
@@ -92,6 +102,6 @@ describe("refundsOnCharge", () => {
       charges: [charge({ id: "ch_test_200" })],
       refunds: [{ id: "re_row_shaped", charge_id: "ch_test_200" } as never],
     });
-    expect(refundsOnCharge(state, "ch_test_200")).toEqual({ found: [] });
+    expect(refundsOnCharge(state, "ch_test_200")).toEqual({ found: [], path: "/refunds" });
   });
 });

--- a/packages/twin-stripe/test/checks-contract.test.ts
+++ b/packages/twin-stripe/test/checks-contract.test.ts
@@ -13,6 +13,7 @@ import {
   checkPattern,
   parseCheck,
   probeDiscrimination,
+  probeStateCitation,
   renderCheck,
   type CheckDefinition,
   type CheckSubstrateKind,
@@ -469,5 +470,71 @@ describe("migrated sentences", () => {
     expect(renderCheck(eventEmitted, { event_type: "charge.refunded" })).toBe(
       "charge.refunded is emitted",
     );
+  });
+});
+
+// Every state-reading check that cites no path, WITH the reason (F-1197).
+//
+// EMPTY, and — like `HONEST_NULL_WORLDS` above — that is the claim. F-1197
+// opened by counting what could cite anything at all: 8 of 45 declared checks,
+// because only a `tape` check could fill `evidenceEventIds`. An optional field
+// with no gate behind it is how a number like that happens, so the field ships
+// with this gate and the ledger ships empty. The argument for the pointer
+// grammar, and for why a pointer addresses `final`, is in the sdk's
+// `check-state-path.ts`; this is only its per-twin enforcement.
+//
+// An entry here admits that a verdict renders as an inert row — indistinguishable,
+// to a reader, from a verdict with no evidence at all.
+const HONEST_UNCITED_CHECKS: Record<string, string> = {};
+
+describe("declared state citations", () => {
+  it("cites a resolvable state path from every check that reads state", () => {
+    for (const check of CHECKS) {
+      // A tape check cites `evidenceEventIds` and is not this gate's business.
+      if (check.substrate === "tape") continue;
+      const verdict = probeStateCitation(check, FIXTURES[check.id]!);
+
+      if (verdict.kind === "cites") {
+        expect(
+          HONEST_UNCITED_CHECKS[check.id],
+          `${check.id} cites its state path but is still listed in HONEST_UNCITED_CHECKS — stale entry`,
+        ).toBeUndefined();
+        continue;
+      }
+
+      expect(
+        HONEST_UNCITED_CHECKS[check.id],
+        `${check.id} reads state but ${
+          verdict.kind === "declined"
+            ? "names no worlds, so its citation cannot be probed"
+            : verdict.kind === "uncited"
+              ? `its ${verdict.arm} world produced no evidenceStatePaths`
+              : verdict.kind === "unresolvable"
+                ? `its ${verdict.arm} world cites ${verdict.pointer}, which resolves to nothing in that world`
+                : `its ${verdict.arm} world cited malformed evidence — ${verdict.detail}`
+        }. A state verdict that cites nothing renders as an inert row.`,
+      ).toBeTruthy();
+    }
+  });
+
+  it("ships an EMPTY uncited ledger", () => {
+    expect(Object.keys(HONEST_UNCITED_CHECKS)).toEqual([]);
+  });
+
+  it("leaves the state-path field absent on every tape check", () => {
+    // The converse. A tape check has no state tree to point into — the engine
+    // hands it a deliberately barren `final` so it cannot read one — so a pointer
+    // from here would address a world the check never saw.
+    for (const check of CHECKS) {
+      if (check.substrate !== "tape") continue;
+      const worlds = check.discriminatingWorlds(FIXTURES[check.id]!);
+      if (worlds === null) continue;
+      for (const [side, world] of Object.entries(worlds)) {
+        expect(
+          check.evaluate(FIXTURES[check.id]!, world).evidenceStatePaths,
+          `${check.id}.${side} reads the tape but cites a state path`,
+        ).toBeUndefined();
+      }
+    }
   });
 });


### PR DESCRIPTION
Closes F-1197 (twins half).

## The measurement this fixes

B1's promise is *"every criterion verdict points at the evidence that produced it."* [F-980](https://linear.app/pome-sh/issue/F-980) built the pointer, [F-1076](https://linear.app/pome-sh/issue/F-1076) carried it into the declarations. `CheckOutcome.evidenceEventIds` answers *which recorded call produced this verdict* — and only a `substrate: "tape"` check can fill it, which its own comment said out loud:

> Only a `substrate: "tape"` check can fill it; state-reading checks leave it absent, because their evidence is a path into the state tree and **this pointer does not model that**.

Counted against `285d48d`:

| twin | final | seed+final | **tape** |
| -- | -- | -- | -- |
| github | 11 | 1 | **2** |
| stripe | 7 | 0 | **4** |
| gmail | 6 | 0 | **1** |
| linear | 6 | 1 | **1** |
| slack | 4 | 1 | **0** |
| **total** | **34** | **3** | **8** |

**8 of 45 declared checks could cite anything. The other 37 cited nothing** — not a call, not a state path, nothing a report could turn into an affordance. Every slack `[code]` criterion was in that set, because slack declares zero tape checks.

This PR models that. `CheckOutcome.evidenceStatePaths` is the state-substrate sibling: RFC 6901 JSON Pointers into the twin's own exported tree. All 37 fill it, and a gate keeps them filling it.

## What reviewers should look at

**`packages/sdk/src/check-state-path.ts`** — the whole design argument lives here. New module rather than growing `checks.ts` (already at the 500-line health limit), same split `check-discrimination.ts` made: `checks.ts` DEFINES the grammar a declaration is written in, these EXERCISE one.

Three decisions worth disagreeing with if you're going to:

1. **A pointer always addresses `final`, never `seed`** — even for a delta check. The reader has the final tree on screen, so a pointer into a seed nothing renders would relocate the dead affordance rather than remove it. The two seed-side resolutions (`github.no-new-labels`, `linear.issue-threaded-reply`) deliberately *drop* their citation rather than pass one through; both sites say so.

2. **A failed lookup cites too**, via `searched` on the missing arm. This is the thing the gate caught: `github.issue-exists` FAILS by not finding the issue, so a design where only a successful resolution can cite leaves the verdict a reader most wants to inspect pointing nowhere. The honest citation there is not the row (there is none) but the list — *this is where I looked, see for yourself that it is not in it.*

3. **RFC 6901 over a friendlier syntax.** It resolves or it does not — no partial match, no fuzzy segment — so the consumer can ask a total question and get a total answer. That is exactly what pome-cloud's `criterion-evidence.ts` needs to decide between rendering an affordance and rendering none, and a pointer language with a maybe in it cannot honour F-980's rule that a row never advertises a jump that then does nothing.

**The gate — `probeStateCitation` + an EMPTY `HONEST_UNCITED_CHECKS` per twin.** 8-of-45 is precisely what an optional field with no gate behind it looks like from the outside, so the field ships with the gate rather than after it. It reuses the worlds each check already declares (`discriminatingWorlds` is required), so it costs no new fixtures.

It probes **both** arms deliberately: a citation present on a pass and absent on a fail would be worse than none, because its absence starts reading as a verdict class. The converse arm asserts every `tape` check leaves the field absent — a tape check is handed a barren `final` precisely so it cannot read one.

## Reviewer notes

- **`Resolved<T>` changed shape in all five twins** (`{ found, path }` / `{ missing, searched? }`). That is most of the diff line count. The `missOutcome` / `missSkip` helpers exist so the "cite what you searched" rule is written once per twin rather than at ~14 call sites each.
- **`findRepo` now returns the index** beside the row, computed in the same loop that decides which repo matched. A second `findIndex` at the call site would be a second copy of the `full_name` / `owner+name` fallback, free to drift.
- **`linear.issue-estimate` and `linear.issue-assignee` use `fieldPath`**, which falls back to the row when the export omits the key. An unset estimate and an absent assignee are real, common, and exactly the verdicts a reader wants to open — a pointer at a key the row does not have would strip the affordance from those rows specifically.
- **Existing `check-state.test.ts` expectations moved** in slack/gmail/linear/stripe. Those are the resolver shape assertions, updated with a line saying what the new field means; no behaviour assertion was loosened.

## CI

`npm test` (8 workspaces, 2086 tests), `npm run typecheck`, `npm run build`, `test:contract`, `lint:code-health`, `lint:dead-code`, `lint:no-catch`, `lint:copy-markers`, `gate:no-eval`, `lint:no-cloud-imports`, `lint:legacy-markers` — all green locally.

`checksDigest` is unaffected: it hashes `{id, substrate, pattern}` only, so no pin looks skewed and no sentence moved. `test:contract` agrees.

## What ships next, in order

1. **This PR.**
2. `release:` PR — `@pome-sh/sdk` + the five twins, then a `packages-v29` GitHub Release.
3. pome-cloud's renderer half (https://github.com/pome-sh/pome-cloud/pull/514) — written to compile against today's pins, so it can land in either order.
4. pome-cloud pin bump, which collapses one tolerant read there into a plain property access.

The routing caveat on the ticket said the twins half could not ship while [F-949](https://linear.app/pome-sh/issue/F-949) is open. The B2 block it points at answers that: *"✅ The twins half is NOT blocked — Lane E is paused until after us"* (Ao, 2026-08-03), and PR #237 must not merge mid-flight. F-1197 is in B1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)