### PR TITLE
twin-linear's agent-session mutation inputs take Linear's field names (F-1176)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,20 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.21.15
+
+### Patch Changes
+
+- **Breaking for agents driving Linear agent sessions.** The bundled Linear
+  twin's four agent-session mutation inputs now take Linear's field names, and
+  only Linear's (F-1176). `AgentSessionUpdateInput` drops `id` and `status`,
+  `AgentSessionCreateOnIssue` / `OnComment` drop `appUserId` and `plan`, and
+  `AgentActivityCreateInput` takes `agentSessionId` + `content` in place of
+  `sessionId` / `type` / `body`. Session status is no longer settable — Linear
+  has no field for it, so status follows the emitted activity. No task in the
+  corpus drove these mutations, so nothing in `cli/tasks/` or `examples/`
+  changed.
+
 ## 0.21.14
 
 ### Patch Changes

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.21.14",
+  "version": "0.21.15",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "cli": {
       "name": "@pome-sh/cli",
-      "version": "0.21.14",
+      "version": "0.21.15",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.29",

--- a/packages/twin-linear/CHANGELOG.md
+++ b/packages/twin-linear/CHANGELOG.md
@@ -1,6 +1,45 @@
 # @pome-sh/twin-linear — CHANGELOG
 
 
+## 0.4.0 — 2026-08-08
+
+**Breaking.** The four agent-session mutation inputs now take Linear's field
+names, and only Linear's (F-1176). F-1172 fixed the `AgentSession` output type
+and left the inputs inventing fields; verified against live introspection at
+`https://api.linear.app/graphql`:
+
+| input | removed | now |
+| -- | -- | -- |
+| `AgentSessionCreateOnIssue` | `appUserId`, `plan` | `issueId`, `externalUrls` |
+| `AgentSessionCreateOnComment` | `appUserId`, `plan` | `commentId`, `externalUrls` |
+| `AgentSessionUpdateInput` | `id`, `status` | `plan`, `externalUrls` |
+| `AgentActivityCreateInput` | `sessionId`, `type`, `body` | `agentSessionId`, `content`, `signal`, `ephemeral` |
+
+`agentSessionUpdate(id:)` is now `String!` — upstream `id` is a mutation
+argument on this mutation, never a field of the input.
+
+**Session status is no longer settable.** Linear declares no `status` on
+`AgentSessionUpdateInput`; status follows the emitted activity, as Linear's agent
+guide describes ("updated automatically based on the agent's emitted
+activities"). `agentActivityCreate` now moves it: `thought`/`action` → `active`,
+`elicitation` → `awaitingInput`, `response` → `complete`, `error` → `error`,
+`prompt` → `pending`. Linear does not publish that table, so it is registered as
+a twin-owned divergence in `REFERENCE-DIVERGENCES.md`.
+
+`AgentActivity` follows the input: `content: JSON!` and `signal` replace `type`
+and `body`, `session` becomes `agentSession`, and `user` is non-null. Accepting
+Linear's `content` while emitting an invented `body` would round-trip to neither
+Linear nor itself.
+
+`agent_activities` gains `content_json` and `signal` and drops `body`. An
+existing `LINEAR_TWIN_DB` file migrates on open; `action` rows recorded before
+this release backfill with an empty `parameter`, because the old shape had
+nowhere to keep one.
+
+The subset guard now covers all four inputs plus `AgentActivity` and
+`AgentActivitySignal` — nine guarded types, up from three — and carries tests
+proving it fails on an invented member rather than passing vacuously.
+
 ## 0.3.5 — 2026-08-06
 
 Its MCP tool table is now derived from `fixtures/mcp-tools-list.raw.json`

--- a/packages/twin-linear/REFERENCE-DIVERGENCES.md
+++ b/packages/twin-linear/REFERENCE-DIVERGENCES.md
@@ -27,8 +27,43 @@ Emulate’s Linear package may be used as a **coverage checklist**. It is **neve
 | OAuth actor | user vs app | Seed `oauth_apps[].actor` authoritative |
 | Webhook headers | `Linear-Delivery`, `Linear-Event`, optional `Linear-Signature` | Emitted on mutation dispatch |
 | Agent sessions | Subset for local agent tests | GraphQL-only create/update/activity (not in MCP launch set) |
+| Agent session status | Follows emitted activities; mapping unpublished | Twin-owned transition table — see below |
+| `AgentActivityCreateInput.content` | `JSONObject!` validated against the `AgentActivityContent` union | Same field, validated member-for-member; `bodyData` / `resultData` unmodelled |
 | MCP documents tools | Full parent set incl. initiative | Gate-1: project/team/issue/cycle parents only |
 | MCP tool count | ~50+ live tools | Frozen 22-tool Gate-1 subset |
+
+## Agent-session status transitions (twin-owned, F-1176)
+
+Linear declares no `status` on `AgentSessionUpdateInput`. Status follows the
+activity the agent emits — Linear's agent guide says session state is "updated
+automatically based on the agent's emitted activities. No manual state management
+is required." That much is upstream truth and the twin implements it.
+
+Which activity yields which status is **not published**, and introspection cannot
+show behaviour. The twin owns this table:
+
+| activity content type | resulting session status |
+| --- | --- |
+| `thought`, `action` | `active` |
+| `elicitation` | `awaitingInput` |
+| `response` | `complete` |
+| `error` | `error` |
+| `prompt` | `pending` |
+
+Do not treat it as verified upstream behaviour. Replace it with the real mapping
+if Linear ever documents one. The alternative — refusing to derive status at all —
+leaves every twin session frozen at `pending`, which is worse fidelity than a
+named guess.
+
+## Scalar-level divergences on the guarded agent types
+
+The subset guard in `test/linear-schema-subset.test.ts` compares member NAMES, so
+these two pass it and are recorded here instead:
+
+| surface | Linear | twin | why |
+| --- | --- | --- | --- |
+| `AgentSessionUpdateInput.plan` | `JSONObject` | `String` | The twin stores a plan as opaque text; nothing reads into it |
+| `AgentActivity.content` | `AgentActivityContent` union | `JSON!` | The twin validates the union on input but does not model six output types to serve it |
 
 ## Webhook asymmetries (documented Gate-0 gaps)
 
@@ -39,7 +74,7 @@ These are intentional twin divergences — not silent stubs:
 | `agentSessionCreateOnIssue` | `AgentSessionEvent` create webhook | Emits webhook (`action: created`) |
 | `agentSessionCreateOnComment` | Same family as on-issue create | **No webhook** — session row only (mention path stays quiet) |
 | `createProject` / `updateProject` (MCP `save_project`) | Project create/update webhook | **No webhook emit** — projects mutate SQLite state only |
-| `agentActivityCreate` with `type: prompt` | Prompted session event | Emits `AgentSessionEvent` / `prompted` |
+| `agentActivityCreate` with `content: {type: prompt}` | Prompted session event | Emits `AgentSessionEvent` / `prompted` |
 | Issue / comment CRUD | Issue / Comment webhooks | Emitted (create/update/remove/archive) |
 
 ## Other non-oracles

--- a/packages/twin-linear/fixtures/linear-introspection.json
+++ b/packages/twin-linear/fixtures/linear-introspection.json
@@ -1,14 +1,62 @@
 {
   "_readme": "Committed slice of Linear's real GraphQL introspection. A type absent here is UNGUARDED. Regenerate with `node scripts/regen-linear-introspection.mjs`; never hand-edit.",
   "source": "https://api.linear.app/graphql",
-  "fetched_at": "2026-08-02T14:52:09.995Z",
+  "fetched_at": "2026-08-07T23:11:18.871Z",
   "query_sha256": "6029c665c71a485e86c4524bfa6793eb6cb2f0f6ab48e6277bc4d5a62fbe1079",
   "guarded_types": [
+    "AgentActivity",
+    "AgentActivityCreateInput",
+    "AgentActivitySignal",
     "AgentSession",
+    "AgentSessionCreateOnComment",
+    "AgentSessionCreateOnIssue",
     "AgentSessionExternalUrlInput",
-    "AgentSessionStatus"
+    "AgentSessionStatus",
+    "AgentSessionUpdateInput"
   ],
   "types": {
+    "AgentActivity": {
+      "kind": "OBJECT",
+      "fields": {
+        "agentSession": "AgentSession!",
+        "archivedAt": "DateTime",
+        "content": "AgentActivityContent!",
+        "contextualMetadata": "JSON",
+        "createdAt": "DateTime!",
+        "ephemeral": "Boolean!",
+        "id": "ID!",
+        "pushSummary": "AgentActivityPushSummary",
+        "queued": "Boolean!",
+        "sentAt": "DateTime",
+        "signal": "AgentActivitySignal",
+        "signalMetadata": "JSON",
+        "sourceComment": "Comment",
+        "sourceMetadata": "JSON",
+        "updatedAt": "DateTime!",
+        "user": "User!"
+      }
+    },
+    "AgentActivityCreateInput": {
+      "kind": "INPUT_OBJECT",
+      "inputFields": {
+        "agentSessionId": "String!",
+        "content": "JSONObject!",
+        "contextualMetadata": "JSONObject",
+        "ephemeral": "Boolean",
+        "id": "String",
+        "signal": "AgentActivitySignal",
+        "signalMetadata": "JSONObject"
+      }
+    },
+    "AgentActivitySignal": {
+      "kind": "ENUM",
+      "enumValues": [
+        "auth",
+        "continue",
+        "select",
+        "stop"
+      ]
+    },
     "AgentSession": {
       "kind": "OBJECT",
       "fields": {
@@ -44,6 +92,22 @@
         "workspaceDiffFiles": "[AgentSessionWorkspaceDiffFile!]"
       }
     },
+    "AgentSessionCreateOnComment": {
+      "kind": "INPUT_OBJECT",
+      "inputFields": {
+        "commentId": "String!",
+        "externalLink": "String",
+        "externalUrls": "[AgentSessionExternalUrlInput!]"
+      }
+    },
+    "AgentSessionCreateOnIssue": {
+      "kind": "INPUT_OBJECT",
+      "inputFields": {
+        "externalLink": "String",
+        "externalUrls": "[AgentSessionExternalUrlInput!]",
+        "issueId": "String!"
+      }
+    },
     "AgentSessionExternalUrlInput": {
       "kind": "INPUT_OBJECT",
       "inputFields": {
@@ -61,6 +125,18 @@
         "pending",
         "stale"
       ]
+    },
+    "AgentSessionUpdateInput": {
+      "kind": "INPUT_OBJECT",
+      "inputFields": {
+        "addedExternalUrls": "[AgentSessionExternalUrlInput!]",
+        "dismissedAt": "DateTime",
+        "externalLink": "String",
+        "externalUrls": "[AgentSessionExternalUrlInput!]",
+        "plan": "JSONObject",
+        "removedExternalUrls": "[String!]",
+        "userState": "[AgentSessionUserStateInput!]"
+      }
     }
   }
 }

--- a/packages/twin-linear/package.json
+++ b/packages/twin-linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-linear",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "description": "Deterministic Linear-shaped twin for agent testing — SQLite-backed GraphQL + MCP + OAuth.",
   "private": true,
   "type": "module",

--- a/packages/twin-linear/route-inputs.json
+++ b/packages/twin-linear/route-inputs.json
@@ -343,8 +343,8 @@
         {
           "name": "id",
           "location": "argument",
-          "required": false,
-          "type": "String"
+          "required": true,
+          "type": "String!"
         },
         {
           "name": "input",

--- a/packages/twin-linear/scripts/regen-linear-introspection.mjs
+++ b/packages/twin-linear/scripts/regen-linear-introspection.mjs
@@ -30,28 +30,29 @@ const LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql";
  * The upstream types the twin models and must not drift from. Extend this list
  * (and re-run) when the twin starts emulating another Linear type.
  *
- * SCOPE — READ THIS BEFORE ASSUMING COVERAGE. These are the OUTPUT-side types
- * plus the one input object the twin mirrors exactly. The twin's MUTATION INPUT
- * types are deliberately NOT guarded yet, because they still diverge from
- * Linear and adding them here would fail immediately:
+ * SCOPE. Both sides of the agent-session surface are guarded: the output types
+ * and enums the twin emits, and the four mutation input objects it accepts
+ * (F-1176). The guard is name-based — a member the twin declares must be a
+ * member Linear declares. It does not compare SDL types; two scalar-level
+ * divergences are open and written up in `REFERENCE-DIVERGENCES.md`.
  *
- *   - `AgentSessionUpdateInput` upstream declares externalLink, externalUrls,
- *     addedExternalUrls, removedExternalUrls, plan, dismissedAt, userState —
- *     no `status` and no `id`. Upstream, session status moves via agent
- *     activities, not through `agentSessionUpdate` at all. The twin declares
- *     id, status, plan, externalUrls.
- *   - `AgentSessionCreateOnIssue` / `AgentSessionCreateOnComment` are not
- *     Linear type names at all (upstream has `AgentSessionCreateInput`: id,
- *     issueId, appUserId, context) and the twin adds `plan`.
- *   - `AgentActivityCreateInput` — twin: sessionId, type, body, ephemeral;
- *     Linear: id, agentSessionId, signal, signalMetadata, contextualMetadata,
- *     content, ephemeral.
- *
- * These predate F-1172 (the old `state` / `agentUserId` were equally invented)
- * and reconciling them is its own piece of work, tracked separately. Until
- * then: the guard proves nothing about the mutation-input surface.
+ * Deprecated upstream fields count as declared. `AgentSession.externalUrls`,
+ * `externalLink`, `externalLinks`, `type` and `workspaceDiffFiles` are all
+ * deprecated but real, and appear only under `includeDeprecated: true` — which
+ * is why the query below passes it. Dropping that flag would make the fixture
+ * claim Linear removed fields it still serves.
  */
-const GUARDED_TYPES = ["AgentSession", "AgentSessionStatus", "AgentSessionExternalUrlInput"];
+const GUARDED_TYPES = [
+  "AgentSession",
+  "AgentSessionStatus",
+  "AgentSessionExternalUrlInput",
+  "AgentActivity",
+  "AgentActivitySignal",
+  "AgentSessionCreateOnIssue",
+  "AgentSessionCreateOnComment",
+  "AgentSessionUpdateInput",
+  "AgentActivityCreateInput",
+];
 
 const QUERY = `query PomeTwinLinearIntrospection($name: String!) {
   __type(name: $name) {

--- a/packages/twin-linear/src/db.ts
+++ b/packages/twin-linear/src/db.ts
@@ -260,7 +260,8 @@ CREATE TABLE IF NOT EXISTS agent_activities (
   session_id TEXT NOT NULL,
   user_id TEXT,
   type TEXT NOT NULL,
-  body TEXT NOT NULL,
+  content_json TEXT NOT NULL,
+  signal TEXT,
   ephemeral INTEGER NOT NULL DEFAULT 0,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL,
@@ -339,6 +340,41 @@ export function migrate(db: LinearTwinDatabase): void {
   ensureColumn(db, "issues", "parent_id", "TEXT");
   ensureColumn(db, "comments", "parent_id", "TEXT");
   migrateAgentSessions(db);
+  migrateAgentActivities(db);
+}
+
+/**
+ * F-1176 — carry a pre-`content` `agent_activities` table forward.
+ *
+ * The twin used to store an activity as a flat `type` + `body` pair. Linear's
+ * `AgentActivityCreateInput` takes a single `content` object discriminated on
+ * `type`, so the body moves inside it. Same reasoning as
+ * `migrateAgentSessions`: `CREATE TABLE IF NOT EXISTS` will not reshape an
+ * existing `LINEAR_TWIN_DB` file, and an unmigrated one would fail later at
+ * `mapAgentActivity` instead of here.
+ *
+ * `action` activities recorded before this change carry only a body, so they
+ * backfill as `{type: "action", action: <body>, parameter: ""}` — Linear's
+ * `parameter` is non-null and the old shape had nowhere to keep one.
+ */
+function migrateAgentActivities(db: LinearTwinDatabase): void {
+  const columns = (db.prepare("PRAGMA table_info(agent_activities)").all() as Array<{ name: string }>).map(
+    (column) => column.name
+  );
+  if (columns.includes("content_json")) return;
+
+  db.exec("ALTER TABLE agent_activities ADD COLUMN content_json TEXT NOT NULL DEFAULT '{}'");
+  if (!columns.includes("signal")) db.exec("ALTER TABLE agent_activities ADD COLUMN signal TEXT");
+  if (columns.includes("body")) {
+    db.exec(
+      `UPDATE agent_activities
+          SET content_json = CASE
+                WHEN type = 'action' THEN json_object('type', type, 'action', body, 'parameter', '')
+                ELSE json_object('type', type, 'body', body)
+              END`
+    );
+    db.exec("ALTER TABLE agent_activities DROP COLUMN body");
+  }
 }
 
 /**

--- a/packages/twin-linear/src/domain/agents.ts
+++ b/packages/twin-linear/src/domain/agents.ts
@@ -2,10 +2,12 @@
 import { notFound } from "../errors.js";
 import type {
   LinearAgentActivity,
+  LinearAgentActivityContent,
+  LinearAgentActivitySignal,
   LinearAgentSession,
   LinearAgentSessionExternalUrl,
 } from "../types.js";
-import { assertBody, normalizeActivityType, normalizeSessionStatus } from "./normalize.js";
+import { deriveSessionStatus } from "./normalize.js";
 import type { ActorContext, LinearDomain } from "./linear-domain.js";
 import { mapAgentActivity, mapAgentSession, type AgentActivityRow, type AgentSessionRow } from "./rows.js";
 import { emitWebhook } from "./webhooks.js";
@@ -23,24 +25,39 @@ export function getAgentSession(domain: LinearDomain, ref: string): LinearAgentS
   return row ? mapAgentSession(row) : null;
 }
 
+/**
+ * Linear's `AgentSessionCreateOnIssue`, plus `appUserId`, which is NOT part of
+ * that input upstream and is NOT accepted over GraphQL (F-1176). It exists here
+ * because the twin creates sessions internally too — a delegated issue or an
+ * @mention names the app the session belongs to, and upstream that identity
+ * arrives with the credential rather than in the input.
+ */
 export type AgentSessionOnIssueInput = {
   issueId: string;
   appUserId?: string;
-  plan?: string | null;
   externalUrls?: LinearAgentSessionExternalUrl[] | null;
 };
 
 export type AgentSessionOnCommentInput = {
   commentId: string;
   appUserId?: string;
+  externalUrls?: LinearAgentSessionExternalUrl[] | null;
+};
+
+/**
+ * `AgentSessionUpdateInput`, which upstream carries no `status` (F-1176). Status
+ * moves through `createAgentActivity`.
+ */
+export type AgentSessionPatch = {
   plan?: string | null;
   externalUrls?: LinearAgentSessionExternalUrl[] | null;
 };
 
-export type AgentSessionPatch = {
-  status?: string;
-  plan?: string | null;
-  externalUrls?: LinearAgentSessionExternalUrl[] | null;
+export type AgentActivityCreateInput = {
+  agentSessionId: string;
+  content: LinearAgentActivityContent;
+  signal?: LinearAgentActivitySignal;
+  ephemeral?: boolean;
 };
 
 export async function createAgentSessionOnIssue(
@@ -68,7 +85,7 @@ export async function createAgentSessionOnIssue(
       null,
       agent.id,
       "pending",
-      input.plan ?? null,
+      null,
       JSON.stringify(input.externalUrls ?? []),
       now,
       now
@@ -111,7 +128,7 @@ export async function createAgentSessionOnComment(
       comment.id,
       agent.id,
       "pending",
-      input.plan ?? null,
+      null,
       JSON.stringify(input.externalUrls ?? []),
       now,
       now
@@ -135,14 +152,12 @@ export function updateAgentSession(
   domain.db
     .prepare(
       `UPDATE agent_sessions SET
-          status = COALESCE(?, status),
           plan = CASE WHEN ? THEN ? ELSE plan END,
           external_urls_json = CASE WHEN ? THEN ? ELSE external_urls_json END,
           updated_at = ?
          WHERE id = ?`
     )
     .run(
-      input.status ? normalizeSessionStatus(input.status) : null,
       input.plan !== undefined ? 1 : 0,
       input.plan ?? null,
       input.externalUrls !== undefined ? 1 : 0,
@@ -153,31 +168,49 @@ export function updateAgentSession(
   return domain.requireAgentSession(session.id);
 }
 
+/**
+ * Emitting an activity is also how a session's status moves (F-1176). Linear has
+ * no `status` on `AgentSessionUpdateInput`; the status follows the activity, and
+ * `deriveSessionStatus` holds the mapping.
+ */
 export async function createAgentActivity(
   domain: LinearDomain,
-  input: { sessionId: string; type: string; body: string; ephemeral?: boolean },
+  input: AgentActivityCreateInput,
   actor: ActorContext = {}
 ): Promise<LinearAgentActivity> {
   domain.requireScopes(actor, ["write"]);
-  assertBody(input.body);
-  const session = domain.requireAgentSession(input.sessionId);
+  const session = domain.requireAgentSession(input.agentSessionId);
   const viewer = domain.resolveViewer(actor);
-  const type = normalizeActivityType(input.type);
+  const type = input.content.type;
   const now = domain.tick();
   const id = domain.nextId("agent_activity");
   const ephemeral =
     typeof input.ephemeral === "boolean" ? input.ephemeral : type === "thought" || type === "action";
   domain.db
     .prepare(
-      `INSERT INTO agent_activities(id, session_id, user_id, type, body, ephemeral, created_at, updated_at)
-         VALUES (?,?,?,?,?,?,?,?)`
+      `INSERT INTO agent_activities(id, session_id, user_id, type, content_json, signal, ephemeral, created_at, updated_at)
+         VALUES (?,?,?,?,?,?,?,?,?)`
     )
-    .run(id, session.id, viewer.id, type, input.body, ephemeral ? 1 : 0, now, now);
+    .run(
+      id,
+      session.id,
+      viewer.id,
+      type,
+      JSON.stringify(input.content),
+      input.signal ?? null,
+      ephemeral ? 1 : 0,
+      now,
+      now
+    );
+  const status = deriveSessionStatus(type);
+  domain.db
+    .prepare("UPDATE agent_sessions SET status = ?, updated_at = ? WHERE id = ?")
+    .run(status, now, session.id);
   if (type === "prompt") {
     await emitWebhook(domain, {
       type: "AgentSessionEvent",
       action: "prompted",
-      data: { id: session.id, status: session.status },
+      data: { id: session.id, status },
       actor: viewer,
       teamId: session.issueId ? domain.requireIssue(session.issueId).teamId : null,
     });

--- a/packages/twin-linear/src/domain/index.ts
+++ b/packages/twin-linear/src/domain/index.ts
@@ -4,4 +4,10 @@
 export { LinearDomain } from "./linear-domain.js";
 export type { ActorContext, PendingCode } from "./linear-domain.js";
 export type { IssueCreateInput, IssueUpdateInput, IssueListFilter } from "./issues.js";
+export type {
+  AgentActivityCreateInput,
+  AgentSessionOnCommentInput,
+  AgentSessionOnIssueInput,
+  AgentSessionPatch,
+} from "./agents.js";
 export { emitWebhook, issueWebhookPayload, commentWebhookPayload } from "./webhooks.js";

--- a/packages/twin-linear/src/domain/linear-domain.ts
+++ b/packages/twin-linear/src/domain/linear-domain.ts
@@ -383,7 +383,7 @@ export class LinearDomain {
   }
 
   createAgentActivity(
-    input: { sessionId: string; type: string; body: string; ephemeral?: boolean },
+    input: agents.AgentActivityCreateInput,
     actor: ActorContext = {}
   ): Promise<LinearAgentActivity> {
     return agents.createAgentActivity(this, input, actor);

--- a/packages/twin-linear/src/domain/normalize.ts
+++ b/packages/twin-linear/src/domain/normalize.ts
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
+import { z } from "zod";
 import { LinearTwinError, badUserInput } from "../errors.js";
 import { byteLength } from "../ids.js";
 import {
   BODY_MAX_BYTES,
   TITLE_MAX_BYTES,
+  type LinearAgentActivityContent,
+  type LinearAgentActivitySignal,
   type LinearAgentActivityType,
   type LinearAgentSessionStatus,
   type LinearIssuePriority,
@@ -80,15 +83,82 @@ export function normalizeSessionStatus(value: string): LinearAgentSessionStatus 
   return value as LinearAgentSessionStatus;
 }
 
-export function normalizeActivityType(value: string): LinearAgentActivityType {
-  const allowed: LinearAgentActivityType[] = [
-    "thought",
-    "elicitation",
-    "action",
-    "response",
-    "error",
-    "prompt",
-  ];
-  if (!allowed.includes(value as LinearAgentActivityType)) badUserInput(`Invalid agent activity type: ${value}`);
-  return value as LinearAgentActivityType;
+/** Linear's `AgentActivitySignal` members, verbatim (F-1176). */
+export const AGENT_ACTIVITY_SIGNALS: LinearAgentActivitySignal[] = ["stop", "continue", "auth", "select"];
+
+/**
+ * `AgentActivityCreateInput.content`, member-for-member with Linear's
+ * `AgentActivityContent` union (F-1176). Strict on purpose: an unknown key here
+ * is a caller writing against a shape Linear does not accept, and the twin's
+ * rule is a loud error over a silent stub.
+ *
+ * `bodyData` / `resultData` are omitted — Linear derives them server-side from
+ * the markdown body, and the twin does not model rich text.
+ */
+const agentActivityContentSchema = z.union([
+  z.object({ type: z.enum(["thought", "elicitation", "response"]), body: z.string().min(1) }).strict(),
+  z.object({ type: z.literal("prompt"), body: z.string().min(1), title: z.string().optional() }).strict(),
+  z
+    .object({ type: z.literal("error"), body: z.string().min(1), reasonCode: z.string().optional() })
+    .strict(),
+  z
+    .object({
+      type: z.literal("action"),
+      action: z.string().min(1),
+      parameter: z.string(),
+      result: z.string().optional(),
+    })
+    .strict(),
+]);
+
+export function parseActivityContent(value: unknown): LinearAgentActivityContent {
+  const parsed = agentActivityContentSchema.safeParse(value);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    badUserInput(
+      `agentActivityCreate content: ${issue ? `${issue.path.join(".") || "content"} ${issue.message}` : "invalid"}`
+    );
+  }
+  const content = parsed.data as LinearAgentActivityContent;
+  if ("body" in content) assertBody(content.body);
+  return content;
+}
+
+export function normalizeActivitySignal(value: string): LinearAgentActivitySignal {
+  if (!AGENT_ACTIVITY_SIGNALS.includes(value as LinearAgentActivitySignal)) {
+    badUserInput(`Invalid agent activity signal: ${value}`);
+  }
+  return value as LinearAgentActivitySignal;
+}
+
+/**
+ * The status an emitted activity moves its session to (F-1176).
+ *
+ * Upstream truth, verified: `AgentSessionUpdateInput` has no `status` field at
+ * all, and Linear's agent guide states that session state is "updated
+ * automatically based on the agent's emitted activities. No manual state
+ * management is required." So status following activities is Linear's model,
+ * not the twin's invention.
+ *
+ * The table itself IS twin-owned — Linear does not publish which activity type
+ * yields which status, and introspection cannot show behaviour. It is
+ * registered as a known divergence in `REFERENCE-DIVERGENCES.md`. The mapping
+ * is the semantically forced one: work in progress is `active`, asking the user
+ * something waits on them, a final answer or a failure ends the session, and a
+ * fresh prompt puts the session back in the queue.
+ */
+export function deriveSessionStatus(type: LinearAgentActivityType): LinearAgentSessionStatus {
+  switch (type) {
+    case "thought":
+    case "action":
+      return "active";
+    case "elicitation":
+      return "awaitingInput";
+    case "response":
+      return "complete";
+    case "error":
+      return "error";
+    case "prompt":
+      return "pending";
+  }
 }

--- a/packages/twin-linear/src/domain/rows.ts
+++ b/packages/twin-linear/src/domain/rows.ts
@@ -203,7 +203,8 @@ export type AgentActivityRow = {
   session_id: string;
   user_id: string | null;
   type: string;
-  body: string;
+  content_json: string;
+  signal: string | null;
   ephemeral: number;
   created_at: string;
   updated_at: string;
@@ -399,7 +400,8 @@ export function mapAgentActivity(row: AgentActivityRow): LinearAgentActivity {
     sessionId: row.session_id,
     userId: row.user_id,
     type: row.type as LinearAgentActivity["type"],
-    body: row.body,
+    content: JSON.parse(row.content_json) as LinearAgentActivity["content"],
+    signal: row.signal as LinearAgentActivity["signal"],
     ephemeral: !!row.ephemeral,
     createdAt: row.created_at,
     updatedAt: row.updated_at,

--- a/packages/twin-linear/src/graphql/formatters.ts
+++ b/packages/twin-linear/src/graphql/formatters.ts
@@ -318,12 +318,12 @@ export function createFormatters(commands: LinearDomain, actor: ActorContext): G
 
   const formatAgentActivity = (activity: LinearAgentActivity) => ({
     id: activity.id,
-    type: activity.type,
-    body: activity.body,
+    content: activity.content,
+    signal: activity.signal,
     ephemeral: activity.ephemeral,
     createdAt: activity.createdAt,
     updatedAt: activity.updatedAt,
-    session: () => formatAgentSession(commands.requireAgentSession(activity.sessionId)),
+    agentSession: () => formatAgentSession(commands.requireAgentSession(activity.sessionId)),
     user: () => (activity.userId ? formatUser(commands.requireUser(activity.userId)) : null),
   });
 

--- a/packages/twin-linear/src/graphql/mutation-inputs.ts
+++ b/packages/twin-linear/src/graphql/mutation-inputs.ts
@@ -1,7 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 import { z } from "zod";
 import { badUserInput } from "../errors.js";
-import type { IssueCreateInput, IssueUpdateInput } from "../domain/index.js";
+import type {
+  AgentActivityCreateInput,
+  AgentSessionOnCommentInput,
+  AgentSessionOnIssueInput,
+  AgentSessionPatch,
+  IssueCreateInput,
+  IssueUpdateInput,
+} from "../domain/index.js";
+import { normalizeActivitySignal, parseActivityContent } from "../domain/normalize.js";
 
 const optionalString = z.string().nullish();
 const optionalStringArray = z.array(z.string()).nullish();
@@ -98,11 +106,15 @@ const agentSessionExternalUrlSchema = z
   .strict();
 const optionalExternalUrls = z.array(agentSessionExternalUrlSchema).nullish();
 
+/**
+ * The four agent-session mutation inputs mirror Linear's field names exactly
+ * (F-1176). Each is a SUBSET of the upstream input — never a superset. Notably
+ * `AgentSessionUpdateInput` has no `status` and no `id`: `id` is a mutation
+ * argument upstream, and status follows the emitted activity.
+ */
 export const agentSessionOnIssueInputSchema = z
   .object({
     issueId: z.string().min(1),
-    appUserId: z.string().optional(),
-    plan: optionalString,
     externalUrls: optionalExternalUrls,
   })
   .strict();
@@ -110,16 +122,12 @@ export const agentSessionOnIssueInputSchema = z
 export const agentSessionOnCommentInputSchema = z
   .object({
     commentId: z.string().min(1),
-    appUserId: z.string().optional(),
-    plan: optionalString,
     externalUrls: optionalExternalUrls,
   })
   .strict();
 
 export const agentSessionUpdateInputSchema = z
   .object({
-    id: z.string().min(1).optional(),
-    status: z.string().optional(),
     plan: optionalString,
     externalUrls: optionalExternalUrls,
   })
@@ -127,9 +135,9 @@ export const agentSessionUpdateInputSchema = z
 
 export const agentActivityCreateInputSchema = z
   .object({
-    sessionId: z.string().min(1),
-    type: z.string().min(1),
-    body: z.string().min(1),
+    agentSessionId: z.string().min(1),
+    content: z.unknown(),
+    signal: z.string().optional(),
     ephemeral: z.boolean().optional(),
   })
   .strict();
@@ -231,46 +239,31 @@ export function parseWebhookCreateInput(input: unknown) {
   };
 }
 
-export function parseAgentSessionOnIssueInput(input: unknown) {
+export function parseAgentSessionOnIssueInput(input: unknown): AgentSessionOnIssueInput {
   const raw = parseOrBadUserInput(agentSessionOnIssueInputSchema, input, "agentSessionCreateOnIssue input");
-  return {
-    issueId: raw.issueId,
-    appUserId: raw.appUserId,
-    plan: raw.plan ?? null,
-    externalUrls: raw.externalUrls ?? null,
-  };
+  return { issueId: raw.issueId, externalUrls: raw.externalUrls ?? null };
 }
 
-export function parseAgentSessionOnCommentInput(input: unknown) {
+export function parseAgentSessionOnCommentInput(input: unknown): AgentSessionOnCommentInput {
   const raw = parseOrBadUserInput(
     agentSessionOnCommentInputSchema,
     input,
     "agentSessionCreateOnComment input"
   );
-  return {
-    commentId: raw.commentId,
-    appUserId: raw.appUserId,
-    plan: raw.plan ?? null,
-    externalUrls: raw.externalUrls ?? null,
-  };
+  return { commentId: raw.commentId, externalUrls: raw.externalUrls ?? null };
 }
 
-export function parseAgentSessionUpdateInput(input: unknown) {
+export function parseAgentSessionUpdateInput(input: unknown): AgentSessionPatch {
   const raw = parseOrBadUserInput(agentSessionUpdateInputSchema, input, "agentSessionUpdate input");
-  return {
-    id: raw.id,
-    status: raw.status,
-    plan: raw.plan,
-    externalUrls: raw.externalUrls,
-  };
+  return { plan: raw.plan, externalUrls: raw.externalUrls };
 }
 
-export function parseAgentActivityCreateInput(input: unknown) {
+export function parseAgentActivityCreateInput(input: unknown): AgentActivityCreateInput {
   const raw = parseOrBadUserInput(agentActivityCreateInputSchema, input, "agentActivityCreate input");
   return {
-    sessionId: raw.sessionId,
-    type: raw.type,
-    body: raw.body,
+    agentSessionId: raw.agentSessionId,
+    content: parseActivityContent(raw.content),
+    signal: raw.signal === undefined ? undefined : normalizeActivitySignal(raw.signal),
     ephemeral: raw.ephemeral,
   };
 }

--- a/packages/twin-linear/src/graphql/resolvers.ts
+++ b/packages/twin-linear/src/graphql/resolvers.ts
@@ -199,17 +199,10 @@ export function createRootValue(ctx: GraphQLRuntimeContext): Record<string, unkn
       );
       return payload({ agentSession: formatAgentSession(session) });
     },
-    agentSessionUpdate: ({ id, input }: { id?: string; input: unknown }) => {
-      const parsed = parseAgentSessionUpdateInput(input);
-      const session = commands.updateAgentSession(
-        String(id ?? parsed.id),
-        {
-          status: parsed.status,
-          plan: parsed.plan,
-          externalUrls: parsed.externalUrls,
-        },
-        actor
-      );
+    agentSessionUpdate: ({ id, input }: { id: string; input: unknown }) => {
+      // `id` is a mutation argument upstream, and non-null — it is not a field
+      // of AgentSessionUpdateInput (F-1176).
+      const session = commands.updateAgentSession(id, parseAgentSessionUpdateInput(input), actor);
       return payload({ agentSession: formatAgentSession(session) });
     },
     agentActivityCreate: async ({ input }: { input: unknown }) => {

--- a/packages/twin-linear/src/graphql/schema.ts
+++ b/packages/twin-linear/src/graphql/schema.ts
@@ -9,6 +9,7 @@ export const linearGraphQLSchema: GraphQLSchema = buildSchema(`
   scalar PaginationOrderBy
   scalar DateTime
   scalar JSON
+  scalar JSONObject
 
   type Query {
     viewer: User!
@@ -61,7 +62,7 @@ export const linearGraphQLSchema: GraphQLSchema = buildSchema(`
     webhookDelete(id: String!): DeletePayload!
     agentSessionCreateOnIssue(input: AgentSessionCreateOnIssue!): AgentSessionPayload!
     agentSessionCreateOnComment(input: AgentSessionCreateOnComment!): AgentSessionPayload!
-    agentSessionUpdate(id: String, input: AgentSessionUpdateInput!): AgentSessionPayload!
+    agentSessionUpdate(id: String!, input: AgentSessionUpdateInput!): AgentSessionPayload!
     agentActivityCreate(input: AgentActivityCreateInput!): AgentActivityPayload!
   }
 
@@ -324,15 +325,23 @@ export const linearGraphQLSchema: GraphQLSchema = buildSchema(`
     activities(first: Int, after: String, last: Int, before: String): AgentActivityConnection!
   }
 
+  """Linear's AgentActivitySignal, member-for-member (F-1176)."""
+  enum AgentActivitySignal {
+    stop
+    continue
+    auth
+    select
+  }
+
   type AgentActivity {
-    id: String!
-    type: String!
-    body: String!
+    id: ID!
+    content: JSON!
+    signal: AgentActivitySignal
     ephemeral: Boolean!
-    createdAt: String!
-    updatedAt: String!
-    session: AgentSession!
-    user: User
+    createdAt: DateTime!
+    updatedAt: DateTime!
+    agentSession: AgentSession!
+    user: User!
   }
 
   type NodeRef {
@@ -492,31 +501,32 @@ export const linearGraphQLSchema: GraphQLSchema = buildSchema(`
     label: String!
   }
 
+  """Linear's AgentSessionCreateOnIssue, subset (F-1176)."""
   input AgentSessionCreateOnIssue {
     issueId: String!
-    appUserId: String
-    plan: String
     externalUrls: [AgentSessionExternalUrlInput!]
   }
 
+  """Linear's AgentSessionCreateOnComment, subset (F-1176)."""
   input AgentSessionCreateOnComment {
     commentId: String!
-    appUserId: String
-    plan: String
     externalUrls: [AgentSessionExternalUrlInput!]
   }
 
+  """
+  Linear's AgentSessionUpdateInput, subset (F-1176). There is deliberately no
+  status here — Linear has none. Session status moves through agentActivityCreate.
+  """
   input AgentSessionUpdateInput {
-    id: String
-    status: AgentSessionStatus
     plan: String
     externalUrls: [AgentSessionExternalUrlInput!]
   }
 
+  """Linear's AgentActivityCreateInput, subset (F-1176)."""
   input AgentActivityCreateInput {
-    sessionId: String!
-    type: String!
-    body: String!
+    agentSessionId: String!
+    content: JSONObject!
+    signal: AgentActivitySignal
     ephemeral: Boolean
   }
 `);

--- a/packages/twin-linear/src/state.ts
+++ b/packages/twin-linear/src/state.ts
@@ -93,12 +93,15 @@ export function exportLinearState(db: LinearTwinDatabase): LinearStateExport {
   );
 
   const agentActivities = capped(
-    db
-      .prepare(
-        `SELECT id, session_id AS sessionId, user_id AS userId, type, body, ephemeral,
-                created_at AS createdAt FROM agent_activities ORDER BY created_at DESC, id DESC`
-      )
-      .all() as unknown[],
+    (
+      db
+        .prepare(
+          `SELECT id, session_id AS sessionId, user_id AS userId, type, content_json AS content,
+                  signal, ephemeral, created_at AS createdAt
+             FROM agent_activities ORDER BY created_at DESC, id DESC`
+        )
+        .all() as Array<Record<string, unknown>>
+    ).map((activity) => ({ ...activity, content: parseJson(activity.content) })),
     "agentActivities",
     truncatedCollections,
     true

--- a/packages/twin-linear/src/types.ts
+++ b/packages/twin-linear/src/types.ts
@@ -18,6 +18,7 @@ export type LinearWorkflowStateType =
 export type LinearTokenType = "personal" | "oauth_access" | "oauth_refresh" | "client_credentials";
 export type LinearTokenActorType = "user" | "app";
 export type LinearIssuePriority = 0 | 1 | 2 | 3 | 4;
+/** Linear's `AgentActivityType` enum, member-for-member. */
 export type LinearAgentActivityType =
   | "thought"
   | "elicitation"
@@ -25,6 +26,30 @@ export type LinearAgentActivityType =
   | "response"
   | "error"
   | "prompt";
+/** Linear's `AgentActivitySignal` enum, member-for-member (F-1176). */
+export type LinearAgentActivitySignal = "stop" | "continue" | "auth" | "select";
+/**
+ * One member of Linear's `AgentActivityContent` union, as it arrives on
+ * `AgentActivityCreateInput.content` (F-1176). Five of the six members carry a
+ * `body`; `action` carries a call and its parameter instead.
+ */
+export type LinearAgentActivityBodyContent = {
+  type: "thought" | "elicitation" | "response" | "error" | "prompt";
+  body: string;
+  /** `prompt` only. */
+  title?: string;
+  /** `error` only. */
+  reasonCode?: string;
+};
+export type LinearAgentActivityActionContent = {
+  type: "action";
+  action: string;
+  parameter: string;
+  result?: string;
+};
+export type LinearAgentActivityContent =
+  | LinearAgentActivityBodyContent
+  | LinearAgentActivityActionContent;
 /** Linear's `AgentSessionStatus` enum, member-for-member (F-1172). */
 export type LinearAgentSessionStatus =
   | "pending"
@@ -251,8 +276,10 @@ export type LinearAgentActivity = {
   id: string;
   sessionId: string;
   userId: string | null;
+  /** The discriminant of `content`, kept as a column so status can be derived and indexed. */
   type: LinearAgentActivityType;
-  body: string;
+  content: LinearAgentActivityContent;
+  signal: LinearAgentActivitySignal | null;
   ephemeral: boolean;
   createdAt: string;
   updatedAt: string;

--- a/packages/twin-linear/test/agent-session-inputs.test.ts
+++ b/packages/twin-linear/test/agent-session-inputs.test.ts
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-1176: the four agent-session mutation inputs take Linear's field names, and
+// only Linear's. `test/linear-schema-subset.test.ts` proves the SDL declares no
+// invented field; this proves the twin BEHAVES that way over the wire — an
+// invented field is rejected, Linear's names are accepted, and session status
+// moves through agentActivityCreate because Linear has no `status` to set.
+import { describe, expect, it } from "vitest";
+import { createRecorderStore } from "@pome-sh/sdk/server";
+import {
+  DEFAULT_LINEAR_TOKEN,
+  createLinearTwinApp,
+  openLinearTwinDatabase,
+} from "../src/index.js";
+import { testSeed } from "./_helpers.js";
+
+const SECRET = "linear-agent-inputs-test-secret!!";
+
+function app() {
+  process.env.TWIN_AUTH_SECRET = SECRET;
+  return createLinearTwinApp({
+    db: openLinearTwinDatabase(":memory:"),
+    seed: testSeed(),
+    recorder: createRecorderStore(),
+    runId: "agent-inputs-test",
+  });
+}
+
+type GraphQLResult = { data?: Record<string, any>; errors?: Array<{ message: string }> };
+
+async function graphql(
+  instance: ReturnType<typeof createLinearTwinApp>,
+  query: string,
+  variables?: Record<string, unknown>
+): Promise<GraphQLResult> {
+  const response = await instance.request("/graphql", {
+    method: "POST",
+    headers: { authorization: `Bearer ${DEFAULT_LINEAR_TOKEN}`, "content-type": "application/json" },
+    body: JSON.stringify({ query, variables }),
+  });
+  return (await response.json()) as GraphQLResult;
+}
+
+async function session(instance: ReturnType<typeof createLinearTwinApp>): Promise<string> {
+  const issues = await graphql(instance, `query { issues(first: 1) { nodes { id } } }`);
+  const created = await graphql(
+    instance,
+    `mutation ($input: AgentSessionCreateOnIssue!) {
+       agentSessionCreateOnIssue(input: $input) { agentSession { id status } }
+     }`,
+    { input: { issueId: issues.data?.issues.nodes[0].id as string } }
+  );
+  expect(created.errors).toBeUndefined();
+  expect(created.data?.agentSessionCreateOnIssue.agentSession.status).toBe("pending");
+  return created.data?.agentSessionCreateOnIssue.agentSession.id as string;
+}
+
+async function emit(
+  instance: ReturnType<typeof createLinearTwinApp>,
+  agentSessionId: string,
+  content: Record<string, unknown>,
+  extra: Record<string, unknown> = {}
+): Promise<GraphQLResult> {
+  return graphql(
+    instance,
+    `mutation ($input: AgentActivityCreateInput!) {
+       agentActivityCreate(input: $input) {
+         agentActivity { id content signal ephemeral agentSession { id status } }
+       }
+     }`,
+    { input: { agentSessionId, content, ...extra } }
+  );
+}
+
+describe("agent-session mutation inputs take Linear's field names (F-1176)", () => {
+  it.each([
+    ["AgentSessionCreateOnIssue", "appUserId", `mutation { agentSessionCreateOnIssue(input: { issueId: "x", appUserId: "y" }) { success } }`],
+    ["AgentSessionCreateOnIssue", "plan", `mutation { agentSessionCreateOnIssue(input: { issueId: "x", plan: "p" }) { success } }`],
+    ["AgentSessionCreateOnComment", "appUserId", `mutation { agentSessionCreateOnComment(input: { commentId: "x", appUserId: "y" }) { success } }`],
+    ["AgentSessionUpdateInput", "status", `mutation { agentSessionUpdate(id: "x", input: { status: active }) { success } }`],
+    ["AgentSessionUpdateInput", "id", `mutation { agentSessionUpdate(id: "x", input: { id: "x" }) { success } }`],
+    ["AgentActivityCreateInput", "sessionId", `mutation { agentActivityCreate(input: { agentSessionId: "x", sessionId: "x", content: {} }) { success } }`],
+    ["AgentActivityCreateInput", "body", `mutation { agentActivityCreate(input: { agentSessionId: "x", body: "b", content: {} }) { success } }`],
+  ])("%s rejects the invented field %s", async (typeName, field, query) => {
+    const result = await graphql(app(), query);
+    expect(result.errors?.[0]?.message).toContain(`Field "${field}" is not defined by type "${typeName}"`);
+  });
+
+  it("agentSessionUpdate requires id as an argument, because upstream it is not a field of the input", async () => {
+    const result = await graphql(app(), `mutation { agentSessionUpdate(input: { plan: "p" }) { success } }`);
+    expect(result.errors?.[0]?.message).toContain(
+      'Field "agentSessionUpdate" argument "id" of type "String!" is required'
+    );
+  });
+
+  it("agentSessionUpdate sets plan and externalUrls without touching status", async () => {
+    const instance = app();
+    const id = await session(instance);
+    const updated = await graphql(
+      instance,
+      `mutation ($id: String!, $input: AgentSessionUpdateInput!) {
+         agentSessionUpdate(id: $id, input: $input) { agentSession { status plan externalUrls } }
+       }`,
+      { id, input: { plan: "PLAN", externalUrls: [{ url: "https://example.test/r", label: "run" }] } }
+    );
+    expect(updated.errors).toBeUndefined();
+    expect(updated.data?.agentSessionUpdate.agentSession).toEqual({
+      status: "pending",
+      plan: "PLAN",
+      externalUrls: [{ url: "https://example.test/r", label: "run" }],
+    });
+  });
+});
+
+describe("session status moves through agent activities, not agentSessionUpdate (F-1176)", () => {
+  it.each([
+    [{ type: "thought", body: "looking" }, "active"],
+    [{ type: "action", action: "search", parameter: "term" }, "active"],
+    [{ type: "elicitation", body: "which repo?" }, "awaitingInput"],
+    [{ type: "response", body: "done" }, "complete"],
+    [{ type: "error", body: "exploded" }, "error"],
+    [{ type: "prompt", body: "please fix" }, "pending"],
+  ])("a %o activity leaves the session %s", async (content, status) => {
+    const instance = app();
+    const id = await session(instance);
+    const result = await emit(instance, id, content);
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.agentActivityCreate.agentActivity.agentSession.status).toBe(status);
+    expect(result.data?.agentActivityCreate.agentActivity.content).toEqual(content);
+  });
+
+  it("carries a signal through, and rejects one Linear does not declare", async () => {
+    const instance = app();
+    const id = await session(instance);
+    const accepted = await emit(instance, id, { type: "response", body: "done" }, { signal: "stop" });
+    expect(accepted.errors).toBeUndefined();
+    expect(accepted.data?.agentActivityCreate.agentActivity.signal).toBe("stop");
+
+    const rejected = await graphql(
+      instance,
+      `mutation { agentActivityCreate(input: { agentSessionId: "${id}", content: {}, signal: cancel }) { success } }`
+    );
+    expect(rejected.errors?.[0]?.message).toContain('Value "cancel" does not exist in "AgentActivitySignal"');
+  });
+
+  it("rejects content that is not one of Linear's AgentActivityContent members", async () => {
+    const instance = app();
+    const id = await session(instance);
+
+    for (const content of [
+      { type: "thought" }, // body is required on a thought
+      { type: "thought", body: "hi", extra: "no" }, // strict: no unknown keys
+      { type: "summary", body: "hi" }, // not an AgentActivityType
+      { type: "action", action: "search" }, // parameter is required on an action
+    ]) {
+      const result = await emit(instance, id, content);
+      expect(result.errors?.[0]?.message, JSON.stringify(content)).toContain("agentActivityCreate content");
+    }
+  });
+
+  it("an activity on an unknown session is a not-found, not a silent create", async () => {
+    const result = await emit(app(), "agent_session_nope", { type: "thought", body: "hi" });
+    expect(result.errors?.[0]?.message).toContain("Agent session not found");
+  });
+});

--- a/packages/twin-linear/test/agent-session-migration.test.ts
+++ b/packages/twin-linear/test/agent-session-migration.test.ts
@@ -158,3 +158,61 @@ describe("a pre-rename agent_sessions table migrates on open (F-1172)", () => {
     db.close();
   });
 });
+
+/**
+ * F-1176: `agent_activities` used to store a flat `type` + `body` pair. Linear's
+ * `AgentActivityCreateInput` takes a single `content` object, so the body moved
+ * inside it — same no-op-CREATE-TABLE hazard as above, one table over.
+ */
+function seedPreContentDatabase(): string {
+  const dir = mkdtempSync(join(tmpdir(), "twin-linear-activity-migration-"));
+  temporaries.push(dir);
+  const path = join(dir, "linear.db");
+
+  const db = openLinearTwinDatabase(path);
+  const commands = new LinearDomain(db);
+  commands.seed(testSeed());
+  const issue = commands.listIssues()[0]!;
+  const appUser = commands.listUsers().find((user) => user.app) ?? commands.listUsers()[0]!;
+
+  db.prepare(
+    `INSERT INTO agent_sessions(id, issue_id, comment_id, app_user_id, status, plan, external_urls_json, created_at, updated_at)
+       VALUES (?,?,?,?,?,?,?,?,?)`
+  ).run("legacy_session", issue.id, null, appUser.id, "active", null, "[]", "2026-08-02T00:00:00.000Z", "2026-08-02T00:00:00.000Z");
+
+  // Put agent_activities back into the pre-content shape.
+  db.exec("ALTER TABLE agent_activities ADD COLUMN body TEXT NOT NULL DEFAULT ''");
+  db.exec("ALTER TABLE agent_activities DROP COLUMN content_json");
+  db.exec("ALTER TABLE agent_activities DROP COLUMN signal");
+  const insert = db.prepare(
+    `INSERT INTO agent_activities(id, session_id, user_id, type, body, ephemeral, created_at, updated_at)
+       VALUES (?,?,?,?,?,?,?,?)`
+  );
+  insert.run("legacy_thought", "legacy_session", appUser.id, "thought", "thinking", 1, "2026-08-02T00:00:00.000Z", "2026-08-02T00:00:00.000Z");
+  insert.run("legacy_action", "legacy_session", appUser.id, "action", "search_issues", 1, "2026-08-02T00:00:01.000Z", "2026-08-02T00:00:01.000Z");
+  db.close();
+  return path;
+}
+
+describe("a pre-content agent_activities table migrates on open (F-1176)", () => {
+  it("folds type + body into Linear's content object", () => {
+    const path = seedPreContentDatabase();
+    const activities = new LinearDomain(openLinearTwinDatabase(path)).listAgentActivities("legacy_session");
+
+    expect(activities.map((activity) => activity.content)).toEqual([
+      { type: "thought", body: "thinking" },
+      // The old shape had nowhere to keep a parameter, so it backfills empty
+      // rather than inventing one.
+      { type: "action", action: "search_issues", parameter: "" },
+    ]);
+    expect(activities.every((activity) => activity.signal === null)).toBe(true);
+  });
+
+  it("is idempotent, and does not re-run on an already-migrated file", () => {
+    const path = seedPreContentDatabase();
+    const before = new LinearDomain(openLinearTwinDatabase(path)).listAgentActivities("legacy_session");
+    expect(new LinearDomain(openLinearTwinDatabase(path)).listAgentActivities("legacy_session")).toEqual(
+      before
+    );
+  });
+});

--- a/packages/twin-linear/test/linear-schema-subset.test.ts
+++ b/packages/twin-linear/test/linear-schema-subset.test.ts
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 /**
- * F-1172 guard: every field the twin declares on a Linear type must be a field
- * Linear actually declares.
+ * F-1172 / F-1176 guard: every field the twin declares on a Linear type must be
+ * a field Linear actually declares — on the output types AND on the four
+ * agent-session mutation inputs.
  *
  * This is a SUBSET check, not an equality check. The twin models a slice of
  * Linear on purpose — missing fields are ordinary coverage scope. Inventing a
@@ -23,7 +24,10 @@ import {
   GraphQLEnumType,
   GraphQLInputObjectType,
   GraphQLObjectType,
+  buildSchema,
+  printSchema,
   type GraphQLNamedType,
+  type GraphQLSchema,
 } from "graphql";
 import { describe, expect, it } from "vitest";
 import { AGENT_SESSION_STATUSES } from "../src/domain/normalize.js";
@@ -52,20 +56,29 @@ const upstream = JSON.parse(
  * fixture, so that deleting a type from the fixture fails loudly instead of
  * silently removing coverage.
  *
- * SCOPE — this list is the OUTPUT-side surface plus the one input object the
- * twin mirrors exactly. The twin's mutation INPUT types (`AgentSessionUpdateInput`,
- * `AgentSessionCreateOnIssue` / `OnComment`, `AgentActivityCreateInput`) still
- * declare fields Linear does not — `AgentSessionUpdateInput` upstream has no
- * `status` and no `id` at all, for instance. That divergence predates F-1172
- * and is tracked separately; see the SCOPE note on `GUARDED_TYPES` in
- * `scripts/regen-linear-introspection.mjs`. Do not read this file as evidence
- * about the input surface.
+ * SCOPE — both directions of the agent-session surface. The four mutation INPUT
+ * types are here too (F-1176), so this file is evidence about the input surface
+ * as well as the output one. Keep it in step with `GUARDED_TYPES` in
+ * `scripts/regen-linear-introspection.mjs`.
  */
-const MUST_BE_GUARDED = ["AgentSession", "AgentSessionStatus", "AgentSessionExternalUrlInput"];
+const MUST_BE_GUARDED = [
+  "AgentSession",
+  "AgentSessionStatus",
+  "AgentSessionExternalUrlInput",
+  "AgentActivity",
+  "AgentActivitySignal",
+  "AgentSessionCreateOnIssue",
+  "AgentSessionCreateOnComment",
+  "AgentSessionUpdateInput",
+  "AgentActivityCreateInput",
+];
 
 /** Member names the twin declares for a named type, or null if it declares no such type. */
-function twinMembers(name: string): { kind: string; members: string[] } | null {
-  const type: GraphQLNamedType | undefined = linearGraphQLSchema.getType(name) ?? undefined;
+function twinMembers(name: string, schema: GraphQLSchema = linearGraphQLSchema): {
+  kind: string;
+  members: string[];
+} | null {
+  const type: GraphQLNamedType | undefined = schema.getType(name) ?? undefined;
   if (!type) return null;
   if (type instanceof GraphQLObjectType) return { kind: "OBJECT", members: Object.keys(type.getFields()) };
   if (type instanceof GraphQLInputObjectType) {
@@ -82,7 +95,27 @@ function upstreamMembers(entry: UpstreamType): string[] {
   return Object.keys(entry.fields ?? entry.inputFields ?? {}).concat(entry.enumValues ?? []);
 }
 
-describe("twin GraphQL types stay a subset of Linear's real schema (F-1172)", () => {
+/** The members a schema declares on `name` that Linear does not. This IS the guard. */
+function inventedMembers(name: string, schema: GraphQLSchema = linearGraphQLSchema): string[] {
+  const entry = upstream.types[name];
+  if (!entry) throw new Error(`${name} is absent from linear-introspection.json, so it is unguarded`);
+  const declared = new Set(upstreamMembers(entry));
+  return (twinMembers(name, schema)?.members ?? []).filter((member) => !declared.has(member)).sort();
+}
+
+/**
+ * The twin's own SDL with one extra field spliced onto a type, rebuilt through
+ * `buildSchema` exactly as `src/graphql/schema.ts` does. Used to prove the guard
+ * can fail — see the test at the bottom of this file.
+ */
+function schemaWithInventedMember(typeName: string, declaration: string): GraphQLSchema {
+  const sdl = printSchema(linearGraphQLSchema);
+  const opener = new RegExp(`^(input|type|enum) ${typeName} \\{$`, "m");
+  if (!opener.test(sdl)) throw new Error(`${typeName} is not declared in the twin's SDL`);
+  return buildSchema(sdl.replace(opener, (header) => `${header}\n  ${declaration}`));
+}
+
+describe("twin GraphQL types stay a subset of Linear's real schema (F-1172, F-1176)", () => {
   it("guards the types it claims to guard", () => {
     expect(upstream.source).toBe("https://api.linear.app/graphql");
     for (const name of MUST_BE_GUARDED) {
@@ -105,8 +138,7 @@ describe("twin GraphQL types stay a subset of Linear's real schema (F-1172)", ()
       // model one under names Linear does not use.
       if (!twin) return;
       expect(twin.kind).toBe((entry as UpstreamType).kind);
-      const declared = new Set(upstreamMembers(entry as UpstreamType));
-      const invented = twin.members.filter((member) => !declared.has(member)).sort();
+      const invented = inventedMembers(name);
       expect(invented, `${name} declares members Linear does not: ${invented.join(", ")}`).toEqual([]);
     });
   }
@@ -116,6 +148,35 @@ describe("twin GraphQL types stay a subset of Linear's real schema (F-1172)", ()
     // against) can drift apart; a value the domain accepts but the SDL rejects
     // would blow up at serialisation time, not at authoring time.
     expect(AGENT_SESSION_STATUSES.slice().sort()).toEqual(twinMembers("AgentSessionStatus")?.members.sort());
+  });
+
+  /**
+   * A guard that cannot fail is not a guard. `MUST_BE_GUARDED` proves the
+   * fixture has upstream truth to compare against; these prove the comparison
+   * itself bites. Each case splices an invented member into the twin's own SDL,
+   * rebuilds it the way `src/graphql/schema.ts` does, and asserts the guard
+   * names exactly that member — so this fails if the check is ever softened
+   * into a no-op.
+   */
+  it.each([
+    ["AgentSessionUpdateInput", "status: AgentSessionStatus", "status"],
+    ["AgentSessionCreateOnIssue", "appUserId: String", "appUserId"],
+    ["AgentSessionCreateOnComment", "appUserId: String", "appUserId"],
+    ["AgentActivityCreateInput", "sessionId: String", "sessionId"],
+    ["AgentActivity", "body: String", "body"],
+    ["AgentSession", "externalUrl: String", "externalUrl"],
+  ])("the guard catches an invented %s.%s", (typeName, declaration, member) => {
+    expect(inventedMembers(typeName)).toEqual([]);
+    expect(inventedMembers(typeName, schemaWithInventedMember(typeName, declaration))).toEqual([member]);
+  });
+
+  it("an invented enum member is caught too", () => {
+    expect(
+      twinMembers("AgentActivitySignal", buildSchema("enum AgentActivitySignal { stop cancel }"))?.members
+    ).toEqual(["stop", "cancel"]);
+    expect(
+      inventedMembers("AgentActivitySignal", buildSchema("enum AgentActivitySignal { stop cancel }"))
+    ).toEqual(["cancel"]);
   });
 
   it("AgentSession carries the fields the twin promises to model", () => {

--- a/packages/twin-linear/test/partial-update-tristate.test.ts
+++ b/packages/twin-linear/test/partial-update-tristate.test.ts
@@ -70,11 +70,12 @@ function callTool(commands: LinearDomain, name: string, args: Record<string, unk
 
 async function seededSession(commands: LinearDomain, plan: string) {
   const issue = commands.listIssues()[0]!;
-  return commands.createAgentSessionOnIssue({
+  // Linear's create inputs carry no plan (F-1176) — the plan arrives on update.
+  const session = await commands.createAgentSessionOnIssue({
     issueId: issue.id,
-    plan,
     externalUrls: [{ url: "https://example.test/run/1", label: "run" }],
   });
+  return commands.updateAgentSession(session.id, { plan });
 }
 
 describe("agentSessionUpdate partial-update tri-state (F-1166)", () => {
@@ -83,21 +84,19 @@ describe("agentSessionUpdate partial-update tri-state (F-1166)", () => {
     const session = await seededSession(commands, "PLAN-RESIDUE");
 
     const updated = commands.updateAgentSession(session.id, {
-      status: "active",
       plan: undefined,
       externalUrls: undefined,
     });
 
     expect(updated.plan).toBe("PLAN-RESIDUE");
     expect(updated.externalUrls).toEqual([{ url: "https://example.test/run/1", label: "run" }]);
-    expect(updated.status).toBe("active");
   });
 
   it("leaves plan untouched when the key is absent", async () => {
     const commands = domain();
     const session = await seededSession(commands, "PLAN-RESIDUE");
 
-    const updated = commands.updateAgentSession(session.id, { status: "active" });
+    const updated = commands.updateAgentSession(session.id, {});
 
     expect(updated.plan).toBe("PLAN-RESIDUE");
     expect(updated.externalUrls).toEqual([{ url: "https://example.test/run/1", label: "run" }]);
@@ -123,17 +122,15 @@ describe("agentSessionUpdate partial-update tri-state (F-1166)", () => {
   });
 
   it("parses a present-but-undefined plan as 'not provided', not as null", () => {
-    expect(parseAgentSessionUpdateInput({ id: "x", status: "active", plan: undefined }).plan).toBeUndefined();
-    expect(parseAgentSessionUpdateInput({ id: "x", status: "active" }).plan).toBeUndefined();
-    expect(parseAgentSessionUpdateInput({ id: "x", plan: null }).plan).toBeNull();
-    expect(parseAgentSessionUpdateInput({ id: "x", plan: "PLAN" }).plan).toBe("PLAN");
-    expect(
-      parseAgentSessionUpdateInput({ id: "x", status: "active", externalUrls: undefined }).externalUrls
-    ).toBeUndefined();
-    expect(parseAgentSessionUpdateInput({ id: "x", externalUrls: null }).externalUrls).toBeNull();
+    expect(parseAgentSessionUpdateInput({ plan: undefined }).plan).toBeUndefined();
+    expect(parseAgentSessionUpdateInput({}).plan).toBeUndefined();
+    expect(parseAgentSessionUpdateInput({ plan: null }).plan).toBeNull();
+    expect(parseAgentSessionUpdateInput({ plan: "PLAN" }).plan).toBe("PLAN");
+    expect(parseAgentSessionUpdateInput({ externalUrls: undefined }).externalUrls).toBeUndefined();
+    expect(parseAgentSessionUpdateInput({ externalUrls: null }).externalUrls).toBeNull();
   });
 
-  it("preserves plan across a GraphQL agentSessionUpdate that only sets status", async () => {
+  it("preserves plan across a GraphQL agentSessionUpdate that only sets externalUrls", async () => {
     const instance = app();
     const issues = await graphql(instance, `query { issues(first: 1) { nodes { id } } }`);
     const issueId = issues.data?.issues.nodes[0].id as string;
@@ -143,27 +140,30 @@ describe("agentSessionUpdate partial-update tri-state (F-1166)", () => {
       `mutation ($input: AgentSessionCreateOnIssue!) {
          agentSessionCreateOnIssue(input: $input) { agentSession { id plan externalUrls } }
        }`,
-      {
-        input: {
-          issueId,
-          plan: "PLAN-RESIDUE",
-          externalUrls: [{ url: "https://example.test/run/1", label: "run" }],
-        },
-      }
+      { input: { issueId } }
     );
     const sessionId = created.data?.agentSessionCreateOnIssue.agentSession.id as string;
+
+    const seeded = await graphql(
+      instance,
+      `mutation ($id: String!, $input: AgentSessionUpdateInput!) {
+         agentSessionUpdate(id: $id, input: $input) { agentSession { plan } }
+       }`,
+      { id: sessionId, input: { plan: "PLAN-RESIDUE" } }
+    );
+    expect(seeded.errors).toBeUndefined();
 
     const updated = await graphql(
       instance,
       `mutation ($id: String!, $input: AgentSessionUpdateInput!) {
          agentSessionUpdate(id: $id, input: $input) { agentSession { id status plan externalUrls } }
        }`,
-      { id: sessionId, input: { status: "active" } }
+      { id: sessionId, input: { externalUrls: [{ url: "https://example.test/run/1", label: "run" }] } }
     );
 
     expect(updated.errors).toBeUndefined();
     expect(updated.data?.agentSessionUpdate.agentSession).toMatchObject({
-      status: "active",
+      status: "pending",
       plan: "PLAN-RESIDUE",
       externalUrls: [{ url: "https://example.test/run/1", label: "run" }],
     });
@@ -178,9 +178,16 @@ describe("agentSessionUpdate partial-update tri-state (F-1166)", () => {
       `mutation ($input: AgentSessionCreateOnIssue!) {
          agentSessionCreateOnIssue(input: $input) { agentSession { id } }
        }`,
-      { input: { issueId, plan: "PLAN-RESIDUE" } }
+      { input: { issueId } }
     );
     const sessionId = created.data?.agentSessionCreateOnIssue.agentSession.id as string;
+    await graphql(
+      instance,
+      `mutation ($id: String!, $input: AgentSessionUpdateInput!) {
+         agentSessionUpdate(id: $id, input: $input) { agentSession { plan } }
+       }`,
+      { id: sessionId, input: { plan: "PLAN-RESIDUE" } }
+    );
 
     const updated = await graphql(
       instance,


### PR DESCRIPTION
Closes F-1176.

## The decision came first

Recorded as a `[DECISION]` comment on F-1176 before any code: **option 1, full fidelity**, with one scoped known-divergence.

**Live re-verification.** Re-introspected `https://api.linear.app/graphql` unauthenticated rather than trusting the ticket. The ticket's four lists are exactly right. Two extras it did not have:

- `id` on `agentSessionUpdate` is a **mutation argument**, and non-null upstream — `agentSessionUpdate(id: String!, input: AgentSessionUpdateInput!)`. The twin declared it nullable. Second divergence on the same mutation.
- `AgentActivityContent` is a **union, introspectable member by member**: `{type, body, bodyData}` for thought/response/elicitation, `{type, body, title, bodyData}` for prompt, `{type, body, reasonCode, bodyData}` for error, `{type, action, parameter, result, resultData}` for action. So `type` + `body` → `content: {type, body}` is a rename with one level of nesting, not the "different design" the ticket assumed. `AgentActivitySignal` = `stop | continue | auth | select`.

**Two stale notes corrected.** `scripts/regen-linear-introspection.mjs` claimed `AgentSessionCreateOnIssue` / `OnComment` "are not Linear type names at all". They are — both exist upstream under those exact names. (`AgentSessionCreateInput` also exists, separately; that is where `appUserId` lives upstream.) Separately: `externalUrls`, `externalLink`, `externalLinks`, `type` and `workspaceDiffFiles` on the `AgentSession` output type are **deprecated but still declared** — they appear only under `includeDeprecated: true`. The regen script already passes it, so the fixture is right, but anyone re-checking by hand without the flag will wrongly conclude Linear removed them.

**Blast radius, measured.** `cli/tasks/` (42 files): **0**. `examples/` (8): **0**. Anything driving `agentSessionUpdate` with `status`, anywhere: **0**. Every caller is inside `packages/twin-linear`. The corpus migration option 1 was sized against is empty, and with zero customers there is no shim to write — so option 1 is materially cheaper than the ticket assumed.

**Against option 2 (names only).** Its premise is that the 1:1 mapping runs out; the introspected content union shows it does not. It would leave `status` on the update input — the single most consequential divergence in the ticket — and register a gap that cost near zero to close. It also leaves the guard dishonest: the four types would pass against an allowlist rather than against upstream.

**Against option 3 (register wholesale).** Writes down "our mutation inputs are not Linear's" as policy for the one surface where an agent's arguments cross the wire, which is the failure the twins exist to prevent and the thing F-1172 refused to do on the output side. Worse, it ratchets the drift guard onto a wrong baseline, freezing `sessionId` / `type` / `body` / `status` as protected twin vocabulary. Registering is for divergences you cannot close.

## The guard's starting red

Extending `GUARDED_TYPES` was the first commit-worthy act, and it failed on all five newly-covered types immediately — the ticket's starting evidence:

```
FAIL AgentSessionUpdateInput declares no field Linear does not have
  AgentSessionUpdateInput declares members Linear does not: id, status
FAIL AgentActivityCreateInput declares no field Linear does not have
  AgentActivityCreateInput declares members Linear does not: body, sessionId, type
FAIL AgentSessionCreateOnIssue declares no field Linear does not have
  AgentSessionCreateOnIssue declares members Linear does not: appUserId, plan
FAIL AgentSessionCreateOnComment declares no field Linear does not have
  AgentSessionCreateOnComment declares members Linear does not: appUserId, plan
FAIL AgentActivity declares no field Linear does not have
  AgentActivity declares members Linear does not: body, session, type

Tests  5 failed | 7 passed (12)
```

All nine guarded types now pass on merit, with no allowlist entry.

## What changed

| input | removed | now |
| -- | -- | -- |
| `AgentSessionCreateOnIssue` | `appUserId`, `plan` | `issueId`, `externalUrls` |
| `AgentSessionCreateOnComment` | `appUserId`, `plan` | `commentId`, `externalUrls` |
| `AgentSessionUpdateInput` | `id`, `status` | `plan`, `externalUrls` |
| `AgentActivityCreateInput` | `sessionId`, `type`, `body` | `agentSessionId`, `content`, `signal`, `ephemeral` |

`agentSessionUpdate(id:)` is now `String!`.

**Status is no longer settable.** Linear has no field to set it with; it follows the emitted activity, which is Linear's documented model ("updated automatically based on the agent's emitted activities. No manual state management is required."). `agentActivityCreate` moves it: `thought`/`action` → `active`, `elicitation` → `awaitingInput`, `response` → `complete`, `error` → `error`, `prompt` → `pending`. Linear does not publish that table and introspection cannot show behaviour, so it is the **one** invented thing here and it is registered in `REFERENCE-DIVERGENCES.md` as twin-owned, not passed off as upstream truth. Deriving nothing would freeze every session at `pending`, which is worse fidelity than a named guess.

**`AgentActivity` follows the input** onto `content` / `agentSession` / `signal`, `user: User!`. Accepting Linear's `content` while emitting an invented `body` would round-trip to neither Linear nor itself. `agent_activities` gains `content_json` and `signal` and drops `body`; an existing `LINEAR_TWIN_DB` file migrates on open, with `action` rows backfilling an empty `parameter` because the old shape had nowhere to keep one.

`appUserId` survives on the **domain** command only, never over GraphQL — the twin creates sessions internally when an issue is delegated or an app is @mentioned, and upstream that identity arrives with the credential rather than in the input.

## The guard can fail, and that is now a test

Not a manual observation. `it.each` splices an invented member into the twin's **own** SDL via `printSchema`, rebuilds it through `buildSchema` exactly as `src/graphql/schema.ts` does, and asserts the guard names exactly that member — for `status` on the update input, `appUserId` on both creates, `sessionId` on activity create, `body` on `AgentActivity`, `externalUrl` on `AgentSession`, plus an invented enum member. Each case also asserts the real schema reports `[]` first, so the test cannot pass by comparing nothing. If the check is ever softened into a no-op, these go red.

Also added `test/agent-session-inputs.test.ts`: every invented field is rejected over the wire with the GraphQL error naming it, `id` is required as an argument, the full six-row status table is exercised end to end, `signal` round-trips and an undeclared signal is rejected, and malformed `content` (missing body, unknown key, non-`AgentActivityType`, action without parameter) is a loud error rather than a silent stub.

## Migration

No corpus change was needed. In-repo callers migrated in this PR: `partial-update-tristate.test.ts` seeds a plan through `agentSessionUpdate` instead of the create input and no longer sets `status`; `domain/{agents,normalize,rows,index,linear-domain}.ts`, `graphql/{schema,mutation-inputs,resolvers,formatters}.ts`, `types.ts`, `db.ts` and `state.ts` follow the rename.

## Left open, deliberately

Two scalar-level divergences, written up in `REFERENCE-DIVERGENCES.md` rather than fixed, because the guard is name-based by F-1172's design: input `plan` is `String` where upstream is `JSONObject`, and output `content` is `JSON!` where upstream is the `AgentActivityContent` union.

## Gates

`npm run typecheck` exit 0. `npm test` exit 0 — 10 suites, all passing. `knip`, `lint-code-health`, `check-copy-markers`, `no-catch-and-continue`, `check-twin-leaf-portability`, `check-twin-chunk-laziness`, `check-workspace-pins-match-workspace`, `lint-no-cloud-imports`, `capture-mcp-tools-list --check --offline` and `check-version-bump-required` all clean. Versions: twin-linear 0.4.0, `@pome-sh/cli` 0.21.14 (the CLI inlines the twin into its bundle).
