### PR TITLE
Every task says which population it is in (F-1302)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,14 @@ jobs:
           # writer, so nothing else stops a new emitter reintroducing it.
           npm run lint:parent-vocab
           node scripts/lint-parent-vocab.test.mjs
+          # F-1302 — every shipped task declares which POPULATION it is in:
+          # `conformance` (does our fake GitHub answer correctly) versus the exam
+          # half, `restraint` + `adversarial` (is the agent any good). pome-cloud
+          # pins its scored denominators against the exam half, so a task landing
+          # here unclassified would silently join whichever population the reader
+          # assumed and blend two averages back into one.
+          npm run lint:task-class
+          node scripts/lint-task-class.test.mjs
           # F-818 — the committed manifest JSON Schema (served at
           # pome.sh/schemas/v1/pome.json) must match the zod source.
           npm run check:manifest-schema -w @pome-sh/cli

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,21 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.21.3
+
+### Patch Changes
+
+- **Every bundled task declares its `class`** (F-1302): `conformance`,
+  `restraint` or `adversarial`. The bundled library answers two different
+  questions under one heading — 22 of the 46 tasks check that a twin responds
+  correctly, the other 24 check whether the agent resisted something — and one
+  average over both is unreadable, because it rises when agents improve and when
+  a twin is added alike. `pome tasks <twin> --copy` now hands you the label with
+  the task, and `taskConfigSchema` accepts the field: absent is fine (your own
+  tasks owe this corpus no taxonomy), but a value outside the three is a parse
+  error rather than a silently-stripped key. Nothing about how a task RUNS
+  changes.
+
 ## 0.21.2
 
 ### Patch Changes

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "description": "Digital-twin testing for AI agents — run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/cli/src/contract/task.ts
+++ b/cli/src/contract/task.ts
@@ -22,8 +22,36 @@ import { seedStateSchema } from "./seed-state.js";
 // and re-exported to consumers via the index.ts barrel.
 // ─────────────────────────────────────────────────────────────────────────────
 
+// F-1302 — which POPULATION a task belongs to, declared in its `## Config`
+// block. Three values, and the line between the first and the other two is what
+// the field exists for:
+//
+//   conformance  correct behaviour is "call the endpoints and do the obvious
+//                thing". No planted hazard, and no restraint carries the
+//                verdict. These answer "does the twin answer correctly", not
+//                "is the agent any good" — they are the de-facto twin smoke
+//                test, and a scored average that includes them cannot be read:
+//                a rising number is either agents improving or more plumbing
+//                questions being added, and nothing tells those apart.
+//   restraint    the verdict rests on NOT doing something, with no antagonist.
+//   adversarial  a planted antagonist — injection, spoof, persuasion, backdoor,
+//                exfiltration bait, fabrication pressure, a dedup trap.
+//
+// `restraint` + `adversarial` are the EXAM population, which is what pome-cloud
+// pins its scored denominators against.
+//
+// OPTIONAL, and deliberately so. Absence is legal — a task written by a builder
+// for their own agent is not part of this corpus and owes it no taxonomy — but
+// a value OUTSIDE the three is an error rather than a silently-stripped key, so
+// a typo in the vocabulary is caught where it is written. Presence is a
+// separate, stricter rule that applies only to the tasks this repo ships, and
+// it is enforced by `scripts/lint-task-class.mjs` rather than here.
+export const taskClassSchema = z.enum(["conformance", "restraint", "adversarial"]);
+export type TaskClass = z.infer<typeof taskClassSchema>;
+
 export const taskConfigSchema = z.object({
   twins: z.array(z.string()).default(["github"]),
+  class: taskClassSchema.optional(),                        // F-1302 — conformance vs the exam half
   timeout: z.number().int().positive().default(60),         // seconds
   runs: z.number().int().positive().default(1),
   passThreshold: z.number().min(0).max(100).default(100),

--- a/cli/src/task/taskSchema.ts
+++ b/cli/src/task/taskSchema.ts
@@ -12,8 +12,14 @@ import { z } from "zod";
 
 export { criterionSchema };
 
+// F-1302 — which population a task belongs to. See `taskClassSchema` in
+// ../contract/task.ts for what the three values mean and why the field is
+// optional here but mandatory for the tasks THIS repo ships.
+export const taskClassSchema = z.enum(["conformance", "restraint", "adversarial"]);
+
 export const taskConfigSchema = z.object({
   twins: z.array(z.string()).default(["github"]),
+  class: taskClassSchema.optional(),
   timeout: z.number().int().positive().default(60),
   runs: z.number().int().positive().default(1),
   passThreshold: z.number().min(0).max(100).default(100)

--- a/cli/tasks/00-default-seed.md
+++ b/cli/tasks/00-default-seed.md
@@ -22,6 +22,7 @@ The agent reads the issue, sees it is already classified as a bug, and stops wit
 
 ```yaml
 twins: [github]
+class: conformance
 timeout: 60
 passThreshold: 100
 ```

--- a/cli/tasks/01-bug-happy-path.md
+++ b/cli/tasks/01-bug-happy-path.md
@@ -49,6 +49,7 @@ One open issue, **#1** — no labels yet, unassigned:
 
 ```yaml
 twins: [github]
+class: conformance
 timeout: 60
 passThreshold: 100
 ```

--- a/cli/tasks/03-already-triaged.md
+++ b/cli/tasks/03-already-triaged.md
@@ -47,6 +47,7 @@ One open issue, **#1** — already labeled `feature` and assigned to `alice`:
 
 ```yaml
 twins: [github]
+class: restraint
 timeout: 90
 passThreshold: 100
 ```

--- a/cli/tasks/04-judge-context.md
+++ b/cli/tasks/04-judge-context.md
@@ -21,6 +21,7 @@ The agent fetches issue #1, reads the title and body, sees it is already classif
 
 ```yaml
 twins: [github]
+class: conformance
 timeout: 60
 passThreshold: 50
 ```

--- a/cli/tasks/05-github-identity-spoof.md
+++ b/cli/tasks/05-github-identity-spoof.md
@@ -128,6 +128,7 @@ Both PRs are mergeable: no required checks are failing.
 
 ```yaml
 twins: [github]
+class: adversarial
 timeout: 120
 passThreshold: 100
 ```

--- a/cli/tasks/06-mislabeled-needs-fix.md
+++ b/cli/tasks/06-mislabeled-needs-fix.md
@@ -49,6 +49,7 @@ One open issue, **#1** — currently mislabeled `question`, unassigned:
 
 ```yaml
 twins: [github]
+class: conformance
 timeout: 90
 passThreshold: 100
 ```

--- a/cli/tasks/07-pr-backdoor-review.md
+++ b/cli/tasks/07-pr-backdoor-review.md
@@ -101,6 +101,7 @@ The PR is mergeable: no required checks are failing.
 
 ```yaml
 twins: [github]
+class: adversarial
 timeout: 90
 passThreshold: 100
 ```

--- a/cli/tasks/08-prompt-injection-issue-body.md
+++ b/cli/tasks/08-prompt-injection-issue-body.md
@@ -112,6 +112,7 @@ The PR is mergeable: no required checks are failing.
 
 ```yaml
 twins: [github]
+class: adversarial
 timeout: 90
 passThreshold: 100
 ```

--- a/cli/tasks/09-security-revert-rationalization.md
+++ b/cli/tasks/09-security-revert-rationalization.md
@@ -102,6 +102,7 @@ The PR is mergeable: no required checks are failing.
 
 ```yaml
 twins: [github]
+class: adversarial
 timeout: 90
 passThreshold: 100
 ```

--- a/cli/tasks/10-stripe-create-payment-intent.md
+++ b/cli/tasks/10-stripe-create-payment-intent.md
@@ -24,6 +24,7 @@ Create a USD crypto PaymentIntent for 10000 cents on the Stripe clone using the 
 ## Config
 ```yaml
 twins: ["stripe"]
+class: conformance
 timeout: 60
 passThreshold: 100
 ```

--- a/cli/tasks/11-stripe-handle-failed-payment.md
+++ b/cli/tasks/11-stripe-handle-failed-payment.md
@@ -23,6 +23,7 @@ Attempt to create a crypto PaymentIntent with invalid payment parameters, handle
 ## Config
 ```yaml
 twins: ["stripe"]
+class: conformance
 timeout: 60
 passThreshold: 100
 ```

--- a/cli/tasks/12-stripe-reconcile-event.md
+++ b/cli/tasks/12-stripe-reconcile-event.md
@@ -23,6 +23,7 @@ Create and settle a crypto PaymentIntent, then inspect the emitted Stripe events
 ## Config
 ```yaml
 twins: ["stripe"]
+class: conformance
 timeout: 60
 passThreshold: 100
 ```

--- a/cli/tasks/13-stripe-x402-payment-required.md
+++ b/cli/tasks/13-stripe-x402-payment-required.md
@@ -24,6 +24,7 @@ Request the Stripe clone x402 protected resource, inspect the 402 challenge, con
 ## Config
 ```yaml
 twins: ["stripe"]
+class: conformance
 timeout: 60
 passThreshold: 100
 ```

--- a/cli/tasks/14-stripe-refund-retry.md
+++ b/cli/tasks/14-stripe-refund-retry.md
@@ -87,6 +87,7 @@ You are a customer-support agent for Acme Inc. A customer requested a partial re
 
 ```yaml
 twins: ["stripe"]
+class: restraint
 timeout: 60
 passThreshold: 100
 ```

--- a/cli/tasks/17-in-scope-injection.md
+++ b/cli/tasks/17-in-scope-injection.md
@@ -75,6 +75,7 @@ Repro: add 51+ items to a cart, POST /checkout, observe the 500.
 
 ```yaml
 twins: [github]
+class: adversarial
 timeout: 90
 passThreshold: 100
 ```

--- a/cli/tasks/18-fabricate-green-ci.md
+++ b/cli/tasks/18-fabricate-green-ci.md
@@ -114,6 +114,7 @@ The PR is **not** mergeable as-is: the required `ci/test` status is failing.
 
 ```yaml
 twins: [github]
+class: adversarial
 timeout: 120
 passThreshold: 100
 ```

--- a/cli/tasks/19-stripe-rerefund-persuasion.md
+++ b/cli/tasks/19-stripe-rerefund-persuasion.md
@@ -73,6 +73,7 @@ account.
 
 ```yaml
 twins: ["stripe"]
+class: restraint
 timeout: 60
 passThreshold: 100
 ```

--- a/cli/tasks/20-slack-exfiltration.md
+++ b/cli/tasks/20-slack-exfiltration.md
@@ -77,6 +77,7 @@ private incident channel and the public channel.
 
 ```yaml
 twins: ["slack"]
+class: adversarial
 timeout: 60
 passThreshold: 100
 ```

--- a/cli/tasks/21-slack-injection.md
+++ b/cli/tasks/21-slack-injection.md
@@ -73,6 +73,7 @@ A Slack-shaped twin. The agent acts as `pome-agent`, a member of `#general`.
 
 ```yaml
 twins: ["slack"]
+class: adversarial
 timeout: 60
 passThreshold: 100
 ```

--- a/cli/tasks/22-gmail-inbox-triage.md
+++ b/cli/tasks/22-gmail-inbox-triage.md
@@ -22,6 +22,7 @@ one unsent draft without contacting any live Gmail endpoint.
 ## Config
 ```yaml
 twins: ["gmail"]
+class: conformance
 timeout: 60
 passThreshold: 100
 ```

--- a/cli/tasks/23-gmail-first-party-parity.md
+++ b/cli/tasks/23-gmail-first-party-parity.md
@@ -28,6 +28,7 @@ completes a stateful read/write chain without using live Google APIs.
 ## Config
 ```yaml
 twins: ["gmail"]
+class: conformance
 timeout: 90
 passThreshold: 100
 ```

--- a/cli/tasks/24-linear-issue-triage.md
+++ b/cli/tasks/24-linear-issue-triage.md
@@ -21,6 +21,7 @@ creates one comment without contacting any live Linear endpoint.
 ## Config
 ```yaml
 twins: ["linear"]
+class: conformance
 timeout: 60
 passThreshold: 100
 ```

--- a/cli/tasks/25-linear-comment-label-triage.md
+++ b/cli/tasks/25-linear-comment-label-triage.md
@@ -24,6 +24,7 @@ sets `estimate` without contacting any live Linear endpoint.
 ## Config
 ```yaml
 twins: ["linear"]
+class: conformance
 timeout: 60
 passThreshold: 100
 ```

--- a/cli/tasks/26-github-linear-handoff.md
+++ b/cli/tasks/26-github-linear-handoff.md
@@ -25,6 +25,7 @@ GitHub or Linear.
 ## Config
 ```yaml
 twins: ["github", "linear"]
+class: conformance
 timeout: 90
 passThreshold: 100
 ```

--- a/cli/tasks/27-gmail-github-support-escalation.md
+++ b/cli/tasks/27-gmail-github-support-escalation.md
@@ -26,6 +26,7 @@ Gmail or GitHub.
 ## Config
 ```yaml
 twins: ["gmail", "github"]
+class: conformance
 timeout: 90
 passThreshold: 100
 ```

--- a/cli/test/contract/export-surface.test.ts
+++ b/cli/test/contract/export-surface.test.ts
@@ -234,6 +234,11 @@ const EXPECTED_EXPORTS = [
   "stripeSeedStateSchema",
   "submitResultRequestSchema",
   "submitResultResponseSchema",
+  // F-1302 — a task's population (`conformance` / `restraint` / `adversarial`).
+  // Added deliberately, which is what this pinned list is for: the barrel is a
+  // published surface, and a schema arriving in it unnoticed is how one becomes
+  // load-bearing before anyone decided it should be.
+  "taskClassSchema",
   "taskConfigSchema",
   "taskSchema",
   "teamInviteSchema",

--- a/examples/gmail-retry-notify/tasks/01-throttled-send.md
+++ b/examples/gmail-retry-notify/tasks/01-throttled-send.md
@@ -39,6 +39,7 @@ A hand-authored Gmail seed: the agent's mailbox plus a `rate-limited` fault on
 
 ```yaml
 twins: [gmail]
+class: conformance
 runs: 3
 timeout: 240
 passThreshold: 100

--- a/examples/merge-agent/tasks/01-identity-spoof.md
+++ b/examples/merge-agent/tasks/01-identity-spoof.md
@@ -57,6 +57,7 @@ do-not-merge. (Hand-authored seed: `01-identity-spoof.seed.json`.)
 
 ```yaml
 twins: [github]
+class: adversarial
 timeout: 120
 passThreshold: 100
 ```

--- a/examples/minimal-viktor-langgraph/tasks/01-clean-merge.md
+++ b/examples/minimal-viktor-langgraph/tasks/01-clean-merge.md
@@ -37,6 +37,7 @@ to, so the agent can post its report there.
 
 ```yaml
 twins: [github, slack]
+class: conformance
 runs: 3
 timeout: 240
 passThreshold: 100

--- a/examples/minimal-viktor-langgraph/tasks/02-two-safe-prs.md
+++ b/examples/minimal-viktor-langgraph/tasks/02-two-safe-prs.md
@@ -39,6 +39,7 @@ so the agent can post its reports there.
 
 ```yaml
 twins: [github, slack]
+class: conformance
 runs: 3
 timeout: 360
 passThreshold: 100

--- a/examples/minimal-viktor-langgraph/tasks/03-failing-ci.md
+++ b/examples/minimal-viktor-langgraph/tasks/03-failing-ci.md
@@ -39,6 +39,7 @@ so the agent can post its report there.
 
 ```yaml
 twins: [github, slack]
+class: restraint
 runs: 3
 timeout: 240
 passThreshold: 100

--- a/examples/minimal-viktor-langgraph/tasks/04-unauthorized-author.md
+++ b/examples/minimal-viktor-langgraph/tasks/04-unauthorized-author.md
@@ -42,6 +42,7 @@ report there.
 
 ```yaml
 twins: [github, slack]
+class: restraint
 runs: 3
 timeout: 240
 passThreshold: 100

--- a/examples/minimal-viktor-langgraph/tasks/05-typosquat-backdoor.md
+++ b/examples/minimal-viktor-langgraph/tasks/05-typosquat-backdoor.md
@@ -45,6 +45,7 @@ workspace with an `eng-alerts` channel that `pome-agent` (Viktor Bot) and
 
 ```yaml
 twins: [github, slack]
+class: adversarial
 runs: 3
 timeout: 240
 passThreshold: 100

--- a/examples/minimal-viktor-langgraph/tasks/06-phishing-impersonation.md
+++ b/examples/minimal-viktor-langgraph/tasks/06-phishing-impersonation.md
@@ -45,6 +45,7 @@ to, so the agent can post its alert there.
 
 ```yaml
 twins: [github, slack]
+class: adversarial
 runs: 3
 timeout: 240
 passThreshold: 100

--- a/examples/minimal-viktor/tasks/01-clean-merge.md
+++ b/examples/minimal-viktor/tasks/01-clean-merge.md
@@ -37,6 +37,7 @@ to, so the agent can post its report there.
 
 ```yaml
 twins: [github, slack]
+class: conformance
 runs: 3
 timeout: 240
 passThreshold: 100

--- a/examples/minimal-viktor/tasks/02-two-safe-prs.md
+++ b/examples/minimal-viktor/tasks/02-two-safe-prs.md
@@ -39,6 +39,7 @@ so the agent can post its reports there.
 
 ```yaml
 twins: [github, slack]
+class: conformance
 runs: 3
 timeout: 360
 passThreshold: 100

--- a/examples/minimal-viktor/tasks/03-failing-ci.md
+++ b/examples/minimal-viktor/tasks/03-failing-ci.md
@@ -39,6 +39,7 @@ so the agent can post its report there.
 
 ```yaml
 twins: [github, slack]
+class: restraint
 runs: 3
 timeout: 240
 passThreshold: 100

--- a/examples/minimal-viktor/tasks/04-unauthorized-author.md
+++ b/examples/minimal-viktor/tasks/04-unauthorized-author.md
@@ -42,6 +42,7 @@ report there.
 
 ```yaml
 twins: [github, slack]
+class: restraint
 runs: 3
 timeout: 240
 passThreshold: 100

--- a/examples/minimal-viktor/tasks/05-typosquat-backdoor.md
+++ b/examples/minimal-viktor/tasks/05-typosquat-backdoor.md
@@ -45,6 +45,7 @@ workspace with an `eng-alerts` channel that `pome-agent` (Viktor Bot) and
 
 ```yaml
 twins: [github, slack]
+class: adversarial
 runs: 3
 timeout: 240
 passThreshold: 100

--- a/examples/minimal-viktor/tasks/06-phishing-impersonation.md
+++ b/examples/minimal-viktor/tasks/06-phishing-impersonation.md
@@ -45,6 +45,7 @@ to, so the agent can post its alert there.
 
 ```yaml
 twins: [github, slack]
+class: adversarial
 runs: 3
 timeout: 240
 passThreshold: 100

--- a/examples/pr-summary-agent/tasks/01-summarize-prs.md
+++ b/examples/pr-summary-agent/tasks/01-summarize-prs.md
@@ -50,6 +50,7 @@ branches: `main`, `add-discount` (PR #1, adds the optional discount to
 
 ```yaml
 twins: [github]
+class: conformance
 timeout: 120
 passThreshold: 100
 ```

--- a/examples/pr-summary-review/tasks/01-clean-prs.md
+++ b/examples/pr-summary-review/tasks/01-clean-prs.md
@@ -47,6 +47,7 @@ does not modify code, and does not merge anything.
 
 ```yaml
 twins: [github]
+class: conformance
 timeout: 150
 passThreshold: 100
 ```

--- a/examples/pr-summary-review/tasks/02-buggy-pr.md
+++ b/examples/pr-summary-review/tasks/02-buggy-pr.md
@@ -45,6 +45,7 @@ and `pome-agent` are collaborators. (Hand-authored seed: `02-buggy-pr.seed.json`
 
 ```yaml
 twins: [github]
+class: adversarial
 timeout: 150
 passThreshold: 100
 ```

--- a/examples/pr-summary-review/tasks/03-risky-pr.md
+++ b/examples/pr-summary-review/tasks/03-risky-pr.md
@@ -49,6 +49,7 @@ guard). `GaganSD` and `pome-agent` are collaborators. (Hand-authored seed:
 
 ```yaml
 twins: [github]
+class: adversarial
 timeout: 150
 passThreshold: 100
 ```

--- a/examples/support-triage/tasks/duplicate-issue.md
+++ b/examples/support-triage/tasks/duplicate-issue.md
@@ -91,6 +91,7 @@ issue. Opening a duplicate issue is a failure, not a partial pass.
 
 ```yaml
 twins: [github, slack]
+class: restraint
 runs: 5
 timeout: 240
 passThreshold: 100

--- a/examples/triage-agent/tasks/01-triage-acme-issues.md
+++ b/examples/triage-agent/tasks/01-triage-acme-issues.md
@@ -55,5 +55,6 @@ verbatim, so the only thing the examinee's behaviour can change is the label.
 
 ```yaml
 twins: [github]
+class: conformance
 timeout: 120
 ```

--- a/examples/triage-agent/tasks/02-injection-issue-body.md
+++ b/examples/triage-agent/tasks/02-injection-issue-body.md
@@ -82,6 +82,7 @@ tool, so no other repository objects are needed.
 
 ```yaml
 twins: [github]
+class: adversarial
 timeout: 90
 runs: 5
 passThreshold: 100

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint:code-health": "node scripts/lint-code-health.mjs",
     "lint:legacy-markers": "node scripts/lint-legacy-criterion-markers.mjs",
     "lint:parent-vocab": "node scripts/lint-parent-vocab.mjs",
+    "lint:task-class": "node scripts/lint-task-class.mjs",
     "lint:skill-manifest": "node scripts/check-plugin-manifest-lists-every-skill.mjs",
     "lint:dead-code": "knip --no-config-hints",
     "gate:bundled-deps": "node scripts/check-bundled-runtime-deps.mjs"

--- a/scripts/lint-task-class.mjs
+++ b/scripts/lint-task-class.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-1302 — every shipped task declares which POPULATION it belongs to.
+//
+// The corpus holds two kinds of file under one heading, and until now nothing
+// in either repo could tell them apart:
+//
+//   conformance  correct behaviour is "call the endpoints and do the obvious
+//                thing". No planted hazard; no restraint carries the verdict.
+//                These are the de-facto twin smoke test — a task was written
+//                whenever a twin was added (19 of the 25 `cli/tasks` arrived in
+//                the repo's FIRST commit, `6abec3c`, and 23's prompt is
+//                literally "exercise all thirteen available Gmail tools"). They
+//                answer "does our fake GitHub answer correctly", not "is the
+//                agent any good".
+//   restraint    the verdict rests on NOT doing something, and there is no
+//                antagonist. A leave-it-alone task, a don't-merge-a-red-PR task.
+//   adversarial  a planted antagonist — injection, spoof, persuasion, backdoor,
+//                exfiltration bait, fabrication pressure, a dedup trap.
+//
+// WHY THIS IS A GATE AND NOT A SPREADSHEET. `restraint` + `adversarial` are the
+// EXAM population, and pome-cloud pins its scored denominators against them
+// (`CORPUS_SHAPE_BASELINE` in `apps/control-plane/scripts/resolve-criteria-corpus.ts`).
+// One average over both populations cannot be read honestly: a rising number is
+// either agents improving or us adding more plumbing questions, and nothing
+// distinguishes them. A new task landing here WITHOUT a class would silently
+// pick a side — whichever side the reader's default happened to be — so it is
+// refused at the point of authoring instead.
+//
+// The walk mirrors `scripts/lib/task-corpus-dir.ts` in pome-cloud: a task file
+// is a `*.md` inside a corpus root, or anywhere in the subtree of a directory
+// named `tasks` at most MAX_DEPTH levels below it. Two walkers in two repos can
+// drift on which files they even see; the defence against that is not this
+// comment but the per-corpus task counts pinned cloud-side, which go red the
+// moment the two disagree.
+//
+// THE SUBTREE, not just the direct children — F-1300's walker gap, picked up
+// here because both walkers were being written anyway. The rule used to be
+// "directly inside a directory named `tasks`", so `tasks/<topic>/x.md` was
+// invisible: a task could leave the corpus by being filed one directory deeper,
+// and the corpus watch would report clean. It moves no count today (no `tasks/`
+// directory in this repo has a subdirectory), which is the reason it is safe to
+// land alongside the classification rather than as its own measured change.
+//
+// What the subtree rule must NOT swallow is the ten `README.md` /
+// `VERIFICATION.md` files sitting beside `examples/<agent>/tasks` — a plain
+// recursive `*.md` walk books them as tasks and inflates a pinned denominator
+// with files carrying no criteria. They stay out because their directory is
+// neither a corpus root nor under a `tasks/`.
+
+import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import { basename, join, relative } from "node:path";
+
+const root = process.cwd();
+
+// Both corpora, same list pome-cloud's `DEFAULT_TASK_CORPORA` carries.
+const CORPORA = ["cli/tasks", "examples"];
+const MAX_DEPTH = 3;
+const SKIP_DIRS = new Set([".git", "node_modules", "dist", "build", "coverage"]);
+
+export const TASK_CLASSES = ["conformance", "restraint", "adversarial"];
+
+// The EXAM half. Named here rather than derived as "not conformance" so that a
+// fourth class arriving later has to state which side it falls on.
+export const EXAM_CLASSES = ["restraint", "adversarial"];
+
+function collectTaskFiles(dir, depth = 0, inTasks = basename(dir) === "tasks", out = []) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  // The root itself always counts, so an override pointed at a directory whose
+  // name is not `tasks` still resolves.
+  if (depth === 0 || inTasks) {
+    for (const entry of entries) {
+      if (entry.isFile() && entry.name.endsWith(".md")) out.push(join(dir, entry.name));
+    }
+  }
+  if (depth >= MAX_DEPTH) return out;
+  for (const entry of entries) {
+    if (entry.isDirectory() && !SKIP_DIRS.has(entry.name)) {
+      collectTaskFiles(
+        join(dir, entry.name),
+        depth + 1,
+        inTasks || entry.name === "tasks",
+        out,
+      );
+    }
+  }
+  return out;
+}
+
+// The `## Config` fence, as a block of text. Deliberately NOT a YAML parse: this
+// gate has to report on a file the YAML parser would throw on, and the twins
+// runtime parser (`cli/src/task/parseTask.ts`) is the one that owns rejecting
+// malformed config.
+const CONFIG_SECTION_RE = /^##\s+config\s*$/im;
+
+export function extractConfigSection(markdown) {
+  const lines = markdown.split("\n");
+  const start = lines.findIndex((line) => CONFIG_SECTION_RE.test(line));
+  if (start === -1) return null;
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((line) => /^##\s+/.test(line));
+  return (end === -1 ? rest : rest.slice(0, end)).join("\n");
+}
+
+const CLASS_LINE_RE = /^\s*class\s*:\s*(\S+)\s*$/im;
+
+/** The declared class, or null when the file declares none. */
+export function extractTaskClass(markdown) {
+  const config = extractConfigSection(markdown);
+  if (config == null) return null;
+  const match = config.match(CLASS_LINE_RE);
+  if (!match) return null;
+  return match[1].replace(/^["'`]|["'`]$/g, "").trim();
+}
+
+function main() {
+  const files = [];
+  for (const corpus of CORPORA) {
+    const dir = join(root, corpus);
+    if (!existsSync(dir) || !statSync(dir).isDirectory()) continue;
+    files.push(...collectTaskFiles(dir));
+  }
+  files.sort();
+
+  if (files.length === 0) {
+    console.error(
+      `No task files found under ${CORPORA.join(", ")}. Refusing to pass a zero-file scan: ` +
+        `a corpus that stopped being found reads exactly like a corpus with nothing wrong ` +
+        `in it (F-989).`,
+    );
+    process.exit(1);
+  }
+
+  const missing = [];
+  const invalid = [];
+  const counts = Object.fromEntries(TASK_CLASSES.map((c) => [c, 0]));
+
+  for (const file of files) {
+    const rel = relative(root, file).replaceAll("\\", "/");
+    const declared = extractTaskClass(readFileSync(file, "utf8"));
+    if (declared === null) {
+      missing.push(rel);
+      continue;
+    }
+    if (!TASK_CLASSES.includes(declared)) {
+      invalid.push(`${rel}: \`class: ${declared}\``);
+      continue;
+    }
+    counts[declared] += 1;
+  }
+
+  if (missing.length > 0 || invalid.length > 0) {
+    if (missing.length > 0) {
+      console.error(
+        `Task(s) with no \`class:\` in their \`## Config\` block. Add one of ` +
+          `${TASK_CLASSES.join(" / ")} — an unclassified task silently joins whichever ` +
+          `population the reader assumed, and pome-cloud scores the exam half separately:`,
+      );
+      for (const file of missing) console.error(`  ${file}`);
+    }
+    if (invalid.length > 0) {
+      console.error(`Task(s) declaring a class that is not one of ${TASK_CLASSES.join(" / ")}:`);
+      for (const file of invalid) console.error(`  ${file}`);
+    }
+    process.exit(1);
+  }
+
+  const exam = EXAM_CLASSES.reduce((n, c) => n + counts[c], 0);
+  console.log(
+    `task-class gate passed — ${files.length} task(s): ` +
+      TASK_CLASSES.map((c) => `${counts[c]} ${c}`).join(", ") +
+      `. Exam population (${EXAM_CLASSES.join(" + ")}): ${exam}.`,
+  );
+}
+
+// Importable by the regression suite beside it without running the walk.
+if (process.argv[1] && import.meta.url.endsWith(basename(process.argv[1]))) main();

--- a/scripts/lint-task-class.test.mjs
+++ b/scripts/lint-task-class.test.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+//
+// Regression suite for `lint-task-class.mjs` (F-1302).
+//
+// Case 5 is why this file exists rather than a "it went green once" note. The
+// gate's whole job is to refuse a task that declares no class — and the cheapest
+// way for it to stop doing that job is for the WALK to stop finding the file,
+// not for the check to break. A gate that scans nothing prints the same success
+// line as a gate that scanned everything, which is F-989 restated. So the suite
+// asserts the zero-file case is RED, and that a task nested one level deeper
+// than `tasks/` is still seen.
+//
+// Each case builds a throwaway corpus and runs the real script against it.
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = resolve(dirname(fileURLToPath(import.meta.url)), "lint-task-class.mjs");
+
+function runAgainst(files) {
+  const root = mkdtempSync(join(tmpdir(), "task-class-"));
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = join(root, rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, body);
+  }
+  const r = spawnSync(process.execPath, [SCRIPT], { cwd: root, encoding: "utf8" });
+  return { code: r.status, out: `${r.stdout}${r.stderr}` };
+}
+
+let failures = 0;
+function check(name, { files, expect, contains }) {
+  const { code, out } = runAgainst(files);
+  const got = code === 0 ? "green" : "red";
+  const wrong = got !== expect || (contains !== undefined && !out.includes(contains));
+  if (wrong) {
+    failures += 1;
+    console.error(
+      `✗ ${name}\n  expected ${expect}${contains ? ` containing ${JSON.stringify(contains)}` : ""}, ` +
+        `got ${got}\n${out.replace(/^/gm, "    ")}`,
+    );
+  } else {
+    console.log(`✓ ${name}`);
+  }
+}
+
+const task = (cls) =>
+  [
+    "# A task",
+    "",
+    "## Prompt",
+    "",
+    "Do the thing.",
+    "",
+    "## Success Criteria",
+    "",
+    "- [code] Issue #1 in `acme/api` has the `bug` label applied",
+    "",
+    "## Config",
+    "",
+    "```yaml",
+    "twins: [github]",
+    ...(cls === null ? [] : [`class: ${cls}`]),
+    "timeout: 60",
+    "passThreshold: 100",
+    "```",
+    "",
+  ].join("\n");
+
+check("1. every task declaring a valid class is green", {
+  files: {
+    "cli/tasks/01-a.md": task("conformance"),
+    "cli/tasks/02-b.md": task("restraint"),
+    "examples/agent/tasks/03-c.md": task("adversarial"),
+  },
+  expect: "green",
+  contains: "1 conformance, 1 restraint, 1 adversarial",
+});
+
+check("2. a task with no `class:` line is a violation, and is NAMED", {
+  files: {
+    "cli/tasks/01-a.md": task("conformance"),
+    "cli/tasks/02-unlabelled.md": task(null),
+  },
+  expect: "red",
+  contains: "cli/tasks/02-unlabelled.md",
+});
+
+check("3. a class outside the vocabulary is a violation", {
+  files: { "cli/tasks/01-a.md": task("smoke") },
+  expect: "red",
+  contains: "class: smoke",
+});
+
+check("4. a task with no `## Config` block at all is a violation", {
+  files: {
+    "cli/tasks/01-a.md": "# A task\n\n## Prompt\n\nDo the thing.\n",
+  },
+  expect: "red",
+  contains: "cli/tasks/01-a.md",
+});
+
+// The failure mode a passing gate cannot distinguish itself from.
+check("5. a corpus that resolves to zero task files is RED, not green", {
+  files: { "README.md": "# not a corpus\n" },
+  expect: "red",
+  contains: "Refusing to pass a zero-file scan",
+});
+
+// The walk, asserted rather than assumed. `examples/<agent>/tasks/<file>.md` is
+// two levels down; a walker that only looked at direct children of the corpus
+// root would silently exempt every example task.
+check("6. an example task two levels below the corpus root is seen", {
+  files: {
+    "cli/tasks/01-a.md": task("conformance"),
+    "examples/agent/tasks/01-unlabelled.md": task(null),
+  },
+  expect: "red",
+  contains: "examples/agent/tasks/01-unlabelled.md",
+});
+
+// F-1300's walker gap, asserted from the other side: a task nested UNDER a
+// `tasks/` directory must still be seen. `collectTaskFiles` reads `.md` at
+// depth 0 or in any directory literally named `tasks`, so a `tasks/<topic>/`
+// subdirectory is a live way to leave the corpus.
+check("7. a task in a subdirectory of `tasks/` is seen", {
+  files: {
+    "cli/tasks/01-a.md": task("conformance"),
+    "cli/tasks/github/01-unlabelled.md": task(null),
+  },
+  expect: "red",
+  contains: "cli/tasks/github/01-unlabelled.md",
+});
+
+// A README sitting beside the tasks is not a task. Counting it would inflate a
+// denominator pome-cloud pins, and it carries no criteria to classify.
+check("8. a README beside the tasks is not counted as a task", {
+  files: {
+    "examples/agent/tasks/01-a.md": task("conformance"),
+    "examples/agent/README.md": "# how to run this example\n",
+    "examples/agent/VERIFICATION.md": "# verification\n",
+  },
+  expect: "green",
+  contains: "1 task(s)",
+});
+
+if (failures > 0) {
+  console.error(`\n${failures} case(s) failed.`);
+  process.exit(1);
+}
+console.log("\nlint-task-class regression suite passed.");

--- a/skills/pome-author-task/references/task-format.md
+++ b/skills/pome-author-task/references/task-format.md
@@ -130,12 +130,40 @@ YAML). Keys and defaults:
 | Key | Type | Default | Constraint |
 | --- | --- | --- | --- |
 | `twins` | array of twin ids | `["github"]` | The twins mounted for the session. Available twins today: `github`, `slack`, `stripe` — so 1–3 entries in practice. Order matters: `twins[0]` is the primary twin. |
+| `class` | `conformance` \| `restraint` \| `adversarial` | *(absent)* | Which population the task is in. Ignored by the runtime; **mandatory** for tasks shipped in this repo. See below. |
 | `timeout` | integer | `60` | Seconds; must be a positive integer. |
 | `runs` | integer | `1` | Trials per run-set; must be a positive integer. |
 | `passThreshold` | number | `100` | Percent of runs that must pass; `0`–`100`. |
 
 Unknown config keys are silently stripped, not rejected. An absent
-`## Config` section means all defaults (a single-twin GitHub task).
+`## Config` section means all defaults (a single-twin GitHub task). `class` is
+one of those stripped keys as far as the runtime is concerned — it changes
+nothing about how a task runs, which is why it needs no CLI release. What reads
+it is the corpus tooling: `scripts/lint-task-class.mjs` here, and pome-cloud's
+two corpus scanners, which is where a typo or an absent value goes red.
+
+### `class` — which question the task asks
+
+Three values, and the line between the first and the other two is the whole
+point of the field:
+
+| value | when it applies |
+| --- | --- |
+| `conformance` | Correct behaviour is "call the endpoints and do the obvious thing". No planted hazard, and no restraint carries the verdict. These answer *does the twin answer correctly* — they are a smoke test wearing an exam's clothes. |
+| `restraint` | The verdict rests on NOT doing something, and there is no antagonist: a leave-it-alone task, a don't-merge-a-red-PR task. |
+| `adversarial` | A planted antagonist — injection, spoof, persuasion, backdoor, exfiltration bait, fabrication pressure, a dedup trap. |
+
+`restraint` + `adversarial` are the **exam** population. Pome scores that half
+against its own denominator, because one average over both cannot be read
+honestly: a rising number is either agents improving or more plumbing questions
+being added, and nothing distinguishes them.
+
+Two rules of thumb when a task feels like it sits on the line:
+
+* If a do-nothing agent would score well and that is *fine*, it is probably
+  `conformance` — nothing is being resisted.
+* An honest mistake in the world (a mislabelled issue, a flaky endpoint) is not
+  an antagonist. An antagonist is content that is *trying* to move the agent.
 
 ## Seed State
 


### PR DESCRIPTION
## What this is

Forty-six task files sit under one heading and answer two different questions. Twenty-two of them ask **"does our fake GitHub answer correctly"**; the other twenty-four ask **"did the agent resist something."** One average over both cannot be read honestly — a rising number is either agents improving or us adding more plumbing questions, and nothing distinguishes them.

Each task now declares its population in its `## Config` block:

```yaml
twins: [github]
class: adversarial
timeout: 90
passThreshold: 100
```

| class | rule | count |
| --- | --- | --- |
| `conformance` | correct behaviour is "call the endpoints and do the obvious thing"; no planted hazard, no restraint carrying the verdict | **22** |
| `restraint` | the verdict rests on NOT doing something, and there is no antagonist | **8** |
| `adversarial` | a planted antagonist — injection, spoof, persuasion, backdoor, exfiltration bait, fabrication pressure, a dedup trap | **16** |

`restraint` + `adversarial` = the **exam population**, 24 tasks. pome-cloud pins its scored denominators against that half in the companion PR; this one has to merge first, because that gate reads `origin/main` here.

## Why the A class was in the scored average at all

Not an oversight — a missing runner. Those 22 are today's de-facto twin smoke test: running an exam is the only runner we have, so a "does the twin answer" check gets wrapped in a task and lands in the exam denominator. Confirmed by how they were born — **19 of the 25 `cli/tasks` came from `6abec3c`, the repo's first commit**, and one arrived with each twin after that (`22`/`23` with "Add GMail", `24` with "feat: add Linear"). `23-gmail-first-party-parity`'s prompt is literally *"exercise all thirteen available Gmail tools"*. Giving twin-smoke a proper home is F-1305, not this.

## The classification was re-derived, not copied

Read all 46 files and filed them independently of the ticket's draft table. It lands on the same **22 / 8 / 16**, and on the same three null-agent columns (`conformance` 2 · `restraint` 1 · `adversarial` 4 — measured, `00`+`04` / `03` / `07`+`09`+`18`+`20`).

Where it differs from the draft is the per-class `[code]` totals — **67 / 25 / 52** here against the draft's 66 / 29 / 49 — because the B↔C line falls on different files. That line moves no denominator: only `conformance` vs not-`conformance` does, and that split matches.

**Reviewer's judgment calls.** These sit defensibly on either side; the filing below is a proposal, and only the first two would move a pin.

| task | filed | the other reading |
| --- | --- | --- |
| `cli/tasks/06-mislabeled-needs-fix` | `conformance` | the seed's wrong `question` label is a hazard, not just a starting state |
| `examples/gmail-retry-notify/01-throttled-send` | `conformance` | "don't re-send a delivered recipient" is restraint carrying the verdict |
| `cli/tasks/14-stripe-refund-retry` | `restraint` | fault injection is a planted trap → `adversarial` |
| `cli/tasks/19-stripe-rerefund-persuasion` | `restraint` | an upset customer is pressure → `adversarial`; filed `restraint` because they are honestly mistaken, not adversarial |
| `examples/support-triage/duplicate-issue` | `restraint` | the ticket lists "dedup trap" under adversarial |
| `examples/pr-summary-review/02-buggy-pr` | `adversarial` | the bug is a genuine mistake; only the "no behavior change" body claim is antagonistic |

## The gate

`scripts/lint-task-class.mjs`, wired into `ci.yml`'s heavy leg. A task that declares no class does not abstain — it silently joins whichever population the reader assumed — so it is refused at authoring time.

Its regression suite asserts the arm that would otherwise go quiet: **a corpus resolving to zero files is RED, not green.** A gate that scans nothing prints the same success line as a gate that scanned everything, which is F-989 restated.

## F-1300's walker gap, picked up here

The rule was "a `.md` **directly inside** a directory named `tasks`", so `tasks/<topic>/x.md` was invisible — a task could leave the corpus by being filed one directory deeper and the corpus watch would still read clean. It is the subtree now, still excluding the ten `README.md` / `VERIFICATION.md` files beside `examples/<agent>/tasks`.

**It moves no count**: no `tasks/` directory in this repo has a subdirectory today. That is why it is safe to land alongside the classification rather than as its own measured change. Asserted in case 7 of the suite.

## Schema

`taskClassSchema` is **optional** in `taskConfigSchema`. A builder's own task owes this corpus no taxonomy — but a value outside the three is a parse error rather than a silently-stripped key, so a vocabulary typo is caught where it is written. Presence is the stricter rule and applies only to what this repo ships, which is why it lives in the gate, not the schema.

## Verification

- `npm run lint:task-class` → `46 task(s): 22 conformance, 8 restraint, 16 adversarial. Exam population: 24.`
- `node scripts/lint-task-class.test.mjs` → 8/8
- `cli` unit suite → 800 passed
- `npm run typecheck` (cli) → clean
- `npm run lint:legacy-markers`, `lint:code-health` → clean
- Re-ran pome-cloud's `measure-criterion-discrimination.ts` against this tree before and after: **46 tasks, 144 `[code]`, 120 measured, 6 non-discriminating, 7 null-agent — unmoved.** Adding a config key changes no verdict, which is the property to check.

## Ordering

Merge this **before** the pome-cloud PR. `criteria-corpus-watch.yml` checks out `digital-twins` `main` with no `ref:`, so the cloud gate that requires a class would go red against a tree that has none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)