### PR TITLE
Wire becomes a publishable artifact for consumers outside this repo (F-949)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,20 @@ jobs:
       # the PR's actual base (a push to main has already merged).
       - if: github.event_name == 'pull_request'
         run: node scripts/ci/check-version-bump-required.mjs "${{ github.event.pull_request.base.sha }}"
+      # F-949 — @pome-sh/wire publishes to GitHub Packages, and the two ways that
+      # silently stops working are both readable straight from its package.json:
+      # `private: true` makes `npm publish -w` skip the workspace and EXIT 0 (a
+      # green release that published nothing), and a wrong `publishConfig.registry`
+      # would aim it at public npm, which cannot be undone after 72 hours. The
+      # full tarball audit needs a build and lives in release.yml's publish-wire
+      # job; these two assertions need neither, so they run pre-merge where the
+      # regression is still cheap to fix.
+      - run: node scripts/ci/check-wire-tarball.mjs --manifest-only
+      # Regression suite for the shared publish-decision logic. Asserts a 401
+      # from GitHub Packages is never read as "unpublished" (which would bypass
+      # the never-publish-behind-latest floor check) and that the npmjs and
+      # GitHub Packages lanes cannot block each other.
+      - run: node scripts/ci/decide-publish.test.mjs
       # F-1226 — the plugin manifest is what makes the `skills` installer render
       # one select-all row instead of six unticked checkboxes. It has to live in
       # the always-on block: adding a skill touches only `skills/`, which the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 name: release
-# The single release pipeline for the two published packages, replacing
+# The single release pipeline for the three published packages, replacing
 # cli-release.yml (Changesets + a manual "publish the @pome-sh/* batch first"
 # gate that produced 16 batch releases in 14 days, 4 of them consecutive
 # failures) and sdk-publish.yml.
@@ -12,6 +12,35 @@ name: release
 # are diff-gated separately: the CLI bundles the internal packages, the adapter
 # bundles the wire types, and neither depends on the other's version. There is
 # no lockstep to enforce and therefore no sync-versions script.
+#
+# @pome-sh/wire is the THIRD publish target and the odd one out (F-949). Same
+# version-diff model, different registry and different audience: GitHub Packages
+# (npm.pkg.github.com), for cross-repo internal consumers like pome-cloud — not
+# end users. It stays bundled-inlined into the two npmjs tarballs exactly as
+# before (tsup `noExternal`); publishing it is ADDITIVE, not a replacement.
+#
+# Hence FOUR jobs in two independent lanes — plan → publish for npmjs,
+# plan-wire → publish-wire for GitHub Packages — rather than a third matrix
+# entry and a third `decide` call:
+#
+#   - The auth MECHANISM differs. npmjs uses OIDC Trusted Publishing (no token,
+#     `id-token: write`, provenance); GitHub Packages uses GITHUB_TOKEN with
+#     `packages: write` and an .npmrc auth line. One job cannot honestly do
+#     both, and a shared job would carry four pieces of OIDC cargo (the
+#     setup-node v6 pin for actions/setup-node#1551, the npm@11.5.1 pin for the
+#     provenance crash, `NPM_CONFIG_PROVENANCE`, `id-token: write`) under a
+#     comment explaining that none of it applies to wire.
+#   - The lanes must not be able to break each other. GitHub Packages requires
+#     auth even to READ, and a read failure is deliberately a hard failure (a
+#     401 must never be mistaken for "unpublished" — that would bypass the
+#     never-publish-behind-latest floor check). If that read lived in `plan`,
+#     any GitHub Packages 401/403/outage — or an org owner flipping the
+#     package's visibility settings — would fail `plan` and silently skip the
+#     @pome-sh/cli and @pome-sh/adapter-claude-sdk publishes, which have nothing
+#     to do with GitHub Packages. Blast radius now matches the artifact.
+#
+# The shared decision logic lives in scripts/ci/decide-publish.sh (tested by
+# scripts/ci/decide-publish.test.mjs) so the two lanes cannot drift.
 on:
   push:
     branches: [main]
@@ -26,7 +55,7 @@ permissions:
 
 jobs:
   plan:
-    name: which packages need publishing
+    name: which npm packages need publishing
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -38,53 +67,50 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - name: Compare local versions against the registry
+      # Deliberately reads ONLY registry.npmjs.org. @pome-sh/wire's diff lives in
+      # `plan-wire` so that a GitHub Packages 401/outage cannot skip the two npmjs
+      # publishes: a failure here fails `plan`, and everything needing it is
+      # skipped. Blast radius matches the artifact.
+      - name: Compare local versions against npm
         id: diff
         run: |
           set -euo pipefail
-          # Folded in from the deleted scripts/check-cli-version-floor.sh (F-724):
-          # never publish from a version base BEHIND npm's published latest —
-          # that retags `latest` backwards for every existing user. A version
-          # that differs but does not sort above the registry's is a hard fail,
-          # not a skip.
-          decide() {
-            local name="$1" manifest="$2" output="$3"
-            local local_version registry_version npm_view_err
-            local_version="$(node -p "require('./${manifest}').version")"
-            npm_view_err="$(mktemp)"
-            if registry_version="$(npm view "${name}" version 2>"${npm_view_err}")"; then
-              :
-            elif grep -q "E404" "${npm_view_err}"; then
-              # Genuinely unpublished (brand-new package) — 0.0.0 is correct.
-              registry_version="0.0.0"
-            else
-              # A registry/network/auth error is NOT "unpublished": treating it
-              # as 0.0.0 would make any local version look publishable and
-              # bypass the floor check below, which exists specifically to
-              # stop retagging npm's latest backwards.
-              echo "::error::npm view ${name} failed for a reason other than 'not found':"
-              cat "${npm_view_err}" >&2
-              rm -f "${npm_view_err}"
-              exit 1
-            fi
-            rm -f "${npm_view_err}"
-            echo "${name} — local: ${local_version}, registry: ${registry_version}"
-            if [ "${local_version}" = "${registry_version}" ]; then
-              echo "${output}=false" >> "$GITHUB_OUTPUT"
-              echo "  ↳ unchanged; nothing to publish."
-              return 0
-            fi
-            local highest
-            highest="$(printf '%s\n%s\n' "${local_version}" "${registry_version}" | sort -V | tail -n1)"
-            if [ "${highest}" != "${local_version}" ]; then
-              echo "::error::${name} local version ${local_version} is BEHIND npm latest ${registry_version}. Publishing would retag latest backwards."
-              exit 1
-            fi
-            echo "${output}=true" >> "$GITHUB_OUTPUT"
-            echo "  ↳ will publish ${local_version}."
-          }
-          decide "@pome-sh/cli" "cli/package.json" "cli"
-          decide "@pome-sh/adapter-claude-sdk" "packages/adapter-claude-sdk/package.json" "adapter"
+          scripts/ci/decide-publish.sh "@pome-sh/cli" "cli/package.json" "cli"
+          scripts/ci/decide-publish.sh "@pome-sh/adapter-claude-sdk" "packages/adapter-claude-sdk/package.json" "adapter"
+
+  plan-wire:
+    name: does @pome-sh/wire need publishing
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # GitHub Packages — unlike registry.npmjs.org — requires a token even to
+      # READ a version. Without this the read answers 401, and a 401 is a hard
+      # failure by design (never mistaken for "unpublished"), so this permission
+      # is what stands between the workflow and a permanently red wire release.
+      packages: read
+    outputs:
+      wire: ${{ steps.diff.outputs.wire }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      # Auth for the GitHub Packages read, and nothing else. Deliberately ONLY
+      # the `//host/:_authToken` line and never a `@pome-sh:registry=` scope
+      # mapping — see the header of decide-publish.sh for why that distinction
+      # is load-bearing. `$HOME/.npmrc` rather than a project `.npmrc` so the
+      # token never sits inside the workspace.
+      - name: Authenticate reads against GitHub Packages
+        env:
+          GITHUB_PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          printf '//npm.pkg.github.com/:_authToken=%s\n' "${GITHUB_PACKAGES_TOKEN}" >> "$HOME/.npmrc"
+      - name: Compare the local version against GitHub Packages
+        id: diff
+        run: |
+          set -euo pipefail
+          scripts/ci/decide-publish.sh "@pome-sh/wire" "packages/wire/package.json" "wire" "https://npm.pkg.github.com"
 
   publish:
     name: publish ${{ matrix.package }}
@@ -164,3 +190,69 @@ jobs:
         run: npm publish -w ${{ matrix.package }} --access public
         env:
           NPM_CONFIG_PROVENANCE: "true"
+
+  # @pome-sh/wire → GitHub Packages. See the file header for why this is its own
+  # lane. On what it deliberately does NOT run: `gate:bundled-deps` and
+  # `test:pack` are assertions about the two npmjs TARBALLS (no leaked
+  # @pome-sh/* deps, five twins boot, a consumer typechecks against the shipped
+  # declarations). They say nothing about wire's own tarball, and they still run
+  # on every PR and on both npmjs publishes — which is what keeps wire's
+  # bundled-inlining role verified. Publishing wire does not change that role:
+  # cli/ and adapter/ depend on it as a devDependency and tsup inlines it, so no
+  # end user ever resolves it from a registry.
+  publish-wire:
+    name: publish @pome-sh/wire (GitHub Packages)
+    needs: plan-wire
+    if: needs.plan-wire.outputs.wire == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # No `registry-url`: that would point the DEFAULT registry at GitHub
+      # Packages for the whole job and `npm ci` would try to fetch zod,
+      # typescript and vitest from there. Registry selection for wire is
+      # explicit at publish time instead.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm ci
+      # wire has no internal @pome-sh/* dependency, so it is the first node in
+      # scripts/build.mjs's topological order and builds standalone. Explicit
+      # here (rather than relying on wire's own `prepublishOnly`) so a build
+      # failure reads as a build failure.
+      - name: Build @pome-sh/wire
+        run: npm run build -w @pome-sh/wire
+      - name: Typecheck and test @pome-sh/wire
+        run: |
+          set -euo pipefail
+          npm run typecheck -w @pome-sh/wire
+          npm test -w @pome-sh/wire
+      # trace-contract.json is in wire's `files`, so it SHIPS — and it embeds
+      # wire's own version. Without this the tarball can carry a contract
+      # descriptor claiming a different version than the package.json beside it.
+      - name: Trace-contract descriptor matches the shipped version
+        run: npm run check:trace-contract -w @pome-sh/wire
+      # wire's published dist is what a cross-repo consumer resolves through its
+      # `exports` map — an export pointing at a file the tarball does not carry
+      # is only observable from OUTSIDE the workspace, where npm's workspace
+      # symlink is not there to paper over it.
+      - name: Audit the wire tarball
+        run: npm run gate:wire-tarball
+      # Two independent guarantees that this cannot land on registry.npmjs.org:
+      # `publishConfig.registry` in packages/wire/package.json, and this
+      # explicit `--registry`. `publishConfig` alone is enough on every npm
+      # version this repo pins, but a publish to the wrong registry is not an
+      # error you can take back — public npm has no unpublish after 72 hours.
+      # No `--access public`: on GitHub Packages access is a property of the
+      # package/repository, not a publish flag.
+      - name: Publish to GitHub Packages
+        env:
+          GITHUB_PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          printf '//npm.pkg.github.com/:_authToken=%s\n' "${GITHUB_PACKAGES_TOKEN}" >> "$HOME/.npmrc"
+          npm publish -w @pome-sh/wire --registry https://npm.pkg.github.com

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,21 +43,29 @@ live at **https://docs.pome.sh**.
   ...` from the root. The former `cli/package-lock.json` and
   `cli/pnpm-workspace.yaml` (the changesets/manypkg root marker) are gone.
 - **Internal `@pome-sh/*` deps are `"*"`** — sdk, wire and the five
-  twins are `private: true` workspace members resolved by npm's workspace
-  linking, never from the registry. Never reintroduce an exact version pin
-  between them: the exact pins drifted and installed a second registry copy of
-  `@pome-sh/shared-types` (two zod schema identities at one runtime).
+  twins are workspace members resolved by npm's workspace linking, never from
+  a registry. Never reintroduce an exact version pin between them: the exact
+  pins drifted and installed a second registry copy of `@pome-sh/shared-types`
+  (two zod schema identities at one runtime). This holds for `@pome-sh/wire`
+  even though it is now published (F-949): in-repo consumers must keep
+  resolving it through the workspace, never through GitHub Packages.
 
-## Releases (`@pome-sh/cli`, `@pome-sh/adapter-claude-sdk`)
+## Releases (`@pome-sh/cli`, `@pome-sh/adapter-claude-sdk`, `@pome-sh/wire`)
 
-Those two packages are the ONLY things published to npm. Everything else
-(`@pome-sh/sdk`, `@pome-sh/wire`, the five `@pome-sh/twin-*`) is a
-`private: true` workspace member bundled into them by tsup
+`@pome-sh/cli` and `@pome-sh/adapter-claude-sdk` are the ONLY things published
+to npm for end users. `@pome-sh/wire` is published to **GitHub Packages**
+(`npm.pkg.github.com`) for internal cross-repo consumers — pome-cloud — while
+ALSO still being bundled into both npm tarballs by tsup; publishing it was
+additive and changed nothing about how this repo consumes it (F-949).
+Everything else (`@pome-sh/sdk`, the five `@pome-sh/twin-*`) is a
+`private: true` workspace member bundled into the two npm tarballs by tsup
 (`noExternal: [/^@pome-sh\//]`).
 
-The full runbook — the version-diff-on-push model, why the two packages
-version independently, and the version-bump-required CI gate — lives in
-[`RELEASING.md`](RELEASING.md). One repo-specific historical note that
+The full runbook — the version-diff-on-push model, why the three packages
+version independently, why the npmjs and GitHub Packages publishes are separate
+jobs with different auth (OIDC vs `GITHUB_TOKEN`), the one-time package
+visibility step a maintainer owns, and the version-bump-required CI gate —
+lives in [`RELEASING.md`](RELEASING.md). One repo-specific historical note that
 doesn't belong there: F-1180's `RELEASE_BOT_TOKEN` / release-PR check verifier
 applied to the old Changesets version PR; this lane has no bot-pushed version
 PR, so that machinery is gone with `cli-release.yml`.
@@ -84,8 +92,10 @@ section in the same PR.
 | Every third-party dep of a package INLINED into the CLI bundle is declared by the CLI (a bundled package's own `dependencies` are never installed for it) | [`scripts/check-bundled-runtime-deps.mjs`](scripts/check-bundled-runtime-deps.mjs) via `npm run gate:bundled-deps` in [`ci.yml`](.github/workflows/ci.yml) and [`release.yml`](.github/workflows/release.yml) |
 | Both published tarballs install and run with no access to this workspace; all five twins boot from the CLI tarball; a consumer typechecks against the adapter's shipped declarations | [`scripts/clean-room-pack-test.mjs`](scripts/clean-room-pack-test.mjs) via `npm run test:pack` in [`ci.yml`](.github/workflows/ci.yml) and [`release.yml`](.github/workflows/release.yml) |
 | Package barrels + file-size hygiene | [`scripts/lint-code-health.mjs`](scripts/lint-code-health.mjs) |
-| A published version is never behind npm `latest` — a publish must not retag `latest` backwards (an unpublished package's `0.0.0` baseline passes) | the `plan` job in [`.github/workflows/release.yml`](.github/workflows/release.yml) |
-| A PR touching a package's publish-relevant paths (`cli/`, `packages/twin-*/`, `packages/wire/`, `packages/sdk/` for the CLI; `packages/adapter-claude-sdk/`, `packages/wire/` for the adapter) must bump that package's own `package.json` version against the PR's base — `release.yml` only publishes on a version diff, so an unbumped change merges clean and silently never reaches npm | [`scripts/ci/check-version-bump-required.mjs`](scripts/ci/check-version-bump-required.mjs) in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) (PR-only; see [`RELEASING.md`](RELEASING.md)) |
+| A published version is never behind its registry's `latest` — a publish must not retag `latest` backwards (an unpublished package's `0.0.0` baseline passes; a 404 is "unpublished", a 401/network error is a hard failure, which matters for GitHub Packages where an under-scoped read answers 401 for a package that exists) | [`scripts/ci/decide-publish.sh`](scripts/ci/decide-publish.sh), called by the `plan` and `plan-wire` jobs in [`.github/workflows/release.yml`](.github/workflows/release.yml); regression: [`scripts/ci/decide-publish.test.mjs`](scripts/ci/decide-publish.test.mjs) |
+| The npmjs and GitHub Packages release lanes cannot block each other — `plan`/`publish` never reads `npm.pkg.github.com` and `plan-wire`/`publish-wire` never reads npmjs. A GitHub Packages 401 (which an org owner can cause from the package settings UI, with no commit) is a hard failure by design, so a shared `plan` job would let it silently skip the `@pome-sh/cli` and `@pome-sh/adapter-claude-sdk` publishes | job wiring in [`.github/workflows/release.yml`](.github/workflows/release.yml); asserted by [`scripts/ci/decide-publish.test.mjs`](scripts/ci/decide-publish.test.mjs) |
+| A PR touching a package's publish-relevant paths (`cli/`, `packages/twin-*/`, `packages/wire/`, `packages/sdk/` for the CLI; `packages/adapter-claude-sdk/`, `packages/wire/` for the adapter; `packages/wire/` for wire itself) must bump that package's own `package.json` version **above** the PR's base — `release.yml` only publishes on a version diff, so an unbumped change merges clean and silently never reaches the registry, and a version that differs DOWNWARD (a stale branch rebased past a release) hard-fails the release floor check after merge, taking its whole lane's publishes with it. `packages/wire/` intentionally appears in all three entries: a wire change alters three separate published artifacts (the two npm tarballs it is inlined into, plus wire's own GitHub Packages release), so it needs three bumps. Version-only bumps of the other two are accepted rather than adding an exception list (see `cli/CHANGELOG.md` 0.21.7) | [`scripts/ci/check-version-bump-required.mjs`](scripts/ci/check-version-bump-required.mjs) in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) (PR-only; see [`RELEASING.md`](RELEASING.md)) |
+| `@pome-sh/wire` is published to GitHub Packages ONLY, never npmjs; its manifest is `private: false` (not merely absent — `npm publish -w` on a `private: true` workspace warns and EXITS 0, so the regression is a green release that published nothing); and every path it declares in `exports`/`main`/`types` physically ships in its tarball, with no dangling `.map` and no hard links. Inside this workspace every consumer resolves wire through npm's workspace symlink to the full source tree, so an export pointing at a file `files` does not ship resolves forever here and dies with `ERR_PACKAGE_PATH_NOT_EXPORTED` only in a cross-repo consumer's repo. Registry selection is doubly pinned — `publishConfig.registry` in the manifest and an explicit `--registry` at publish time — because a mistaken publish to public npm cannot be taken back after 72 hours | [`scripts/ci/check-wire-tarball.mjs`](scripts/ci/check-wire-tarball.mjs) — `npm run gate:wire-tarball` in the `publish-wire` job of [`.github/workflows/release.yml`](.github/workflows/release.yml), and the network-free `--manifest-only` half in [`ci.yml`](.github/workflows/ci.yml)'s always-on block so the two silent-failure modes are caught pre-merge |
 | Every tool a bundled example registers is answered by the twin it targets, on that example's own task seed. A tool the twin refuses (4xx/5xx) reds the gate naming the example, the tool, and the twin's status; a newly added tool with no probe reds it too, as does an `expect_status` exemption that no longer fires. `typecheck:examples` is green on a well-typed tool whose endpoint 404s and `smoke:examples` returns before any tool fires, which is how `comment_on_pull_request` 404'd in two examples for their entire existence. Needs no model | [`scripts/probe-example-tools.mjs`](scripts/probe-example-tools.mjs) (`npm run probe:examples`) in [`.github/workflows/ci.yml`](.github/workflows/ci.yml), fixture arguments in [`config/example-tool-probes.json`](config/example-tool-probes.json); regression: [`scripts/probe-example-tools.test.mjs`](scripts/probe-example-tools.test.mjs) |
 | Every endpoint a twin DECLARES is called and answered. The endpoint set is read from each twin's own `tools/list`, never from the manifest, so a twin that gains a tool gains a probe with no hand edit and a declared tool no probe supplies arguments for is a red naming the twin and the endpoint; a refusal names the tool, the status, and the twin's own error text. The row above probes what seven bundled EXAMPLES expose, which reached 9 of the 137 declared tools and none of stripe's; slack's 8 and linear's 15 uncalled tools were reached by nothing over the MCP wire, because their own suites drive them through `executeTool()` on the domain — the layer `comment_on_pull_request` was NOT broken at. The two gates have different subjects and neither replaces the other: an example red points at `examples/`, a twin red at `packages/twin-*/`. Status is read from the twin's recorded event, not the HTTP response, because MCP JSON-RPC answers 200 for a tool that failed. Needs no model, no API key, and no socket — every twin boots in-process on `:memory:` against its own default seed. The delta this closed is measured in [`docs/declared-endpoint-coverage.md`](docs/declared-endpoint-coverage.md) | [`scripts/probe-twin-endpoints.mjs`](scripts/probe-twin-endpoints.mjs) (`npm run probe:twins`) in [`.github/workflows/ci.yml`](.github/workflows/ci.yml), fixture arguments in [`config/twin-endpoint-probes.json`](config/twin-endpoint-probes.json); regression: [`scripts/probe-twin-endpoints.test.mjs`](scripts/probe-twin-endpoints.test.mjs) |
 | Every member of the event union (`otelEventSchema` — the seven `eventSchema` variants plus `OtelSpanEvent`) has at least one wire fixture under `packages/wire/test/fixtures/v1/event/<Kind>/`, and the kind list in `trace-contract.json` is enumerated from the zod union rather than typed out. Adding a kind with no fixture, or renaming one and leaving its directory behind, fails BOTH `emit:trace-contract` and `--check` — regenerating is not an escape hatch. The old script read no schema at all: `canonicalSchemas` was a hardcoded four-string literal and the rest was a directory walk, so a new kind moved zero bytes and the byte-compare was green by construction, which is how M1 shipped `LlmTurnEvent` with no fixture anywhere | [`packages/wire/scripts/emit-trace-contract.mjs`](packages/wire/scripts/emit-trace-contract.mjs) (`npm run check:trace-contract -w @pome-sh/wire`) in [`.github/workflows/ci.yml`](.github/workflows/ci.yml); regression: [`packages/wire/scripts/emit-trace-contract.test.mjs`](packages/wire/scripts/emit-trace-contract.test.mjs). The dropped/renamed half is `typecheck` — `test/export-surface.test.ts` guards the per-kind types, `test/v1-event-corpus.test.ts` keys its coverage map on `OtelEvent["kind"]` |
@@ -116,7 +126,8 @@ signed digests before rebuilding runtime snapshots. That promotion is operated
 from the private `pome-sh/pome-cloud` repo — maintainers: see
 `docs/runbooks/twin-release-and-promotion.md` there.
 
-Only `@pome-sh/cli` and `@pome-sh/adapter-claude-sdk` are published to npm.
+Only `@pome-sh/cli` and `@pome-sh/adapter-claude-sdk` are published to npm;
+`@pome-sh/wire` is published to GitHub Packages for sibling repositories only.
 Everything else is internal to the CLI tarball, so the old per-package
 version-bump runbook (`PACKAGE_RELEASE.md`, one changeset per `packages/*`
 member) is gone; see [`RELEASING.md`](RELEASING.md) for what replaced it.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,10 +1,15 @@
 # Releasing
 
-Two packages are published to npm: `@pome-sh/cli` and
-`@pome-sh/adapter-claude-sdk`. Everything else in this repo (`@pome-sh/sdk`,
-`@pome-sh/wire`, the five `@pome-sh/twin-*`) is `private: true` and bundled
-into those two tarballs by tsup — it is never installed from the registry, so
-it never needs its own release.
+Two packages are published to **npm** for end users: `@pome-sh/cli` and
+`@pome-sh/adapter-claude-sdk`. One package is published to **GitHub Packages**
+for internal cross-repo consumers: `@pome-sh/wire`. Everything else in this
+repo (`@pome-sh/sdk`, the five `@pome-sh/twin-*`) is `private: true` and
+bundled into the two npm tarballs by tsup — it is never installed from a
+registry, so it never needs its own release.
+
+`@pome-sh/wire` is the odd one out and worth reading the section on before
+touching it: it is published AND still bundled. Publishing it did not change
+how the CLI or the adapter consume it.
 
 ## The model
 
@@ -12,15 +17,19 @@ it never needs its own release.
 version-diff driven, on every push to `main`:
 
 1. Bump the version in the package's own `package.json` —
-   `cli/package.json` for the CLI, `packages/adapter-claude-sdk/package.json`
-   for the adapter — and add the user-facing entry to that package's own
-   `CHANGELOG.md`.
+   `cli/package.json` for the CLI,
+   `packages/adapter-claude-sdk/package.json` for the adapter,
+   `packages/wire/package.json` for wire — and add the entry to that
+   package's own `CHANGELOG.md`.
 2. Merge the PR to `main`.
 3. `release.yml`'s `plan` job compares each package's local version against
-   what's currently on npm. A package whose version is unchanged is skipped.
-   A package whose version differs publishes. A package whose version is
-   *behind* npm's published `latest` is a hard failure, not a skip — that
-   would retag `latest` backwards for every existing user.
+   what's currently on its registry. A package whose version is unchanged is
+   skipped. A package whose version differs publishes. A package whose version
+   is *behind* the registry's published `latest` is a hard failure, not a skip
+   — that would retag `latest` backwards for every existing consumer. A package
+   the registry has never seen (404) baselines at `0.0.0` and publishes; an
+   auth or network error is NOT treated as "unpublished", because that would
+   bypass the floor check.
 
 That's the whole runbook. There is no changeset file to add, no version PR
 to wait on, and no batch release to sequence — the previous flow (Changesets
@@ -29,16 +38,21 @@ now-deleted `PACKAGE_RELEASE.md`) produced 16 batch releases in 14 days, four
 of them consecutive failures, before this repo collapsed to one CLI and one
 adapter as the only publishable surfaces.
 
-## The two packages version independently
+## The three packages version independently
 
-`@pome-sh/cli` and `@pome-sh/adapter-claude-sdk` are on their own version
-lines (D11) and are diff-gated separately in the same workflow run — the CLI
-bundles the internal packages, the adapter bundles `@pome-sh/wire`, and
-neither depends on the other's published version. There is no lockstep to
-enforce, so there is no sync-versions script: bump one, both, or neither,
-depending on what actually changed.
+`@pome-sh/cli`, `@pome-sh/adapter-claude-sdk` and `@pome-sh/wire` are on their
+own version lines (D11) and are diff-gated separately in the same workflow run
+— the CLI bundles the internal packages, the adapter bundles `@pome-sh/wire`,
+and none depends on another's published version. There is no lockstep to
+enforce and no sync-versions script.
 
-Both packages are pre-1.0, so npm's `^0.x` caret semantics apply
+Independent version *lines* is not the same as independent *bumps*, and the one
+coupling worth knowing up front: because wire's compiled output is inlined into
+both npm tarballs, a change under `packages/wire/` is publish-relevant for all
+three, so it needs all three bumped. Anything else — a CLI-only change, an
+adapter-only change — bumps only its own package. See "Before you merge".
+
+All three packages are pre-1.0, so npm's `^0.x` caret semantics apply
 (`^0.N.x` never crosses into `0.N+1`) — **minor plays the major role**:
 
 - **Minor (`0.N+1.0`)** — anything a consumer must act on: a breaking change
@@ -47,6 +61,82 @@ Both packages are pre-1.0, so npm's `^0.x` caret semantics apply
 - **Patch (`0.N.x`)** — everything else: additive exports/flags, internal
   implementation swaps behind an unchanged surface, dependency bumps, bug
   fixes.
+
+## `@pome-sh/wire` — published AND bundled
+
+`@pome-sh/wire` is a third published artifact with a different registry and a
+different audience, and it did not stop being a bundled one (F-949).
+
+|  | `@pome-sh/cli`, `@pome-sh/adapter-claude-sdk` | `@pome-sh/wire` |
+| --- | --- | --- |
+| Registry | `registry.npmjs.org` | `npm.pkg.github.com` (GitHub Packages) |
+| Audience | end users — `npx @pome-sh/cli`, `npm i @pome-sh/adapter-claude-sdk` | internal cross-repo consumers, i.e. `pome-sh/pome-cloud` |
+| Auth | npm OIDC Trusted Publishing (`id-token: write`, provenance attestation, no stored token) | `GITHUB_TOKEN` + `packages: write`, via an `.npmrc` auth line |
+| Jobs | `plan` → `publish` (a matrix over the two) | `plan-wire` → `publish-wire` |
+| Reachable without auth | yes | no — GitHub Packages requires a token even to read |
+
+**Publishing wire changed nothing about how this repo consumes it.** `cli/` and
+`packages/adapter-claude-sdk/` still declare it as a **devDependency** at `"*"`
+(workspace-resolved), and tsup's `noExternal: [/^@pome-sh\//]` still inlines
+its compiled output into both tarballs. Neither published npmjs tarball has an
+`@pome-sh/*` dependency, and `scripts/clean-room-pack-test.mjs` fails if that
+ever changes. Nobody installing the CLI or the adapter fetches wire. Do not
+"simplify" this by turning wire into a real dependency of either: that would
+put a GitHub-Packages-only, auth-required package in an end user's install
+graph, and their `npm i` would 401.
+
+Why GitHub Packages rather than public npm: wire is trace-vocabulary
+infrastructure (Zod schemas, the OTel span extension, secret redaction) with no
+stable public API promise. Publishing it to npmjs would make it look like a
+supported end-user library and would invite pins we do not intend to honour.
+The only thing that genuinely needs it across a repo boundary is pome-cloud.
+
+`@pome-sh/wire` publishes as `@pome-sh/…` because GitHub Packages scopes npm
+packages to the account that owns the linked repository — the scope must equal
+the org name, and `@pome-sh` matches the `pome-sh` org. The package is linked to
+this repository through the `repository` field already in
+`packages/wire/package.json`, which must keep naming the repo's **canonical**
+path (`pome-sh/digital-twins`; `pome-sh/pome-twins` is an old name GitHub
+redirects, and some local git remotes still use it).
+
+The two lanes are deliberately independent — `plan`/`publish` never reads GitHub
+Packages and `plan-wire`/`publish-wire` never reads npmjs — so an outage or a
+permissions change on one registry cannot skip the other's publishes. That
+matters because a GitHub Packages read failure is a *hard* failure by design (a
+401 must never be read as "unpublished", which would bypass the floor check), so
+it would otherwise be an outage on one registry silently blocking releases on
+the other.
+
+### One-time manual step for a maintainer
+
+GitHub Packages' npm registry supports granular permissions, so a package's
+visibility is settable independently of its linked repository — **but only once
+the package exists**, and only by someone with admin on the package. This
+repository is public, so the first publish produces a package whose access is
+inherited from a public repository. Making it genuinely private is a manual,
+post-first-publish step for an org owner at
+`github.com/orgs/pome-sh/packages/npm/wire/settings`:
+
+1. **First**, under *Manage Actions access*, add `pome-sh/digital-twins` with
+   the **Write** role.
+2. **Then** turn off *Inherit access from repository* and set visibility to
+   **Private**.
+3. Grant the `pome-cloud` consumers read.
+
+> **Do step 1 before step 2.** Disabling inheritance clears the package's
+> Actions-access list, which is where this repository's `GITHUB_TOKEN` gets its
+> permission. Skip it and `plan-wire`'s read answers 401 — a hard failure by
+> design, because a 401 must never be mistaken for "unpublished" — so every
+> subsequent wire release is red until someone re-grants it in the UI. Nothing
+> in the code can detect or repair this; it is a settings change with no commit
+> attached. (The `plan`/`publish` lane for the two npm packages is deliberately
+> independent, so this cannot stop the CLI or the adapter from publishing — see
+> the job comments in `release.yml`.)
+
+Until that is done, treat wire's contents as public. Nothing secret may ever go
+into it — which is true regardless: wire is types and redaction logic, no
+credentials, no domain data, no control-plane contract (that lives in
+`cli/src/contract/`).
 
 ## Before you merge
 
@@ -57,9 +147,20 @@ is the gate. If your change doesn't warrant a release (docs, tests, CI-only),
 it shouldn't be touching a publish-relevant path in the first place; if it
 does, bump the version in the same PR rather than in a follow-up.
 
+**A change under `packages/wire/` requires THREE bumps** — wire's own version,
+the CLI's, and the adapter's. That is not the gate double-counting: wire's bytes
+are inlined into both npmjs tarballs, so a wire fix reaches an end user only via
+a CLI or adapter release, and reaches pome-cloud only via a wire release. Three
+artifacts change, so three versions move.
+
+**Bumping wire's version also means re-running `npm run emit:trace-contract -w
+@pome-sh/wire`** in the same commit. `packages/wire/trace-contract.json` embeds
+wire's own `version`, so `check:trace-contract` (a required `ci.yml` gate) fails
+on a bump until the file is regenerated. It is one line, but it is not optional.
+
 ## What CI runs before publish
 
-Both tarballs are built and, before `npm publish`, go through the same
+The two npm tarballs are built and, before `npm publish`, go through the same
 guardrails that run on every PR — the bundled-runtime-dependency gate
 (`npm run gate:bundled-deps`) and a clean-room pack test (`npm run test:pack`)
 that installs both tarballs with no access to this workspace, boots all five
@@ -67,6 +168,39 @@ twins from the CLI tarball, and typechecks a consumer against the adapter's
 shipped declarations — plus an npm-registry hard-link tarball check (E415).
 Publishing uses npm OIDC Trusted Publishing with provenance; no `NPM_TOKEN` is
 stored for either package.
+
+`@pome-sh/wire` runs its own build, typecheck, unit tests,
+`check:trace-contract` (the shipped `trace-contract.json` embeds wire's version,
+so this is what stops a tarball carrying a descriptor that disagrees with the
+`package.json` beside it), and `npm run gate:wire-tarball`
+([`scripts/ci/check-wire-tarball.mjs`](scripts/ci/check-wire-tarball.mjs)),
+which packs wire and asserts:
+
+- every `exports`/`main`/`types` target is physically in the tarball. Inside
+  this workspace those resolve through npm's workspace symlink whether or not
+  `files` ships them, so this failure is invisible here and lands as
+  `ERR_PACKAGE_PATH_NOT_EXPORTED` in a cross-repo consumer's build;
+- no hard links (E415) and no dangling `.map` files — the same rule
+  `test:pack` enforces on the other two tarballs (F-943);
+- `private` is exactly `false` and `publishConfig.registry` is GitHub Packages.
+
+Those last two assertions also run **pre-merge**, on every PR, via
+`npm run gate:wire-manifest` (the same script, `--manifest-only`, needing no
+build and no network). They are the pair worth catching early: `npm publish -w`
+on a `private: true` workspace prints a warning and **exits 0**, so that
+regression would otherwise produce a green release that published nothing, and a
+mistaken publish to public npm cannot be undone after 72 hours.
+
+`gate:bundled-deps` and `test:pack` are deliberately NOT re-run in
+`publish-wire`: they are assertions about the other two tarballs, and they
+already gate every PR and both npmjs publishes.
+
+The shared version-diff decision is
+[`scripts/ci/decide-publish.sh`](scripts/ci/decide-publish.sh), covered by
+[`scripts/ci/decide-publish.test.mjs`](scripts/ci/decide-publish.test.mjs) —
+which mocks `npm` to assert, among other cases, that a GitHub Packages 401 is a
+hard failure rather than a `0.0.0` baseline, and that the two lanes cannot block
+each other.
 
 ## Twin container images
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,25 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.21.8
+
+### Patch Changes
+
+- **No CLI change.** Version-only bump, for the same reason 0.21.7 was: F-949
+  made `@pome-sh/wire` an independently published artifact on GitHub Packages
+  for cross-repo consumers, which touched `packages/wire/package.json` —
+  publish-relevant for the CLI, because the CLI inlines wire into its bundle.
+  Here it genuinely is not: only wire's packaging metadata changed, no wire
+  source, so the CLI bundle is byte-identical in content. Bumped anyway rather
+  than adding an exception list to the gate, per 0.21.7.
+
+  Nothing about how the CLI consumes wire changed and nothing may: wire is
+  still a `devDependency` at `"*"`, still inlined by tsup's `noExternal`, and
+  the published CLI tarball still declares no `@pome-sh/*` dependency. Wire's
+  GitHub Packages copy requires a GitHub token even to read, so an end user who
+  had to resolve it would get a 401 on `npm i` — the bundling is what keeps
+  that impossible.
+
 ## 0.21.7
 
 ### Patch Changes

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.21.7",
+  "version": "0.21.8",
   "description": "Digital-twin testing for AI agents — run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "cli": {
       "name": "@pome-sh/cli",
-      "version": "0.21.2",
+      "version": "0.21.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.29",
@@ -7285,7 +7285,7 @@
     },
     "packages/adapter-claude-sdk": {
       "name": "@pome-sh/adapter-claude-sdk",
-      "version": "0.3.1",
+      "version": "0.3.3",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.221.0",
@@ -7341,7 +7341,7 @@
     },
     "packages/twin-github": {
       "name": "@pome-sh/twin-github",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.1.0",
@@ -7365,7 +7365,7 @@
     },
     "packages/twin-gmail": {
       "name": "@pome-sh/twin-gmail",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.1.0",
@@ -7386,7 +7386,7 @@
     },
     "packages/twin-linear": {
       "name": "@pome-sh/twin-linear",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.1.0",
@@ -7473,7 +7473,7 @@
     },
     "packages/wire": {
       "name": "@pome-sh/wire",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^26.1.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "lint:skill-manifest": "node scripts/check-plugin-manifest-lists-every-skill.mjs",
     "lint:twin-chunks": "node scripts/check-twin-chunk-laziness.mjs",
     "lint:dead-code": "knip --no-config-hints",
-    "gate:bundled-deps": "node scripts/check-bundled-runtime-deps.mjs"
+    "gate:bundled-deps": "node scripts/check-bundled-runtime-deps.mjs",
+    "gate:wire-tarball": "node scripts/ci/check-wire-tarball.mjs",
+    "gate:wire-manifest": "node scripts/ci/check-wire-tarball.mjs --manifest-only"
   },
   "engines": {
     "node": ">=24",

--- a/packages/README.md
+++ b/packages/README.md
@@ -6,7 +6,9 @@ not an install surface.** The only thing end users install is
 `@pome-sh/wire`, and all five twins inside its tarball. This doc is the
 internal architecture map for contributors — what each package is, why it's
 shaped the way it is, and which of the eight are actually reachable from
-outside this repo.
+outside this repo. (`@pome-sh/wire` is additionally published to GitHub
+Packages for sibling *repositories*, not for users — see "Private vs.
+published".)
 
 ## The registry: one typed source of truth for five twins
 
@@ -100,24 +102,38 @@ shape, auth, and MCP surfaces.
 
 ## Private vs. published
 
-Two packages in this repo are published to npm. Everything else under
-`packages/` is `private: true` and reaches users only as bytes inlined into
-one of those two tarballs — there is no `npm install` for it, ever.
+Two packages in this repo are published to **npm** for end users. One
+(`@pome-sh/wire`) is published to **GitHub Packages** for internal cross-repo
+consumers. Everything else under `packages/` is `private: true` and reaches
+users only as bytes inlined into one of the two npm tarballs — there is no
+`npm install` for it, ever.
 
-| Directory | Workspace name | Role | On npm? |
+| Directory | Workspace name | Role | Published? |
 | --- | --- | --- | --- |
 | [`sdk/`](./sdk/) | `@pome-sh/sdk` | Twin engine — HTTP mount, auth, recorder, MCP dispatch, SQLite | No — bundled into `@pome-sh/cli` |
-| [`wire/`](./wire/) | `@pome-sh/wire` | Trace surface — recorder-events, redaction, OTel schemas | No — bundled into `@pome-sh/cli` and `@pome-sh/adapter-claude-sdk` |
+| [`wire/`](./wire/) | `@pome-sh/wire` | Trace surface — recorder-events, redaction, OTel schemas | **Both** — bundled into `@pome-sh/cli` and `@pome-sh/adapter-claude-sdk`, *and* published to GitHub Packages (`npm.pkg.github.com`) for pome-cloud (F-949) |
 | [`twin-github/`](./twin-github/), `twin-stripe/`, `twin-slack/`, `twin-gmail/`, `twin-linear/` | `@pome-sh/twin-*` | The five digital twins | No — bundled into `@pome-sh/cli`; also published as signed GHCR container images for pome-cloud |
-| [`adapter-claude-sdk/`](./adapter-claude-sdk/) | `@pome-sh/adapter-claude-sdk` | Claude Agent SDK adapter for user agent code | **Yes** |
+| [`adapter-claude-sdk/`](./adapter-claude-sdk/) | `@pome-sh/adapter-claude-sdk` | Claude Agent SDK adapter for user agent code | **Yes** — npm |
 
-"Bundled" means tsup's `noExternal: [/^@pome-sh\//]` inlines the private
+"Bundled" means tsup's `noExternal: [/^@pome-sh\//]` inlines the internal
 package's compiled output straight into the publishing package's own `dist/`
-at build time (`cli/tsup.config.ts`); the private package never appears in the
+at build time (`cli/tsup.config.ts`); the internal package never appears in the
 published `package.json`'s `dependencies` and is never fetched from the
 registry at install time. The end-user **`pome` CLI** itself lives at repo
-root [`cli/`](../cli/), not under `packages/` — it's the other published
+root [`cli/`](../cli/), not under `packages/` — it's the other npm-published
 package, alongside `@pome-sh/adapter-claude-sdk` here.
 
-For how the two published packages version and release, see
+`@pome-sh/wire` is the only row that is both, and the distinction matters
+because the two paths never meet. `cli/` and `adapter-claude-sdk/` depend on it
+as a **devDependency** at `"*"` and tsup inlines it, so an end user's install
+graph contains no `@pome-sh/wire` at all — which is load-bearing, because the
+GitHub Packages copy requires a GitHub token even to read and would 401 for
+them. The GitHub Packages copy exists for exactly one reason: `pome-cloud`
+lives in a different repository and needs the same trace vocabulary, and
+duplicating Zod schemas across a repo boundary is what produced the two-schema-
+identities bug that dissolved `@pome-sh/shared-types` in the first place. See
+[`RELEASING.md`](../RELEASING.md) for the publish model and the one-time
+package-visibility step.
+
+For how the three published packages version and release, see
 [`RELEASING.md`](../RELEASING.md) at the repo root.

--- a/packages/adapter-claude-sdk/CHANGELOG.md
+++ b/packages/adapter-claude-sdk/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @pome-sh/adapter-claude-sdk — CHANGELOG
 
+## 0.3.3 — 2026-08-06
+
+No user-visible change. Version-only bump: F-949 made `@pome-sh/wire` an
+independently published artifact on GitHub Packages for cross-repo consumers,
+which touched `packages/wire/package.json` — publish-relevant for this package,
+because tsup inlines wire's compiled output into the bundle and its
+`dist/index.d.ts`. Only wire's packaging metadata changed, no wire source, so
+this tarball is byte-identical in content.
+
+One clarification to 0.3.2's note below: it says a bare re-export of
+`@pome-sh/wire/correlation` in the shipped `dist/index.d.ts` "resolves nowhere
+for a consumer, since wire is never published." Wire *is* now published — to
+GitHub Packages, which requires a GitHub token even to read — so that specifier
+still resolves nowhere for an end user, and the local `src/correlation.ts`
+re-export is still required. The conclusion is unchanged; only the reason is.
+Do not turn wire into a real dependency of this package on the strength of it
+being published: an end user's `npm i` would 401.
+
 ## 0.3.2 — 2026-08-06
 
 Internal restructure — no API, behaviour or type change for consumers.

--- a/packages/adapter-claude-sdk/package.json
+++ b/packages/adapter-claude-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/adapter-claude-sdk",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Pome adapter for Anthropic's Claude Agent SDK \u2014 wraps query() and tools so agent traces land in the Pome trace format.",
   "private": false,
   "type": "module",

--- a/packages/adapter-claude-sdk/src/correlation.ts
+++ b/packages/adapter-claude-sdk/src/correlation.ts
@@ -11,8 +11,11 @@
 // only; tsup's declaration bundler keeps bare specifiers external. Re-exporting
 // straight from the barrel therefore emits a literal
 // `export { CORRELATION_HEADER } from '@pome-sh/wire/correlation'` into
-// `dist/index.d.ts` — a specifier that resolves nowhere for a consumer, because
-// wire is `private: true` and is never published. The JS is fine (inlined), so
+// `dist/index.d.ts` — a specifier that resolves nowhere for a consumer. Wire is
+// published (F-949), but to GitHub Packages, which requires a GitHub token even
+// to read: an end user resolving that specifier gets a 401, not a package. So
+// the conclusion is unchanged and this file is still required. The JS is fine
+// (inlined), so
 // nothing breaks until the consumer runs `tsc`, which is the failure mode the
 // pack test's non-`skipLibCheck` consumer compile exists to catch. (Setting
 // `dts.resolve` instead makes the dts bundler drag in the whole wire barrel and

--- a/packages/adapter-claude-sdk/tsup.config.ts
+++ b/packages/adapter-claude-sdk/tsup.config.ts
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// The adapter is the second (and only other) published package. It bundles its
-// internal `@pome-sh/*` dependency — the wire types + redaction helpers — via
-// `noExternal`, because `@pome-sh/wire` is `private: true` and would be
-// unresolvable from the registry.
+// The adapter is the second of the two packages published to npm. It bundles
+// its internal `@pome-sh/*` dependency — the wire types + redaction helpers —
+// via `noExternal`. `@pome-sh/wire` IS published (F-949), but to GitHub
+// Packages, which requires a GitHub token even to read; declaring it as a real
+// dependency would 401 on an end user's `npm i`. Bundling is what keeps wire out
+// of their install graph, so `noExternal` must stay.
 //
 // Everything else stays external and stays a real dependency: the OpenTelemetry
 // packages (a consumer's app almost certainly has its own OTel SDK, and two

--- a/packages/wire/CHANGELOG.md
+++ b/packages/wire/CHANGELOG.md
@@ -1,0 +1,52 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# @pome-sh/wire — CHANGELOG
+
+Wire had no changelog before 0.2.1 because it had never been published. Earlier
+versions exist only as bytes inlined into `@pome-sh/cli` and
+`@pome-sh/adapter-claude-sdk`; their history is in those packages' changelogs.
+
+## 0.2.1 — 2026-08-06
+
+**First published version.** Packaging only — no schema, type, export or
+behaviour change from 0.2.0.
+
+`@pome-sh/wire` was `private: true` and reached the outside world only as bytes
+tsup inlined into `@pome-sh/cli` and `@pome-sh/adapter-claude-sdk`. It is now
+also published as an independently versioned artifact to **GitHub Packages**
+(`npm.pkg.github.com`), for consumers in other repositories — today
+`pome-sh/pome-cloud`, which speaks the same trace vocabulary and had been
+reaching it across a repo boundary through npm-installed internal packages
+(F-949).
+
+- `private: true` → `private: false`; added
+  `publishConfig.registry: https://npm.pkg.github.com`. It is **not** on npmjs
+  and is not an end-user install surface — reading it requires a GitHub token.
+- `README.md` added to the `files` field so the published package has a readme.
+- `!dist/**/*.map` added to `files`. `tsconfig.json` sets `sourceMap: true` and
+  no `src/` ships, so every emitted `.js.map` was a dangling map with no
+  `sourcesContent` — 14 of them. `scripts/clean-room-pack-test.mjs` already
+  treats a dangling map in a published tarball as a hard failure for the other
+  two packages (F-943); wire's tarball now holds to the same rule. Local builds
+  keep their maps.
+- Published by the new `publish-wire` job in `.github/workflows/release.yml`,
+  on the same version-diff-on-push model as the two npm packages but with
+  `GITHUB_TOKEN` auth instead of npm OIDC Trusted Publishing.
+- `trace-contract.json` moves by exactly one line: it embeds wire's own
+  `version`, so `check:trace-contract` fails on any version bump until
+  `emit:trace-contract` is re-run. Every future wire release must regenerate it
+  in the same commit.
+
+**The bundled path is unchanged.** `cli/` and `packages/adapter-claude-sdk/`
+still declare wire as a `devDependency` at `"*"` and tsup's
+`noExternal: [/^@pome-sh\//]` still inlines it, so neither published npm
+tarball has an `@pome-sh/wire` dependency and no end user ever resolves it from
+a registry. Do not turn wire into a runtime dependency of either: GitHub
+Packages requires auth to read, so an end user's `npm i` would 401.
+
+Verified from outside the workspace before release: the packed tarball installs
+into a bare directory with `zod` as its only peer, all six subpath exports
+import, and a consumer typechecks against the shipped declarations under
+`NodeNext` without `skipLibCheck`.

--- a/packages/wire/README.md
+++ b/packages/wire/README.md
@@ -10,9 +10,20 @@ redaction, and framework-agnostic tool-call correlation. The `pome` CLI, the twi
 engine (`@pome-sh/sdk`), the first-party twins and the Claude adapter all speak
 this vocabulary; the wire format is the contract, not any one library.
 
-Internal (`private: true`): it is never published. The CLI inlines it into its
-single bundle (`cli/tsup.config.ts` `noExternal`), and the twin images copy its
-built `dist/`.
+Internal infrastructure, published two ways and installed by end users through
+neither:
+
+- **Bundled** — the CLI and the Claude adapter inline it into their single
+  bundles (`cli/tsup.config.ts` `noExternal`), and the twin images copy its
+  built `dist/`. Both declare it as a `devDependency` at `"*"`, so no published
+  npm tarball has an `@pome-sh/wire` dependency and nothing on npmjs resolves
+  it. This is how every consumer *inside this repo* gets it.
+- **Published to GitHub Packages** (`npm.pkg.github.com`, not npmjs) as an
+  independently versioned artifact, for consumers in *other repositories* —
+  today that means `pome-sh/pome-cloud`, which needs the same trace vocabulary
+  and must not fork a second copy of these Zod schemas. Reading it requires a
+  GitHub token; it is not an end-user install surface and has no public API
+  promise. See [`RELEASING.md`](../../RELEASING.md).
 
 ## What is NOT here
 

--- a/packages/wire/package.json
+++ b/packages/wire/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pome-sh/wire",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pome's wire format — Zod schemas for recorder events, the OpenTelemetry extension surface, secret redaction, and framework-agnostic trace correlation. Shared by every twin, the sdk, the adapter and the CLI.",
-  "private": true,
+  "private": false,
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -35,9 +35,14 @@
   },
   "files": [
     "dist",
+    "!dist/**/*.map",
     "package.json",
-    "trace-contract.json"
+    "trace-contract.json",
+    "README.md"
   ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/pome-sh/digital-twins.git",

--- a/packages/wire/trace-contract.json
+++ b/packages/wire/trace-contract.json
@@ -1,6 +1,6 @@
 {
   "package": "@pome-sh/wire",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "zod": {
     "range": "^4.1.13",
     "major": 4

--- a/scripts/check-bundled-runtime-deps.mjs
+++ b/scripts/check-bundled-runtime-deps.mjs
@@ -88,14 +88,19 @@ if (missing.length > 0) {
   process.exit(1);
 }
 
-// Also flag @pome-sh/* left in the published runtime deps: those packages are
-// `private: true`, so a leaked spec would be unresolvable on install.
+// Also flag @pome-sh/* left in the published runtime deps: none of them is
+// installable by an end user, so a leaked spec breaks the install.
 const leakedInternal = [...declared].filter((spec) => spec.startsWith("@pome-sh/"));
 if (leakedInternal.length > 0) {
   console.error(
-    `Bundled-runtime-dependency gate FAILED: ${cliManifest.name} declares private internal packages as runtime dependencies: ${leakedInternal.join(", ")}`,
+    `Bundled-runtime-dependency gate FAILED: ${cliManifest.name} declares internal packages as runtime dependencies: ${leakedInternal.join(", ")}`,
   );
-  console.error("They are `private: true` and would be unresolvable from the registry.");
+  console.error(
+    "They are not installable by an end user: the sdk and the twins are `private: true`\n" +
+      "and on no registry at all, and `@pome-sh/wire` is published only to GitHub Packages,\n" +
+      "which answers 401 without a GitHub token (F-949). All of them are inlined by the\n" +
+      "bundler instead — remove the dependency, do not publish it.",
+  );
   process.exit(1);
 }
 

--- a/scripts/ci/check-version-bump-required.mjs
+++ b/scripts/ci/check-version-bump-required.mjs
@@ -38,10 +38,28 @@ function versionAt(ref, manifestPath) {
   }
 }
 
+/**
+ * Numeric-segment ordering, matching the `sort -V` that release.yml's
+ * decide-publish.sh uses for the same comparison. Deliberately not semver-aware
+ * about prerelease tags: this repo publishes plain `0.N.P` and a dependency-free
+ * gate is worth more here than prerelease precedence it would never exercise.
+ */
+function isAhead(candidate, baseline) {
+  const parse = (version) => String(version).split(".").map((part) => Number.parseInt(part, 10) || 0);
+  const [a, b] = [parse(candidate), parse(baseline)];
+  for (let index = 0; index < Math.max(a.length, b.length); index += 1) {
+    const left = a[index] ?? 0;
+    const right = b[index] ?? 0;
+    if (left !== right) return left > right;
+  }
+  return false;
+}
+
 const PACKAGES = [
   {
     name: "@pome-sh/cli",
     manifest: "cli/package.json",
+    registry: "npm",
     // Bundled: the twins + wire + sdk are inlined via tsup, so a change to
     // any of them is a change to the CLI's published artifact too.
     pathPrefixes: ["cli/", "packages/twin-", "packages/wire/", "packages/sdk/"],
@@ -49,7 +67,26 @@ const PACKAGES = [
   {
     name: "@pome-sh/adapter-claude-sdk",
     manifest: "packages/adapter-claude-sdk/package.json",
+    registry: "npm",
     pathPrefixes: ["packages/adapter-claude-sdk/", "packages/wire/"],
+  },
+  {
+    // Published to GitHub Packages, not npmjs (F-949), for cross-repo consumers
+    // like pome-cloud. Its own independent version line and therefore its own
+    // independent check.
+    //
+    // `packages/wire/` deliberately appears in THREE entries and that is not
+    // double-counting — it is three different published artifacts that all
+    // change when wire changes. A wire source change alters the bytes tsup
+    // inlines into the CLI's and the adapter's tarballs, so both of those need
+    // a release for a user to see it, AND wire itself needs one for pome-cloud
+    // to see it. Three bumps for one wire change is the correct answer, not a
+    // gate bug; the wrong answer is the silent non-release the gate exists to
+    // prevent.
+    name: "@pome-sh/wire",
+    manifest: "packages/wire/package.json",
+    registry: "GitHub Packages (npm.pkg.github.com)",
+    pathPrefixes: ["packages/wire/"],
   },
 ];
 
@@ -68,7 +105,22 @@ for (const pkg of PACKAGES) {
     failures.push(
       `${pkg.name}: publish-relevant paths changed but ${pkg.manifest}'s version ` +
         `is still ${headVersion}. release.yml only publishes on a version diff — ` +
-        `bump it, or this change never reaches npm.`,
+        `bump it, or this change never reaches ${pkg.registry}.`,
+    );
+    continue;
+  }
+
+  // "Differs" is not enough: a version that differs DOWNWARD (a stale branch
+  // rebased past a release, or a bad merge resolution) passed this gate and
+  // then hard-failed release.yml's floor check after merge — and since that
+  // check runs before any publish, one downgraded package took its whole lane's
+  // publishes down with it. Catch it in the PR, where it costs one line.
+  if (!isAhead(headVersion, baseVersion)) {
+    failures.push(
+      `${pkg.name}: ${pkg.manifest}'s version ${headVersion} is BEHIND the base branch's ` +
+        `${baseVersion}. Publishing would retag the registry's latest backwards, so ` +
+        `release.yml refuses — and refuses before publishing anything else in the same ` +
+        `lane. Rebase and bump above ${baseVersion}.`,
     );
   }
 }

--- a/scripts/ci/check-wire-tarball.mjs
+++ b/scripts/ci/check-wire-tarball.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+//
+// Release gate for @pome-sh/wire's own tarball (F-949).
+//
+// `scripts/clean-room-pack-test.mjs` audits the two npmjs tarballs — it asserts
+// they carry NO `@pome-sh/*` dependency, which is the assertion that keeps wire
+// inlined rather than installed. It says nothing about wire's own tarball,
+// because until F-949 wire had no tarball: it was `private: true` and reached
+// users only as bytes inside the CLI's and the adapter's `dist/`.
+//
+// Now it is also published to GitHub Packages for cross-repo consumers
+// (pome-cloud), and that install path has failure modes the workspace hides.
+//
+//   1. Inside this repo every consumer resolves `@pome-sh/wire` through npm's
+//      workspace symlink to `packages/wire/`, where the whole source tree
+//      exists, so an `exports` subpath pointing at a file the `files` field
+//      does not ship resolves fine forever. A cross-repo consumer gets only
+//      what is in the tarball, and the failure is
+//      ERR_PACKAGE_PATH_NOT_EXPORTED on their first import — in their repo.
+//   2. `npm publish` on a `private: true` workspace EXITS 0 with a warning
+//      ("Skipping workspace …, marked as private"). A one-character regression
+//      to `private: true` would therefore produce a fully green release that
+//      published nothing — exactly the silence
+//      `check-version-bump-required.mjs` exists to abolish.
+//   3. Publishing to the wrong registry cannot be undone; public npm has no
+//      unpublish window after 72 hours.
+//
+// Modes:
+//   --manifest-only  Assert only the properties readable from package.json
+//                    (private, publishConfig.registry). No build, no `npm
+//                    pack`, no network — so ci.yml runs this on every PR, and
+//                    2 and 3 above are caught BEFORE merge rather than by a
+//                    red release job after the npmjs publishes already went out.
+//   (default)        The above, plus pack wire and audit the real tarball.
+//                    Requires a built `packages/wire/dist`.
+//
+// Usage: node scripts/ci/check-wire-tarball.mjs [--manifest-only] [--keep]
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const KEEP = process.argv.includes("--keep");
+const MANIFEST_ONLY = process.argv.includes("--manifest-only");
+const MANIFEST_PATH = join(ROOT, "packages", "wire", "package.json");
+const EXPECTED_REGISTRY = "https://npm.pkg.github.com";
+
+const failures = [];
+const manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+
+// ── Manifest assertions (no build, no network) ───────────────────────────────
+
+// Stricter than npm, on purpose. npm publishes a manifest with no `private`
+// field at all quite happily — but `private: true` makes `npm publish -w` exit
+// 0 having published nothing, so the difference between "absent" and
+// "explicitly false" is the difference between a silent regression and a loud
+// one. Requiring `false` keeps the intent in the file where a reviewer sees it.
+if (manifest.private !== false) {
+  failures.push(
+    `packages/wire/package.json has \`private: ${JSON.stringify(manifest.private)}\`; it must be exactly \`false\`.\n` +
+      "    `private: true` is worse than a publish failure: `npm publish -w` skips a private\n" +
+      "    workspace with a warning and EXITS 0, so the release goes green having published\n" +
+      "    nothing. An absent field would publish, but states nothing to a reviewer.",
+  );
+}
+
+if (manifest.publishConfig?.registry !== EXPECTED_REGISTRY) {
+  failures.push(
+    `packages/wire/package.json \`publishConfig.registry\` must be ${EXPECTED_REGISTRY} — ` +
+      `found ${JSON.stringify(manifest.publishConfig?.registry)}.\n` +
+      "    wire is internal infrastructure for cross-repo consumers, not an end-user package.\n" +
+      "    A mistaken publish to registry.npmjs.org cannot be taken back after 72 hours.",
+  );
+}
+
+/** Every file path an `exports` map points at, conditions and subpaths flattened. */
+function exportTargets(exportsField) {
+  const targets = new Set();
+  const walk = (node) => {
+    if (typeof node === "string") targets.add(node.replace(/^\.\//, ""));
+    else if (node && typeof node === "object") for (const value of Object.values(node)) walk(value);
+  };
+  walk(exportsField);
+  return targets;
+}
+
+// `main`/`types` are the pre-`exports` resolution path; older tooling and
+// bundlers still read them, so they have to ship too.
+const declaredPaths = exportTargets(manifest.exports);
+for (const field of ["main", "types"]) {
+  if (typeof manifest[field] === "string") declaredPaths.add(manifest[field].replace(/^\.\//, ""));
+}
+declaredPaths.delete("package.json"); // always in the tarball; not a build output
+
+// ── Tarball assertions ──────────────────────────────────────────────────────
+
+function auditTarball() {
+  const workDirectory = mkdtempSync(join(tmpdir(), "pome-wire-tarball-"));
+  try {
+    // --ignore-scripts: wire's `prepublishOnly` would rebuild, which would hide
+    // a "published a stale dist" bug. The caller is expected to have built.
+    execFileSync(
+      "npm",
+      ["pack", "-w", "@pome-sh/wire", "--ignore-scripts", "--pack-destination", workDirectory],
+      { cwd: ROOT, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    const tarballName = readdirSync(workDirectory).find((file) => file.endsWith(".tgz"));
+    if (!tarballName) {
+      failures.push("`npm pack -w @pome-sh/wire` produced no tarball");
+      return;
+    }
+    const tarball = join(workDirectory, tarballName);
+    console.log(`packed ${tarballName}`);
+
+    const hardLinks = execFileSync("tar", ["-tvf", tarball], { encoding: "utf8" })
+      .split("\n")
+      .filter((line) => line.startsWith("h"));
+    if (hardLinks.length > 0) {
+      failures.push(
+        `tarball contains hard links — the registry rejects these (E415):\n${hardLinks.join("\n")}`,
+      );
+    }
+
+    // npm wraps every tarball entry in a top-level `package/` directory.
+    const shipped = new Set(
+      execFileSync("tar", ["-tf", tarball], { encoding: "utf8" })
+        .split("\n")
+        .map((line) => line.trim().replace(/^package\//, ""))
+        .filter(Boolean),
+    );
+
+    const missing = [...declaredPaths].filter((path) => !shipped.has(path));
+    if (missing.length > 0) {
+      failures.push(
+        "these paths are declared in packages/wire/package.json (`exports`/`main`/`types`) but are\n" +
+          "    NOT in the tarball, so a cross-repo consumer's import dies with\n" +
+          "    ERR_PACKAGE_PATH_NOT_EXPORTED:\n" +
+          missing.map((path) => `      - ${path}`).join("\n") +
+          "\n    Fix: add the file's directory to the `files` field, or drop the export.",
+      );
+    }
+
+    // wire's tsconfig sets `sourceMap: true` and no `src/` ships, so every
+    // emitted `.js.map` would be a dangling map with no `sourcesContent`.
+    // `files` excludes them (`!dist/**/*.map`). clean-room-pack-test.mjs
+    // already treats a dangling map in a published tarball as a hard failure
+    // for the other two packages (F-943); wire holds to the same rule.
+    const sourcemaps = [...shipped].filter((path) => path.endsWith(".map"));
+    if (sourcemaps.length > 0) {
+      failures.push(
+        `tarball contains ${sourcemaps.length} dangling sourcemap(s) — no \`src/\` ships, so they\n` +
+          "    resolve to nothing for a consumer. `files` should keep excluding `!dist/**/*.map`:\n" +
+          sourcemaps.map((path) => `      - ${path}`).join("\n"),
+      );
+    }
+
+    console.log(
+      `  ✓ ${declaredPaths.size} declared path(s) ship, no hard links, no dangling sourcemaps`,
+    );
+  } finally {
+    if (KEEP) console.log(`--keep: left the packed tarball at ${workDirectory}`);
+    else rmSync(workDirectory, { recursive: true, force: true });
+  }
+}
+
+if (!MANIFEST_ONLY) auditTarball();
+
+if (failures.length > 0) {
+  console.error(
+    `\n@pome-sh/wire ${MANIFEST_ONLY ? "manifest" : "tarball"} audit FAILED:`,
+  );
+  for (const failure of failures) console.error(`\n  - ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  MANIFEST_ONLY
+    ? `@pome-sh/wire manifest audit passed — private: false, publishConfig targets ${EXPECTED_REGISTRY}.`
+    : `@pome-sh/wire tarball audit passed — publishConfig targets ${EXPECTED_REGISTRY}, tarball is consumable.`,
+);

--- a/scripts/ci/decide-publish.sh
+++ b/scripts/ci/decide-publish.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# "Does this package need publishing?" — the version-diff decision behind
+# release.yml's publish jobs. Compares a package's local package.json version
+# against what its registry currently serves and writes `<output>=true|false`
+# to $GITHUB_OUTPUT.
+#
+# Folded in from the deleted scripts/check-cli-version-floor.sh (F-724): never
+# publish from a version base BEHIND the registry's published latest — that
+# retags `latest` backwards for every existing consumer. A version that differs
+# but does not sort above the registry's is a hard fail, not a skip.
+#
+# Extracted from an inline `decide()` in release.yml by F-949, when
+# @pome-sh/wire became a third publish target on a DIFFERENT registry
+# (npm.pkg.github.com). Two callers now need identical semantics against
+# different registries and with different auth, and the wire decision must be
+# able to fail without taking the two npmjs publishes down with it — so this
+# lives in one tested file instead of being copy-pasted into a second job.
+# Regression suite: scripts/ci/decide-publish.test.mjs.
+#
+# Usage: decide-publish.sh <package-name> <manifest-path> <output-key> [registry]
+#
+#   registry — optional. Omitted ⇒ npm's default (registry.npmjs.org). Passed
+#   explicitly for GitHub Packages. Deliberately an ARGUMENT rather than an
+#   `@scope:registry=` line in .npmrc: a scope mapping would redirect EVERY
+#   @pome-sh/* read, including @pome-sh/cli's and the adapter's, to a registry
+#   where they do not exist — and every release would then look like a
+#   brand-new package with a 0.0.0 baseline, silently disabling the floor check.
+
+set -euo pipefail
+
+if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
+  echo "usage: $0 <package-name> <manifest-path> <output-key> [registry]" >&2
+  exit 2
+fi
+
+name="$1"
+manifest="$2"
+output="$3"
+registry="${4:-}"
+
+# Never empty, so "${view[@]}" cannot trip `set -u` on an empty-array expansion.
+view=(npm view "${name}" version)
+if [ -n "${registry}" ]; then
+  view+=(--registry "${registry}")
+fi
+
+local_version="$(node -p "require('./${manifest}').version")"
+
+npm_view_err="$(mktemp)"
+if registry_version="$("${view[@]}" 2>"${npm_view_err}")"; then
+  :
+elif grep -q "E404" "${npm_view_err}"; then
+  # Genuinely unpublished (brand-new package) — 0.0.0 is the correct baseline.
+  # This is the path a first-ever publish takes. GitHub Packages answers 404
+  # for a name that has never been published under the owner, exactly as npmjs
+  # does, so the first release needs no special case.
+  registry_version="0.0.0"
+else
+  # A registry/network/auth error is NOT "unpublished". Treating it as 0.0.0
+  # would make any local version look publishable and bypass the floor check
+  # below, which exists specifically to stop retagging `latest` backwards.
+  #
+  # This matters MORE for GitHub Packages: an absent or under-scoped token
+  # answers 401 for a package that exists, and a 401 must never be mistaken
+  # for "nothing published yet".
+  echo "::error::npm view ${name} failed for a reason other than 'not found':"
+  cat "${npm_view_err}" >&2
+  rm -f "${npm_view_err}"
+  exit 1
+fi
+rm -f "${npm_view_err}"
+
+echo "${name} — local: ${local_version}, registry (${registry:-registry.npmjs.org}): ${registry_version}"
+
+if [ "${local_version}" = "${registry_version}" ]; then
+  echo "${output}=false" >> "${GITHUB_OUTPUT}"
+  echo "  ↳ unchanged; nothing to publish."
+  exit 0
+fi
+
+highest="$(printf '%s\n%s\n' "${local_version}" "${registry_version}" | sort -V | tail -n1)"
+if [ "${highest}" != "${local_version}" ]; then
+  echo "::error::${name} local version ${local_version} is BEHIND the registry's published latest ${registry_version}. Publishing would retag latest backwards."
+  exit 1
+fi
+
+echo "${output}=true" >> "${GITHUB_OUTPUT}"
+echo "  ↳ will publish ${local_version}."

--- a/scripts/ci/decide-publish.test.mjs
+++ b/scripts/ci/decide-publish.test.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+/**
+ * Regression coverage for scripts/ci/decide-publish.sh (F-949).
+ *
+ * Mocks `npm` on PATH so every registry answer is exercised without a network:
+ * unpublished (E404 ⇒ publish from a 0.0.0 baseline), unchanged (skip), ahead
+ * (publish), BEHIND (hard fail — the floor check that stops retagging `latest`
+ * backwards), and 401/403/5xx (hard fail — an auth or transport error must
+ * never be read as "nothing published yet", which would bypass the floor
+ * check). The 401 case is the one GitHub Packages actually produces for a
+ * package that exists but the token cannot read, so it is the reason this
+ * distinction is load-bearing rather than theoretical.
+ *
+ * Also asserts the registry argument is passed through as `--registry` for the
+ * GitHub Packages caller and NOT passed for the npmjs callers, and that
+ * release.yml wires the jobs up so a GitHub Packages failure cannot block the
+ * two npmjs publishes.
+ */
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const SCRIPT = join(ROOT, "scripts/ci/decide-publish.sh");
+
+let failures = 0;
+function check(label, condition, detail = "") {
+  if (condition) {
+    console.log(`  ✓ ${label}`);
+    return;
+  }
+  failures += 1;
+  console.error(`  ✗ ${label}${detail ? `\n      ${detail}` : ""}`);
+}
+
+/**
+ * Run decide-publish.sh with a mocked npm.
+ * `answer` is a bash snippet that stands in for `npm view`'s behaviour.
+ */
+function run({ answer, localVersion, registry }) {
+  const dir = mkdtempSync(join(tmpdir(), "decide-publish-"));
+  try {
+    writeFileSync(join(dir, "manifest.json"), JSON.stringify({ version: localVersion }));
+    const npm = join(dir, "npm");
+    writeFileSync(
+      npm,
+      `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> "${join(dir, "argv.txt")}"\n${answer}\n`,
+    );
+    chmodSync(npm, 0o755);
+
+    const githubOutput = join(dir, "github-output.txt");
+    writeFileSync(githubOutput, "");
+    const result = spawnSync(
+      "bash",
+      [SCRIPT, "@pome-sh/thing", "manifest.json", "thing", ...(registry ? [registry] : [])],
+      {
+        cwd: dir,
+        encoding: "utf8",
+        env: { ...process.env, PATH: `${dir}:${process.env.PATH}`, GITHUB_OUTPUT: githubOutput },
+      },
+    );
+    return {
+      status: result.status,
+      stdout: result.stdout ?? "",
+      stderr: result.stderr ?? "",
+      output: readFileSync(githubOutput, "utf8").trim(),
+      argv: readFileSync(join(dir, "argv.txt"), "utf8").trim(),
+    };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const E404 = `echo "npm error code E404" >&2
+echo 'npm error 404 Not Found - GET https://npm.pkg.github.com/@pome-sh%2fthing - npm package "thing" does not exist under owner "pome-sh"' >&2
+exit 1`;
+const E401 = `echo "npm error code E401" >&2
+echo "npm error 401 Unauthorized - GET https://npm.pkg.github.com/@pome-sh%2fthing" >&2
+exit 1`;
+const E403 = `echo "npm error code E403" >&2
+echo "npm error 403 Forbidden - GET https://npm.pkg.github.com/@pome-sh%2fthing" >&2
+exit 1`;
+const SERVER_ERROR = `echo "npm error code E500" >&2
+echo "npm error 500 Internal Server Error" >&2
+exit 1`;
+
+console.log("decide-publish.sh");
+
+// A package the registry has never seen must publish, not fail. This is the
+// first-ever-publish path for @pome-sh/wire on GitHub Packages.
+{
+  const r = run({ answer: E404, localVersion: "0.2.1" });
+  check("E404 (never published) ⇒ publishes from a 0.0.0 baseline", r.status === 0 && r.output === "thing=true", `status=${r.status} output=${r.output}`);
+  check("E404 reports the 0.0.0 baseline in the log", r.stdout.includes("0.0.0"), r.stdout);
+}
+
+// Unchanged ⇒ skip.
+{
+  const r = run({ answer: `echo "0.2.1"`, localVersion: "0.2.1" });
+  check("same version ⇒ skip", r.status === 0 && r.output === "thing=false", `status=${r.status} output=${r.output}`);
+}
+
+// Ahead ⇒ publish.
+{
+  const r = run({ answer: `echo "0.2.0"`, localVersion: "0.2.1" });
+  check("local ahead of registry ⇒ publish", r.status === 0 && r.output === "thing=true", `status=${r.status} output=${r.output}`);
+}
+
+// Behind ⇒ hard fail. Publishing would retag `latest` backwards.
+{
+  const r = run({ answer: `echo "9.9.9"`, localVersion: "0.2.1" });
+  check("local BEHIND registry ⇒ hard fail", r.status !== 0, `status=${r.status}`);
+  check("behind-fail writes no output (job must not proceed)", r.output === "", `output=${r.output}`);
+  check("behind-fail explains the retag risk", r.stdout.includes("retag latest backwards"), r.stdout);
+}
+
+// Multi-digit ordering: `sort -V` must not compare 0.2.10 as lower than 0.2.9.
+{
+  const r = run({ answer: `echo "0.2.9"`, localVersion: "0.2.10" });
+  check("0.2.10 counts as ahead of 0.2.9 (version sort, not lexical)", r.status === 0 && r.output === "thing=true", `status=${r.status} output=${r.output}`);
+}
+
+// Auth / transport failures must NOT be read as "unpublished".
+for (const [label, answer] of [
+  ["401 (GitHub Packages, token cannot read an existing package)", E401],
+  ["403", E403],
+  ["500", SERVER_ERROR],
+]) {
+  const r = run({ answer, localVersion: "0.2.1" });
+  check(`${label} ⇒ hard fail, never a 0.0.0 baseline`, r.status !== 0 && r.output === "", `status=${r.status} output=${r.output}`);
+  check(`${label} does not claim "unchanged" or publish`, !r.output.includes("true"), r.output);
+}
+
+// The registry argument must reach npm as --registry, and must be absent for npmjs.
+{
+  const gh = run({ answer: `echo "0.2.0"`, localVersion: "0.2.1", registry: "https://npm.pkg.github.com" });
+  check(
+    "registry argument is passed as --registry",
+    gh.argv.includes("--registry https://npm.pkg.github.com"),
+    gh.argv,
+  );
+  const npmjs = run({ answer: `echo "0.2.0"`, localVersion: "0.2.1" });
+  check("no registry argument ⇒ npm's default registry, no --registry flag", !npmjs.argv.includes("--registry"), npmjs.argv);
+}
+
+// Argument validation.
+{
+  const dir = mkdtempSync(join(tmpdir(), "decide-publish-args-"));
+  try {
+    const r = spawnSync("bash", [SCRIPT, "only-one-arg"], { cwd: dir, encoding: "utf8" });
+    check("too few arguments ⇒ usage error", r.status === 2, `status=${r.status}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// The wiring assertion: a GitHub Packages outage must not block the npmjs
+// publishes. `publish` depends on `plan` (npmjs only) and `publish-wire` on
+// `plan-wire` (GitHub Packages only) — never the other way round.
+console.log("\nrelease.yml wiring");
+{
+  const workflow = readFileSync(join(ROOT, ".github/workflows/release.yml"), "utf8");
+  const jobOf = (name) => {
+    const start = workflow.indexOf(`\n  ${name}:\n`);
+    if (start === -1) return "";
+    const rest = workflow.slice(start + 1);
+    const next = rest.slice(1).search(/\n  \w[\w-]*:\n/);
+    return next === -1 ? rest : rest.slice(0, next + 1);
+  };
+
+  const plan = jobOf("plan");
+  const planWire = jobOf("plan-wire");
+  const publish = jobOf("publish");
+  const publishWire = jobOf("publish-wire");
+
+  check("all four jobs exist", [plan, planWire, publish, publishWire].every(Boolean));
+  check(
+    "plan (npmjs) does not read GitHub Packages",
+    !plan.includes("npm.pkg.github.com"),
+    "a GitHub Packages read in `plan` would let a GH outage block the npmjs publishes",
+  );
+  check("plan-wire reads GitHub Packages", planWire.includes("npm.pkg.github.com"));
+  check("publish needs plan only", /needs:\s*plan\s*$/m.test(publish) && !publish.includes("plan-wire"));
+  check("publish-wire needs plan-wire only", publishWire.includes("needs: plan-wire"));
+  // Inspect the actual publish command line, not the surrounding prose — the
+  // comments above it legitimately mention both `--access public` and npmjs.
+  const wirePublishCommand = publishWire
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.startsWith("npm publish"));
+  check("publish-wire has an `npm publish` command", Boolean(wirePublishCommand), publishWire);
+  check(
+    "publish-wire publishes to GitHub Packages explicitly (belt and braces with publishConfig)",
+    wirePublishCommand?.includes("--registry https://npm.pkg.github.com"),
+    wirePublishCommand,
+  );
+  check(
+    "publish-wire never passes --access public (not a GitHub Packages concept)",
+    !wirePublishCommand?.includes("--access"),
+    wirePublishCommand,
+  );
+  check(
+    "publish-wire publishes only the wire workspace",
+    wirePublishCommand?.includes("-w @pome-sh/wire"),
+    wirePublishCommand,
+  );
+  check("plan-wire has packages: read", planWire.includes("packages: read"));
+  check("publish-wire has packages: write", publishWire.includes("packages: write"));
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) failed.`);
+  process.exit(1);
+}
+console.log("\nAll decide-publish.sh checks passed.");

--- a/scripts/ci/decide-publish.test.mjs
+++ b/scripts/ci/decide-publish.test.mjs
@@ -175,13 +175,20 @@ console.log("\nrelease.yml wiring");
   const publish = jobOf("publish");
   const publishWire = jobOf("publish-wire");
 
+  // A regex rather than `.includes("npm.pkg.github.com")`: this is a text
+  // search over workflow YAML, not URL-host validation, and the `.includes`
+  // spelling trips CodeQL's js/incomplete-url-substring-sanitization heuristic
+  // — which is a real bug pattern when you are checking an actual URL, and a
+  // false positive here. Saying it as a pattern match says what it is.
+  const READS_GITHUB_PACKAGES = /npm\.pkg\.github\.com/;
+
   check("all four jobs exist", [plan, planWire, publish, publishWire].every(Boolean));
   check(
     "plan (npmjs) does not read GitHub Packages",
-    !plan.includes("npm.pkg.github.com"),
+    !READS_GITHUB_PACKAGES.test(plan),
     "a GitHub Packages read in `plan` would let a GH outage block the npmjs publishes",
   );
-  check("plan-wire reads GitHub Packages", planWire.includes("npm.pkg.github.com"));
+  check("plan-wire reads GitHub Packages", READS_GITHUB_PACKAGES.test(planWire));
   check("publish needs plan only", /needs:\s*plan\s*$/m.test(publish) && !publish.includes("plan-wire"));
   check("publish-wire needs plan-wire only", publishWire.includes("needs: plan-wire"));
   // Inspect the actual publish command line, not the surrounding prose — the

--- a/scripts/clean-room-pack-test.mjs
+++ b/scripts/clean-room-pack-test.mjs
@@ -1,7 +1,12 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Clean-room release gate for the two published packages.
+// Clean-room release gate for the two packages published to npm. (`@pome-sh/wire`
+// is also published, but to GitHub Packages for cross-repo consumers, and is
+// audited separately by scripts/ci/check-wire-tarball.mjs — F-949. What matters
+// HERE is the assertion below that neither npm tarball declares an `@pome-sh/*`
+// dependency: that is what keeps wire inlined rather than installed, and it must
+// keep holding now that wire is resolvable-but-401 rather than nonexistent.)
 //
 // Packs `@pome-sh/cli` and `@pome-sh/adapter-claude-sdk`, installs each tarball
 // into a throwaway directory with NO access to this workspace, and drives them
@@ -29,7 +34,7 @@
 //
 // The adapter checks:
 //   - packed manifest declares no `@pome-sh/*` dependency (its wire types are
-//     bundled; `@pome-sh/wire` is private)
+//     bundled; `@pome-sh/wire` is not installable by an end user)
 //   - no dangling `.map` files, no compiled `dist/examples/` directory
 //   - runtime import of `flushPomeTelemetry` with the peer installed
 //   - a real consumer file TYPECHECKS against the shipped `dist/index.d.ts`.


### PR DESCRIPTION
## What

Makes `@pome-sh/wire` independently publishable to **GitHub Packages** (`npm.pkg.github.com`), so `pome-cloud` can consume the trace vocabulary across the repo boundary without npm-installing internal packages. This is the only piece of F-949 that has to cross that boundary — pome-cloud owning its control-plane contract types locally is separate work, and this PR does not touch pome-cloud.

**Publishing wire is additive, not a replacement.** `cli/` and `packages/adapter-claude-sdk/` still declare wire as a `devDependency` at `"*"`, tsup's `noExternal` still inlines it, and neither npm tarball gains an `@pome-sh/*` dependency. `npm run test:pack` still passes on both — that's the assertion that keeps wire inlined rather than installed, and it stays load-bearing now that wire is resolvable-but-401 rather than nonexistent.

## Shape

Four jobs in two independent lanes: `plan → publish` (npmjs, OIDC) and `plan-wire → publish-wire` (GitHub Packages, `GITHUB_TOKEN`).

A separate lane rather than a third `publish` matrix entry, for two reasons:

1. **The auth mechanisms differ.** A shared job would carry `id-token: write`, `NPM_CONFIG_PROVENANCE`, the setup-node v6 pin (actions/setup-node#1551 is an OIDC-path bug) and the npm@11.5.1 pin (an OIDC-provenance crash) under a comment explaining none of it applies to wire.
2. **The lanes must not be able to break each other.** GitHub Packages requires auth even to *read*, and a read failure is deliberately a hard failure — a 401 must never be mistaken for "unpublished", which would bypass the never-publish-behind-latest floor check. Had that read lived in the shared `plan` job, any GitHub Packages 401/outage — including an org owner changing the package's visibility settings, with no commit and no review — would fail `plan` and silently skip the `@pome-sh/cli` and `@pome-sh/adapter-claude-sdk` publishes. Blast radius now matches the artifact.

The shared version-diff decision moved out of inline YAML into `scripts/ci/decide-publish.sh` so the two lanes can't drift, with `decide-publish.test.mjs` mocking `npm` to cover 404-is-unpublished, 401/403/500-is-not, the floor check, version-sort ordering, and the job wiring itself.

## Two silent-failure modes now caught pre-merge

Both are readable from `packages/wire/package.json` alone, so `ci.yml` runs that half of the tarball gate with no build and no network:

- **`npm publish -w` on a `private: true` workspace warns and EXITS 0.** Verified against npm 11.5.1's source (`execWorkspaces` catches `EPRIVATE` and only logs). A one-character regression would be a fully green release that published nothing — exactly the silence `check-version-bump-required.mjs` exists to abolish. The gate requires `private` to be exactly `false`, not merely absent.
- **A publish to public npm can't be undone after 72 hours.** Registry selection is doubly pinned: `publishConfig.registry` in the manifest *and* an explicit `--registry` at publish time. Confirmed from npm's source that `npm publish -w` reads the *workspace's* `publishConfig` (not the root's) and that CLI flags win over it.

## Rode along (found by review)

- **wire's tarball was shipping 14 dangling sourcemaps.** `tsconfig` sets `sourceMap: true` and no `src/` ships, so they resolved to nothing. `clean-room-pack-test.mjs` already treats this as a hard failure for the other two tarballs (F-943); `files` now excludes `!dist/**/*.map` and the gate asserts it. Local builds keep their maps.
- **The version-bump gate accepted a version that differed *downward*.** A stale branch rebased past a release passed CI and then hard-failed `release.yml`'s floor check after merge. This PR promotes that from "one package doesn't publish" to "nothing in that lane publishes", so the gate now requires strictly-ahead. (This PR was itself an instance — see below.)
- **Four comments** in `tsup.config.ts`, `src/correlation.ts`, `check-bundled-runtime-deps.mjs` and `clean-room-pack-test.mjs` asserted wire is `private: true` and unpublishable. They're now true only in the sense that matters — unresolvable *by an end user* — so they say that, and say why `noExternal` must stay.

## Three version bumps

`cli` 0.21.7 → **0.21.8**, `adapter-claude-sdk` 0.3.2 → **0.3.3**, `wire` 0.2.0 → **0.2.1**.

The cli/adapter bumps are forced by the pre-existing gate (verified: it hard-fails without them) because `packages/wire/` is publish-relevant for both. Both are version-only — no wire source changed, so both bundles are byte-identical in content. Following the precedent `cli/CHANGELOG.md` 0.21.7 set for this exact situation five commits ago: bump rather than add an exception list to the gate.

`trace-contract.json` embeds wire's own version, so it's regenerated (one line); `RELEASING.md` now says every wire bump must.

## Verified locally

`lint:dead-code` (knip) · `build` · `typecheck` · `gate:bundled-deps` · **`test:pack`** (both tarballs' manifests still pure, all five twins boot, adapter consumer typechecks against shipped dts) · full suite (9 workspaces, ~3000 tests) · every `ci.yml` gate · `actionlint` + `shellcheck` on both workflows · new gates negative-tested (they go red before they go green).

Beyond CI: the packed wire tarball was installed into a directory **outside this repo** with only `zod` — all six subpath exports import, and a consumer typechecks under `NodeNext` without `skipLibCheck`.

## Not provable until this actually runs

- **The first publish itself.** `GITHUB_TOKEN` + `packages: write` is the documented path and `repository` correctly names the canonical `pome-sh/digital-twins`, but the org's **Package creation** setting can 403 it. Worth checking `github.com/organizations/pome-sh/settings/packages` before merge.
- **The authenticated read.** I confirmed GitHub Packages answers `404` unauthenticated for a name that doesn't exist under the owner (so `E404` ⇒ unpublished is right, and the first publish takes the `0.0.0`-baseline path), and `401` for one that exists but you can't read. The authenticated-read shape for a package that doesn't exist yet is the one case only a real run proves.

## Maintainer action after the first publish

The repo is public, so wire's package inherits public-repo access. GitHub Packages' npm registry supports granular permissions, so it can be made private — but **only after the package exists**, and the order matters: add `pome-sh/digital-twins` to *Manage Actions access* with **Write** *first*, then disable inheritance. Disabling inheritance clears that list, and without it `plan-wire`'s read 401s and every wire release goes red with no commit to revert. Written up in `RELEASING.md`.

Ticket: F-949 · **Do not merge** — separate review step.
