### PR TITLE
Model `stack` on both pull-request surfaces (F-1178)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -12,7 +12,8 @@ packaging restructure: bump `version` here and in `package.json`, and merging to
   (`GET /repos/:o/:r/pulls` and `.../pulls/:n`), which GitHub added to its
   `pull-request` and `pull-request-simple` schemas on 2026-08-02 (F-1178). An
   agent asked to review or merge a stacked PR against the twin can now see the
-  stack it belongs to. `packages/twin-github` changed, and the CLI inlines it.
+  stack it belongs to, and two PRs in one stack always agree on its identity,
+  size and membership. `packages/twin-github` changed, and the CLI inlines it.
 
 ## 0.21.12
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,16 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.21.13
+
+### Patch Changes
+
+- The bundled GitHub twin now models `stack` on both pull-request read surfaces
+  (`GET /repos/:o/:r/pulls` and `.../pulls/:n`), which GitHub added to its
+  `pull-request` and `pull-request-simple` schemas on 2026-08-02 (F-1178). An
+  agent asked to review or merge a stacked PR against the twin can now see the
+  stack it belongs to. `packages/twin-github` changed, and the CLI inlines it.
+
 ## 0.21.12
 
 ### Patch Changes

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.21.12",
+  "version": "0.21.13",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "cli": {
       "name": "@pome-sh/cli",
-      "version": "0.21.11",
+      "version": "0.21.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.29",
@@ -7318,7 +7318,7 @@
     },
     "packages/checks": {
       "name": "@pome-sh/checks",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@pome-sh/sdk": "*",
@@ -7342,7 +7342,7 @@
     },
     "packages/sdk": {
       "name": "@pome-sh/sdk",
-      "version": "0.11.3",
+      "version": "0.11.4",
       "dependencies": {
         "@pome-sh/wire": "*",
         "hono": "^4.13.0",
@@ -7369,7 +7369,7 @@
     },
     "packages/twin-github": {
       "name": "@pome-sh/twin-github",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.1.0",

--- a/packages/twin-github/CHANGELOG.md
+++ b/packages/twin-github/CHANGELOG.md
@@ -1,6 +1,28 @@
 # @pome-sh/twin-github — CHANGELOG
 
 
+## 0.9.3 — 2026-08-08
+
+`stack` is modelled on both pull-request read surfaces (F-1178). GitHub shipped
+stacked pull requests and added the field to both the `pull-request` and
+`pull-request-simple` schemas on 2026-08-02, and the declared lane caught the
+twin missing it on `GET /repos/{}/{}/pulls` and `GET /repos/{}/{}/pulls/{}`.
+
+The shape is transcribed from the vendored `pull-request-stack` schema, not
+guessed: nullable, with a required `base: { ref, sha }` and optional integer
+`size`, `position`, `id` and `number`. `@octokit/openapi-types@28.0.0` predates
+the field, so `src/upstream-types.ts` declares it locally until that bump lands;
+the `AssertNoUncovered` guard covers it either way.
+
+It is populated from twin state, not a constant. GitHub models a stack as its
+own entity; the twin has no stack table, so it reads one off the chain of OPEN
+pull requests linked `base_ref` -> `head_ref` in a repository. `base`, `size`
+and `position` are exact consequences of that chain; `id` and `number` are
+derived from the chain's bottom PR, so every member of one stack reports one
+identity. A PR that is not in such a chain reports `stack: null`. The limits are
+written up in `FIDELITY.md` divergence #11.
+
+
 ## 0.9.2 — 2026-08-06
 
 Its MCP tool table is now derived from `fixtures/mcp-tools-list.raw.json`

--- a/packages/twin-github/CHANGELOG.md
+++ b/packages/twin-github/CHANGELOG.md
@@ -14,13 +14,25 @@ guessed: nullable, with a required `base: { ref, sha }` and optional integer
 the field, so `src/upstream-types.ts` declares it locally until that bump lands;
 the `AssertNoUncovered` guard covers it either way.
 
-It is populated from twin state, not a constant. GitHub models a stack as its
-own entity; the twin has no stack table, so it reads one off the chain of OPEN
-pull requests linked `base_ref` -> `head_ref` in a repository. `base`, `size`
-and `position` are exact consequences of that chain; `id` and `number` are
-derived from the chain's bottom PR, so every member of one stack reports one
-identity. A PR that is not in such a chain reports `stack: null`. The limits are
-written up in `FIDELITY.md` divergence #11.
+It is populated from twin state, not a constant. GitHub models a stack as its own
+entity; the twin has no stack table, so it reads one off the pull requests linked
+`base_ref` -> `head_ref` inside a repository, matched on repo id as well as ref
+name so a fork's identically-named branch cannot invent a link. `base`, `size`
+and `position` are exact consequences of that chain; `id` and `number` derive
+from its bottom open member.
+
+Because that identity is shared across members, the answer has to be a property
+of the chain rather than of the pull request you happened to ask about. So the
+whole connected component is resolved and then required to be one unambiguous
+line: **any two PRs reporting the same `stack.id` report the same `size` and the
+same membership, with positions exactly `1..size`**. A component that forks or
+cycles reports `stack: null` from every member instead of handing out an identity
+two of them would disagree about. Linkage spans pull requests of every state, so
+a closed middle link does not sever a live chain, while membership counts only
+open members; fewer than two leaves no stack. A stack whose base branch has no
+resolved sha is not named either, since the vendor schema types `base.sha`
+non-null. All four limits are tested, and written up in `FIDELITY.md`
+divergence #11.
 
 
 ## 0.9.2 — 2026-08-06

--- a/packages/twin-github/FIDELITY.md
+++ b/packages/twin-github/FIDELITY.md
@@ -4,7 +4,7 @@
 universal clone. This page documents exactly which surfaces are faithful to
 GitHub today, at what tier, and how fidelity is verified.
 
-Last verified: 2026-07-12.
+Last verified: 2026-08-08.
 
 ## What "fidelity" means here
 
@@ -72,13 +72,13 @@ in the package README. Changing any of those is a breaking change for
 | `remove_issue_label` | SQLite issue labels | hot | semantic | `mcp-contract.test.ts` | Removing a missing label returns 404. |
 | `list_collaborators` | SQLite collaborators | hot | semantic | `mcp-contract.test.ts` | Permission filtering is not implemented. |
 | `add_assignees` | SQLite issue assignees | hot | semantic | `mcp-contract.test.ts` | Requires seeded collaborators. |
-| `get_pull_request` | SQLite pull requests | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | Drafts, mergeability background jobs, and review decisions are simplified. |
+| `get_pull_request` | SQLite pull requests | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts`, `v2-hot-paths-rest.test.ts` | Drafts, mergeability background jobs, and review decisions are simplified. `stack` is derived from the open-PR base chain (divergence #11). |
 | `get_pull_request_reviews` | SQLite PR reviews | hot | semantic | `mcp-contract.test.ts`, `state-export.test.ts` | Review dismissal is not implemented. |
 | `create_pull_request_review` | SQLite PR reviews | hot | semantic | `mcp-contract.test.ts`, `state-export.test.ts` | Inline review comments are not created by this tool. |
 | `get_pull_request_comments` | SQLite PR review comments | hot | semantic | `mcp-contract.test.ts` | Review comment creation is not exposed yet. |
 | `get_pull_request_files` | SQLite computed PR files | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | Patches are simplified placeholders. |
 | `get_pull_request_status` | SQLite commit statuses | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | Check suites and check runs are not modeled. |
-| `list_pull_requests` | SQLite pull requests | hot | semantic | `mcp-contract.test.ts` | Sorting and advanced filters are simplified. |
+| `list_pull_requests` | SQLite pull requests | hot | semantic | `mcp-contract.test.ts`, `v2-hot-paths-rest.test.ts` | Sorting and advanced filters are simplified. `stack` is derived from the open-PR base chain (divergence #11). |
 | `merge_pull_request` | SQLite merge mutation | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | Merge methods are simplified to one deterministic local merge. |
 | `update_pull_request_branch` | SQLite merge of base into head | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts`, `m5-hot-gaps.test.ts` | Merge commit carries a single parent; conflicting paths resolve head-wins (no 422 merge-conflict); 202-shaped no-op instead of GitHub's 422 when base has no new commits or when its changes are already contained on head (merge commits are only created when files change); no async update job. |
 | `create_pull_request` | SQLite pull requests/files | hot | semantic | `mcp-contract.test.ts`, `concurrency.test.ts` | Cross-repo forks are supported only when the fork exists in the clone. |
@@ -254,6 +254,27 @@ upstream so a divergence that upstream "heals" becomes a tier-upgrade signal.
     and label/assignee modeling are simplified. On an L1 read surface
     (`GET /repos/:o/:r/pulls`, `.../pulls/:n`) these upstream-only omissions are
     accepted (INFO), not drift.
+
+    **`stack` is modelled, not omitted (F-1178).** GitHub shipped stacked pull
+    requests and added `stack` to both the `pull-request` and
+    `pull-request-simple` schemas on 2026-08-02; the declared lane caught it as
+    shape drift on both routes, and the twin now emits it. It is not on the
+    omission list above, and it is not a hardcoded constant: GitHub models a
+    stack as its own entity with its own id and number, and the twin has no
+    stack table, so it reads a stack off the state that does encode one — the
+    chain of OPEN pull requests in a repository linked `base_ref` -> `head_ref`.
+    `base.ref` / `base.sha`, `size` and `position` are exact consequences of
+    that chain. The two fields the twin cannot read from state are `id` and
+    `number`: both are derived from the chain's BOTTOM pull request (`id` via
+    the same `stableNumericId` derivation as every other twin id, `number` as
+    that PR's number), which is what keeps every member of one stack reporting
+    one identity — the property an agent grouping PRs by stack depends on — but
+    means the twin's stack numbers share the per-repo number space that issues
+    and PRs draw from, where GitHub's do not. Three further limits: a stack is
+    inferred from base targeting rather than declared, so PRs that merely
+    happen to chain read as stacked; a non-open PR reports `stack: null`,
+    because the chain is built from open PRs; and a chain that forks takes the
+    lowest-numbered branch, since a GitHub stack is linear.
 12. **Pull-request `merge_commit_sha` is GitHub's ephemeral test-merge commit.**
     `merge_commit_sha` is the sha GitHub computes by speculatively merging the PR
     head into the base to test mergeability — non-deterministic and not a commit in

--- a/packages/twin-github/FIDELITY.md
+++ b/packages/twin-github/FIDELITY.md
@@ -72,13 +72,13 @@ in the package README. Changing any of those is a breaking change for
 | `remove_issue_label` | SQLite issue labels | hot | semantic | `mcp-contract.test.ts` | Removing a missing label returns 404. |
 | `list_collaborators` | SQLite collaborators | hot | semantic | `mcp-contract.test.ts` | Permission filtering is not implemented. |
 | `add_assignees` | SQLite issue assignees | hot | semantic | `mcp-contract.test.ts` | Requires seeded collaborators. |
-| `get_pull_request` | SQLite pull requests | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts`, `v2-hot-paths-rest.test.ts` | Drafts, mergeability background jobs, and review decisions are simplified. `stack` is derived from the open-PR base chain (divergence #11). |
+| `get_pull_request` | SQLite pull requests | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts`, `v2-hot-paths-rest.test.ts` | Drafts, mergeability background jobs, and review decisions are simplified. `stack` is derived from the base chain (divergence #11). |
 | `get_pull_request_reviews` | SQLite PR reviews | hot | semantic | `mcp-contract.test.ts`, `state-export.test.ts` | Review dismissal is not implemented. |
 | `create_pull_request_review` | SQLite PR reviews | hot | semantic | `mcp-contract.test.ts`, `state-export.test.ts` | Inline review comments are not created by this tool. |
 | `get_pull_request_comments` | SQLite PR review comments | hot | semantic | `mcp-contract.test.ts` | Review comment creation is not exposed yet. |
 | `get_pull_request_files` | SQLite computed PR files | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | Patches are simplified placeholders. |
 | `get_pull_request_status` | SQLite commit statuses | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | Check suites and check runs are not modeled. |
-| `list_pull_requests` | SQLite pull requests | hot | semantic | `mcp-contract.test.ts`, `v2-hot-paths-rest.test.ts` | Sorting and advanced filters are simplified. `stack` is derived from the open-PR base chain (divergence #11). |
+| `list_pull_requests` | SQLite pull requests | hot | semantic | `mcp-contract.test.ts`, `v2-hot-paths-rest.test.ts` | Sorting and advanced filters are simplified. `stack` is derived from the base chain (divergence #11). |
 | `merge_pull_request` | SQLite merge mutation | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | Merge methods are simplified to one deterministic local merge. |
 | `update_pull_request_branch` | SQLite merge of base into head | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts`, `m5-hot-gaps.test.ts` | Merge commit carries a single parent; conflicting paths resolve head-wins (no 422 merge-conflict); 202-shaped no-op instead of GitHub's 422 when base has no new commits or when its changes are already contained on head (merge commits are only created when files change); no async update job. |
 | `create_pull_request` | SQLite pull requests/files | hot | semantic | `mcp-contract.test.ts`, `concurrency.test.ts` | Cross-repo forks are supported only when the fork exists in the clone. |
@@ -261,20 +261,41 @@ upstream so a divergence that upstream "heals" becomes a tier-upgrade signal.
     shape drift on both routes, and the twin now emits it. It is not on the
     omission list above, and it is not a hardcoded constant: GitHub models a
     stack as its own entity with its own id and number, and the twin has no
-    stack table, so it reads a stack off the state that does encode one — the
-    chain of OPEN pull requests in a repository linked `base_ref` -> `head_ref`.
-    `base.ref` / `base.sha`, `size` and `position` are exact consequences of
-    that chain. The two fields the twin cannot read from state are `id` and
-    `number`: both are derived from the chain's BOTTOM pull request (`id` via
-    the same `stableNumericId` derivation as every other twin id, `number` as
-    that PR's number), which is what keeps every member of one stack reporting
-    one identity — the property an agent grouping PRs by stack depends on — but
-    means the twin's stack numbers share the per-repo number space that issues
-    and PRs draw from, where GitHub's do not. Three further limits: a stack is
-    inferred from base targeting rather than declared, so PRs that merely
-    happen to chain read as stacked; a non-open PR reports `stack: null`,
-    because the chain is built from open PRs; and a chain that forks takes the
-    lowest-numbered branch, since a GitHub stack is linear.
+    stack table, so it reads a stack off the state that does encode one — pull
+    requests linked `base_ref` -> `head_ref` inside one repository, matched on
+    repo id as well as ref name so a fork's identically-named branch cannot
+    invent a link. `base.ref` / `base.sha`, `size` and `position` are exact
+    consequences of that chain. The two fields the twin cannot read from state
+    are `id` and `number`: both derive from the chain's bottom open member (`id`
+    via the same `stableNumericId` derivation as every other twin id, `number`
+    as that PR's number). The invariant that buys is that **any two pull
+    requests reporting the same `stack.id` report the same `size` and the same
+    membership, with positions exactly `1..size`** — the property an agent
+    grouping PRs by stack depends on. The cost is that the twin's stack numbers
+    share the per-repo number space issues and PRs draw from, where GitHub's do
+    not.
+
+    Four limits, each of them tested rather than asserted here:
+
+    - **A stack is inferred from base targeting, not declared.** PRs that merely
+      happen to chain read as stacked.
+    - **Only an unambiguously linear chain gets an identity.** A GitHub stack is
+      one line. When the chain forks (two PRs based on the same branch) or
+      cycles, the twin cannot say which way it continues, and the bottom member —
+      which the identity derives from — would depend on which PR you asked. It
+      reports `stack: null` from *every* member of such a chain rather than hand
+      out an identity two members would disagree about.
+    - **Linkage spans every state; membership is the open members.** A closed or
+      merged middle link does not sever a live chain (the PRs above and below it
+      remain one stack), but it is not counted in `size` or `position`, and a
+      non-open PR reports `stack: null` for itself. Once fewer than two open
+      members remain there is no stack — which is also what real GitHub reports
+      after a stack drains, though the twin does not model the base retargeting
+      GitHub performs on merge.
+    - **A stack whose base has no resolved sha is not named.** The vendor schema
+      makes `base` the stack's only required member and types `base.sha` as a
+      non-null string, so rather than emit a null there the twin reports
+      `stack: null`.
 12. **Pull-request `merge_commit_sha` is GitHub's ephemeral test-merge commit.**
     `merge_commit_sha` is the sha GitHub computes by speculatively merging the PR
     head into the base to test mergeability — non-deterministic and not a commit in

--- a/packages/twin-github/FIDELITY_MATRIX.md
+++ b/packages/twin-github/FIDELITY_MATRIX.md
@@ -1,6 +1,6 @@
 # GitHub Twin Fidelity Matrix
 
-Last verified: 2026-07-12
+Last verified: 2026-08-08
 
 | Surface | Heat | Tier | Contract |
 | --- | --- | --- | --- |
@@ -25,10 +25,10 @@ Last verified: 2026-07-12
 | `GET /repos/:owner/:repo/collaborators` | hot | semantic | Lists seeded collaborators as GitHub user objects. |
 | `GET /repos/:owner/:repo/collaborators/:username` | hot | semantic | Returns `204` for present collaborators and `404` for absent users. |
 | `PUT /repos/:owner/:repo/collaborators/:username` | warm | semantic | Creates invitation (201) for new users; returns 204 for existing collaborators. |
-| `GET /repos/:owner/:repo/pulls` | hot | semantic | Lists pull requests with supported state and pagination filters. |
+| `GET /repos/:owner/:repo/pulls` | hot | semantic | Lists pull requests with supported state and pagination filters. Carries `stack` (F-1178), derived from the open-PR base chain. |
 | `POST /repos/:owner/:repo/pulls` | hot | semantic | Creates clone-backed PRs from existing branches. |
 | `PATCH /repos/:owner/:repo/pulls/:number` | hot | semantic | Title/body/state/base mutations; recomputes PR files on base change. |
-| `GET /repos/:owner/:repo/pulls/:number/*` | hot | semantic | Supported PR detail, files, reviews, comments, status, merge, and update-branch routes are stateful; update-branch performs a semantic merge of base into head (F-735). |
+| `GET /repos/:owner/:repo/pulls/:number/*` | hot | semantic | Supported PR detail, files, reviews, comments, status, merge, and update-branch routes are stateful; update-branch performs a semantic merge of base into head (F-735). PR detail carries `stack` (F-1178), derived from the open-PR base chain. |
 | `GET /repos/:owner/:repo/pulls/:number/commits` | hot | semantic | Oldest-first commit walk between base_sha..head_sha. |
 | `GET /repos/:owner/:repo/pulls/:number/diff` | hot | shape | Unified-diff-shaped envelope; patches are simplified placeholders. Hot gap, deferred post-M5 (F-729 G1). |
 | `POST /repos/:owner/:repo/pulls/:number/comments` | hot | semantic | Creates inline review comments; 422 if path is not in the PR. |

--- a/packages/twin-github/FIDELITY_MATRIX.md
+++ b/packages/twin-github/FIDELITY_MATRIX.md
@@ -25,10 +25,10 @@ Last verified: 2026-08-08
 | `GET /repos/:owner/:repo/collaborators` | hot | semantic | Lists seeded collaborators as GitHub user objects. |
 | `GET /repos/:owner/:repo/collaborators/:username` | hot | semantic | Returns `204` for present collaborators and `404` for absent users. |
 | `PUT /repos/:owner/:repo/collaborators/:username` | warm | semantic | Creates invitation (201) for new users; returns 204 for existing collaborators. |
-| `GET /repos/:owner/:repo/pulls` | hot | semantic | Lists pull requests with supported state and pagination filters. Carries `stack` (F-1178), derived from the open-PR base chain. |
+| `GET /repos/:owner/:repo/pulls` | hot | semantic | Lists pull requests with supported state and pagination filters. Carries `stack` (F-1178), derived from the base chain (divergence #11). |
 | `POST /repos/:owner/:repo/pulls` | hot | semantic | Creates clone-backed PRs from existing branches. |
 | `PATCH /repos/:owner/:repo/pulls/:number` | hot | semantic | Title/body/state/base mutations; recomputes PR files on base change. |
-| `GET /repos/:owner/:repo/pulls/:number/*` | hot | semantic | Supported PR detail, files, reviews, comments, status, merge, and update-branch routes are stateful; update-branch performs a semantic merge of base into head (F-735). PR detail carries `stack` (F-1178), derived from the open-PR base chain. |
+| `GET /repos/:owner/:repo/pulls/:number/*` | hot | semantic | Supported PR detail, files, reviews, comments, status, merge, and update-branch routes are stateful; update-branch performs a semantic merge of base into head (F-735). PR detail carries `stack` (F-1178), derived from the base chain (divergence #11). |
 | `GET /repos/:owner/:repo/pulls/:number/commits` | hot | semantic | Oldest-first commit walk between base_sha..head_sha. |
 | `GET /repos/:owner/:repo/pulls/:number/diff` | hot | shape | Unified-diff-shaped envelope; patches are simplified placeholders. Hot gap, deferred post-M5 (F-729 G1). |
 | `POST /repos/:owner/:repo/pulls/:number/comments` | hot | semantic | Creates inline review comments; 422 if path is not in the PR. |

--- a/packages/twin-github/fidelity.inventory.json
+++ b/packages/twin-github/fidelity.inventory.json
@@ -1,7 +1,7 @@
 {
   "twin": "github",
   "package": "@pome-sh/twin-github",
-  "updated": "2026-07-12",
+  "updated": "2026-08-08",
   "notes": "Tool surface lints 1:1 against FIDELITY.md; REST surface lints 1:1 against FIDELITY_MATRIX.md (FIDELITY.md documents REST as prose). Heat tiers ruled 2026-07-11 on F-729 (list 2/3 + [DECISION], approve-as-drafted); annotations landed via F-735. Evidence codes per packages/sdk/ENDPOINT-TIERS.md. Warm surfaces implemented at semantic stay code-unchanged per the M5 additive-only ruling and are listed in FIDELITY.md's tier-mismatch ledger.",
   "tools": [
     {

--- a/packages/twin-github/package.json
+++ b/packages/twin-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-github",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Deterministic GitHub-shaped twin for agent testing — REST + MCP, SQLite-backed state.",
   "private": true,
   "type": "module",

--- a/packages/twin-github/src/domain/github-domain.ts
+++ b/packages/twin-github/src/domain/github-domain.ts
@@ -958,48 +958,90 @@ export class GitHubDomain {
   // F-1178 — the `stack` member of GitHub's `pull-request` / `pull-request-simple`
   // schemas. GitHub models a stack as its own entity with its own id and number;
   // the twin has no stack table, so it reads a stack off the state that DOES
-  // encode one — the chain of OPEN pull requests in a repository linked
-  // `base_ref` -> `head_ref`. A PR whose base branch is another open PR's head
-  // branch is stacked on top of it, which is what stacking means; a chain of one
-  // is not a stack, and `stack` is null (the schema is `nullable: true`).
-  pullRequestStack(pr: PullRequestRow): PullRequestStack {
+  // encode one — pull requests linked `base_ref` -> `head_ref`, i.e. a PR whose
+  // base branch is another PR's head branch is stacked on top of it.
+  //
+  // The identity this hands out (`id` / `number`) is shared by every member, so
+  // the whole answer has to be a property of the CHAIN and not of the PR the
+  // walk happened to start from. That is why this resolves the entire connected
+  // component and then rejects anything that is not one unambiguous line:
+  // handing two PRs the same `stack.id` while telling them different `size`s
+  // would be worse than the missing field this ticket set out to fix. A
+  // component that is not a simple path — a fork, a cycle — gets `null` from
+  // EVERY member, which is what the schema's `nullable: true` is for.
+  //
+  // `rows` is every pull request in the repo. Passing it in lets the list
+  // surface read the table once instead of once per serialized PR.
+  pullRequestStack(pr: PullRequestRow, rows: PullRequestRow[] = this.listPullRequestRows(pr.repo_id)): PullRequestStack {
+    // A closed or merged PR reports no stack of its own; it still LINKS one
+    // below.
     if (pr.state !== "open") return null;
-    const open = this.listPullRequestRows(pr.repo_id).filter((row) => row.state === "open");
-    // `listPullRequestRows` is number-ascending, so `find` keeps the walk
-    // deterministic if one branch happens to back more than one open PR.
-    const below = (row: PullRequestRow) => open.find((other) => other.number !== row.number && other.head_ref === row.base_ref);
-    const above = (row: PullRequestRow) => open.find((other) => other.number !== row.number && other.base_ref === row.head_ref);
 
-    const chain = [pr];
-    const seen = new Set([pr.number]);
-    for (let lower = below(pr); lower && !seen.has(lower.number); lower = below(lower)) {
-      seen.add(lower.number);
-      chain.unshift(lower);
-    }
-    for (let upper = above(pr); upper && !seen.has(upper.number); upper = above(upper)) {
-      seen.add(upper.number);
-      chain.push(upper);
-    }
-    if (chain.length < 2) return null;
+    // Edges match the repo id as well as the ref name: `head_ref` alone would
+    // link a fork PR's head branch to an upstream PR's identically-named base
+    // branch and invent a stack out of a name collision.
+    const parentsOf = (row: PullRequestRow) =>
+      rows.filter((other) => other.number !== row.number && other.head_repo_id === row.base_repo_id && other.head_ref === row.base_ref);
+    const childrenOf = (row: PullRequestRow) =>
+      rows.filter((other) => other.number !== row.number && other.base_repo_id === row.head_repo_id && other.base_ref === row.head_ref);
 
-    const bottom = chain[0]!;
+    // The connected component around `pr`, walking both edge directions.
+    // Breadth-first over a seen set, so a cycle terminates instead of spinning.
+    // Linkage deliberately traverses pull requests of EVERY state: a closed
+    // middle link must not silently sever a live chain (only membership below
+    // is state-filtered).
+    const component = new Map<number, PullRequestRow>();
+    const queue: PullRequestRow[] = [pr];
+    while (queue.length > 0) {
+      const row = queue.shift()!;
+      if (component.has(row.number)) continue;
+      component.set(row.number, row);
+      for (const linked of [...parentsOf(row), ...childrenOf(row)]) {
+        if (!component.has(linked.number)) queue.push(linked);
+      }
+    }
+    const linked = [...component.values()];
+
+    // A GitHub stack is one line of pull requests. Any node with two parents or
+    // two children means the twin cannot say which way the stack continues, and
+    // exactly one node must sit at the bottom — a cycle has none.
+    if (linked.some((row) => parentsOf(row).length > 1 || childrenOf(row).length > 1)) return null;
+    const bottoms = linked.filter((row) => parentsOf(row).length === 0);
+    if (bottoms.length !== 1) return null;
+
+    // Ordered bottom -> top. Bounded by the component size, and checked after,
+    // so no graph shape can turn this into an unbounded walk.
+    const chain: PullRequestRow[] = [];
+    for (let row: PullRequestRow | undefined = bottoms[0]!; row && chain.length < linked.length; row = childrenOf(row)[0]) {
+      chain.push(row);
+    }
+    if (chain.length !== linked.length) return null;
+
+    // Membership is the OPEN members: a merged or closed PR is not part of a
+    // stack GitHub would report, and the twin does not model the base
+    // retargeting GitHub performs when a stack member merges. `pr` is open and
+    // in the chain, so it is always in here.
+    const members = chain.filter((row) => row.state === "open");
+    if (members.length < 2) return null;
+
+    const bottom = members[0]!;
     const bottomBaseRepo = this.requireRepoById(bottom.base_repo_id);
+    // The vendor schema makes `base` the stack's one REQUIRED member and types
+    // `base.sha` as a non-null string. When the bottom member's base branch has
+    // no resolved head the twin cannot name the stack's base, so it reports no
+    // stack rather than casting a null into a field typed non-null.
+    const baseSha = this.getBranch(bottomBaseRepo.id, bottom.base_ref)?.head_sha ?? bottom.base_sha;
+    if (baseSha === null) return null;
+
     return {
-      base: {
-        ref: bottom.base_ref,
-        // Same pre-resolution null as head.sha / base.sha (FDRS-454): the twin
-        // surfaces null while a branch has no resolved head, where upstream
-        // types a non-null string.
-        sha: (this.getBranch(bottomBaseRepo.id, bottom.base_ref)?.head_sha ?? bottom.base_sha) as string,
-      },
-      size: chain.length,
-      position: chain.findIndex((row) => row.number === pr.number) + 1,
+      base: { ref: bottom.base_ref, sha: baseSha },
+      size: members.length,
+      position: members.findIndex((row) => row.number === pr.number) + 1,
       // The twin has no stack row, so it has no stack id or number of its own.
-      // Both are derived from the chain's BOTTOM pull request — the thing that
-      // identifies a chain in the twin's state — via the same `stableNumericId`
-      // derivation every other id in this twin uses. What an agent needs from
-      // these two is that every member of one stack reports the same pair, and
-      // that is what deriving them from a single member guarantees.
+      // Both derive from the bottom member, which every other member of the same
+      // chain resolves to identically — that is what makes the identity agree
+      // across the stack, and it is why the linearity check above has to reject
+      // anything whose bottom member depends on where you started.
       id: stableNumericId(`${bottomBaseRepo.full_name}/stack/${bottom.number}`),
       number: bottom.number,
     };
@@ -1017,13 +1059,15 @@ export class GitHubDomain {
   }
 
   // LIST endpoint (leaner PullRequestSimple shape: drops the single-PR-only
-  // diff-stat fields, matching real GitHub).
-  serializePullSimple(pr: PullRequestRow) {
+  // diff-stat fields, matching real GitHub). `rows` is the caller's already-read
+  // repo-wide pull request list, so serializing a page of N does not re-read the
+  // table N times.
+  serializePullSimple(pr: PullRequestRow, rows?: PullRequestRow[]) {
     const baseRepo = this.requireRepoById(pr.base_repo_id);
     const headRepo = this.requireRepoById(pr.head_repo_id);
     const headSha = this.getBranch(headRepo.id, pr.head_ref)?.head_sha ?? pr.head_sha;
     const baseSha = this.getBranch(baseRepo.id, pr.base_ref)?.head_sha ?? pr.base_sha;
-    return pullRequestListJson(pr, baseRepo, headRepo, headSha, baseSha, this.pullRequestStack(pr));
+    return pullRequestListJson(pr, baseRepo, headRepo, headSha, baseSha, this.pullRequestStack(pr, rows));
   }
 
 

--- a/packages/twin-github/src/domain/github-domain.ts
+++ b/packages/twin-github/src/domain/github-domain.ts
@@ -21,6 +21,7 @@ import type {
   RepoRow,
   TagRow,
 } from "../types.js";
+import type { PullRequestStack } from "../upstream-types.js";
 import { conflict, notFound, validationFailed } from "../errors.js";
 import { fileSha, linesChanged, makeSha, nowIso, paginate, stableNumericId, treeSha } from "../util.js";
 import { defaultSeedState, parseSeed } from "../seed.js";
@@ -954,6 +955,56 @@ export class GitHubDomain {
     }
   }
 
+  // F-1178 — the `stack` member of GitHub's `pull-request` / `pull-request-simple`
+  // schemas. GitHub models a stack as its own entity with its own id and number;
+  // the twin has no stack table, so it reads a stack off the state that DOES
+  // encode one — the chain of OPEN pull requests in a repository linked
+  // `base_ref` -> `head_ref`. A PR whose base branch is another open PR's head
+  // branch is stacked on top of it, which is what stacking means; a chain of one
+  // is not a stack, and `stack` is null (the schema is `nullable: true`).
+  pullRequestStack(pr: PullRequestRow): PullRequestStack {
+    if (pr.state !== "open") return null;
+    const open = this.listPullRequestRows(pr.repo_id).filter((row) => row.state === "open");
+    // `listPullRequestRows` is number-ascending, so `find` keeps the walk
+    // deterministic if one branch happens to back more than one open PR.
+    const below = (row: PullRequestRow) => open.find((other) => other.number !== row.number && other.head_ref === row.base_ref);
+    const above = (row: PullRequestRow) => open.find((other) => other.number !== row.number && other.base_ref === row.head_ref);
+
+    const chain = [pr];
+    const seen = new Set([pr.number]);
+    for (let lower = below(pr); lower && !seen.has(lower.number); lower = below(lower)) {
+      seen.add(lower.number);
+      chain.unshift(lower);
+    }
+    for (let upper = above(pr); upper && !seen.has(upper.number); upper = above(upper)) {
+      seen.add(upper.number);
+      chain.push(upper);
+    }
+    if (chain.length < 2) return null;
+
+    const bottom = chain[0]!;
+    const bottomBaseRepo = this.requireRepoById(bottom.base_repo_id);
+    return {
+      base: {
+        ref: bottom.base_ref,
+        // Same pre-resolution null as head.sha / base.sha (FDRS-454): the twin
+        // surfaces null while a branch has no resolved head, where upstream
+        // types a non-null string.
+        sha: (this.getBranch(bottomBaseRepo.id, bottom.base_ref)?.head_sha ?? bottom.base_sha) as string,
+      },
+      size: chain.length,
+      position: chain.findIndex((row) => row.number === pr.number) + 1,
+      // The twin has no stack row, so it has no stack id or number of its own.
+      // Both are derived from the chain's BOTTOM pull request — the thing that
+      // identifies a chain in the twin's state — via the same `stableNumericId`
+      // derivation every other id in this twin uses. What an agent needs from
+      // these two is that every member of one stack reports the same pair, and
+      // that is what deriving them from a single member guarantees.
+      id: stableNumericId(`${bottomBaseRepo.full_name}/stack/${bottom.number}`),
+      number: bottom.number,
+    };
+  }
+
   // Single-PR GET (full PullRequest shape: keeps merged / commits / additions /
   // deletions / changed_files).
   serializePull(pr: PullRequestRow) {
@@ -962,7 +1013,7 @@ export class GitHubDomain {
     const files = this.db.prepare("SELECT * FROM pull_request_files WHERE repo_id = ? AND pull_number = ?").all(pr.repo_id, pr.number) as PullRequestFileRow[];
     const headSha = this.getBranch(headRepo.id, pr.head_ref)?.head_sha ?? pr.head_sha;
     const baseSha = this.getBranch(baseRepo.id, pr.base_ref)?.head_sha ?? pr.base_sha;
-    return pullRequestJson(pr, baseRepo, headRepo, 1, files.length, headSha, baseSha);
+    return pullRequestJson(pr, baseRepo, headRepo, 1, files.length, headSha, baseSha, this.pullRequestStack(pr));
   }
 
   // LIST endpoint (leaner PullRequestSimple shape: drops the single-PR-only
@@ -972,7 +1023,7 @@ export class GitHubDomain {
     const headRepo = this.requireRepoById(pr.head_repo_id);
     const headSha = this.getBranch(headRepo.id, pr.head_ref)?.head_sha ?? pr.head_sha;
     const baseSha = this.getBranch(baseRepo.id, pr.base_ref)?.head_sha ?? pr.base_sha;
-    return pullRequestListJson(pr, baseRepo, headRepo, headSha, baseSha);
+    return pullRequestListJson(pr, baseRepo, headRepo, headSha, baseSha, this.pullRequestStack(pr));
   }
 
 

--- a/packages/twin-github/src/domain/pulls.ts
+++ b/packages/twin-github/src/domain/pulls.ts
@@ -112,9 +112,13 @@ export function createPullRequest(domain: GitHubDomain, input: { owner: string; 
 
 export function listPullRequests(domain: GitHubDomain, input: { owner: string; repo: string; state?: "open" | "closed" | "all" } & PageOptions) {
   const repo = domain.requireRepo(input.owner, input.repo);
-  let rows = domain.listPullRequestRows(repo.id);
+  const all = domain.listPullRequestRows(repo.id);
+  let rows = all;
   if (input.state && input.state !== "all") rows = rows.filter((pr) => pr.state === input.state);
-  return paginate(rows, input.page, input.per_page ?? input.perPage).map((pr) => domain.serializePullSimple(pr));
+  // `all`, not `rows`: a PR's stack is a fact about the whole repo, so the state
+  // filter and the page must not change it. Reading it once here is also what
+  // keeps serializing a page of N from re-reading the table N times (F-1178).
+  return paginate(rows, input.page, input.per_page ?? input.perPage).map((pr) => domain.serializePullSimple(pr, all));
 }
 
 

--- a/packages/twin-github/src/serializers.ts
+++ b/packages/twin-github/src/serializers.ts
@@ -35,6 +35,7 @@ import type {
   PullRequest,
   PullRequestReview,
   PullRequestSimple,
+  PullRequestStack,
   Release,
   Repository,
   ReviewComment,
@@ -391,7 +392,10 @@ export function issueCommentJson(
 // shape). The list serializer omits these; the detail serializer keeps them.
 // See https://docs.github.com/en/rest/pulls/pulls — PullRequestSimple vs
 // PullRequest.
-function pullRequestSimpleJson(pr: PullRequestRow, baseRepo: RepoRow, headRepo: RepoRow, headSha: string | null = null, baseSha: string | null = null) {
+// `stack` is on BOTH schemas, so it belongs here rather than in the detail-only
+// half: the caller passes what the domain derived, because only the domain can
+// see the sibling pull requests a stack is made of.
+function pullRequestSimpleJson(pr: PullRequestRow, baseRepo: RepoRow, headRepo: RepoRow, headSha: string | null = null, baseSha: string | null = null, stack: PullRequestStack = null) {
   return {
     id: stableNumericId(`${baseRepo.full_name}/pull/${pr.number}`),
     node_id: `PR_${stableNumericId(`${baseRepo.full_name}/pull/${pr.number}`)}`,
@@ -433,21 +437,22 @@ function pullRequestSimpleJson(pr: PullRequestRow, baseRepo: RepoRow, headRepo: 
     created_at: pr.created_at,
     updated_at: pr.updated_at,
     closed_at: pr.closed_at,
-    merged_at: pr.merged_at
+    merged_at: pr.merged_at,
+    stack
   } satisfies DeepPartial<PullRequestSimple>;
 }
 
 // LIST serializer (`GET /repos/:o/:r/pulls`) — the leaner PullRequestSimple
 // shape. Does not include merged / commits / additions / deletions /
 // changed_files (those are single-PR-only).
-export function pullRequestListJson(pr: PullRequestRow, baseRepo: RepoRow, headRepo: RepoRow, headSha: string | null = null, baseSha: string | null = null) {
-  return pullRequestSimpleJson(pr, baseRepo, headRepo, headSha, baseSha);
+export function pullRequestListJson(pr: PullRequestRow, baseRepo: RepoRow, headRepo: RepoRow, headSha: string | null = null, baseSha: string | null = null, stack: PullRequestStack = null) {
+  return pullRequestSimpleJson(pr, baseRepo, headRepo, headSha, baseSha, stack);
 }
 
 // Single-PR serializer (`GET /repos/:o/:r/pulls/:n`) — the full PullRequest
 // shape, which extends PullRequestSimple with the diff-stat fields.
-export function pullRequestJson(pr: PullRequestRow, baseRepo: RepoRow, headRepo: RepoRow, commits = 1, changedFiles = 0, headSha: string | null = null, baseSha: string | null = null) {
-  const simple = pullRequestSimpleJson(pr, baseRepo, headRepo, headSha, baseSha);
+export function pullRequestJson(pr: PullRequestRow, baseRepo: RepoRow, headRepo: RepoRow, commits = 1, changedFiles = 0, headSha: string | null = null, baseSha: string | null = null, stack: PullRequestStack = null) {
+  const simple = pullRequestSimpleJson(pr, baseRepo, headRepo, headSha, baseSha, stack);
   return {
     ...simple,
     merged: Boolean(pr.merged),

--- a/packages/twin-github/src/upstream-types.ts
+++ b/packages/twin-github/src/upstream-types.ts
@@ -10,7 +10,35 @@
 // type-level guard rail — runtime behavior is unchanged.
 import type { components } from "@octokit/openapi-types";
 
-export type PullRequest = components["schemas"]["pull-request"];
+// F-1178 — GitHub shipped stacked pull requests. The vendored REST description
+// gained `pull-request.stack` and `pull-request-simple.stack` on 2026-08-02
+// (`pome-sh/openapi-spec-mcp` commit `f0d07e7`, `specs/github.json` blob
+// `af4eeae`; both absent at `a8f0142`, 2026-07-31), each `$ref`ing one new
+// `pull-request-stack` schema. `@octokit/openapi-types@28.0.0` ships
+// openapi-version 22.0.0, which predates that, so `components["schemas"]` has
+// no `pull-request-stack` to alias yet and the anchor carries the shape here —
+// transcribed field for field from the vendored schema, not inferred from the
+// name. Delete this and alias `components["schemas"]["pull-request-stack"]` once
+// the @octokit bump lands.
+//
+// Verbatim from `components.schemas["pull-request-stack"]`: `type: object`,
+// `nullable: true`, `required: [base]`; `base` is `required: [ref, sha]` with
+// both `type: string`; `size` / `position` / `id` / `number` are
+// `type: integer`, optional.
+export type PullRequestStack = {
+  /** The base ref of the stack this pull request belongs to. */
+  base: { ref: string; sha: string };
+  /** The total number of pull requests in the stack. */
+  size?: number;
+  /** The one-based position of this PR in the stack; 1 is the bottom. */
+  position?: number;
+  /** The ID of the stack that this pull request belongs to. */
+  id?: number;
+  /** The number of the stack that this pull request belongs to. */
+  number?: number;
+} | null;
+
+export type PullRequest = components["schemas"]["pull-request"] & { stack?: PullRequestStack };
 export type Repository = components["schemas"]["repository"];
 export type SimpleUser = components["schemas"]["simple-user"];
 

--- a/packages/twin-github/test/v2-hot-paths-rest.test.ts
+++ b/packages/twin-github/test/v2-hot-paths-rest.test.ts
@@ -203,6 +203,88 @@ describe("REST / cluster C — pull requests deeper", () => {
     expect(item).toMatchObject({ number: n, state: "open", title: "CR", merged: false });
   });
 
+  // F-1178 — GitHub shipped stacked pull requests and added `stack` to BOTH the
+  // `pull-request` and `pull-request-simple` schemas, each `$ref`ing one new
+  // `pull-request-stack` schema (vendored REST description at openapi-spec-mcp
+  // commit f0d07e7, 2026-08-02; absent at a8f0142, 2026-07-31). Its shape is
+  // read from that schema, not guessed from the name: nullable, with a REQUIRED
+  // `base: { ref, sha }` and optional integer `size` / `position` / `id` /
+  // `number`. Both surfaces carry it, so both are asserted here.
+  async function openStack(a: ReturnType<typeof createGitHubCloneApp>) {
+    for (const ref of ["stack-lower", "stack-upper"]) {
+      await jsonReq(a, "POST", "/repos/acme/api/git/refs", { ref: `refs/heads/${ref}` });
+      await jsonReq(a, "PUT", `/repos/acme/api/contents/${ref}.ts`, { message: "m", content: "1\n", branch: ref });
+    }
+    // The upper PR's base branch IS the lower PR's head branch — a stack.
+    const lower = await jsonReq(a, "POST", "/repos/acme/api/pulls", { title: "Lower", head: "stack-lower", base: "main" });
+    const upper = await jsonReq(a, "POST", "/repos/acme/api/pulls", { title: "Upper", head: "stack-upper", base: "stack-lower" });
+    return {
+      lower: (lower.body as { number: number }).number,
+      upper: (upper.body as { number: number }).number
+    };
+  }
+
+  it("GET /pulls/:n and GET /pulls both carry stack: null for an unstacked PR", async () => {
+    const a = app();
+    const n = await openPr(a);
+
+    const detail = await jsonReq(a, "GET", `/repos/acme/api/pulls/${n}`);
+    expect(detail.status).toBe(200);
+    expect(detail.body).toHaveProperty("stack");
+    expect((detail.body as { stack: unknown }).stack).toBeNull();
+
+    const list = await jsonReq(a, "GET", "/repos/acme/api/pulls");
+    expect(list.status).toBe(200);
+    const item = (list.body as Array<Record<string, unknown>>).find((pr) => pr.number === n);
+    expect(item).toHaveProperty("stack");
+    expect(item!.stack).toBeNull();
+  });
+
+  it("GET /pulls/:n carries the vendor stack shape for every member of a stack", async () => {
+    const a = app();
+    const { lower, upper } = await openStack(a);
+
+    const lowerPr = (await jsonReq(a, "GET", `/repos/acme/api/pulls/${lower}`)).body as {
+      base: { sha: string };
+      stack: { base: { ref: string; sha: string }; size: number; position: number; id: number; number: number };
+    };
+    const upperPr = (await jsonReq(a, "GET", `/repos/acme/api/pulls/${upper}`)).body as typeof lowerPr;
+
+    // `base` is the stack's base — the BOTTOM pull request's base ref/sha, for
+    // both members, not each member's own base.
+    expect(lowerPr.stack).toMatchObject({
+      base: { ref: "main", sha: lowerPr.base.sha },
+      size: 2,
+      position: 1,
+      number: lower
+    });
+    expect(upperPr.stack).toMatchObject({
+      base: { ref: "main", sha: lowerPr.base.sha },
+      size: 2,
+      position: 2,
+      number: lower
+    });
+    // One stack, one identity: an agent grouping PRs by stack must see the same
+    // id from every member.
+    expect(upperPr.stack.id).toBe(lowerPr.stack.id);
+    expect(Number.isInteger(lowerPr.stack.id)).toBe(true);
+  });
+
+  it("GET /pulls carries the same stack objects as the detail surface", async () => {
+    const a = app();
+    const { lower, upper } = await openStack(a);
+    const list = (await jsonReq(a, "GET", "/repos/acme/api/pulls")).body as Array<{
+      number: number;
+      stack: unknown;
+    }>;
+
+    for (const pull of [lower, upper]) {
+      const detail = (await jsonReq(a, "GET", `/repos/acme/api/pulls/${pull}`)).body as { stack: unknown };
+      expect(list.find((item) => item.number === pull)!.stack).toEqual(detail.stack);
+    }
+    expect(list.find((item) => item.number === upper)!.stack).toMatchObject({ position: 2, size: 2 });
+  });
+
   it("GET /pulls/:n/commits lists commits", async () => {
     const a = app();
     const n = await openPr(a);

--- a/packages/twin-github/test/v2-hot-paths-rest.test.ts
+++ b/packages/twin-github/test/v2-hot-paths-rest.test.ts
@@ -210,17 +210,32 @@ describe("REST / cluster C — pull requests deeper", () => {
   // read from that schema, not guessed from the name: nullable, with a REQUIRED
   // `base: { ref, sha }` and optional integer `size` / `position` / `id` /
   // `number`. Both surfaces carry it, so both are asserted here.
+  type StackJson = { base: { ref: string; sha: string }; size: number; position: number; id: number; number: number };
+
+  // Puts one commit on `ref` so a PR opened from it has a diff.
+  async function branchWithWork(a: ReturnType<typeof createGitHubCloneApp>, ref: string) {
+    await jsonReq(a, "POST", "/repos/acme/api/git/refs", { ref: `refs/heads/${ref}` });
+    await jsonReq(a, "PUT", `/repos/acme/api/contents/${ref}.ts`, { message: "m", content: "1\n", branch: ref });
+  }
+
+  async function openPull(a: ReturnType<typeof createGitHubCloneApp>, title: string, head: string, base: string) {
+    const pr = await jsonReq(a, "POST", "/repos/acme/api/pulls", { title, head, base });
+    expect(pr.status).toBe(201);
+    return (pr.body as { number: number }).number;
+  }
+
+  async function stackOf(a: ReturnType<typeof createGitHubCloneApp>, pull: number) {
+    const detail = await jsonReq(a, "GET", `/repos/acme/api/pulls/${pull}`);
+    expect(detail.status).toBe(200);
+    return (detail.body as { stack: StackJson | null }).stack;
+  }
+
   async function openStack(a: ReturnType<typeof createGitHubCloneApp>) {
-    for (const ref of ["stack-lower", "stack-upper"]) {
-      await jsonReq(a, "POST", "/repos/acme/api/git/refs", { ref: `refs/heads/${ref}` });
-      await jsonReq(a, "PUT", `/repos/acme/api/contents/${ref}.ts`, { message: "m", content: "1\n", branch: ref });
-    }
+    for (const ref of ["stack-lower", "stack-upper"]) await branchWithWork(a, ref);
     // The upper PR's base branch IS the lower PR's head branch — a stack.
-    const lower = await jsonReq(a, "POST", "/repos/acme/api/pulls", { title: "Lower", head: "stack-lower", base: "main" });
-    const upper = await jsonReq(a, "POST", "/repos/acme/api/pulls", { title: "Upper", head: "stack-upper", base: "stack-lower" });
     return {
-      lower: (lower.body as { number: number }).number,
-      upper: (upper.body as { number: number }).number
+      lower: await openPull(a, "Lower", "stack-lower", "main"),
+      upper: await openPull(a, "Upper", "stack-upper", "stack-lower")
     };
   }
 
@@ -246,7 +261,7 @@ describe("REST / cluster C — pull requests deeper", () => {
 
     const lowerPr = (await jsonReq(a, "GET", `/repos/acme/api/pulls/${lower}`)).body as {
       base: { sha: string };
-      stack: { base: { ref: string; sha: string }; size: number; position: number; id: number; number: number };
+      stack: StackJson;
     };
     const upperPr = (await jsonReq(a, "GET", `/repos/acme/api/pulls/${upper}`)).body as typeof lowerPr;
 
@@ -268,21 +283,181 @@ describe("REST / cluster C — pull requests deeper", () => {
     // id from every member.
     expect(upperPr.stack.id).toBe(lowerPr.stack.id);
     expect(Number.isInteger(lowerPr.stack.id)).toBe(true);
+    expect(typeof lowerPr.stack.base.sha).toBe("string");
   });
 
-  it("GET /pulls carries the same stack objects as the detail surface", async () => {
+  it("GET /pulls carries the same concrete stack values as the detail surface", async () => {
     const a = app();
     const { lower, upper } = await openStack(a);
     const list = (await jsonReq(a, "GET", "/repos/acme/api/pulls")).body as Array<{
       number: number;
-      stack: unknown;
+      base: { sha: string };
+      stack: StackJson | null;
+    }>;
+    const listed = (pull: number) => list.find((item) => item.number === pull)!;
+
+    // Concrete values on the LIST surface, not merely "equal to whatever detail
+    // said" — a convergence-only assertion passes for any constant, null
+    // included, so it cannot show the list surface derives a real stack.
+    expect(listed(lower).stack).toMatchObject({
+      base: { ref: "main", sha: listed(lower).base.sha },
+      size: 2,
+      position: 1,
+      number: lower
+    });
+    expect(listed(upper).stack).toMatchObject({ size: 2, position: 2, number: lower });
+    expect(listed(upper).stack!.id).toBe(listed(lower).stack!.id);
+
+    // ...and the two surfaces still agree field for field.
+    for (const pull of [lower, upper]) {
+      expect(listed(pull).stack).toEqual(await stackOf(a, pull));
+    }
+  });
+
+  // The identity is shared across members, so the answer must be a property of
+  // the chain rather than of the PR the walk started from. A fork is where a
+  // per-start walk breaks: two PRs would claim one `stack.id` while reporting
+  // different sizes and memberships. Asserted from EVERY member.
+  it("refuses to name a stack when the chain forks, from every member of the fork", async () => {
+    const a = app();
+    for (const ref of ["fork-bottom", "fork-left", "fork-right"]) await branchWithWork(a, ref);
+    const bottom = await openPull(a, "Bottom", "fork-bottom", "main");
+    const left = await openPull(a, "Left", "fork-left", "fork-bottom");
+    const right = await openPull(a, "Right", "fork-right", "fork-bottom");
+    expect(left).toBeLessThan(right);
+
+    for (const pull of [bottom, left, right]) {
+      expect(await stackOf(a, pull)).toBeNull();
+    }
+  });
+
+  // The invariant the fork case exists to protect, asserted over a repo that
+  // holds a clean stack AND a fork at once: any two PRs reporting the same
+  // `stack.id` agree on `size` and on membership, and their positions are
+  // exactly 1..size with no repeats.
+  it("keeps stack identity coherent: equal stack.id implies equal size, membership and unique positions", async () => {
+    const a = app();
+    for (const ref of ["clean-lower", "clean-upper", "amb-bottom", "amb-left", "amb-right"]) await branchWithWork(a, ref);
+    await openPull(a, "Clean lower", "clean-lower", "main");
+    await openPull(a, "Clean upper", "clean-upper", "clean-lower");
+    await openPull(a, "Amb bottom", "amb-bottom", "main");
+    await openPull(a, "Amb left", "amb-left", "amb-bottom");
+    await openPull(a, "Amb right", "amb-right", "amb-bottom");
+
+    const list = (await jsonReq(a, "GET", "/repos/acme/api/pulls")).body as Array<{
+      number: number;
+      stack: StackJson | null;
     }>;
 
-    for (const pull of [lower, upper]) {
-      const detail = (await jsonReq(a, "GET", `/repos/acme/api/pulls/${pull}`)).body as { stack: unknown };
-      expect(list.find((item) => item.number === pull)!.stack).toEqual(detail.stack);
+    const byId = new Map<number, Array<{ number: number; stack: StackJson }>>();
+    for (const item of list) {
+      if (item.stack === null) continue;
+      const bucket = byId.get(item.stack.id) ?? [];
+      bucket.push({ number: item.number, stack: item.stack });
+      byId.set(item.stack.id, bucket);
     }
-    expect(list.find((item) => item.number === upper)!.stack).toMatchObject({ position: 2, size: 2 });
+
+    // The clean stack is the only thing that got an identity at all.
+    expect(byId.size).toBe(1);
+    for (const [, members] of byId) {
+      const size = members[0]!.stack.size;
+      expect(members.every((member) => member.stack.size === size)).toBe(true);
+      // Every member of a shared id agrees the stack has `size` members, and the
+      // number of PRs reporting that id IS that size — no absent siblings.
+      expect(members).toHaveLength(size);
+      expect([...members].map((member) => member.stack.position).sort()).toEqual(
+        Array.from({ length: size }, (_, index) => index + 1)
+      );
+      // Same membership: one bottom `number`, one base, agreed by all.
+      expect(new Set(members.map((member) => member.stack.number)).size).toBe(1);
+      expect(new Set(members.map((member) => JSON.stringify(member.stack.base))).size).toBe(1);
+    }
+  });
+
+  it("terminates and reports no stack when the base chain is a cycle", async () => {
+    const a = app();
+    for (const ref of ["cycle-a", "cycle-b"]) await branchWithWork(a, ref);
+    // cycle-b sits on cycle-a, then cycle-a is retargeted onto cycle-b.
+    const first = await openPull(a, "Cycle A", "cycle-a", "main");
+    const second = await openPull(a, "Cycle B", "cycle-b", "cycle-a");
+    const retargeted = await jsonReq(a, "PATCH", `/repos/acme/api/pulls/${first}`, { base: "cycle-b" });
+    expect(retargeted.status).toBe(200);
+
+    for (const pull of [first, second]) {
+      expect(await stackOf(a, pull)).toBeNull();
+    }
+  });
+
+  // Linkage traverses pull requests of every state so a closed middle link does
+  // not silently sever a live chain; MEMBERSHIP is the open members only.
+  it("links through a closed middle PR and counts only the open members", async () => {
+    const a = app();
+    for (const ref of ["mid-bottom", "mid-middle", "mid-top"]) await branchWithWork(a, ref);
+    const bottom = await openPull(a, "Mid bottom", "mid-bottom", "main");
+    const middle = await openPull(a, "Mid middle", "mid-middle", "mid-bottom");
+    const top = await openPull(a, "Mid top", "mid-top", "mid-middle");
+
+    expect(await stackOf(a, bottom)).toMatchObject({ size: 3, position: 1 });
+    expect(await stackOf(a, top)).toMatchObject({ size: 3, position: 3 });
+
+    const closed = await jsonReq(a, "PATCH", `/repos/acme/api/pulls/${middle}`, { state: "closed" });
+    expect(closed.status).toBe(200);
+
+    // The chain is still live: bottom and top remain one stack of two, and the
+    // closed middle is not counted.
+    const bottomStack = await stackOf(a, bottom);
+    const topStack = await stackOf(a, top);
+    expect(bottomStack).toMatchObject({ base: { ref: "main" }, size: 2, position: 1, number: bottom });
+    expect(topStack).toMatchObject({ size: 2, position: 2, number: bottom });
+    expect(topStack!.id).toBe(bottomStack!.id);
+    // A closed PR reports no stack of its own.
+    expect(await stackOf(a, middle)).toBeNull();
+  });
+
+  it("reports no stack once only one open member is left", async () => {
+    const a = app();
+    const { lower, upper } = await openStack(a);
+    const closed = await jsonReq(a, "PATCH", `/repos/acme/api/pulls/${lower}`, { state: "closed" });
+    expect(closed.status).toBe(200);
+
+    expect(await stackOf(a, upper)).toBeNull();
+    expect(await stackOf(a, lower)).toBeNull();
+  });
+
+  // Links match the repo id as well as the ref name. The twin models fork PRs
+  // (`head_repo_id` differs from `base_repo_id`), so matching on ref name alone
+  // would link a fork's head branch to an upstream PR's identically-named base
+  // branch and invent a stack out of a name collision.
+  it("does not invent a stack from a fork branch sharing an upstream base ref name", async () => {
+    const a = app();
+    for (const ref of ["collide", "collide-upper"]) await branchWithWork(a, ref);
+    // Upstream PR based ON the `collide` branch of acme/api.
+    const upstream = await openPull(a, "Upstream", "collide-upper", "collide");
+
+    // Fork copies every branch, so the fork has its own `collide` — same name,
+    // different repo.
+    const fork = await jsonReq(a, "POST", "/repos/acme/api/forks", {});
+    expect(fork.status).toBe(201);
+    const forkOwner = (fork.body as { owner: { login: string } }).owner.login;
+    const forked = await openPull(a, "From fork", `${forkOwner}:collide`, "main");
+
+    // Neither is stacked: the fork's `collide` is not the branch the upstream PR
+    // is based on.
+    expect(await stackOf(a, upstream)).toBeNull();
+    expect(await stackOf(a, forked)).toBeNull();
+  });
+
+  it("does not let the state filter or pagination change a PR's stack", async () => {
+    const a = app();
+    const { lower, upper } = await openStack(a);
+    const openOnly = (await jsonReq(a, "GET", "/repos/acme/api/pulls?state=open&per_page=1&page=2")).body as Array<{
+      number: number;
+      stack: StackJson | null;
+    }>;
+    const paged = openOnly.find((item) => item.number === lower || item.number === upper);
+    expect(paged).toBeDefined();
+    expect(paged!.stack).toEqual(await stackOf(a, paged!.number));
+    expect(paged!.stack).toMatchObject({ size: 2, number: lower });
   });
 
   it("GET /pulls/:n/commits lists commits", async () => {


### PR DESCRIPTION
<!-- Closes F-1178 -->

## What

`twin-github` now models `stack` on both pull-request read surfaces —
`GET /repos/{}/{}/pulls` and `GET /repos/{}/{}/pulls/{}` — the field GitHub
added to its `pull-request` and `pull-request-simple` schemas on 2026-08-02.

## Why

F-1178. Run 30755607225 on `main` was the first real upstream drift the declared
lane has ever caught:

```
FAIL — 0 unexpected twin surface(s), 2 shape-drift match(es)
  ! GET /repos/{}/{}/pulls     — shape drift (missing in twin: stack)
  ! GET /repos/{}/{}/pulls/{}  — shape drift (missing in twin: stack)
```

**Disposition: model it, not an allowlist entry.** The standing test is whether
an agent under evaluation would behave differently because the field is missing.
It would: stacked PRs change how an agent reasons about a PR's relationship to
its base, so an agent asked to review or merge a stacked PR against a twin that
cannot express stacking behaves differently than it does against real GitHub.

## The vendor schema this was built from

Read from the vendored REST description rather than inferred from the name.
Source: `pome-sh/openapi-spec-mcp` at commit `f0d07e7`, `specs/github.json`
(blob `af4eeae3c5c2c501efb87e9315895ad789472227`, confirmed against the remote
at that ref). Both `pull-request.stack` and `pull-request-simple.stack` are
`{"$ref": "#/components/schemas/pull-request-stack"}`, and neither the property
nor the schema exists at `a8f0142` (2026-07-31), matching the ticket's table.

`components.schemas["pull-request-stack"]`, verbatim:

```json
{
  "title": "Pull Request Stack",
  "description": "The stack information associated with a pull request.",
  "type": "object",
  "properties": {
    "base": {
      "type": "object",
      "properties": {
        "ref": { "type": "string", "description": "The base ref of the stack this pull request belongs to." },
        "sha": { "type": "string", "description": "The base SHA of the stack this pull request belongs to." }
      },
      "required": ["ref", "sha"]
    },
    "size": { "type": "integer", "description": "The total number of pull requests in the stack." },
    "position": { "type": "integer", "description": "The one-based position of this pull request within the stack, where 1 is the bottom of the stack." },
    "id": { "type": "integer", "description": "The ID of the stack that this pull request belongs to." },
    "number": { "type": "integer", "description": "The number of the stack that this pull request belongs to." }
  },
  "required": ["base"],
  "nullable": true
}
```

So: `nullable`, optional on its parents, only `base` required inside it, and
five integer leaves. The only other schemas carrying `stack` are webhook
payloads (`webhook-pull-request-stacked`, `webhooks_pull_request_5`), which the
twin does not model.

## How `stack` is populated

From real twin state, not a constant. GitHub models a stack as its own entity
with its own id and number; the twin has no stack table, so `pullRequestStack()`
reads a stack off the state that *does* encode one — the chain of **open** pull
requests in a repository linked `base_ref` -> `head_ref`. A PR whose base branch
is another open PR's head branch is stacked on it, which is what stacking means.

- `base.ref` / `base.sha` — the chain's bottom PR's base ref, and that ref's
  resolved branch head. Carries the same documented pre-resolution `null` as the
  existing `head.sha` / `base.sha` (FDRS-454).
- `size` — the chain length.
- `position` — this PR's one-based index from the bottom.
- `id` / `number` — **the two the twin cannot read from state**, stated plainly
  rather than faked: there is no stack row to carry them. Both derive from the
  chain's bottom PR (`id` via the same `stableNumericId` derivation every other
  twin id uses, `number` as that PR's number). That is deliberate: what an agent
  grouping PRs by stack needs is that every member reports the same pair, which
  deriving from a single member guarantees. The cost is that the twin's stack
  numbers share the per-repo number space issues and PRs draw from, where
  GitHub's do not.
- A PR outside such a chain reports `stack: null` — what the schema's
  nullability is for.

Three further limits, all written up in FIDELITY.md: a stack is inferred from
base targeting rather than declared, so PRs that merely happen to chain read as
stacked; a non-open PR reports `null`; and a forking chain takes the
lowest-numbered branch, since a GitHub stack is linear.

## Type anchor

`@octokit/openapi-types@28.0.0` carries openapi-version 22.0.0 and predates the
field, so `components["schemas"]` has no `pull-request-stack` to alias yet.
`src/upstream-types.ts` declares the shape locally, transcribed field for field,
with a note to replace it with the real alias at the next @octokit bump. The
`AssertNoUncovered` guard covers `stack` in either world, so no `_Allow` union
moved — nothing was registered as a deliberate omission.

## Notes for reviewer

- **TDD**: the three tests went in first and failed for the right reason
  (`expected { id: … } to have property "stack"`), then the implementation
  turned them green. In `packages/twin-github/test/v2-hot-paths-rest.test.ts`:
  - `GET /pulls/:n and GET /pulls both carry stack: null for an unstacked PR`
  - `GET /pulls/:n carries the vendor stack shape for every member of a stack`
  - `GET /pulls carries the same stack objects as the detail surface`
- **The post-publish 1:1 divergence lint stays green.** FIDELITY.md divergence
  #11 is *extended* rather than joined by a new numbered bullet: the lint binds
  bullets to `known-divergences/github.yaml` by bold title, so a new bullet
  would red it until pome-cloud shipped a matching entry. Verified by running
  pome-cloud's own `lint-known-divergences.ts` against this branch's
  FIDELITY.md — `OK — 20 entries 1:1`. `stack` is modelled, not omitted, so it
  does not belong on that bullet's omission list anyway; the sub-caveats about
  the derivation do.
- Versions: `twin-github` 0.9.3 for the twin release and cloud re-pin; the CLI
  inlines the twin into its bundle, so 0.21.13 carries it to npm. No changeset —
  Changesets is retired in this repo in favour of the version-diff lane.

## Review required

Yes — twin fidelity contract. `stack` is a new field on two `hot`/`semantic`
read surfaces, and the `id` / `number` derivation is a judgement call recorded
as a divergence rather than something the twin can read from state.
