### PR TITLE
pome-run-task should pass agent_model on finalize_run

### DIFF
--- a/skills/pome-run-task/README.md
+++ b/skills/pome-run-task/README.md
@@ -69,9 +69,11 @@ https://mcp.pome.sh/mcp`) so the `run_task` / `finalize_run` / `get_report` /
    (`references/launch-managed-agent.md`); anything else → REST
    (`references/launch-rest.md`). The launcher assembles from `examinee_launch`,
    starts the examinee, and watches for idle.
-3. **Finalize immediately** — `finalize_run(session_id, agent_token)` the instant
-   the examinee idles, while the twin tape is still live. A late finalize loses
-   the tape.
+3. **Finalize immediately** — `finalize_run(session_id, agent_token,
+   agent_model=<examinee model>)` the instant the examinee idles, while the
+   twin tape is still live. Pass the model the examinee actually ran on
+   (intake Model line / launcher config); required for the report. A late
+   finalize loses the tape.
 4. **Report** — `get_report(run_id)`: score, criteria (kind/status), provenance
    `hosted`, the `app.pome.sh` link.
 5. **Fix loop** — on a failure, hand the report's `## Handoff (fix prompt)` to the

--- a/skills/pome-run-task/SKILL.md
+++ b/skills/pome-run-task/SKILL.md
@@ -78,9 +78,13 @@ final state + events off the **still-live** twins; once the session leaves
 `ready`/`running` the sandbox is torn down and the tape is gone — it errors, and
 the run is unrecoverable. So the moment the launcher reports the examinee idle
 (done / awaiting-input with no more tool calls coming), call
-`finalize_run(session_id, agent_token)` **immediately** — before any cleanup,
-before narrating anything. It scores synchronously against the pulled tape and
-returns `{ run_id, score, judge_model, dashboard_url }`. One evaluation per run.
+`finalize_run(session_id, agent_token, agent_model=<examinee model>)`
+**immediately** — before any cleanup, before narrating anything. Pass
+`agent_model` from the intake Model line (or whatever model the launcher
+configured); it is required for the report — omit only if truly unknown
+(the report Model column stays blank). It scores synchronously against the
+pulled tape and returns `{ run_id, score, judge_model, dashboard_url }`.
+One evaluation per run.
 
 ## 4. Narrate the report
 

--- a/skills/pome-run-task/references/launch-managed-agent.md
+++ b/skills/pome-run-task/references/launch-managed-agent.md
@@ -65,7 +65,9 @@ Poll the session (`ant beta:sessions retrieve --session-id <sid>`). Idle =
 the examinee has finished the kickoff task and is emitting no further tool calls
 (terminal/completed, or awaiting input with nothing more coming). The moment it
 idles, **stop polling and go to SKILL.md §3** — `finalize_run(session_id,
-agent_token)` on the **Pome** `session_id` (not the `ant` session id), while the
-twin sandbox is still up. Do not tear the `ant` session down first: if the twin
-session expires or is finalized-too-late, the tape is gone. `finalize_run` pulls
-the tape and scores; only then is the managed-agent session safe to discard.
+agent_token, agent_model=<examinee model>)` on the **Pome** `session_id` (not
+the `ant` session id), while the twin sandbox is still up. Pass the model the
+examinee actually ran on (required for the report). Do not tear the `ant`
+session down first: if the twin session expires or is finalized-too-late, the
+tape is gone. `finalize_run` pulls the tape and scores; only then is the
+managed-agent session safe to discard.

--- a/skills/pome-run-task/references/launch-rest.md
+++ b/skills/pome-run-task/references/launch-rest.md
@@ -63,5 +63,7 @@ tool-confirmation handshake, so the F-787 deadlock does not apply.
    (it exits, or blocks with no further requests). Detection is process-level:
    watch the process, or the twin request stream going quiet.
 4. The instant it idles, go to **SKILL.md §3**: `finalize_run(session_id,
-   agent_token)` on the Pome `session_id`, while the twin sandbox is still up.
-   Do not shut the twins down first — a late finalize loses the tape.
+   agent_token, agent_model=<examinee model>)` on the Pome `session_id`,
+   while the twin sandbox is still up. Pass the model the examinee actually
+   ran on (required for the report). Do not shut the twins down first — a
+   late finalize loses the tape.


### PR DESCRIPTION
## What
`pome-run-task` skill, README, and launch refs now tell coaches to pass `agent_model` (the examinee model from intake / launcher config) on `finalize_run`.

## Why
Coaches were finalizing without naming the examinee model, so the report Model column stayed blank when telemetry did not fill it. Companion MCP/docs guidance lands in `pome-cloud`.

## Notes for reviewer
No hardcoded model slug — value is whatever the examinee actually ran on.