### PR TITLE
Each twin is actually a lazily-loaded chunk now (F-1306)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,16 @@ jobs:
       # F-778 — the legacy D/P criterion markers are retired; fail on any
       # reintroduction outside the parser's own legacy-detection code.
       - run: node scripts/lint-legacy-criterion-markers.mjs
+      # F-1306 — "each twin is a lazily-loaded chunk" was a comment in
+      # registry.ts and a 0.21.0 headline, and it was false for github, gmail and
+      # linear for six releases: five modules on the CLI's startup path imported
+      # those twins' package ROOTS to reach a zod seed schema, and a root export
+      # carries the domain and the Hono app too. `pome --version` parsed 698 KB of
+      # three twin servers. Nothing failed, so nothing noticed — it took a manual
+      # audit. Static-graph walk, no build and no install needed, so it belongs in
+      # this block rather than behind the heavy gate.
+      - run: node scripts/check-twin-chunk-laziness.mjs
+      - run: node scripts/check-twin-chunk-laziness.test.mjs
       # F-745 / D4 — no catch-and-continue in the SDK twin engine
       # (packages/sdk/src): every statement catch must throw, return an
       # error/sentinel, or reject. Dependency-free, runs before `npm ci`.

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,63 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.21.6
+
+### Patch Changes
+
+- **"Each twin is a lazily-loaded chunk" is now true** (F-1306). 0.21.0 shipped
+  that sentence as a headline, `cli/src/twin/registry.ts` says it in its header,
+  and `cli/tsup.config.ts` says it again. For three of the five twins it was
+  false, and had been for six releases. Measured against the built bundle with an
+  ESM loader hook that logs every module Node actually loads:
+
+  | invocation | before | after | Δ |
+  | --- | --- | --- | --- |
+  | `pome --version` | 1183.6 KB (19 files) | **587.1 KB** (22 files) | **−596.5 KB (−50%)** |
+  | `pome twin start github` | 1187.9 KB (21 files) | **791.4 KB** (24 files) | **−396.5 KB (−33%)** |
+
+  On `pome --version` — a command that reads a build-time constant and exits —
+  github's, gmail's and linear's full domains loaded: their SQLite schemas, their
+  Hono apps, their REST route tables, and linear's GraphQL executor. 697.9 KB of
+  three twin servers, parsed to print `0.21.5`. Now none of the five load, and
+  `pome twin start github` pays for github alone instead of also parsing gmail's
+  and linear's servers (492.8 KB → 0 KB).
+
+  **The cause was one import chain, not the bundler.** `splitting: true` and the
+  `import()` calls in `TWIN_REGISTRY` were doing their job; six modules on the
+  startup path defeated them by top-level-importing the twins' PACKAGE ROOTS to
+  reach a zod seed schema — `task/parseTask.ts`, `task/taskSchema.ts`,
+  `task/githubSeedCompat.ts`, `task/seed-compiler.ts` and
+  `task/seed-compiler-hosted.ts` — plus `task/seed-verifier.ts`, which really does
+  want `GitHubDomain` but is only reachable from `pome compile-seeds`. A root
+  export also carries the domain and the server, so wanting `seedSchema` bought
+  the whole twin.
+
+  The fix does not thread `async` through the parser. Each twin's `seed.ts` was
+  already a pure-data leaf (zod and nothing else), so it is now published as a
+  `./seed` subpath and the five schema readers import that instead — same
+  synchronous signatures, no test call site changed. `seed-verifier.ts`, the one
+  genuine domain consumer, became `async` behind an `import()`.
+
+- **A twin's assertable vocabulary no longer drags its tool table along.**
+  `@pome-sh/twin-github/checks` is loaded on every invocation on purpose —
+  `pome checks` lists, looks up and digests the vocabulary synchronously — but
+  `check-params.ts` read the two-element `TAPE_ASSERTABLE_TOOLS` list from
+  `tools.ts`, which is 649 lines of zod tool schemas and `executeTool`'s domain
+  dispatch. The constant moved to its own module (`tools.ts` re-exports it, so
+  nothing else moved), taking 33.8 KB out of the always-loaded set. The other four
+  twins' check graphs were already clean; this was the only accidental edge.
+
+- **A gate now asserts it**, because the claim above went six releases unchecked
+  and was found by a manual audit rather than by CI.
+  `scripts/check-twin-chunk-laziness.mjs` walks the CLI's static import graph and
+  fails if it reaches any twin's package root, `db.ts` or `domain/` — and fails
+  just as loudly if a twin's `checks.ts` STOPS being reachable, since the cheap
+  way to pass a laziness gate is to break `pome checks`. It reads the twins' real
+  `exports` maps, needs no build, and has its own nine-case regression suite
+  (`scripts/check-twin-chunk-laziness.test.mjs`) whose first job is proving the
+  gate can go red.
+
 ## 0.21.5
 
 ### Patch Changes

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.21.5",
+  "version": "0.21.6",
   "description": "Digital-twin testing for AI agents — run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/cli/src/cli/compile-seeds.ts
+++ b/cli/src/cli/compile-seeds.ts
@@ -166,7 +166,7 @@ async function compileOne(taskPath: string, opts: CompileOptions): Promise<FileR
   }
 
   try {
-    verifySeedWithTwin(result.seed);
+    await verifySeedWithTwin(result.seed);
   } catch (err) {
     return { path: taskPath, status: "error", message: (err as Error).message };
   }

--- a/cli/src/task/githubSeedCompat.ts
+++ b/cli/src/task/githubSeedCompat.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-import { parseSeed, seedSchema } from "@pome-sh/twin-github";
+// `/seed`, not the package root (F-1306) — see `parseTask.ts`'s note.
+import { parseSeed, seedSchema } from "@pome-sh/twin-github/seed";
 
 // Bundled scenario sidecars and legacy compile output used singular `assignee`
 // on issues; @pome-sh/twin-github's seedSchema expects `assignees[]`. Zod strips

--- a/cli/src/task/parseTask.ts
+++ b/cli/src/task/parseTask.ts
@@ -4,15 +4,22 @@ import { readFile } from "node:fs/promises";
 import { basename, extname } from "node:path";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
-import { defaultSeedState, seedSchema } from "@pome-sh/twin-github";
+// The `/seed` SUBPATH, never the package root (F-1306). What this module wants
+// from a twin is its zod seed schema and its default world — pure data. The root
+// export additionally carries the domain, the SQLite schema, the Hono app and
+// (for linear) a GraphQL executor, and `main.ts` reaches this module on every
+// invocation, so importing the root here made `pome --version` parse three twins'
+// entire server. `seed.ts` in each twin imports nothing but `zod`, so the
+// subpath is a leaf. See `cli/src/twin/registry.ts` for the lazy boot path.
+import { defaultSeedState, seedSchema } from "@pome-sh/twin-github/seed";
 import {
   defaultSeedState as defaultGmailSeedState,
   gmailSeedSchema,
-} from "@pome-sh/twin-gmail";
+} from "@pome-sh/twin-gmail/seed";
 import {
   defaultSeedState as defaultLinearSeedState,
   linearSeedSchema as linearSeedStateSchema,
-} from "@pome-sh/twin-linear";
+} from "@pome-sh/twin-linear/seed";
 import { parseGitHubSeedState } from "./githubSeedCompat.js";
 import {
   criterionSchema,

--- a/cli/src/task/seed-compiler-hosted.ts
+++ b/cli/src/task/seed-compiler-hosted.ts
@@ -16,7 +16,8 @@ import { z } from "zod";
 import { resolveCredentials } from "../cli/credentials.js";
 import { HostedAuthError, HostedOrchError, HostedQuotaError } from "../hosted/errors.js";
 import { parseGitHubSeedState } from "./githubSeedCompat.js";
-import { seedSchema as seedStateSchema } from "@pome-sh/twin-github";
+// `/seed`, not the package root (F-1306) — see `parseTask.ts`'s note.
+import { seedSchema as seedStateSchema } from "@pome-sh/twin-github/seed";
 import type { CompileResult } from "./seed-compiler.js";
 
 const DEFAULT_TIMEOUT_MS = 60_000;

--- a/cli/src/task/seed-compiler.ts
+++ b/cli/src/task/seed-compiler.ts
@@ -14,7 +14,8 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { zodOutputFormat } from "@anthropic-ai/sdk/helpers/zod";
 import { parseGitHubSeedState } from "./githubSeedCompat.js";
-import { seedSchema as seedStateSchema } from "@pome-sh/twin-github";
+// `/seed`, not the package root (F-1306) — see `parseTask.ts`'s note.
+import { seedSchema as seedStateSchema } from "@pome-sh/twin-github/seed";
 
 export const COMPILER_MODEL = "claude-opus-4-7";
 

--- a/cli/src/task/seed-verifier.ts
+++ b/cli/src/task/seed-verifier.ts
@@ -7,10 +7,18 @@
  * referencing a branch with no files.
  *
  * Throws if the twin rejects the seed; otherwise returns silently.
+ *
+ * ASYNC because the twin import is DYNAMIC (F-1306). This is the one seed-side
+ * module that genuinely needs the github twin's domain and SQLite schema — every
+ * other one wants only the zod schema and reads it from `@pome-sh/twin-github/seed`.
+ * A top-level import here put 205 KB of domain into the CLI's startup path via
+ * `main.ts → compile-seeds.ts`, on every invocation including `pome --version`,
+ * to serve one command. `import()` inside the function is the same shape
+ * `cli/src/twin/registry.ts` uses to keep each twin's boot lazy.
  */
-import { GitHubDomain, openGitHubCloneDatabase } from "@pome-sh/twin-github";
 
-export function verifySeedWithTwin(seed: unknown): void {
+export async function verifySeedWithTwin(seed: unknown): Promise<void> {
+  const { GitHubDomain, openGitHubCloneDatabase } = await import("@pome-sh/twin-github");
   // `:memory:` SQLite — torn down when this function returns and `db`
   // goes out of scope. No filesystem side-effects, no cleanup needed.
   const db = openGitHubCloneDatabase(":memory:");

--- a/cli/src/task/taskSchema.ts
+++ b/cli/src/task/taskSchema.ts
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
-import { seedSchema as githubSeedStateSchema } from "@pome-sh/twin-github";
-import { gmailSeedSchema as gmailSeedStateSchema } from "@pome-sh/twin-gmail";
-import { linearSeedSchema as linearSeedStateSchema } from "@pome-sh/twin-linear";
+// The `/seed` subpath, not the package root (F-1306): a schema is data, and the
+// roots carry each twin's domain + server. See `parseTask.ts`'s note.
+import { seedSchema as githubSeedStateSchema } from "@pome-sh/twin-github/seed";
+import { gmailSeedSchema as gmailSeedStateSchema } from "@pome-sh/twin-gmail/seed";
+import { linearSeedSchema as linearSeedStateSchema } from "@pome-sh/twin-linear/seed";
 // Criterion kinds are owned by the published contract. The markdown marker
 // grammar is `[code]`/`[model]` (F-778); `criterionSchema`'s tolerant input
 // (legacy `D`/`P` enum values) exists only for 0.3.0-era persisted artifacts,

--- a/cli/src/twin/registry.ts
+++ b/cli/src/twin/registry.ts
@@ -15,6 +15,21 @@
 //      all five twins (and five SQLite schemas) into the CLI's startup path;
 //   2. `pome twin start github` only pays for github.
 //
+// THIS MODULE IS NOT THE WHOLE STORY, and for six releases it was the wrong
+// half of it (F-1306). Everything above was true here and false in aggregate:
+// `cli/src/task/{parseTask,taskSchema,githubSeedCompat,seed-compiler,
+// seed-compiler-hosted}.ts` top-level-imported twin-github/gmail/linear's
+// PACKAGE ROOTS to reach a zod seed schema, and a root export carries the domain
+// and the Hono app too — so `pome --version` parsed 698 KB of three twin servers
+// while this file's header said it did not. A twin's laziness is a property of
+// the CLI's whole static graph, not of this file.
+//
+// If you need a twin's seed schema or its default world, import its `./seed`
+// subpath: `seed.ts` is a zod-only leaf, and that is why the fix needed no
+// `async` threading. `scripts/check-twin-chunk-laziness.mjs` is the standing
+// gate — it fails on any static edge from the CLI to a twin's root, `db.ts` or
+// `domain/`, so this comment cannot go stale again without CI saying so.
+//
 // `version` is the exception: it is a build-time JSON import of the twin's own
 // manifest, so it is inlined into the bundle and needs no module resolution at
 // runtime. `cli/src/recorder/specMeta.ts` reports these in every run's

--- a/cli/tsup.config.ts
+++ b/cli/tsup.config.ts
@@ -11,6 +11,13 @@
 // mean each twin lands in its own lazily-loaded chunk: `pome twin start github`
 // never parses the other four twins or their SQLite schemas.
 //
+// Necessary but NOT sufficient, which is why F-1306 exists: splitting can only
+// defer what nothing on the startup path statically imports, and five modules
+// under `src/task/` imported three twins' package roots for a zod seed schema.
+// Both settings were doing their job and the claim was still false —
+// `pome --version` loaded 1183.6 KB, of which 697.9 KB was three twin servers.
+// `scripts/check-twin-chunk-laziness.mjs` asserts the graph these settings need.
+//
 // Entry name is `src/cli/main` rather than the default `main` deliberately —
 // `dist/src/cli/main.js` is the `bin` target, the path `contract/cli-start.test.mjs`
 // spawns, and the path quickstart-smoke runs. Keeping it identical means no

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lint:parent-vocab": "node scripts/lint-parent-vocab.mjs",
     "lint:task-class": "node scripts/lint-task-class.mjs",
     "lint:skill-manifest": "node scripts/check-plugin-manifest-lists-every-skill.mjs",
+    "lint:twin-chunks": "node scripts/check-twin-chunk-laziness.mjs",
     "lint:dead-code": "knip --no-config-hints",
     "gate:bundled-deps": "node scripts/check-bundled-runtime-deps.mjs"
   },

--- a/packages/twin-github/CHANGELOG.md
+++ b/packages/twin-github/CHANGELOG.md
@@ -1,6 +1,23 @@
 # @pome-sh/twin-github — CHANGELOG
 
 
+## 0.9.1 — 2026-08-06
+
+Two additive changes, no behavior change (F-1306).
+
+- New `./seed` subpath export: `seedSchema`, `parseSeed` and `defaultSeedState`
+  from a module whose only import is `zod`. The CLI needs a seed schema on its
+  startup path and was reading it from the package ROOT, which also exports
+  `GitHubDomain`, `openGitHubCloneDatabase` and `createGitHubCloneApp` — so a
+  schema lookup pulled 200 KB of twin into `pome --version`. The root keeps
+  exporting all three names.
+- `TAPE_ASSERTABLE_TOOLS` moved from `tools.ts` to `tape-assertable-tools.ts`
+  (`tools.ts` re-exports it, so `routes.ts`, the root and
+  `test/tool-stamping.test.ts` are unchanged). `check-params.ts` reads it, and
+  `./checks` is loaded on every CLI invocation because `pome checks` needs the
+  vocabulary synchronously — which meant 649 lines of tool schemas and
+  `executeTool`'s domain dispatch loaded with it.
+
 ## 0.9.0 — 2026-08-04
 
 `No new issues were created in \`<repo>\`` is declarable, and the curriculum's

--- a/packages/twin-github/package.json
+++ b/packages/twin-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-github",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Deterministic GitHub-shaped twin for agent testing — REST + MCP, SQLite-backed state.",
   "private": true,
   "type": "module",
@@ -18,6 +18,10 @@
     "./checks": {
       "types": "./dist/src/checks.d.ts",
       "default": "./dist/src/checks.js"
+    },
+    "./seed": {
+      "types": "./dist/src/seed.d.ts",
+      "default": "./dist/src/seed.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/twin-github/src/check-params.ts
+++ b/packages/twin-github/src/check-params.ts
@@ -13,7 +13,11 @@
 // repair — the sentence should be re-rendered from the check instead.
 
 import { oneOf, type CheckParamType } from "@pome-sh/sdk/checks";
-import { TAPE_ASSERTABLE_TOOLS } from "./tools.js";
+// From the standalone data module, NOT from `./tools.js` (F-1306): this file is
+// in the eager import graph of `@pome-sh/twin-github/checks`, which the CLI
+// loads on every invocation, and `tools.ts` carries ~40 zod tool schemas plus
+// `executeTool`'s domain dispatch. `tools.ts` re-exports the same constant.
+import { TAPE_ASSERTABLE_TOOLS } from "./tape-assertable-tools.js";
 
 // Issue and pull-request numbers. `[1-9][0-9]*` rather than `\d+`: GitHub
 // numbers entities from 1, so `#0` names nothing and `#01` is a different

--- a/packages/twin-github/src/tape-assertable-tools.ts
+++ b/packages/twin-github/src/tape-assertable-tools.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The actions the recorder stamps on BOTH the MCP and the REST door.
+//
+// This is DATA, and it lives alone (F-1306). It used to live in `tools.ts`, next
+// to `executeTool` and ~40 zod tool schemas, and `check-params.ts` imported it
+// from there — which put the twin's entire MCP tool dispatch into the import
+// graph of `@pome-sh/twin-github/checks`, a module whose whole job is to hand a
+// CLI a list of assertable sentences. `pome checks` needs those sentences
+// synchronously, so that subpath is loaded on every CLI invocation; 649 lines of
+// tool schemas rode along for a two-element string list.
+//
+// `tools.ts` re-exports the constant, so `routes.ts`, the package root and
+// `test/tool-stamping.test.ts` all still read it from where they always did.
+//
+// ── Why the set is exactly these two ──────────────────────────────────────────
+//
+// `create_commit_status` and `create_check_run` are the only tools whose REST
+// route is stamped with the same action name as their MCP tool dispatch. That is
+// what makes `create_commit_status was never called` answerable: an agent that
+// fabricates a status via `POST /repos/:owner/:repo/statuses/:sha` must fail the
+// check exactly as one going through `tools/call` does.
+//
+// The set is small on purpose and MUST NOT be widened by editing this line
+// alone. This twin has ~40 tools and only these two have their REST route
+// stamped; adding a third name without stamping its route would hand the check
+// a sentence it cannot honour — "never called" over a run that called it by
+// REST, the negative false-pass D4 forbids outright. `tool` is `null` on every
+// unstamped surface, and `null` means "no declared action for this surface",
+// never "no action happened".
+//
+// Two things make that hard to get wrong: `test/tool-stamping.test.ts` keeps one
+// REST probe per member and asserts its key set equals this set, and
+// `toolActionName`'s param pattern is generated from this set, so a criterion
+// cannot name an action outside it.
+export const TAPE_ASSERTABLE_TOOLS = ["create_commit_status", "create_check_run"] as const;

--- a/packages/twin-github/src/tools.ts
+++ b/packages/twin-github/src/tools.ts
@@ -450,26 +450,15 @@ export function isMutatingTool(name: string) {
 
 // F-1125 — the actions a tape check may assert "was never called" about.
 //
-// Membership is a PROMISE, not a label: every name here is stamped as
-// `RecorderEvent.tool` on BOTH doors an agent can reach the action through —
-// the MCP tool dispatch and the REST route that performs the same thing. That
-// is what makes `create_commit_status was never called` answerable, because an
-// agent that fabricates a status via `POST /repos/:owner/:repo/statuses/:sha`
-// must fail the check exactly as one going through `tools/call` does.
-//
-// The set is small on purpose and MUST NOT be widened by editing this line
-// alone. This twin has ~40 tools and only these two have their REST route
-// stamped; adding a third name without stamping its route would hand the check
-// a sentence it cannot honour — "never called" over a run that called it by
-// REST, the negative false-pass D4 forbids outright. `tool` is `null` on every
-// unstamped surface, and `null` means "no declared action for this surface",
-// never "no action happened".
-//
-// Two things make that hard to get wrong: `test/tool-stamping.test.ts` keeps one
-// REST probe per member and asserts its key set equals this set, and
-// `toolActionName`'s param pattern is generated from this set, so a criterion
-// cannot name an action outside it.
-export const TAPE_ASSERTABLE_TOOLS = ["create_commit_status", "create_check_run"] as const;
+// The constant MOVED to `./tape-assertable-tools.js` (F-1306) and is re-exported
+// here so `routes.ts`, the package root and `test/tool-stamping.test.ts` keep
+// reading it from where they always did. It left because `check-params.ts` reads
+// it too, and importing it from this module put ~40 zod tool schemas and
+// `executeTool`'s whole domain dispatch into the import graph of
+// `@pome-sh/twin-github/checks` — a subpath the CLI loads on every invocation
+// because `pome checks` needs the vocabulary synchronously. See that file for
+// why membership is a promise rather than a label.
+export { TAPE_ASSERTABLE_TOOLS } from "./tape-assertable-tools.js";
 
 export function executeTool(
   domain: GitHubDomain,

--- a/packages/twin-gmail/CHANGELOG.md
+++ b/packages/twin-gmail/CHANGELOG.md
@@ -1,6 +1,18 @@
 # @pome-sh/twin-gmail — CHANGELOG
 
 
+## 0.3.4 — 2026-08-06
+
+New `./seed` subpath export (F-1306): `gmailSeedSchema`, `parseSeed`,
+`defaultSeedState` and the rest of `seed.ts` — a module whose only imports are
+`zod` and this twin's own fault/search-query validators. Nothing else changed.
+
+The CLI's task parser needs a seed schema on its startup path and was reading it
+from the package ROOT, which also exports `GmailDomain`, `openGmailTwinDatabase`
+and `createGmailTwinApp`. A schema lookup therefore loaded 252 KB of this twin's
+domain, REST routes and MCP surface on every `pome` invocation, including
+`pome --version`. The root keeps exporting all of these names.
+
 ## 0.3.3 — 2026-08-04
 
 Dependency-only patch (#302): `hono` `^4.12.31` → `^4.13.0`, `zod` `^4.1.13` → `^4.4.3`, `@hono/node-server` `^2.0.10` → `^2.1.0`.

--- a/packages/twin-gmail/package.json
+++ b/packages/twin-gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-gmail",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Deterministic Gmail-shaped twin for agent testing — SQLite-backed domain core.",
   "private": true,
   "type": "module",
@@ -18,6 +18,10 @@
     "./checks": {
       "types": "./dist/src/checks.d.ts",
       "default": "./dist/src/checks.js"
+    },
+    "./seed": {
+      "types": "./dist/src/seed.d.ts",
+      "default": "./dist/src/seed.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/twin-linear/CHANGELOG.md
+++ b/packages/twin-linear/CHANGELOG.md
@@ -1,6 +1,19 @@
 # @pome-sh/twin-linear — CHANGELOG
 
 
+## 0.3.4 — 2026-08-06
+
+New `./seed` subpath export (F-1306): `linearSeedSchema`, `parseSeed`,
+`defaultSeedState` and the rest of `seed.ts` — a module whose only imports are
+`zod`, `./types.js` and `./webhook-url.js`. Nothing else changed.
+
+The CLI's task parser needs a seed schema on its startup path and was reading it
+from the package ROOT, which also exports `LinearDomain`,
+`openLinearTwinDatabase` and `createLinearTwinApp`. A schema lookup therefore
+loaded 241 KB of this twin's domain, GraphQL executor and MCP surface on every
+`pome` invocation, including `pome --version`. The root keeps exporting all of
+these names.
+
 ## 0.3.3 — 2026-08-04
 
 Dependency-only patch (#302): `hono` `^4.12.31` → `^4.13.0`, `zod` `^4.1.13` → `^4.4.3`, `@hono/node-server` `^2.0.10` → `^2.1.0`.

--- a/packages/twin-linear/package.json
+++ b/packages/twin-linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-linear",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Deterministic Linear-shaped twin for agent testing — SQLite-backed GraphQL + MCP + OAuth.",
   "private": true,
   "type": "module",
@@ -18,6 +18,10 @@
     "./checks": {
       "types": "./dist/src/checks.d.ts",
       "default": "./dist/src/checks.js"
+    },
+    "./seed": {
+      "types": "./dist/src/seed.d.ts",
+      "default": "./dist/src/seed.js"
     },
     "./package.json": "./package.json"
   },

--- a/scripts/check-twin-chunk-laziness.mjs
+++ b/scripts/check-twin-chunk-laziness.mjs
@@ -1,0 +1,308 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+//
+// The gate that makes "each twin is a lazily-loaded chunk" a fact instead of a
+// comment (F-1306).
+//
+// `cli/tsup.config.ts` and `cli/src/twin/registry.ts` both claim it, and
+// CHANGELOG 0.21.0 shipped it as a headline. It was false for three of the five
+// twins for five releases: `cli/src/task/{parseTask,taskSchema,githubSeedCompat,
+// seed-compiler,seed-compiler-hosted}.ts` top-level-imported the PACKAGE ROOT of
+// twin-github/gmail/linear to reach a zod seed schema, and `seed-verifier.ts`
+// imported the root to reach `GitHubDomain`. Each of those roots also exports the
+// twin's domain, its SQLite schema and its Hono app, so `pome --version` parsed
+// ~600 KB of three twins' servers. Nothing failed; the claim just stopped being
+// true, quietly, and was found by an audit rather than by CI.
+//
+// The rule is structural, so it cannot drift as twins grow:
+//
+//   The CLI's STATIC import graph must not reach any twin's package root
+//   (`src/index.ts`), its database module (`src/db.ts`), or anything under
+//   `src/domain/`. A twin's domain is reached through `import()` inside
+//   `TWIN_REGISTRY`'s own methods — nowhere else.
+//
+// and the complement is asserted too, because the cheap way to pass a
+// laziness gate is to break a command:
+//
+//   Every twin's `src/checks.ts` MUST stay statically reachable. `pome checks`
+//   lists, looks up and digests the declared vocabulary synchronously; deferring
+//   it behind `import()` would move the cost, not remove it, and would turn
+//   `findCheck`/`twinOf` async for no gain.
+//
+// Dependency-free and build-free on purpose: it reads TypeScript sources and the
+// twins' real `exports` maps, so it runs in CI's always-on block before `npm ci`,
+// and it cannot disagree with the bundler about which subpath resolves where.
+//
+// Usage: node scripts/check-twin-chunk-laziness.mjs [--verbose]
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+
+// `process.cwd()`, as `lint-parent-vocab.mjs` and `lint-task-class.mjs` do: CI
+// runs every gate from the repo root, and it lets the regression suite point the
+// real script at a throwaway tree instead of at this repo.
+const ROOT = process.cwd();
+const ENTRY = resolve(ROOT, "cli/src/cli/main.ts");
+const VERBOSE = process.argv.includes("--verbose");
+
+/** Workspace `@pome-sh/*` specifiers → source file, read from each package's
+ *  own `exports` map so a renamed subpath cannot silently stop being checked. */
+function buildSpecifierMap() {
+  const map = new Map();
+  const packagesDir = join(ROOT, "packages");
+  if (!existsSync(packagesDir)) return map;
+  for (const dir of readdirSync(packagesDir)) {
+    const manifestPath = join(packagesDir, dir, "package.json");
+    if (!existsSync(manifestPath)) continue;
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    if (!manifest.name?.startsWith("@pome-sh/")) continue;
+    for (const [subpath, target] of Object.entries(manifest.exports ?? {})) {
+      // `{ types, default }` conditions or a bare string; either way we want the
+      // JS target, then map `dist/src/foo.js` (or `dist/foo.js`) back to source.
+      const js = typeof target === "string" ? target : target.default;
+      if (typeof js !== "string" || !js.endsWith(".js")) continue;
+      const sourceRel = js
+        .replace(/^\.\//, "")
+        .replace(/^dist\/(?:src\/)?/, "src/")
+        .replace(/\.js$/, ".ts");
+      const sourcePath = join(packagesDir, dir, sourceRel);
+      if (!existsSync(sourcePath)) continue;
+      const specifier = subpath === "." ? manifest.name : `${manifest.name}${subpath.slice(1)}`;
+      map.set(specifier, sourcePath);
+    }
+  }
+  return map;
+}
+
+const SPECIFIERS = buildSpecifierMap();
+
+/**
+ * Blank out comments and string/template bodies, keeping newlines so the text
+ * stays line-addressable.
+ *
+ * Load-bearing, not hygiene: `cli/src/cli/init-sdk.ts` embeds the scaffolded
+ * agent's SOURCE in a template literal, and that source contains
+ * `import { query, tool, withPome } from "@pome-sh/adapter-claude-sdk";`. A
+ * regex over raw text reads that as a real edge and reports a package the CLI
+ * never imports — and by the same mistake would report a twin root as eager
+ * because a scaffold string mentions one. Scaffolds are the one place this repo
+ * writes import statements it does not execute, and it writes several.
+ */
+function stripNonCode(source) {
+  const blank = (text) => text.replace(/[^\n]/g, " ");
+  let out = "";
+  let index = 0;
+  while (index < source.length) {
+    const char = source[index];
+    const next = source[index + 1];
+    if (char === "/" && next === "/") {
+      const end = source.indexOf("\n", index);
+      const stop = end === -1 ? source.length : end;
+      out += blank(source.slice(index, stop));
+      index = stop;
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      const end = source.indexOf("*/", index + 2);
+      const stop = end === -1 ? source.length : end + 2;
+      out += blank(source.slice(index, stop));
+      index = stop;
+      continue;
+    }
+    if (char === "`") {
+      let cursor = index + 1;
+      while (cursor < source.length && source[cursor] !== "`") {
+        cursor += source[cursor] === "\\" ? 2 : 1;
+      }
+      const stop = Math.min(cursor + 1, source.length);
+      out += blank(source.slice(index, stop));
+      index = stop;
+      continue;
+    }
+    out += char;
+    index += 1;
+  }
+  return out;
+}
+// Ordinary quoted strings are left alone deliberately: they cannot span lines, and
+// every pattern below is anchored to the start of one, so a specifier inside a
+// single-line string can never sit where an import statement would.
+
+/**
+ * Runtime static import specifiers in one TypeScript source.
+ *
+ * Type-only edges are EXCLUDED because they are erased before the bundler sees
+ * them — both the `import type` / `export type` form and the form where every
+ * named binding is individually marked (`import { type A, type B } from …`).
+ * Counting either would fail this gate on an edge that emits no code, which is
+ * the failure mode that gets a gate deleted rather than fixed.
+ *
+ * `import()` is EXCLUDED because a dynamic import is the thing this gate wants.
+ */
+function staticImportSpecifiers(rawSource) {
+  const source = stripNonCode(rawSource);
+  const found = [];
+  const pattern =
+    /^[ \t]*(?:import|export)\b([\s\S]*?)from\s*["']([^"']+)["']|^[ \t]*import\s*["']([^"']+)["']/gm;
+  let match;
+  while ((match = pattern.exec(source)) !== null) {
+    const specifier = match[2] ?? match[3];
+    const clause = match[1] ?? "";
+    if (/^\s*type\b/.test(clause)) continue;
+    const braced = clause.match(/\{([\s\S]*)\}/);
+    if (braced) {
+      const named = braced[1]
+        .split(",")
+        .map((part) => part.trim())
+        .filter(Boolean);
+      const hasDefaultOrNamespace = /^\s*(?:[A-Za-z_$][\w$]*\s*,|\*)/.test(clause);
+      if (named.length > 0 && !hasDefaultOrNamespace && named.every((n) => /^type\s/.test(n))) {
+        continue;
+      }
+    }
+    found.push(specifier);
+  }
+  return found;
+}
+
+function resolveSpecifier(specifier, fromFile) {
+  if (specifier.startsWith(".")) {
+    const base = resolve(dirname(fromFile), specifier);
+    const candidates = base.endsWith(".js")
+      ? [`${base.slice(0, -3)}.ts`]
+      : [base, `${base}.ts`, join(base, "index.ts")];
+    return candidates.find((candidate) => existsSync(candidate) && candidate.endsWith(".ts")) ?? null;
+  }
+  // Third-party, node builtins and JSON asset imports carry no twin edges.
+  return SPECIFIERS.get(specifier) ?? null;
+}
+
+/** Files statically reachable from `entry`, each mapped to the file that first
+ *  pulled it in — so a violation can be reported as a chain a human can follow. */
+function reachable(entry) {
+  const importedBy = new Map([[entry, null]]);
+  const stack = [entry];
+  while (stack.length > 0) {
+    const file = stack.pop();
+    let source;
+    try {
+      source = readFileSync(file, "utf8");
+    } catch {
+      continue;
+    }
+    for (const specifier of staticImportSpecifiers(source)) {
+      const target = resolveSpecifier(specifier, file);
+      if (target === null || importedBy.has(target)) continue;
+      importedBy.set(target, file);
+      stack.push(target);
+    }
+  }
+  return importedBy;
+}
+
+function chainFor(file, importedBy) {
+  const chain = [];
+  for (let current = file; current; current = importedBy.get(current)) {
+    chain.push(relative(ROOT, current));
+  }
+  return chain.reverse();
+}
+
+const TWIN_DIRS = existsSync(join(ROOT, "packages"))
+  ? readdirSync(join(ROOT, "packages")).filter((dir) => dir.startsWith("twin-"))
+  : [];
+
+if (TWIN_DIRS.length === 0) {
+  // A gate that silently passes on an empty tree reads as coverage it does not
+  // have — the lesson `lint-parent-vocab.test.mjs` case 2 records.
+  console.error(`No packages/twin-* found under ${ROOT}. Run this from the repo root.`);
+  process.exit(1);
+}
+
+if (!existsSync(ENTRY)) {
+  console.error(`CLI entry not found: ${relative(ROOT, ENTRY)}. Run this from the repo root.`);
+  process.exit(1);
+}
+
+/** Reaching any of these means the twin's whole server came along: `index.ts` is
+ *  the barrel that exports it, `db.ts` is the SQLite schema, `domain/` is the
+ *  state machine. Every other twin module worth deferring hangs off one of them. */
+function domainViolation(file) {
+  const rel = relative(ROOT, file).split("/").join("/");
+  for (const dir of TWIN_DIRS) {
+    const prefix = `packages/${dir}/`;
+    if (!rel.startsWith(prefix)) continue;
+    const inside = rel.slice(prefix.length);
+    if (inside === "src/index.ts") return { twin: dir, what: "package root (exports the domain and the Hono app)" };
+    if (inside === "src/db.ts") return { twin: dir, what: "SQLite schema" };
+    if (inside.startsWith("src/domain/")) return { twin: dir, what: "domain" };
+  }
+  return null;
+}
+
+const importedBy = reachable(ENTRY);
+const violations = [];
+for (const file of importedBy.keys()) {
+  const hit = domainViolation(file);
+  if (hit) violations.push({ file, ...hit });
+}
+
+const missingChecks = TWIN_DIRS.map((dir) => join(ROOT, "packages", dir, "src/checks.ts"))
+  .filter((path) => existsSync(path))
+  .filter((path) => !importedBy.has(path));
+
+if (VERBOSE) {
+  const perPackage = new Map();
+  for (const file of importedBy.keys()) {
+    const rel = relative(ROOT, file);
+    const key = rel.startsWith("packages/") ? rel.split("/").slice(0, 2).join("/") : "cli";
+    perPackage.set(key, (perPackage.get(key) ?? 0) + 1);
+  }
+  console.log(`Statically reachable from ${relative(ROOT, ENTRY)}: ${importedBy.size} files`);
+  for (const [key, count] of [...perPackage].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${String(count).padStart(4)}  ${key}`);
+  }
+}
+
+let failed = false;
+
+if (violations.length > 0) {
+  failed = true;
+  console.error(
+    `\n${violations.length} twin module(s) are STATICALLY reachable from the CLI entry — they load on every ` +
+      `\`pome\` invocation, including \`pome --version\`:\n`,
+  );
+  for (const violation of violations) {
+    console.error(`  ${relative(ROOT, violation.file)}  — ${violation.twin}'s ${violation.what}`);
+    for (const [index, step] of chainFor(violation.file, importedBy).entries()) {
+      console.error(`      ${index === 0 ? "" : "-> "}${step}`);
+    }
+    console.error("");
+  }
+  console.error(
+    "Reach a twin's domain through `import()` inside its `TWIN_REGISTRY` entry\n" +
+      "(cli/src/twin/registry.ts). If all you need is a seed schema or a default\n" +
+      "world, import the twin's `/seed` subpath — it is a zod-only leaf.\n",
+  );
+}
+
+if (missingChecks.length > 0) {
+  failed = true;
+  console.error(
+    `\n${missingChecks.length} twin's declared check vocabulary is NO LONGER statically reachable:\n`,
+  );
+  for (const path of missingChecks) console.error(`  ${relative(ROOT, path)}`);
+  console.error(
+    "\n`pome checks` lists, looks up and digests these synchronously (cli/src/cli/checks.ts).\n" +
+      "Deferring them behind `import()` moves the cost instead of removing it and makes\n" +
+      "`findCheck`/`twinOf`/`localDigest` async for no gain. Keep the static import and\n" +
+      "keep the checks graph free of domain edges instead.\n",
+  );
+}
+
+if (failed) process.exit(1);
+
+console.log(
+  `check-twin-chunk-laziness: OK — ${TWIN_DIRS.length} twins, no domain/db/package-root edge in the ` +
+    `CLI's static graph (${importedBy.size} files), every declared check vocabulary still reachable.`,
+);

--- a/scripts/check-twin-chunk-laziness.test.mjs
+++ b/scripts/check-twin-chunk-laziness.test.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+//
+// Regression suite for `check-twin-chunk-laziness.mjs` (F-1306).
+//
+// The gate exists because a laziness claim went five releases without anyone
+// checking it, so the thing most worth proving is that this gate CAN go red —
+// and goes red on the exact shapes that shipped: an indirect chain through two
+// CLI modules (how `parseTask.ts` did it), and a package-root import for a value
+// that a leaf subpath already exports.
+//
+// Cases 5 and 6 guard the two ways a gate like this quietly stops working: a
+// scaffold's template-literal source counted as a real edge (false red, and the
+// gate gets deleted), and a type-only import counted as a runtime edge (same).
+// Each case builds a throwaway tree and runs the real script against it.
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = resolve(dirname(fileURLToPath(import.meta.url)), "check-twin-chunk-laziness.mjs");
+
+/** A minimal twin: a package root that re-exports domain + seed, a db module, a
+ *  domain module, a zod-free `seed.ts` leaf, and a `checks.ts` the gate requires
+ *  to stay reachable. */
+function twinFiles(name) {
+  const dir = `packages/twin-${name}/`;
+  return {
+    [`${dir}package.json`]: JSON.stringify({
+      name: `@pome-sh/twin-${name}`,
+      exports: {
+        ".": { types: "./dist/src/index.d.ts", default: "./dist/src/index.js" },
+        "./checks": { types: "./dist/src/checks.d.ts", default: "./dist/src/checks.js" },
+        "./seed": { types: "./dist/src/seed.d.ts", default: "./dist/src/seed.js" },
+      },
+    }),
+    [`${dir}src/index.ts`]: [
+      `export { ${name}Domain } from "./domain/index.js";`,
+      `export { open${name}Database } from "./db.js";`,
+      `export { seedSchema } from "./seed.js";`,
+    ].join("\n"),
+    [`${dir}src/db.ts`]: `export function open${name}Database() { return {}; }\n`,
+    [`${dir}src/domain/index.ts`]: `export class ${name}Domain {}\n`,
+    [`${dir}src/seed.ts`]: `export const seedSchema = { parse: (v) => v };\n`,
+    [`${dir}src/checks.ts`]: `export const CHECKS = [];\n`,
+  };
+}
+
+function runAgainst(cliFiles, { twins = ["alpha"] } = {}) {
+  const root = mkdtempSync(join(tmpdir(), "twin-laziness-"));
+  const files = { ...cliFiles };
+  for (const twin of twins) Object.assign(files, twinFiles(twin));
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = join(root, rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, body);
+  }
+  const result = spawnSync(process.execPath, [SCRIPT], { cwd: root, encoding: "utf8" });
+  return { code: result.status, out: `${result.stdout}${result.stderr}` };
+}
+
+let failures = 0;
+function check(name, { files, twins, expect, contains }) {
+  const { code, out } = runAgainst(files, { twins });
+  const got = code === 0 ? "green" : "red";
+  const problems = [];
+  if (got !== expect) problems.push(`expected ${expect}, got ${got}`);
+  if (contains && !out.includes(contains)) problems.push(`output missing ${JSON.stringify(contains)}`);
+  if (problems.length > 0) {
+    failures += 1;
+    console.error(`✗ ${name}\n  ${problems.join("\n  ")}\n${out.replace(/^/gm, "    ")}`);
+  } else {
+    console.log(`✓ ${name}`);
+  }
+}
+
+const MAIN = "cli/src/cli/main.ts";
+const CHECKS_IMPORT = `import { CHECKS } from "@pome-sh/twin-alpha/checks";\nvoid CHECKS;\n`;
+
+check("1. the shipped shape is green: `/checks` statically, domain via import()", {
+  files: {
+    [MAIN]: `${CHECKS_IMPORT}export async function boot() { return import("@pome-sh/twin-alpha"); }\n`,
+  },
+  expect: "green",
+});
+
+check("2. a direct package-root import is red", {
+  files: {
+    [MAIN]: `${CHECKS_IMPORT}import { seedSchema } from "@pome-sh/twin-alpha";\nvoid seedSchema;\n`,
+  },
+  expect: "red",
+  contains: "package root",
+});
+
+check("3. an INDIRECT root import two CLI modules deep is red (the F-1306 shape)", {
+  files: {
+    [MAIN]: `${CHECKS_IMPORT}import { parseTask } from "../task/parseTask.js";\nvoid parseTask;\n`,
+    "cli/src/task/parseTask.ts": `import { schema } from "./taskSchema.js";\nexport const parseTask = () => schema;\n`,
+    "cli/src/task/taskSchema.ts": `import { seedSchema } from "@pome-sh/twin-alpha";\nexport const schema = seedSchema;\n`,
+  },
+  expect: "red",
+  contains: "taskSchema.ts",
+});
+
+check("4. the same value read from the `/seed` leaf is green", {
+  files: {
+    [MAIN]: `${CHECKS_IMPORT}import { parseTask } from "../task/parseTask.js";\nvoid parseTask;\n`,
+    "cli/src/task/parseTask.ts": `import { schema } from "./taskSchema.js";\nexport const parseTask = () => schema;\n`,
+    "cli/src/task/taskSchema.ts": `import { seedSchema } from "@pome-sh/twin-alpha/seed";\nexport const schema = seedSchema;\n`,
+  },
+  expect: "green",
+});
+
+check("5. a root import inside a SCAFFOLD template literal is not an edge", {
+  files: {
+    [MAIN]:
+      `${CHECKS_IMPORT}export const scaffold = \`\n` +
+      `import { seedSchema } from "@pome-sh/twin-alpha";\n` +
+      `console.log(seedSchema);\n\`;\n`,
+  },
+  expect: "green",
+});
+
+check("6. a type-only root import is not a runtime edge", {
+  files: {
+    [MAIN]:
+      `${CHECKS_IMPORT}import type { seedSchema } from "@pome-sh/twin-alpha";\n` +
+      `import { type seedSchema as S2 } from "@pome-sh/twin-alpha";\n` +
+      `export type A = typeof seedSchema;\nexport type B = typeof S2;\n`,
+  },
+  expect: "green",
+});
+
+check("7. dropping a twin's checks from the static graph is red", {
+  files: { [MAIN]: `export async function boot() { return import("@pome-sh/twin-alpha"); }\n` },
+  expect: "red",
+  contains: "NO LONGER statically reachable",
+});
+
+check("8. every twin is checked, not just the first", {
+  files: {
+    [MAIN]:
+      `${CHECKS_IMPORT}import { CHECKS as C2 } from "@pome-sh/twin-beta/checks";\n` +
+      `import { seedSchema } from "@pome-sh/twin-beta";\nvoid C2; void seedSchema;\n`,
+  },
+  twins: ["alpha", "beta"],
+  expect: "red",
+  contains: "twin-beta",
+});
+
+check("9. a db.ts edge is red even without touching the root", {
+  files: {
+    [MAIN]: `${CHECKS_IMPORT}import { x } from "../../../packages/twin-alpha/src/db.js";\nvoid x;\n`,
+  },
+  expect: "red",
+  contains: "SQLite schema",
+});
+
+if (failures > 0) {
+  console.error(`\n${failures} case(s) failed.`);
+  process.exit(1);
+}
+console.log(`\ncheck-twin-chunk-laziness.test: 9 cases passed.`);


### PR DESCRIPTION
Closes F-1306. Follow-up from F-948's live DX audit (PR #320), where this was found and deliberately deferred.

## The claim, and what it actually was

`cli/src/twin/registry.ts`'s header, `cli/tsup.config.ts`'s header and CHANGELOG 0.21.0 all say each twin is a lazily-loaded chunk. For **github, gmail and linear it was false**, and had been since 0.21.0 — six releases.

Measured with an ESM loader hook (`register()` + a `load` hook logging every module URL Node actually resolves) against the built bundle, and re-confirmed against the packed `pome-sh-cli-0.21.6.tgz`:

| invocation | before | after | Δ |
| --- | --- | --- | --- |
| `pome --version` | **1183.6 KB** (19 files) | **587.1 KB** (22 files) | **−596.5 KB (−50.4%)** |
| `pome twin start github` | **1187.9 KB** (21 files) | **791.4 KB** (24 files) | **−396.5 KB (−33.4%)** |

Per-twin domain verdict on `pome --version` — "domain" meaning the file that actually defines `class <X>Domain` / `open<X>Database` / the twin's `CREATE TABLE` DDL, not merely a chunk that mentions the name:

| twin | before | after |
| --- | --- | --- |
| github | **EAGER** 205.1 KB | LAZY |
| gmail | **EAGER** 252.1 KB | LAZY |
| linear | **EAGER** 240.7 KB | LAZY |
| slack | LAZY | LAZY |
| stripe | LAZY | LAZY |

697.9 KB of three twin servers — SQLite schemas, Hono apps, REST route tables, linear's GraphQL executor — parsed to print `0.21.5` and exit. On `pome twin start github`, gmail's and linear's servers (492.8 KB) loaded and were never called; that is now 0 KB.

## Root cause — one chain, not the two the ticket guessed

The ticket named two static-import chains and guessed `cli/src/cli/checks.ts` was "likely the *larger* contributor". **It isn't a contributor at all.** All five twins' `/checks` subgraphs were already free of domain, `db.ts` and server edges — verified by walking the static import graph from `cli/src/cli/checks.ts`: 0 files under any twin's `src/domain/`, 0 `db.ts`.

What made it look otherwise is esbuild code splitting. Because `parseTask.ts` statically imported gmail's package root, gmail's domain modules and gmail's checks modules became reachable from the same set of chunk roots, so esbuild merged them into one 252 KB chunk. Reading "the chunk containing GMAIL_CHECKS also contains openGmailTwinDatabase" then looks like the checks chunk dragging in the domain. The control is slack and stripe — the two twins `parseTask.ts` does *not* import — whose checks landed in their own clean chunks (15.9 KB / inlined) with their domains in separate chunks that never loaded.

The real cause was **six** modules (the ticket named one), all reaching a twin's PACKAGE ROOT for a zod seed schema, where the root also exports the domain and the Hono app:

```
cli/src/cli/main.ts
  -> cli/src/task/parseTask.ts            -> twin-{github,gmail,linear}   (seedSchema, defaultSeedState)
  -> cli/src/task/taskSchema.ts           -> twin-{github,gmail,linear}   (seedSchema)
  -> cli/src/task/githubSeedCompat.ts     -> twin-github                  (seedSchema, parseSeed)
  -> cli/src/task/seed-compiler.ts        -> twin-github                  (seedSchema)
  -> cli/src/task/seed-compiler-hosted.ts -> twin-github                  (seedSchema)
  -> cli/src/task/seed-verifier.ts        -> twin-github                  (GitHubDomain — genuine)
```

## The fix

**No `async` threading was needed, and no test call site moved.** Each twin's `seed.ts` was *already* a pure-data leaf (zod; plus its own query/URL validators for gmail and linear) — 1 to 4 files, zero domain edges. So it is published as an additive `./seed` subpath export and the five schema readers import that. Every signature stays synchronous.

`seed-verifier.ts` is the one genuine domain consumer — it boots an in-memory twin to catch cross-reference errors schema validation can't. It's only reachable from `pome compile-seeds`, so it became `async` behind an `import()` (`compileOne` was already `async`; one call site, one `await`).

Separately, the ticket's "restructure CHECKS as pure data" hint *did* apply in exactly one place: github's `check-params.ts` read the two-element `TAPE_ASSERTABLE_TOOLS` from `tools.ts`, i.e. 649 lines of zod tool schemas and `executeTool`'s domain dispatch (33.8 KB built). The constant moved to its own module; `tools.ts` re-exports it so `routes.ts`, the package root and `test/tool-stamping.test.ts` are untouched.

The `/checks` subpaths stay eagerly loaded **on purpose**: `pome checks` lists, looks up and digests the vocabulary synchronously, so deferring it would move the cost, not remove it, and would make `findCheck`/`twinOf`/`localDigest` async for nothing. The ticket's instinct here was right.

## A gate, because a comment was the only thing asserting this

`scripts/check-twin-chunk-laziness.mjs` walks the CLI's static import graph and fails on any edge to a twin's package root, `db.ts` or `domain/`, printing the chain. Against the pre-fix tree it names 39 modules and points at `parseTask.ts`. It also fails if a twin's `checks.ts` *stops* being reachable — the cheap way to pass a laziness gate is to break `pome checks`.

Structural (no file allowlist to drift), reads the twins' real `exports` maps (can't disagree with the bundler), needs no build or `npm ci`, so it runs in ci.yml's always-on block. `check-twin-chunk-laziness.test.mjs` is 9 cases whose first job is proving the gate can go red — including the indirect two-hop shape that actually shipped, and the two false-red traps: a scaffold's template-literal source (`init-sdk.ts` embeds an agent that imports `@pome-sh/adapter-claude-sdk`; the first draft reported it as eager) and type-only imports.

## Verification

- `npm run build` ✅ · `npm run typecheck` ✅ · `npm run lint:dead-code` (knip) ✅
- Full suite: **2977 tests / 287 files, 0 failures** across all 9 workspaces — CLI at **1022 passed / 107 files**, no flakes seen, no file-parallelism retry needed
- `npm run test:contract` ✅ (104 pass, 5 skip) · `npm run test:pack` ✅ — all five twins boot from the tarball and `/healthz` 200
- All 22 ci.yml gates run locally green, including `gate:bundled-deps`, `check-first-party-twin-registration`, `check-workspace-pins-match-workspace`, `lint-code-health`, `check-version-bump-required`
- **`checksDigest(GITHUB_CHECKS)` is byte-identical before and after** — `sha256:f8338f11c222cfd12111874f3fb1dacc5771f07e2e7de130180d060193e77798`, 15 checks — so the `pome checks add` handshake against the control plane is unaffected. Confirmed by rebuilding twin-github at both revisions and comparing.
- Laziness re-verified against the **packed tarball**, not only the workspace build.

## Notes for review

- Version bumps: cli `0.21.6`, twin-github `0.9.1`, twin-gmail/twin-linear `0.3.4`. The twins are `private: true`; their versions are what `specMeta.ts` reports as `twin_versions` in meta.json, so pome-cloud can attribute behavior to an exact twin build.
- The 0.21.0 changelog entry is left as written — it's the record of what was claimed. 0.21.6 states plainly that it was false for three of five twins and by how much.
- `registry.ts` and `tsup.config.ts` headers now say what they do *not* cover (a twin's laziness is a property of the whole static graph, not of either file) and point at the gate.
