### PR TITLE
`@pome-sh/checks` 0.1.3 — verify the release runbook end to end (F-1380)

### DIFF
--- a/packages/checks/CHANGELOG.md
+++ b/packages/checks/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @pome-sh/checks
 
+## 0.1.3
+
+No change to the published surface — `dist/` is byte-identical to 0.1.2, so no
+declaration moved and no consumer's verdict changes. The declaration layer has
+not been touched since 0.1.2 was cut (`38acaf9`), which is the version-bump
+gate doing its job rather than an absence of work.
+
+What this version is for: it is the first release cut by following
+[`RELEASING.md`](../../RELEASING.md) end to end since the `packages-v*` batch
+flow was replaced by version-diff-on-push, and it exists to prove that runbook
+is followable — bump, merge, `release.yml` publishes, pome-cloud pins. The
+consumer half is the part that was actually owed: pome-cloud has been pinned at
+0.1.1 since before 0.1.2 shipped, so F-1157's redaction-survival vocabulary has
+not reached the grader.
+
+Version-only bumps are accepted here rather than carrying an exception list,
+per `cli/CHANGELOG.md` 0.21.7.
+
 ## 0.1.2
 
 Carries F-1157 to the grader. Three things move in `dist/`:

--- a/packages/checks/package.json
+++ b/packages/checks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/checks",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Pome's grading vocabulary — the check declarations, seed schemas and default seeds of all five digital twins, plus the check DSL they are written in. Declarations only: no twin server, no database, no routes, no tools.",
   "private": false,
   "type": "module",


### PR DESCRIPTION
## What

Bumps `@pome-sh/checks` 0.1.2 → 0.1.3 with a changelog entry. Nothing else.

`dist/` is byte-identical to 0.1.2 — the declaration layer has not moved since `38acaf9` cut 0.1.2, which is `check-version-bump-required.mjs` doing its job rather than an absence of work. Version-only bumps are accepted here rather than carrying an exception list, per `cli/CHANGELOG.md` 0.21.7.

## Why

[F-1380](https://linear.app/pome-sh/issue/F-1380) rewrote pome-sh/agent-skills' package-release skill after finding it documented the deleted `packages-v*` batch flow — 6 of the 12 file paths it named were gone from this repo, including the runbook it deferred to (`PACKAGE_RELEASE.md`) and the workflow it said published (`sdk-publish.yml`). The replacement is [`pome-npm-release`](https://github.com/pome-sh/agent-skills/pull/21), written against `RELEASING.md` and `release.yml`.

That ticket's acceptance criterion is to follow the replacement end to end and confirm no step needed outside knowledge. This PR is that walk. It is the first release cut by following the new runbook since the batch flow was retired on 2026-08-04.

**The consumer half is the part genuinely owed.** pome-cloud has been pinned at `@pome-sh/checks` 0.1.1 in both `apps/control-plane/package.json` and `apps/mcp/package.json` since before 0.1.2 shipped, so F-1157's redaction-survival vocabulary (`probeRedactionSurvival`, `REDACTION_PLACEHOLDER`, `isRedacted`, and the gmail/slack declaration changes) has never reached the grader. The pin bump follows in pome-cloud once this publishes.

## Notes for reviewer

Both gates this PR is subject to were run locally against `origin/main` before pushing:

```
$ node scripts/ci/check-version-bump-required.mjs $(git rev-parse origin/main)
Version bump check OK (no publish-relevant path changed an unbumped package, or none touched).

$ GITHUB_OUTPUT=... bash scripts/ci/decide-publish.sh "@pome-sh/checks" "packages/checks/package.json" "checks"
@pome-sh/checks — local: 0.1.3, registry (registry.npmjs.org): 0.1.2
  ↳ will publish 0.1.3.
```

So on merge, `release.yml`'s `plan` sets `checks=true`, the `publish` matrix builds, runs `gate:bundled-deps` + `test:pack` + `gate:checks-tarball` + the E415 check, and publishes 0.1.3 via OIDC. `cli`, `adapter-claude-sdk` and `wire` are all level with their registries and will be skipped.

The runbook held: every step came from `RELEASING.md` and the two scripts, with nothing needed from outside them.

## Merge

Squash and merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)