### PR TITLE
fix: DX findings from the post-restructure live audit (Lane H)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,25 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.21.2
+
+### Patch Changes
+
+- **F-948 live-audit fixes.** `pome twin reset linear` was rejected as
+  "Unknown twin" — `twin reset` hardcoded its own supported-twin set instead
+  of deriving it from the registry, so it silently fell out of sync when
+  linear shipped. `pome twin start --help` had the same drift: the `<name>`
+  argument's description listed four twins, missing linear. Both now derive
+  from `TWIN_NAME_LIST`.
+- The scaffolded quickstart agent (`examples/agents/scripted-triage-agent.ts`)
+  now runs via `node` instead of `npx tsx`. `pome run`'s egress-floor proxy
+  (deny-by-default: twin hosts + LLM providers + loopback only) was refusing
+  npx's own registry lookup for `tsx` on a machine that had never run it
+  before, so the documented zero-install quickstart (`pome init && pome run
+  --local tasks/01-bug-happy-path.md`) silently produced an empty trace.
+  Node ≥ 24 strips this file's type annotations natively, so no package
+  resolution — and no egress-floor conflict — is needed at all.
+
 ## 0.21.0
 
 ### Minor Changes

--- a/cli/README.md
+++ b/cli/README.md
@@ -42,7 +42,7 @@ local/OSS package release.
 pome login                       # one-time; opens the dashboard to sign in
 pome init                        # scaffolds tasks/, examples/agents/, runs/, pome.config.json
 pome register agent my-agent     # scopes runs to this project
-pome run tasks/01-bug-happy-path.md --agent "npx tsx examples/agents/scripted-triage-agent.ts"
+pome run tasks/01-bug-happy-path.md --agent "node examples/agents/scripted-triage-agent.ts"
 pome inspect latest              # trace/audit view of the last run
 ```
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Digital-twin testing for AI agents — run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -64,7 +64,7 @@ import {
   readManifest,
   writeManifest,
 } from "./project-config.js";
-import { createGitHubSmokeApp } from "../twin/registry.js";
+import { createGitHubSmokeApp, isTwinName, TWIN_NAME_LIST } from "../twin/registry.js";
 import {
   buildFixPrompt,
   buildGroupFixPrompt,
@@ -81,7 +81,17 @@ import type { RecorderEvent } from "../types/shared.js";
 const PACKAGE_VERSION = readPackageVersion();
 const SESSION_CREATE_FORMATS = new Set(["text", "json", "env"]);
 const DEFAULT_AGENT_FILE = "examples/agents/scripted-triage-agent.ts";
-const DEFAULT_AGENT_COMMAND = `npx tsx ${DEFAULT_AGENT_FILE}`;
+// `node` (not `npx tsx`): Node ≥ 24 strips this file's type annotations
+// natively, so the scaffolded zero-install quickstart never has to resolve a
+// package over the network. `npx tsx` used to be the default, but `pome run`
+// pipes the agent's traffic through the egress-floor proxy (deny-by-default,
+// twin hosts + LLM providers + loopback only) — so on a machine that has
+// never run `npx tsx` before, npx's own registry lookup for tsx gets refused
+// by that same floor, the scaffolded agent silently never starts, and the
+// documented `pome init && pome run --local tasks/01-bug-happy-path.md`
+// quickstart ends in an empty trace ("twin runtime emitted no HTTP events")
+// with no error pointing at the real cause.
+const DEFAULT_AGENT_COMMAND = `node ${DEFAULT_AGENT_FILE}`;
 const MANIFEST_SCHEMA_URL = "https://pome.sh/schemas/v1/pome.json";
 
 // Injected by tsup (`define: { PKG_VERSION }`) so the bundled CLI never has to
@@ -1241,7 +1251,7 @@ export function createProgram() {
   const twin = program.command("twin").description("Manage local twins");
   twin
     .command("start")
-    .argument("<name>", "Twin name (github | slack | stripe | gmail)")
+    .argument("<name>", `Twin name (${TWIN_NAME_LIST.join(" | ")})`)
     .option(
       "--port <port>",
       "Port to bind (default: $PORT, else GMAIL_TWIN_PORT/3336 for gmail, else 3333)",
@@ -1259,9 +1269,8 @@ export function createProgram() {
     .argument("[name]", "Twin name (default: github)", "github")
     .description("Reset standalone twin state")
     .action(async (name: string) => {
-      const supported = new Set(["github", "slack", "stripe", "gmail"]);
-      if (!supported.has(name)) {
-        throw new Error(`Unknown twin '${name}'. Supported: ${[...supported].join(", ")}.`);
+      if (!isTwinName(name)) {
+        throw new Error(`Unknown twin '${name}'. Supported: ${TWIN_NAME_LIST.join(", ")}.`);
       }
       const dbPaths =
         name === "gmail"

--- a/cli/test/e2e/runTask.test.ts
+++ b/cli/test/e2e/runTask.test.ts
@@ -44,7 +44,7 @@ describe("Pome scenario runner (capture-only)", () => {
       for (const taskPath of scenarios) {
         const result = await runTask({
           taskPath,
-          agentCommand: "npx tsx examples/agents/scripted-triage-agent.ts",
+          agentCommand: "node examples/agents/scripted-triage-agent.ts",
           artifactsDir,
           captureServerCommand: captureServerForTests,
         });

--- a/cli/test/e2e/runTaskAdapterSignals.test.ts
+++ b/cli/test/e2e/runTaskAdapterSignals.test.ts
@@ -65,7 +65,7 @@ describe("runTask + POME_ADAPTER_SIGNALS_PATH", () => {
       const result = await runTask({
         taskPath: "tasks/01-bug-happy-path.md",
         captureServerCommand: captureServerForTests,
-        agentCommand: "npx tsx examples/agents/scripted-triage-agent.ts",
+        agentCommand: "node examples/agents/scripted-triage-agent.ts",
         artifactsDir,
       });
 

--- a/cli/test/e2e/twinReset.test.ts
+++ b/cli/test/e2e/twinReset.test.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// F-948 DX audit regression — `pome twin reset` hardcoded its own supported-
+// twin set (`new Set(["github", "slack", "stripe", "gmail"])`) instead of
+// deriving it from `TWIN_NAME_LIST`, the single source of truth the registry
+// refactor introduced specifically so a new twin can't silently fall out of
+// sync (see registry.ts's own header comment). Linear shipped as a full
+// first-party twin but `pome twin reset linear` rejected it as "Unknown
+// twin", even though `pome twin start linear` worked fine. This test locks
+// `twin reset` to accept every twin in TWIN_NAME_LIST, and locks the
+// unknown-twin error text (for both `twin start` and `twin reset`) to list
+// all five names.
+
+import { spawn } from "node:child_process";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { TWIN_NAME_LIST } from "../../src/twin/registry.js";
+import { resolveTsxBin } from "../../scripts/lib/resolve-tsx.js";
+
+const CLI_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+const TSX_BIN = resolveTsxBin(import.meta.url);
+const MAIN_TS = join(CLI_ROOT, "src", "cli", "main.ts");
+
+async function runCli(args: string[]): Promise<{ code: number | null; output: string }> {
+  const cwd = await mkdtemp(join(tmpdir(), "pome-twin-reset-e2e-"));
+  return await new Promise((resolve, reject) => {
+    const child = spawn(TSX_BIN, [MAIN_TS, ...args], {
+      cwd,
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "";
+    child.stdout?.on("data", (chunk) => { output += chunk; });
+    child.stderr?.on("data", (chunk) => { output += chunk; });
+    child.once("error", reject);
+    child.once("exit", (code) => resolve({ code, output }));
+  });
+}
+
+describe("pome twin reset (e2e)", () => {
+  it.each(TWIN_NAME_LIST)("accepts every first-party twin: %s", async (name) => {
+    const { code, output } = await runCli(["twin", "reset", name]);
+    expect(output).not.toContain("Unknown twin");
+    expect(output).toContain(`Standalone ${name} twin state reset.`);
+    expect(code).toBe(0);
+  });
+
+  it("rejects an unrecognized twin and lists all five supported names", async () => {
+    const { code, output } = await runCli(["twin", "reset", "nonexistent-twin-name"]);
+    expect(code).not.toBe(0);
+    for (const name of TWIN_NAME_LIST) {
+      expect(output).toContain(name);
+    }
+  });
+});
+
+describe("pome twin start — unknown-twin error (e2e)", () => {
+  it("lists all five supported names, not just a subset", async () => {
+    const { code, output } = await runCli(["twin", "start", "nonexistent-twin-name"]);
+    expect(code).not.toBe(0);
+    for (const name of TWIN_NAME_LIST) {
+      expect(output).toContain(name);
+    }
+  });
+
+  it("--help documents every first-party twin in the <name> argument", async () => {
+    const { output } = await runCli(["twin", "start", "--help"]);
+    for (const name of TWIN_NAME_LIST) {
+      expect(output).toContain(name);
+    }
+  });
+});

--- a/cli/test/unit/init-sdk.test.ts
+++ b/cli/test/unit/init-sdk.test.ts
@@ -111,7 +111,7 @@ describe("pome init --sdk", () => {
     };
     expect(cfg.agent.framework).toBeUndefined();
     expect(cfg.command).toBe(
-      "npx tsx examples/agents/scripted-triage-agent.ts",
+      "node examples/agents/scripted-triage-agent.ts",
     );
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "cli": {
       "name": "@pome-sh/cli",
-      "version": "0.21.1",
+      "version": "0.21.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.29",


### PR DESCRIPTION
## Summary

Live-audited the just-published `npx @pome-sh/cli@latest` (0.21.1) flow against a genuinely clean environment/cache per F-948 (Lane H of the Package restructure milestone), and fixed two real bugs plus one severe quickstart regression found along the way:

- `pome twin reset <name>` hardcoded its own supported-twin set to `["github","slack","stripe","gmail"]`, so `pome twin reset linear` failed with `Unknown twin 'linear'` even though linear is a full first-party twin and `pome twin start linear` works fine. Now derived from `TWIN_NAME_LIST`/`isTwinName`, the same source of truth every other twin-name check in the CLI already uses.
- `pome twin start --help` documented the `<name>` argument as `(github | slack | stripe | gmail)` — missing linear. Now derived from `TWIN_NAME_LIST` too, so a sixth twin can't silently fall out of sync with the help text again.
- The scaffolded zero-install quickstart (`pome init` then `pome run --local tasks/01-bug-happy-path.md`, the exact flow root README.md documents) defaulted the agent command to `npx tsx examples/agents/scripted-triage-agent.ts`. `pome run` pipes the agent's traffic through the egress-floor proxy (deny-by-default: twin hosts + LLM providers + loopback only), so on a machine that has never run `npx tsx` before, npx's own registry lookup for `tsx` gets refused by that same floor. The agent silently never starts, and the run ends in an empty trace ("twin runtime emitted no HTTP events") with nothing pointing at the real cause. Switched the default to `node examples/agents/scripted-triage-agent.ts` — Node ≥ 24 (already this project's hard prerequisite) strips this file's type annotations natively, so this removes the network dependency entirely. Verified end to end: the same documented quickstart now captures 3 real `TwinHttpEvent`s instead of zero.

## Found but NOT fixed here (flagged for follow-up)

3 of the 5 twins (github, gmail, linear) load their full domain chunk (~700 KB combined) on **every** CLI invocation, including `pome --version` — not lazily, despite CHANGELOG.md's 0.21.0 entry and `registry.ts`'s own header comment both claiming per-twin lazy chunks. Confirmed with an ESM loader hook tracing actual module loads against the real published tarball.

**Correction after independent review** (which re-traced this in the built `dist/` bundle rather than trusting source alone): the root cause is **two separate static-import chains**, not one, and my original "slack/stripe are correctly lazy" claim doesn't hold up either:
- `cli/src/task/parseTask.ts` (imported statically by `main.ts`) top-level-imports `defaultSeedState`/`seedSchema` from `@pome-sh/twin-{github,gmail,linear}` — the chain I originally named.
- `cli/src/cli/checks.ts` (imported statically by `main.ts`, **not mentioned in my original write-up**) top-level-imports each twin's `CHECKS` array from its `/checks` subpath. gmail/linear's `/checks` chunks pull in `defineTwin`/`openTwinDatabase`/`createApp` (full domain/server factory) because their `checks.ts` isn't cleanly separated from domain code — likely the *larger* contributor to the ~700 KB, not `parseTask.ts`.
- Slack's `/checks` chunk also loads on every invocation (same static chain) — it's just small enough (16 KB) not to show up as "the full domain chunk." Github/stripe's `CHECKS` arrays are inlined directly into `main.js` rather than split into a chunk, so calling them "lazy" was inaccurate too — they're just cheap to inline.

Net: a follow-up scoped only to `parseTask.ts`'s seed-resolution call sites will fix roughly half the problem and leave `checks.ts`'s per-twin `/checks` static imports — probably the bigger piece — untouched. The follow-up ticket should scope both files, and re-verify "lazy" claims for all 5 twins empirically (chunk-load tracing against the built tarball) rather than by reading `registry.ts`'s header comment.

Fixing this safely still means threading async through several synchronous helper call paths (1022+ existing tests exercise them) — a bigger, riskier change than belongs in this audit's fix PR.

## Test plan

- [x] `npx vitest run --no-file-parallelism` — 1022/1022 passing (cli workspace)
- [x] `tsc --noEmit` — clean
- [x] New e2e coverage (`cli/test/e2e/twinReset.test.ts`) exercises `twin reset` against every twin in `TWIN_NAME_LIST`, plus the unknown-twin error text for both `twin reset` and `twin start`, plus `twin start --help` completeness
- [x] Manually verified against the real installed `@pome-sh/cli@0.21.1` tarball in a clean temp dir: `twin reset linear` now succeeds, `twin start --help` lists linear, unknown-twin error lists all five names
- [x] Manually verified the fixed quickstart end to end from a rebuilt dist: `pome init && pome run --local tasks/01-bug-happy-path.md` now records 3 real `TwinHttpEvent`s (label + assignee mutations) instead of an empty trace
- [x] Independent review verified all 3 fixes correct, the new test non-tautological (drives the real CLI via a spawned subprocess), and re-traced the lazy-chunk claim independently against the built dist (found the diagnosis above needed correcting, applied here)