### PR TITLE
The agent-session mutation inputs are Linear's, and so is the model they imply (F-1176)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,24 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.21.17
+
+### Patch Changes
+
+- The bundled Linear twin's agent-session mutation inputs are Linear's own now
+  (F-1176), which is publish-relevant for the CLI because it inlines the twin
+  into its bundle. `packages/twin-linear` went to 0.4.0; see its CHANGELOG for
+  the full surface.
+
+  Observable from `pome run --local` if a task drives agent sessions over
+  GraphQL. `agentSessionUpdate` no longer takes `status` or an `id` input field
+  (its `id` argument is non-null, as upstream), the two creates no longer take
+  `appUserId` or `plan`, and `agentActivityCreate` takes
+  `{ agentSessionId, content, signal }` rather than `{ sessionId, type, body }`.
+  A session's status now moves through the activities the agent emits, because
+  upstream there is no other way to move it. No bundled task or example drove
+  any of these, so nothing in `cli/tasks/` or `examples/` changed.
+
 ## 0.21.16
 
 ### Patch Changes

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.21.16",
+  "version": "0.21.17",
   "description": "Digital-twin testing for AI agents — run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/packages/twin-linear/CHANGELOG.md
+++ b/packages/twin-linear/CHANGELOG.md
@@ -1,6 +1,74 @@
 # @pome-sh/twin-linear — CHANGELOG
 
 
+## 0.4.0 — 2026-08-09
+
+The agent-session **mutation inputs** are Linear's now, and so is the model they
+imply (F-1176). 0.3.0 fixed the output type and said so in the guard's own
+words — *do not read this file as evidence about the input surface*. This is
+that surface.
+
+**Breaking, on all four inputs.** Every field below is one Linear does not
+declare, verified against `https://api.linear.app/graphql` directly:
+
+| Mutation | Was | Is |
+| --- | --- | --- |
+| `agentSessionUpdate` | `id: String` argument; input `{ id, status, plan, externalUrls }` | `id: String!` argument; input `{ plan, externalUrls }` |
+| `agentSessionCreateOnIssue` | `{ issueId, appUserId, plan, externalUrls }` | `{ issueId, externalUrls }` |
+| `agentSessionCreateOnComment` | `{ commentId, appUserId, plan, externalUrls }` | `{ commentId, externalUrls }` |
+| `agentActivityCreate` | `{ sessionId, type, body, ephemeral }` | `{ agentSessionId, content, signal, ephemeral }` |
+
+**A session's status now follows its activities.** This is the behavioural half,
+and it is why the change is a minor rather than a patch: upstream there is no
+`status` on `agentSessionUpdate` at all, so an agent written against real Linear
+literally could not drive the twin the way the twin expected, and vice versa. A
+session still starts `pending`; `thought` / `action` make it `active`,
+`elicitation` `awaitingInput`, `response` `complete`, `error` `error`, and
+`prompt` returns it to `pending`. That table is the one invented thing in the
+change — Linear says only that state "is updated automatically based on the
+agent's emitted activities" and never publishes which yields which — so it is
+named, bounded, and written up in `REFERENCE-DIVERGENCES.md`. Set a plan through
+`agentSessionUpdate`, which is where Linear declares `plan`; it is no longer on
+create.
+
+**`content` replaces `type` + `body`.** Linear's `AgentActivityContent` is a
+union discriminated on `type` whose six members are
+`AgentActivity{Thought,Action,Response,Elicitation,Error,Prompt}Content`. Five
+carry `body`; `action` carries `action` / `parameter` / `result` and no `body`
+at all, which is why the old flat pair could not survive. The twin parses
+`content` against those six members and refuses a malformed one at the boundary.
+`AgentActivity` moves with it — accepting Linear's `content` while emitting an
+invented `body` would round-trip to neither Linear nor itself — so the output
+type is now `{ id, content, signal, ephemeral, createdAt, updatedAt,
+agentSession, user }`. `session` was the twin's own spelling and is gone; `user`
+is non-null, as Linear declares it.
+
+**An existing `LINEAR_TWIN_DB` file migrates in place on open.**
+`agent_activities` gains `content_json` and `signal`, carries each old row's
+`{ type, body }` into content verbatim, drops `type` and `body`, and re-adopts
+any activity whose author the `ON DELETE SET NULL` foreign key had cleared. The
+carry is literal even for `action`, whose upstream member has no `body`:
+inventing an `action` / `parameter` split out of one free-text field would be
+worse than a faithful record of what the row said. Idempotent, and a no-op on a
+database created by the current schema.
+
+**The guard covers the whole family now.** `GUARDED_TYPES` gains
+`AgentSessionUpdateInput`, `AgentSessionCreateOnIssue` / `OnComment`,
+`AgentActivityCreateInput`, `AgentActivity` and `AgentActivitySignal` — it went
+red on all of them the moment they were added, which was the point — and
+`test/linear-schema-subset.test.ts` gains a block that proves the guard can
+fail, driving the same comparison against a schema built to be wrong. The
+SCOPE note that carved the input surface out of F-1172's claim is deleted.
+
+Two scalar-level gaps stay open and are written up rather than fixed, because
+the guard is name-based by F-1172's design: input `plan` is `String` where
+upstream is `JSONObject`, and output `content` is `JSON!` where upstream is the
+union. Input `content` **is** `JSONObject!`, as upstream.
+
+`packages/twin-linear/route-inputs.json` changes by two lines —
+`agentSessionUpdate`'s `id` argument is `String!`, required — which is the
+declared-fidelity lane seeing the second, smaller divergence close.
+
 ## 0.3.5 — 2026-08-06
 
 Its MCP tool table is now derived from `fixtures/mcp-tools-list.raw.json`

--- a/packages/twin-linear/REFERENCE-DIVERGENCES.md
+++ b/packages/twin-linear/REFERENCE-DIVERGENCES.md
@@ -27,6 +27,7 @@ Emulate’s Linear package may be used as a **coverage checklist**. It is **neve
 | OAuth actor | user vs app | Seed `oauth_apps[].actor` authoritative |
 | Webhook headers | `Linear-Delivery`, `Linear-Event`, optional `Linear-Signature` | Emitted on mutation dispatch |
 | Agent sessions | Subset for local agent tests | GraphQL-only create/update/activity (not in MCP launch set) |
+| Agent session status | Follows the agent's emitted activities; Linear publishes no table | Twin-owned mapping — see “Agent session status” below (F-1176) |
 | MCP documents tools | Full parent set incl. initiative | Gate-1: project/team/issue/cycle parents only |
 | MCP tool count | ~50+ live tools | Frozen 22-tool Gate-1 subset |
 
@@ -39,8 +40,60 @@ These are intentional twin divergences — not silent stubs:
 | `agentSessionCreateOnIssue` | `AgentSessionEvent` create webhook | Emits webhook (`action: created`) |
 | `agentSessionCreateOnComment` | Same family as on-issue create | **No webhook** — session row only (mention path stays quiet) |
 | `createProject` / `updateProject` (MCP `save_project`) | Project create/update webhook | **No webhook emit** — projects mutate SQLite state only |
-| `agentActivityCreate` with `type: prompt` | Prompted session event | Emits `AgentSessionEvent` / `prompted` |
+| `agentActivityCreate` with `content.type: prompt` | Prompted session event | Emits `AgentSessionEvent` / `prompted`, carrying the status the activity just produced |
 | Issue / comment CRUD | Issue / Comment webhooks | Emitted (create/update/remove/archive) |
+
+## Agent session status — the one invented behaviour (F-1176)
+
+The agent-session mutation inputs are Linear's, field for field, and
+[`test/linear-schema-subset.test.ts`](test/linear-schema-subset.test.ts) guards
+all four against Linear's real introspection. One thing in that change could
+not be read off upstream and is therefore twin-owned, named here rather than
+left to be discovered.
+
+Upstream, `AgentSessionUpdateInput` has no `status` field: Linear's agent guide
+says only that session state “is updated automatically based on the agent's
+emitted activities. No manual state management is required.” So the *shape* of
+the model is verified upstream truth — status follows activities, and is not
+settable through the update mutation — while the *table* is ours:
+
+| activity `content.type` | resulting `AgentSession.status` |
+| --- | --- |
+| `thought`, `action` | `active` |
+| `elicitation` | `awaitingInput` |
+| `response` | `complete` |
+| `error` | `error` |
+| `prompt` | `pending` |
+
+Linear never publishes which activity yields which status, and introspection
+cannot show behaviour. The alternative to naming this table was a twin whose
+sessions sit at `pending` forever, which is worse fidelity than a documented
+mapping. It lives in exactly one place —
+`AGENT_ACTIVITY_SESSION_STATUS` in [`src/domain/normalize.ts`](src/domain/normalize.ts).
+
+### Scalar-level gaps left open on the same surface
+
+The subset guard is name-based by F-1172's design, so these pass it. They are
+open, not fixed, and closing them is separate work:
+
+| Field | Linear | Twin |
+| --- | --- | --- |
+| `AgentSessionUpdateInput.plan` | `JSONObject` | `String` |
+| `AgentActivity.content` (output) | `AgentActivityContent` union | `JSON!` |
+
+`AgentActivityCreateInput.content` *is* `JSONObject!`, as upstream, and is
+parsed against the six union members (`normalizeActivityContent`), so a
+malformed payload is refused at the boundary rather than stored.
+
+### Fields on these types the twin does not model
+
+Ordinary coverage scope — a subset, not a divergence — listed so nobody
+re-derives it: `externalLink`, `addedExternalUrls`, `removedExternalUrls`,
+`dismissedAt` and `userState` on the session inputs; `id`, `signalMetadata` and
+`contextualMetadata` on `AgentActivityCreateInput`. Linear's
+`AgentSessionCreateInput` (the pull-request-scoped create, and where
+`appUserId` actually lives upstream) and `AgentSessionUserStateInput` are not
+declared at all.
 
 ## Other non-oracles
 

--- a/packages/twin-linear/fixtures/linear-introspection.json
+++ b/packages/twin-linear/fixtures/linear-introspection.json
@@ -1,14 +1,62 @@
 {
   "_readme": "Committed slice of Linear's real GraphQL introspection. A type absent here is UNGUARDED. Regenerate with `node scripts/regen-linear-introspection.mjs`; never hand-edit.",
   "source": "https://api.linear.app/graphql",
-  "fetched_at": "2026-08-02T14:52:09.995Z",
+  "fetched_at": "2026-08-09T13:38:23.130Z",
   "query_sha256": "6029c665c71a485e86c4524bfa6793eb6cb2f0f6ab48e6277bc4d5a62fbe1079",
   "guarded_types": [
+    "AgentActivity",
+    "AgentActivityCreateInput",
+    "AgentActivitySignal",
     "AgentSession",
+    "AgentSessionCreateOnComment",
+    "AgentSessionCreateOnIssue",
     "AgentSessionExternalUrlInput",
-    "AgentSessionStatus"
+    "AgentSessionStatus",
+    "AgentSessionUpdateInput"
   ],
   "types": {
+    "AgentActivity": {
+      "kind": "OBJECT",
+      "fields": {
+        "agentSession": "AgentSession!",
+        "archivedAt": "DateTime",
+        "content": "AgentActivityContent!",
+        "contextualMetadata": "JSON",
+        "createdAt": "DateTime!",
+        "ephemeral": "Boolean!",
+        "id": "ID!",
+        "pushSummary": "AgentActivityPushSummary",
+        "queued": "Boolean!",
+        "sentAt": "DateTime",
+        "signal": "AgentActivitySignal",
+        "signalMetadata": "JSON",
+        "sourceComment": "Comment",
+        "sourceMetadata": "JSON",
+        "updatedAt": "DateTime!",
+        "user": "User!"
+      }
+    },
+    "AgentActivityCreateInput": {
+      "kind": "INPUT_OBJECT",
+      "inputFields": {
+        "agentSessionId": "String!",
+        "content": "JSONObject!",
+        "contextualMetadata": "JSONObject",
+        "ephemeral": "Boolean",
+        "id": "String",
+        "signal": "AgentActivitySignal",
+        "signalMetadata": "JSONObject"
+      }
+    },
+    "AgentActivitySignal": {
+      "kind": "ENUM",
+      "enumValues": [
+        "auth",
+        "continue",
+        "select",
+        "stop"
+      ]
+    },
     "AgentSession": {
       "kind": "OBJECT",
       "fields": {
@@ -44,6 +92,22 @@
         "workspaceDiffFiles": "[AgentSessionWorkspaceDiffFile!]"
       }
     },
+    "AgentSessionCreateOnComment": {
+      "kind": "INPUT_OBJECT",
+      "inputFields": {
+        "commentId": "String!",
+        "externalLink": "String",
+        "externalUrls": "[AgentSessionExternalUrlInput!]"
+      }
+    },
+    "AgentSessionCreateOnIssue": {
+      "kind": "INPUT_OBJECT",
+      "inputFields": {
+        "externalLink": "String",
+        "externalUrls": "[AgentSessionExternalUrlInput!]",
+        "issueId": "String!"
+      }
+    },
     "AgentSessionExternalUrlInput": {
       "kind": "INPUT_OBJECT",
       "inputFields": {
@@ -61,6 +125,18 @@
         "pending",
         "stale"
       ]
+    },
+    "AgentSessionUpdateInput": {
+      "kind": "INPUT_OBJECT",
+      "inputFields": {
+        "addedExternalUrls": "[AgentSessionExternalUrlInput!]",
+        "dismissedAt": "DateTime",
+        "externalLink": "String",
+        "externalUrls": "[AgentSessionExternalUrlInput!]",
+        "plan": "JSONObject",
+        "removedExternalUrls": "[String!]",
+        "userState": "[AgentSessionUserStateInput!]"
+      }
     }
   }
 }

--- a/packages/twin-linear/package.json
+++ b/packages/twin-linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-linear",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "description": "Deterministic Linear-shaped twin for agent testing — SQLite-backed GraphQL + MCP + OAuth.",
   "private": true,
   "type": "module",

--- a/packages/twin-linear/route-inputs.json
+++ b/packages/twin-linear/route-inputs.json
@@ -343,8 +343,8 @@
         {
           "name": "id",
           "location": "argument",
-          "required": false,
-          "type": "String"
+          "required": true,
+          "type": "String!"
         },
         {
           "name": "input",

--- a/packages/twin-linear/scripts/regen-linear-introspection.mjs
+++ b/packages/twin-linear/scripts/regen-linear-introspection.mjs
@@ -30,28 +30,28 @@ const LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql";
  * The upstream types the twin models and must not drift from. Extend this list
  * (and re-run) when the twin starts emulating another Linear type.
  *
- * SCOPE — READ THIS BEFORE ASSUMING COVERAGE. These are the OUTPUT-side types
- * plus the one input object the twin mirrors exactly. The twin's MUTATION INPUT
- * types are deliberately NOT guarded yet, because they still diverge from
- * Linear and adding them here would fail immediately:
+ * SCOPE — this covers the agent-session family on BOTH sides of the wire since
+ * F-1176: the output types, the enums, and every mutation input the twin
+ * declares for them. F-1172 covered the output type only, and said so here;
+ * that carve-out is gone because the inputs were reconciled rather than
+ * registered.
  *
- *   - `AgentSessionUpdateInput` upstream declares externalLink, externalUrls,
- *     addedExternalUrls, removedExternalUrls, plan, dismissedAt, userState —
- *     no `status` and no `id`. Upstream, session status moves via agent
- *     activities, not through `agentSessionUpdate` at all. The twin declares
- *     id, status, plan, externalUrls.
- *   - `AgentSessionCreateOnIssue` / `AgentSessionCreateOnComment` are not
- *     Linear type names at all (upstream has `AgentSessionCreateInput`: id,
- *     issueId, appUserId, context) and the twin adds `plan`.
- *   - `AgentActivityCreateInput` — twin: sessionId, type, body, ephemeral;
- *     Linear: id, agentSessionId, signal, signalMetadata, contextualMetadata,
- *     content, ephemeral.
- *
- * These predate F-1172 (the old `state` / `agentUserId` were equally invented)
- * and reconciling them is its own piece of work, tracked separately. Until
- * then: the guard proves nothing about the mutation-input surface.
+ * Two Linear types this list deliberately omits, because the twin declares
+ * neither: `AgentSessionCreateInput` (the pull-request-scoped create, and where
+ * `appUserId` actually lives upstream) and `AgentSessionUserStateInput`.
+ * Guarding a type the twin does not model would prove nothing.
  */
-const GUARDED_TYPES = ["AgentSession", "AgentSessionStatus", "AgentSessionExternalUrlInput"];
+const GUARDED_TYPES = [
+  "AgentActivity",
+  "AgentActivityCreateInput",
+  "AgentActivitySignal",
+  "AgentSession",
+  "AgentSessionCreateOnComment",
+  "AgentSessionCreateOnIssue",
+  "AgentSessionExternalUrlInput",
+  "AgentSessionStatus",
+  "AgentSessionUpdateInput",
+];
 
 const QUERY = `query PomeTwinLinearIntrospection($name: String!) {
   __type(name: $name) {

--- a/packages/twin-linear/src/db.ts
+++ b/packages/twin-linear/src/db.ts
@@ -259,8 +259,8 @@ CREATE TABLE IF NOT EXISTS agent_activities (
   id TEXT PRIMARY KEY,
   session_id TEXT NOT NULL,
   user_id TEXT,
-  type TEXT NOT NULL,
-  body TEXT NOT NULL,
+  content_json TEXT NOT NULL DEFAULT '{}',
+  signal TEXT,
   ephemeral INTEGER NOT NULL DEFAULT 0,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL,
@@ -339,6 +339,51 @@ export function migrate(db: LinearTwinDatabase): void {
   ensureColumn(db, "issues", "parent_id", "TEXT");
   ensureColumn(db, "comments", "parent_id", "TEXT");
   migrateAgentSessions(db);
+  migrateAgentActivities(db);
+}
+
+/**
+ * F-1176 — carry a pre-`content` `agent_activities` table forward.
+ *
+ * Same reasoning as `migrateAgentSessions` below: `CREATE TABLE IF NOT EXISTS`
+ * leaves an existing file on its old columns, and dropping `type` / `body`
+ * without carrying them over would answer `{}` for every activity ever
+ * recorded.
+ *
+ * The carry is literal — an old row that said `type=thought, body=X` becomes
+ * `{"type":"thought","body":"X"}`, which is exactly what it meant. That is a
+ * valid `AgentActivityContent` for five of the six types. It is NOT one for
+ * `action`, whose upstream member carries `action` / `parameter` and no `body`
+ * at all — but the honest carry of a legacy row is what it said, and inventing
+ * an `action` / `parameter` split out of one free-text field would be worse.
+ * Nothing re-validates content on read, and no writer produces that shape
+ * again.
+ */
+function migrateAgentActivities(db: LinearTwinDatabase): void {
+  const columns = (db.prepare("PRAGMA table_info(agent_activities)").all() as Array<{ name: string }>).map(
+    (column) => column.name
+  );
+  if (!columns.includes("content_json")) {
+    db.exec("ALTER TABLE agent_activities ADD COLUMN content_json TEXT NOT NULL DEFAULT '{}'");
+  }
+  if (!columns.includes("signal")) db.exec("ALTER TABLE agent_activities ADD COLUMN signal TEXT");
+  if (columns.includes("type") && columns.includes("body")) {
+    db.exec(
+      `UPDATE agent_activities
+          SET content_json = json_object('type', type, 'body', body)
+        WHERE content_json = '{}'`
+    );
+  }
+  if (columns.includes("type")) db.exec("ALTER TABLE agent_activities DROP COLUMN type");
+  if (columns.includes("body")) db.exec("ALTER TABLE agent_activities DROP COLUMN body");
+  // Linear declares `AgentActivity.user: User!`. A row whose author was cleared
+  // by the `ON DELETE SET NULL` foreign key adopts its session's app user
+  // rather than reaching `readActivityUserId` and failing the whole read.
+  db.exec(
+    `UPDATE agent_activities
+        SET user_id = (SELECT app_user_id FROM agent_sessions WHERE agent_sessions.id = session_id)
+      WHERE user_id IS NULL`
+  );
 }
 
 /**

--- a/packages/twin-linear/src/domain/agents.ts
+++ b/packages/twin-linear/src/domain/agents.ts
@@ -2,10 +2,15 @@
 import { notFound } from "../errors.js";
 import type {
   LinearAgentActivity,
+  LinearAgentActivitySignal,
   LinearAgentSession,
   LinearAgentSessionExternalUrl,
 } from "../types.js";
-import { assertBody, normalizeActivityType, normalizeSessionStatus } from "./normalize.js";
+import {
+  AGENT_ACTIVITY_SESSION_STATUS,
+  normalizeActivityContent,
+  normalizeActivitySignal,
+} from "./normalize.js";
 import type { ActorContext, LinearDomain } from "./linear-domain.js";
 import { mapAgentActivity, mapAgentSession, type AgentActivityRow, type AgentSessionRow } from "./rows.js";
 import { emitWebhook } from "./webhooks.js";
@@ -23,24 +28,40 @@ export function getAgentSession(domain: LinearDomain, ref: string): LinearAgentS
   return row ? mapAgentSession(row) : null;
 }
 
+/**
+ * `appUserId` is deliberately NOT on the wire (F-1176) — Linear's
+ * `AgentSessionCreateOnIssue` declares `issueId`, `externalLink` and
+ * `externalUrls`, and nothing else. It stays here because the twin's OWN
+ * delegate and mention paths create sessions for a named app user, which is
+ * what Linear does implicitly from the delegation that triggered them.
+ */
 export type AgentSessionOnIssueInput = {
   issueId: string;
   appUserId?: string;
-  plan?: string | null;
   externalUrls?: LinearAgentSessionExternalUrl[] | null;
 };
 
 export type AgentSessionOnCommentInput = {
   commentId: string;
   appUserId?: string;
+  externalUrls?: LinearAgentSessionExternalUrl[] | null;
+};
+
+/**
+ * No `status`. Upstream `AgentSessionUpdateInput` has no such field: a session's
+ * status follows the activities its agent emits (F-1176). See
+ * `AGENT_ACTIVITY_SESSION_STATUS`.
+ */
+export type AgentSessionPatch = {
   plan?: string | null;
   externalUrls?: LinearAgentSessionExternalUrl[] | null;
 };
 
-export type AgentSessionPatch = {
-  status?: string;
-  plan?: string | null;
-  externalUrls?: LinearAgentSessionExternalUrl[] | null;
+export type AgentActivityCreateInput = {
+  agentSessionId: string;
+  content: unknown;
+  signal?: string | null;
+  ephemeral?: boolean;
 };
 
 export async function createAgentSessionOnIssue(
@@ -68,7 +89,7 @@ export async function createAgentSessionOnIssue(
       null,
       agent.id,
       "pending",
-      input.plan ?? null,
+      null,
       JSON.stringify(input.externalUrls ?? []),
       now,
       now
@@ -111,7 +132,7 @@ export async function createAgentSessionOnComment(
       comment.id,
       agent.id,
       "pending",
-      input.plan ?? null,
+      null,
       JSON.stringify(input.externalUrls ?? []),
       now,
       now
@@ -135,14 +156,12 @@ export function updateAgentSession(
   domain.db
     .prepare(
       `UPDATE agent_sessions SET
-          status = COALESCE(?, status),
           plan = CASE WHEN ? THEN ? ELSE plan END,
           external_urls_json = CASE WHEN ? THEN ? ELSE external_urls_json END,
           updated_at = ?
          WHERE id = ?`
     )
     .run(
-      input.status ? normalizeSessionStatus(input.status) : null,
       input.plan !== undefined ? 1 : 0,
       input.plan ?? null,
       input.externalUrls !== undefined ? 1 : 0,
@@ -155,29 +174,40 @@ export function updateAgentSession(
 
 export async function createAgentActivity(
   domain: LinearDomain,
-  input: { sessionId: string; type: string; body: string; ephemeral?: boolean },
+  input: AgentActivityCreateInput,
   actor: ActorContext = {}
 ): Promise<LinearAgentActivity> {
   domain.requireScopes(actor, ["write"]);
-  assertBody(input.body);
-  const session = domain.requireAgentSession(input.sessionId);
+  const session = domain.requireAgentSession(input.agentSessionId);
   const viewer = domain.resolveViewer(actor);
-  const type = normalizeActivityType(input.type);
+  const content = normalizeActivityContent(input.content);
+  const signal: LinearAgentActivitySignal | null = input.signal
+    ? normalizeActivitySignal(input.signal)
+    : null;
   const now = domain.tick();
   const id = domain.nextId("agent_activity");
   const ephemeral =
-    typeof input.ephemeral === "boolean" ? input.ephemeral : type === "thought" || type === "action";
+    typeof input.ephemeral === "boolean"
+      ? input.ephemeral
+      : content.type === "thought" || content.type === "action";
   domain.db
     .prepare(
-      `INSERT INTO agent_activities(id, session_id, user_id, type, body, ephemeral, created_at, updated_at)
+      `INSERT INTO agent_activities(id, session_id, user_id, content_json, signal, ephemeral, created_at, updated_at)
          VALUES (?,?,?,?,?,?,?,?)`
     )
-    .run(id, session.id, viewer.id, type, input.body, ephemeral ? 1 : 0, now, now);
-  if (type === "prompt") {
+    .run(id, session.id, viewer.id, JSON.stringify(content), signal, ephemeral ? 1 : 0, now, now);
+  // The session follows the activity — upstream has no other way to move it,
+  // and no `status` on `agentSessionUpdate` to do it by hand (F-1176).
+  const status = AGENT_ACTIVITY_SESSION_STATUS[content.type];
+  domain.db
+    .prepare("UPDATE agent_sessions SET status = ?, updated_at = ? WHERE id = ?")
+    .run(status, now, session.id);
+  if (content.type === "prompt") {
     await emitWebhook(domain, {
       type: "AgentSessionEvent",
       action: "prompted",
-      data: { id: session.id, status: session.status },
+      // The status the activity just produced, not the one it replaced.
+      data: { id: session.id, status },
       actor: viewer,
       teamId: session.issueId ? domain.requireIssue(session.issueId).teamId : null,
     });
@@ -194,10 +224,10 @@ export function getAgentActivity(domain: LinearDomain, ref: string): LinearAgent
   return row ? mapAgentActivity(row) : null;
 }
 
-export function listAgentActivities(domain: LinearDomain, sessionId: string): LinearAgentActivity[] {
+export function listAgentActivities(domain: LinearDomain, agentSessionId: string): LinearAgentActivity[] {
   return (
     domain.db
       .prepare("SELECT * FROM agent_activities WHERE session_id = ? ORDER BY created_at, id")
-      .all(sessionId) as AgentActivityRow[]
+      .all(agentSessionId) as AgentActivityRow[]
   ).map(mapAgentActivity);
 }

--- a/packages/twin-linear/src/domain/linear-domain.ts
+++ b/packages/twin-linear/src/domain/linear-domain.ts
@@ -383,7 +383,7 @@ export class LinearDomain {
   }
 
   createAgentActivity(
-    input: { sessionId: string; type: string; body: string; ephemeral?: boolean },
+    input: agents.AgentActivityCreateInput,
     actor: ActorContext = {}
   ): Promise<LinearAgentActivity> {
     return agents.createAgentActivity(this, input, actor);
@@ -393,8 +393,8 @@ export class LinearDomain {
     return agents.getAgentActivity(this, ref);
   }
 
-  listAgentActivities(sessionId: string): LinearAgentActivity[] {
-    return agents.listAgentActivities(this, sessionId);
+  listAgentActivities(agentSessionId: string): LinearAgentActivity[] {
+    return agents.listAgentActivities(this, agentSessionId);
   }
 
   listOAuthApps(): LinearOAuthApp[] {

--- a/packages/twin-linear/src/domain/normalize.ts
+++ b/packages/twin-linear/src/domain/normalize.ts
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
+import { z } from "zod";
 import { LinearTwinError, badUserInput } from "../errors.js";
 import { byteLength } from "../ids.js";
 import {
   BODY_MAX_BYTES,
   TITLE_MAX_BYTES,
+  type LinearAgentActivityContent,
+  type LinearAgentActivitySignal,
   type LinearAgentActivityType,
   type LinearAgentSessionStatus,
   type LinearIssuePriority,
@@ -73,22 +76,98 @@ export function readSessionStatus(value: string): LinearAgentSessionStatus {
   return value as LinearAgentSessionStatus;
 }
 
-export function normalizeSessionStatus(value: string): LinearAgentSessionStatus {
-  if (!AGENT_SESSION_STATUSES.includes(value as LinearAgentSessionStatus)) {
-    badUserInput(`Invalid agent session status: ${value}`);
+/**
+ * An activity's author, read back OUT of storage. Linear declares
+ * `AgentActivity.user: User!`, and `agent_activities.user_id` is nullable only
+ * because its foreign key is `ON DELETE SET NULL` — nothing in the twin writes
+ * a null. Same reasoning as `readSessionStatus`: fail here, naming the row,
+ * rather than at GraphQL non-null serialisation, which names neither (F-1176).
+ */
+export function readActivityUserId(activityId: string, value: string | null): string {
+  if (!value) {
+    throw new LinearTwinError(
+      500,
+      "INTERNAL_SERVER_ERROR",
+      `Agent activity "${activityId}" has no user. Linear declares AgentActivity.user as non-null; ` +
+        `this row's author was cleared, which no code path in this twin does.`
+    );
   }
-  return value as LinearAgentSessionStatus;
+  return value;
 }
 
-export function normalizeActivityType(value: string): LinearAgentActivityType {
-  const allowed: LinearAgentActivityType[] = [
-    "thought",
-    "elicitation",
-    "action",
-    "response",
-    "error",
-    "prompt",
-  ];
-  if (!allowed.includes(value as LinearAgentActivityType)) badUserInput(`Invalid agent activity type: ${value}`);
-  return value as LinearAgentActivityType;
+/** Linear's AgentActivitySignal members, verbatim (F-1176). */
+export const AGENT_ACTIVITY_SIGNALS = ["stop", "continue", "auth", "select"] as const satisfies
+  readonly LinearAgentActivitySignal[];
+
+/**
+ * THE ONE INVENTED THING IN F-1176 — how an activity moves the session.
+ *
+ * Upstream, `agentSessionUpdate` has no `status` field at all: Linear's agent
+ * guide says session state "is updated automatically based on the agent's
+ * emitted activities. No manual state management is required." So the SHAPE of
+ * the model is verified upstream truth — status follows activities, and is not
+ * settable through the update mutation. Linear never publishes WHICH activity
+ * yields which status, and introspection cannot show behaviour, so this
+ * particular table is twin-owned and written up in `REFERENCE-DIVERGENCES.md`.
+ *
+ * The alternative to naming it was a twin whose sessions sit at `pending`
+ * forever, which is worse fidelity than a documented mapping.
+ */
+export const AGENT_ACTIVITY_SESSION_STATUS: Record<LinearAgentActivityType, LinearAgentSessionStatus> = {
+  thought: "active",
+  action: "active",
+  elicitation: "awaitingInput",
+  response: "complete",
+  error: "error",
+  prompt: "pending",
+};
+
+/**
+ * Linear's `AgentActivityContent`, as a parser.
+ *
+ * Upstream declares the input field as `JSONObject!` and validates server-side,
+ * where introspection cannot see it — so this mirrors the OUTPUT union, which
+ * introspection can. Strict on unknown keys, because the twin's rule is a loud
+ * refusal over a silent stub: a misspelled `bodyy` should name itself here
+ * rather than round-trip out as content nobody can read.
+ */
+const bodyContent = { body: z.string().min(1), bodyData: z.unknown().optional() };
+const agentActivityContentSchema: z.ZodType<LinearAgentActivityContent> = z.discriminatedUnion(
+  "type",
+  [
+    z.object({ type: z.literal("thought"), ...bodyContent }).strict(),
+    z.object({ type: z.literal("response"), ...bodyContent }).strict(),
+    z.object({ type: z.literal("elicitation"), ...bodyContent }).strict(),
+    z.object({ type: z.literal("prompt"), ...bodyContent, title: z.string().nullish() }).strict(),
+    z.object({ type: z.literal("error"), ...bodyContent, reasonCode: z.string().nullish() }).strict(),
+    z
+      .object({
+        type: z.literal("action"),
+        action: z.string().min(1),
+        parameter: z.string().min(1),
+        result: z.string().nullish(),
+        resultData: z.unknown().optional(),
+      })
+      .strict(),
+  ]
+);
+
+export function normalizeActivityContent(value: unknown): LinearAgentActivityContent {
+  const parsed = agentActivityContentSchema.safeParse(value);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    badUserInput(
+      `Invalid agent activity content${issue ? `: ${issue.path.join(".") || "type"} — ${issue.message}` : ""}`
+    );
+  }
+  const content = parsed.data;
+  if ("body" in content) assertBody(content.body);
+  return content;
+}
+
+export function normalizeActivitySignal(value: string): LinearAgentActivitySignal {
+  if (!AGENT_ACTIVITY_SIGNALS.includes(value as LinearAgentActivitySignal)) {
+    badUserInput(`Invalid agent activity signal: ${value}`);
+  }
+  return value as LinearAgentActivitySignal;
 }

--- a/packages/twin-linear/src/domain/rows.ts
+++ b/packages/twin-linear/src/domain/rows.ts
@@ -22,8 +22,10 @@ import type {
   LinearWorkflowState,
   LinearWorkflowStateType,
   LinearAgentSessionExternalUrl,
+  LinearAgentActivityContent,
+  LinearAgentActivitySignal,
 } from "../types.js";
-import { readSessionStatus } from "./normalize.js";
+import { readActivityUserId, readSessionStatus } from "./normalize.js";
 
 export type OrgRow = {
   id: string;
@@ -202,8 +204,8 @@ export type AgentActivityRow = {
   id: string;
   session_id: string;
   user_id: string | null;
-  type: string;
-  body: string;
+  content_json: string;
+  signal: string | null;
   ephemeral: number;
   created_at: string;
   updated_at: string;
@@ -396,10 +398,10 @@ export function mapAgentSession(row: AgentSessionRow): LinearAgentSession {
 export function mapAgentActivity(row: AgentActivityRow): LinearAgentActivity {
   return {
     id: row.id,
-    sessionId: row.session_id,
-    userId: row.user_id,
-    type: row.type as LinearAgentActivity["type"],
-    body: row.body,
+    agentSessionId: row.session_id,
+    userId: readActivityUserId(row.id, row.user_id),
+    content: JSON.parse(row.content_json) as LinearAgentActivityContent,
+    signal: row.signal as LinearAgentActivitySignal | null,
     ephemeral: !!row.ephemeral,
     createdAt: row.created_at,
     updatedAt: row.updated_at,

--- a/packages/twin-linear/src/graphql/formatters.ts
+++ b/packages/twin-linear/src/graphql/formatters.ts
@@ -318,13 +318,13 @@ export function createFormatters(commands: LinearDomain, actor: ActorContext): G
 
   const formatAgentActivity = (activity: LinearAgentActivity) => ({
     id: activity.id,
-    type: activity.type,
-    body: activity.body,
+    content: activity.content,
+    signal: activity.signal,
     ephemeral: activity.ephemeral,
     createdAt: activity.createdAt,
     updatedAt: activity.updatedAt,
-    session: () => formatAgentSession(commands.requireAgentSession(activity.sessionId)),
-    user: () => (activity.userId ? formatUser(commands.requireUser(activity.userId)) : null),
+    agentSession: () => formatAgentSession(commands.requireAgentSession(activity.agentSessionId)),
+    user: () => formatUser(commands.requireUser(activity.userId)),
   });
 
   function formatIssue(issue: LinearIssue) {

--- a/packages/twin-linear/src/graphql/mutation-inputs.ts
+++ b/packages/twin-linear/src/graphql/mutation-inputs.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { z } from "zod";
 import { badUserInput } from "../errors.js";
+import { AGENT_ACTIVITY_SIGNALS } from "../domain/normalize.js";
 import type { IssueCreateInput, IssueUpdateInput } from "../domain/index.js";
 
 const optionalString = z.string().nullish();
@@ -98,11 +99,13 @@ const agentSessionExternalUrlSchema = z
   .strict();
 const optionalExternalUrls = z.array(agentSessionExternalUrlSchema).nullish();
 
+// F-1176 — these four mirror Linear's mutation inputs. `appUserId` and a
+// create-time `plan` are gone (Linear declares neither), `status` is gone (a
+// session's status follows its activities), and `id` is the mutation's own
+// non-null argument rather than an input field.
 export const agentSessionOnIssueInputSchema = z
   .object({
     issueId: z.string().min(1),
-    appUserId: z.string().optional(),
-    plan: optionalString,
     externalUrls: optionalExternalUrls,
   })
   .strict();
@@ -110,16 +113,12 @@ export const agentSessionOnIssueInputSchema = z
 export const agentSessionOnCommentInputSchema = z
   .object({
     commentId: z.string().min(1),
-    appUserId: z.string().optional(),
-    plan: optionalString,
     externalUrls: optionalExternalUrls,
   })
   .strict();
 
 export const agentSessionUpdateInputSchema = z
   .object({
-    id: z.string().min(1).optional(),
-    status: z.string().optional(),
     plan: optionalString,
     externalUrls: optionalExternalUrls,
   })
@@ -127,9 +126,14 @@ export const agentSessionUpdateInputSchema = z
 
 export const agentActivityCreateInputSchema = z
   .object({
-    sessionId: z.string().min(1),
-    type: z.string().min(1),
-    body: z.string().min(1),
+    agentSessionId: z.string().min(1),
+    // `JSONObject!` upstream. The envelope is checked here; which of Linear's
+    // six `AgentActivityContent` members it is, and whether it is well formed,
+    // is the domain's `normalizeActivityContent` — the same split as
+    // `priority` and `normalizePriority`, and the reason a bad content names
+    // itself rather than surfacing as a stray "expected string".
+    content: z.record(z.string(), z.unknown()),
+    signal: z.enum(AGENT_ACTIVITY_SIGNALS).nullish(),
     ephemeral: z.boolean().optional(),
   })
   .strict();
@@ -233,12 +237,7 @@ export function parseWebhookCreateInput(input: unknown) {
 
 export function parseAgentSessionOnIssueInput(input: unknown) {
   const raw = parseOrBadUserInput(agentSessionOnIssueInputSchema, input, "agentSessionCreateOnIssue input");
-  return {
-    issueId: raw.issueId,
-    appUserId: raw.appUserId,
-    plan: raw.plan ?? null,
-    externalUrls: raw.externalUrls ?? null,
-  };
+  return { issueId: raw.issueId, externalUrls: raw.externalUrls ?? null };
 }
 
 export function parseAgentSessionOnCommentInput(input: unknown) {
@@ -247,30 +246,20 @@ export function parseAgentSessionOnCommentInput(input: unknown) {
     input,
     "agentSessionCreateOnComment input"
   );
-  return {
-    commentId: raw.commentId,
-    appUserId: raw.appUserId,
-    plan: raw.plan ?? null,
-    externalUrls: raw.externalUrls ?? null,
-  };
+  return { commentId: raw.commentId, externalUrls: raw.externalUrls ?? null };
 }
 
 export function parseAgentSessionUpdateInput(input: unknown) {
   const raw = parseOrBadUserInput(agentSessionUpdateInputSchema, input, "agentSessionUpdate input");
-  return {
-    id: raw.id,
-    status: raw.status,
-    plan: raw.plan,
-    externalUrls: raw.externalUrls,
-  };
+  return { plan: raw.plan, externalUrls: raw.externalUrls };
 }
 
 export function parseAgentActivityCreateInput(input: unknown) {
   const raw = parseOrBadUserInput(agentActivityCreateInputSchema, input, "agentActivityCreate input");
   return {
-    sessionId: raw.sessionId,
-    type: raw.type,
-    body: raw.body,
+    agentSessionId: raw.agentSessionId,
+    content: raw.content,
+    signal: raw.signal ?? null,
     ephemeral: raw.ephemeral,
   };
 }

--- a/packages/twin-linear/src/graphql/resolvers.ts
+++ b/packages/twin-linear/src/graphql/resolvers.ts
@@ -199,17 +199,10 @@ export function createRootValue(ctx: GraphQLRuntimeContext): Record<string, unkn
       );
       return payload({ agentSession: formatAgentSession(session) });
     },
-    agentSessionUpdate: ({ id, input }: { id?: string; input: unknown }) => {
-      const parsed = parseAgentSessionUpdateInput(input);
-      const session = commands.updateAgentSession(
-        String(id ?? parsed.id),
-        {
-          status: parsed.status,
-          plan: parsed.plan,
-          externalUrls: parsed.externalUrls,
-        },
-        actor
-      );
+    // `id` is non-null on the schema, as it is upstream — there is no longer an
+    // `input.id` to fall back to (F-1176).
+    agentSessionUpdate: ({ id, input }: { id: string; input: unknown }) => {
+      const session = commands.updateAgentSession(id, parseAgentSessionUpdateInput(input), actor);
       return payload({ agentSession: formatAgentSession(session) });
     },
     agentActivityCreate: async ({ input }: { input: unknown }) => {

--- a/packages/twin-linear/src/graphql/schema.ts
+++ b/packages/twin-linear/src/graphql/schema.ts
@@ -9,6 +9,7 @@ export const linearGraphQLSchema: GraphQLSchema = buildSchema(`
   scalar PaginationOrderBy
   scalar DateTime
   scalar JSON
+  scalar JSONObject
 
   type Query {
     viewer: User!
@@ -61,7 +62,7 @@ export const linearGraphQLSchema: GraphQLSchema = buildSchema(`
     webhookDelete(id: String!): DeletePayload!
     agentSessionCreateOnIssue(input: AgentSessionCreateOnIssue!): AgentSessionPayload!
     agentSessionCreateOnComment(input: AgentSessionCreateOnComment!): AgentSessionPayload!
-    agentSessionUpdate(id: String, input: AgentSessionUpdateInput!): AgentSessionPayload!
+    agentSessionUpdate(id: String!, input: AgentSessionUpdateInput!): AgentSessionPayload!
     agentActivityCreate(input: AgentActivityCreateInput!): AgentActivityPayload!
   }
 
@@ -324,15 +325,29 @@ export const linearGraphQLSchema: GraphQLSchema = buildSchema(`
     activities(first: Int, after: String, last: Int, before: String): AgentActivityConnection!
   }
 
+  """Linear's AgentActivitySignal, member-for-member (F-1176)."""
+  enum AgentActivitySignal {
+    stop
+    continue
+    auth
+    select
+  }
+
   type AgentActivity {
-    id: String!
-    type: String!
-    body: String!
+    id: ID!
+    """
+    Linear's AgentActivityContent union, carried as an opaque payload: a
+    {type, body} object for five of the six members, {type, action, parameter}
+    for the action member. The union itself is a scalar-level divergence,
+    written up in REFERENCE-DIVERGENCES.md (F-1176).
+    """
+    content: JSON!
+    signal: AgentActivitySignal
     ephemeral: Boolean!
-    createdAt: String!
-    updatedAt: String!
-    session: AgentSession!
-    user: User
+    createdAt: DateTime!
+    updatedAt: DateTime!
+    agentSession: AgentSession!
+    user: User!
   }
 
   type NodeRef {
@@ -492,31 +507,30 @@ export const linearGraphQLSchema: GraphQLSchema = buildSchema(`
     label: String!
   }
 
+  """Linear's AgentSessionCreateOnIssue, minus the fields the twin does not model (F-1176)."""
   input AgentSessionCreateOnIssue {
     issueId: String!
-    appUserId: String
-    plan: String
     externalUrls: [AgentSessionExternalUrlInput!]
   }
 
   input AgentSessionCreateOnComment {
     commentId: String!
-    appUserId: String
-    plan: String
     externalUrls: [AgentSessionExternalUrlInput!]
   }
 
+  """
+  Linear declares no status and no id field here (F-1176). Status follows the
+  agent's activities; id is the mutation's own non-null argument.
+  """
   input AgentSessionUpdateInput {
-    id: String
-    status: AgentSessionStatus
     plan: String
     externalUrls: [AgentSessionExternalUrlInput!]
   }
 
   input AgentActivityCreateInput {
-    sessionId: String!
-    type: String!
-    body: String!
+    agentSessionId: String!
+    content: JSONObject!
+    signal: AgentActivitySignal
     ephemeral: Boolean
   }
 `);

--- a/packages/twin-linear/src/state.ts
+++ b/packages/twin-linear/src/state.ts
@@ -93,12 +93,15 @@ export function exportLinearState(db: LinearTwinDatabase): LinearStateExport {
   );
 
   const agentActivities = capped(
-    db
-      .prepare(
-        `SELECT id, session_id AS sessionId, user_id AS userId, type, body, ephemeral,
-                created_at AS createdAt FROM agent_activities ORDER BY created_at DESC, id DESC`
-      )
-      .all() as unknown[],
+    (
+      db
+        .prepare(
+          `SELECT id, session_id AS agentSessionId, user_id AS userId, content_json AS content,
+                  signal, ephemeral, created_at AS createdAt
+           FROM agent_activities ORDER BY created_at DESC, id DESC`
+        )
+        .all() as Array<Record<string, unknown>>
+    ).map((row) => ({ ...row, content: parseJson(row.content) })),
     "agentActivities",
     truncatedCollections,
     true

--- a/packages/twin-linear/src/types.ts
+++ b/packages/twin-linear/src/types.ts
@@ -18,6 +18,7 @@ export type LinearWorkflowStateType =
 export type LinearTokenType = "personal" | "oauth_access" | "oauth_refresh" | "client_credentials";
 export type LinearTokenActorType = "user" | "app";
 export type LinearIssuePriority = 0 | 1 | 2 | 3 | 4;
+/** Linear's `AgentActivityType` enum, member-for-member — the `content` discriminator. */
 export type LinearAgentActivityType =
   | "thought"
   | "elicitation"
@@ -25,6 +26,26 @@ export type LinearAgentActivityType =
   | "response"
   | "error"
   | "prompt";
+/** Linear's `AgentActivitySignal` enum, member-for-member (F-1176). */
+export type LinearAgentActivitySignal = "stop" | "continue" | "auth" | "select";
+/**
+ * Linear's `AgentActivityContent` union, member-for-member (F-1176).
+ *
+ * Upstream this is a real GraphQL union discriminated on `type`, whose six
+ * members are `AgentActivity{Thought,Action,Response,Elicitation,Error,Prompt}
+ * Content`. Five of the six carry `body`; `action` carries `action` /
+ * `parameter` / `result` instead, which is why an activity's payload cannot be
+ * flattened back to the `{ type, body }` pair the twin used to accept.
+ *
+ * `bodyData` / `resultData` are upstream's structured companions to the text
+ * fields. The twin does not derive them, but it accepts and stores them rather
+ * than refusing an agent that was written against real Linear and sends them.
+ */
+export type LinearAgentActivityContent =
+  | { type: "thought" | "response" | "elicitation"; body: string; bodyData?: unknown }
+  | { type: "prompt"; body: string; title?: string | null; bodyData?: unknown }
+  | { type: "error"; body: string; reasonCode?: string | null; bodyData?: unknown }
+  | { type: "action"; action: string; parameter: string; result?: string | null; resultData?: unknown };
 /** Linear's `AgentSessionStatus` enum, member-for-member (F-1172). */
 export type LinearAgentSessionStatus =
   | "pending"
@@ -249,10 +270,15 @@ export type LinearAgentSession = {
 
 export type LinearAgentActivity = {
   id: string;
-  sessionId: string;
-  userId: string | null;
-  type: LinearAgentActivityType;
-  body: string;
+  agentSessionId: string;
+  /**
+   * Non-null, matching Linear's `AgentActivity.user: User!`. The column is
+   * still nullable — its FK is `ON DELETE SET NULL` — so this is enforced at
+   * the read boundary, next to the status check, rather than assumed.
+   */
+  userId: string;
+  content: LinearAgentActivityContent;
+  signal: LinearAgentActivitySignal | null;
   ephemeral: boolean;
   createdAt: string;
   updatedAt: string;

--- a/packages/twin-linear/test/agent-activity-migration.test.ts
+++ b/packages/twin-linear/test/agent-activity-migration.test.ts
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-1176: `agent_activities` stopped carrying `type` / `body` and started
+// carrying Linear's `content`. Same reopening hazard F-1172 documented for
+// `agent_sessions`: `CREATE TABLE IF NOT EXISTS` is a no-op on a database that
+// already has the table, so a `LINEAR_TWIN_DB` file written before this change
+// would open clean on the old columns — and then answer `{}` for the content of
+// every activity it had ever recorded, which reads as an empty session rather
+// than as a schema mismatch.
+//
+// This builds a genuinely pre-content table — asserting its column set equals
+// the frozen pre-content list before going anywhere near the migration — and
+// then reopens it with the shipping code.
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { LinearDomain, openLinearTwinDatabase } from "../src/index.js";
+import { testSeed } from "./_helpers.js";
+
+/** `agent_activities` exactly as twin-linear 0.3.5 declared it. */
+const PRE_CONTENT_COLUMNS = [
+  "id",
+  "session_id",
+  "user_id",
+  "type",
+  "body",
+  "ephemeral",
+  "created_at",
+  "updated_at",
+];
+
+const temporaries: string[] = [];
+
+afterEach(() => {
+  for (const dir of temporaries.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function columnsOf(db: { prepare: (sql: string) => { all: () => unknown[] } }): string[] {
+  return (db.prepare("PRAGMA table_info(agent_activities)").all() as Array<{ name: string }>).map(
+    (column) => column.name
+  );
+}
+
+/**
+ * Write a database whose `agent_activities` table is in the pre-content shape,
+ * carrying one row per activity type plus one whose author has been cleared.
+ */
+async function seedPreContentDatabase(): Promise<{ path: string; sessionId: string; appUserId: string }> {
+  const dir = mkdtempSync(join(tmpdir(), "twin-linear-activity-migration-"));
+  temporaries.push(dir);
+  const path = join(dir, "linear.db");
+
+  const db = openLinearTwinDatabase(path);
+  const commands = new LinearDomain(db);
+  commands.seed(testSeed());
+  const issue = commands.listIssues()[0]!;
+  const session = await commands.createAgentSessionOnIssue({ issueId: issue.id });
+
+  // Put the table back into the 0.3.5 shape, so what follows is the real old
+  // schema and not an approximation of it.
+  db.exec("ALTER TABLE agent_activities ADD COLUMN type TEXT NOT NULL DEFAULT ''");
+  db.exec("ALTER TABLE agent_activities ADD COLUMN body TEXT NOT NULL DEFAULT ''");
+  db.exec("ALTER TABLE agent_activities DROP COLUMN content_json");
+  db.exec("ALTER TABLE agent_activities DROP COLUMN signal");
+  expect(columnsOf(db).sort()).toEqual([...PRE_CONTENT_COLUMNS].sort());
+
+  const insert = db.prepare(
+    `INSERT INTO agent_activities(id, session_id, user_id, type, body, ephemeral, created_at, updated_at)
+       VALUES (?,?,?,?,?,?,?,?)`
+  );
+  for (const type of ["thought", "action", "response"]) {
+    insert.run(
+      `legacy_${type}`,
+      session.id,
+      session.appUserId,
+      type,
+      `an old ${type}`,
+      0,
+      "2026-08-01T00:00:00.000Z",
+      "2026-08-01T00:00:00.000Z"
+    );
+  }
+  // The one row the `ON DELETE SET NULL` foreign key can produce.
+  insert.run(
+    "legacy_orphan",
+    session.id,
+    null,
+    "thought",
+    "an old thought",
+    0,
+    "2026-08-01T00:00:00.000Z",
+    "2026-08-01T00:00:00.000Z"
+  );
+  db.close();
+  return { path, sessionId: session.id, appUserId: session.appUserId };
+}
+
+describe("a pre-content agent_activities table migrates on open (F-1176)", () => {
+  it("swaps type/body for content_json and signal instead of opening clean", async () => {
+    const { path } = await seedPreContentDatabase();
+
+    const db = openLinearTwinDatabase(path);
+
+    expect(columnsOf(db)).toEqual(expect.arrayContaining(["content_json", "signal"]));
+    expect(columnsOf(db)).not.toContain("type");
+    expect(columnsOf(db)).not.toContain("body");
+    db.close();
+  });
+
+  it("carries what the old row said into content, verbatim", async () => {
+    const { path, sessionId } = await seedPreContentDatabase();
+
+    const db = openLinearTwinDatabase(path);
+    const activities = new LinearDomain(db).listAgentActivities(sessionId);
+
+    const byId = new Map(activities.map((activity) => [activity.id, activity.content]));
+    expect(byId.get("legacy_thought")).toEqual({ type: "thought", body: "an old thought" });
+    expect(byId.get("legacy_response")).toEqual({ type: "response", body: "an old response" });
+    // `action` is the one member upstream carries no `body` on. The honest
+    // carry of a legacy row is what it said, not an invented action/parameter
+    // split — see `migrateAgentActivities`.
+    expect(byId.get("legacy_action")).toEqual({ type: "action", body: "an old action" });
+    expect(activities.every((activity) => activity.signal === null)).toBe(true);
+    db.close();
+  });
+
+  it("gives a cleared author back its session's app user, since Linear's is non-null", async () => {
+    const { path, sessionId, appUserId } = await seedPreContentDatabase();
+
+    const db = openLinearTwinDatabase(path);
+    const activities = new LinearDomain(db).listAgentActivities(sessionId);
+
+    expect(activities.find((activity) => activity.id === "legacy_orphan")?.userId).toBe(appUserId);
+    db.close();
+  });
+
+  it("is idempotent — reopening a migrated database changes nothing", async () => {
+    const { path, sessionId } = await seedPreContentDatabase();
+
+    const first = openLinearTwinDatabase(path);
+    const before = new LinearDomain(first).listAgentActivities(sessionId);
+    const columns = columnsOf(first);
+    first.close();
+
+    const second = openLinearTwinDatabase(path);
+    expect(columnsOf(second)).toEqual(columns);
+    expect(new LinearDomain(second).listAgentActivities(sessionId)).toEqual(before);
+    second.close();
+  });
+
+  it("fails legibly if an activity somehow reaches the read boundary with no author", async () => {
+    const { path, sessionId } = await seedPreContentDatabase();
+    const db = openLinearTwinDatabase(path);
+    db.prepare("UPDATE agent_activities SET user_id = NULL WHERE id = ?").run("legacy_thought");
+
+    expect(() => new LinearDomain(db).listAgentActivities(sessionId)).toThrowError(
+      /Agent activity "legacy_thought" has no user/
+    );
+    db.close();
+  });
+});

--- a/packages/twin-linear/test/agent-session-inputs.test.ts
+++ b/packages/twin-linear/test/agent-session-inputs.test.ts
@@ -1,0 +1,455 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-1176: the agent-session MUTATION INPUTS are Linear's, and so is the model
+// they imply.
+//
+// F-1172 fixed the output type and said, in the guard file's own words, "do not
+// read this file as evidence about the input surface". The inputs still carried
+// `status` and `id` on `AgentSessionUpdateInput`, `appUserId` and `plan` on the
+// two creates, and `sessionId` / `type` / `body` on `AgentActivityCreateInput`
+// — none of which Linear declares. `test/linear-schema-subset.test.ts` now
+// guards the NAMES against Linear's real introspection; this file drives the
+// BEHAVIOUR they imply, which introspection cannot show:
+//
+//   * an argument Linear does not accept is refused here too, and
+//   * a session's status moves through activities, because upstream there is
+//     no other way to move it.
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_LINEAR_TOKEN,
+  LinearDomain,
+  createLinearTwinApp,
+  exportLinearState,
+  openLinearTwinDatabase,
+} from "../src/index.js";
+import { AGENT_ACTIVITY_SESSION_STATUS } from "../src/domain/normalize.js";
+import { testSeed } from "./_helpers.js";
+
+function app() {
+  return createLinearTwinApp({
+    db: openLinearTwinDatabase(":memory:"),
+    seed: testSeed(),
+    runId: "agent-inputs-test",
+  });
+}
+
+function domain() {
+  const db = openLinearTwinDatabase(":memory:");
+  const commands = new LinearDomain(db);
+  commands.seed(testSeed());
+  return commands;
+}
+
+async function graphql(
+  instance: ReturnType<typeof createLinearTwinApp>,
+  query: string,
+  variables?: Record<string, unknown>
+) {
+  const response = await instance.request("/graphql", {
+    method: "POST",
+    headers: { authorization: `Bearer ${DEFAULT_LINEAR_TOKEN}`, "content-type": "application/json" },
+    body: JSON.stringify({ query, variables }),
+  });
+  return (await response.json()) as { data?: Record<string, any>; errors?: Array<{ message: string }> };
+}
+
+async function newSession(instance: ReturnType<typeof createLinearTwinApp>) {
+  const issues = await graphql(instance, `query { issues(first: 1) { nodes { id } } }`);
+  const created = await graphql(
+    instance,
+    `mutation ($input: AgentSessionCreateOnIssue!) {
+       agentSessionCreateOnIssue(input: $input) { agentSession { id status } }
+     }`,
+    { input: { issueId: issues.data?.issues.nodes[0].id } }
+  );
+  expect(created.errors).toBeUndefined();
+  return created.data?.agentSessionCreateOnIssue.agentSession as { id: string; status: string };
+}
+
+const CREATE_ACTIVITY = `mutation ($input: AgentActivityCreateInput!) {
+  agentActivityCreate(input: $input) {
+    agentActivity {
+      id
+      content
+      signal
+      ephemeral
+      user { id }
+      agentSession { id status }
+    }
+  }
+}`;
+
+describe("the mutation inputs refuse what Linear refuses (F-1176)", () => {
+  it("agentSessionUpdate has no status field — status is not settable by hand", async () => {
+    const instance = app();
+    const session = await newSession(instance);
+
+    const updated = await graphql(
+      instance,
+      `mutation ($id: String!, $input: AgentSessionUpdateInput!) {
+         agentSessionUpdate(id: $id, input: $input) { agentSession { status } }
+       }`,
+      { id: session.id, input: { status: "active" } }
+    );
+
+    expect(updated.errors?.[0]?.message).toMatch(
+      /Field "status" is not defined by type "AgentSessionUpdateInput"/
+    );
+  });
+
+  it("agentSessionUpdate has no id field — id is the mutation's own argument", async () => {
+    const instance = app();
+    const session = await newSession(instance);
+
+    const updated = await graphql(
+      instance,
+      `mutation ($id: String!, $input: AgentSessionUpdateInput!) {
+         agentSessionUpdate(id: $id, input: $input) { agentSession { id } }
+       }`,
+      { id: session.id, input: { id: session.id } }
+    );
+
+    expect(updated.errors?.[0]?.message).toMatch(
+      /Field "id" is not defined by type "AgentSessionUpdateInput"/
+    );
+  });
+
+  it("agentSessionUpdate refuses a null id, because Linear declares String!", async () => {
+    const instance = app();
+    await newSession(instance);
+
+    const updated = await graphql(
+      instance,
+      `mutation ($id: String, $input: AgentSessionUpdateInput!) {
+         agentSessionUpdate(id: $id, input: $input) { agentSession { id } }
+       }`,
+      { id: null, input: {} }
+    );
+
+    // A nullable variable cannot even be supplied to a non-null argument.
+    expect(updated.errors?.[0]?.message).toMatch(/\$id.*of type "String".*"String!"/s);
+  });
+
+  it("the create inputs carry neither appUserId nor plan", async () => {
+    const instance = app();
+    const issues = await graphql(instance, `query { issues(first: 1) { nodes { id } } }`);
+    const issueId = issues.data?.issues.nodes[0].id as string;
+
+    for (const [field, value] of [
+      ["appUserId", "user_agent"],
+      ["plan", "PLAN"],
+    ] as const) {
+      const created = await graphql(
+        instance,
+        `mutation ($input: AgentSessionCreateOnIssue!) {
+           agentSessionCreateOnIssue(input: $input) { agentSession { id } }
+         }`,
+        { input: { issueId, [field]: value } }
+      );
+      expect(created.errors?.[0]?.message).toMatch(
+        new RegExp(`Field "${field}" is not defined by type "AgentSessionCreateOnIssue"`)
+      );
+    }
+  });
+
+  it("agentActivityCreate takes agentSessionId and content, not sessionId/type/body", async () => {
+    const instance = app();
+    const session = await newSession(instance);
+
+    const legacy = await graphql(instance, CREATE_ACTIVITY, {
+      input: { sessionId: session.id, type: "thought", body: "thinking" },
+    });
+    expect(legacy.errors?.map((error) => error.message).join(" ")).toMatch(
+      /Field "sessionId" is not defined by type "AgentActivityCreateInput"/
+    );
+
+    const current = await graphql(instance, CREATE_ACTIVITY, {
+      input: { agentSessionId: session.id, content: { type: "thought", body: "thinking" } },
+    });
+    expect(current.errors).toBeUndefined();
+    expect(current.data?.agentActivityCreate.agentActivity.content).toEqual({
+      type: "thought",
+      body: "thinking",
+    });
+  });
+});
+
+describe("a session's status follows its activities (F-1176)", () => {
+  it("moves the session for every AgentActivityType, from the one table that says so", async () => {
+    // Driven off the table itself so a member added to `AgentActivityType`
+    // without a transition cannot pass by being forgotten here.
+    for (const [type, expected] of Object.entries(AGENT_ACTIVITY_SESSION_STATUS)) {
+      const instance = app();
+      const session = await newSession(instance);
+      expect(session.status).toBe("pending");
+
+      const content =
+        type === "action" ? { type, action: "search", parameter: "twin" } : { type, body: `a ${type}` };
+      const emitted = await graphql(instance, CREATE_ACTIVITY, {
+        input: { agentSessionId: session.id, content },
+      });
+
+      expect(emitted.errors, `${type} was refused`).toBeUndefined();
+      expect(
+        emitted.data?.agentActivityCreate.agentActivity.agentSession.status,
+        `${type} should leave the session ${expected}`
+      ).toBe(expected);
+    }
+  });
+
+  it("keeps moving the session as the agent works, ending complete", async () => {
+    const instance = app();
+    const session = await newSession(instance);
+
+    const statuses: string[] = [];
+    for (const content of [
+      { type: "thought", body: "reading the issue" },
+      { type: "action", action: "search", parameter: "twin" },
+      { type: "elicitation", body: "which team owns this?" },
+      { type: "response", body: "done" },
+    ]) {
+      const emitted = await graphql(instance, CREATE_ACTIVITY, {
+        input: { agentSessionId: session.id, content },
+      });
+      expect(emitted.errors).toBeUndefined();
+      statuses.push(emitted.data?.agentActivityCreate.agentActivity.agentSession.status);
+    }
+
+    expect(statuses).toEqual(["active", "active", "awaitingInput", "complete"]);
+  });
+
+  it("stamps the session's updatedAt when an activity moves it", async () => {
+    const commands = domain();
+    const issue = commands.listIssues()[0]!;
+    const session = await commands.createAgentSessionOnIssue({ issueId: issue.id });
+
+    await commands.createAgentActivity({
+      agentSessionId: session.id,
+      content: { type: "response", body: "done" },
+    });
+
+    const after = commands.requireAgentSession(session.id);
+    expect(after.status).toBe("complete");
+    expect(after.updatedAt).not.toBe(session.updatedAt);
+  });
+});
+
+describe("content is Linear's AgentActivityContent, not a free-text body (F-1176)", () => {
+  it("round-trips an action's action/parameter/result, which carry no body upstream", async () => {
+    const instance = app();
+    const session = await newSession(instance);
+
+    const emitted = await graphql(instance, CREATE_ACTIVITY, {
+      input: {
+        agentSessionId: session.id,
+        content: { type: "action", action: "search", parameter: "twin", result: "4 hits" },
+      },
+    });
+
+    expect(emitted.errors).toBeUndefined();
+    expect(emitted.data?.agentActivityCreate.agentActivity.content).toEqual({
+      type: "action",
+      action: "search",
+      parameter: "twin",
+      result: "4 hits",
+    });
+  });
+
+  it("refuses a body on an action, and an action on a thought", async () => {
+    const instance = app();
+    const session = await newSession(instance);
+
+    for (const content of [
+      { type: "action", body: "searched for twin" },
+      { type: "thought", body: "thinking", action: "search" },
+    ]) {
+      const emitted = await graphql(instance, CREATE_ACTIVITY, {
+        input: { agentSessionId: session.id, content },
+      });
+      expect(emitted.errors?.[0]?.message).toMatch(/Invalid agent activity content/);
+    }
+  });
+
+  it("refuses a type Linear does not have", async () => {
+    const instance = app();
+    const session = await newSession(instance);
+
+    const emitted = await graphql(instance, CREATE_ACTIVITY, {
+      input: { agentSessionId: session.id, content: { type: "musing", body: "hmm" } },
+    });
+
+    expect(emitted.errors?.[0]?.message).toMatch(/Invalid agent activity content/);
+  });
+
+  it("carries prompt's title and error's reasonCode, and an agent's bodyData", async () => {
+    const instance = app();
+    const session = await newSession(instance);
+
+    const prompted = await graphql(instance, CREATE_ACTIVITY, {
+      input: {
+        agentSessionId: session.id,
+        content: { type: "prompt", body: "review this", title: "Review", bodyData: { blocks: 1 } },
+      },
+    });
+    expect(prompted.errors).toBeUndefined();
+    expect(prompted.data?.agentActivityCreate.agentActivity.content).toMatchObject({
+      title: "Review",
+      bodyData: { blocks: 1 },
+    });
+
+    const failed = await graphql(instance, CREATE_ACTIVITY, {
+      input: {
+        agentSessionId: session.id,
+        content: { type: "error", body: "rate limited", reasonCode: "RATE_LIMIT" },
+      },
+    });
+    expect(failed.errors).toBeUndefined();
+    expect(failed.data?.agentActivityCreate.agentActivity.content).toMatchObject({
+      reasonCode: "RATE_LIMIT",
+    });
+  });
+
+  it("defaults ephemeral from the content's type, as it did from the old type field", async () => {
+    const instance = app();
+    const session = await newSession(instance);
+
+    const thought = await graphql(instance, CREATE_ACTIVITY, {
+      input: { agentSessionId: session.id, content: { type: "thought", body: "thinking" } },
+    });
+    const response = await graphql(instance, CREATE_ACTIVITY, {
+      input: { agentSessionId: session.id, content: { type: "response", body: "done" } },
+    });
+
+    expect(thought.data?.agentActivityCreate.agentActivity.ephemeral).toBe(true);
+    expect(response.data?.agentActivityCreate.agentActivity.ephemeral).toBe(false);
+  });
+});
+
+describe("signal, agentSession and user complete the AgentActivity surface (F-1176)", () => {
+  it("round-trips a signal and refuses one Linear does not declare", async () => {
+    const instance = app();
+    const session = await newSession(instance);
+
+    const stopped = await graphql(instance, CREATE_ACTIVITY, {
+      input: {
+        agentSessionId: session.id,
+        content: { type: "response", body: "stopping" },
+        signal: "stop",
+      },
+    });
+    expect(stopped.errors).toBeUndefined();
+    expect(stopped.data?.agentActivityCreate.agentActivity.signal).toBe("stop");
+
+    const bogus = await graphql(instance, CREATE_ACTIVITY, {
+      input: {
+        agentSessionId: session.id,
+        content: { type: "response", body: "halting" },
+        signal: "halt",
+      },
+    });
+    expect(bogus.errors?.[0]?.message).toMatch(/Value "halt" does not exist in "AgentActivitySignal"/);
+  });
+
+  it("leaves signal null when the agent sends none", async () => {
+    const instance = app();
+    const session = await newSession(instance);
+
+    const emitted = await graphql(instance, CREATE_ACTIVITY, {
+      input: { agentSessionId: session.id, content: { type: "thought", body: "thinking" } },
+    });
+
+    expect(emitted.data?.agentActivityCreate.agentActivity.signal).toBeNull();
+  });
+
+  it("names the session `agentSession` and always has a user", async () => {
+    const instance = app();
+    const session = await newSession(instance);
+
+    const emitted = await graphql(instance, CREATE_ACTIVITY, {
+      input: { agentSessionId: session.id, content: { type: "thought", body: "thinking" } },
+    });
+
+    const activity = emitted.data?.agentActivityCreate.agentActivity;
+    expect(activity.agentSession.id).toBe(session.id);
+    expect(activity.user.id).toBeTruthy();
+
+    // `session` was the twin's own spelling; Linear has no such field.
+    const stale = await graphql(
+      instance,
+      `query ($id: String!) { agentSession(id: $id) { activities(first: 5) { nodes { session { id } } } } }`,
+      { id: session.id }
+    );
+    expect(stale.errors?.[0]?.message).toMatch(/Cannot query field "session" on type "AgentActivity"/);
+  });
+
+  it("reads the activities back off the session in order", async () => {
+    const instance = app();
+    const session = await newSession(instance);
+    for (const body of ["first", "second"]) {
+      await graphql(instance, CREATE_ACTIVITY, {
+        input: { agentSessionId: session.id, content: { type: "thought", body } },
+      });
+    }
+
+    const read = await graphql(
+      instance,
+      `query ($id: String!) {
+         agentSession(id: $id) { status activities(first: 10) { nodes { content } } }
+       }`,
+      { id: session.id }
+    );
+
+    expect(read.errors).toBeUndefined();
+    expect(read.data?.agentSession.activities.nodes.map((node: any) => node.content.body)).toEqual([
+      "first",
+      "second",
+    ]);
+    expect(read.data?.agentSession.status).toBe("active");
+  });
+});
+
+// The `AgentSessionEvent` / `prompted` webhook is a documented twin behaviour
+// (REFERENCE-DIVERGENCES.md). Its `status` used to be read off the session
+// BEFORE the activity landed, which was harmless while nothing moved the
+// session and is a lie now that the activity is what moves it.
+describe("the prompted webhook carries the status the activity produced (F-1176)", () => {
+  it("reports pending after a prompt lands on an active session", async () => {
+    const db = openLinearTwinDatabase(":memory:");
+    const commands = new LinearDomain(db);
+    // The destination is refused by the SSRF guard, which is fine: the delivery
+    // and its payload are recorded either way.
+    commands.seed(
+      testSeed({
+        webhooks: [
+          {
+            id: "webhook_agent",
+            label: "Agent sessions",
+            url: "http://127.0.0.1:9/blocked",
+            resourceTypes: ["AgentSessionEvent"],
+            allPublicTeams: true,
+            enabled: true,
+          },
+        ],
+      })
+    );
+    const issue = commands.listIssues()[0]!;
+    const session = await commands.createAgentSessionOnIssue({ issueId: issue.id });
+
+    await commands.createAgentActivity({
+      agentSessionId: session.id,
+      content: { type: "thought", body: "working" },
+    });
+    expect(commands.requireAgentSession(session.id).status).toBe("active");
+
+    await commands.createAgentActivity({
+      agentSessionId: session.id,
+      content: { type: "prompt", body: "which team owns this?" },
+    });
+
+    const prompted = (exportLinearState(db).webhookDeliveries as Array<Record<string, any>>).find(
+      (delivery) => delivery.action === "prompted"
+    );
+    expect(prompted?.payload.data).toMatchObject({ id: session.id, status: "pending" });
+    expect(commands.requireAgentSession(session.id).status).toBe("pending");
+  });
+});

--- a/packages/twin-linear/test/linear-schema-subset.test.ts
+++ b/packages/twin-linear/test/linear-schema-subset.test.ts
@@ -23,7 +23,9 @@ import {
   GraphQLEnumType,
   GraphQLInputObjectType,
   GraphQLObjectType,
+  buildSchema,
   type GraphQLNamedType,
+  type GraphQLSchema,
 } from "graphql";
 import { describe, expect, it } from "vitest";
 import { AGENT_SESSION_STATUSES } from "../src/domain/normalize.js";
@@ -52,20 +54,27 @@ const upstream = JSON.parse(
  * fixture, so that deleting a type from the fixture fails loudly instead of
  * silently removing coverage.
  *
- * SCOPE — this list is the OUTPUT-side surface plus the one input object the
- * twin mirrors exactly. The twin's mutation INPUT types (`AgentSessionUpdateInput`,
- * `AgentSessionCreateOnIssue` / `OnComment`, `AgentActivityCreateInput`) still
- * declare fields Linear does not — `AgentSessionUpdateInput` upstream has no
- * `status` and no `id` at all, for instance. That divergence predates F-1172
- * and is tracked separately; see the SCOPE note on `GUARDED_TYPES` in
- * `scripts/regen-linear-introspection.mjs`. Do not read this file as evidence
- * about the input surface.
+ * SCOPE — the whole agent-session family, both directions of the wire (F-1176).
+ * F-1172 covered the OUTPUT type plus the one input object the twin mirrored
+ * exactly, and this file used to carry a note saying so; the four mutation
+ * INPUT types were then reconciled rather than registered, so the note is gone
+ * and this file IS evidence about the input surface.
  */
-const MUST_BE_GUARDED = ["AgentSession", "AgentSessionStatus", "AgentSessionExternalUrlInput"];
+const MUST_BE_GUARDED = [
+  "AgentActivity",
+  "AgentActivityCreateInput",
+  "AgentActivitySignal",
+  "AgentSession",
+  "AgentSessionCreateOnComment",
+  "AgentSessionCreateOnIssue",
+  "AgentSessionExternalUrlInput",
+  "AgentSessionStatus",
+  "AgentSessionUpdateInput",
+];
 
-/** Member names the twin declares for a named type, or null if it declares no such type. */
-function twinMembers(name: string): { kind: string; members: string[] } | null {
-  const type: GraphQLNamedType | undefined = linearGraphQLSchema.getType(name) ?? undefined;
+/** Member names a schema declares for a named type, or null if it declares no such type. */
+function twinMembers(schema: GraphQLSchema, name: string): { kind: string; members: string[] } | null {
+  const type: GraphQLNamedType | undefined = schema.getType(name) ?? undefined;
   if (!type) return null;
   if (type instanceof GraphQLObjectType) return { kind: "OBJECT", members: Object.keys(type.getFields()) };
   if (type instanceof GraphQLInputObjectType) {
@@ -80,6 +89,12 @@ function twinMembers(name: string): { kind: string; members: string[] } | null {
 /** Member names Linear declares for a fixture entry. */
 function upstreamMembers(entry: UpstreamType): string[] {
   return Object.keys(entry.fields ?? entry.inputFields ?? {}).concat(entry.enumValues ?? []);
+}
+
+/** The members a schema declares that Linear does not — the defect this file hunts. */
+function inventedMembers(entry: UpstreamType, twin: { members: string[] }): string[] {
+  const declared = new Set(upstreamMembers(entry));
+  return twin.members.filter((member) => !declared.has(member)).sort();
 }
 
 describe("twin GraphQL types stay a subset of Linear's real schema (F-1172)", () => {
@@ -100,13 +115,12 @@ describe("twin GraphQL types stay a subset of Linear's real schema (F-1172)", ()
     it(`${name} declares no field Linear does not have`, () => {
       const entry = upstream.types[name];
       expect(entry).toBeDefined();
-      const twin = twinMembers(name);
+      const twin = twinMembers(linearGraphQLSchema, name);
       // The twin is allowed not to model a type at all; it is not allowed to
       // model one under names Linear does not use.
       if (!twin) return;
       expect(twin.kind).toBe((entry as UpstreamType).kind);
-      const declared = new Set(upstreamMembers(entry as UpstreamType));
-      const invented = twin.members.filter((member) => !declared.has(member)).sort();
+      const invented = inventedMembers(entry as UpstreamType, twin);
       expect(invented, `${name} declares members Linear does not: ${invented.join(", ")}`).toEqual([]);
     });
   }
@@ -115,13 +129,97 @@ describe("twin GraphQL types stay a subset of Linear's real schema (F-1172)", ()
     // Two declarations of the same enum (SDL + the TS union the writers validate
     // against) can drift apart; a value the domain accepts but the SDL rejects
     // would blow up at serialisation time, not at authoring time.
-    expect(AGENT_SESSION_STATUSES.slice().sort()).toEqual(twinMembers("AgentSessionStatus")?.members.sort());
+    expect(AGENT_SESSION_STATUSES.slice().sort()).toEqual(
+      twinMembers(linearGraphQLSchema, "AgentSessionStatus")?.members.sort()
+    );
   });
 
   it("AgentSession carries the fields the twin promises to model", () => {
-    const twin = twinMembers("AgentSession");
+    const twin = twinMembers(linearGraphQLSchema, "AgentSession");
     expect(twin?.members.slice().sort()).toEqual(
       ["activities", "appUser", "comment", "createdAt", "externalUrls", "id", "issue", "plan", "status", "updatedAt"]
     );
+  });
+
+  it("AgentActivity carries the fields the twin promises to model", () => {
+    const twin = twinMembers(linearGraphQLSchema, "AgentActivity");
+    expect(twin?.members.slice().sort()).toEqual(
+      ["agentSession", "content", "createdAt", "ephemeral", "id", "signal", "updatedAt", "user"]
+    );
+  });
+
+  // A subset check passes on a type that declares nothing, so the four mutation
+  // inputs are pinned member-for-member as well: F-1176's whole point is that
+  // an agent's ARGUMENTS cross this wire, and silently narrowing one of these
+  // back down would be as invisible to the subset check as never widening it.
+  it("the mutation inputs carry the fields the twin promises to accept (F-1176)", () => {
+    const declared = (name: string) => twinMembers(linearGraphQLSchema, name)?.members.slice().sort();
+    expect(declared("AgentSessionCreateOnIssue")).toEqual(["externalUrls", "issueId"]);
+    expect(declared("AgentSessionCreateOnComment")).toEqual(["commentId", "externalUrls"]);
+    expect(declared("AgentSessionUpdateInput")).toEqual(["externalUrls", "plan"]);
+    expect(declared("AgentActivityCreateInput")).toEqual([
+      "agentSessionId",
+      "content",
+      "ephemeral",
+      "signal",
+    ]);
+  });
+
+  // `agentSessionUpdate(id:)` is the second, smaller divergence F-1176 found on
+  // the same mutation: upstream declares `id: String!`, and a nullable one lets
+  // the twin accept a call that real Linear rejects outright.
+  it("agentSessionUpdate takes a non-null id argument, as Linear does (F-1176)", () => {
+    const field = linearGraphQLSchema.getMutationType()?.getFields().agentSessionUpdate;
+    const id = field?.args.find((argument) => argument.name === "id");
+    expect(String(id?.type)).toBe("String!");
+  });
+});
+
+/**
+ * The guard has to be able to FAIL. A subset check reads as green in exactly
+ * the same way whether it compared something or nothing, which is how the four
+ * mutation inputs went unexamined for two releases — so this drives the same
+ * comparison the block above drives, against a schema built to be wrong.
+ */
+describe("the subset guard fires on an invented member (F-1176)", () => {
+  const wrong = buildSchema(`
+    type Query { _unused: String }
+    input AgentSessionUpdateInput { plan: String status: String id: String }
+    type AgentActivity { id: ID! content: JSON! body: String! }
+    enum AgentActivitySignal { stop halt }
+    scalar JSON
+  `);
+
+  it("names the invented field on an input type", () => {
+    const twin = twinMembers(wrong, "AgentSessionUpdateInput");
+    expect(twin).not.toBeNull();
+    // Exactly the pair F-1176 was filed about, and nothing else.
+    expect(inventedMembers(upstream.types.AgentSessionUpdateInput as UpstreamType, twin!)).toEqual([
+      "id",
+      "status",
+    ]);
+  });
+
+  it("names the invented field on an output type", () => {
+    const twin = twinMembers(wrong, "AgentActivity");
+    expect(inventedMembers(upstream.types.AgentActivity as UpstreamType, twin!)).toEqual(["body"]);
+  });
+
+  it("names the invented member on an enum", () => {
+    const twin = twinMembers(wrong, "AgentActivitySignal");
+    expect(inventedMembers(upstream.types.AgentActivitySignal as UpstreamType, twin!)).toEqual(["halt"]);
+  });
+
+  it("stays green on the same shapes with the invented members removed", () => {
+    const right = buildSchema(`
+      type Query { _unused: String }
+      input AgentSessionUpdateInput { plan: String }
+      type AgentActivity { id: ID! content: JSON! }
+      enum AgentActivitySignal { stop }
+      scalar JSON
+    `);
+    for (const name of ["AgentSessionUpdateInput", "AgentActivity", "AgentActivitySignal"]) {
+      expect(inventedMembers(upstream.types[name] as UpstreamType, twinMembers(right, name)!)).toEqual([]);
+    }
   });
 });

--- a/packages/twin-linear/test/partial-update-tristate.test.ts
+++ b/packages/twin-linear/test/partial-update-tristate.test.ts
@@ -62,19 +62,43 @@ async function graphql(
   };
 }
 
+/** Create a session over GraphQL, then give it a plan — the only way in, since F-1176. */
+async function sessionWithPlan(instance: ReturnType<typeof createLinearTwinApp>, plan: string) {
+  const issues = await graphql(instance, `query { issues(first: 1) { nodes { id } } }`);
+  const issueId = issues.data?.issues.nodes[0].id as string;
+  const created = await graphql(
+    instance,
+    `mutation ($input: AgentSessionCreateOnIssue!) {
+       agentSessionCreateOnIssue(input: $input) { agentSession { id } }
+     }`,
+    { input: { issueId, externalUrls: [{ url: "https://example.test/run/1", label: "run" }] } }
+  );
+  const sessionId = created.data?.agentSessionCreateOnIssue.agentSession.id as string;
+  await graphql(
+    instance,
+    `mutation ($id: String!, $input: AgentSessionUpdateInput!) {
+       agentSessionUpdate(id: $id, input: $input) { agentSession { id } }
+     }`,
+    { id: sessionId, input: { plan } }
+  );
+  return sessionId;
+}
+
 function callTool(commands: LinearDomain, name: string, args: Record<string, unknown>) {
   const tool = linearTools.find((candidate) => candidate.name === name);
   if (!tool) throw new Error(`Unknown MCP tool: ${name}`);
   return tool.handler(commands, args, { reportDelta: () => {} } as never);
 }
 
+// Linear's `AgentSessionCreateOnIssue` carries no `plan` (F-1176), so a seeded
+// session's plan arrives through the update mutation that does.
 async function seededSession(commands: LinearDomain, plan: string) {
   const issue = commands.listIssues()[0]!;
-  return commands.createAgentSessionOnIssue({
+  const session = await commands.createAgentSessionOnIssue({
     issueId: issue.id,
-    plan,
     externalUrls: [{ url: "https://example.test/run/1", label: "run" }],
   });
+  return commands.updateAgentSession(session.id, { plan });
 }
 
 describe("agentSessionUpdate partial-update tri-state (F-1166)", () => {
@@ -83,24 +107,24 @@ describe("agentSessionUpdate partial-update tri-state (F-1166)", () => {
     const session = await seededSession(commands, "PLAN-RESIDUE");
 
     const updated = commands.updateAgentSession(session.id, {
-      status: "active",
       plan: undefined,
-      externalUrls: undefined,
+      externalUrls: [{ url: "https://example.test/run/2", label: "rerun" }],
     });
 
     expect(updated.plan).toBe("PLAN-RESIDUE");
-    expect(updated.externalUrls).toEqual([{ url: "https://example.test/run/1", label: "run" }]);
-    expect(updated.status).toBe("active");
+    expect(updated.externalUrls).toEqual([{ url: "https://example.test/run/2", label: "rerun" }]);
   });
 
   it("leaves plan untouched when the key is absent", async () => {
     const commands = domain();
     const session = await seededSession(commands, "PLAN-RESIDUE");
 
-    const updated = commands.updateAgentSession(session.id, { status: "active" });
+    const updated = commands.updateAgentSession(session.id, {
+      externalUrls: [{ url: "https://example.test/run/2", label: "rerun" }],
+    });
 
     expect(updated.plan).toBe("PLAN-RESIDUE");
-    expect(updated.externalUrls).toEqual([{ url: "https://example.test/run/1", label: "run" }]);
+    expect(updated.externalUrls).toEqual([{ url: "https://example.test/run/2", label: "rerun" }]);
   });
 
   it("clears plan when the key is present and null", async () => {
@@ -123,64 +147,36 @@ describe("agentSessionUpdate partial-update tri-state (F-1166)", () => {
   });
 
   it("parses a present-but-undefined plan as 'not provided', not as null", () => {
-    expect(parseAgentSessionUpdateInput({ id: "x", status: "active", plan: undefined }).plan).toBeUndefined();
-    expect(parseAgentSessionUpdateInput({ id: "x", status: "active" }).plan).toBeUndefined();
-    expect(parseAgentSessionUpdateInput({ id: "x", plan: null }).plan).toBeNull();
-    expect(parseAgentSessionUpdateInput({ id: "x", plan: "PLAN" }).plan).toBe("PLAN");
-    expect(
-      parseAgentSessionUpdateInput({ id: "x", status: "active", externalUrls: undefined }).externalUrls
-    ).toBeUndefined();
-    expect(parseAgentSessionUpdateInput({ id: "x", externalUrls: null }).externalUrls).toBeNull();
+    expect(parseAgentSessionUpdateInput({ plan: undefined }).plan).toBeUndefined();
+    expect(parseAgentSessionUpdateInput({}).plan).toBeUndefined();
+    expect(parseAgentSessionUpdateInput({ plan: null }).plan).toBeNull();
+    expect(parseAgentSessionUpdateInput({ plan: "PLAN" }).plan).toBe("PLAN");
+    expect(parseAgentSessionUpdateInput({ externalUrls: undefined }).externalUrls).toBeUndefined();
+    expect(parseAgentSessionUpdateInput({ externalUrls: null }).externalUrls).toBeNull();
   });
 
-  it("preserves plan across a GraphQL agentSessionUpdate that only sets status", async () => {
+  it("preserves plan across a GraphQL agentSessionUpdate that only sets externalUrls", async () => {
     const instance = app();
-    const issues = await graphql(instance, `query { issues(first: 1) { nodes { id } } }`);
-    const issueId = issues.data?.issues.nodes[0].id as string;
-
-    const created = await graphql(
-      instance,
-      `mutation ($input: AgentSessionCreateOnIssue!) {
-         agentSessionCreateOnIssue(input: $input) { agentSession { id plan externalUrls } }
-       }`,
-      {
-        input: {
-          issueId,
-          plan: "PLAN-RESIDUE",
-          externalUrls: [{ url: "https://example.test/run/1", label: "run" }],
-        },
-      }
-    );
-    const sessionId = created.data?.agentSessionCreateOnIssue.agentSession.id as string;
+    const sessionId = await sessionWithPlan(instance, "PLAN-RESIDUE");
 
     const updated = await graphql(
       instance,
       `mutation ($id: String!, $input: AgentSessionUpdateInput!) {
          agentSessionUpdate(id: $id, input: $input) { agentSession { id status plan externalUrls } }
        }`,
-      { id: sessionId, input: { status: "active" } }
+      { id: sessionId, input: { externalUrls: [{ url: "https://example.test/run/2", label: "rerun" }] } }
     );
 
     expect(updated.errors).toBeUndefined();
     expect(updated.data?.agentSessionUpdate.agentSession).toMatchObject({
-      status: "active",
       plan: "PLAN-RESIDUE",
-      externalUrls: [{ url: "https://example.test/run/1", label: "run" }],
+      externalUrls: [{ url: "https://example.test/run/2", label: "rerun" }],
     });
   });
 
   it("still clears plan through GraphQL when null is sent explicitly", async () => {
     const instance = app();
-    const issues = await graphql(instance, `query { issues(first: 1) { nodes { id } } }`);
-    const issueId = issues.data?.issues.nodes[0].id as string;
-    const created = await graphql(
-      instance,
-      `mutation ($input: AgentSessionCreateOnIssue!) {
-         agentSessionCreateOnIssue(input: $input) { agentSession { id } }
-       }`,
-      { input: { issueId, plan: "PLAN-RESIDUE" } }
-    );
-    const sessionId = created.data?.agentSessionCreateOnIssue.agentSession.id as string;
+    const sessionId = await sessionWithPlan(instance, "PLAN-RESIDUE");
 
     const updated = await graphql(
       instance,


### PR DESCRIPTION
Executive summary: F-1172 fixed the `AgentSession` **output** type and scoped itself there in the guard's own words — *"Do not read this file as evidence about the input surface."* Nothing then read the input surface, so all four agent-session mutation inputs still declared fields Linear does not have. This closes them, and with them the behavioural divergence hiding behind `status`: upstream a session's status follows the activities its agent emits, so adopting Linear's input shape means adopting Linear's state-transition model. Reviewer should know that **one** thing in this change is invented — the activity → status table — and that it is named, lives in one place, and is written up rather than left to be discovered.

## What

The four inputs become Linear's, verified against `https://api.linear.app/graphql` (unauthenticated introspection) rather than quoted:

| Mutation | Was | Is |
| --- | --- | --- |
| `agentSessionUpdate` | `id: String` argument; input `{ id, status, plan, externalUrls }` | `id: String!` argument; input `{ plan, externalUrls }` |
| `agentSessionCreateOnIssue` | `{ issueId, appUserId, plan, externalUrls }` | `{ issueId, externalUrls }` |
| `agentSessionCreateOnComment` | `{ commentId, appUserId, plan, externalUrls }` | `{ commentId, externalUrls }` |
| `agentActivityCreate` | `{ sessionId, type, body, ephemeral }` | `{ agentSessionId, content, signal, ephemeral }` |

A session still starts `pending`, then follows its activities: `thought`/`action` → `active`, `elicitation` → `awaitingInput`, `response` → `complete`, `error` → `error`, `prompt` → `pending`. `content` replaces `type` + `body` and `AgentActivity` moves with it (`content` / `agentSession` / `signal` / `user: User!`). `GUARDED_TYPES` gains all four inputs plus `AgentActivity` and `AgentActivitySignal`, and the SCOPE note carving the input surface out of F-1172's claim is deleted.

## Why

Same defect as F-1172 with the arrows reversed: an agent written against real Linear sends arguments this twin rejects, and one written against this twin sends arguments Linear rejects. `status` is the consequential one and is not a naming problem — upstream `AgentSessionUpdateInput` has no such field at all, so an agent written against Linear literally could not drive the twin the way the twin expected.

The guard's silence was the second half of the problem. `MUST_BE_GUARDED` covered three types; these four were not passing, they were *unexamined* — and a subset check reads identically whether it compared something or nothing.

## Notes for reviewer

**Start with** `packages/twin-linear/test/linear-schema-subset.test.ts` (what is now guarded, and the block proving the guard can fail) and `REFERENCE-DIVERGENCES.md` (the one invented thing, plus what is deliberately not modelled). Everything else follows.

**The red is the evidence.** Extending `GUARDED_TYPES` first, before touching a line of source, produced exactly:

```
AgentSessionUpdateInput      declares members Linear does not: id, status
AgentSessionCreateOnIssue    declares members Linear does not: appUserId, plan
AgentSessionCreateOnComment  declares members Linear does not: appUserId, plan
AgentActivityCreateInput     declares members Linear does not: body, sessionId, type
AgentActivity                declares members Linear does not: body, session, type
```

**The fixture refresh is purely additive.** `AgentSession`, `AgentSessionStatus` and `AgentSessionExternalUrlInput` come back **byte-identical** and `query_sha256` is unchanged, so re-running the regen script added six types without quietly moving the existing baseline.

**The one invented thing.** Linear's agent guide says only that session state *"is updated automatically based on the agent's emitted activities. No manual state management is required."* It never publishes which activity yields which status, and introspection cannot show behaviour. So the *shape* is verified upstream truth (status is not settable through `agentSessionUpdate`; it follows activities) while the *table* is ours. It exists once, as `AGENT_ACTIVITY_SESSION_STATUS`, and the alternative was sessions frozen at `pending` forever — worse fidelity than a documented mapping.

**`content` is not a rename.** Linear's `AgentActivityContent` is a union discriminated on `type`; five of its six members carry `body`, but `action` carries `action` / `parameter` / `result` and no `body` at all, which is why the flat pair could not survive. `normalizeActivityContent` parses against all six and refuses a malformed payload at the boundary. The output type had to move in the same change — accepting Linear's `content` while emitting an invented `body` would round-trip to neither Linear nor itself.

**The migration, and the one honest compromise in it.** An existing `LINEAR_TWIN_DB` file opens on the old columns, so `agent_activities` gains `content_json` and `signal`, carries each old row's `{ type, body }` into content **verbatim**, drops `type` / `body`, and re-adopts any activity whose author the `ON DELETE SET NULL` foreign key had cleared. The literal carry produces `{"type":"action","body":…}`, which is not a shape upstream emits — but the old row said exactly that, and inventing an `action` / `parameter` split out of one free-text field would be worse. No writer produces it again.

**Recorded, not fixed:** two scalar-level gaps stay open, because the guard is name-based by F-1172's design and closing them is different work — input `plan` is `String` where upstream is `JSONObject`, and output `content` is `JSON!` where upstream is the union. Input `content` **is** `JSONObject!`, as upstream. Both are in `REFERENCE-DIVERGENCES.md`, along with the fields deliberately not modelled (`externalLink`, `addedExternalUrls`, `removedExternalUrls`, `dismissedAt`, `userState`, and activity `id` / `signalMetadata` / `contextualMetadata`).

**Blast radius, measured before choosing full fidelity over a written-down divergence:** zero hits in `cli/tasks/`, zero in `examples/`, zero anywhere driving `agentSessionUpdate` with `status`. Every caller was inside `packages/twin-linear`, which is why this is one package and no task migration.

**`route-inputs.json` moves by two lines** — `agentSessionUpdate`'s `id` argument becomes `String!` / required. That is the declared-fidelity lane seeing the second, smaller divergence on the same mutation close.

**Version bump:** `@pome-sh/twin-linear` 0.3.5 → **0.4.0** (minor, not patch — the wire surface breaks) and `@pome-sh/cli` 0.21.16 → 0.21.17, since tsup inlines the twin into the CLI tarball. `@pome-sh/checks` is untouched: none of the changed files fall inside its declaration-layer globs.

## Tests / CI

Local, all green:

- `npm test` — 10 workspaces, 3,193 tests
- `npm run typecheck`, `npm run build`
- `npm run test:contract` — 104 pass / 0 fail
- `npm run gate:route-inputs`, `npm run lint:route-inputs`
- `npm run lint:dead-code`, `lint:code-health`, `lint:parent-vocab`, `lint:twin-chunks`, `lint:twin-leaves`, `lint:legacy-markers`, `lint:no-catch`, `lint:task-class`, `lint:copy-markers`, `lint:skill-manifest`
- `npm run gate:no-eval`, `gate:no-native`, `gate:bundled-deps`, `gate:mcp-tools-list`, `gate:checks-manifest`, `gate:wire-manifest`, `lint:no-cloud-imports`
- `npm run probe:twins`, `npm run probe:examples` (43 tools / 7 examples), `npm run smoke:examples`, `npm run typecheck:examples`
- `node scripts/ci/check-version-bump-required.mjs $(git merge-base origin/main HEAD)`

New coverage: `test/agent-session-inputs.test.ts` (18 cases — every refusal Linear makes, the transition table driven off the table itself, the content union, `signal`, and the `prompted` webhook now carrying the status the activity produced) and `test/agent-activity-migration.test.ts` (the pre-`content` table, asserted to be in the real 0.3.5 shape before the migration touches it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)