### PR TITLE
chore(cli): refresh the registry lock after packages-v30

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.11.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pome-sh/cli",
-      "version": "0.11.0",
+      "version": "0.19.0",
       "bundleDependencies": [
         "@pome-sh/sdk",
         "@pome-sh/shared-types",
@@ -25,13 +25,13 @@
         "@anthropic-ai/sdk": "^0.110.0",
         "@hono/node-server": "^2.0.10",
         "@openrouter/ai-sdk-provider": "^3.0.0",
-        "@pome-sh/sdk": "0.8.0",
-        "@pome-sh/shared-types": "0.12.2",
-        "@pome-sh/twin-github": "0.5.0",
-        "@pome-sh/twin-gmail": "0.2.0",
-        "@pome-sh/twin-linear": "0.1.0",
-        "@pome-sh/twin-slack": "0.2.2",
-        "@pome-sh/twin-stripe": "0.2.5",
+        "@pome-sh/sdk": "0.11.0",
+        "@pome-sh/shared-types": "0.14.0",
+        "@pome-sh/twin-github": "0.8.2",
+        "@pome-sh/twin-gmail": "0.3.2",
+        "@pome-sh/twin-linear": "0.3.2",
+        "@pome-sh/twin-slack": "0.3.2",
+        "@pome-sh/twin-stripe": "0.4.3",
         "ai": "^7.0.18",
         "commander": "^15.0.0",
         "hono": "^4.10.7",
@@ -1168,12 +1168,12 @@
       }
     },
     "node_modules/@pome-sh/sdk": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@pome-sh/sdk/-/sdk-0.8.0.tgz",
-      "integrity": "sha512-LmN5vLoloCu7zDgXIgBA0iUpQ4wbXShv7+XnZtNjyJQm9+/HUA1XJAIa5G7ST4NSI8x7t7wbBuu6FsAjIwln1A==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/sdk/-/sdk-0.11.0.tgz",
+      "integrity": "sha512-/qfFX7WbnjbQejNhxYuoeEkGv0WvmO3xlfWKejy+1DGIjHjVE2i/bY/qtA8Kmd0fWhHP6b28zXhymWcpEEEFIQ==",
       "inBundle": true,
       "dependencies": {
-        "@pome-sh/shared-types": "0.12.2",
+        "@pome-sh/shared-types": "0.14.0",
         "hono": "^4.12.31",
         "zod": "^4.1.13"
       },
@@ -1190,24 +1190,24 @@
       }
     },
     "node_modules/@pome-sh/shared-types": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.12.2.tgz",
-      "integrity": "sha512-NRyhI4K90jm8xSygKXGio2IW6Fe2hO1LQmZblVKscyfOHB7QKa4OXyEuEDZxiHXyue9e2Y69jLUtqCTYI0kbGg==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.14.0.tgz",
+      "integrity": "sha512-sAhC1XT3afHQCeuRXVTkYxUBwrHPOprAl98MMDXsxjBHCZJ5fKTyvYwubP1xfBs++Rpe3TFr3/xjp4ptKIAccw==",
       "inBundle": true,
       "peerDependencies": {
         "zod": "^4.1.13"
       }
     },
     "node_modules/@pome-sh/twin-github": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@pome-sh/twin-github/-/twin-github-0.5.0.tgz",
-      "integrity": "sha512-tPhJBah0czBFtSKXRQNE46ioRt8tsZzfMLtQikgpo60WmS+lZPwaVvXlOoBU8ejeNMvkY7+YpMkuDcYxqKm7ew==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@pome-sh/twin-github/-/twin-github-0.8.2.tgz",
+      "integrity": "sha512-N3xLr0x4OtgEsH/dWqaDgNxw6jvTCZYTPsl4wUmXt73ucHtUzDfgiSARoSWGf3OLIG5JX/Vmk7qlzcwhhlFvRw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.10",
-        "@pome-sh/sdk": "0.8.0",
-        "@pome-sh/shared-types": "0.12.2",
+        "@pome-sh/sdk": "0.11.0",
+        "@pome-sh/shared-types": "0.14.0",
         "hono": "^4.12.31",
         "zod": "^4.1.13"
       },
@@ -1219,14 +1219,14 @@
       }
     },
     "node_modules/@pome-sh/twin-gmail": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@pome-sh/twin-gmail/-/twin-gmail-0.2.0.tgz",
-      "integrity": "sha512-dvc66gg3LmiNrfsQq7asRF0nYz/rLvuHtySJ4NL3rhGL1hpPLJccPuSD5dkzg4ygsfiOFwql3I1Wcjdp8eCuJA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@pome-sh/twin-gmail/-/twin-gmail-0.3.2.tgz",
+      "integrity": "sha512-fVMhXs9M/Ky0JhH8IZ7BN03YW1zj5S75TzPW/ABPZx2YjVgpwD63/mO65Jjg5vaB4cObvptwNvSmB85bcWGDDw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.10",
-        "@pome-sh/sdk": "0.5.1",
+        "@pome-sh/sdk": "0.11.0",
         "hono": "^4.12.31",
         "zod": "^4.1.13"
       },
@@ -1237,48 +1237,17 @@
         "node": ">=24"
       }
     },
-    "node_modules/@pome-sh/twin-gmail/node_modules/@pome-sh/sdk": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@pome-sh/sdk/-/sdk-0.5.1.tgz",
-      "integrity": "sha512-v0nmdFsdla+IMsTn5qm2N5YC8S0fzacOrvT+pKgWSCcdwgV0hJkoaZMuYd8SmJ+ki+mIlOoGox/y7knc4Dxpbw==",
-      "inBundle": true,
-      "dependencies": {
-        "@pome-sh/shared-types": "0.12.0",
-        "hono": "^4.12.27",
-        "zod": "^4.1.13"
-      },
-      "engines": {
-        "node": ">=24"
-      },
-      "peerDependencies": {
-        "@hono/node-server": "^2.0.8"
-      },
-      "peerDependenciesMeta": {
-        "@hono/node-server": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@pome-sh/twin-gmail/node_modules/@pome-sh/shared-types": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.12.0.tgz",
-      "integrity": "sha512-6YTujcaSInyNB4ZQnLs/5k9J9/AS4pEl5njxEOV+U8QYiq+LF1LswTC7fGIe9XOuaM3+e6pWcMhuvihBhqDjtA==",
-      "inBundle": true,
-      "peerDependencies": {
-        "zod": "^4.1.13"
-      }
-    },
     "node_modules/@pome-sh/twin-linear": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@pome-sh/twin-linear/-/twin-linear-0.1.0.tgz",
-      "integrity": "sha512-6VFc+a/1AhR1J4OgEw4K/9MzZxXSwdOH5UtcPK1YKNetC0jpm7j0JcezVI7V2lQ1wS5/IcZlQJYsPSSY0Xdmbg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@pome-sh/twin-linear/-/twin-linear-0.3.2.tgz",
+      "integrity": "sha512-7kE/KNjQ70cIyzOunwxIr8YAFzBcbK3ozZvjv3FtlKvR74LMrFAvsjXxqyjQlonz5hrPPpcGJkSSuDj6L4rA2w==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.10",
-        "@pome-sh/sdk": "0.5.1",
+        "@pome-sh/sdk": "0.11.0",
         "graphql": "^16.11.0",
-        "hono": "^4.12.27",
+        "hono": "^4.12.31",
         "zod": "^4.1.13"
       },
       "bin": {
@@ -1288,48 +1257,17 @@
         "node": ">=24"
       }
     },
-    "node_modules/@pome-sh/twin-linear/node_modules/@pome-sh/sdk": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@pome-sh/sdk/-/sdk-0.5.1.tgz",
-      "integrity": "sha512-v0nmdFsdla+IMsTn5qm2N5YC8S0fzacOrvT+pKgWSCcdwgV0hJkoaZMuYd8SmJ+ki+mIlOoGox/y7knc4Dxpbw==",
-      "inBundle": true,
-      "dependencies": {
-        "@pome-sh/shared-types": "0.12.0",
-        "hono": "^4.12.27",
-        "zod": "^4.1.13"
-      },
-      "engines": {
-        "node": ">=24"
-      },
-      "peerDependencies": {
-        "@hono/node-server": "^2.0.8"
-      },
-      "peerDependenciesMeta": {
-        "@hono/node-server": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@pome-sh/twin-linear/node_modules/@pome-sh/shared-types": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.12.0.tgz",
-      "integrity": "sha512-6YTujcaSInyNB4ZQnLs/5k9J9/AS4pEl5njxEOV+U8QYiq+LF1LswTC7fGIe9XOuaM3+e6pWcMhuvihBhqDjtA==",
-      "inBundle": true,
-      "peerDependencies": {
-        "zod": "^4.1.13"
-      }
-    },
     "node_modules/@pome-sh/twin-slack": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@pome-sh/twin-slack/-/twin-slack-0.2.2.tgz",
-      "integrity": "sha512-1O6KhK5OUqcbAkFV2HA7KK6uMqkASUDZgc6FoU6RG17kkHLLZkvnrk5mJ/m15AefFaMaEmRMpG15iRX8v2nmdQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@pome-sh/twin-slack/-/twin-slack-0.3.2.tgz",
+      "integrity": "sha512-WpzRwamj0X8UhYytoOK6A+c1BhHpFfoTh5Ttu+uwdsrH+FmQtHWlDYnWxdc9x3cRrsvqT6ORzBdneg/q2F3Ttg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.10",
-        "@pome-sh/sdk": "0.5.1",
-        "@pome-sh/shared-types": "0.12.0",
-        "hono": "^4.12.27",
+        "@pome-sh/sdk": "0.11.0",
+        "@pome-sh/shared-types": "0.14.0",
+        "hono": "^4.12.31",
         "zod": "^4.1.13"
       },
       "bin": {
@@ -1339,48 +1277,17 @@
         "node": ">=24"
       }
     },
-    "node_modules/@pome-sh/twin-slack/node_modules/@pome-sh/sdk": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@pome-sh/sdk/-/sdk-0.5.1.tgz",
-      "integrity": "sha512-v0nmdFsdla+IMsTn5qm2N5YC8S0fzacOrvT+pKgWSCcdwgV0hJkoaZMuYd8SmJ+ki+mIlOoGox/y7knc4Dxpbw==",
-      "inBundle": true,
-      "dependencies": {
-        "@pome-sh/shared-types": "0.12.0",
-        "hono": "^4.12.27",
-        "zod": "^4.1.13"
-      },
-      "engines": {
-        "node": ">=24"
-      },
-      "peerDependencies": {
-        "@hono/node-server": "^2.0.8"
-      },
-      "peerDependenciesMeta": {
-        "@hono/node-server": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@pome-sh/twin-slack/node_modules/@pome-sh/shared-types": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.12.0.tgz",
-      "integrity": "sha512-6YTujcaSInyNB4ZQnLs/5k9J9/AS4pEl5njxEOV+U8QYiq+LF1LswTC7fGIe9XOuaM3+e6pWcMhuvihBhqDjtA==",
-      "inBundle": true,
-      "peerDependencies": {
-        "zod": "^4.1.13"
-      }
-    },
     "node_modules/@pome-sh/twin-stripe": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@pome-sh/twin-stripe/-/twin-stripe-0.2.5.tgz",
-      "integrity": "sha512-f47GD0Ido5mogrZB2URuBuP1CNv5cr46YsNW9jWl1ThZUoJpUDAzVc0XKl8bAj65yNgr04xrJyWpP7/8HhXpDw==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@pome-sh/twin-stripe/-/twin-stripe-0.4.3.tgz",
+      "integrity": "sha512-9FqpausgH4ZH1/dwCXHUpoTd7g8EQkLP6A0QEdi5mdqE/GRFoeY9FEEcRflIiLHiTxsz/8lnF5vzc/AaKJK9Qw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.10",
-        "@pome-sh/sdk": "0.5.1",
-        "@pome-sh/shared-types": "0.12.0",
-        "hono": "^4.12.27",
+        "@pome-sh/sdk": "0.11.0",
+        "@pome-sh/shared-types": "0.14.0",
+        "hono": "^4.12.31",
         "zod": "^4.1.13"
       },
       "bin": {
@@ -1388,37 +1295,6 @@
       },
       "engines": {
         "node": ">=24"
-      }
-    },
-    "node_modules/@pome-sh/twin-stripe/node_modules/@pome-sh/sdk": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@pome-sh/sdk/-/sdk-0.5.1.tgz",
-      "integrity": "sha512-v0nmdFsdla+IMsTn5qm2N5YC8S0fzacOrvT+pKgWSCcdwgV0hJkoaZMuYd8SmJ+ki+mIlOoGox/y7knc4Dxpbw==",
-      "inBundle": true,
-      "dependencies": {
-        "@pome-sh/shared-types": "0.12.0",
-        "hono": "^4.12.27",
-        "zod": "^4.1.13"
-      },
-      "engines": {
-        "node": ">=24"
-      },
-      "peerDependencies": {
-        "@hono/node-server": "^2.0.8"
-      },
-      "peerDependenciesMeta": {
-        "@hono/node-server": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@pome-sh/twin-stripe/node_modules/@pome-sh/shared-types": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@pome-sh/shared-types/-/shared-types-0.12.0.tgz",
-      "integrity": "sha512-6YTujcaSInyNB4ZQnLs/5k9J9/AS4pEl5njxEOV+U8QYiq+LF1LswTC7fGIe9XOuaM3+e6pWcMhuvihBhqDjtA==",
-      "inBundle": true,
-      "peerDependencies": {
-        "zod": "^4.1.13"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {


### PR DESCRIPTION
Executive summary: `PACKAGE_RELEASE.md` step 4 — regenerate `cli/package-lock.json` against npm now that packages-v30 is published. The drift it clears is older than this batch: the committed lock still resolved `@pome-sh/sdk@0.8.0` and `@pome-sh/shared-types@0.12.2`, several batches back. Lock-only diff, no manifest change.

## What

`cd cli && npm install --package-lock-only` against the registry. The lock now resolves the versions `cli/package.json` actually pins: shared-types 0.14.0, sdk 0.11.0, and the five twins.

## Why

A clean `npm ci` in `cli/` was resolving packages several batches old. `cli-ci` never noticed, because it rewrites the `@pome-sh/*` pins onto locally-packed tarballs before installing (F-1132) — so the committed lock sits on no green path at all. That is the same blind spot that made `cli-release` the only job able to see F-1200's version problem, one commit after it merged.

## Notes for reviewer

**Verified against the registry, not a tarball.** `rm -rf node_modules && npm ci` from this lock, then the CLI's own typecheck, build and full suite: 90 files, 824 tests green, resolving the published 0.14.0. That is the first time in this release chain the CLI has been proven against what npm actually serves rather than against a local pack.

Worth considering separately: nothing currently fails when this lock goes stale. A check that `npm ci` in `cli/` resolves the pinned versions would have caught the older drift, and would have caught F-1200's problem before it reached `main`.

## Tests / CI

- `npm ci` in `cli/` from this lock — clean
- CLI `npm run typecheck`, `npm run build`, `npm test` — 90 files, 824 tests green