### PR TITLE
Twin tool tables import the MCP fixture loader without dragging in node:sqlite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,18 @@ jobs:
       # this block rather than behind the heavy gate.
       - run: node scripts/check-twin-chunk-laziness.mjs
       - run: node scripts/check-twin-chunk-laziness.test.mjs
+      # pome-cloud's fidelity-watch reads twin declarations — the stripe tool
+      # table, github's and slack's 501 envelopes, linear's GraphQL schema —
+      # straight out of a pome-twins checkout, under BUN, which implements no
+      # `node:sqlite`. F-1325 pointed every twin's tool table at the sdk ROOT
+      # barrel for its (dependency-free) fixture loader; the barrel re-exports
+      # `openTwinDatabase`, so `import "@pome-sh/sdk"` executes
+      # `import { DatabaseSync } from "node:sqlite"`. Every twins suite runs on
+      # Node and stayed green; pome-cloud's daily cron went red the next morning
+      # in a repo this repo's CI does not run. Same static-graph walk as the gate
+      # above, no build and no install needed.
+      - run: node scripts/check-twin-leaf-portability.mjs
+      - run: node scripts/check-twin-leaf-portability.test.mjs
       # F-745 / D4 — no catch-and-continue in the SDK twin engine
       # (packages/sdk/src): every statement catch must throw, return an
       # error/sentinel, or reject. Dependency-free, runs before `npm ci`.

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,19 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.21.12
+
+### Patch Changes
+
+- **No CLI change.** Version-only bump: the twin tool tables moved off the
+  `@pome-sh/sdk` root barrel and onto the new `@pome-sh/sdk/mcp-tool-fixture`
+  subpath, so `packages/twin-*` and `packages/sdk` changed — publish-relevant
+  for the CLI, because the CLI inlines both into its bundle. Nothing a CLI user
+  sees moves: the same loader, the same fixtures, the same `tools/list` bytes.
+  The import site changed because the root barrel re-exports `openTwinDatabase`
+  and therefore `node:sqlite`, which loads the tool tables only on Node, and
+  pome-cloud reads them under bun.
+
 ## 0.21.11
 
 ### Patch Changes

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.21.11",
+  "version": "0.21.12",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lint:task-class": "node scripts/lint-task-class.mjs",
     "lint:skill-manifest": "node scripts/check-plugin-manifest-lists-every-skill.mjs",
     "lint:twin-chunks": "node scripts/check-twin-chunk-laziness.mjs",
+    "lint:twin-leaves": "node scripts/check-twin-leaf-portability.mjs",
     "lint:dead-code": "knip --no-config-hints",
     "gate:bundled-deps": "node scripts/check-bundled-runtime-deps.mjs",
     "gate:wire-tarball": "node scripts/ci/check-wire-tarball.mjs",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,6 +1,21 @@
 # @pome-sh/sdk
 
 
+## 0.11.4 — 2026-08-07
+
+`loadMcpToolFixture` and the rest of `mcp-tool-fixture.ts` are now reachable on
+their own `@pome-sh/sdk/mcp-tool-fixture` subpath, alongside `./server`,
+`./parity`, `./checks` and `./db`. The root barrel still exports them — Node
+callers are unaffected.
+
+The root barrel is not a free way to reach a dependency-free module: it
+re-exports `openTwinDatabase` from `./db.js`, whose first line is
+`import { DatabaseSync } from "node:sqlite"`. Importing `@pome-sh/sdk` for
+`loadMcpToolFixture` therefore loads the SQLite driver, and any runtime without
+that builtin — bun, which is what pome-cloud's fidelity-watch runs — cannot load
+the importing module at all. `mcp-tool-fixture.ts` has no imports of its own;
+this subpath is how a caller gets it that way.
+
 ## 0.11.3 — 2026-08-06
 
 A shared, hash-locked MCP tool-table fixture loader (F-1325).

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/sdk",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Twin engine for Pome digital twins \u2014 defineTwin() + serve(): HTTP mounting, bearer auth, trace recorder, MCP dispatch, SQLite-backed state.",
   "private": true,
   "type": "module",
@@ -26,6 +26,10 @@
     "./db": {
       "types": "./dist/db.d.ts",
       "default": "./dist/db.js"
+    },
+    "./mcp-tool-fixture": {
+      "types": "./dist/mcp-tool-fixture.d.ts",
+      "default": "./dist/mcp-tool-fixture.js"
     },
     "./failure-injection-rules": {
       "types": "./dist/failure-injection-rules.d.ts",

--- a/packages/twin-github/src/tools.ts
+++ b/packages/twin-github/src/tools.ts
@@ -1,5 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-import { loadMcpToolFixture } from "@pome-sh/sdk";
+// `@pome-sh/sdk/mcp-tool-fixture` rather than the `@pome-sh/sdk` root: the root
+// barrel re-exports `openTwinDatabase`, so importing it EXECUTES `db.ts`'s
+// `import { DatabaseSync } from "node:sqlite"`. pome-cloud's fidelity-watch
+// loads twin tool tables under bun, which implements no `node:sqlite`, and this
+// file's own dependencies are a fixture loader, zod and types. The loader module
+// has no imports at all.
+import { loadMcpToolFixture } from "@pome-sh/sdk/mcp-tool-fixture";
 import { z } from "zod";
 import type { StateDelta } from "@pome-sh/wire";
 import metaListing from "../fixtures/mcp-tools-list.meta.json" with { type: "json" };

--- a/packages/twin-gmail/src/mcp.ts
+++ b/packages/twin-gmail/src/mcp.ts
@@ -1,15 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0
+// The two VALUES come from `@pome-sh/sdk/mcp-tool-fixture`, not the root barrel:
+// the barrel re-exports `openTwinDatabase`, so importing it EXECUTES `db.ts`'s
+// `import { DatabaseSync } from "node:sqlite"` and this module stops loading in
+// any runtime without that builtin (bun, which is what pome-cloud's
+// fidelity-watch runs). `ToolCallContext`/`ToolSpec` stay on the root as
+// `import type` — erased before emit, so they carry no runtime edge.
 import {
   deriveMcpToolTable,
   loadMcpToolFixture,
   type McpToolImplementation,
-  type ToolCallContext,
-  type ToolSpec,
-} from "@pome-sh/sdk";
+} from "@pome-sh/sdk/mcp-tool-fixture";
+import type { ToolCallContext, ToolSpec } from "@pome-sh/sdk";
 import { z } from "zod";
 import metaListing from "../fixtures/mcp-tools-list.meta.json" with { type: "json" };
 import rawListing from "../fixtures/mcp-tools-list.raw.json" with { type: "json" };
-import { GmailDomain } from "./domain/index.js";
+// `import type`: `GmailDomain` appears only in handler signatures here, and the
+// domain barrel reaches `db.ts` -> the sdk root -> `node:sqlite`. tsc and bun
+// both elide it today because nothing uses it as a value — spelling that out
+// keeps it true if someone later does.
+import type { GmailDomain } from "./domain/index.js";
 import { invalidArgument } from "./errors.js";
 import { identityFromSession } from "./identity.js";
 import {

--- a/packages/twin-linear/src/mcp.ts
+++ b/packages/twin-linear/src/mcp.ts
@@ -1,13 +1,18 @@
 // file-size: Linear MCP tool surface — one registry of tool defs + handlers pending further split.
 // SPDX-License-Identifier: Apache-2.0
 // file-size: MCP launch tool table co-located with canonical fixture mapping.
+// The two VALUES come from `@pome-sh/sdk/mcp-tool-fixture`, not the root barrel:
+// the barrel re-exports `openTwinDatabase`, so importing it EXECUTES `db.ts`'s
+// `import { DatabaseSync } from "node:sqlite"` and this module stops loading in
+// any runtime without that builtin (bun, which is what pome-cloud's
+// fidelity-watch runs). `ToolCallContext`/`ToolSpec` stay on the root as
+// `import type` — erased before emit, so they carry no runtime edge.
 import {
   deriveMcpToolTable,
   loadMcpToolFixture,
   type McpToolImplementation,
-  type ToolCallContext,
-  type ToolSpec,
-} from "@pome-sh/sdk";
+} from "@pome-sh/sdk/mcp-tool-fixture";
+import type { ToolCallContext, ToolSpec } from "@pome-sh/sdk";
 import type { z } from "zod";
 import metaListing from "../fixtures/mcp-tools-list.meta.json" with { type: "json" };
 import rawListing from "../fixtures/mcp-tools-list.raw.json" with { type: "json" };

--- a/packages/twin-slack/src/tools.ts
+++ b/packages/twin-slack/src/tools.ts
@@ -1,5 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-import { loadMcpToolFixture } from "@pome-sh/sdk";
+// `@pome-sh/sdk/mcp-tool-fixture` rather than the `@pome-sh/sdk` root: the root
+// barrel re-exports `openTwinDatabase`, so importing it EXECUTES `db.ts`'s
+// `import { DatabaseSync } from "node:sqlite"`. pome-cloud's fidelity-watch
+// loads twin tool tables under bun, which implements no `node:sqlite`, and this
+// file's own dependencies are a fixture loader, zod and types. The loader module
+// has no imports at all.
+import { loadMcpToolFixture } from "@pome-sh/sdk/mcp-tool-fixture";
 import { z } from "zod";
 import type { StateDelta } from "@pome-sh/wire";
 import metaListing from "../fixtures/mcp-tools-list.meta.json" with { type: "json" };

--- a/packages/twin-stripe/src/tools.ts
+++ b/packages/twin-stripe/src/tools.ts
@@ -7,7 +7,13 @@
 // tools.ts so the MCP wrapper in app.ts (AGENT-A) just works:
 // `executeTool(domain, name, args)`.
 
-import { loadMcpToolFixture } from "@pome-sh/sdk";
+// `@pome-sh/sdk/mcp-tool-fixture` rather than the `@pome-sh/sdk` root: the root
+// barrel re-exports `openTwinDatabase`, so importing it EXECUTES `db.ts`'s
+// `import { DatabaseSync } from "node:sqlite"`. pome-cloud's fidelity-watch
+// imports THIS module under bun — `sandboxes/stripe/level2.test.ts` reads
+// `isMutatingTool` off it — and bun implements no `node:sqlite`. The loader
+// module has no imports at all.
+import { loadMcpToolFixture } from "@pome-sh/sdk/mcp-tool-fixture";
 import { z } from "zod";
 import metaListing from "../fixtures/mcp-tools-list.meta.json" with { type: "json" };
 import rawListing from "../fixtures/mcp-tools-list.raw.json" with { type: "json" };

--- a/scripts/check-twin-chunk-laziness.mjs
+++ b/scripts/check-twin-chunk-laziness.mjs
@@ -35,8 +35,14 @@
 //
 // Usage: node scripts/check-twin-chunk-laziness.mjs [--verbose]
 
-import { existsSync, readFileSync, readdirSync } from "node:fs";
-import { dirname, join, relative, resolve } from "node:path";
+import { existsSync, readdirSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+
+// The import lexer and the graph walk are shared with
+// `check-twin-leaf-portability.mjs` — two gates asking reachability questions
+// about the same graph must not hold two opinions about what a type-only import
+// is.
+import { buildSpecifierMap, chainFor, reachable } from "./lib/static-import-graph.mjs";
 
 // `process.cwd()`, as `lint-parent-vocab.mjs` and `lint-task-class.mjs` do: CI
 // runs every gate from the repo root, and it lets the regression suite point the
@@ -45,168 +51,7 @@ const ROOT = process.cwd();
 const ENTRY = resolve(ROOT, "cli/src/cli/main.ts");
 const VERBOSE = process.argv.includes("--verbose");
 
-/** Workspace `@pome-sh/*` specifiers → source file, read from each package's
- *  own `exports` map so a renamed subpath cannot silently stop being checked. */
-function buildSpecifierMap() {
-  const map = new Map();
-  const packagesDir = join(ROOT, "packages");
-  if (!existsSync(packagesDir)) return map;
-  for (const dir of readdirSync(packagesDir)) {
-    const manifestPath = join(packagesDir, dir, "package.json");
-    if (!existsSync(manifestPath)) continue;
-    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
-    if (!manifest.name?.startsWith("@pome-sh/")) continue;
-    for (const [subpath, target] of Object.entries(manifest.exports ?? {})) {
-      // `{ types, default }` conditions or a bare string; either way we want the
-      // JS target, then map `dist/src/foo.js` (or `dist/foo.js`) back to source.
-      const js = typeof target === "string" ? target : target.default;
-      if (typeof js !== "string" || !js.endsWith(".js")) continue;
-      const sourceRel = js
-        .replace(/^\.\//, "")
-        .replace(/^dist\/(?:src\/)?/, "src/")
-        .replace(/\.js$/, ".ts");
-      const sourcePath = join(packagesDir, dir, sourceRel);
-      if (!existsSync(sourcePath)) continue;
-      const specifier = subpath === "." ? manifest.name : `${manifest.name}${subpath.slice(1)}`;
-      map.set(specifier, sourcePath);
-    }
-  }
-  return map;
-}
-
-const SPECIFIERS = buildSpecifierMap();
-
-/**
- * Blank out comments and string/template bodies, keeping newlines so the text
- * stays line-addressable.
- *
- * Load-bearing, not hygiene: `cli/src/cli/init-sdk.ts` embeds the scaffolded
- * agent's SOURCE in a template literal, and that source contains
- * `import { query, tool, withPome } from "@pome-sh/adapter-claude-sdk";`. A
- * regex over raw text reads that as a real edge and reports a package the CLI
- * never imports — and by the same mistake would report a twin root as eager
- * because a scaffold string mentions one. Scaffolds are the one place this repo
- * writes import statements it does not execute, and it writes several.
- */
-function stripNonCode(source) {
-  const blank = (text) => text.replace(/[^\n]/g, " ");
-  let out = "";
-  let index = 0;
-  while (index < source.length) {
-    const char = source[index];
-    const next = source[index + 1];
-    if (char === "/" && next === "/") {
-      const end = source.indexOf("\n", index);
-      const stop = end === -1 ? source.length : end;
-      out += blank(source.slice(index, stop));
-      index = stop;
-      continue;
-    }
-    if (char === "/" && next === "*") {
-      const end = source.indexOf("*/", index + 2);
-      const stop = end === -1 ? source.length : end + 2;
-      out += blank(source.slice(index, stop));
-      index = stop;
-      continue;
-    }
-    if (char === "`") {
-      let cursor = index + 1;
-      while (cursor < source.length && source[cursor] !== "`") {
-        cursor += source[cursor] === "\\" ? 2 : 1;
-      }
-      const stop = Math.min(cursor + 1, source.length);
-      out += blank(source.slice(index, stop));
-      index = stop;
-      continue;
-    }
-    out += char;
-    index += 1;
-  }
-  return out;
-}
-// Ordinary quoted strings are left alone deliberately: they cannot span lines, and
-// every pattern below is anchored to the start of one, so a specifier inside a
-// single-line string can never sit where an import statement would.
-
-/**
- * Runtime static import specifiers in one TypeScript source.
- *
- * Type-only edges are EXCLUDED because they are erased before the bundler sees
- * them — both the `import type` / `export type` form and the form where every
- * named binding is individually marked (`import { type A, type B } from …`).
- * Counting either would fail this gate on an edge that emits no code, which is
- * the failure mode that gets a gate deleted rather than fixed.
- *
- * `import()` is EXCLUDED because a dynamic import is the thing this gate wants.
- */
-function staticImportSpecifiers(rawSource) {
-  const source = stripNonCode(rawSource);
-  const found = [];
-  const pattern =
-    /^[ \t]*(?:import|export)\b([\s\S]*?)from\s*["']([^"']+)["']|^[ \t]*import\s*["']([^"']+)["']/gm;
-  let match;
-  while ((match = pattern.exec(source)) !== null) {
-    const specifier = match[2] ?? match[3];
-    const clause = match[1] ?? "";
-    if (/^\s*type\b/.test(clause)) continue;
-    const braced = clause.match(/\{([\s\S]*)\}/);
-    if (braced) {
-      const named = braced[1]
-        .split(",")
-        .map((part) => part.trim())
-        .filter(Boolean);
-      const hasDefaultOrNamespace = /^\s*(?:[A-Za-z_$][\w$]*\s*,|\*)/.test(clause);
-      if (named.length > 0 && !hasDefaultOrNamespace && named.every((n) => /^type\s/.test(n))) {
-        continue;
-      }
-    }
-    found.push(specifier);
-  }
-  return found;
-}
-
-function resolveSpecifier(specifier, fromFile) {
-  if (specifier.startsWith(".")) {
-    const base = resolve(dirname(fromFile), specifier);
-    const candidates = base.endsWith(".js")
-      ? [`${base.slice(0, -3)}.ts`]
-      : [base, `${base}.ts`, join(base, "index.ts")];
-    return candidates.find((candidate) => existsSync(candidate) && candidate.endsWith(".ts")) ?? null;
-  }
-  // Third-party, node builtins and JSON asset imports carry no twin edges.
-  return SPECIFIERS.get(specifier) ?? null;
-}
-
-/** Files statically reachable from `entry`, each mapped to the file that first
- *  pulled it in — so a violation can be reported as a chain a human can follow. */
-function reachable(entry) {
-  const importedBy = new Map([[entry, null]]);
-  const stack = [entry];
-  while (stack.length > 0) {
-    const file = stack.pop();
-    let source;
-    try {
-      source = readFileSync(file, "utf8");
-    } catch {
-      continue;
-    }
-    for (const specifier of staticImportSpecifiers(source)) {
-      const target = resolveSpecifier(specifier, file);
-      if (target === null || importedBy.has(target)) continue;
-      importedBy.set(target, file);
-      stack.push(target);
-    }
-  }
-  return importedBy;
-}
-
-function chainFor(file, importedBy) {
-  const chain = [];
-  for (let current = file; current; current = importedBy.get(current)) {
-    chain.push(relative(ROOT, current));
-  }
-  return chain.reverse();
-}
+const SPECIFIERS = buildSpecifierMap(ROOT);
 
 const TWIN_DIRS = existsSync(join(ROOT, "packages"))
   ? readdirSync(join(ROOT, "packages")).filter((dir) => dir.startsWith("twin-"))
@@ -240,7 +85,7 @@ function domainViolation(file) {
   return null;
 }
 
-const importedBy = reachable(ENTRY);
+const { importedBy } = reachable([ENTRY], SPECIFIERS);
 const violations = [];
 for (const file of importedBy.keys()) {
   const hit = domainViolation(file);
@@ -274,7 +119,8 @@ if (violations.length > 0) {
   );
   for (const violation of violations) {
     console.error(`  ${relative(ROOT, violation.file)}  — ${violation.twin}'s ${violation.what}`);
-    for (const [index, step] of chainFor(violation.file, importedBy).entries()) {
+    const chain = chainFor(violation.file, importedBy, (path) => relative(ROOT, path));
+    for (const [index, step] of chain.entries()) {
       console.error(`      ${index === 0 ? "" : "-> "}${step}`);
     }
     console.error("");

--- a/scripts/check-twin-leaf-portability.mjs
+++ b/scripts/check-twin-leaf-portability.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+//
+// The gate that keeps the twin modules OTHER RUNTIMES import loadable by them.
+//
+// pome-cloud's `tools/fidelity-watch` runs under BUN, and several of its suites
+// read declarations straight out of a pome-twins checkout — the stripe tool
+// table for `isMutatingTool`, github's and slack's 501 envelopes, linear's
+// GraphQL schema. Bun implements no `node:sqlite`. `packages/sdk/src/db.ts`
+// opens with `import { DatabaseSync } from "node:sqlite"`, and the sdk's ROOT
+// barrel re-exports `openTwinDatabase` from it — so one import of
+// `@pome-sh/sdk` (rather than a leaf subpath) puts the whole engine's SQLite
+// driver on the module-load path of a file whose own dependencies are zod and
+// a JSON fixture.
+//
+// That is exactly what F-1325 did. It moved every twin's tool table onto a
+// shared, dependency-free loader — `packages/sdk/src/mcp-tool-fixture.ts`, no
+// imports at all — and each twin reached it through the barrel. The twins'
+// own suites run on Node, where `node:sqlite` exists, so all of them stayed
+// green; pome-cloud's daily fidelity-watch cron went red the next morning with
+// `error: No such built-in module: node:sqlite` and one failing assertion, in
+// a repo the change had not touched.
+//
+// The rule is structural, so it cannot drift as twins grow:
+//
+//   No module in ENTRIES may statically reach a builtin that non-Node runtimes
+//   do not implement. ENTRIES is every twin's MCP tool table (found by looking
+//   for the F-1325 loader call, so a new twin is covered with no hand edit)
+//   plus CROSS_RUNTIME_LEAVES, the named modules pome-cloud imports directly.
+//
+// A twin's SERVER is deliberately out of scope: `src/index.ts`, `src/db.ts` and
+// `src/twin.ts` ARE the SQLite-backed engine, and nothing loads them anywhere
+// but Node. This gate is about the declaration leaves, which have no business
+// dragging a database driver behind them in any runtime.
+//
+// Dependency-free and build-free on purpose: it reads TypeScript sources and
+// the packages' real `exports` maps, so it runs in CI's always-on block before
+// `npm ci`.
+//
+// Usage: node scripts/check-twin-leaf-portability.mjs [--verbose]
+
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+
+import { buildSpecifierMap, chainFor, reachable } from "./lib/static-import-graph.mjs";
+
+// `process.cwd()`, as the sibling gates do: CI runs every gate from the repo
+// root, and it lets the regression suite point the real script at a throwaway
+// tree instead of at this repo.
+const ROOT = process.cwd();
+const VERBOSE = process.argv.includes("--verbose");
+const rel = (path) => relative(ROOT, path).split("\\").join("/");
+
+/**
+ * Builtins a twin declaration leaf may not reach. Keyed by module specifier,
+ * valued by the reason, which is printed on failure — a gate whose message does
+ * not say which runtime broke gets "fixed" by adding an exception.
+ */
+const OFF_LIMITS_BUILTINS = new Map([
+  [
+    "node:sqlite",
+    "bun implements no `node:sqlite`, and pome-cloud's fidelity-watch runs under bun",
+  ],
+]);
+
+/**
+ * Twin modules pome-cloud imports directly, beyond the tool tables found below.
+ * Taken from its real import sites (`tools/fidelity-watch`, via `twinModule()`);
+ * pome-cloud's own `lint-twin-imports` gate is what keeps that list honest on
+ * its side. A listed path that does not exist is a hard failure, not a skip —
+ * a stale entry silently covering nothing is how this gate would stop working.
+ */
+const CROSS_RUNTIME_LEAVES = [
+  // `sandboxes/stripe/level2.test.ts` — `isMutatingTool` (also covered as a
+  // tool table; listed because it is the import site the regression came from).
+  "packages/twin-stripe/src/tools.ts",
+  // `lint-twin-namespace.test.ts` — the frozen 501 envelopes.
+  "packages/twin-github/src/unsupported-envelope.ts",
+  "packages/twin-slack/src/unsupported-envelope.ts",
+  "packages/twin-stripe/src/errors.ts",
+  // `twin-linear-schema.ts` — `linearGraphQLSchema`.
+  "packages/twin-linear/src/graphql/schema.ts",
+];
+
+/** The F-1325 loader call. A module that makes it IS a twin's MCP tool table,
+ *  whatever the file is named (`tools.ts` on github/slack/stripe, `mcp.ts` on
+ *  gmail/linear). */
+const TOOL_TABLE_MARKER = "loadMcpToolFixture(";
+
+function walkTs(dir, out = []) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const abs = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "dist") continue;
+      walkTs(abs, out);
+      continue;
+    }
+    if (entry.name.endsWith(".ts") && !entry.name.endsWith(".d.ts")) out.push(abs);
+  }
+  return out;
+}
+
+const packagesDir = join(ROOT, "packages");
+const TWIN_DIRS = existsSync(packagesDir)
+  ? readdirSync(packagesDir).filter(
+      (dir) => dir.startsWith("twin-") && statSync(join(packagesDir, dir)).isDirectory(),
+    )
+  : [];
+
+if (TWIN_DIRS.length === 0) {
+  // A gate that silently passes on an empty tree reads as coverage it does not
+  // have — the lesson `lint-parent-vocab.test.mjs` case 2 records.
+  console.error(`No packages/twin-* found under ${ROOT}. Run this from the repo root.`);
+  process.exit(1);
+}
+
+/** Each twin's tool-table module(s), discovered rather than listed. */
+const toolTables = [];
+const twinsWithNoToolTable = [];
+for (const dir of TWIN_DIRS) {
+  const found = walkTs(join(packagesDir, dir, "src")).filter((file) =>
+    readFileSync(file, "utf8").includes(TOOL_TABLE_MARKER),
+  );
+  if (found.length === 0) {
+    twinsWithNoToolTable.push(dir);
+    continue;
+  }
+  toolTables.push(...found);
+}
+
+if (twinsWithNoToolTable.length > 0) {
+  // The cheap way to pass a reachability gate is to remove the thing it walks.
+  // Every first-party twin derives its tool table from a fixture (F-1325); a
+  // twin that no longer calls the loader has either regressed to a hand-written
+  // table or renamed the loader, and either way this gate just stopped checking
+  // it.
+  console.error(
+    `\n${twinsWithNoToolTable.length} twin(s) have no module calling \`${TOOL_TABLE_MARKER}\`, so this ` +
+      `gate covers no tool table for them:\n`,
+  );
+  for (const dir of twinsWithNoToolTable) console.error(`  packages/${dir}`);
+  console.error(
+    "\nEvery twin derives its MCP tool table from a fixture (F-1325). Restore the\n" +
+      "loader call, or update TOOL_TABLE_MARKER in this script if the loader was renamed.\n",
+  );
+  process.exit(1);
+}
+
+const missingLeaves = CROSS_RUNTIME_LEAVES.filter((path) => !existsSync(join(ROOT, path)));
+if (missingLeaves.length > 0) {
+  console.error(
+    `\n${missingLeaves.length} entry in CROSS_RUNTIME_LEAVES does not exist, so it covers nothing:\n`,
+  );
+  for (const path of missingLeaves) console.error(`  ${path}`);
+  console.error(
+    "\npome-cloud imports these modules by path from a pome-twins checkout. If one moved,\n" +
+      "pome-cloud's import is already broken — fix the path here and there together.\n",
+  );
+  process.exit(1);
+}
+
+const ENTRIES = [
+  ...new Set([...toolTables, ...CROSS_RUNTIME_LEAVES.map((path) => join(ROOT, path))]),
+];
+
+const SPECIFIERS = buildSpecifierMap(ROOT);
+const violations = [];
+
+// Walked one entry at a time on purpose: a shared walk would report the chain
+// through whichever entry happened to reach the builtin first, and the useful
+// output here is "THIS module pome-cloud imports cannot load, by THIS route".
+for (const entry of ENTRIES) {
+  const { importedBy, external } = reachable([entry], SPECIFIERS);
+  for (const edge of external) {
+    const reason = OFF_LIMITS_BUILTINS.get(edge.specifier);
+    if (!reason) continue;
+    violations.push({
+      entry,
+      specifier: edge.specifier,
+      reason,
+      chain: [...chainFor(edge.from, importedBy, rel), edge.specifier],
+    });
+  }
+}
+
+if (VERBOSE) {
+  console.log(`Entries checked (${ENTRIES.length}):`);
+  for (const entry of ENTRIES) console.log(`  ${rel(entry)}`);
+}
+
+if (violations.length > 0) {
+  console.error(
+    `\n${violations.length} twin module(s) that another runtime imports statically reach a builtin ` +
+      `that runtime does not have:\n`,
+  );
+  for (const violation of violations) {
+    console.error(`  ${rel(violation.entry)}  — reaches ${violation.specifier}`);
+    console.error(`      ${violation.reason}`);
+    for (const [index, step] of violation.chain.entries()) {
+      console.error(`      ${index === 0 ? "" : "-> "}${step}`);
+    }
+    console.error("");
+  }
+  console.error(
+    "The usual cause is an import of the `@pome-sh/sdk` ROOT barrel for a value a leaf\n" +
+      "subpath already exports: the barrel re-exports `openTwinDatabase`, which is\n" +
+      "`node:sqlite`. Import the leaf instead — `@pome-sh/sdk/mcp-tool-fixture` for the\n" +
+      "F-1325 tool-table loader, `@pome-sh/sdk/db` for the database types. Types are\n" +
+      "free either way: `import type` is erased and this gate ignores it.\n",
+  );
+  process.exit(1);
+}
+
+console.log(
+  `check-twin-leaf-portability: OK — ${ENTRIES.length} cross-runtime twin module(s) across ` +
+    `${TWIN_DIRS.length} twins, none reaching ${[...OFF_LIMITS_BUILTINS.keys()].join(", ")}.`,
+);

--- a/scripts/check-twin-leaf-portability.test.mjs
+++ b/scripts/check-twin-leaf-portability.test.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+//
+// Regression suite for `check-twin-leaf-portability.mjs`.
+//
+// The gate exists because a green twins CI shipped a change that could not be
+// LOADED by the runtime pome-cloud reads those files with, so the thing most
+// worth proving is that it goes red on the exact shape that shipped: a tool
+// table importing the `@pome-sh/sdk` ROOT for the F-1325 fixture loader, when
+// the root barrel re-exports the `node:sqlite`-backed database module.
+//
+// The rest of the cases guard the ways a gate like this quietly stops working:
+// the leaf subpath is not recognised as clean (false red, and the gate gets
+// deleted); a type-only import counted as a runtime edge (same); the lexer
+// swallowing a real import that sits below a statement (false GREEN, the worst
+// of the three); a twin's tool table no longer found, so it is silently no
+// longer walked; and a named cross-runtime leaf that no longer exists.
+//
+// Each case builds a throwaway tree and runs the real script against it.
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = resolve(dirname(fileURLToPath(import.meta.url)), "check-twin-leaf-portability.mjs");
+
+/** A minimal sdk: a root barrel that re-exports the `node:sqlite` driver (the
+ *  real shape), plus the dependency-free fixture loader on its own subpath. */
+const SDK_FILES = {
+  "packages/sdk/package.json": JSON.stringify({
+    name: "@pome-sh/sdk",
+    exports: {
+      ".": { types: "./dist/index.d.ts", default: "./dist/index.js" },
+      "./db": { types: "./dist/db.d.ts", default: "./dist/db.js" },
+      "./mcp-tool-fixture": {
+        types: "./dist/mcp-tool-fixture.d.ts",
+        default: "./dist/mcp-tool-fixture.js",
+      },
+    },
+  }),
+  "packages/sdk/src/index.ts": [
+    `export { openTwinDatabase } from "./db.js";`,
+    `export { loadMcpToolFixture } from "./mcp-tool-fixture.js";`,
+  ].join("\n"),
+  "packages/sdk/src/db.ts": [
+    `import { DatabaseSync } from "node:sqlite";`,
+    `export const openTwinDatabase = () => new DatabaseSync(":memory:");`,
+  ].join("\n"),
+  "packages/sdk/src/mcp-tool-fixture.ts": `export const loadMcpToolFixture = (input) => input;\n`,
+};
+
+/**
+ * A minimal twin. `toolTable` is the body of the module that calls the loader;
+ * the other files exist so the twin has a domain worth NOT reaching, and the
+ * five named `CROSS_RUNTIME_LEAVES` the real gate carries.
+ */
+function twinFiles(name, toolTable) {
+  const dir = `packages/twin-${name}/`;
+  return {
+    [`${dir}package.json`]: JSON.stringify({
+      name: `@pome-sh/twin-${name}`,
+      exports: { ".": { types: "./dist/src/index.d.ts", default: "./dist/src/index.js" } },
+    }),
+    [`${dir}src/tools.ts`]: toolTable,
+    [`${dir}src/domain/index.ts`]: `import { openTwinDatabase } from "@pome-sh/sdk";\nexport const domain = openTwinDatabase;\n`,
+  };
+}
+
+/** The named leaves the real script insists exist. Kept trivially clean so a
+ *  case only ever fails on the thing it is about. */
+const LEAF_FILES = {
+  "packages/twin-github/src/unsupported-envelope.ts": `export const unsupportedEnvelope = { body: {} };\n`,
+  "packages/twin-slack/src/unsupported-envelope.ts": `export const unsupportedEnvelope = { body: {} };\n`,
+  "packages/twin-stripe/src/errors.ts": `export const unsupported = () => ({ body: {} });\n`,
+  "packages/twin-linear/src/graphql/schema.ts": `export const linearGraphQLSchema = "type Query { a: Int }";\n`,
+};
+
+const CLEAN_TABLE = [
+  `import { loadMcpToolFixture } from "@pome-sh/sdk/mcp-tool-fixture";`,
+  `export const fixture = loadMcpToolFixture({});`,
+].join("\n");
+
+/**
+ * `CROSS_RUNTIME_LEAVES` names `packages/twin-stripe/src/tools.ts` and every
+ * twin needs a tool table, so a tree always carries the five real twin dirs.
+ * `extra` overwrites any of them.
+ */
+function runAgainst(extra = {}, { bare = false } = {}) {
+  const root = mkdtempSync(join(tmpdir(), "twin-leaf-portability-"));
+  const files = bare ? {} : { ...SDK_FILES };
+  if (!bare) {
+    for (const twin of ["github", "gmail", "linear", "slack", "stripe"]) {
+      Object.assign(files, twinFiles(twin, CLEAN_TABLE));
+    }
+    Object.assign(files, LEAF_FILES);
+  }
+  Object.assign(files, extra);
+  for (const [rel, body] of Object.entries(files)) {
+    if (body === null) continue; // an explicit "this file does not exist"
+    const abs = join(root, rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, body);
+  }
+  const result = spawnSync(process.execPath, [SCRIPT], { cwd: root, encoding: "utf8" });
+  return { code: result.status, out: `${result.stdout}${result.stderr}` };
+}
+
+let failures = 0;
+function check(name, { files, expect, contains, bare }) {
+  const { code, out } = runAgainst(files, { bare });
+  const got = code === 0 ? "green" : "red";
+  const problems = [];
+  if (got !== expect) problems.push(`expected ${expect}, got ${got}`);
+  if (contains && !out.includes(contains)) problems.push(`output missing ${JSON.stringify(contains)}`);
+  if (problems.length > 0) {
+    failures += 1;
+    console.error(`✗ ${name}\n  ${problems.join("\n  ")}\n${out.replace(/^/gm, "    ")}`);
+  } else {
+    console.log(`✓ ${name}`);
+  }
+}
+
+check("1. the fixed shape is green: every tool table on the `/mcp-tool-fixture` leaf", {
+  files: {},
+  expect: "green",
+});
+
+check("2. a tool table importing the sdk ROOT is red (the shape F-1325 shipped)", {
+  files: {
+    "packages/twin-stripe/src/tools.ts": [
+      `import { loadMcpToolFixture } from "@pome-sh/sdk";`,
+      `export const fixture = loadMcpToolFixture({});`,
+    ].join("\n"),
+  },
+  expect: "red",
+  contains: "node:sqlite",
+});
+
+check("3. the failure names the module and prints the chain to the builtin", {
+  files: {
+    "packages/twin-slack/src/tools.ts": [
+      `import { loadMcpToolFixture } from "@pome-sh/sdk";`,
+      `export const fixture = loadMcpToolFixture({});`,
+    ].join("\n"),
+  },
+  expect: "red",
+  contains: "packages/sdk/src/db.ts",
+});
+
+check("4. an INDIRECT edge through the twin's own domain is red", {
+  files: {
+    "packages/twin-github/src/tools.ts": [
+      CLEAN_TABLE,
+      `import { domain } from "./domain/index.js";`,
+      `export const d = domain;`,
+    ].join("\n"),
+  },
+  expect: "red",
+  contains: "twin-github/src/domain/index.ts",
+});
+
+check("5. a type-only import of the sdk root is not a runtime edge", {
+  files: {
+    "packages/twin-gmail/src/tools.ts": [
+      CLEAN_TABLE,
+      `import type { openTwinDatabase } from "@pome-sh/sdk";`,
+      `import { type openTwinDatabase as O2 } from "@pome-sh/sdk";`,
+      `export type A = typeof openTwinDatabase;`,
+      `export type B = typeof O2;`,
+    ].join("\n"),
+  },
+  expect: "green",
+});
+
+check("6. an import BELOW a statement is still seen (a lexer that swallowed it would go false-green)", {
+  files: {
+    "packages/twin-slack/src/tools.ts": [
+      CLEAN_TABLE,
+      `export const marker = { name: "x" };`,
+      `import { openTwinDatabase } from "@pome-sh/sdk";`,
+      `export const d = openTwinDatabase;`,
+    ].join("\n"),
+  },
+  expect: "red",
+  contains: "node:sqlite",
+});
+
+check("7. a named cross-runtime leaf that reaches the builtin is red, tool table or not", {
+  files: {
+    "packages/twin-linear/src/graphql/schema.ts": [
+      `import { openTwinDatabase } from "@pome-sh/sdk";`,
+      `export const linearGraphQLSchema = String(openTwinDatabase);`,
+    ].join("\n"),
+  },
+  expect: "red",
+  contains: "twin-linear/src/graphql/schema.ts",
+});
+
+check("8. a twin whose tool table stopped calling the loader is red, not silently unwalked", {
+  files: {
+    "packages/twin-gmail/src/tools.ts": `export const toolDefinitions = [{ name: "hand_written" }];\n`,
+  },
+  expect: "red",
+  contains: "packages/twin-gmail",
+});
+
+check("9. a named cross-runtime leaf that no longer exists is red, not skipped", {
+  files: { "packages/twin-stripe/src/errors.ts": null },
+  expect: "red",
+  contains: "covers nothing",
+});
+
+check("10. an empty tree is red — a gate with nothing to walk is not coverage", {
+  files: { "package.json": JSON.stringify({ name: "root" }) },
+  bare: true,
+  expect: "red",
+  contains: "Run this from the repo root",
+});
+
+if (failures > 0) {
+  console.error(`\n${failures} case(s) failed.`);
+  process.exit(1);
+}
+console.log(`\ncheck-twin-leaf-portability.test: 10 cases passed.`);

--- a/scripts/lib/static-import-graph.mjs
+++ b/scripts/lib/static-import-graph.mjs
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The static import graph of this repo's TypeScript sources, read from the
+// sources themselves.
+//
+// Extracted from `check-twin-chunk-laziness.mjs` (F-1306) when a second gate
+// needed the same walk: `check-twin-leaf-portability.mjs` asks which twin
+// modules can still be loaded by a runtime without `node:sqlite`. Both ask a
+// reachability question about the same graph, and two hand-rolled copies of an
+// import lexer would be two chances to disagree about what a type-only import
+// is.
+//
+// Dependency-free and build-free on purpose: it reads TypeScript sources and
+// each package's real `exports` map, so it runs in CI's always-on block before
+// `npm ci`, and it cannot disagree with the bundler about which subpath
+// resolves where.
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+/** Workspace `@pome-sh/*` specifiers → source file, read from each package's
+ *  own `exports` map so a renamed subpath cannot silently stop being checked. */
+export function buildSpecifierMap(root) {
+  const map = new Map();
+  const packagesDir = join(root, "packages");
+  if (!existsSync(packagesDir)) return map;
+  for (const dir of readdirSync(packagesDir)) {
+    const manifestPath = join(packagesDir, dir, "package.json");
+    if (!existsSync(manifestPath)) continue;
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    if (!manifest.name?.startsWith("@pome-sh/")) continue;
+    for (const [subpath, target] of Object.entries(manifest.exports ?? {})) {
+      // `{ types, default }` conditions or a bare string; either way we want the
+      // JS target, then map `dist/src/foo.js` (or `dist/foo.js`) back to source.
+      const js = typeof target === "string" ? target : target.default;
+      if (typeof js !== "string" || !js.endsWith(".js")) continue;
+      const sourceRel = js
+        .replace(/^\.\//, "")
+        .replace(/^dist\/(?:src\/)?/, "src/")
+        .replace(/\.js$/, ".ts");
+      const sourcePath = join(packagesDir, dir, sourceRel);
+      if (!existsSync(sourcePath)) continue;
+      const specifier = subpath === "." ? manifest.name : `${manifest.name}${subpath.slice(1)}`;
+      map.set(specifier, sourcePath);
+    }
+  }
+  return map;
+}
+
+/**
+ * Blank out comments and string/template bodies, keeping newlines so the text
+ * stays line-addressable.
+ *
+ * Load-bearing, not hygiene: `cli/src/cli/init-sdk.ts` embeds the scaffolded
+ * agent's SOURCE in a template literal, and that source contains
+ * `import { query, tool, withPome } from "@pome-sh/adapter-claude-sdk";`. A
+ * regex over raw text reads that as a real edge and reports a package the CLI
+ * never imports — and by the same mistake would report a twin root as eager
+ * because a scaffold string mentions one. Scaffolds are the one place this repo
+ * writes import statements it does not execute, and it writes several.
+ */
+export function stripNonCode(source) {
+  const blank = (text) => text.replace(/[^\n]/g, " ");
+  let out = "";
+  let index = 0;
+  while (index < source.length) {
+    const char = source[index];
+    const next = source[index + 1];
+    if (char === "/" && next === "/") {
+      const end = source.indexOf("\n", index);
+      const stop = end === -1 ? source.length : end;
+      out += blank(source.slice(index, stop));
+      index = stop;
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      const end = source.indexOf("*/", index + 2);
+      const stop = end === -1 ? source.length : end + 2;
+      out += blank(source.slice(index, stop));
+      index = stop;
+      continue;
+    }
+    if (char === "`") {
+      let cursor = index + 1;
+      while (cursor < source.length && source[cursor] !== "`") {
+        cursor += source[cursor] === "\\" ? 2 : 1;
+      }
+      const stop = Math.min(cursor + 1, source.length);
+      out += blank(source.slice(index, stop));
+      index = stop;
+      continue;
+    }
+    out += char;
+    index += 1;
+  }
+  return out;
+}
+// Ordinary quoted strings are left alone deliberately: they cannot span lines, and
+// every pattern below is anchored to the start of one, so a specifier inside a
+// single-line string can never sit where an import statement would.
+
+/**
+ * Runtime static import specifiers in one TypeScript source.
+ *
+ * Type-only edges are EXCLUDED because they are erased before the bundler sees
+ * them — both the `import type` / `export type` form and the form where every
+ * named binding is individually marked (`import { type A, type B } from …`).
+ * Counting either would fail a gate on an edge that emits no code, which is
+ * the failure mode that gets a gate deleted rather than fixed.
+ *
+ * `import()` is EXCLUDED because a dynamic import is a deferred edge: it is the
+ * thing the laziness gate wants, and it is not executed at module load, which
+ * is what the portability gate asks about.
+ *
+ * The clause is matched with the characters an import clause can actually
+ * contain (`[\w$*,{}\s]` — identifiers, `as`, `type`, braces, a namespace star)
+ * rather than `[\s\S]`. Anything else would let one match span two statements:
+ * `export const x = 1;` on one line and a real `import … from …` on the next
+ * matched as a SINGLE clause, which both mis-reads the first statement as an
+ * edge AND consumes the second, so the real import is never seen. A gate that
+ * reports the wrong edge is annoying; one that silently stops seeing a real one
+ * is the failure mode these gates exist to prevent.
+ */
+export function staticImportSpecifiers(rawSource) {
+  const source = stripNonCode(rawSource);
+  const found = [];
+  const pattern =
+    /^[ \t]*(?:import|export)\b([\w$*,{}\s]*?)from\s*["']([^"']+)["']|^[ \t]*import\s*["']([^"']+)["']/gm;
+  let match;
+  while ((match = pattern.exec(source)) !== null) {
+    const specifier = match[2] ?? match[3];
+    const clause = match[1] ?? "";
+    if (/^\s*type\b/.test(clause)) continue;
+    const braced = clause.match(/\{([\s\S]*)\}/);
+    if (braced) {
+      const named = braced[1]
+        .split(",")
+        .map((part) => part.trim())
+        .filter(Boolean);
+      const hasDefaultOrNamespace = /^\s*(?:[A-Za-z_$][\w$]*\s*,|\*)/.test(clause);
+      if (named.length > 0 && !hasDefaultOrNamespace && named.every((n) => /^type\s/.test(n))) {
+        continue;
+      }
+    }
+    found.push(specifier);
+  }
+  return found;
+}
+
+/** A specifier → the `.ts` source it resolves to, or null for third-party
+ *  packages, node builtins and JSON asset imports. */
+export function resolveSpecifier(specifier, fromFile, specifiers) {
+  if (specifier.startsWith(".")) {
+    const base = resolve(dirname(fromFile), specifier);
+    const candidates = base.endsWith(".js")
+      ? [`${base.slice(0, -3)}.ts`]
+      : [base, `${base}.ts`, join(base, "index.ts")];
+    return candidates.find((candidate) => existsSync(candidate) && candidate.endsWith(".ts")) ?? null;
+  }
+  return specifiers.get(specifier) ?? null;
+}
+
+/**
+ * Every `.ts` file statically reachable from `entries`, each mapped to the file
+ * that first pulled it in — so a violation can be reported as a chain a human
+ * can follow — plus every specifier that resolved to no file in this repo
+ * (node builtins, third-party packages, JSON assets), recorded with the file
+ * that imported it.
+ *
+ * @param entries absolute paths to seed the walk with.
+ * @param specifiers the map from {@link buildSpecifierMap}.
+ */
+export function reachable(entries, specifiers) {
+  const importedBy = new Map();
+  const external = [];
+  const stack = [];
+  for (const entry of entries) {
+    if (importedBy.has(entry)) continue;
+    importedBy.set(entry, null);
+    stack.push(entry);
+  }
+  while (stack.length > 0) {
+    const file = stack.pop();
+    let source;
+    try {
+      source = readFileSync(file, "utf8");
+    } catch {
+      continue;
+    }
+    for (const specifier of staticImportSpecifiers(source)) {
+      const target = resolveSpecifier(specifier, file, specifiers);
+      if (target === null) {
+        external.push({ from: file, specifier });
+        continue;
+      }
+      if (importedBy.has(target)) continue;
+      importedBy.set(target, file);
+      stack.push(target);
+    }
+  }
+  return { importedBy, external };
+}
+
+/** The import chain that first pulled `file` in, root-first, as repo-relative
+ *  paths. */
+export function chainFor(file, importedBy, relativeTo) {
+  const chain = [];
+  for (let current = file; current; current = importedBy.get(current)) {
+    chain.push(relativeTo(current));
+  }
+  return chain.reverse();
+}


### PR DESCRIPTION
## What broke

pome-cloud's daily `fidelity-watch` cron is red. `tools/fidelity-watch` runs
under **bun**, and `sandboxes/stripe/level2.test.ts` reads `isMutatingTool`
straight out of a pome-twins checkout:

```ts
const { isMutatingTool } = await import(twinModule("packages/twin-stripe/src/tools.js"));
```

That import throws `error: No such built-in module: node:sqlite`.

### CI evidence

| run | when | step "Fidelity-watch tests" |
| --- | --- | --- |
| scheduled `31095282169` | 2026-08-06 10:57Z | **success** |
| dispatch `31161334518` | 2026-08-07 08:21Z, first run after F-1325 | **failure**, `1612 pass / 1 fail` |

The `node:sqlite` error immediately precedes the one failing assertion,
`Level-2 tool coverage > covers exactly the mutating tools (== isMutatingTool list)`.
Reproduced locally against pome-cloud `main` plus a **built** pome-twins `main`
(an unbuilt checkout is misleading — CI does `npm ci && npm run build` on the
twins side).

## Why the barrel is the culprit

F-1325 extracted the MCP tool-table loader into
`packages/sdk/src/mcp-tool-fixture.ts` — a module with **no imports at all** —
and had each twin reach it through the package barrel:

```ts
import { loadMcpToolFixture } from "@pome-sh/sdk";
```

`packages/sdk/src/index.ts` re-exports `openTwinDatabase` from `./db.js`, and
`db.ts` opens with `import { DatabaseSync } from "node:sqlite"`. So importing
the barrel for a dependency-free loader executes the SQLite driver. Before
F-1325 those `tools.ts` files imported only `zod` and local types.

Every twins suite runs on Node, where `node:sqlite` exists, so this repo's CI
was green throughout. The runtime that could not load the file is one repo over.

## The fix

- `@pome-sh/sdk` gains a `./mcp-tool-fixture` subpath export, following the
  shape of the four it already publishes (`./server`, `./parity`, `./checks`,
  `./db`). No build change was needed: the sdk builds with plain
  `tsc -p tsconfig.build.json` over `src/**/*.ts`, so `dist/mcp-tool-fixture.js`
  and its `.d.ts` were already emitted 1:1 — the subpath is pure `package.json`.
- `twin-{github,slack,stripe}/src/tools.ts` import the subpath.
- **gmail and linear had the same defect**, one file over. Their `tools.ts`
  does not touch the sdk, but F-1325 migrated them onto the loader in
  `src/mcp.ts`, which imports `deriveMcpToolTable` + `loadMcpToolFixture` from
  the barrel. Both throw under bun today
  (`bun -e "await import('packages/twin-gmail/src/mcp.ts')"`), so both moved.
  The values go to the subpath; `ToolCallContext`/`ToolSpec` stay on the root as
  `import type`, which is erased. gmail's `GmailDomain` import becomes
  `import type` as well — it is used only in handler signatures, and the domain
  barrel is that module's other route to `node:sqlite`.
- The barrel keeps exporting `loadMcpToolFixture`. Node callers are fine either
  way and removing it would break them for nothing.

## Before / after

`POME_TWIN_SRC=<this branch, built> bun test` in `pome-cloud/tools/fidelity-watch`:

```
 1612 pass
 1 fail
 5613 expect() calls
Ran 1613 tests across 82 files.
```

```
 1613 pass
 0 fail
 5634 expect() calls
Ran 1613 tests across 82 files.
```

## How the regression guard fires

`scripts/check-twin-leaf-portability.mjs`, modelled on
`check-twin-chunk-laziness.mjs`: dependency-free, build-free, runs in ci.yml's
always-on block before `npm ci`.

> No module in ENTRIES may statically reach a builtin that non-Node runtimes do
> not implement (today: `node:sqlite`).

ENTRIES is every twin's MCP tool table — discovered by looking for the F-1325
loader call, so a new twin is covered with no hand edit — plus
`CROSS_RUNTIME_LEAVES`, the modules pome-cloud imports by path (stripe's tool
table, github's and slack's 501 envelopes, stripe's errors, linear's GraphQL
schema). A twin with no loader call, a listed leaf that does not exist, and an
empty tree are all hard failures, so the gate cannot quietly stop covering
anything. A twin's server (`index.ts`, `db.ts`, `twin.ts`) is deliberately out
of scope — that IS the SQLite-backed engine and nothing loads it off Node.

Reverting one line of this PR:

```
$ node scripts/check-twin-leaf-portability.mjs

1 twin module(s) that another runtime imports statically reach a builtin that runtime does not have:

  packages/twin-stripe/src/tools.ts  — reaches node:sqlite
      bun implements no `node:sqlite`, and pome-cloud's fidelity-watch runs under bun
      packages/twin-stripe/src/tools.ts
      -> packages/sdk/src/index.ts
      -> packages/sdk/src/db.ts
      -> node:sqlite
```

`scripts/check-twin-leaf-portability.test.mjs` runs the real script against ten
throwaway trees, including the exact shape F-1325 shipped.

The import lexer and graph walk move into `scripts/lib/static-import-graph.mjs`,
shared with `check-twin-chunk-laziness.mjs` — two gates asking reachability
questions about the same graph should not hold two opinions about what a
type-only import is. The move fixes one lexer bug on the way: the clause
pattern was `[\s\S]*?`, so `export const x = 1;` followed by a real
`import … from …` on the next line matched as a single clause, reporting the
first statement as an edge **and** consuming the second, so the real import
went unseen — a false green. Case 6 of the new suite is the standing guard; the
nine existing chunk-laziness cases still pass.

## Version bump

`check-version-bump-required.mjs` demands one (`packages/sdk/` and
`packages/twin-*` are publish-relevant for the bundled CLI), verified by
running it against the base with the bump reverted. `@pome-sh/cli`
0.21.11 → 0.21.12 and `@pome-sh/sdk` 0.11.3 → 0.11.4, both with changelog
entries.

## Gates run

`lint:dead-code`, `gate:no-native`, `gate:no-eval`, `build`, `typecheck`,
`typecheck:examples`, `smoke:examples`, `probe:examples`, `probe:twins`,
`gate:bundled-deps`, `gate:checks-tarball`, `test:contract`,
`contract/cli-start.test.mjs`, `test:pack`, `fidelity:parity` across all five
twins, every workspace `npm test` + twin-github coverage, the whole always-on
cheap block, and `check-version-bump-required.mjs`. All green.

Not touched, known red on main and out of scope: `validate:mcp` (F-1354),
`contract/run.mjs` file coverage (F-1353).
