### PR TITLE
The checks subpath surface is pinned by the names pome-cloud actually imports (F-1349)

### DIFF
--- a/packages/checks/CHANGELOG.md
+++ b/packages/checks/CHANGELOG.md
@@ -1,5 +1,26 @@
 # @pome-sh/checks
 
+## 0.1.1
+
+No change to the published surface — `dist/` is byte-identical to 0.1.0, so no
+declaration moved and no consumer's verdict changes. What moved is the test that
+protects that surface, and it moved because the surface acquired a real consumer:
+pome-cloud F-1349 pointed all 19 of its grading import sites here, so the
+per-twin subpaths are now load-bearing rather than provided-for-later.
+
+- `per-twin subpaths` pins each twin's seed schema by its EXACT name instead of
+  asking whether any of three names is present. The old assertion passed as long
+  as one of `seedSchema` / `gmailSeedSchema` / `linearSeedSchema` existed on the
+  module, so gmail exporting `seedSchema` would have been green here and a
+  compile error in the consumer.
+- The same arm now pins `defaultSeedState` (github/gmail/linear/slack) and
+  `defaultSeed` (stripe), which nothing pinned before. The barrel exports the
+  same values under prefixed aliases (`defaultGitHubSeed`, …) and the barrel arm
+  covers those, so a subpath dropping or renaming them was invisible.
+- Each subpath's default seed is called and round-tripped through that subpath's
+  own `parseSeed`, since a factory that is present but broken reads the same as
+  one that works.
+
 ## 0.1.0
 
 First release. Carries the grading vocabulary of all five digital twins so a

--- a/packages/checks/package.json
+++ b/packages/checks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pome-sh/checks",
-  "version": "0.1.0",
-  "description": "Pome's grading vocabulary \u2014 the check declarations, seed schemas and default seeds of all five digital twins, plus the check DSL they are written in. Declarations only: no twin server, no database, no routes, no tools.",
+  "version": "0.1.1",
+  "description": "Pome's grading vocabulary — the check declarations, seed schemas and default seeds of all five digital twins, plus the check DSL they are written in. Declarations only: no twin server, no database, no routes, no tools.",
   "private": false,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/checks/test/surface.test.ts
+++ b/packages/checks/test/surface.test.ts
@@ -120,9 +120,12 @@ describe("zod schema identity", () => {
 });
 
 describe("dsl", () => {
-  // The symbols pome-cloud's 13 `@pome-sh/sdk/checks` import sites use. `export *`
+  // The symbols pome-cloud's 13 `@pome-sh/checks/dsl` import sites use. `export *`
   // means an ADDITION needs no edit here; this list is what makes a REMOVAL a
   // named failure in this repo instead of a TypeError in the consumer's.
+  //
+  // Those sites read `@pome-sh/sdk/checks` until F-1349 moved them, which is the
+  // ticket that made this list describe a real consumer rather than a planned one.
   it("re-exports the check DSL pome-cloud imports", () => {
     for (const name of [
       "defineCheck",
@@ -156,6 +159,20 @@ describe("dsl", () => {
 describe("per-twin subpaths", () => {
   // Each subpath keeps the twin's OWN names, so a pome-cloud import site moves
   // by changing the specifier and nothing else.
+  //
+  // F-1349 made this arm load-bearing rather than illustrative: pome-cloud now
+  // imports these subpaths for real, and it reaches for the TWIN'S names, not
+  // the barrel's prefixed aliases. `defaultSeedState` (github/gmail/linear/slack)
+  // and `defaultSeed` (stripe) are what `criterion-discrimination.ts` and
+  // `apps/mcp/src/task/parseTask.ts` bind their null-agent worlds from; the
+  // barrel exports the same values as `defaultGitHubSeed` and friends, so the
+  // barrel arm above stays green if a subpath drops or renames them.
+  //
+  // The seed-schema expectation is per-twin and EXACT for the same reason. It
+  // used to be `["seedSchema","gmailSeedSchema","linearSeedSchema"].some(n => n in module)`,
+  // which passes as long as ANY of the three is present — so gmail exporting
+  // `seedSchema` instead of `gmailSeedSchema` would have been green here and a
+  // compile error in `apps/mcp/src/task/taskSchema.ts`.
   const modules = { github, gmail, linear, slack, stripe } as const;
   const arrays = {
     github: "GITHUB_CHECKS",
@@ -164,13 +181,48 @@ describe("per-twin subpaths", () => {
     slack: "SLACK_CHECKS",
     stripe: "STRIPE_CHECKS",
   } as const;
+  // The exact name each subpath must expose, twin by twin. Not a list to search:
+  // the point is that gmail's schema is called `gmailSeedSchema` and github's is
+  // called `seedSchema`, and a consumer's import breaks if either moves.
+  const seedSchemas = {
+    github: "seedSchema",
+    gmail: "gmailSeedSchema",
+    linear: "linearSeedSchema",
+    slack: "seedSchema",
+    stripe: "seedSchema",
+  } as const;
+  const defaultSeeds = {
+    github: "defaultSeedState",
+    gmail: "defaultSeedState",
+    linear: "defaultSeedState",
+    slack: "defaultSeedState",
+    stripe: "defaultSeed",
+  } as const;
 
   for (const [twin, module] of Object.entries(modules)) {
-    it(`${twin} exposes its array, parseSeed and a schema under the twin's own names`, () => {
-      expect(module).toHaveProperty(arrays[twin as keyof typeof arrays]);
+    it(`${twin} exposes its array, parseSeed, seed schema and default seed under the twin's own names`, () => {
+      const key = twin as keyof typeof modules;
+      expect(module).toHaveProperty(arrays[key]);
       expect(module).toHaveProperty("parseSeed");
-      const schemaNames = ["seedSchema", "gmailSeedSchema", "linearSeedSchema"];
-      expect(schemaNames.some((name) => name in module), `${twin} seed schema`).toBe(true);
+      expect(module, `${twin}: pome-cloud imports { ${seedSchemas[key]} } from @pome-sh/checks/${twin}`).toHaveProperty(
+        seedSchemas[key],
+      );
+      expect(module, `${twin}: pome-cloud imports { ${defaultSeeds[key]} } from @pome-sh/checks/${twin}`).toHaveProperty(
+        defaultSeeds[key],
+      );
+    });
+
+    // Presence is not enough for the default seed: it is a FACTORY, and one that
+    // returned a stale shared object would hand every graded run the same mutated
+    // world. The barrel arm round-trips these through their own schema; this
+    // asserts the subpath hands out the same callable, since that is the one
+    // pome-cloud actually calls.
+    it(`${twin}'s subpath default seed is callable and parses`, () => {
+      const key = twin as keyof typeof modules;
+      const make = (module as Record<string, unknown>)[defaultSeeds[key]] as () => unknown;
+      const parse = (module as Record<string, unknown>).parseSeed as (raw: unknown) => unknown;
+      expect(typeof make, `${twin} default seed`).toBe("function");
+      expect(() => parse(make()), twin).not.toThrow();
     });
 
     // `applySeed` writes SQLite rows and `loadSeedFromEnv` reads process.env.


### PR DESCRIPTION
<!-- Closes F-1349 (the digital-twins half) -->

## What

Tightens `packages/checks/test/surface.test.ts`'s `per-twin subpaths` arm and bumps `@pome-sh/checks` to `0.1.1`. `dist/` is byte-identical to `0.1.0` — no declaration moved, so no consumer's verdict changes.

## Why

pome-cloud [#560](https://github.com/pome-sh/pome-cloud/pull/560) (F-1349) points all 19 of its grading import sites at this package. That turns `per-twin subpaths` from an arm describing a planned consumer into one describing a real one, and two holes that were survivable while nothing imported the subpaths are not survivable now.

**The seed-schema assertion was `.some()`.** It asked whether *any* of `seedSchema` / `gmailSeedSchema` / `linearSeedSchema` was present on the module. gmail exporting `seedSchema` instead of `gmailSeedSchema` would have been green here and a compile error in `apps/mcp/src/task/taskSchema.ts`. Now per-twin and exact.

**`defaultSeedState` and `defaultSeed` were pinned nowhere.** The barrel exports the same values under prefixed aliases (`defaultGitHubSeed`, …) and the barrel arm covers those — so a subpath dropping or renaming them was invisible on this side, while pome-cloud's `criterion-discrimination.ts` and `apps/mcp/src/task/parseTask.ts` build their null-agent worlds from exactly those subpath names.

Each default seed is also called and round-tripped through its own subpath's `parseSeed`, since a factory that is present but broken reads the same as one that works.

## Notes for reviewer

Verified the tightened arm fails for the reason it was written: renaming `gmailSeedSchema` → `seedSchema` in `src/gmail.ts` turns it red with `gmail: pome-cloud imports { gmailSeedSchema } from @pome-sh/checks/gmail`. The old assertion stayed green through the same edit.

The version bump is what `check-version-bump-required.mjs` requires of any change under `packages/checks/` (`pathPrefixes: ["packages/checks/"]`), and is what carries the hardened test to a released artifact. On merge, `release.yml`'s `plan` job sees `0.1.1` ≠ `0.1.0` and publishes.

**On AGENTS.md's "there is deliberately no drift gate" for this package** — that reasoning is about *this repo*, and it holds: `packages/checks/src/*.ts` are `export … from` lines, so there is no second copy here to drift. It does not cover the separation introduced at *publish* time, because tsup **bundles** the twin output rather than depending on it, so the tarball carries a snapshot taken at build time. pome-cloud is the only place `@pome-sh/checks` and the pinned `@pome-sh/twin-*` packages are both installed, so the complementary gate lives there (`checks-package-drift.test.ts`, in [#560](https://github.com/pome-sh/pome-cloud/pull/560)). It already has something to say: `@pome-sh/checks@0.1.0` bundles gmail and linear at the unpublishable `0.3.4`, whose descriptions differ from the `0.3.3` pome-cloud pins. Nothing that binds differs — all five `checksDigest` values match — which is why that gate compares the binding surface and not prose.

## Review required

Yes — touches the twin fidelity contract's published surface. Test and packaging only; no declaration changes.