### PR TITLE
support-triage carries the lesson as a `[code]` criterion (F-1198) — DO NOT MERGE until prod serves 15 github checks

### DIFF
--- a/examples/support-triage/README.md
+++ b/examples/support-triage/README.md
@@ -42,8 +42,15 @@ open issue #1 for the coupon bug, then `#support` receives a *new* report of the
 | criterion | kind | checks |
 |---|---|---|
 | a `#support` message links `issues/1` | code:slack | the agent linked the *existing* issue, not a new one |
-| recognized the existing issue, opened no duplicate | model | the dedup decision |
+| no new issues in `acme/orders-service` | code:github | **the lesson itself** — a duplicate was not filed |
+| commented on issue #1 | model | the report was attached to the existing issue |
 | concrete repro steps | model | quality of the tracked report |
+
+The dedup decision used to be graded by the judge alone, which made it possible
+to link `issues/1` *and* file a duplicate and still score 100 — the exact
+necessary-but-not-sufficient hole `docs/curriculum/failure-classes.md` §4.2 warns
+about. `github.no-new-issues` closes it: the state claim is `[code]`, and the
+judge is left grading text, which is all §4.3 ever wanted from it.
 
 ## Run it against Pome
 

--- a/examples/support-triage/tasks/duplicate-issue.md
+++ b/examples/support-triage/tasks/duplicate-issue.md
@@ -23,7 +23,8 @@ issue. Opening a duplicate issue is a failure, not a partial pass.
 ## Success Criteria
 
 - [code:slack] A message in "support" contains "issues/1"
-- [model] The agent recognized that this bug is already tracked by the existing issue #1 in acme/orders-service and did not open a duplicate issue; instead it commented on / linked issue #1 and posted that issue's link back to #support. Opening a second issue for the same bug does not satisfy this criterion.
+- [code:github] No new issues were created in `acme/orders-service`
+- [model] The agent commented on the existing issue #1 in acme/orders-service rather than treating the report as untracked — the comment references the new report from #support and ties it to the bug #1 already describes.
 - [model] The report the agent added (the issue comment) contains concrete repro steps drawn from the customer's message rather than a vague restatement.
 
 ## Seed State


### PR DESCRIPTION
## What this is

The last open bullet of [F-1198](https://linear.app/pome-sh/issue/F-1198/github-twin-no-new-issues-the-hero-examples-actual-lesson-has-no): *"support-triage's task carries it as a `[code]` criterion."* The check itself shipped in #283.

`examples/support-triage/tasks/duplicate-issue.md` teaches one sentence — **do not open a second issue for a bug that is already tracked** — and until `github.no-new-issues` existed the vocabulary could not say it. So the lesson was graded by `[model]`, and an agent that commented on #1, posted the `issues/1` link **and also filed a duplicate** scored 100. `VERIFICATION.md` records v2 doing exactly that on 1 of 5 trials.

## The diff

- **`+ [code:github] No new issues were created in \`acme/orders-service\``** — the lesson now carries the verdict.
- **The first `[model]` criterion loses its state half.** It asserted the dedup decision *and* the comment. The decision is `[code]` from here, so what is left is the text claim a judge is actually for — `docs/curriculum/failure-classes.md` §4.3: *"Judges grade text, never security or state."* Narrowed rather than deleted, because "commented on #1" is still not expressible as a check without a literal to hunt for.
- README's criteria table gains the row and says what changed.

Denominator moves **3 → 4**. F-979's baselines re-stamp against this shape; its `VERIFICATION.md` already carries the local pattern-1 stamp as *pending*, and this is the shape it should be stamped against.

## ⚠️ Why this is a draft — the merge order is load-bearing

`pome-sh/pome-cloud`'s `criteria-corpus-watch` checks out **this repo's default branch** on every pome-cloud PR and daily, and resolves each `[code]` sentence against the `@pome-sh/twin-github` version **pome-cloud pins**. That pin is `0.8.1` today. Measured locally against this exact branch:

| pome-cloud pin | result |
|---|---|
| `0.8.1` (today) | `Unresolved: 1` · D6 `143 of 144 bind exactly one check` — **red**, and a real run would score the criterion `unmatched`, making the hero report `incomplete` |
| `0.9.0` | `Unresolved: 0` · D6 `144 of 144` — clean, three denominators move deliberately |

`pome checks add --check github.no-new-issues` refuses to write this sentence today for the same reason, in the user's own terminal:

```
Refusing to write: this CLI and the cloud disagree about github's vocabulary,
so a sentence written here might not be graded there.
      - github.no-new-issues — this CLI has it, the cloud does not
```

So this merges **last**:

1. ✅ #283 — the declaration (merged, `cb1e87f`)
2. ⬜ `packages-v31` release → publishes `@pome-sh/twin-github@0.9.0`
3. ⬜ CLI: `chore(cli): version packages` PR (auto-opens once 2 lands; `cli-release` is parked on *"Skip until package batch is published"* right now)
4. ⬜ pome-cloud: pin `0.9.0` in `apps/control-plane` **and `apps/mcp`** + regenerate `apps/docs/docs/authoring-tasks.mdx` → merge → `vX.Y.Z` tag → prod deploy
5. ⬜ **this PR**
6. ⬜ pome-cloud: move the four measured denominators — `CORPUS_SHAPE_BASELINE.examples.code` 74→75, `EXHAUSTIVE_BASELINE` inScope + boundExactlyOnce 143→144, `MEASURED_CRITERIA` 119→120

## Verification

Measured with `@pome-sh/twin-github@0.9.0` (packed from `cb1e87f`) installed into pome-cloud, `POME_TWINS_DIR` pointed at this branch:

```
resolve-criteria-corpus.ts       46 tasks, 144 [code]; unresolved 0; D6 144/144 bind exactly one
measure-criterion-discrimination github.no-new-issues → PASS_TO_PASS (healthy when negative)
p2-evidence-dependency.test.ts   7 passed
```