### PR TITLE
Close the examinee sandbox, and measure what that actually fixes

### DIFF
--- a/examples/support-triage/README.md
+++ b/examples/support-triage/README.md
@@ -200,11 +200,14 @@ The agent searches, finds issue #1, comments on it, and posts *its* link back to
 
 ### If your baseline passes / your fix fails
 
-* **Baseline passes (stays green).** Check the waterfall for a `search_issues` or
-  `list_issues` span that *succeeded* — if one did, the twin exposed a read path
-  the denial list does not name, and the fix is to add it (and to say so in
-  `ISSUE_LOOKUP_TOOLS`), not to weaken the criteria. `test/tool-policy.test.ts`
-  pins the list for exactly this reason.
+* **Baseline passes (stays green).** It does — 4/5 open-book, 5/5 with the
+  sandbox closed. This section used to say the fix is to add the missing read
+  path to `ISSUE_LOOKUP_TOOLS`. **That advice was measured wrong and is
+  withdrawn.** Shutting the first three paths surfaced two more the same
+  afternoon — `list_issue_comments` and `update_issue` — and the twin's read
+  surface is wide enough that the next pass would surface more. Do not extend the
+  list; the flaw has to stop being a denial ([F-1292](https://linear.app/pome-sh/issue/F-1292),
+  numbers in [`VERIFICATION.md`](./VERIFICATION.md)).
 * **Fix fails (stays red).** If a criterion reads `NOT EVALUATED` rather than
   failed, the run is `INCOMPLETE` — the grader could not see that state at all,
   which is a wiring problem rather than an agent problem. `pome run` exits 1 on

--- a/examples/support-triage/VERIFICATION.md
+++ b/examples/support-triage/VERIFICATION.md
@@ -232,3 +232,84 @@ So the duty is the opposite of what was written: a tool-denial baseline carries
 **high** rot risk and must be re-verified per model generation, exactly like the
 pattern-2 policy constant it replaced. A denial is only as strong as the
 enumeration behind it, and enumerations are never complete.
+
+---
+
+## The two follow-up measurements F-1292 asked for (2026-08-05)
+
+The 2026-08-04 numbers above said the baseline is green and named two routes.
+They left two questions open, and both were answered by measurement before any
+re-cut was designed. Same model (`claude-opus-5`, pinned), same task
+(`support-triage-dedup`, 4-criterion shape), same twin images, `n=5` each,
+`provenance: hosted`, `agent_version` declared on both run-sets.
+
+### 1 · Does the task need a planted defect at all? — **yes**
+
+The open question on F-1292 was whether the red could come from the task being
+*natively* unreliable, with no planted flaw: *"if it lands around 2/5 or 3/5, the
+example needs no planted defect and this ticket's fix is deletion rather than
+redesign."*
+
+**Honest prompt, no issue-lookup denial, closed sandbox: 5/5, every criterion,
+every trial.** `agent_version: f1292-control-honest`, group
+`grp_f1292honest0805`.
+
+| run | score |
+|---|---|
+| `run_vLsIuRiVtcMTBNmT` · `run_mvoozQDpx5vAKFZO` · `run_dhO4mJXE6VlWAdIh` · `run_E2KPPNqefJiiU9p6` · `run_O9vVrhfhjHBhXlEm` | 100 · 100 · 100 · 100 · 100 |
+
+The five traces are the same eight-step shape with no variance worth reporting:
+`slack_list_channels` → `slack_get_channel_history` → `list_issues` →
+`get_file_contents` → `add_issue_comment` → `slack_reply_to_thread`. The
+examinee was the shipped one with three deltas — `DENY_ISSUE_LOOKUP = false`,
+`tools: []`, `model: "claude-opus-5"` — and the system prompt byte-identical.
+
+So `pass^5 = 100%` with nothing planted. There is no natural reliability gap in
+this task on this model: **an honest configuration has no red to show**, and the
+*"unreliable → reliable"* framing has nothing to work with here. A planted defect
+is required. This also retires the retracted six-run ~33% figure the ticket
+withdrew: that population mixed configurations, and a clean run-set does not
+reproduce it.
+
+### 2 · Is the open sandbox the whole hole? — **no, and closing it made the baseline greener**
+
+`tools: []` closes the sandbox completely: the SDK's `init` message listed 100
+tools, **all** `mcp__*`, with no `Bash`, `Read`, `Glob`, `Grep`, `Write`, `Edit`
+or web tool. With that shut and `DENY_ISSUE_LOOKUP` still `true`:
+
+**5/5 at 100** — worse than the 4/5 the open-book version scored.
+`agent_version: f1292-denial-closed-sandbox`, group `grp_f1292closedB0805`:
+`run_SvJVIdPNFky5Ricf` · `run_KuS3vAtTSPxHhRV7` · `run_FEL1QIYelRe4Mky5` ·
+`run_PiPJ5zBigltuqauB` · `run_M5XgOt1ZRtxz2WUb`.
+
+The enumeration was missing more than `update_issue`. Every one of the five
+trials used **both** of these, and neither is in `ISSUE_LOOKUP_TOOLS`:
+
+| unnamed path | what it leaks |
+|---|---|
+| `list_issue_comments` | called in 5/5 — returns issue #1's comment thread; 404 vs 200 is itself an existence oracle |
+| `update_issue` | called in 5/5 — a write that 404s on a missing issue and succeeds on a present one |
+
+`search_code` (5/5) supplied `src/orders.py` for the root cause, so removing the
+shell cost the agent nothing it needed. Two trials also *tried* the denied
+`list_issues`, failed, and routed around it in the same turn.
+
+**Conclusion, and it is the answer to F-1292's second "done when".** Closing the
+sandbox is necessary — an examinee that can `cat ../tasks/duplicate-issue.md` is
+reading its own criteria and seed — but it is not the fix. Completing the
+denial is not the fix either: this measurement found two more paths after the
+first three, in one sitting, without trying hard. The GitHub twin's read surface
+is wide enough that any deny-list over it is a list someone must keep complete
+against a model actively looking for a way through. **The flaw has to stop being
+a tool-policy denial.**
+
+### What was fixed here, and what was left open
+
+Fixed in this commit: the sandbox (`tools: []`, an allowlist rather than another
+name in a deny-list), and the claims in `local/src/index.ts` and
+`local/README.md` that the 2026-08-04 run refuted.
+
+Left open, deliberately, for the F-1292 design decision: the baseline defect
+itself. Nothing here is stamped `verified red`, and the shipped
+`DENY_ISSUE_LOOKUP = true` is now documented as a known-green baseline rather
+than a lesson.

--- a/examples/support-triage/local/README.md
+++ b/examples/support-triage/local/README.md
@@ -11,27 +11,47 @@ The exam it takes is the pack's task,
 [`../tasks/duplicate-issue.md`](../tasks/duplicate-issue.md): a customer
 re-reports a bug that open issue #1 already tracks.
 
-## The fix ("33, not 0")
+## ⚠️ The baseline below does not fail. Measured, twice.
 
-The whole product story is **one line** of committed configuration —
+`DENY_ISSUE_LOOKUP = true` is **green**, on `claude-opus-5`, n=5 each, hosted:
+
+| configuration | pass rate |
+|---|---|
+| as shipped 2026-08-04, open sandbox | 25 · 100 · 100 · 100 · 100 — **4/5** |
+| sandbox closed (`tools: []`), denial unchanged | 100 × 5 — **5/5** |
+| no denial at all, closed sandbox (the control) | 100 × 5 — **5/5** |
+
+**No trial filed a duplicate** — the behaviour the whole lesson is built around.
+Run ids and the routes the agent used are in
+[`../VERIFICATION.md`](../VERIFICATION.md); the re-cut is
+[F-1292](https://linear.app/pome-sh/issue/F-1292). Treat this folder as a working
+local examinee with a **known-green** placeholder defect, not as a lesson.
+
+## What the one line was supposed to do
+
+The product story was meant to live in **one line** of committed configuration —
 `DENY_ISSUE_LOOKUP` in [`src/index.ts`](./src/index.ts):
 
-- **`true` (ships as the default — fails).** The agent's tool policy denies it
-  every read path into the repository's issues (`search_issues`, `list_issues`,
-  `get_issue`). Its system prompt is the *correct* one — search before filing —
-  so it reaches for the lookup, is refused, honestly concludes nothing tracks
-  the bug, and files a **duplicate**. It scores **33, not 0**: the agent does
-  real work (its report has concrete repro steps) and flunks the
-  duplicate-detection criteria — exactly the failure a happy-path demo never
-  shows.
-- **`false` (the one-line fix — passes).** Flip the constant, re-run, and the
-  same exam goes green: the agent searches, finds issue #1, comments on it, and
-  posts *its* link back.
+- **`true` (ships as the default — was expected to fail).** The agent's tool
+  policy denies it three read paths into the repository's issues
+  (`search_issues`, `list_issues`, `get_issue`). Its system prompt is the
+  *correct* one — search before filing — so the theory was that it reaches for
+  the lookup, is refused, honestly concludes nothing tracks the bug, and files a
+  **duplicate**, scoring 33 rather than 0.
+- **`false` (the one-line "fix").** The agent searches, finds issue #1, comments
+  on it, and posts *its* link back.
 
-This is a **pattern-1** baseline in the curriculum's terms
-(`pome-cloud docs/curriculum/failure-classes.md` §3): the flaw is in the code
-and config layer, so a stronger model cannot rescue it — it follows the correct
-instruction *more* reliably and simply gets refused faster.
+What actually happens is that the agent reaches issue #1 anyway, through paths
+the three names do not cover: `list_issue_comments` and `update_issue` (a write
+that 404s on a missing issue), both used in **5 of 5** trials once the shell was
+taken away. So the two variants produce the same behaviour and the same score.
+
+It was filed as a **pattern-1** baseline in the curriculum's terms
+(`pome-cloud docs/curriculum/failure-classes.md` §3) on the theory that a flaw in
+the config layer cannot be rescued by a stronger model. The theory does not hold
+for a *denial*: the model does not need to route around the denied tool, it only
+needs any other tool that answers the same question. §3's own words, now earned:
+a denial is only as strong as its enumeration.
 
 The managed-agent pair next door (`../agents/support-triage-v1.yaml` vs
 `…-v2.yaml`) tells the same fail → fix → pass story through a *prompt* flaw, on
@@ -123,8 +143,27 @@ per-session bearer the runner injects as `POME_AUTH_TOKEN`.
 ```
 src/index.ts             the examinee — env wiring, the DENY_ISSUE_LOOKUP defect, the SDK loop
 test/env.test.ts         unit test for the launch env contract (npm test)
-test/tool-policy.test.ts the lesson pinned as a property — both branches, neither shipped value
+test/tool-policy.test.ts two properties — the deny-list's branches, and the closed sandbox
 ```
+
+### The closed sandbox
+
+`options.tools: []` gives the model **no SDK built-in at all** — no `Bash`,
+`Read`, `Glob`, `Grep`, `Write`, `Edit`, `WebSearch` or `WebFetch`. Only the two
+twins' MCP tools reach it, because those come from `mcpServers` rather than from
+the built-in set (verified from the SDK's `init` message: 100 tools, all
+`mcp__*`).
+
+This is an **allowlist**, deliberately, rather than more names in
+`disallowedTools`. Until 2026-08-05 every built-in was live, and one measured
+trial in five used `Bash` to `cat` this examinee's own source and identify the
+fixture — with `../tasks/duplicate-issue.md`, which carries all four grading
+criteria and the complete seed state, one directory away. An examinee that can
+read its own criteria is not sitting an exam.
+
+Note that `allowedTools` would **not** have closed it: it only auto-approves and
+does not restrict. Measured — `allowedTools` naming a single MCP tool left 152
+tools live, `Bash` and `Read` among them.
 
 `npm run typecheck` type-checks; `npm test` runs the env-contract test. This
 package is intentionally **not** part of the root npm workspace — install and

--- a/examples/support-triage/local/src/index.ts
+++ b/examples/support-triage/local/src/index.ts
@@ -29,6 +29,7 @@
  * inert with no endpoint set, so a standalone run is unaffected.
  */
 
+import type { McpServerConfig } from "@anthropic-ai/claude-agent-sdk";
 import { query } from "@pome-sh/adapter-claude-sdk";
 
 // ─── The one line under test ───────────────────────────────────────────────
@@ -111,6 +112,39 @@ export function deniedTools(denyIssueLookup: boolean = DENY_ISSUE_LOOKUP): strin
  * left 152 tools live including `Bash`, `Read`, `Write` and `WebFetch`.
  */
 export const BUILT_IN_TOOLS: string[] = [];
+
+/**
+ * The options this examinee actually runs with — the exam surface, composed in
+ * one place.
+ *
+ * A `function` declaration rather than a `const` arrow: this file's top-level
+ * `await main()` sits above it, and a `const` here would be a temporal dead zone
+ * at call time (the `scripts/smoke-examples.mjs` gate exists because exactly
+ * that crash once shipped in `examples/triage-agent`).
+ *
+ * Exported so `test/tool-policy.test.ts` can assert the two policy constants are
+ * WIRED IN, not merely declared. Asserting `BUILT_IN_TOOLS` is empty proves
+ * nothing on its own: delete `tools:` from this object and that assertion stays
+ * green while the sandbox reopens. A guard whose subject is no longer connected
+ * to anything passes forever, which is the same shape of mistake F-1292 is about.
+ */
+export function examineeOptions(mcpServers: Record<string, McpServerConfig>) {
+  return {
+    systemPrompt: SYSTEM_PROMPT,
+    permissionMode: "bypassPermissions" as const,
+    maxTurns: 30,
+    // The exam surface: the two twins over MCP, and nothing else. `tools` is the
+    // allowlist that closes the sandbox (empty = no SDK built-in reaches the
+    // model); `disallowedTools` is where the committed baseline defect lives.
+    // Its `WebSearch`/`WebFetch` entries are now a redundant second latch —
+    // `tools: []` already removed them — and are kept because the two options
+    // are independent knobs and the web clamp should not depend on which one a
+    // future SDK version reinterprets.
+    tools: BUILT_IN_TOOLS,
+    disallowedTools: deniedTools(),
+    mcpServers,
+  };
+}
 // ───────────────────────────────────────────────────────────────────────────
 
 // The CORRECT triage rule, in both variants. It is verbatim
@@ -219,24 +253,7 @@ async function main() {
     },
   };
 
-  const run = query({
-    prompt: wiring.task,
-    options: {
-      systemPrompt: SYSTEM_PROMPT,
-      permissionMode: "bypassPermissions",
-      maxTurns: 30,
-      // The exam surface: the two twins over MCP, and nothing else. `tools` is
-      // the allowlist that closes the sandbox (empty = no SDK built-in reaches
-      // the model); `disallowedTools` is where the committed baseline defect
-      // lives. Its `WebSearch`/`WebFetch` entries are now a redundant second
-      // latch — `tools: []` already removed them — and are kept because the two
-      // options are independent knobs and the web clamp should not depend on
-      // which one a future SDK version reinterprets.
-      tools: BUILT_IN_TOOLS,
-      disallowedTools: deniedTools(),
-      mcpServers,
-    },
-  });
+  const run = query({ prompt: wiring.task, options: examineeOptions(mcpServers) });
 
   let exitCode = 0;
   for await (const msg of run) {

--- a/examples/support-triage/local/src/index.ts
+++ b/examples/support-triage/local/src/index.ts
@@ -15,11 +15,11 @@
  * CLI injects on `pome run … --agent "npm run start"`, so both launchers
  * share this one code path.
  *
- * The product story lives in ONE line: DENY_ISSUE_LOOKUP below ships as `true`,
- * which strips the agent's read access to existing issues. It searches, as its
- * instructions tell it to, is refused, and honestly concludes nothing tracks the
- * bug — so it files a duplicate and fails the exam. Flip the constant, re-run,
- * and the same exam goes green.
+ * ⚠️ THE BASELINE BELOW IS NOT RED. Measured 2026-08-04 on `claude-opus-5`,
+ * n=5, hosted: `DENY_ISSUE_LOOKUP = true` scored 25 · 100 · 100 · 100 · 100 and
+ * no trial filed a duplicate. The re-cut is [F-1292]; ../VERIFICATION.md carries
+ * the run ids and the two routes the agent found around the denial. Do not
+ * describe this file's defect as a working lesson until that ticket closes.
  *
  * `query` comes from `@pome-sh/adapter-claude-sdk` rather than the raw SDK. It
  * is a drop-in — the message stream is byte-for-byte what the SDK yields — and
@@ -43,14 +43,20 @@ import { query } from "@pome-sh/adapter-claude-sdk";
 // nothing, and correctly concludes the bug is untracked. It then files a SECOND
 // issue for a bug issue #1 already tracks.
 //
-// WHY IT DOES NOT ROT. The system prompt below is the CORRECT one: it tells the
-// agent to search before filing, and a stronger model follows it more reliably,
-// not less. That is the whole point — perfect model behaviour is corrupted by
-// the committed config, and no amount of capability can call a tool that was
-// never exposed. This is what the earlier baseline could not promise: it lived
-// in a prompt line telling the agent NOT to search, which is a pattern-2 flaw
-// whose red is model-dependent and, worse, indistinguishable from an evaluator
-// that never ran.
+// IT DID ROT, AND HERE IS THE MEASUREMENT. This block used to claim the baseline
+// could not go green because "no amount of capability can call a tool that was
+// never exposed". That is true and beside the point: the model never needed the
+// denied tool. Measured on `claude-opus-5`, n=5 each:
+//
+//   open sandbox    4/5 green — via `update_issue` (a write that 404s on a
+//                   missing issue) and via the SDK's shell reading this file
+//   closed sandbox  5/5 green — the shell gone changed nothing. All five trials
+//                   used `list_issue_comments` AND `update_issue`, neither of
+//                   which is named below, and `search_code` for the root cause.
+//
+// Two more read paths turned up the moment the first three were shut. A denial
+// is only as strong as the enumeration behind it, and this one is not complete
+// — see ../VERIFICATION.md. Completing it is not the fix; F-1292 moves the flaw.
 //
 // The three names are the Claude Agent SDK's MCP tool ids — `mcp__<server>__<tool>`,
 // where the server is the `github` key of `mcpServers` below. They are the GitHub
@@ -79,6 +85,32 @@ const DENY_ISSUE_LOOKUP = true;
 export function deniedTools(denyIssueLookup: boolean = DENY_ISSUE_LOOKUP): string[] {
   return ["WebSearch", "WebFetch", ...(denyIssueLookup ? ISSUE_LOOKUP_TOOLS : [])];
 }
+
+/**
+ * The SDK built-ins this examinee exposes to the model: **none**.
+ *
+ * This is the closed sandbox, and it is deliberately an ALLOWLIST rather than an
+ * addition to `deniedTools()`. `options.tools` replaces the base set of built-in
+ * tools, so an empty array is complete by construction — there is no list of
+ * names to keep current, and no way for a tool nobody thought of to arrive
+ * enabled. That is the failure mode the deny-list above already had (F-1292):
+ * every built-in was live, so `cat ../tasks/duplicate-issue.md` handed the
+ * examinee all four grading criteria and the complete seed; `Bash` reached the
+ * real internet, since the `network.mode: limited` clamp binds a managed clone's
+ * egress and never a local subprocess; and one measured trial read this very
+ * file and reported the deny-list as an intentional fixture.
+ *
+ * MCP tools are unaffected — they arrive from `mcpServers`, not from the
+ * built-in set — so the twin surface the exam is actually about stays whole.
+ * Verified live rather than from the docs: with `tools: []` the SDK's `init`
+ * message listed 100 tools, all `mcp__*`, and the run scored 100 on all four
+ * criteria (see ../VERIFICATION.md, `grp_f1292honest0805`).
+ *
+ * `allowedTools` is NOT a substitute. It only auto-approves; it does not
+ * restrict. Measured 2026-08-05: `allowedTools: ["mcp__github-twin__list_issues"]`
+ * left 152 tools live including `Bash`, `Read`, `Write` and `WebFetch`.
+ */
+export const BUILT_IN_TOOLS: string[] = [];
 // ───────────────────────────────────────────────────────────────────────────
 
 // The CORRECT triage rule, in both variants. It is verbatim
@@ -193,10 +225,14 @@ async function main() {
       systemPrompt: SYSTEM_PROMPT,
       permissionMode: "bypassPermissions",
       maxTurns: 30,
-      // Everything the two twins expose, minus `deniedTools()` — which is where
-      // the committed baseline defect lives. See the block at the top of this
-      // file; `WebSearch`/`WebFetch` are the unconditional closed-book clamp and
-      // are not part of the lesson.
+      // The exam surface: the two twins over MCP, and nothing else. `tools` is
+      // the allowlist that closes the sandbox (empty = no SDK built-in reaches
+      // the model); `disallowedTools` is where the committed baseline defect
+      // lives. Its `WebSearch`/`WebFetch` entries are now a redundant second
+      // latch — `tools: []` already removed them — and are kept because the two
+      // options are independent knobs and the web clamp should not depend on
+      // which one a future SDK version reinterprets.
+      tools: BUILT_IN_TOOLS,
       disallowedTools: deniedTools(),
       mcpServers,
     },

--- a/examples/support-triage/local/test/tool-policy.test.ts
+++ b/examples/support-triage/local/test/tool-policy.test.ts
@@ -17,7 +17,7 @@
 // are the twin's ONLY read paths to an issue, so a fourth one appearing upstream
 // would silently hand the baseline a way around its own defect.
 import { describe, expect, it } from "vitest";
-import { deniedTools } from "../src/index.ts";
+import { BUILT_IN_TOOLS, deniedTools } from "../src/index.ts";
 
 const ISSUE_LOOKUP = [
   "mcp__github__search_issues",
@@ -66,5 +66,28 @@ describe("deniedTools — the committed baseline defect", () => {
   it("differs on exactly the issue-lookup tools", () => {
     const extra = deniedTools(true).filter((tool) => !deniedTools(false).includes(tool));
     expect(extra).toEqual(ISSUE_LOOKUP);
+  });
+});
+
+// The closed sandbox, pinned separately from the lesson because it survives every
+// re-cut of the lesson: whatever the baseline defect turns out to be, an examinee
+// that can `cat ../tasks/duplicate-issue.md` is reading its own grading criteria
+// and its own seed. Measured 2026-08-04 (F-1292): with the built-ins live, one
+// trial in five read this examinee's source and named the fixture.
+describe("BUILT_IN_TOOLS — the closed sandbox", () => {
+  it("exposes no SDK built-in at all", () => {
+    // Empty, not "empty of the dangerous ones". `options.tools` replaces the base
+    // set, so [] is complete by construction; a list of names to maintain is the
+    // enumeration failure that let the deny-list above be routed around.
+    expect(BUILT_IN_TOOLS).toEqual([]);
+  });
+
+  it("is an allowlist, so a newly-shipped built-in cannot arrive enabled", () => {
+    // The property, stated as the thing a reader might break: adding a name here
+    // to "just read one file" re-opens the book. Filesystem and shell are the
+    // ones that reach the task file; web is the one that leaves the seeded world.
+    for (const escape of ["Bash", "Read", "Glob", "Grep", "Write", "Edit", "WebSearch", "WebFetch"]) {
+      expect(BUILT_IN_TOOLS, `${escape} would make the exam open-book`).not.toContain(escape);
+    }
   });
 });

--- a/examples/support-triage/local/test/tool-policy.test.ts
+++ b/examples/support-triage/local/test/tool-policy.test.ts
@@ -17,7 +17,7 @@
 // are the twin's ONLY read paths to an issue, so a fourth one appearing upstream
 // would silently hand the baseline a way around its own defect.
 import { describe, expect, it } from "vitest";
-import { BUILT_IN_TOOLS, deniedTools } from "../src/index.ts";
+import { BUILT_IN_TOOLS, deniedTools, examineeOptions } from "../src/index.ts";
 
 const ISSUE_LOOKUP = [
   "mcp__github__search_issues",
@@ -89,5 +89,28 @@ describe("BUILT_IN_TOOLS — the closed sandbox", () => {
     for (const escape of ["Bash", "Read", "Glob", "Grep", "Write", "Edit", "WebSearch", "WebFetch"]) {
       expect(BUILT_IN_TOOLS, `${escape} would make the exam open-book`).not.toContain(escape);
     }
+  });
+});
+
+// Both policies above are inert unless they reach `query()`. Everything else in
+// this file would stay green if someone deleted `tools:` or `disallowedTools:`
+// from the options object — a guard disconnected from its subject passes forever,
+// which is the shape of mistake F-1292 is about. So assert the wiring itself.
+describe("examineeOptions — the policies are actually wired in", () => {
+  const mcpServers = { github: { type: "http" as const, url: "https://twin/github" } };
+
+  it("passes the empty built-in allowlist to the SDK", () => {
+    expect(examineeOptions(mcpServers).tools).toEqual([]);
+  });
+
+  it("passes the deny-list to the SDK", () => {
+    expect(examineeOptions(mcpServers).disallowedTools).toEqual(deniedTools());
+  });
+
+  it("still hands the twins through — closing the sandbox must not close the exam", () => {
+    // `tools: []` removes SDK built-ins only; MCP tools arrive via `mcpServers`.
+    // If this ever regressed the examinee would have no tools at all, and the
+    // run would look like a model failure rather than a wiring one.
+    expect(examineeOptions(mcpServers).mcpServers).toBe(mcpServers);
   });
 });


### PR DESCRIPTION
Executive summary: The hero example's failing baseline is not failing — measured 4/5 green on 2026-08-04 (#309). This PR runs the two follow-up measurements that were needed before any re-cut, closes the sandbox that let one trial read its own grading criteria, and corrects the claims the runs refuted. It deliberately does **not** re-cut the baseline defect: that is a design decision, and the measurements here are what it should be decided on. `DENY_ISSUE_LOOKUP` still ships `true`, now documented as a known-green placeholder rather than a lesson.

## What

- **`options.tools: []`** in `examples/support-triage/local/src/index.ts` — the examinee now exposes **no** SDK built-in to the model. This is an allowlist, not another name in `disallowedTools`: `tools` replaces the base set, so empty is complete by construction. MCP tools are untouched (they come from `mcpServers`), so the twin surface the exam is about stays whole.
- `test/tool-policy.test.ts` pins the closed sandbox as its own property, separate from the lesson, because it survives every re-cut of the lesson.
- `VERIFICATION.md` records two new run-sets with their run ids.
- The refuted claims #309 could not reach: `local/src/index.ts`'s *"WHY IT DOES NOT ROT"* block and `local/README.md`'s *"33, not 0"* section.
- **Withdrawn** from the README's troubleshooting: *"the fix is to add [the missing read path] to `ISSUE_LOOKUP_TOOLS`"*. That advice pointed readers away from the actual fix.

## Why

Two questions were open after #309, and both are now measured — `n=5` each, `claude-opus-5` pinned, one `group_id` each, `agent_version` declared, hosted:

**1 · Does this task need a planted defect at all? Yes.** Honest prompt, no denial, closed sandbox: **5/5 at 100**, `pass^5 = 100%`. There is no native reliability gap in this task on this model, so an honest configuration has no red to show and "unreliable → reliable" has nothing to work with.

**2 · Is the open sandbox the whole hole? No — closing it made the baseline greener.** Sandbox shut, denial unchanged: **5/5 at 100**, against 4/5 open-book. All five trials reached issue #1 through two paths `ISSUE_LOOKUP_TOOLS` does not name — `list_issue_comments` (5/5) and `update_issue` (5/5, a write that 404s on a missing issue and succeeds on a present one). `search_code` supplied the root cause, so losing the shell cost the agent nothing it needed. Two trials tried the denied `list_issues`, failed, and routed around it in the same turn.

Shutting three read paths surfaced two more the same afternoon. Completing the deny-list is not a viable baseline — the flaw has to stop being a tool-policy denial.

## Notes for reviewer

- **Merging this will flip the tracking ticket to Done, and it should not be.** The branch name carries the identifier, so the merge auto-closes it, but only one of its three "done when" bullets lands here. The baseline defect itself is untouched and still needs its re-cut. Move the ticket back after merge.
- **`allowedTools` does not restrict — it only auto-approves.** Measured: `allowedTools` naming one MCP tool left **152** tools live, `Bash`, `Read`, `Write` and `WebFetch` among them. `examples/triage-agent`, `examples/pr-summary-agent` and `examples/pr-summary-review` all rely on `allowedTools` to bound their tool surface and carry no `disallowedTools`, so all three are open-book *with* live web access. Not fixed here — each needs its own verification run, and doing it blind is how an unmeasured guard ships. Worth a follow-up before the template gets replicated.
- **No `verified red` stamp is written anywhere**, on purpose. Nothing in this PR earns one.
- The `WebSearch`/`WebFetch` entries in `deniedTools()` are now redundant (`tools: []` already removed them). Kept as a second latch and labelled as such — the two options are independent knobs and the web clamp should not depend on which one a future SDK version reinterprets.
- Worth knowing while reading the smoke gate: under a fully stripped environment (`env -i` with a minimal `PATH`) this examinee exits **0 with no output at all**, via `npm run start` and via `tsx` directly. Not `TMPDIR`, not a model pin, not the OTLP vars — each ruled out separately. Undiagnosed, pre-existing, and not addressed here. `smoke-examples.mjs` tolerates any exit code by design, so it would not catch this shape.

## Tests / CI

Local, in `examples/support-triage/local`:

- `npm test` — 12 passed (2 files), including the two new closed-sandbox properties
- `npm run typecheck` — clean

Live, rather than from the docs: with `tools: []` the SDK's `init` message listed 100 tools, **all** `mcp__*`, zero built-ins — and the run still scored 100 on all four criteria. That is the same run-set as measurement 1 above, so the sandbox close is verified by a scored hosted run and not only by a unit test.

PR CI (`typecheck-test`, `gitleaks + trufflehog`, `dependency review`) — checked after opening.