### PR TITLE
Wire also publishes to public npm, alongside its existing GitHub Packages target (F-949)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,34 +22,50 @@ name: release
 # declaration layer on its own restores that path without reversing the
 # privatisation that fixed the two-zod-identities bug (F-942).
 #
-# @pome-sh/wire is the THIRD publish target and the odd one out (F-949). Same
-# version-diff model, different registry and different audience: GitHub Packages
-# (npm.pkg.github.com), for cross-repo internal consumers like pome-cloud — not
-# end users. It stays bundled-inlined into the two npmjs tarballs exactly as
-# before (tsup `noExternal`); publishing it is ADDITIVE, not a replacement.
+# @pome-sh/wire (F-949) publishes to BOTH registries now, independently, from
+# the SAME version line. It originally shipped to GitHub Packages only, for
+# cross-repo internal consumers like pome-cloud — not end users. pome-cloud's
+# migration off the deprecated @pome-sh/shared-types needs to npm-install wire
+# too, and a scope can only resolve from one registry per consumer: pome-cloud's
+# other unavoidable @pome-sh/* deps (sdk, twin-*) exist only on public npmjs, so
+# routing @pome-sh/wire there for GitHub Packages would break those. Public npm
+# has no confidentiality downside for wire — it is trace-vocabulary Zod schemas
+# with no domain logic or secrets, already audited clean when the GitHub
+# Packages target shipped. Publishing to npmjs is ADDITIVE: the GitHub Packages
+# target is untouched, and wire stays bundled-inlined into the two npmjs
+# tarballs exactly as before (tsup `noExternal`).
 #
-# Hence FOUR jobs in two independent lanes — plan → publish for npmjs,
-# plan-wire → publish-wire for GitHub Packages — rather than a third matrix
-# entry and a third `decide` call:
+# Hence wire is now the npmjs lane's FOURTH matrix entry (`plan`/`publish`,
+# alongside cli/adapter/checks) AND still has its own GitHub Packages lane
+# (`plan-wire`/`publish-wire`) — not a replacement of one lane by the other:
 #
-#   - The auth MECHANISM differs. npmjs uses OIDC Trusted Publishing (no token,
-#     `id-token: write`, provenance); GitHub Packages uses GITHUB_TOKEN with
-#     `packages: write` and an .npmrc auth line. One job cannot honestly do
-#     both, and a shared job would carry four pieces of OIDC cargo (the
-#     setup-node v6 pin for actions/setup-node#1551, the npm@11.5.1 pin for the
-#     provenance crash, `NPM_CONFIG_PROVENANCE`, `id-token: write`) under a
-#     comment explaining that none of it applies to wire.
+#   - The auth MECHANISM differs per registry, not per package. npmjs uses OIDC
+#     Trusted Publishing (no token, `id-token: write`, provenance); GitHub
+#     Packages uses GITHUB_TOKEN with `packages: write` and an .npmrc auth line.
+#     One job cannot honestly do both, and a shared job would carry four pieces
+#     of OIDC cargo (the setup-node v6 pin for actions/setup-node#1551, the
+#     npm@11.5.1 pin for the provenance crash, `NPM_CONFIG_PROVENANCE`,
+#     `id-token: write`) under a comment explaining that none of it applies to
+#     the GitHub Packages publish.
 #   - The lanes must not be able to break each other. GitHub Packages requires
 #     auth even to READ, and a read failure is deliberately a hard failure (a
 #     401 must never be mistaken for "unpublished" — that would bypass the
 #     never-publish-behind-latest floor check). If that read lived in `plan`,
 #     any GitHub Packages 401/403/outage — or an org owner flipping the
 #     package's visibility settings — would fail `plan` and silently skip the
-#     @pome-sh/cli and @pome-sh/adapter-claude-sdk publishes, which have nothing
-#     to do with GitHub Packages. Blast radius now matches the artifact.
+#     @pome-sh/cli, @pome-sh/adapter-claude-sdk and @pome-sh/checks publishes,
+#     which have nothing to do with GitHub Packages. Blast radius now matches
+#     the artifact. Symmetrically, wire's npmjs decision/publish lives entirely
+#     in `plan`/`publish` so an npmjs outage cannot take down the GitHub
+#     Packages publish either.
+#   - Wire's own `publishConfig.registry` still points at GitHub Packages (and
+#     ci.yml's `gate:wire-manifest` still asserts that on every PR — it is what
+#     `publish-wire` relies on by default). The npmjs-lane `publish` step
+#     therefore passes an explicit `--registry https://registry.npmjs.org` for
+#     wire ONLY, which outranks `publishConfig`. See the comment on that step.
 #
 # The shared decision logic lives in scripts/ci/decide-publish.sh (tested by
-# scripts/ci/decide-publish.test.mjs) so the two lanes cannot drift.
+# scripts/ci/decide-publish.test.mjs) so the lanes cannot drift.
 on:
   push:
     branches: [main]
@@ -72,15 +88,17 @@ jobs:
       cli: ${{ steps.diff.outputs.cli }}
       adapter: ${{ steps.diff.outputs.adapter }}
       checks: ${{ steps.diff.outputs.checks }}
+      wireNpm: ${{ steps.diff.outputs.wireNpm }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      # Deliberately reads ONLY registry.npmjs.org. @pome-sh/wire's diff lives in
-      # `plan-wire` so that a GitHub Packages 401/outage cannot skip the two npmjs
-      # publishes: a failure here fails `plan`, and everything needing it is
-      # skipped. Blast radius matches the artifact.
+      # Deliberately reads ONLY registry.npmjs.org (the `registry` argument is
+      # omitted below, including for wire). @pome-sh/wire's GitHub Packages diff
+      # lives separately in `plan-wire` so that a GitHub Packages 401/outage
+      # cannot skip the npmjs publishes: a failure here fails `plan`, and
+      # everything needing it is skipped. Blast radius matches the artifact.
       - name: Compare local versions against npm
         id: diff
         run: |
@@ -88,6 +106,12 @@ jobs:
           scripts/ci/decide-publish.sh "@pome-sh/cli" "cli/package.json" "cli"
           scripts/ci/decide-publish.sh "@pome-sh/adapter-claude-sdk" "packages/adapter-claude-sdk/package.json" "adapter"
           scripts/ci/decide-publish.sh "@pome-sh/checks" "packages/checks/package.json" "checks"
+          # wire's npmjs decision — independent of, and output-named distinctly
+          # from, plan-wire's `wire` output below (that one reads GitHub
+          # Packages). Same manifest, same version line, two registries decided
+          # separately: wire could be publishable on npmjs while already
+          # up to date (or even behind) on GitHub Packages, or vice versa.
+          scripts/ci/decide-publish.sh "@pome-sh/wire" "packages/wire/package.json" "wireNpm"
 
   plan-wire:
     name: does @pome-sh/wire need publishing
@@ -126,7 +150,7 @@ jobs:
   publish:
     name: publish ${{ matrix.package }}
     needs: plan
-    if: needs.plan.outputs.cli == 'true' || needs.plan.outputs.adapter == 'true' || needs.plan.outputs.checks == 'true'
+    if: needs.plan.outputs.cli == 'true' || needs.plan.outputs.adapter == 'true' || needs.plan.outputs.checks == 'true' || needs.plan.outputs.wireNpm == 'true'
     runs-on: ubuntu-latest
     strategy:
       # Never cancel a sibling mid-publish: a half-published set is worse than
@@ -146,6 +170,22 @@ jobs:
           # need an .npmrc change it cannot make without breaking @pome-sh/cli.
           - package: "@pome-sh/checks"
             enabled: ${{ needs.plan.outputs.checks }}
+          # @pome-sh/wire — the odd one out twice over (F-949). It is on this
+          # npmjs lane ADDITIONALLY to (not instead of) its separate GitHub
+          # Packages jobs further down in this file: pome-cloud's migration off
+          # @pome-sh/shared-types needs to npm-install wire, and the rest of its
+          # unavoidable @pome-sh/* deps only exist on public npmjs, so wire has
+          # to resolve from there too. `enabled` is `wireNpm`, not `wire` — the
+          # latter is the OTHER job's GitHub Packages output; reusing that name
+          # here would silently wire this job to the wrong decision. wire's own
+          # `publishConfig.registry` still targets GitHub Packages, so its
+          # Publish step below (and only its) passes an explicit
+          # `--registry` to land on npmjs instead. It skips the
+          # `gate:checks-tarball` step (`matrix.package == '@pome-sh/checks'`
+          # only) since that audit is specific to `@pome-sh/checks`'s six-inlined-
+          # workspace tarball shape and has no wire equivalent.
+          - package: "@pome-sh/wire"
+            enabled: ${{ needs.plan.outputs.wireNpm }}
     permissions:
       contents: read
       id-token: write # npm OIDC Trusted Publishing (provenance)
@@ -212,9 +252,31 @@ jobs:
             exit 1
           fi
           echo "E415 hard-link check OK: $tgz"
+      # @pome-sh/wire's own package.json sets `publishConfig.registry` to
+      # GitHub Packages (npm.pkg.github.com) as its DEFAULT — see
+      # publish-wire's "Publish to GitHub Packages" step and
+      # RELEASING.md — and ci.yml's `gate:wire-manifest` asserts that value on
+      # every PR, so it cannot be changed or removed here without failing that
+      # gate. `publishConfig` outranks the ambient registry that
+      # `registry-url: https://registry.npmjs.org` above configured, so
+      # publishing wire on THIS lane with no override would either silently
+      # attempt GitHub Packages (wrong registry, and this job never
+      # authenticates against it — ENEEDAUTH) or, if it somehow succeeded,
+      # publish wire to GitHub Packages twice while npmjs got nothing. An
+      # explicit `--registry` flag outranks `publishConfig` and is the only
+      # thing that reliably wins here — the same reasoning `publish-wire`
+      # applies in the opposite direction for defence-in-depth. cli, adapter
+      # and checks have no `publishConfig.registry`, so they fall through to
+      # the plain `npm publish` and pick up the registry `setup-node` wrote.
       - name: Publish
         if: matrix.enabled == 'true'
-        run: npm publish -w ${{ matrix.package }} --access public
+        run: |
+          set -euo pipefail
+          if [ "${{ matrix.package }}" = "@pome-sh/wire" ]; then
+            npm publish -w "${{ matrix.package }}" --access public --registry https://registry.npmjs.org
+          else
+            npm publish -w "${{ matrix.package }}" --access public
+          fi
         env:
           NPM_CONFIG_PROVENANCE: "true"
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,12 +1,14 @@
 # Releasing
 
-Three packages are published to **npm**: `@pome-sh/cli` and
-`@pome-sh/adapter-claude-sdk` for end users, and `@pome-sh/checks` — the grading
-vocabulary — for the cloud grader in `pome-sh/pome-cloud`. One package is
-published to **GitHub Packages** for internal cross-repo consumers:
-`@pome-sh/wire`. Everything else in this repo (`@pome-sh/sdk`, the five
-`@pome-sh/twin-*`) is `private: true` and bundled into those tarballs by tsup —
-it is never installed from a registry, so it never needs its own release.
+Four packages are published to **npm**: `@pome-sh/cli` and
+`@pome-sh/adapter-claude-sdk` for end users, `@pome-sh/checks` — the grading
+vocabulary — for the cloud grader in `pome-sh/pome-cloud`, and `@pome-sh/wire`
+for pome-cloud's migration off `@pome-sh/shared-types`. `@pome-sh/wire` is ALSO
+published to **GitHub Packages**, independently, from the same version line —
+it is the only package on two registries. Everything else in this repo
+(`@pome-sh/sdk`, the five `@pome-sh/twin-*`) is `private: true` and bundled
+into those tarballs by tsup — it is never installed from a registry, so it
+never needs its own release.
 
 `@pome-sh/checks` is the one whose *staleness* is a product bug rather than a
 missed feature: pome-cloud grades every `[code]` criterion out of it, so an
@@ -15,8 +17,8 @@ unpublished correction means a frozen grading engine (F-1308). See
 for why it is a separate package instead of un-privatising the twins.
 
 `@pome-sh/wire` is the odd one out and worth reading the section on before
-touching it: it is published AND still bundled. Publishing it did not change
-how the CLI or the adapter consume it.
+touching it: it is published to two registries AND still bundled. Publishing
+it did not change how the CLI or the adapter consume it.
 
 ## The model
 
@@ -71,52 +73,92 @@ All four packages are pre-1.0, so npm's `^0.x` caret semantics apply
   implementation swaps behind an unchanged surface, dependency bumps, bug
   fixes.
 
-## `@pome-sh/wire` — published AND bundled
+## `@pome-sh/wire` — published to TWO registries, and still bundled
 
-`@pome-sh/wire` is a third published artifact with a different registry and a
-different audience, and it did not stop being a bundled one (F-949).
+`@pome-sh/wire` is a published artifact on two registries with two different
+audiences, and it did not stop being a bundled one (F-949, extended to add the
+public-npm target for pome-cloud's `@pome-sh/shared-types` migration).
 
-|  | `@pome-sh/cli`, `@pome-sh/adapter-claude-sdk` | `@pome-sh/wire` |
-| --- | --- | --- |
-| Registry | `registry.npmjs.org` | `npm.pkg.github.com` (GitHub Packages) |
-| Audience | end users — `npx @pome-sh/cli`, `npm i @pome-sh/adapter-claude-sdk` | internal cross-repo consumers, i.e. `pome-sh/pome-cloud` |
-| Auth | npm OIDC Trusted Publishing (`id-token: write`, provenance attestation, no stored token) | `GITHUB_TOKEN` + `packages: write`, via an `.npmrc` auth line |
-| Jobs | `plan` → `publish` (a matrix over the two) | `plan-wire` → `publish-wire` |
-| Reachable without auth | yes | no — GitHub Packages requires a token even to read |
+|  | `@pome-sh/cli`, `@pome-sh/adapter-claude-sdk`, `@pome-sh/checks` | `@pome-sh/wire` on npmjs | `@pome-sh/wire` on GitHub Packages |
+| --- | --- | --- | --- |
+| Registry | `registry.npmjs.org` | `registry.npmjs.org` | `npm.pkg.github.com` (GitHub Packages) |
+| Audience | end users — `npx @pome-sh/cli`, `npm i @pome-sh/adapter-claude-sdk`, `npm i @pome-sh/checks` | `pome-sh/pome-cloud`, whose other `@pome-sh/*` deps (sdk, twin-*) only resolve from npmjs | `pome-sh/pome-cloud`'s original target, still supported |
+| Auth | npm OIDC Trusted Publishing (`id-token: write`, provenance attestation, no stored token) | same OIDC mechanism, same `publish` job | `GITHUB_TOKEN` + `packages: write`, via an `.npmrc` auth line |
+| Jobs | `plan` → `publish` (a matrix, wire is the fourth entry) | `plan` → `publish` | `plan-wire` → `publish-wire` |
+| Reachable without auth | yes | yes | no — GitHub Packages requires a token even to read |
+
+wire's `publishConfig.registry` in `packages/wire/package.json` still names
+GitHub Packages — that is its *default*, and `ci.yml`'s `gate:wire-manifest`
+asserts it on every PR — so the npmjs-lane `publish` job overrides it with an
+explicit `--registry https://registry.npmjs.org` flag for wire only. See the
+comment on that step in `release.yml`.
 
 **Publishing wire changed nothing about how this repo consumes it.** `cli/` and
 `packages/adapter-claude-sdk/` still declare it as a **devDependency** at `"*"`
 (workspace-resolved), and tsup's `noExternal: [/^@pome-sh\//]` still inlines
 its compiled output into both tarballs. Neither published npmjs tarball has an
 `@pome-sh/*` dependency, and `scripts/clean-room-pack-test.mjs` fails if that
-ever changes. Nobody installing the CLI or the adapter fetches wire. Do not
-"simplify" this by turning wire into a real dependency of either: that would
-put a GitHub-Packages-only, auth-required package in an end user's install
-graph, and their `npm i` would 401.
+ever changes. Nobody installing the CLI or the adapter fetches wire from either
+registry. Do not "simplify" this by turning wire into a real dependency of
+either: that would put a registry-resolved package in an end user's install
+graph for no reason tsup doesn't already solve.
 
-Why GitHub Packages rather than public npm: wire is trace-vocabulary
-infrastructure (Zod schemas, the OTel span extension, secret redaction) with no
-stable public API promise. Publishing it to npmjs would make it look like a
-supported end-user library and would invite pins we do not intend to honour.
-The only thing that genuinely needs it across a repo boundary is pome-cloud.
+Why wire went to GitHub Packages first, and why npmjs got added rather than
+replacing it: wire is trace-vocabulary infrastructure (Zod schemas, the OTel
+span extension, secret redaction) with no stable public API promise, and
+GitHub Packages kept it out of the public npm namespace where it would look
+like a supported end-user library. That reasoning still holds — nothing about
+wire's confidentiality or audit status changed — but a single `@pome-sh` scope
+can only resolve from one registry per *consumer*, and pome-cloud's other
+`@pome-sh/*` dependencies (sdk, twin-*) exist only on public npmjs. Routing
+wire through GitHub Packages for that consumer would require an `.npmrc`
+change pome-cloud cannot make without breaking those other installs, so wire
+now publishes to both, independently, from the same version line.
 
-`@pome-sh/wire` publishes as `@pome-sh/…` because GitHub Packages scopes npm
-packages to the account that owns the linked repository — the scope must equal
-the org name, and `@pome-sh` matches the `pome-sh` org. The package is linked to
-this repository through the `repository` field already in
-`packages/wire/package.json`, which must keep naming the repo's **canonical**
-path (`pome-sh/digital-twins`; `pome-sh/pome-twins` is an old name GitHub
-redirects, and some local git remotes still use it).
+`@pome-sh/wire` publishes as `@pome-sh/…` on GitHub Packages because that
+registry scopes npm packages to the account that owns the linked repository —
+the scope must equal the org name, and `@pome-sh` matches the `pome-sh` org.
+The package is linked to this repository through the `repository` field
+already in `packages/wire/package.json`, which must keep naming the repo's
+**canonical** path (`pome-sh/digital-twins`; `pome-sh/pome-twins` is an old
+name GitHub redirects, and some local git remotes still use it).
 
-The two lanes are deliberately independent — `plan`/`publish` never reads GitHub
-Packages and `plan-wire`/`publish-wire` never reads npmjs — so an outage or a
-permissions change on one registry cannot skip the other's publishes. That
-matters because a GitHub Packages read failure is a *hard* failure by design (a
-401 must never be read as "unpublished", which would bypass the floor check), so
-it would otherwise be an outage on one registry silently blocking releases on
-the other.
+### One-time manual bootstrap for wire's npmjs target
 
-### One-time manual step for a maintainer
+npm's OIDC Trusted Publishing cannot be configured for a package that has never
+been published — the Trusted Publisher settings live on the package's own
+npmjs.com page, and that page does not exist until a first version lands on the
+registry. `@pome-sh/wire` has never been on `registry.npmjs.org` (only on
+GitHub Packages), so the FIRST run of the `publish` job's OIDC-based `npm
+publish -w @pome-sh/wire --registry https://registry.npmjs.org` step **will
+fail** — this is npm's documented bootstrap limitation, not a bug in this
+workflow. A maintainer must, once:
+
+1. Publish the initial npmjs version out of band — a local `npm publish -w
+   @pome-sh/wire --access public --registry https://registry.npmjs.org` from a
+   clean build, authenticated with a classic token or `npm login` as someone
+   with publish rights on the `@pome-sh` org.
+2. On npmjs.com, under the now-existing `@pome-sh/wire` package's *Settings →
+   Trusted Publisher*, add this repository (`pome-sh/digital-twins`), the
+   workflow file (`.github/workflows/release.yml`), and the `publish` job —
+   the same way `@pome-sh/cli`, `@pome-sh/adapter-claude-sdk` and
+   `@pome-sh/checks` are already configured there.
+
+Until step 2 is done, every subsequent version bump's `publish` run for
+`@pome-sh/wire` on the npmjs lane fails the same way. This is a one-time
+bootstrap, not a per-release step, and it does not affect
+`publish-wire`/GitHub Packages, which has its own token-based auth and needs
+no npmjs configuration.
+
+The npmjs and GitHub Packages lanes are deliberately independent — `plan`/
+`publish` never reads GitHub Packages and `plan-wire`/`publish-wire` never
+reads npmjs — so an outage or a permissions change on one registry cannot skip
+the other's publishes. That matters because a GitHub Packages read failure is
+a *hard* failure by design (a 401 must never be read as "unpublished", which
+would bypass the floor check); without the independence it would otherwise be
+an outage on one registry silently blocking releases on the other.
+
+### One-time manual step for a maintainer (GitHub Packages)
 
 GitHub Packages' npm registry supports granular permissions, so a package's
 visibility is settable independently of its linked repository — **but only once


### PR DESCRIPTION
## Summary
- pome-cloud's migration off the deprecated `@pome-sh/shared-types` needs to npm-install `@pome-sh/wire`. A scope can only resolve from one registry per consumer, and pome-cloud's other unavoidable `@pome-sh/*` deps (sdk, twin-*) only exist on public npmjs — so wire, which npm-installed cleanly at GitHub Packages, needs to be reachable from npmjs too.
- Adds `@pome-sh/wire` as a fourth matrix entry on the existing npmjs/OIDC `plan`/`publish` lane, purely additive. The GitHub Packages `plan-wire`/`publish-wire` lane is completely untouched — wire now publishes to both registries independently from the same version line.
- `wire`'s `publishConfig.registry` still defaults to GitHub Packages (`ci.yml`'s `gate:wire-manifest` still asserts that value on every PR), so the npmjs lane's `Publish` step passes an explicit `--registry https://registry.npmjs.org` override for wire only — everything else in that job (`cli`/`adapter`/`checks`) is untouched and keeps relying on the ambient registry `setup-node` configured.
- `scripts/ci/decide-publish.sh` and `scripts/ci/check-version-bump-required.mjs` needed no changes: one version bump already satisfies both registries' publish decisions.
- No version bump: `@pome-sh/wire` has never been published to `registry.npmjs.org`, so `decide-publish.sh`'s E404 path baselines it at `0.0.0` there and the current `0.2.1` publishes cleanly on the first run.
- `RELEASING.md` updated to describe the dual-registry model, including a one-time manual bootstrap npm OIDC Trusted Publishing needs for a package that has never been published to npmjs before (see below).

## Important: one-time manual step required before this can publish successfully
npm's OIDC Trusted Publishing cannot be configured for a package that has never been published — the Trusted Publisher settings live on the package's own npmjs.com page, which does not exist until a first version is on the registry. Since `@pome-sh/wire` has never been on npmjs, the very first run of this workflow's wire/npmjs publish step will fail for that reason (not a bug in this PR). A maintainer needs to, once:
1. Publish the initial npmjs version out of band (local `npm publish -w @pome-sh/wire --access public --registry https://registry.npmjs.org` from a clean build, authenticated as an `@pome-sh` org publisher).
2. Configure a Trusted Publisher for the new `@pome-sh/wire` npmjs package pointing at this repo, `.github/workflows/release.yml`, and the `publish` job — the same way `@pome-sh/cli`/`@pome-sh/adapter-claude-sdk`/`@pome-sh/checks` are already configured.

Details are in `RELEASING.md`'s new "One-time manual bootstrap for wire's npmjs target" section.

## Test plan
- [x] `npm run lint:dead-code` — passes
- [x] `npm run build` — passes (wire builds first in the workspace topological order, as before)
- [x] `npm run typecheck` — passes
- [x] `npm run test:pack` — passes, unaffected (asserts the two npmjs tarballs, unrelated to wire's own tarball)
- [x] `npm run gate:wire-manifest` / `npm run gate:wire-tarball` — pass; confirm `publishConfig.registry` is still `https://npm.pkg.github.com`, unchanged
- [x] `npm run gate:bundled-deps` — passes
- [x] Full workspace test suite (wire, sdk, adapter, all four packaged twins, checks, cli, twin-github coverage) — all pass
- [x] `node scripts/ci/decide-publish.test.mjs` — passes, including the release.yml wiring assertions (npmjs lane cannot read GitHub Packages, `publish` depends on `plan` only, `publish-wire` depends on `plan-wire` only)
- [x] `node scripts/ci/check-version-bump-required.mjs $(git merge-base main HEAD)` — passes; this PR touches no `packages/wire/` path, so no version bump is demanded
- [ ] CI on this PR (pending)
- [ ] Manual npmjs bootstrap step above, before merge changes anything in production