### PR TITLE
The coach declares which version it is running (F-899)

### DIFF
--- a/examples/support-triage/README.md
+++ b/examples/support-triage/README.md
@@ -42,22 +42,23 @@ open issue #1 for the coupon bug, then `#support` receives a *new* report of the
 
 ## Run it against Pome
 
-The two versions are exercised as **two distinct agents** end-to-end, so the
-dashboard shows two separate identities with separate scores.
+The two versions are **one agent at two declared versions**, so the dashboard
+can show the v1→v2 delta rather than two unrelated identities with no
+relationship between them.
 
 1. **Register on Cloud Managed Agents** — create each agent from its YAML on
    Anthropic's Managed Agents platform (`ant beta:agents create`, model
    `claude-sonnet-5`).
-2. **Register on Pome** (control MCP) — one call per version, so each accrues its
-   own history:
+2. **Register on Pome** (control MCP) — once. The version is not part of the
+   identity; it is declared per run in step 3:
    ```
-   register_agent(name="support-triage-v1", twins=["github","slack"])
-   register_agent(name="support-triage-v2", twins=["github","slack"])
+   register_agent(name="support-triage", twins=["github","slack"])
    ```
-3. **Run** — for each agent id, `run_trials(task_id, agent_id, n=5)`. Each
-   trial returns an `examinee_launch` spec (per-session twin MCP URLs, a bearer,
-   `always_allow`, a `network.mode: limited` clamp, web tools off). Assemble the
-   examinee clone from that spec (mirrors
+3. **Run** — `run_trials(task_id, agent_id, agent_version="v1", n=5)`, then the
+   same call with `agent_version="v2"`. Each trial returns an `examinee_launch`
+   spec (per-session twin MCP URLs, a bearer, `always_allow`, a
+   `network.mode: limited` clamp, web tools off). Assemble the examinee clone
+   from that spec (mirrors
    `pome-run-task/references/launch-managed-agent.md`), give it
    `examinee_task.prompt`, and let it work.
 4. **Finalize** — `finalize_run(session_id, agent_token)` the instant the
@@ -65,8 +66,13 @@ dashboard shows two separate identities with separate scores.
    `get_report` for the score. Tear the clone down afterward — clones are
    ephemeral, one per trial.
 
-The self-fix loop is the swap between step 3's two agents: run v1 → watch it fail
-by filing a duplicate → switch to v2 (the one-line fix) → watch it pass.
+The self-fix loop is the swap between step 3's two versions: run v1 → watch it
+fail by filing a duplicate → re-run as v2 (the one-line fix) → watch it pass.
+Declare the version on **both** runs. Run-sets are partitioned by
+`(agent, task, agent_version)`, so two runs under one label are read as one
+agent tried twice — and the v1→v2 improvement gets reported as that agent
+being unreliable. Pass the v1 run's `group_id` as the v2 run's
+`baseline_group_id` and the report pairs them into a fail→green comparison.
 
 ## Local examinee
 

--- a/examples/support-triage/VERIFICATION.md
+++ b/examples/support-triage/VERIFICATION.md
@@ -68,13 +68,20 @@ pristine; a stronger model may or may not remove the last flake.
 
 ## Reproduce
 
-1. Register two agents on Pome: `register_agent(name="support-triage-v1",
-   twins=["github","slack"])` and the same for `-v2`.
-2. For each, `run_trials(task_id, agent_id, n=5)`; assemble each trial's
-   clone from `examinee_launch` (env clamp, vault `static_bearer` per twin URL,
-   `always_allow` on every `mcp_toolset`, web tools off), model
-   `claude-sonnet-5`, `system` = that version's prompt; kick off with
-   `examinee_task.prompt`.
+> The runs recorded above were made with the two prompts registered as two
+> separate Pome agents. That is no longer the shape to copy: it produces two
+> unrelated identities with no delta between them. The steps below are the
+> current one — one agent, a declared version per run — which is what pairs the
+> two run-sets into a fail→green comparison.
+
+1. Register one agent on Pome: `register_agent(name="support-triage",
+   twins=["github","slack"])`.
+2. `run_trials(task_id, agent_id, agent_version="v1", n=5)`, then the same with
+   `agent_version="v2"` and the v1 run's `group_id` as `baseline_group_id`.
+   For each trial, assemble the clone from `examinee_launch` (env clamp, vault
+   `static_bearer` per twin URL, `always_allow` on every `mcp_toolset`, web
+   tools off), model `claude-sonnet-5`, `system` = that version's prompt; kick
+   off with `examinee_task.prompt`.
 3. Poll the managed-agent session to idle, then `finalize_run(session_id,
    agent_token)` immediately (tape is pulled from the still-live twin session).
 4. The two versions differ by one line — `agents/support-triage-v1.yaml` vs

--- a/examples/support-triage/local/README.md
+++ b/examples/support-triage/local/README.md
@@ -42,9 +42,12 @@ This folder is built to be spawned as a **local subprocess** by the coach
    cd support-triage-local && npm install
    ```
 
-2. **Mint the run** — `run_task(task_id, agent_id)` seeds live twin sandboxes
-   and returns `examinee_task` (the kickoff prompt) and `examinee_launch`
-   (per-twin MCP URLs + the session bearer).
+2. **Mint the run** — `run_task(task_id, agent_id, agent_version="v1")` seeds
+   live twin sandboxes and returns `examinee_task` (the kickoff prompt) and
+   `examinee_launch` (per-twin MCP URLs + the session bearer). Declare the
+   version: after you swap in the fix below, the re-run declares `"v2"`, and
+   that is what keeps the failing run and the fixed one from being read as one
+   agent tried twice.
 
 3. **Spawn with the env contract** — map the spec onto the env and start the
    process:

--- a/skills/pome-run-task/README.md
+++ b/skills/pome-run-task/README.md
@@ -59,11 +59,14 @@ https://mcp.pome.sh/mcp`) so the `run_task` / `finalize_run` / `get_report` /
 
 ## The run loop
 
-1. **Mint** — `run_task(task_id, agent_id, group_id)` → `session_id`,
-   `agent_token` (SENSITIVE, memory-only), `examinee_task`, `examinee_launch`.
-   Mint the `group_id` upfront so an attempt's trials aggregate as one exam (a
-   post-fix rerun opens a new group and links back — see step 5); for a `runs: N`
-   task use `run_trials(n, task_id, group_id)`, the batch form. Heal a
+1. **Mint** — `run_task(task_id, agent_id, agent_version, group_id)` →
+   `session_id`, `agent_token` (SENSITIVE, memory-only), `examinee_task`,
+   `examinee_launch`. Pass `agent_version` from the manifest's `agent.version`
+   on every run — run-sets are partitioned by it, so an unversioned run cannot
+   be told apart from a later one. Mint the `group_id` upfront so an attempt's
+   trials aggregate as one exam (a post-fix rerun opens a new group, bumps the
+   version, and links back — see step 5); for a `runs: N` task use
+   `run_trials(n, task_id, agent_version, group_id)`, the batch form. Heal a
    `twins not enabled` 400 with one additive `register_agent` (F-784).
 2. **Launch** — dispatch on the Runtime line: managed agent → `ant`
    (`references/launch-managed-agent.md`); anything else → REST
@@ -76,9 +79,11 @@ https://mcp.pome.sh/mcp`) so the `run_task` / `finalize_run` / `get_report` /
    `hosted`, the `app.pome.sh` link.
 5. **Fix loop** — on a failure, hand the report's `## Handoff (fix prompt)` to the
    builder; they edit the **examinee** prompt; re-run only the failed tasks
-   (same `agent_id`) as a fresh run-set — a **new** `group_id` carrying the
-   failing run's group_id as `baseline_group_id` (the report's `## Rerun after
-   fixing` section pre-fills both); diff the two reports and show the delta.
+   (same `agent_id`, a **new** `agent_version` — the edited prompt is a
+   different thing under test) as a fresh run-set — a **new** `group_id`
+   carrying the failing run's group_id as `baseline_group_id` (the report's
+   `## Rerun after fixing` section pre-fills all three); diff the two reports
+   and show the delta.
    Anti-cheat guardrail: never weaken a criterion/`passThreshold` or edit the
    seed to force a green — a criterion fix goes back through author/verify.
 

--- a/skills/pome-run-task/SKILL.md
+++ b/skills/pome-run-task/SKILL.md
@@ -33,17 +33,25 @@ attempt — the baseline and any *pre-fix* flaky retries — so they aggregate a
 one exam (aggregation keys on `(group_id, task)`; never reuse a `group_id`
 across different tasks). A **post-fix** rerun is the exception: it opens a *new*
 `group_id` and links back to the baseline via `baseline_group_id` (see §5).
-Then call `run_task(task_id, agent_id, group_id)` (the
+Then call `run_task(task_id, agent_id, agent_version, group_id)` (the
 `agent_id` from intake). It seeds live twin sandboxes and returns `session_id`,
 `expires_at`, `agent_token`, `examinee_task` (the prompt + twins the examinee
 sees — no criteria), and `examinee_launch` (the full launch spec).
 
+**`agent_version` on every run.** Read it from the manifest's `agent.version`
+(`pome.json`); if the builder declares none, ask for one before the first run
+rather than sending nothing. It is the label the run declares itself to be, and
+it is what keeps one version's trials from being averaged with another's — the
+dashboard partitions run-sets by `(agent, task, agent_version)`. Never
+auto-bump it: it changes when the builder changes the examinee (§5), and a
+version that moves on its own would split one exam into two run-sets of one.
+
 - **Trials-of-N (the batch form)** — when the task's `## Config` sets `runs: N`
   (a flakiness budget), don't hand-loop `run_task`: call
-  `run_trials(n, task_id, group_id)`, the batch form that provisions all N
-  trials up front under one shared `group_id` and returns a `trials[]` array,
-  each with its own `session_id` + `agent_token`. You still launch and
-  `finalize_run` **each** trial (all N sandboxes share the concurrency quota —
+  `run_trials(n, task_id, agent_version, group_id)`, the batch form that
+  provisions all N trials up front under one shared `group_id` and returns a
+  `trials[]` array, each with its own `session_id` + `agent_token`. You still
+  launch and `finalize_run` **each** trial (all N sandboxes share the quota —
   launch + finalize promptly to free slots). Pass-rate is judged here, not by
   the platform: once the trials finalize, `list_runs(group_id)` gives the
   cross-trial view — compute the fraction passed and compare it to the task's
@@ -121,6 +129,15 @@ re-verified as a fair exam before it counts. Then:
    into one aggregate and destroys the split. (A *pre-fix* flaky retry — same
    examinee, no edit — still shares the group_id; only a post-fix rerun opens a
    new one and links back with `baseline_group_id`.)
+
+   **Bump `agent_version` too, and say so to the builder.** The edited prompt is
+   a different agent, so the rerun declares a different version — have the
+   builder set it in `pome.json` (`agent.version`), or agree one with them and
+   pass it. A fresh `group_id` alone is not enough: the reliability page also
+   partitions the *implicit* run-set by declared version, and the verdict strip
+   asserts "same agent, same prompt" over a run-set. Rerun the fix as `v1` and
+   the platform is being told the failure and the fix are the same agent — the
+   spread it then reports is the fix working, mislabelled as unreliability.
 2. There is no delta field in the report — compute it: pull `get_report` for the
    baseline run and the rerun, diff the Status column per criterion, and report
    the flips (`"leaked to #general: failed → passed"`). Baseline and rerun are


### PR DESCRIPTION
Executive summary: The fix loop tells the coach to open a fresh `group_id` for a post-fix rerun, but never to change the agent's declared version — so the failing run and the fixed run reach the platform under the same identity. Run-sets are partitioned by declared version, which means a rerun as the same version is the platform being told the failure and the fix are one agent, and the gap between them gets reported as that agent's reliability spread. This teaches the coach to pass `agent_version` on every run and to bump it on a post-fix rerun. Docs-only — one SKILL.md.

## What

`skills/pome-run-task/SKILL.md`:

- §1 — `run_task` / `run_trials` take `agent_version`, read from the manifest's `agent.version` (`pome.json`). If the builder declares none, ask for one rather than sending nothing. Never auto-bump: a version that moves on its own splits one exam into run-sets of one.
- §5.1 — the post-fix rerun bumps it, alongside the fresh `group_id` + `baseline_group_id` that were already there, with the reason spelled out so the coach can explain it to the builder.

## Why

A fresh `group_id` alone is not enough. The task reliability page also folds an *implicit* run-set — trials with no group — and that fold partitions by declared version, and the verdict strip asserts "same agent, same prompt" over whatever it folded. Rerun a fix under the unchanged version and the honest reading of those trials is a comparison, but what gets printed is a spread.

The tools have accepted `agent_version` since it was added to the session contract; nothing in the coach path was passing it.

## Notes for reviewer

The platform-side half (persisting the version at mint, partitioning the fold, and the display that makes it visible) is a separate change in the cloud repo. **Land this one first**: with the old skill against the new platform, coaches keep producing unversioned runs and nothing improves.

## Tests / CI

Prose-only change to one skill file — no code paths touched, so no local test command applies. Relying on repo CI.