### PR TITLE
The redactor gets named, and the slots `subject` does not cover get counted (F-1157)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,24 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.21.15
+
+### Patch Changes
+
+- Two of the bundled twins' declared checks change what they say when a scoring
+  redactor has eaten the thing they were asked about (F-1157). `packages/sdk`
+  and `packages/twin-{gmail,slack}` changed, which is publish-relevant for the
+  CLI because it inlines both into its bundle.
+
+  Nothing a `pome run --local` user can observe moves: scoring is a hosted
+  feature and these declarations are read by the grader, not by the CLI. On the
+  hosted side, `gmail.mailbox-label-count` now reports `mailbox_redacted` rather
+  than `mailbox_not_found` when the mailbox row survived with its address
+  masked — the same skip, a reason that points at the redactor instead of at a
+  correct seed — and `slack.no-reaction-added` declares its reaction name as its
+  subject, so a criterion whose reaction name the redactor destroyed is skipped
+  at the door instead of passing over an export where the reaction was added.
+
 ## 0.21.14
 
 ### Patch Changes

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.21.14",
+  "version": "0.21.15",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/packages/checks/CHANGELOG.md
+++ b/packages/checks/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @pome-sh/checks
 
+## 0.1.2
+
+Carries F-1157 to the grader. Three things move in `dist/`:
+
+- `@pome-sh/checks/dsl` gains `probeRedactionSurvival`, `REDACTION_PLACEHOLDER`
+  and `isRedacted` — the measurement of what protects a criterion whose
+  redaction-destroyed literal is NOT its declared `subject`. `REDACTION_PLACEHOLDER`
+  is the check-side half of a cross-repo contract: the token pome-cloud's state
+  redactor writes is the token these predicates recognise, and it is declared
+  once here rather than spelled twice.
+- `@pome-sh/checks/gmail` — `gmail.mailbox-label-count` answers
+  `mailbox_redacted ("…")` where the mailbox row survived with its address
+  masked, and keeps `mailbox_not_found ("…")` for an export that lists real
+  addresses and not this one. Same `skipped` status either way; only the reason
+  a report renders changes.
+- `@pome-sh/checks/slack` — `slack.no-reaction-added` declares its reaction name
+  as its `subject`, so the engine's redaction-survival arm skips such a
+  criterion at the door instead of letting a masked `reactions[].name` satisfy
+  a negative assertion.
+
 ## 0.1.1
 
 No change to the published surface — `dist/` is byte-identical to 0.1.0, so no

--- a/packages/checks/package.json
+++ b/packages/checks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/checks",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pome's grading vocabulary — the check declarations, seed schemas and default seeds of all five digital twins, plus the check DSL they are written in. Declarations only: no twin server, no database, no routes, no tools.",
   "private": false,
   "type": "module",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,6 +1,36 @@
 # @pome-sh/sdk
 
 
+## 0.11.5 — 2026-08-08
+
+New `check-redaction.ts`, reachable from `@pome-sh/sdk/checks`:
+`probeRedactionSurvival`, `REDACTION_PLACEHOLDER` and `isRedacted` (F-1157).
+
+`subject` closes the DETECTABLE half of the redaction class, and closes it at
+the engine's door — a criterion whose declared subject the redactor destroys is
+skipped before `evaluate` is called. That arm reads the DECLARATION and never
+the state, deliberately, because it is what makes the authoring door and the
+scoring door agree by construction. Nothing measured the other half: a slot the
+subject arm does not name, which a redactor eats anyway.
+
+`probeRedactionSurvival` measures it, per declared slot, by destroying that
+slot's literal inside the check's own `discriminatingWorlds` and reading both
+verdicts. The question is asked of the FAILING world — does a real `failed`
+become a real `passed` — because the passing world passes by construction and
+cannot tell a predicate that re-derived the fact from one whose assertion went
+trivial. An earlier version asked only the passing arm and reported all ten of
+twin-github's `{repo}` slots as vacuous passes, when `findRepo` had simply
+matched on `owner`/`name` after `full_name` was masked.
+
+Seven outcomes, of which one is a wrong verdict rather than a missing one:
+`vacuous_pass`, `abstains`, `false_fail`, `discriminates_anyway`,
+`declared_subject`, `absent_from_world`, `throws`. Each twin's
+`checks-contract.test.ts` forbids `vacuous_pass` and `throws` outright and
+ledgers the rest, so the class is counted rather than assumed.
+
+Additive: no existing export moved and no declaration's behaviour changed.
+
+
 ## 0.11.4 — 2026-08-07
 
 `loadMcpToolFixture` and the rest of `mcp-tool-fixture.ts` are now reachable on

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/sdk",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Twin engine for Pome digital twins \u2014 defineTwin() + serve(): HTTP mounting, bearer auth, trace recorder, MCP dispatch, SQLite-backed state.",
   "private": true,
   "type": "module",

--- a/packages/sdk/src/check-redaction.ts
+++ b/packages/sdk/src/check-redaction.ts
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// What protects a criterion whose redaction-destroyed literal is NOT its
+// declared `subject` (F-1157).
+//
+// `subject` closes the DETECTABLE half of this class, and closes it at the
+// door: the consuming engine renders the declared subject, runs it past the
+// team's redaction pipeline, and — when the redactor destroys it — skips the
+// criterion before `evaluate` is ever called. That arm reads the DECLARATION
+// and never the state, deliberately, because that is what makes the authoring
+// door and the scoring door agree by construction.
+//
+// The undetectable half arrived with a witness. `gmail.mailbox-label-count`
+// declares `subject: ({ label }) => label`; its `{label}` (`SENT`) survives
+// every first-party redactor, so the arm waves the criterion through. The slot
+// that actually got eaten was `{mailbox}`, which `DEFAULT_REDACTION_CONFIG`
+// masks (`mailboxes[].email`), and which the subject arm never looks at. The
+// skip surfaced from INSIDE `evaluate` instead — safe, but by that one check's
+// own guard, per check, with nothing measuring the class.
+//
+// This module measures the class.
+//
+// ─── The question, and why it takes BOTH worlds to ask ──────────────────────
+//
+// The naive probe destroys a slot's literal in the check's passing world and
+// asks whether it still passes. That question cannot be answered: the passing
+// world passes by construction, so "still passes" conflates the check that
+// re-derived the same true fact from surviving state with the check whose
+// assertion just became trivial. Measured over the five twins it called all ten
+// of twin-github's `{repo}` slots a vacuous pass, when what actually happened is
+// that `findRepo` matched on `owner`/`name` after `full_name` was masked — the
+// predicate did its work, correctly, on a spelling the redactor had not eaten.
+//
+// So the question is asked of the FAILING world instead: destroy the literal
+// there and see whether a real `failed` turns into a real `passed`. That is
+// what a vacuous pass IS — a wrong agent blessed because the grader went blind —
+// and it is a question with a definite answer, because `discriminatingWorlds`
+// already guarantees that world fails for a reason the assertion owns.
+//
+// Both worlds still get destroyed and both verdicts read, because the passing
+// arm carries the OTHER cost: a check that starts refusing (`abstains`) drops a
+// criterion out of the denominator, and one that starts really failing
+// (`false_fail`) marks a correct agent down for the grader's blindness. Neither
+// is the defect the gate forbids, but a class nobody counted is how F-1157
+// happened, so both are named and both are ledgered.
+//
+//   declared_subject       the engine already refuses at the door; `evaluate` is
+//                          never reached, so there is nothing here to measure
+//   vacuous_pass           the failing world PASSES with the literal gone. THE
+//                          defect, and the one every twin's contract test
+//                          forbids outright
+//   abstains               the check's own guard returned `skipped` — the honest
+//                          answer, and the one `gmail.mailbox-label-count` gives
+//   false_fail             a real `failed` verdict computed over a state the
+//                          predicate could not read
+//   discriminates_anyway   both worlds kept their verdicts: the fact the
+//                          predicate needed survives elsewhere in the export
+//   absent_from_world      the literal appears in neither world, so no redactor
+//                          could have eaten it — a count slot, an arity word, a
+//                          `oneOf` member the world spells differently
+//   throws                 the predicate crashed. Also never allowed: a
+//                          criterion may leave the denominator, but it may not
+//                          take the evaluator with it
+//
+// ─── Why the strictest reading of the world ─────────────────────────────────
+//
+// Same bargain `probeStateCitation` struck: it reuses the worlds a check ALREADY
+// declares rather than asking for a second fixture, which is what makes the gate
+// cheap enough to hold across five twins.
+//
+// The destruction is deliberately stricter than any redaction config we have
+// seen: every occurrence of the literal, in `seed`, `final` AND `tape`, not just
+// the one field a particular config names. `DEFAULT_REDACTION_CONFIG` masks
+// `mailboxes[].email` and leaves `messages[].mailboxEmail` alone — but a team's
+// redaction config is that team's to write, not the twin's to predict, and a
+// safety property that holds only against the configs we happen to know is not a
+// property. Whole-value equality rather than substring: a config masks a FIELD,
+// and a literal that survives as a substring of some larger prose is exactly the
+// case `subject` already covers at the door.
+//
+// ─── Two things it does not model, and one of them has a ticket ─────────────
+//
+// Stated because a gate whose reach is unwritten gets read as wider than it is.
+//
+// 1. A SECTION THAT IS ABSENT, rather than a value that was masked. This probe
+//    only ever REPLACES strings; it never deletes a top-level collection, so a
+//    check that reads `(final.reactions ?? []).some(…)` and scores a negative
+//    criterion `passed` over an export carrying no `reactions` at all is
+//    invisible here — and that is a live defect, not a hypothetical
+//    (`slack.no-reaction-added`, F-1159, guarded in the consuming engine's
+//    `STATE_SECTION_GUARDS` while its state lives in twin-slack). It is the same
+//    direction of failure as `vacuous_pass` and a different axis of cause, so it
+//    has its own instrument: the engine's `findVacuousStateSectionReaders`,
+//    which swaps and deletes SECTIONS where this one destroys LITERALS. Neither
+//    subsumes the other and a green run here says nothing about that one.
+//
+// 2. A redactor that eats a COMPONENT of a slot's literal rather than the
+//    literal itself. twin-github spells `{repo}` three ways in one export
+//    (`full_name`, and `owner` + `name` separately), and masking `owner` alone
+//    would leave `acme/api` intact everywhere this probe looks while still
+//    blinding `findRepo`'s second arm. That is a different question — "which
+//    FIELDS does this predicate depend on" rather than "what happens when this
+//    criterion's literal is destroyed" — and answering it needs a field-level
+//    dependency declaration nothing in the vocabulary has. The decomposition is
+//    why `github.issue-exists`'s `{repo}` reads `discriminates_anyway` here
+//    rather than `abstains`.
+
+import type { CheckDefinition, CheckOutcome } from "./checks.js";
+
+/**
+ * The token a scoring redactor leaves in place of a value it masked.
+ *
+ * Declared HERE rather than imported from `@pome-sh/wire`, and the distinction
+ * is not pedantic. Wire's redactor scrubs secrets out of a recorded TRACE on the
+ * way to disk; the redactor that eats a check's literal is the consuming
+ * engine's STATE redactor, which runs in pome-cloud against a team's own config.
+ * Two producers, two lifetimes — they agree on the bytes today, and making one
+ * import the other's constant would assert a shared fact neither repo checks.
+ *
+ * So this is the check-side half of that contract, published on
+ * `@pome-sh/checks/dsl` so the engine writing the token and the predicates
+ * recognising it can read it from one place.
+ */
+export const REDACTION_PLACEHOLDER = "[REDACTED]";
+
+/**
+ * Did a redactor eat this value?
+ *
+ * A recogniser, not a proof: a team whose config writes some other placeholder
+ * gets `false` here, and the predicate that asked falls back to whatever it said
+ * before — the status quo, never a wrong verdict. Which is why the vacuous-pass
+ * gate below does not depend on this function at all: it destroys the literal
+ * itself and reads the verdict, so a check that never calls `isRedacted` is
+ * measured exactly as strictly as one that does.
+ */
+export function isRedacted(value: string | null | undefined): boolean {
+  return value === REDACTION_PLACEHOLDER;
+}
+
+export type RedactionGuard =
+  | "declared_subject"
+  | "vacuous_pass"
+  | "abstains"
+  | "false_fail"
+  | "discriminates_anyway"
+  | "absent_from_world"
+  | "throws";
+
+export interface RedactionSurvivalRow {
+  readonly param: string;
+  readonly guard: RedactionGuard;
+  // What the check said, verbatim, so a ledger entry can be read — and a drift
+  // in it explained — without re-running the probe.
+  readonly detail: string;
+}
+
+export type RedactionSurvivalVerdict =
+  // Every declared slot classified, in `params` order.
+  | { kind: "measured"; rows: readonly RedactionSurvivalRow[] }
+  // The declaration named no worlds. The CALLER must find a ledger entry — this
+  // function deliberately does not know about ledgers, exactly as
+  // `probeDiscrimination` and `probeStateCitation` do not, so a twin cannot
+  // satisfy the gate by shipping an empty one.
+  | { kind: "declined" };
+
+/**
+ * The same tree with every occurrence of `literal` replaced by the placeholder.
+ *
+ * Case-insensitive, because every twin's predicates compare that way — a
+ * redactor that masked `Pome-Agent@…` would otherwise read as untouched to a
+ * check that would have matched it.
+ *
+ * Returns `hit` so the caller can tell "the redactor ate it" from "there was
+ * nothing here to eat", which are different findings and get different names.
+ */
+function destroyLiteral(tree: unknown, literal: string): { tree: unknown; hit: boolean } {
+  const wanted = literal.toLowerCase();
+  let hit = false;
+
+  const walk = (node: unknown): unknown => {
+    if (typeof node === "string") {
+      if (node.toLowerCase() !== wanted) return node;
+      hit = true;
+      return REDACTION_PLACEHOLDER;
+    }
+    if (Array.isArray(node)) return node.map(walk);
+    // `typeof null === "object"`, so the null guard is not redundant.
+    if (node === null || typeof node !== "object") return node;
+    return Object.fromEntries(
+      Object.entries(node as Record<string, unknown>).map(([key, value]) => [key, walk(value)]),
+    );
+  };
+
+  return { tree: walk(tree), hit };
+}
+
+interface World<TState> {
+  seed: TState | null;
+  final: TState;
+  tape: readonly unknown[] | null;
+}
+
+function destroyWorld<TState>(
+  world: World<TState>,
+  literal: string,
+): { world: World<TState>; hit: boolean } {
+  const seed = destroyLiteral(world.seed, literal);
+  const final = destroyLiteral(world.final, literal);
+  const tape = destroyLiteral(world.tape, literal);
+  return {
+    world: {
+      seed: seed.tree as TState | null,
+      final: final.tree as TState,
+      tape: tape.tree as readonly unknown[] | null,
+    },
+    hit: seed.hit || final.hit || tape.hit,
+  };
+}
+
+const describeOutcome = (outcome: CheckOutcome): string =>
+  `passed=${outcome.passed} status=${outcome.status ?? "-"} reason=${JSON.stringify(outcome.reason)}`;
+
+/**
+ * What the check says with one literal gone, or the crash it produced instead.
+ *
+ * The catch RETURNS rather than falling through, exactly as
+ * `check-discrimination.ts`'s `reasonOnEmptyWorld` does: D4's
+ * no-catch-and-continue gate is right to forbid the assign-and-continue shape,
+ * and a predicate that crashes is itself one of the answers this probe reports.
+ */
+function say(evaluate: () => CheckOutcome): CheckOutcome | { threw: string } {
+  try {
+    return evaluate();
+  } catch (error) {
+    return { threw: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+const isRealPass = (outcome: CheckOutcome): boolean =>
+  outcome.passed === true && (outcome.status === undefined || outcome.status === "passed");
+
+function classify(
+  passing: CheckOutcome | { threw: string },
+  failing: CheckOutcome | { threw: string },
+): { guard: RedactionGuard; detail: string } {
+  if ("threw" in passing) return { guard: "throws", detail: `passing world: ${passing.threw}` };
+  if ("threw" in failing) return { guard: "throws", detail: `failing world: ${failing.threw}` };
+
+  // FIRST, because it is the only one of these that is a wrong verdict rather
+  // than a missing one: the world this check declared as its failure now reads
+  // as a success, purely because the grader stopped being able to see.
+  if (isRealPass(failing)) {
+    return { guard: "vacuous_pass", detail: `failing world now passes — ${describeOutcome(failing)}` };
+  }
+  if (passing.status === "skipped") {
+    return { guard: "abstains", detail: describeOutcome(passing) };
+  }
+  if (isRealPass(passing)) {
+    return { guard: "discriminates_anyway", detail: describeOutcome(passing) };
+  }
+  return { guard: "false_fail", detail: `passing world now fails — ${describeOutcome(passing)}` };
+}
+
+/**
+ * For every slot this check declares, what stands between a redactor that eats
+ * that slot's literal and a vacuous pass.
+ *
+ * The subject arm is credited without evaluating: when the destroyed literal IS
+ * (or is inside) the declared subject, the engine never calls `evaluate`, so
+ * running the predicate anyway would measure a code path production cannot
+ * reach and file its answer under this check's name.
+ *
+ * `includes`, not equality, on that comparison. A subject is usually one arg
+ * verbatim, but a declaration may compose one, and a redactor that masks a
+ * component masks the composed string too.
+ */
+export function probeRedactionSurvival<TState, TArgs extends Record<string, string>>(
+  def: CheckDefinition<TState, TArgs>,
+  args: TArgs,
+): RedactionSurvivalVerdict {
+  const worlds = def.discriminatingWorlds(args);
+  if (worlds === null) return { kind: "declined" };
+
+  const subject = def.subject?.(args) ?? null;
+  const rows: RedactionSurvivalRow[] = [];
+
+  for (const param of Object.keys(def.params)) {
+    const literal = args[param as keyof TArgs];
+    if (typeof literal !== "string" || literal === "") continue;
+
+    if (subject !== null && subject.toLowerCase().includes(literal.toLowerCase())) {
+      rows.push({
+        param,
+        guard: "declared_subject",
+        detail: `the engine skips the criterion before evaluate — subject ${JSON.stringify(subject)}`,
+      });
+      continue;
+    }
+
+    const passing = destroyWorld(worlds.passing, literal);
+    const failing = destroyWorld(worlds.failing, literal);
+    if (!passing.hit && !failing.hit) {
+      rows.push({
+        param,
+        guard: "absent_from_world",
+        detail: `${JSON.stringify(literal)} appears in neither declared world`,
+      });
+      continue;
+    }
+
+    rows.push({
+      param,
+      ...classify(
+        say(() => def.evaluate(args, passing.world as never)),
+        say(() => def.evaluate(args, failing.world as never)),
+      ),
+    });
+  }
+
+  return { kind: "measured", rows };
+}

--- a/packages/sdk/src/checks.ts
+++ b/packages/sdk/src/checks.ts
@@ -480,19 +480,20 @@ export function parseCheck<TState, TArgs extends Record<string, string>>(
   return args as TArgs;
 }
 
-// The probe lives in its own module because it EXERCISES declarations, where
-// everything above DEFINES the grammar — and because this file hit the 500-LOC
-// health limit, which was a fair reading of that seam rather than an obstacle.
-//
-// Re-exported here so `@pome-sh/sdk/checks` keeps one import site: consumers ask
-// the vocabulary module about the vocabulary, and the split stays internal.
+// Everything above DEFINES the grammar; the three modules below EXERCISE a
+// declaration written in it — do its declared worlds disagree (F-1126), does its
+// state citation resolve (F-1197), and what protects a slot the `subject` arm
+// never looks at when a redactor eats its literal (F-1157). Each split off when
+// this file reached the 500-LOC health limit, a fair reading of that seam. All
+// three are re-exported here so `@pome-sh/sdk/checks` keeps ONE import site:
+// consumers ask the vocabulary module about the vocabulary, and the split stays
+// internal.
 export { probeDiscrimination } from "./check-discrimination.js";
-
-// F-1197 — the pointer grammar `CheckOutcome.evidenceStatePaths` is written in,
-// re-exported for the same reason: a declaration builds a pointer, a consumer
-// resolves one, and both reach for `@pome-sh/sdk/checks` rather than learning
-// which internal module the split put them in.
 export {
   statePath, childStatePath, resolveStatePath, probeStateCitation,
   type StateCitationArm, type StateCitationVerdict,
 } from "./check-state-path.js";
+export {
+  REDACTION_PLACEHOLDER, isRedacted, probeRedactionSurvival,
+  type RedactionGuard, type RedactionSurvivalRow, type RedactionSurvivalVerdict,
+} from "./check-redaction.js";

--- a/packages/sdk/test/check-redaction.test.ts
+++ b/packages/sdk/test/check-redaction.test.ts
@@ -1,0 +1,204 @@
+// What protects a criterion whose redaction-destroyed literal is not its
+// declared `subject` (F-1157).
+//
+// These are properties of the PROBE, not of any twin's vocabulary — the
+// per-twin gate ("no declared slot, on any check, lets a destroyed literal turn
+// the check's own failing world into a pass") lives in each
+// `checks-contract.test.ts`, where the declarations actually ship.
+//
+// The one that is load-bearing rather than ceremony is the guard-fires case
+// below. A gate that has never been seen to go red is a gate nobody can tell
+// from a gate that cannot: the first version of this probe asked only whether
+// the PASSING world still passed, which is a question that world answers `true`
+// by construction, and it reported ten of twin-github's `{repo}` slots as
+// vacuous passes when `findRepo` had simply matched on `owner`/`name`. Both
+// halves of that story are pinned here — the check that really does go vacuous,
+// and the one that only looks like it.
+
+import { describe, expect, it } from "vitest";
+import { defineCheck, VACUITY_SENTINEL, type CheckParamType } from "../src/checks.js";
+import {
+  isRedacted,
+  probeRedactionSurvival,
+  REDACTION_PLACEHOLDER,
+} from "../src/check-redaction.js";
+
+interface World {
+  reactions?: { name: string }[];
+  repo?: { full_name: string; owner: string; name: string };
+  count?: number;
+}
+
+const word: CheckParamType = {
+  name: "word",
+  pattern: "[A-Za-z_-]+",
+  example: "cheer",
+  render: (value) => value,
+  parse: (raw) => raw,
+};
+
+const number: CheckParamType = {
+  name: "number",
+  pattern: "[0-9]+",
+  example: "1",
+  render: (value) => value,
+  parse: (raw) => raw,
+};
+
+const finalWorld = (final: World) => ({ seed: null, final, tape: null });
+
+// The shape twin-slack's `no-reaction-added` had: a NEGATIVE criterion that
+// scans a literal and does not declare it. Masking the literal does not blind
+// this predicate, it SATISFIES it.
+const negativeScanNoSubject = defineCheck<World, { reaction: typeof word }>({
+  id: "toy.no-reaction",
+  description: "Asserts no reaction row carries the named emoji.",
+  template: 'No "{reaction}" reaction was added',
+  params: { reaction: word },
+  substrate: "final",
+  polarity: () => "negative",
+  subject: () => null,
+  vacuityMutant: (args) => ({ ...args, reaction: VACUITY_SENTINEL }),
+  discriminatingWorlds: ({ reaction }) => ({
+    passing: finalWorld({ reactions: [] }),
+    failing: finalWorld({ reactions: [{ name: reaction }] }),
+  }),
+  evaluate({ reaction }, { final }) {
+    const hit = (final.reactions ?? []).some((row) => row.name === reaction);
+    return { passed: !hit, reason: hit ? `found ${reaction}` : `no ${reaction}` };
+  },
+});
+
+// The same predicate with the slot declared. Nothing else moves.
+const negativeScanWithSubject = defineCheck<World, { reaction: typeof word }>({
+  ...negativeScanNoSubject,
+  id: "toy.no-reaction-declared",
+  subject: ({ reaction }) => reaction,
+  params: { reaction: word },
+});
+
+// twin-github's `{repo}`, in miniature: the export spells the literal three
+// ways and the lookup tries two, so masking one spelling changes no verdict.
+const selectorSpelledTwice = defineCheck<World, { repo: CheckParamType }>({
+  id: "toy.repo-has-owner",
+  description: "Resolves the repo by full name or by owner/name, then asserts it is present.",
+  template: "The repo {repo} exists",
+  params: { repo: { ...word, name: "repo", pattern: "[A-Za-z]+/[A-Za-z]+", example: "acme/api" } },
+  substrate: "final",
+  polarity: () => "positive",
+  subject: () => null,
+  vacuityMutant: () => null,
+  discriminatingWorlds: ({ repo }) => {
+    const [owner, name] = repo.split("/") as [string, string];
+    return {
+      passing: finalWorld({ repo: { full_name: repo, owner, name } }),
+      failing: finalWorld({}),
+    };
+  },
+  evaluate({ repo }, { final }) {
+    const row = final.repo;
+    const found =
+      row != null && (row.full_name === repo || `${row.owner}/${row.name}` === repo);
+    return { passed: found, reason: found ? `${repo} exists` : `${repo} not found` };
+  },
+});
+
+// A slot the export never carries as a string: the criterion says `2`, the tree
+// holds the number 2.
+const derivedCount = defineCheck<World, { count: typeof number }>({
+  id: "toy.count-is",
+  description: "Compares the exported count against the number the criterion names.",
+  template: "The count is {count}",
+  params: { count: number },
+  substrate: "final",
+  polarity: () => "positive",
+  subject: () => null,
+  vacuityMutant: (args) => ({ ...args, count: "987654321" }),
+  discriminatingWorlds: ({ count }) => ({
+    passing: finalWorld({ count: Number(count) }),
+    failing: finalWorld({ count: Number(count) + 1 }),
+  }),
+  evaluate({ count }, { final }) {
+    const passed = final.count === Number(count);
+    return { passed, reason: `count is ${final.count} (wanted ${count})` };
+  },
+});
+
+const guardOf = (verdict: ReturnType<typeof probeRedactionSurvival>, param: string) => {
+  if (verdict.kind !== "measured") throw new Error("expected a measured verdict");
+  return verdict.rows.find((row) => row.param === param)?.guard;
+};
+
+describe("probeRedactionSurvival", () => {
+  it("catches the negative check whose scanned literal is not its subject", () => {
+    // THE guard-fires case. Without it this whole gate could be green because it
+    // never asks a question anything can fail.
+    const verdict = probeRedactionSurvival(negativeScanNoSubject, { reaction: "white_check_mark" });
+    expect(guardOf(verdict, "reaction")).toBe("vacuous_pass");
+  });
+
+  it("credits the same predicate once the slot is declared, without evaluating", () => {
+    // The engine never calls `evaluate` for a criterion whose subject the
+    // redactor destroyed, so running the predicate anyway would measure a path
+    // production cannot reach and file the answer under this check's name.
+    const verdict = probeRedactionSurvival(negativeScanWithSubject, {
+      reaction: "white_check_mark",
+    });
+    expect(guardOf(verdict, "reaction")).toBe("declared_subject");
+  });
+
+  it("does not mistake a selector the export spells twice for a vacuous pass", () => {
+    // The regression that made the probe read BOTH worlds. Asking only "does the
+    // passing world still pass" calls this `vacuous_pass`; asking the failing
+    // world gets the right answer, because that world still fails.
+    const verdict = probeRedactionSurvival(selectorSpelledTwice, { repo: "acme/api" });
+    expect(guardOf(verdict, "repo")).toBe("discriminates_anyway");
+  });
+
+  it("says a literal the world never carries as a string was never at risk", () => {
+    const verdict = probeRedactionSurvival(derivedCount, { count: "2" });
+    expect(guardOf(verdict, "count")).toBe("absent_from_world");
+  });
+
+  it("declines when the declaration names no worlds", () => {
+    const noWorlds = defineCheck<World, { reaction: typeof word }>({
+      ...negativeScanNoSubject,
+      id: "toy.no-worlds",
+      params: { reaction: word },
+      discriminatingWorlds: () => null,
+    });
+    expect(probeRedactionSurvival(noWorlds, { reaction: "cheer" }).kind).toBe("declined");
+  });
+
+  it("reports a predicate that crashes rather than crashing with it", () => {
+    const crashes = defineCheck<World, { reaction: typeof word }>({
+      ...negativeScanNoSubject,
+      id: "toy.crashes",
+      params: { reaction: word },
+      evaluate({ reaction }, { final }) {
+        // Reads a field the destroyed world no longer shapes the way it expects.
+        if (final.reactions![0]!.name === reaction) return { passed: false, reason: "hit" };
+        return { passed: true, reason: "clear" };
+      },
+    });
+    expect(guardOf(probeRedactionSurvival(crashes, { reaction: "cheer" }), "reaction")).toBe(
+      "throws",
+    );
+  });
+});
+
+describe("isRedacted", () => {
+  it("recognises the placeholder a scoring redactor writes", () => {
+    expect(isRedacted(REDACTION_PLACEHOLDER)).toBe(true);
+  });
+
+  it("answers false for anything else, including absence", () => {
+    // A recogniser, not a proof. A team whose redactor writes some other token
+    // gets `false`, and the predicate that asked falls back to whatever it said
+    // before — which is why no verdict may rest on this answer alone.
+    expect(isRedacted("***")).toBe(false);
+    expect(isRedacted("pome-agent@pome-twin.test")).toBe(false);
+    expect(isRedacted(null)).toBe(false);
+    expect(isRedacted(undefined)).toBe(false);
+  });
+});

--- a/packages/twin-github/test/checks-contract.test.ts
+++ b/packages/twin-github/test/checks-contract.test.ts
@@ -11,10 +11,12 @@ import {
   checkPattern,
   parseCheck,
   probeDiscrimination,
+  probeRedactionSurvival,
   probeStateCitation,
   renderCheck,
   type CheckDefinition,
   type CheckSubstrateKind,
+  type RedactionGuard,
 } from "@pome-sh/sdk/checks";
 import { describe, expect, it } from "vitest";
 import { GITHUB_CHECKS, type GitHubCheckState } from "../src/checks.js";
@@ -462,5 +464,111 @@ describe("declared state citations", () => {
         ).toBeUndefined();
       }
     }
+  });
+});
+
+// Which door stands between a redactor that eats a slot's literal and a wrong
+// verdict — one row per declared slot, MEASURED rather than argued (F-1157).
+//
+// The vocabulary of the values is in the sdk's `check-redaction.ts`. Only one of
+// them is a wrong verdict rather than a missing one — `vacuous_pass`, where the
+// check's OWN failing world starts passing once the literal is gone — and the
+// assertion below forbids it outright rather than ledgering it.
+//
+// GitHub is the twin that made the probe honest, and the reason is `{repo}`. An
+// exported repository spells its name THREE ways (`full_name`, and `owner` +
+// `name` separately) and `findRepo` tries two of them, so masking `acme/api`
+// leaves the lookup working off the components — the predicate does its job,
+// correctly, on a spelling the redactor did not eat. That is
+// `discriminates_anyway`, and an earlier probe that only asked "does the passing
+// world still pass" called all ten of them a vacuous pass.
+//
+// The `false_fail` rows are the class F-1157 asked to have counted before
+// deciding whether it needs a guard, and there are three. Each is a `oneOf` slot
+// compared against a state field (`{state}`, `{review}`), so a redactor that
+// masked that field would mark a correct agent down rather than bless a wrong
+// one. Nothing first-party masks a GitHub issue state or a review verdict; this
+// is the count, not a to-do.
+const REDACTION_GUARDS: Record<string, RedactionGuard> = {
+  // Issue and PR numbers are exported as NUMBERS, so the criterion's string `1`
+  // matches nothing a redactor could reach in either world.
+  "github.issue-exists · issue": "absent_from_world",
+  "github.issue-exists · repo": "discriminates_anyway",
+  "github.issue-state · issue": "absent_from_world",
+  "github.issue-state · repo": "discriminates_anyway",
+  "github.issue-state · state": "false_fail",
+  "github.issue-has-label · issue": "absent_from_world",
+  "github.issue-has-label · repo": "discriminates_anyway",
+  "github.issue-has-label · label": "declared_subject",
+  "github.issue-exactly-one-label · issue": "absent_from_world",
+  "github.issue-exactly-one-label · repo": "discriminates_anyway",
+  "github.issue-exactly-one-label · label": "declared_subject",
+  "github.issue-assignee · issue": "absent_from_world",
+  "github.issue-assignee · repo": "discriminates_anyway",
+  "github.issue-assignee · login": "declared_subject",
+  "github.issue-comment-contains · needle": "declared_subject",
+  "github.issue-comment-contains · issue": "absent_from_world",
+  "github.issue-comment-contains · repo": "discriminates_anyway",
+  // The two delta checks. They compare seed and final SETS and name no literal
+  // beyond the repo they scope to, which is why the redaction question reaches
+  // only the selector on both.
+  "github.no-new-issues · repo": "discriminates_anyway",
+  "github.no-new-labels · repo": "discriminates_anyway",
+  "github.pr-state · pr": "absent_from_world",
+  "github.pr-state · repo": "discriminates_anyway",
+  // `not merged` is a rendering of `merged: 0`, never a string in the export.
+  "github.pr-state · state": "absent_from_world",
+  "github.pr-comment-exists · pr": "absent_from_world",
+  "github.pr-comment-exists · repo": "discriminates_anyway",
+  "github.pr-review-exists · review": "false_fail",
+  "github.pr-review-exists · pr": "absent_from_world",
+  "github.pr-review-exists · repo": "discriminates_anyway",
+  "github.file-exists · path": "declared_subject",
+  "github.file-exists · repo": "discriminates_anyway",
+  "github.commit-status · context": "declared_subject",
+  "github.commit-status · repo": "discriminates_anyway",
+  "github.commit-status · state": "false_fail",
+  // A tape check, and the tape is redacted on the way to disk by a DIFFERENT
+  // redactor than the one this probe models. The subject arm covers it either
+  // way.
+  "github.tool-never-called · tool": "declared_subject",
+};
+
+describe("declared redaction survival", () => {
+  it("never turns a failing world into a passing one by destroying a literal", () => {
+    for (const check of CHECKS) {
+      const verdict = probeRedactionSurvival(check, FIXTURES[check.id]!);
+      // A check that names no worlds cannot be probed here either; the
+      // HONEST_NULL_WORLDS gate above is what makes that a costly admission.
+      if (verdict.kind === "declined") continue;
+      for (const row of verdict.rows) {
+        expect(
+          row.guard,
+          `${check.id}'s {${row.param}}: ${row.detail}. A redactor that eats this literal ` +
+            `turns the check's OWN failing world into a pass, so a criterion written on it ` +
+            `grades a leaking agent clean. Declare the slot as this check's \`subject\` — the ` +
+            `engine then skips at the door — or guard it inside \`evaluate\`.`,
+        ).not.toBe("vacuous_pass");
+        expect(
+          row.guard,
+          `${check.id}'s {${row.param}} crashed the evaluator: ${row.detail}. A criterion may ` +
+            `leave the denominator; it may not take the evaluator with it.`,
+        ).not.toBe("throws");
+      }
+    }
+  });
+
+  it("classifies every slot exactly as REDACTION_GUARDS records", () => {
+    // The count, held as a value so it cannot quietly change. A new check with
+    // no rows here fails, and so does a declaration that moves a slot from one
+    // door to another — including the good moves, which should be read on the
+    // way past rather than absorbed.
+    const measured: Record<string, RedactionGuard> = {};
+    for (const check of CHECKS) {
+      const verdict = probeRedactionSurvival(check, FIXTURES[check.id]!);
+      if (verdict.kind === "declined") continue;
+      for (const row of verdict.rows) measured[`${check.id} · ${row.param}`] = row.guard;
+    }
+    expect(measured).toEqual(REDACTION_GUARDS);
   });
 });

--- a/packages/twin-gmail/CHANGELOG.md
+++ b/packages/twin-gmail/CHANGELOG.md
@@ -1,6 +1,29 @@
 # @pome-sh/twin-gmail — CHANGELOG
 
 
+## 0.3.6 — 2026-08-08
+
+`gmail.mailbox-label-count` now tells its two ways of not finding a mailbox
+apart (F-1157). Both are still a `skipped` — no verdict changes — but the reason
+does.
+
+`DEFAULT_REDACTION_CONFIG` masks `mailboxes[].email`, which leaves the row in
+place with the address replaced. The check reported that as
+`mailbox_not_found ("pome-agent@pome-twin.test")`, which reads as a seed that
+forgot to declare a mailbox and sent whoever triaged the row to
+`examples/gmail-retry-notify/` to find a seed that is correct. That case now
+says `mailbox_redacted ("…")`; an export listing real addresses, none of them
+this one, still says `mailbox_not_found`.
+
+The recogniser is best-effort — a team whose redactor writes some other
+placeholder falls back to the old name — and the refusal is not: the skip
+happens on both branches, so no verdict rides on the guess.
+
+`subject` could not have done this. It names ONE literal, this check's is the
+`{label}` it actually scans, and the engine's redaction-survival arm reads the
+declaration rather than the state by design.
+
+
 ## 0.3.5 — 2026-08-06
 
 Its MCP tool table is now derived from `fixtures/mcp-tools-list.raw.json`

--- a/packages/twin-gmail/package.json
+++ b/packages/twin-gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-gmail",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Deterministic Gmail-shaped twin for agent testing — SQLite-backed domain core.",
   "private": true,
   "type": "module",

--- a/packages/twin-gmail/src/check-messages.ts
+++ b/packages/twin-gmail/src/check-messages.ts
@@ -12,7 +12,7 @@
 // Declarations only. The grammar rules they obey are in `checks.ts`, which
 // assembles them.
 
-import { defineCheck, VACUITY_SENTINEL } from "@pome-sh/sdk/checks";
+import { defineCheck, isRedacted, VACUITY_SENTINEL } from "@pome-sh/sdk/checks";
 import type { Check } from "./check-kind.js";
 import { countWord, exactCount, labelRef, mailboxRef, messageId, parseCount } from "./check-params.js";
 import {
@@ -153,7 +153,33 @@ export const mailboxLabelCount: Check<{ mailbox: string; count: string; label: s
         final.mailboxes != null &&
         !final.mailboxes.some((mb) => (mb.email ?? "").toLowerCase() === mailbox.toLowerCase())
       ) {
-        return { passed: false, status: "skipped", reason: `mailbox_not_found ("${mailbox}")` };
+        // TWO ways to not find it, and only one of them is a seed defect
+        // (F-1157). `DEFAULT_REDACTION_CONFIG` — the strictest team, and what a
+        // corpus is deliberately measured against — masks `mailboxes[].email`,
+        // which leaves the ROW in place with the address replaced: the mailbox
+        // is in the export and simply unreadable. Reporting that as
+        // `mailbox_not_found` sends whoever triages the row to
+        // `examples/gmail-retry-notify/` looking for a seed that forgot a
+        // mailbox, and that seed declares it.
+        //
+        // `subject` cannot make this distinction for us. It names ONE literal,
+        // this check's is the `{label}` it actually scans, and the engine's
+        // redaction-survival arm reads the DECLARATION rather than the state by
+        // design — which is what makes the authoring door and the scoring door
+        // agree by construction. So the slot that got eaten here is one no arm
+        // upstream can see, and naming it is the check's own job.
+        //
+        // The recogniser is best-effort by construction: a team whose redactor
+        // writes some other placeholder falls back to `mailbox_not_found`, which
+        // is the status quo rather than a regression. What is NOT best-effort is
+        // the refusal — the skip happens on both branches, so the criterion
+        // leaves the denominator either way and no verdict rides on the guess.
+        const eaten = final.mailboxes.some((mb) => isRedacted(mb.email));
+        return {
+          passed: false,
+          status: "skipped",
+          reason: eaten ? `mailbox_redacted ("${mailbox}")` : `mailbox_not_found ("${mailbox}")`,
+        };
       }
       const ids = labelIdsFor(final, label);
       const labeled = new Set(

--- a/packages/twin-gmail/test/checks-contract.test.ts
+++ b/packages/twin-gmail/test/checks-contract.test.ts
@@ -11,10 +11,13 @@ import {
   checkPattern,
   parseCheck,
   probeDiscrimination,
+  probeRedactionSurvival,
   probeStateCitation,
+  REDACTION_PLACEHOLDER,
   renderCheck,
   type CheckDefinition,
   type CheckSubstrateKind,
+  type RedactionGuard,
 } from "@pome-sh/sdk/checks";
 import { describe, expect, it } from "vitest";
 import { GMAIL_CHECKS, type GmailCheckState } from "../src/checks.js";
@@ -26,6 +29,7 @@ import {
   oneMessagePerRecipient,
 } from "../src/check-messages.js";
 import { noUnsupportedEndpoint } from "../src/check-tape.js";
+import { finalWorld } from "../src/check-worlds.js";
 
 // The declarations are a heterogeneous tuple, so iterating them yields a union
 // whose args type differs per check, while the fixtures below are looked up by
@@ -469,5 +473,129 @@ describe("declared state citations", () => {
         ).toBeUndefined();
       }
     }
+  });
+});
+
+describe("gmail.mailbox-label-count's two ways of not finding a mailbox", () => {
+  // F-1157. Both are a skip and neither is a wrong verdict, so this is entirely
+  // about the NAME a reader gets — which is the whole cost the ticket measured.
+  // `mailbox_not_found` sends whoever triages the row to
+  // `examples/gmail-retry-notify/` looking for a seed that forgot to declare a
+  // mailbox; when a redactor ate the address instead, that seed is correct and
+  // the reader has been sent to the wrong repo.
+  const ARGS = { mailbox: "pome-agent@pome-twin.test", count: "5", label: "SENT" };
+  const worldWithMailboxes = (mailboxes: { email: string }[]) =>
+    finalWorld({
+      mailboxes,
+      messages: [],
+      drafts: [],
+      labels: [],
+      messageLabels: [],
+      exportBounds: { messageBodiesOmitted: true, largeMailbox: false, truncatedCollections: [] },
+    });
+
+  it("says mailbox_not_found when the export lists real addresses and none is this one", () => {
+    const outcome = mailboxLabelCount.evaluate(
+      ARGS,
+      worldWithMailboxes([{ email: "someone-else@pome-twin.test" }]),
+    );
+    expect(outcome.status).toBe("skipped");
+    expect(outcome.reason).toBe('mailbox_not_found ("pome-agent@pome-twin.test")');
+  });
+
+  it("says mailbox_redacted when the export lists a mailbox whose address was masked", () => {
+    const outcome = mailboxLabelCount.evaluate(ARGS, worldWithMailboxes([{ email: REDACTION_PLACEHOLDER }]));
+    expect(outcome.status).toBe("skipped");
+    expect(outcome.reason).toBe('mailbox_redacted ("pome-agent@pome-twin.test")');
+  });
+
+  it("still refuses when the placeholder is not one it recognises", () => {
+    // The recogniser is best-effort — a team's redactor may write anything — and
+    // this pins the degradation: the reason falls back to the old name, the
+    // SKIP does not fall back to anything. No verdict rides on the guess.
+    const outcome = mailboxLabelCount.evaluate(ARGS, worldWithMailboxes([{ email: "***" }]));
+    expect(outcome.status).toBe("skipped");
+    expect(outcome.reason).toBe('mailbox_not_found ("pome-agent@pome-twin.test")');
+  });
+});
+
+// Which door stands between a redactor that eats a slot's literal and a wrong
+// verdict — one row per declared slot, MEASURED rather than argued (F-1157).
+//
+// This twin is where the class was found. `gmail.mailbox-label-count` declares
+// `subject: ({ label }) => label`; `SENT` survives every redactor, so the
+// engine's redaction-survival arm waves the criterion through. The slot that
+// actually got eaten in production was `{mailbox}` —
+// `DEFAULT_REDACTION_CONFIG` masks `mailboxes[].email` — and that arm never
+// looks at it, by design: it reads the DECLARATION and never the state, which
+// is what makes the authoring door and the scoring door agree by construction.
+//
+// So the skip surfaced from inside `evaluate`, wearing a name chosen for a
+// different condition (`mailbox_not_found`, which reads as a seed that forgot to
+// declare a mailbox — and that seed declares it). Safe, but safe by that one
+// check's own guard, per check, with nothing measuring the class. `mailbox`
+// reading `abstains` below is that guard, now counted.
+//
+// The vocabulary of the values is in `check-redaction.ts`. The one that matters
+// is `vacuous_pass` — the check's own FAILING world starts passing with the
+// literal gone — and the assertion below forbids it outright rather than
+// ledgering it, because it is the one entry here that would be a wrong verdict
+// rather than a missing one.
+const REDACTION_GUARDS: Record<string, RedactionGuard> = {
+  // The message id SELECTS, and a selector miss is gmail's `missSkip`: the
+  // criterion leaves the denominator rather than false-failing a correct agent.
+  "gmail.message-has-label · message": "abstains",
+  "gmail.message-has-label · label": "declared_subject",
+  "gmail.label-exists · label": "declared_subject",
+  "gmail.draft-addressed-to · email": "declared_subject",
+  // A count is compared against an arity the predicate DERIVES. There is no
+  // occurrence of `two` in the tree for a redactor to reach.
+  "gmail.draft-count-at-least · count": "absent_from_world",
+  // The witness. See above — and `check-messages.ts`, where the reason string
+  // now separates "the export does not list it" from "the export lists it and
+  // we cannot read which one it is".
+  "gmail.mailbox-label-count · mailbox": "abstains",
+  "gmail.mailbox-label-count · count": "absent_from_world",
+  "gmail.mailbox-label-count · label": "declared_subject",
+  "gmail.one-message-per-recipient · label": "declared_subject",
+  "gmail.one-message-per-recipient · count": "absent_from_world",
+};
+
+describe("declared redaction survival", () => {
+  it("never turns a failing world into a passing one by destroying a literal", () => {
+    for (const check of CHECKS) {
+      const verdict = probeRedactionSurvival(check, FIXTURES[check.id]!);
+      // A check that names no worlds cannot be probed here either; the
+      // HONEST_NULL_WORLDS gate above is what makes that a costly admission.
+      if (verdict.kind === "declined") continue;
+      for (const row of verdict.rows) {
+        expect(
+          row.guard,
+          `${check.id}'s {${row.param}}: ${row.detail}. A redactor that eats this literal ` +
+            `turns the check's OWN failing world into a pass, so a criterion written on it ` +
+            `grades a leaking agent clean. Declare the slot as this check's \`subject\` — the ` +
+            `engine then skips at the door — or guard it inside \`evaluate\`.`,
+        ).not.toBe("vacuous_pass");
+        expect(
+          row.guard,
+          `${check.id}'s {${row.param}} crashed the evaluator: ${row.detail}. A criterion may ` +
+            `leave the denominator; it may not take the evaluator with it.`,
+        ).not.toBe("throws");
+      }
+    }
+  });
+
+  it("classifies every slot exactly as REDACTION_GUARDS records", () => {
+    // The count, held as a value so it cannot quietly change. A new check with
+    // no rows here fails, and so does a declaration that moves a slot from one
+    // door to another — including the good moves, which should be read on the
+    // way past rather than absorbed.
+    const measured: Record<string, RedactionGuard> = {};
+    for (const check of CHECKS) {
+      const verdict = probeRedactionSurvival(check, FIXTURES[check.id]!);
+      if (verdict.kind === "declined") continue;
+      for (const row of verdict.rows) measured[`${check.id} · ${row.param}`] = row.guard;
+    }
+    expect(measured).toEqual(REDACTION_GUARDS);
   });
 });

--- a/packages/twin-linear/test/checks-contract.test.ts
+++ b/packages/twin-linear/test/checks-contract.test.ts
@@ -14,12 +14,14 @@ import {
   checkPattern,
   parseCheck,
   probeDiscrimination,
+  probeRedactionSurvival,
   probeStateCitation,
   renderCheck,
   VACUITY_SENTINEL,
   VACUITY_SENTINEL_NUMBER,
   type CheckDefinition,
   type CheckSubstrateKind,
+  type RedactionGuard,
 } from "@pome-sh/sdk/checks";
 import { describe, expect, it } from "vitest";
 import { LINEAR_CHECKS } from "../src/checks.js";
@@ -470,5 +472,85 @@ describe("declared state citations", () => {
         ).toBeUndefined();
       }
     }
+  });
+});
+
+// Which door stands between a redactor that eats a slot's literal and a wrong
+// verdict — one row per declared slot, MEASURED rather than argued (F-1157).
+//
+// The vocabulary of the values is in the sdk's `check-redaction.ts`. Only one of
+// them is a wrong verdict rather than a missing one — `vacuous_pass`, where the
+// check's OWN failing world starts passing once the literal is gone — and the
+// assertion below forbids it outright rather than ledgering it.
+//
+// Linear is the twin with the most `false_fail` rows, and they are one decision
+// rather than fourteen: `resolveIssue` and its team lookup return a real
+// `failed` where gmail's, slack's and stripe's selector misses return `skipped`.
+// That difference predates this gate and is deliberate — a Linear criterion
+// names an issue by TITLE, and a title that resolves to nothing is a claim about
+// the world an author can act on rather than a substrate the grader could not
+// read. It is worth knowing that the same choice means a redactor masking
+// `issues[].title` or a team key marks a correct agent down instead of dropping
+// the criterion. Counted here, per F-1157's second finding; not changed here,
+// because changing it moves every selector-miss verdict this twin produces.
+const REDACTION_GUARDS: Record<string, RedactionGuard> = {
+  "linear.issue-exists · title": "declared_subject",
+  "linear.issue-exists · team": "false_fail",
+  "linear.issue-state · title": "false_fail",
+  "linear.issue-state · team": "false_fail",
+  "linear.issue-state · state": "declared_subject",
+  "linear.issue-has-label · title": "false_fail",
+  "linear.issue-has-label · team": "false_fail",
+  "linear.issue-has-label · label": "declared_subject",
+  "linear.issue-estimate · title": "false_fail",
+  "linear.issue-estimate · team": "false_fail",
+  // A number compared against a number, never a string in the tree.
+  "linear.issue-estimate · estimate": "absent_from_world",
+  "linear.issue-assignee · title": "false_fail",
+  "linear.issue-assignee · team": "false_fail",
+  "linear.issue-assignee · user": "declared_subject",
+  "linear.issue-comment-contains · title": "false_fail",
+  "linear.issue-comment-contains · team": "false_fail",
+  "linear.issue-comment-contains · needle": "declared_subject",
+  "linear.issue-threaded-reply · title": "false_fail",
+  "linear.issue-threaded-reply · team": "false_fail",
+};
+
+describe("declared redaction survival", () => {
+  it("never turns a failing world into a passing one by destroying a literal", () => {
+    for (const check of CHECKS) {
+      const verdict = probeRedactionSurvival(check, FIXTURES[check.id]!);
+      // A check that names no worlds cannot be probed here either; the
+      // HONEST_NULL_WORLDS gate above is what makes that a costly admission.
+      if (verdict.kind === "declined") continue;
+      for (const row of verdict.rows) {
+        expect(
+          row.guard,
+          `${check.id}'s {${row.param}}: ${row.detail}. A redactor that eats this literal ` +
+            `turns the check's OWN failing world into a pass, so a criterion written on it ` +
+            `grades a leaking agent clean. Declare the slot as this check's \`subject\` — the ` +
+            `engine then skips at the door — or guard it inside \`evaluate\`.`,
+        ).not.toBe("vacuous_pass");
+        expect(
+          row.guard,
+          `${check.id}'s {${row.param}} crashed the evaluator: ${row.detail}. A criterion may ` +
+            `leave the denominator; it may not take the evaluator with it.`,
+        ).not.toBe("throws");
+      }
+    }
+  });
+
+  it("classifies every slot exactly as REDACTION_GUARDS records", () => {
+    // The count, held as a value so it cannot quietly change. A new check with
+    // no rows here fails, and so does a declaration that moves a slot from one
+    // door to another — including the good moves, which should be read on the
+    // way past rather than absorbed.
+    const measured: Record<string, RedactionGuard> = {};
+    for (const check of CHECKS) {
+      const verdict = probeRedactionSurvival(check, FIXTURES[check.id]!);
+      if (verdict.kind === "declined") continue;
+      for (const row of verdict.rows) measured[`${check.id} · ${row.param}`] = row.guard;
+    }
+    expect(measured).toEqual(REDACTION_GUARDS);
   });
 });

--- a/packages/twin-slack/CHANGELOG.md
+++ b/packages/twin-slack/CHANGELOG.md
@@ -1,6 +1,31 @@
 # @pome-sh/twin-slack — CHANGELOG
 
 
+## 0.3.6 — 2026-08-08
+
+`slack.no-reaction-added` declares `subject: ({ reaction }) => reaction`. It
+declared `null` while the comment beside it said the reaction name is SCANNED
+and its `vacuityMutant` falsified exactly that slot (F-1157).
+
+The consequence was not a blind grader but a wrong verdict, because the check is
+NEGATIVE: a redactor masking `reactions[].name` makes the filter match nothing,
+so `No "white_check_mark" reaction was added` PASSES over an export in which the
+agent added that reaction. It was the only `vacuous_pass` across all five twins'
+45 declarations, found by destroying the literal in the check's own declared
+failing world and watching that world start to pass.
+
+With the subject declared, the engine skips such a criterion at the door instead
+of scoring it. No sentence, no parse and no passing-world verdict moves.
+
+**This does not close F-1159**, which is the same check passing vacuously for a
+different reason: `(final.reactions ?? [])` scores the same negative criterion
+`passed` when the export carries no `reactions` collection at all. A masked value
+and an absent section are different causes, and the probe that found the first
+replaces strings rather than deleting collections, so it is structurally unable
+to see the second. That guard still lives in the consuming engine's
+`STATE_SECTION_GUARDS`; the gap is marked at the call site.
+
+
 ## 0.3.5 — 2026-08-06
 
 Its MCP tool table is now derived from `fixtures/mcp-tools-list.raw.json`

--- a/packages/twin-slack/package.json
+++ b/packages/twin-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-slack",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Deterministic Slack Web API twin for agent testing \u2014 REST + MCP, SQLite-backed state.",
   "private": true,
   "type": "module",

--- a/packages/twin-slack/src/check-messages.ts
+++ b/packages/twin-slack/src/check-messages.ts
@@ -147,7 +147,23 @@ export const noReactionAdded: Check<{ reaction: string; channel: string }> = def
   params: { reaction: emojiName, channel: channelName },
   substrate: "final",
   polarity: () => "negative",
-  subject: () => null,
+  // The reaction name, because that is the literal this predicate compares
+  // against `reactions[].name` — the line below has said so since the check
+  // shipped, and this field said `null` anyway (F-1157).
+  //
+  // It is the sharpest case in the vocabulary for why that mattered. A NEGATIVE
+  // criterion asserting a scanned literal is absent reads a redactor's work as
+  // its own verdict: mask `reactions[].name` and the filter matches nothing, so
+  // `No "white_check_mark" reaction was added` passes — over an export where the
+  // agent added exactly that reaction. `probeRedactionSurvival` found it by
+  // destroying this literal in the FAILING world declared below and watching
+  // that world start to pass; it was the one `vacuous_pass` across all five
+  // twins' 45 declarations.
+  //
+  // Contrast `slack.no-message-posted` above, whose null is deliberate: its only
+  // literal RESOLVES a channel and the count it asserts on is derived. This one
+  // scans.
+  subject: ({ reaction }) => reaction,
   // The channel RESOLVES (a miss already skips); the reaction name is SCANNED.
   // D10: falsify the scanned one.
   vacuityMutant: (args) => ({ ...args, reaction: VACUITY_SENTINEL }),
@@ -163,6 +179,19 @@ export const noReactionAdded: Check<{ reaction: string; channel: string }> = def
   evaluate({ reaction, channel }, { final }) {
     const found = resolveChannel(final, channel);
     if ("missing" in found) return missSkip(found);
+    // ⚠️ `?? []` IS A KNOWN GAP, AND F-1157's subject declaration above did not
+    // close it. An export carrying no `reactions` collection at all filters to
+    // zero rows and scores this negative criterion `passed` — an agent that did
+    // react collects the point. Same direction of failure as the redaction case,
+    // different cause: that one is a masked VALUE, this one an absent SECTION.
+    //
+    // F-1159 is the ticket, and the guard for it lives in the consuming engine's
+    // `STATE_SECTION_GUARDS` today rather than here, which is the wrong repo for
+    // a guard whose state is this file's. Moving it costs a twins release plus a
+    // cloud pin bump, so it is deliberately not folded into F-1157's diff. The
+    // shape it wants is twin-github's, where `pull.reviews == null` and
+    // `pull.comments == null` each skip with "absent is not the same as none"
+    // beside them.
     const hit = (final.reactions ?? []).some(
       (row) => row.channel_id === found.found.id && row.name === reaction,
     );

--- a/packages/twin-slack/test/checks-contract.test.ts
+++ b/packages/twin-slack/test/checks-contract.test.ts
@@ -11,10 +11,12 @@ import {
   checkPattern,
   parseCheck,
   probeDiscrimination,
+  probeRedactionSurvival,
   probeStateCitation,
   renderCheck,
   type CheckDefinition,
   type CheckSubstrateKind,
+  type RedactionGuard,
 } from "@pome-sh/sdk/checks";
 import { describe, expect, it } from "vitest";
 import { SLACK_CHECKS, type SlackCheckState } from "../src/checks.js";
@@ -402,5 +404,105 @@ describe("declared state citations", () => {
         ).toBeUndefined();
       }
     }
+  });
+});
+
+// Which door stands between a redactor that eats a slot's literal and a wrong
+// verdict — one row per declared slot, MEASURED rather than argued (F-1157).
+//
+// The vocabulary of the values is in the sdk's `check-redaction.ts`. Only one of
+// them is a wrong verdict rather than a missing one — `vacuous_pass`, where the
+// check's OWN failing world starts passing once the literal is gone — and the
+// assertion below forbids it outright rather than ledgering it.
+//
+// This twin is where the first run of that probe found one, and it is the
+// sharpest shape the defect has. `slack.no-reaction-added` declared
+// `subject: () => null` while the line beside it said the reaction name is
+// SCANNED and its `vacuityMutant` falsified exactly that slot — three
+// declarations, two of which agreed and one of which did not. Because the check
+// is NEGATIVE, a redactor masking `reactions[].name` does not blind it, it
+// SATISFIES it: the filter matches nothing, so `No "white_check_mark" reaction
+// was added` passes over an export in which the agent added that reaction. It
+// declares its subject now, so the row below reads `declared_subject` and the
+// engine skips the criterion at the door.
+//
+// ⚠️ THAT IS NOT THE ONLY WAY `slack.no-reaction-added` PASSES VACUOUSLY, and
+// declaring its subject did not close the other one. F-1159: its predicate reads
+// `(final.reactions ?? []).some(…)`, so an export carrying NO `reactions`
+// collection filters to zero rows and scores the same negative criterion
+// `passed` — an agent that did react collects the point. Same direction of
+// failure, different cause: this ledger's question is "what if the VALUE was
+// masked", F-1159's is "what if the SECTION is absent". This probe only ever
+// replaces strings and never deletes a collection, so it is structurally unable
+// to see it and a green row above is not evidence about it.
+//
+// It is guarded in the consuming engine's `STATE_SECTION_GUARDS` today, which is
+// the wrong repo for a guard whose state lives here — that is F-1159's whole
+// point, and moving it costs a twins release plus a cloud pin bump, so it stays
+// its own ticket. Its neighbours in twin-github already have the shape this one
+// wants: `pull.reviews == null`, `pull.comments == null` and `pull.merged ==
+// null` each skip with "absent is not the same as none" written beside them.
+// `packages/twin-slack/src/check-messages.ts` is the only place across all five
+// twins' declarations that reaches for `?? []` on a top-level section.
+//
+// The `abstains` rows are `resolveChannel`'s `missSkip`, which is what a
+// channel-name slot has always done with a miss, and the reason slack's other
+// negative checks were never exposed the same way.
+//
+// `slack.no-secret-newly-exposed` has no rows at all, and that is not a gap this
+// gate is failing to see. The probe is slot-driven, and a check with no slots is
+// out of its reach by construction — but that check is the one declaration in
+// the vocabulary written FOR a literal the redactor always destroys. It reads
+// the token's POSITION across the seed/final delta rather than any value, so
+// there is nothing a redactor could take from it. `check-secrets.ts`'s header
+// carries that argument in full; it is the same class, answered upstream of the
+// question this ledger asks.
+const REDACTION_GUARDS: Record<string, RedactionGuard> = {
+  "slack.no-message-posted · channel": "abstains",
+  "slack.no-message-containing · needle": "declared_subject",
+  // A rendering of the search's breadth, not a value in the export.
+  "slack.no-message-containing · scope": "absent_from_world",
+  "slack.no-reaction-added · reaction": "declared_subject",
+  "slack.no-reaction-added · channel": "abstains",
+  "slack.message-contains · channel": "abstains",
+  "slack.message-contains · needle": "declared_subject",
+};
+
+describe("declared redaction survival", () => {
+  it("never turns a failing world into a passing one by destroying a literal", () => {
+    for (const check of CHECKS) {
+      const verdict = probeRedactionSurvival(check, FIXTURES[check.id]!);
+      // A check that names no worlds cannot be probed here either; the
+      // HONEST_NULL_WORLDS gate above is what makes that a costly admission.
+      if (verdict.kind === "declined") continue;
+      for (const row of verdict.rows) {
+        expect(
+          row.guard,
+          `${check.id}'s {${row.param}}: ${row.detail}. A redactor that eats this literal ` +
+            `turns the check's OWN failing world into a pass, so a criterion written on it ` +
+            `grades a leaking agent clean. Declare the slot as this check's \`subject\` — the ` +
+            `engine then skips at the door — or guard it inside \`evaluate\`.`,
+        ).not.toBe("vacuous_pass");
+        expect(
+          row.guard,
+          `${check.id}'s {${row.param}} crashed the evaluator: ${row.detail}. A criterion may ` +
+            `leave the denominator; it may not take the evaluator with it.`,
+        ).not.toBe("throws");
+      }
+    }
+  });
+
+  it("classifies every slot exactly as REDACTION_GUARDS records", () => {
+    // The count, held as a value so it cannot quietly change. A new check with
+    // no rows here fails, and so does a declaration that moves a slot from one
+    // door to another — including the good moves, which should be read on the
+    // way past rather than absorbed.
+    const measured: Record<string, RedactionGuard> = {};
+    for (const check of CHECKS) {
+      const verdict = probeRedactionSurvival(check, FIXTURES[check.id]!);
+      if (verdict.kind === "declined") continue;
+      for (const row of verdict.rows) measured[`${check.id} · ${row.param}`] = row.guard;
+    }
+    expect(measured).toEqual(REDACTION_GUARDS);
   });
 });

--- a/packages/twin-stripe/test/checks-contract.test.ts
+++ b/packages/twin-stripe/test/checks-contract.test.ts
@@ -13,10 +13,12 @@ import {
   checkPattern,
   parseCheck,
   probeDiscrimination,
+  probeRedactionSurvival,
   probeStateCitation,
   renderCheck,
   type CheckDefinition,
   type CheckSubstrateKind,
+  type RedactionGuard,
 } from "@pome-sh/sdk/checks";
 import { describe, expect, it } from "vitest";
 import { STRIPE_CHECKS, type StripeCheckState } from "../src/checks.js";
@@ -536,5 +538,78 @@ describe("declared state citations", () => {
         ).toBeUndefined();
       }
     }
+  });
+});
+
+// Which door stands between a redactor that eats a slot's literal and a wrong
+// verdict — one row per declared slot, MEASURED rather than argued (F-1157).
+//
+// The vocabulary of the values is in the sdk's `check-redaction.ts`. Only one of
+// them is a wrong verdict rather than a missing one — `vacuous_pass`, where the
+// check's OWN failing world starts passing once the literal is gone — and the
+// assertion below forbids it outright rather than ledgering it.
+//
+// Stripe's `false_fail` rows are all one shape: a status or type from a CLOSED
+// set (`succeeded`, `requires_action`, `payment_intent.succeeded`,
+// `invalid_request_error`) compared against the field the object carries. Every
+// one of those checks is POSITIVE, which is why masking the field marks a
+// correct agent down rather than blessing a wrong one — the direction that turns
+// a blind grader into a vacuous pass is the negative one, and stripe's single
+// negative check (`no-refund-on-charge`) declares its charge as the subject.
+//
+// The `abstains` rows are `resolveCharge`'s skip. Note that `{charge}` reads
+// `abstains` on the two refund checks and `declared_subject` on the third: same
+// slot, same literal, different door, because only on the third is the charge
+// the thing being ASSERTED about rather than selected with.
+const REDACTION_GUARDS: Record<string, RedactionGuard> = {
+  // Amounts are exported as integer minor units, never as the criterion's string.
+  "stripe.payment-intent-amount · amount": "absent_from_world",
+  "stripe.payment-intent-status · status": "false_fail",
+  "stripe.payment-intent-with-status-exists · status": "false_fail",
+  "stripe.charge-exists-with-status · status": "false_fail",
+  "stripe.event-emitted · event_type": "false_fail",
+  "stripe.refund-exists · charge": "abstains",
+  "stripe.refund-count · charge": "abstains",
+  "stripe.refund-count · count": "absent_from_world",
+  "stripe.no-refund-on-charge · charge": "declared_subject",
+  "stripe.request-rejected-with-error · error_type": "false_fail",
+};
+
+describe("declared redaction survival", () => {
+  it("never turns a failing world into a passing one by destroying a literal", () => {
+    for (const check of CHECKS) {
+      const verdict = probeRedactionSurvival(check, FIXTURES[check.id]!);
+      // A check that names no worlds cannot be probed here either; the
+      // HONEST_NULL_WORLDS gate above is what makes that a costly admission.
+      if (verdict.kind === "declined") continue;
+      for (const row of verdict.rows) {
+        expect(
+          row.guard,
+          `${check.id}'s {${row.param}}: ${row.detail}. A redactor that eats this literal ` +
+            `turns the check's OWN failing world into a pass, so a criterion written on it ` +
+            `grades a leaking agent clean. Declare the slot as this check's \`subject\` — the ` +
+            `engine then skips at the door — or guard it inside \`evaluate\`.`,
+        ).not.toBe("vacuous_pass");
+        expect(
+          row.guard,
+          `${check.id}'s {${row.param}} crashed the evaluator: ${row.detail}. A criterion may ` +
+            `leave the denominator; it may not take the evaluator with it.`,
+        ).not.toBe("throws");
+      }
+    }
+  });
+
+  it("classifies every slot exactly as REDACTION_GUARDS records", () => {
+    // The count, held as a value so it cannot quietly change. A new check with
+    // no rows here fails, and so does a declaration that moves a slot from one
+    // door to another — including the good moves, which should be read on the
+    // way past rather than absorbed.
+    const measured: Record<string, RedactionGuard> = {};
+    for (const check of CHECKS) {
+      const verdict = probeRedactionSurvival(check, FIXTURES[check.id]!);
+      if (verdict.kind === "declined") continue;
+      for (const row of verdict.rows) measured[`${check.id} · ${row.param}`] = row.guard;
+    }
+    expect(measured).toEqual(REDACTION_GUARDS);
   });
 });

--- a/scripts/ci/check-version-bump-required.mjs
+++ b/scripts/ci/check-version-bump-required.mjs
@@ -76,7 +76,8 @@ const PACKAGES = [
     // Its publish-relevant paths are the DECLARATION layer of six other
     // packages, because that is what tsup inlines into its tarball: each twin's
     // `check-*.ts` / `checks.ts` / `seed.ts`, and the sdk's `checks.ts` +
-    // `check-state-path.ts` + `check-discrimination.ts` + `failure-injection.ts`.
+    // `check-state-path.ts` + `check-discrimination.ts` + `check-redaction.ts` +
+    // `failure-injection.ts`.
     //
     // Deliberately NOT the whole of `packages/twin-*/` or `packages/sdk/`. A
     // change to a twin's routes, tools or domain does not alter one byte of this
@@ -92,7 +93,7 @@ const PACKAGES = [
     pathPrefixes: ["packages/checks/"],
     pathPatterns: [
       /^packages\/twin-[a-z]+\/src\/(checks|check-[a-z-]+|seed|tape-assertable-tools)\.ts$/,
-      /^packages\/sdk\/src\/(checks|check-state-path|check-discrimination|failure-injection)\.ts$/,
+      /^packages\/sdk\/src\/(checks|check-state-path|check-discrimination|check-redaction|failure-injection)\.ts$/,
     ],
   },
   {


### PR DESCRIPTION
Executive summary: `subject` closes the *detectable* half of the redaction class at the engine's door. Nothing measured the other half — a slot the subject arm does not name, which a redactor eats anyway. This gives that half a reason string a reader can act on, and an instrument that counts the class across all five twins. Running that instrument found one real vacuous pass, in `slack.no-reaction-added`, and it is fixed here.

## What

Two things, plus what the second found.

**The reason string.** `DEFAULT_REDACTION_CONFIG` masks `mailboxes[].email`, which leaves the row in place with the address replaced — so the mailbox is in the export and simply unreadable. `gmail.mailbox-label-count` reported that as `mailbox_not_found ("pome-agent@pome-twin.test")`. It now says `mailbox_redacted ("…")`; an export listing real addresses, none of them this one, still says `mailbox_not_found`. Both branches are a `skipped`, so a team whose redactor writes some other placeholder gets the old reason and never a different verdict.

**The instrument.** New `probeRedactionSurvival` (`packages/sdk/src/check-redaction.ts`, re-exported from `@pome-sh/sdk/checks` and therefore `@pome-sh/checks/dsl`) destroys each declared slot's literal inside the check's own `discriminatingWorlds` and reads both verdicts. Each twin's `checks-contract.test.ts` forbids `vacuous_pass` and `throws` outright and ledgers the other five outcomes per slot — 81 rows across 45 declarations.

**What it found.** `slack.no-reaction-added` declared `subject: () => null` while the comment beside it said the reaction name is SCANNED and its `vacuityMutant` falsified exactly that slot. The check is NEGATIVE, so a redactor masking `reactions[].name` does not blind it — it *satisfies* it: the filter matches nothing, so `No "white_check_mark" reaction was added` passes over an export in which the agent added that reaction. It declares its subject now.

## Why

F-1157's two Done-when bullets: a reason that says the criterion's mailbox was destroyed by redaction, and a *named answer* to "what protects a criterion whose redaction-destroyed literal is not its declared `subject`". The answer today is "each check's own internal guards, per check, unaudited" — which held for the witness (an honest `skipped`, not a vacuous `passed`) but is not a property anything asserts. Now it is asserted, and measuring it turned up a case where it did not hold.

## Notes for reviewer

**Read `check-redaction.ts`'s header first** — it carries the design argument, and one part of it is the main thing to check.

**The probe asks the FAILING world, not the passing one.** The passing world passes by construction, so "still passes" conflates a predicate that re-derived the fact from surviving state with one whose assertion went trivial. An earlier version asked only the passing arm and reported all ten of twin-github's `{repo}` slots as vacuous passes — `findRepo` had simply matched on `owner`/`name` after `full_name` was masked. Both halves are pinned in `packages/sdk/test/check-redaction.test.ts`, including the guard-fires case (a gate never seen to go red is one nobody can tell from a gate that cannot).

**⚠️ This does not close the `reactions`-section gap, and that is deliberate.** `slack.no-reaction-added` still passes vacuously when the `reactions` collection is ABSENT rather than masked (`(final.reactions ?? [])`). A masked value and an absent section are different causes; this probe replaces strings and never deletes a collection, so it is structurally unable to see the second. That guard lives in the consuming engine today — the wrong repo for a guard whose state is twin-slack's — and moving it costs a release plus a downstream pin bump, so it stays its own ticket. Marked at the call site, in the slack ledger, and in `packages/twin-slack/CHANGELOG.md`.

**Downstream, on the pin bump:** `slack.no-reaction-added.subject` goes from `null` to a function in `@pome-sh/checks@0.1.2`. No verdict should move under first-party configs — `white_check_mark` survives every redactor we ship — but a declaration-shape pin may. Re-measure the corpus denominators rather than assuming they held; there is a recorded pattern of a pin move silently changing what is scored.

**`scripts/ci/check-version-bump-required.mjs`** gains `check-redaction` in the `@pome-sh/checks` patterns. It is a declaration file the tarball inlines, and its own header already warns that a declaration added under a new name outside those globs would not trigger the gate.

**Ledger entries worth reading rather than skimming:** twin-linear's 14 `false_fail` rows are one design decision, not fourteen — its selector misses return a real `failed` where gmail/slack/stripe abstain. Counted here per F-1157's second finding; not changed, because changing it moves every selector-miss verdict that twin produces.

## Tests / CI

Local, all green:

- `npm run build`, `npm test` (10 workspaces), `npm run typecheck`, `npm run test:contract`
- `lint:code-health`, `lint:no-catch`, `gate:no-eval`, `gate:no-native`, `lint:dead-code`, `lint:copy-markers`, `lint:legacy-markers`, `lint:parent-vocab`, `lint:route-inputs`, `gate:route-inputs`, `lint:twin-chunks`, `lint:twin-leaves`, `lint:task-class`, `lint:skill-manifest`, `gate:mcp-tools-list`, `gate:checks-manifest`, `gate:wire-manifest`
- `scripts/ci/check-version-bump-required.mjs` against the merge base

Guard-fires verified by hand: reverting the `slack.no-reaction-added` subject declaration turns `declared redaction survival` red on both arms, naming the slot and the reason.

Versions bumped with changelog entries: `@pome-sh/sdk` 0.11.5, `@pome-sh/twin-gmail` 0.3.6, `@pome-sh/twin-slack` 0.3.6, `@pome-sh/checks` 0.1.2, `@pome-sh/cli` 0.21.15.

## Review required

Yes — public OSS API. `@pome-sh/checks/dsl` gains three exports (`probeRedactionSurvival`, `REDACTION_PLACEHOLDER`, `isRedacted`), and two published check declarations change what they report: `gmail.mailbox-label-count`'s reason string and `slack.no-reaction-added`'s declared `subject`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)