### PR TITLE
The CLI learns the seed-pre-satisfied exemption the dashboard already has (F-1392)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,23 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.23.1
+
+### Patch Changes
+
+- `pome run --hosted` no longer exits 1 on a run the dashboard renders PASS
+  (F-1392). pome-cloud's F-1296 excludes a criterion the seed already
+  satisfied from the abstention count before deciding a run is incomplete;
+  the CLI counted it like any other unresolved criterion, so a task whose
+  seed already satisfied one check (and nothing else was left ungraded)
+  printed `INCOMPLETE` and failed CI. `scoreFromFinalizeResponse` now
+  exempts a `skipped` result stamped `already_true_in_seed`
+  (`isPreSatisfied`/`PRE_SATISFIED_REASON` in `evalResultView.ts`) from
+  `can_pass`, matching the dashboard's `isRunIncomplete` predicate
+  exactly. Any other skipped reason, and every errored result, still makes
+  a run incomplete. `runScoreLine` now names a pre-satisfied criterion apart
+  from genuine abstentions instead of folding it into "not evaluated".
+
 ## 0.23.0
 
 ### Minor Changes

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -16,10 +16,20 @@ packaging restructure: bump `version` here and in `package.json`, and merging to
   printed `INCOMPLETE` and failed CI. `scoreFromFinalizeResponse` now
   exempts a `skipped` result stamped `already_true_in_seed`
   (`isPreSatisfied`/`PRE_SATISFIED_REASON` in `evalResultView.ts`) from
-  `can_pass`, matching the dashboard's `isRunIncomplete` predicate
-  exactly. Any other skipped reason, and every errored result, still makes
+  `can_pass`. Any other skipped reason, and every errored result, still makes
   a run incomplete. `runScoreLine` now names a pre-satisfied criterion apart
-  from genuine abstentions instead of folding it into "not evaluated".
+  from genuine abstentions instead of folding it into "not evaluated", and an
+  all-excluded run reads `nothing was at risk (N criteria already true in the
+  seed)` rather than the self-contradicting `0 of N criteria not evaluated`.
+  `pome fix-prompt` likewise stops filing a seed-excluded criterion under
+  "not uniformly evaluated", which sent the reader's coding agent hunting for
+  a grader gap that did not exist.
+- The CLI and the dashboard are now walked over one table of wire fixtures
+  (`cli/test/unit/hosted/cross-surface-agreement.test.ts`) so their agreement
+  on run state is checked rather than assumed, including the single shape
+  where they still differ: a run whose criteria are ALL seed-excluded has no
+  denominator, so the CLI calls it `incomplete` and the dashboard renders
+  FAILED at 0/100 (F-1399). Neither passes it and both exit non-zero.
 
 ## 0.23.0
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/cli/src/fix-prompt/prompt.ts
+++ b/cli/src/fix-prompt/prompt.ts
@@ -16,7 +16,7 @@ import { assetPath } from "../cli/assets.js";
 import type { CriterionResult, RecorderEvent } from "../types/shared.js";
 import type { Criterion, Task } from "../task/taskSchema.js";
 import { redactEvent, redactSecrets } from "../recorder/redaction.js";
-import { outcomeOf } from "../hosted/evalResultView.js";
+import { isPreSatisfied, outcomeOf } from "../hosted/evalResultView.js";
 import type { VerdictArtifact } from "../hosted/evalResultCache.js";
 
 export const FIX_PROMPT_TEMPLATE_VERSION = "v1";
@@ -169,18 +169,30 @@ function flattenLine(text: string, max = 300): string {
  *  which trials failed it and what the judge said, failing-first. Criteria
  *  that never failed split honestly: "passed everywhere" requires every
  *  outcome to actually be `passed` — skipped/errored are named as such,
- *  never counted as passes. */
+ *  never counted as passes.
+ *
+ *  F-1392 — a criterion the seed already satisfied is `skipped` on the wire
+ *  and used to land in "not uniformly evaluated", which sends the reader's
+ *  coding agent hunting for a grader gap that does not exist. It is its own
+ *  class here, for the same reason it is its own count in `Score`: the grader
+ *  reached a verdict, and the verdict is that the criterion was never at
+ *  risk. `isPreSatisfied` is the shared predicate, not a second reading of
+ *  the reason string. */
 function renderGroupedSignatures(trials: TrialFixInput[]): string {
   const byCriterion = new Map<
     string,
     { marker: string; hits: Array<{ label: string; reason: string }> }
   >();
-  // Criterion text → the set of non-failed outcomes seen for it.
+  // Criterion text → the set of outcome classes seen for it. "excluded" is a
+  // class here and not in `outcomeOf` (the per-criterion marker stays `-`,
+  // F-1392's trap): this map exists to decide which NOTE a criterion belongs
+  // under, and "the seed already satisfied it" is a different note from "the
+  // grader never reached it".
   const outcomesSeen = new Map<string, Set<string>>();
   for (const trial of trials) {
     for (const result of trial.verdict.criteria_results) {
       const key = result.criterion.text;
-      const outcome = outcomeOf(result);
+      const outcome = isPreSatisfied(result) ? "excluded" : outcomeOf(result);
       if (outcome === "failed") {
         const entry = byCriterion.get(key) ?? {
           marker: criterionMarker(result.criterion),
@@ -196,10 +208,12 @@ function renderGroupedSignatures(trials: TrialFixInput[]): string {
   }
 
   const passedEverywhere: string[] = [];
+  const preSatisfiedEverywhere: string[] = [];
   const notUniformlyEvaluated: string[] = [];
   for (const [key, seen] of outcomesSeen) {
     if (byCriterion.has(key)) continue;
     if (seen.size === 1 && seen.has("passed")) passedEverywhere.push(key);
+    else if (seen.size === 1 && seen.has("excluded")) preSatisfiedEverywhere.push(key);
     else notUniformlyEvaluated.push(key);
   }
 
@@ -212,7 +226,12 @@ function renderGroupedSignatures(trials: TrialFixInput[]): string {
       );
       return `${idx + 1}. ${marker} ${flattenLine(text)} — failed in ${hits.length} of ${completed} completed trials\n${lines.join("\n")}`;
     });
-  if (blocks.length === 0 && passedEverywhere.length === 0 && notUniformlyEvaluated.length === 0) {
+  if (
+    blocks.length === 0 &&
+    passedEverywhere.length === 0 &&
+    preSatisfiedEverywhere.length === 0 &&
+    notUniformlyEvaluated.length === 0
+  ) {
     return "(no criteria recorded)";
   }
   const notes: string[] = [];
@@ -224,9 +243,18 @@ function renderGroupedSignatures(trials: TrialFixInput[]): string {
       `passed in every completed trial: ${passedEverywhere.map((t) => `"${flattenLine(t)}"`).join(" · ")}`,
     );
   }
-  if (notUniformlyEvaluated.length > 0) {
+  if (preSatisfiedEverywhere.length > 0) {
     notes.push(
-      `not uniformly evaluated (skipped or errored in some trials — no pass is claimed for these): ${notUniformlyEvaluated.map((t) => `"${flattenLine(t)}"`).join(" · ")}`,
+      `already true in the seed in every completed trial — excluded from the score, nothing here to fix: ${preSatisfiedEverywhere.map((t) => `"${flattenLine(t)}"`).join(" · ")}`,
+    );
+  }
+  if (notUniformlyEvaluated.length > 0) {
+    // "not evaluated", not "skipped or errored": a criterion that mixes a
+    // seed exclusion with a real pass across trials lands here too, and the
+    // old parenthetical asserted an instrument gap that may not have
+    // happened.
+    notes.push(
+      `not uniformly evaluated (not evaluated in some trials — no pass is claimed for these): ${notUniformlyEvaluated.map((t) => `"${flattenLine(t)}"`).join(" · ")}`,
     );
   }
   return [...blocks, ...notes].join("\n");

--- a/cli/src/hosted/evalResultCache.ts
+++ b/cli/src/hosted/evalResultCache.ts
@@ -190,11 +190,16 @@ export interface RunSet {
  *  `runTaskHosted.ts`'s `exitCode === 0` at write time — itself derived from
  *  `scoreStatus(scoreFromFinalizeResponse(finalized), passThreshold)`. Once
  *  that root predicate stopped treating a pre-satisfied `skipped` as an
- *  abstention, a trial holding only one gets `passed: true` on disk, so a
- *  group holding it no longer trips `anyFailed` and is no longer misrouted to
- *  `pome fix-prompt` as an agent defect. Nothing to change here — the fix
- *  lives upstream, and `evalResultCache.test.ts` pins the group-level
- *  behavior directly against the written artifact. */
+ *  abstention, a trial whose only non-passing criterion is pre-satisfied gets
+ *  `passed: true` on disk, so a group holding it no longer trips `anyFailed`
+ *  and is no longer misrouted to `pome fix-prompt` as an agent defect. (A
+ *  trial where EVERY criterion was pre-satisfied still writes `passed: false`
+ *  — no denominator, no verified pass — and still routes there; what it now
+ *  gets when it arrives is a prompt that names the exclusion instead of
+ *  reporting it as a criterion nobody evaluated, `fix-prompt/prompt.ts`.)
+ *  Nothing to change here — the fix lives upstream, and
+ *  `evalResultCache.test.ts` pins the group-level behavior directly against
+ *  the written artifact. */
 export function groupRunSets(trials: TrialVerdict[]): RunSet[] {
   const byKey = new Map<string, TrialVerdict[]>();
   for (const trial of trials) {

--- a/cli/src/hosted/evalResultCache.ts
+++ b/cli/src/hosted/evalResultCache.ts
@@ -184,7 +184,17 @@ export interface RunSet {
 }
 
 /** Group trials into run sets: trials sharing a group_id form one set; a
- *  null group_id is its own single-run set. */
+ *  null group_id is its own single-run set.
+ *
+ *  F-1392 note on `anyFailed` below: it reads `!t.verdict.passed`, which is
+ *  `runTaskHosted.ts`'s `exitCode === 0` at write time — itself derived from
+ *  `scoreStatus(scoreFromFinalizeResponse(finalized), passThreshold)`. Once
+ *  that root predicate stopped treating a pre-satisfied `skipped` as an
+ *  abstention, a trial holding only one gets `passed: true` on disk, so a
+ *  group holding it no longer trips `anyFailed` and is no longer misrouted to
+ *  `pome fix-prompt` as an agent defect. Nothing to change here — the fix
+ *  lives upstream, and `evalResultCache.test.ts` pins the group-level
+ *  behavior directly against the written artifact. */
 export function groupRunSets(trials: TrialVerdict[]): RunSet[] {
   const byKey = new Map<string, TrialVerdict[]>();
   for (const trial of trials) {

--- a/cli/src/hosted/evalResultView.ts
+++ b/cli/src/hosted/evalResultView.ts
@@ -151,6 +151,24 @@ export type ScoreStatus = "pass" | "fail" | "incomplete";
 // `errored`, still fails this guard — only the one named exemption is
 // narrowed. Deliberately NOT read from the wire's `all_skipped`, which is the
 // narrower every-abstained predicate and would loosen this guard.
+//
+// The one input the two surfaces still word differently, stated so nobody
+// reads the paragraph above as more agreement than there is: a run whose
+// criteria are ALL pre-satisfied (nothing passed, nothing failed, so no
+// denominator). Here it is `incomplete` — `evaluated` is false and the A5
+// guard predates and outranks this exemption. On the dashboard
+// `isRunIncomplete` is false (every abstention is exempt) and
+// `deriveRunStatus` falls through to `satisfaction_score === 100`, which is 0
+// for an empty denominator (`score-merge.ts`), so it renders FAILED while its
+// own `verdictLine` says "nothing was at risk". The two surfaces agree on the
+// only thing a CI caller can act on — neither passes it, both exit non-zero —
+// and disagree on the word. Filed as F-1399 against pome-cloud rather than
+// papered over here: calling it `fail` locally would blame the agent for a run in which
+// nothing was ever at risk, which is the F-925 inversion pointed the other
+// way. `runScoreLine` names this state explicitly instead of printing "0 of N
+// criteria not evaluated".
+// `cross-surface-agreement.test.ts` walks both predicates over one table of
+// wire fixtures so this paragraph cannot quietly stop being true.
 export function scoreStatus(score: Score, passThreshold: number): ScoreStatus {
   if (!score.evaluated || !score.can_pass) return "incomplete";
   return score.satisfaction >= passThreshold ? "pass" : "fail";
@@ -198,6 +216,10 @@ export function twinSkipSuffix(result: CriterionResult): string {
   return twinRelated ? ` (twin: ${twin})` : "";
 }
 
+function criteriaWord(n: number): string {
+  return n === 1 ? "criterion" : "criteria";
+}
+
 export function scoreCountsSummary(score: Score): string {
   return `${score.passed ?? 0} passed, ${score.failed ?? 0} failed, ${score.skipped ?? 0} skipped, ${score.errored ?? 0} errored`;
 }
@@ -216,14 +238,23 @@ export function runScoreLine(
     //
     // F-1392 — `preSatisfied` criteria are named APART from the abstentions
     // instead of folded into "not evaluated", the way the dashboard's
-    // `verdictLine` does (run-status.ts:175-196): a pre-satisfied criterion
+    // `verdictLine` does (run-status.ts:173-199): a pre-satisfied criterion
     // reached a verdict (the grader wasn't gapped), it just tested nothing.
-    // Only reachable here at all when some OTHER criterion is still a genuine
-    // abstention/error — a run whose only non-passing criterion is
-    // pre-satisfied is already `pass`, not `incomplete`.
     const allExcluded = score.skipped + score.errored;
     const unreached = allExcluded - score.preSatisfied;
     const total = score.total_required + allExcluded;
+    // The all-excluded run: nothing passed, nothing failed, and every
+    // criterion that left the denominator left it because the seed already
+    // satisfied it. `unreached` is 0, so the sentence below would read "0 of 2
+    // criteria not evaluated" while the line calls itself incomplete — a
+    // surface stating a count that contradicts its own verdict. Say what
+    // actually happened, in the dashboard's words for the same shape
+    // (`verdictLine`'s "nothing was at risk" branch). Still `incomplete` and
+    // still exit 1: no denominator means no verified pass, which is the A5
+    // guard and is older than this exemption.
+    if (score.total_required === 0 && unreached === 0 && score.preSatisfied > 0) {
+      return `score: incomplete — nothing was at risk (${score.preSatisfied} ${criteriaWord(score.preSatisfied)} already true in the seed); ${scoreCountsSummary(score)}; ${unevaluatedNumericLabel}: ${score.satisfaction}/100`;
+    }
     const preSatisfiedClause =
       score.preSatisfied > 0 ? ` (${score.preSatisfied} already true in the seed)` : "";
     return `score: incomplete — ${unreached} of ${total} criteria not evaluated${preSatisfiedClause}; ${scoreCountsSummary(score)}; ${unevaluatedNumericLabel}: ${score.satisfaction}/100`;

--- a/cli/src/hosted/evalResultView.ts
+++ b/cli/src/hosted/evalResultView.ts
@@ -69,6 +69,13 @@ export type Score = {
   failed: number;
   skipped: number;
   errored: number;
+  // F-1392 — the SUBSET of `skipped` excluded because the seed already
+  // satisfied it (`PRE_SATISFIED_REASON`/`isPreSatisfied` above). Not a
+  // separate outcome — these criteria still count in `skipped` and still
+  // render with the `-` marker (`outcomeOf` keeps mapping them to
+  // `"skipped"`) — but they are not abstentions, so `can_pass` and
+  // `runScoreLine` subtract this count back out of the "not evaluated" tally.
+  preSatisfied: number;
   // = passed + failed. The satisfaction denominator.
   total_required: number;
   // false when total_required === 0 (nothing was evaluated). Renders as
@@ -92,6 +99,34 @@ export function outcomeOf(result: CriterionResult): CriterionOutcome {
   return result.passed ? "passed" : "failed";
 }
 
+// F-1296 (pome-cloud) stamps this reason on a criterion the seed already
+// satisfied — the control plane graded the FINAL state alone, found the
+// criterion true before the agent ran, and moved it out of the score
+// denominator so a task cannot earn credit for doing nothing (AutomationBench's
+// "no reward for doing nothing" rule). Restated here rather than imported: the
+// CLI shares no code with the control plane, and this travels as a string on
+// the `criteria_results` wire shape (`apps/control-plane/src/services/
+// evaluators/deterministic/pre-satisfied.ts` on the pome-cloud side).
+//
+// F-1392 — the CLI is the fifth surface this string has to agree with
+// (score-merge, run-report, run-status and drift-telemetry are the other
+// four, per pre-satisfied.ts's own doc comment). Defined ONCE and read from
+// here at every call site so the string is never repeated inline.
+export const PRE_SATISFIED_REASON = "already_true_in_seed";
+
+/**
+ * Was this criterion excluded for having already been true in the seed?
+ *
+ * Mirrors the dashboard's `isPreSatisfiedResult`
+ * (apps/dashboard/src/lib/run-status.ts) over the same `criteria_results`
+ * wire shape — same predicate, same reason string, two repos.
+ */
+export function isPreSatisfied(
+  result: Pick<CriterionResult, "skipped" | "reason">,
+): boolean {
+  return result.skipped && result.reason === PRE_SATISFIED_REASON;
+}
+
 export type ScoreStatus = "pass" | "fail" | "incomplete";
 
 // Single source of truth for "did this run pass?", applied to a CLOUD score.
@@ -104,11 +139,18 @@ export type ScoreStatus = "pass" | "fail" | "incomplete";
 // partial run into a pass — the same refusal pome-cloud added server-side in
 // F-925 — so the rename must not become a loosening.
 //
-// One rule, two repos: `can_pass` is false for ANY abstention
-// (`uploadAndFinalize.ts`), and pome-cloud's `isRunIncomplete` says
-// `notEvaluated > 0` over the same `criteria_results`. Deliberately NOT read
-// from the wire's `all_skipped`, which is the narrower every-abstained
-// predicate and would loosen this guard.
+// One rule, two repos: `can_pass` is false for any abstention EXCEPT a
+// criterion the seed already satisfied (`PRE_SATISFIED_REASON` above) —
+// `uploadAndFinalize.ts`'s `scoreFromFinalizeResponse` subtracts
+// `preSatisfied` out of the `skipped` tally before deciding `can_pass`, and
+// pome-cloud's `isRunIncomplete` subtracts the same `preSatisfied` count out
+// of `notEvaluated` over the same `criteria_results`
+// (apps/dashboard/src/lib/run-status.ts). F-1392 — the CLI used to count
+// every `skipped` result with no exemption, which called a run INCOMPLETE
+// that the dashboard called PASS. ANY OTHER skipped reason, and every
+// `errored`, still fails this guard — only the one named exemption is
+// narrowed. Deliberately NOT read from the wire's `all_skipped`, which is the
+// narrower every-abstained predicate and would loosen this guard.
 export function scoreStatus(score: Score, passThreshold: number): ScoreStatus {
   if (!score.evaluated || !score.can_pass) return "incomplete";
   return score.satisfaction >= passThreshold ? "pass" : "fail";
@@ -171,9 +213,20 @@ export function runScoreLine(
     // fact the cloud's own header now states. The old copy said "cannot pass",
     // which is a verdict about the AGENT for a gap in the GRADER — the exact
     // inversion F-925 exists to stop, one surface over.
-    const notEvaluated = score.skipped + score.errored;
-    const total = score.total_required + notEvaluated;
-    return `score: incomplete — ${notEvaluated} of ${total} criteria not evaluated; ${scoreCountsSummary(score)}; ${unevaluatedNumericLabel}: ${score.satisfaction}/100`;
+    //
+    // F-1392 — `preSatisfied` criteria are named APART from the abstentions
+    // instead of folded into "not evaluated", the way the dashboard's
+    // `verdictLine` does (run-status.ts:175-196): a pre-satisfied criterion
+    // reached a verdict (the grader wasn't gapped), it just tested nothing.
+    // Only reachable here at all when some OTHER criterion is still a genuine
+    // abstention/error — a run whose only non-passing criterion is
+    // pre-satisfied is already `pass`, not `incomplete`.
+    const allExcluded = score.skipped + score.errored;
+    const unreached = allExcluded - score.preSatisfied;
+    const total = score.total_required + allExcluded;
+    const preSatisfiedClause =
+      score.preSatisfied > 0 ? ` (${score.preSatisfied} already true in the seed)` : "";
+    return `score: incomplete — ${unreached} of ${total} criteria not evaluated${preSatisfiedClause}; ${scoreCountsSummary(score)}; ${unevaluatedNumericLabel}: ${score.satisfaction}/100`;
   }
   return `score: ${score.satisfaction}/100`;
 }

--- a/cli/src/hosted/uploadAndFinalize.ts
+++ b/cli/src/hosted/uploadAndFinalize.ts
@@ -11,7 +11,7 @@ import { gzipSync } from "node:zlib";
 import type { HostedClient } from "./client.js";
 import type { FinalizeResponse, PerTwinStateKeys } from "../types/shared.js";
 import type { Score } from "./evalResultView.js";
-import { outcomeOf } from "./evalResultView.js";
+import { isPreSatisfied, outcomeOf } from "./evalResultView.js";
 import { redactSecrets } from "../recorder/redaction.js";
 
 /** The narrow client surface the upload orchestration needs. `pome eval`
@@ -317,6 +317,14 @@ export async function uploadRunBlobs(
  * locally only when /finalize returns per-criterion results. Older cloud
  * builds omit `criteria_results`; for those, preserve the cloud score as
  * renderable instead of inventing an empty local A5 verdict.
+ *
+ * F-1392 — `can_pass` exempts a `skipped` result stamped
+ * `PRE_SATISFIED_REASON` (`already_true_in_seed`): the seed already satisfied
+ * that criterion, so it is not an abstention and a run holding one can still
+ * pass. Every OTHER skipped reason, and every `errored`, still blocks
+ * `can_pass` — this is the same exemption pome-cloud's `isRunIncomplete`
+ * applies over the same `criteria_results` (F-1296), narrowed to nothing
+ * else.
  */
 export function scoreFromFinalizeResponse(finalized: FinalizeResponse): Score {
   const hasCriteriaResults = finalized.criteria_results !== undefined;
@@ -325,17 +333,26 @@ export function scoreFromFinalizeResponse(finalized: FinalizeResponse): Score {
   const failed = results.filter((r) => outcomeOf(r) === "failed").length;
   const errored = results.filter((r) => outcomeOf(r) === "errored").length;
   const skipped = results.filter((r) => outcomeOf(r) === "skipped").length;
+  const preSatisfied = results.filter(
+    (r) => outcomeOf(r) === "skipped" && isPreSatisfied(r),
+  ).length;
   const totalRequired = passed + failed;
+  // The abstentions that actually block a pass: every skipped result MINUS
+  // the ones the seed already satisfied, plus every errored result (never
+  // exempted — F-1392's "Traps": a pre-satisfied result is a wire-observed
+  // fact for `skipped`, not for `errored`).
+  const unresolvedAbstentions = skipped - preSatisfied + errored;
   return {
     satisfaction: finalized.score,
     passed,
     failed,
     skipped,
     errored,
+    preSatisfied,
     total_required: totalRequired,
     evaluated: hasCriteriaResults ? totalRequired > 0 : true,
     can_pass: hasCriteriaResults
-      ? totalRequired > 0 && skipped === 0 && errored === 0
+      ? totalRequired > 0 && unresolvedAbstentions === 0
       : true,
     results,
     judge_model: finalized.judge_model ?? null,

--- a/cli/src/hosted/uploadAndFinalize.ts
+++ b/cli/src/hosted/uploadAndFinalize.ts
@@ -325,6 +325,15 @@ export async function uploadRunBlobs(
  * `can_pass` — this is the same exemption pome-cloud's `isRunIncomplete`
  * applies over the same `criteria_results` (F-1296), narrowed to nothing
  * else.
+ *
+ * `errored` is a DISPLAY-MODEL state with no wire producer today: it is
+ * reachable only through `CriterionResult.outcome`, which neither this repo's
+ * `criterionResultSchema` nor pome-cloud's carries, so `finalizeResponseSchema`
+ * strips it off every real /finalize response and `outcomeOf` falls back to
+ * passed/skipped. The term stays in the arithmetic because a cloud that starts
+ * emitting it must not thereby acquire a pass — but no wire fixture can
+ * exercise it, and a test that fabricates one is testing the display model, not
+ * this function (`incompleteVerdict.test.ts` does exactly that, and says so).
  */
 export function scoreFromFinalizeResponse(finalized: FinalizeResponse): Score {
   const hasCriteriaResults = finalized.criteria_results !== undefined;

--- a/cli/test/e2e/runTaskHosted.test.ts
+++ b/cli/test/e2e/runTaskHosted.test.ts
@@ -284,6 +284,86 @@ describe("pome run --hosted (e2e via spawn)", () => {
     expect(stderr).toContain("cloud score: 100/100");
   }, 90_000);
 
+  // F-1392 — the sibling of the INCOMPLETE test above. pome-cloud's F-1296
+  // excludes a criterion the seed already satisfied from the dashboard's
+  // abstention denominator (`isRunIncomplete` in
+  // apps/dashboard/src/lib/run-status.ts). Before this fix, the CLI counted
+  // this `skipped` result like any other abstention and printed INCOMPLETE /
+  // exit 1 on a run the dashboard renders PASS.
+  it("prints PASS and exits 0 when the only skipped criterion is pre-satisfied (already_true_in_seed)", async () => {
+    finalizeResponseOverrides = {
+      criteria_results: [
+        {
+          criterion: { type: "code", text: "No unsupported endpoint was called" },
+          outcome: "passed",
+          passed: true,
+          skipped: false,
+          reason: "matched",
+        },
+        {
+          criterion: { type: "code", text: "github.no-new-issues" },
+          outcome: "skipped",
+          passed: false,
+          skipped: true,
+          reason: "already_true_in_seed",
+        },
+      ],
+    };
+    const taskPath = join(tmp, "scn.md");
+    await writeFile(
+      taskPath,
+      [
+        "# Trivial",
+        "",
+        "## Prompt",
+        "Pretend prompt.",
+        "",
+        "## Success Criteria",
+        "- [code] No unsupported endpoint was called",
+        "- [code] github.no-new-issues",
+        "",
+        "## Config",
+        "```yaml",
+        "twins: [github]",
+        "timeout: 30",
+        "passThreshold: 100",
+        "```",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const child = spawn(
+      process.execPath,
+      [
+        "--import",
+        TSX_LOADER,
+        CLI_ENTRY,
+        "run",
+        taskPath,
+        "--api-url",
+        `http://127.0.0.1:${port}`,
+        "--agent",
+        "true",
+        "--artifacts-dir",
+        join(tmp, "runs"),
+      ],
+      {
+        cwd: tmp,
+        env: { ...process.env, POME_API_KEY: "pme_e2e_test" },
+      },
+    );
+
+    let stderr = "";
+    child.stderr.on("data", (d) => (stderr += d.toString()));
+    const code = await new Promise<number>((res) => child.on("close", res));
+
+    expect(code, `stderr was:\n${stderr}`).toBe(0);
+    expect(stderr).toMatch(/PASS/);
+    expect(stderr).not.toMatch(/INCOMPLETE/);
+    expect(stderr).not.toContain("score: incomplete —");
+  }, 90_000);
+
   // F-768 (M1 "Turn-usage into the main ledger") — the whole point of the
   // LlmTurnEvent contract is that per-turn LLM usage, and specifically the
   // cache-read/cache-creation token counts, reaches cloud. On the HOSTED lane

--- a/cli/test/e2e/runTaskHosted.test.ts
+++ b/cli/test/e2e/runTaskHosted.test.ts
@@ -291,18 +291,20 @@ describe("pome run --hosted (e2e via spawn)", () => {
   // this `skipped` result like any other abstention and printed INCOMPLETE /
   // exit 1 on a run the dashboard renders PASS.
   it("prints PASS and exits 0 when the only skipped criterion is pre-satisfied (already_true_in_seed)", async () => {
+    // The wire shape exactly as pome-cloud serializes it: no `outcome` field
+    // (`criterionResultSchema` has none on either side, and the CLI's
+    // `finalizeResponseSchema` strips unknown keys), so the exemption has to
+    // work off `skipped` + `reason` — which is the whole point.
     finalizeResponseOverrides = {
       criteria_results: [
         {
           criterion: { type: "code", text: "No unsupported endpoint was called" },
-          outcome: "passed",
           passed: true,
           skipped: false,
           reason: "matched",
         },
         {
           criterion: { type: "code", text: "github.no-new-issues" },
-          outcome: "skipped",
           passed: false,
           skipped: true,
           reason: "already_true_in_seed",

--- a/cli/test/unit/fix-prompt-group.test.ts
+++ b/cli/test/unit/fix-prompt-group.test.ts
@@ -227,6 +227,44 @@ describe("run-set fix prompt (FDRS-644)", () => {
     expect(prompt).toContain(`"${CRITERIA.comment}"`);
   });
 
+  it("names a seed-excluded criterion apart from the abstentions (F-1392)", () => {
+    // A criterion the seed already satisfied is `skipped` on the wire like an
+    // abstention and means the opposite: the grader DID reach a verdict, and
+    // the verdict is that the criterion was never at risk. Folded into "not
+    // uniformly evaluated", it sends the reader's coding agent looking for an
+    // instrument gap that does not exist — the same conflation F-1392 removed
+    // from the run-level tally.
+    const preSatisfiedResult: CriterionResult = {
+      criterion: { type: "code", text: CRITERIA.comment },
+      passed: false,
+      skipped: true,
+      reason: "already_true_in_seed",
+    };
+    const trials = [
+      trial(1, {
+        passed: false,
+        results: [result(CRITERIA.severity, false, "under-rated"), preSatisfiedResult],
+      }),
+      trial(2, {
+        passed: false,
+        results: [result(CRITERIA.severity, false, "under-rated"), preSatisfiedResult],
+      }),
+    ];
+    const prompt = buildGroupFixUserPrompt({
+      taskName: "scn",
+      groupId: "grp_test",
+      task,
+      trials,
+    });
+    expect(prompt).toContain(
+      `already true in the seed in every completed trial — excluded from the score, nothing here to fix: "${CRITERIA.comment}"`,
+    );
+    expect(prompt).not.toContain("not uniformly evaluated");
+    expect(prompt).not.toContain(
+      `passed in every completed trial: "${CRITERIA.comment}"`,
+    );
+  });
+
   it("flattens hostile judge reasons — no markdown-heading injection (adversarial fix)", () => {
     const hostile = trial(1, {
       passed: false,

--- a/cli/test/unit/hosted/cross-surface-agreement.test.ts
+++ b/cli/test/unit/hosted/cross-surface-agreement.test.ts
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-1392 / D3 — "no surface states more than it checked", applied to the two
+// surfaces that answer ONE question: is this run a pass, a fail, or a run the
+// grader did not finish?
+//
+// The CLI answers it in `scoreFromFinalizeResponse` + `scoreStatus`. The
+// dashboard answers it in `deriveRunStatus` (`apps/dashboard/src/lib/
+// run-status.ts`, pome-cloud). They share no code — the two repos publish no
+// module to each other, and the only thing that crosses is the
+// `criteria_results` wire shape plus one reason string. So "they agree" is a
+// claim someone has to check, and until this file existed nobody did: F-1392
+// was a run the CLI called INCOMPLETE and the dashboard called PASS, shipped
+// for as long as it took a human to notice the two screens disagreeing.
+//
+// `dashboardRunStatus` below is a TRANSCRIPTION of run-status.ts, named line by
+// line so a reviewer can diff it against the original, and deliberately NOT a
+// generalization of it. It is the oracle, not an implementation: nothing in
+// `src/` imports it. When pome-cloud changes its predicate, this table is what
+// goes red.
+//
+// The one row where the two surfaces still differ is in the table too, marked
+// `divergence`, with the reason. A known divergence with a test on it is a
+// fact; the same divergence with no test on it is the F-1392 defect again.
+
+import { describe, expect, it } from "vitest";
+import type { CriterionResult } from "../../../src/contract/index.js";
+import { PRE_SATISFIED_REASON, scoreStatus } from "../../../src/hosted/evalResultView.js";
+import { scoreFromFinalizeResponse } from "../../../src/hosted/uploadAndFinalize.js";
+
+// ── The oracle: pome-cloud's answer, transcribed ────────────────────────────
+//
+// apps/dashboard/src/lib/run-status.ts:
+//   deriveCriteriaCounts  (75-95)  — skipped ⇒ notEvaluated, +preSatisfied when
+//                                    the reason matches; else evaluated (+passed)
+//   isRunIncomplete      (117-122) — total > 0 && notEvaluated - preSatisfied > 0
+//   deriveRunStatus      (135-141) — incomplete first, then
+//                                    satisfaction_score === 100 ? pass : fail
+//
+// The satisfaction score the dashboard reads is the run row's, which the
+// control plane computes in `score-merge.ts:314-315` as
+// `evaluated === 0 ? 0 : round(passed / evaluated * 100)` — the same number
+// /finalize returns to the CLI, so one `satisfaction` input drives both sides
+// of every row below.
+type DashboardStatus = "pass" | "fail" | "incomplete";
+
+function dashboardRunStatus(
+  results: readonly CriterionResult[],
+  satisfactionScore: number,
+): DashboardStatus {
+  let notEvaluated = 0;
+  let preSatisfied = 0;
+  for (const r of results) {
+    if (!r.skipped) continue;
+    notEvaluated += 1;
+    if (r.reason === PRE_SATISFIED_REASON) preSatisfied += 1;
+  }
+  const total = results.length;
+  if (total > 0 && notEvaluated - preSatisfied > 0) return "incomplete";
+  return satisfactionScore === 100 ? "pass" : "fail";
+}
+
+// ── The CLI's answer, through the shipped path ──────────────────────────────
+function cliRunStatus(
+  results: CriterionResult[],
+  satisfactionScore: number,
+): DashboardStatus {
+  const score = scoreFromFinalizeResponse({
+    run_id: "run_x",
+    score: satisfactionScore,
+    dashboard_url: "https://app.pome.sh/runs/run_x",
+    criteria_results: results,
+  });
+  // The dashboard's pass bar is a hard 100 (`satisfaction_score === 100`), so
+  // the comparison only means anything at the CLI's matching threshold. A task
+  // that lowers `passThreshold` is opting the CLI out of that agreement
+  // knowingly, and the dashboard has no field to learn it from.
+  return scoreStatus(score, 100);
+}
+
+const passing = (text: string): CriterionResult => ({
+  criterion: { type: "code", text },
+  passed: true,
+  skipped: false,
+  reason: "matched",
+});
+const failing = (text: string): CriterionResult => ({
+  criterion: { type: "code", text },
+  passed: false,
+  skipped: false,
+  reason: "state did not match",
+});
+const abstained = (text: string): CriterionResult => ({
+  criterion: { type: "code", text },
+  passed: false,
+  skipped: true,
+  reason: "tool_not_recorded",
+});
+const excluded = (text: string): CriterionResult => ({
+  criterion: { type: "code", text },
+  passed: false,
+  skipped: true,
+  reason: PRE_SATISFIED_REASON,
+});
+
+interface Row {
+  name: string;
+  results: CriterionResult[];
+  satisfaction: number;
+  expected: DashboardStatus;
+  /** Set only where the two surfaces are known to word the same run
+   *  differently. The value is the CLI's word; `expected` stays the
+   *  dashboard's. */
+  divergence?: { cli: DashboardStatus; why: string };
+}
+
+const table: Row[] = [
+  {
+    name: "everything passed",
+    results: [passing("a"), passing("b")],
+    satisfaction: 100,
+    expected: "pass",
+  },
+  {
+    name: "one criterion failed",
+    results: [passing("a"), failing("b")],
+    satisfaction: 50,
+    expected: "fail",
+  },
+  {
+    name: "one criterion abstained beside three passes",
+    results: [passing("a"), passing("b"), passing("c"), abstained("d")],
+    satisfaction: 100,
+    expected: "incomplete",
+  },
+  {
+    name: "F-925: an abstention outranks a failing score",
+    results: [passing("a"), failing("b"), abstained("c")],
+    satisfaction: 50,
+    expected: "incomplete",
+  },
+  {
+    name: "every criterion abstained",
+    results: [abstained("a"), abstained("b")],
+    satisfaction: 0,
+    expected: "incomplete",
+  },
+  {
+    // The F-1392 hero shape: support-triage-dedup scores 100 over three
+    // criteria with a fourth excluded as already true in the seed. This is the
+    // row that used to read pass / incomplete.
+    name: "seed-excluded criterion beside three passes",
+    results: [passing("a"), passing("b"), passing("c"), excluded("github.no-new-issues")],
+    satisfaction: 100,
+    expected: "pass",
+  },
+  {
+    name: "seed-excluded criterion beside a real abstention",
+    results: [passing("a"), excluded("github.no-new-issues"), abstained("c")],
+    satisfaction: 100,
+    expected: "incomplete",
+  },
+  {
+    name: "seed-excluded criterion beside a failure",
+    results: [failing("a"), excluded("github.no-new-issues")],
+    satisfaction: 0,
+    expected: "fail",
+  },
+  {
+    name: "every criterion seed-excluded — no denominator",
+    results: [excluded("github.no-new-issues"), excluded("github.no-new-labels")],
+    satisfaction: 0,
+    expected: "fail",
+    divergence: {
+      cli: "incomplete",
+      why:
+        "The dashboard exempts every abstention, falls through to " +
+        "`satisfaction_score === 100`, and gets 0 because the denominator is " +
+        "empty — so it renders FAILED while its own verdictLine says " +
+        '"nothing was at risk". The CLI keeps the older A5 guard ' +
+        "(`total_required > 0` ⇒ not evaluated ⇒ incomplete), which is the " +
+        "honest word for a run in which nothing was ever at risk. Both refuse " +
+        "to pass it and both exit non-zero, so no CI caller can act on the " +
+        "difference; the fix belongs in pome-cloud's deriveRunStatus (F-1399), " +
+        "not in a CLI that would then have to blame the agent for an empty " +
+        "denominator. Retire this row when F-1399 lands.",
+    },
+  },
+];
+
+describe("CLI and dashboard answer `what state is this run in?` the same way (F-1392)", () => {
+  for (const row of table) {
+    const label = row.divergence ? `${row.name} [known divergence]` : row.name;
+    it(label, () => {
+      expect(dashboardRunStatus(row.results, row.satisfaction)).toBe(row.expected);
+      expect(cliRunStatus(row.results, row.satisfaction)).toBe(
+        row.divergence?.cli ?? row.expected,
+      );
+      // Whatever the word, the two surfaces must never split on the only bit
+      // a CI caller can act on: did this run pass?
+      expect(cliRunStatus(row.results, row.satisfaction) === "pass").toBe(
+        dashboardRunStatus(row.results, row.satisfaction) === "pass",
+      );
+    });
+  }
+
+  it("has exactly one known divergence, and it is the empty-denominator row", () => {
+    // A guard on the guard: adding a `divergence` to a row is how this file
+    // would be silenced, so the count is asserted rather than left to review.
+    const diverging = table.filter((row) => row.divergence);
+    expect(diverging.map((row) => row.name)).toEqual([
+      "every criterion seed-excluded — no denominator",
+    ]);
+  });
+});

--- a/cli/test/unit/hosted/evalResultCache.test.ts
+++ b/cli/test/unit/hosted/evalResultCache.test.ts
@@ -184,6 +184,42 @@ describe("verdict artifact (FDRS-644)", () => {
     expect(latestFailedRunSet(sets)?.groupId).toBe("grp_b");
   });
 
+  // F-1392 — `anyFailed` reads `!t.verdict.passed`, so a group holding a
+  // trial whose only non-passing criterion was pre-satisfied must NOT trip
+  // `anyFailed`, or it gets misrouted to `pome fix-prompt` as an agent
+  // defect. This is resolved upstream in `scoreFromFinalizeResponse` (the
+  // trial's `passed` is written correctly at verdict.json write time); this
+  // test pins the group-level behavior against the artifact directly rather
+  // than re-deriving it.
+  it("a group holding a pre-satisfied-only trial (passed: true) is NOT anyFailed", async () => {
+    const trials = [
+      {
+        runDir: "p1",
+        verdict: verdict({
+          group_id: "grp_p",
+          session_id: "p1",
+          passed: true,
+          criteria_results: [
+            {
+              criterion: { type: "code", text: "github.no-new-issues" },
+              passed: false,
+              skipped: true,
+              reason: "already_true_in_seed",
+            },
+          ],
+          finalized_at: "2026-08-10T00:00:00Z",
+        }),
+      },
+      {
+        runDir: "p2",
+        verdict: verdict({ group_id: "grp_p", session_id: "p2", finalized_at: "2026-08-10T00:01:00Z" }),
+      },
+    ];
+    const sets = groupRunSets(trials);
+    expect(sets).toHaveLength(1);
+    expect(sets[0]!.anyFailed).toBe(false);
+  });
+
   it("discoverRunSet(root): latest failed set; all-green roots return set=null with totalSets>0", async () => {
     const tmp = await mkdtemp(join(tmpdir(), "verdict-root-"));
     await writeTrial(tmp, "scn", "g1", { group_id: "grp_g", finalized_at: "2026-07-06T05:00:00Z" });

--- a/cli/test/unit/hosted/incompleteVerdict.test.ts
+++ b/cli/test/unit/hosted/incompleteVerdict.test.ts
@@ -21,6 +21,8 @@
 import { describe, expect, it } from "vitest";
 import type { CriterionResult } from "../../../src/contract/index.js";
 import {
+  isPreSatisfied,
+  PRE_SATISFIED_REASON,
   runScoreLine,
   scoreStatus,
   taskPassed,
@@ -39,11 +41,20 @@ const abstained = (text: string): CriterionResult => ({
   skipped: true,
   reason: "tool_not_recorded",
 });
+// F-1392 — the one exemption: excluded because the seed already satisfied it,
+// not because the grader couldn't reach a verdict.
+const preSatisfied = (text: string): CriterionResult => ({
+  criterion: { type: "code", text },
+  passed: false,
+  skipped: true,
+  reason: PRE_SATISFIED_REASON,
+});
 
 function score(results: CriterionResult[], satisfaction: number): Score {
   const passed = results.filter((r) => !r.skipped && r.passed).length;
   const failed = results.filter((r) => !r.skipped && !r.passed).length;
   const skipped = results.filter((r) => r.skipped).length;
+  const preSatisfiedCount = results.filter((r) => isPreSatisfied(r)).length;
   const totalRequired = passed + failed;
   return {
     satisfaction,
@@ -51,9 +62,10 @@ function score(results: CriterionResult[], satisfaction: number): Score {
     failed,
     skipped,
     errored: 0,
+    preSatisfied: preSatisfiedCount,
     total_required: totalRequired,
     evaluated: totalRequired > 0,
-    can_pass: totalRequired > 0 && skipped === 0,
+    can_pass: totalRequired > 0 && skipped - preSatisfiedCount === 0,
     results,
     judge_model: null,
     judge_tokens_in: null,
@@ -120,5 +132,67 @@ describe("runScoreLine — the copy stops blaming the agent", () => {
     expect(runScoreLine(score([ok("a")], 100), 100, "cloud score")).toBe(
       "score: 100/100",
     );
+  });
+});
+
+// F-1392 — pome-cloud's F-1296 excludes a criterion the seed already
+// satisfied from the abstention denominator (`isRunIncomplete` in
+// apps/dashboard/src/lib/run-status.ts). The CLI counted every `skipped`
+// result with no exemption, so a run the dashboard calls PASS came out
+// `incomplete` / exit 1 in CI. These tests pin the fix at the `isPreSatisfied`
+// predicate and its two call sites (`scoreStatus` via `can_pass`, and
+// `runScoreLine`'s copy).
+describe("isPreSatisfied / PRE_SATISFIED_REASON — the one exemption, keyed on the shared reason string", () => {
+  it("is true only for a skipped result with the exact reason", () => {
+    expect(isPreSatisfied({ skipped: true, reason: PRE_SATISFIED_REASON })).toBe(true);
+    expect(isPreSatisfied({ skipped: true, reason: "tool_not_recorded" })).toBe(false);
+    // Same reason string but NOT skipped (shouldn't happen on the wire, but
+    // the predicate must not key on the string alone).
+    expect(isPreSatisfied({ skipped: false, reason: PRE_SATISFIED_REASON })).toBe(false);
+  });
+});
+
+describe("scoreStatus — a pre-satisfied criterion is not an abstention (F-1392)", () => {
+  it("returns pass for a run whose ONLY non-passing criterion is pre-satisfied", () => {
+    const s = score([ok("a"), ok("b"), preSatisfied("github.no-new-issues")], 100);
+    expect(s.can_pass).toBe(true);
+    expect(scoreStatus(s, 100)).toBe("pass");
+    expect(taskPassed(s, 100)).toBe(true);
+  });
+
+  it("STILL returns incomplete when a genuine abstention accompanies the pre-satisfied one", () => {
+    const s = score(
+      [ok("a"), preSatisfied("github.no-new-issues"), abstained("d")],
+      100,
+    );
+    expect(s.can_pass).toBe(false);
+    expect(scoreStatus(s, 100)).toBe("incomplete");
+  });
+
+  it("STILL refuses to inflate a partial run for any OTHER skip reason — narrowing must not become a loosening", () => {
+    const s = score([ok("a"), ok("b"), ok("c"), abstained("d")], 100);
+    expect(s.can_pass).toBe(false);
+    expect(scoreStatus(s, 100)).toBe("incomplete");
+  });
+});
+
+describe("runScoreLine — pre-satisfied criteria are named apart from abstentions (F-1392)", () => {
+  it("names the pre-satisfied count separately from the not-evaluated count, mirroring the dashboard's verdict line", () => {
+    // 1 real abstention + 1 pre-satisfied — still incomplete (the abstention),
+    // but the line must not say "2 of 4 criteria not evaluated": only the
+    // real abstention failed to reach a verdict.
+    const s = score(
+      [ok("a"), ok("b"), abstained("c"), preSatisfied("github.no-new-issues")],
+      100,
+    );
+    const line = runScoreLine(s, 100, "cloud score");
+    expect(line).toContain("incomplete");
+    expect(line).toContain("1 of 4 criteria not evaluated");
+    expect(line).toContain("1 already true in the seed");
+  });
+
+  it("renders the plain passing line when the only skip is pre-satisfied", () => {
+    const s = score([ok("a"), preSatisfied("github.no-new-issues")], 100);
+    expect(runScoreLine(s, 100, "cloud score")).toBe("score: 100/100");
   });
 });

--- a/cli/test/unit/hosted/incompleteVerdict.test.ts
+++ b/cli/test/unit/hosted/incompleteVerdict.test.ts
@@ -28,6 +28,7 @@ import {
   taskPassed,
   type Score,
 } from "../../../src/hosted/evalResultView.js";
+import { scoreFromFinalizeResponse } from "../../../src/hosted/uploadAndFinalize.js";
 
 const ok = (text: string): CriterionResult => ({
   criterion: { type: "code", text },
@@ -50,27 +51,18 @@ const preSatisfied = (text: string): CriterionResult => ({
   reason: PRE_SATISFIED_REASON,
 });
 
+// Built by the SHIPPED producer rather than re-derived here. This helper used
+// to restate `can_pass` inline, which meant every assertion below could stay
+// green while `scoreFromFinalizeResponse` said something else — a test-local
+// second implementation of the exact predicate whose two implementations
+// disagreeing is the bug this file guards (F-1392).
 function score(results: CriterionResult[], satisfaction: number): Score {
-  const passed = results.filter((r) => !r.skipped && r.passed).length;
-  const failed = results.filter((r) => !r.skipped && !r.passed).length;
-  const skipped = results.filter((r) => r.skipped).length;
-  const preSatisfiedCount = results.filter((r) => isPreSatisfied(r)).length;
-  const totalRequired = passed + failed;
-  return {
-    satisfaction,
-    passed,
-    failed,
-    skipped,
-    errored: 0,
-    preSatisfied: preSatisfiedCount,
-    total_required: totalRequired,
-    evaluated: totalRequired > 0,
-    can_pass: totalRequired > 0 && skipped - preSatisfiedCount === 0,
-    results,
-    judge_model: null,
-    judge_tokens_in: null,
-    judge_tokens_out: null,
-  };
+  return scoreFromFinalizeResponse({
+    run_id: "run_test",
+    score: satisfaction,
+    dashboard_url: "https://app.pome.sh/runs/run_test",
+    criteria_results: results,
+  });
 }
 
 describe("scoreStatus — the third state is named `incomplete`", () => {
@@ -174,6 +166,37 @@ describe("scoreStatus — a pre-satisfied criterion is not an abstention (F-1392
     expect(s.can_pass).toBe(false);
     expect(scoreStatus(s, 100)).toBe("incomplete");
   });
+
+  it("is still incomplete when EVERY criterion was pre-satisfied — no denominator, no verified pass", () => {
+    // The A5 guard (`total_required > 0`) predates this exemption and
+    // outranks it: nothing passed and nothing failed, so there is no score to
+    // clear a threshold with. `runScoreLine` names this state rather than
+    // reporting a contradictory count, and
+    // `cross-surface-agreement.test.ts` records that the dashboard words the
+    // same run differently (it renders FAILED at 0/100) — the two agree that
+    // it is not a pass, which is what the exit code encodes.
+    const s = score([preSatisfied("github.no-new-issues")], 0);
+    expect(s.preSatisfied).toBe(1);
+    expect(s.total_required).toBe(0);
+    expect(s.evaluated).toBe(false);
+    expect(scoreStatus(s, 100)).toBe("incomplete");
+  });
+
+  it("never lets the exemption reach an errored criterion — it subtracts out of `skipped` only", () => {
+    // `errored` has no wire producer: it is reachable only through
+    // `CriterionResult.outcome`, which `finalizeResponseSchema` strips off
+    // every real /finalize response (pinned in `uploadAndFinalize.test.ts`).
+    // So this asserts against the DISPLAY MODEL, where the state exists,
+    // rather than fabricating a finalize response that could never arrive.
+    // What it pins is that `preSatisfied` is subtracted out of the SKIPPED
+    // tally and nothing else — an errored criterion stays in the
+    // not-evaluated count and in the copy.
+    const base = score([ok("a"), preSatisfied("github.no-new-issues")], 100);
+    const withError: Score = { ...base, errored: 1, can_pass: false };
+    const line = runScoreLine(withError, 100, "cloud score");
+    expect(line).toContain("1 of 3 criteria not evaluated");
+    expect(line).toContain("1 already true in the seed");
+  });
 });
 
 describe("runScoreLine — pre-satisfied criteria are named apart from abstentions (F-1392)", () => {
@@ -194,5 +217,38 @@ describe("runScoreLine — pre-satisfied criteria are named apart from abstentio
   it("renders the plain passing line when the only skip is pre-satisfied", () => {
     const s = score([ok("a"), preSatisfied("github.no-new-issues")], 100);
     expect(runScoreLine(s, 100, "cloud score")).toBe("score: 100/100");
+  });
+
+  it("says `nothing was at risk` for an all-excluded run instead of `0 of N criteria not evaluated`", () => {
+    // Nothing passed, nothing failed, and the only criterion left the
+    // denominator because the seed already satisfied it. The count-led
+    // sentence would read "0 of 1 criteria not evaluated" beside the word
+    // incomplete — a line that contradicts itself. Same words the dashboard's
+    // `verdictLine` uses for the same shape.
+    const s = score([preSatisfied("github.no-new-issues")], 0);
+    const line = runScoreLine(s, 100, "cloud score");
+    expect(line).toBe(
+      "score: incomplete — nothing was at risk (1 criterion already true in the seed); 0 passed, 0 failed, 1 skipped, 0 errored; cloud score: 0/100",
+    );
+    expect(line).not.toContain("not evaluated");
+  });
+
+  it("pluralizes the all-excluded line", () => {
+    const s = score(
+      [preSatisfied("github.no-new-issues"), preSatisfied("github.no-new-labels")],
+      0,
+    );
+    expect(runScoreLine(s, 100, "cloud score")).toContain(
+      "nothing was at risk (2 criteria already true in the seed)",
+    );
+  });
+
+  it("keeps the count-led sentence when a real abstention sits beside the exclusions", () => {
+    // Not the all-excluded shape: something genuinely failed to reach a
+    // verdict, so the reader needs the count and the word "not evaluated".
+    const s = score([preSatisfied("github.no-new-issues"), abstained("c")], 0);
+    const line = runScoreLine(s, 100, "cloud score");
+    expect(line).toContain("1 of 2 criteria not evaluated (1 already true in the seed)");
+    expect(line).not.toContain("nothing was at risk");
   });
 });

--- a/cli/test/unit/hosted/uploadAndFinalize.test.ts
+++ b/cli/test/unit/hosted/uploadAndFinalize.test.ts
@@ -10,9 +10,8 @@ import {
   type UploadClient,
 } from "../../../src/hosted/uploadAndFinalize.js";
 import { scoreStatus } from "../../../src/hosted/evalResultView.js";
-import type { CriterionResult as WireCriterionResult } from "../../../src/hosted/evalResultView.js";
 import { HostedOrchError } from "../../../src/hosted/errors.js";
-import type { FinalizeResponse } from "../../../src/contract/index.js";
+import { finalizeResponseSchema, type FinalizeResponse } from "../../../src/contract/index.js";
 
 describe("redactJsonl (FDRS-656 review)", () => {
   it("drops whitespace-only lines so validation and upload agree on row counts", () => {
@@ -239,19 +238,64 @@ describe("scoreFromFinalizeResponse — the seed-pre-satisfied exemption (F-1392
     expect(scoreStatus(score, 100)).toBe("incomplete");
   });
 
-  it("STILL calls the run incomplete when an ERRORED criterion is present, even alongside a pre-satisfied one", () => {
-    // `outcome` is evalResultView's own additive/optional discriminator
-    // (FDRS-591/611) — the wire contract's `criterionResultSchema`
-    // (contract/run.ts) doesn't carry it yet, so it never survives a real
-    // /finalize response. Cast past that gap here to exercise the defensive
-    // `errored` branch `outcomeOf` already supports.
-    const finalized = finalizeResponse(
-      [
+  it("STILL calls the run incomplete when a judge-unavailable criterion sits beside a pre-satisfied one", () => {
+    // The wire shape a judge failure actually arrives in: `skipped: true`
+    // with its own reason. It is not the exempt reason, so it blocks the pass
+    // exactly like any other abstention.
+    const finalized = finalizeResponse([
+      {
+        criterion: { type: "code", text: "No unsupported endpoint was called" },
+        passed: true,
+        skipped: false,
+        reason: "matched",
+      },
+      {
+        criterion: { type: "code", text: "github.no-new-issues" },
+        passed: false,
+        skipped: true,
+        reason: "already_true_in_seed",
+      },
+      {
+        criterion: { type: "model", text: "Severity is set correctly" },
+        passed: false,
+        skipped: true,
+        reason: "judge_unavailable",
+        confidence: 0,
+        judge_model: "test-judge",
+      },
+    ]);
+
+    const score = scoreFromFinalizeResponse(finalized);
+    expect(score.preSatisfied).toBe(1);
+    expect(score.skipped).toBe(2);
+    expect(score.can_pass).toBe(false);
+    expect(scoreStatus(score, 100)).toBe("incomplete");
+  });
+
+  it("cannot see an `errored` criterion at all — `outcome` does not survive the wire", () => {
+    // F-1392 review: a fixture that sets `outcome: "errored"` only typechecks
+    // through a cast, and a cast in a fixture is usually a fixture describing
+    // a state the system cannot produce. This is that case, pinned rather
+    // than cast past. `outcome` is `evalResultView`'s own additive
+    // discriminator (FDRS-591/611); neither this repo's
+    // `criterionResultSchema` nor pome-cloud's carries it, and
+    // `finalizeResponseSchema` is a tolerant reader that STRIPS unknown keys,
+    // so a cloud emitting `outcome` today would have it dropped before
+    // `scoreFromFinalizeResponse` ever saw it. `errored` is therefore always
+    // 0 on the hosted path, and the `errored` term in `can_pass` is a guard
+    // for a producer that does not exist yet — not a branch a wire fixture
+    // can exercise. If this test ever goes red, the wire grew the field and
+    // the errored path became real.
+    const parsed = finalizeResponseSchema.parse({
+      run_id: "run_x",
+      score: 100,
+      dashboard_url: "https://app.pome.sh/runs/run_x",
+      criteria_results: [
         {
-          criterion: { type: "code", text: "github.no-new-issues" },
-          passed: false,
-          skipped: true,
-          reason: "already_true_in_seed",
+          criterion: { type: "code", text: "No unsupported endpoint was called" },
+          passed: true,
+          skipped: false,
+          reason: "matched",
         },
         {
           criterion: { type: "model", text: "Severity is set correctly" },
@@ -262,12 +306,15 @@ describe("scoreFromFinalizeResponse — the seed-pre-satisfied exemption (F-1392
           confidence: 0,
           judge_model: "test-judge",
         },
-      ] as WireCriterionResult[] as FinalizeResponse["criteria_results"],
-    );
+      ],
+    });
 
-    const score = scoreFromFinalizeResponse(finalized);
-    expect(score.preSatisfied).toBe(1);
-    expect(score.errored).toBe(1);
+    expect(parsed.criteria_results?.[1]).not.toHaveProperty("outcome");
+    const score = scoreFromFinalizeResponse(parsed);
+    expect(score.errored).toBe(0);
+    expect(score.skipped).toBe(1);
+    // Still incomplete — via the skipped bucket, which is the only bucket the
+    // wire can put it in.
     expect(score.can_pass).toBe(false);
     expect(scoreStatus(score, 100)).toBe("incomplete");
   });
@@ -277,6 +324,12 @@ describe("scoreFromFinalizeResponse — the seed-pre-satisfied exemption (F-1392
     // guard (`totalRequired > 0`) is untouched by this exemption. F-1392
     // narrows what counts as an ABSTENTION; it does not relax the older rule
     // that a run with nothing passed or failed at all cannot pass regardless.
+    //
+    // This is the one shape where the CLI and the dashboard still word the
+    // same run differently — the dashboard renders FAILED at 0/100 rather
+    // than incomplete. Both refuse to pass it; only the word differs. The
+    // whole table, including this row, is in
+    // `cross-surface-agreement.test.ts`.
     const finalized = finalizeResponse([
       {
         criterion: { type: "code", text: "github.no-new-issues" },

--- a/cli/test/unit/hosted/uploadAndFinalize.test.ts
+++ b/cli/test/unit/hosted/uploadAndFinalize.test.ts
@@ -3,8 +3,16 @@
 
 import { gunzipSync } from "node:zlib";
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { redactJsonl, uploadRunBlobs, type UploadClient } from "../../../src/hosted/uploadAndFinalize.js";
+import {
+  redactJsonl,
+  scoreFromFinalizeResponse,
+  uploadRunBlobs,
+  type UploadClient,
+} from "../../../src/hosted/uploadAndFinalize.js";
+import { scoreStatus } from "../../../src/hosted/evalResultView.js";
+import type { CriterionResult as WireCriterionResult } from "../../../src/hosted/evalResultView.js";
 import { HostedOrchError } from "../../../src/hosted/errors.js";
+import type { FinalizeResponse } from "../../../src/contract/index.js";
 
 describe("redactJsonl (FDRS-656 review)", () => {
   it("drops whitespace-only lines so validation and upload agree on row counts", () => {
@@ -163,5 +171,135 @@ describe("uploadRunBlobs — meta.json (D18.1)", () => {
 
     const keys = await uploadRunBlobs(client, "ses_1", BLOBS);
     expect(keys.metaKey).toBeNull();
+  });
+});
+
+// F-1392 — pome-cloud's F-1296 moved a seed-pre-satisfied criterion out of
+// the dashboard's abstention denominator (`isRunIncomplete` in
+// apps/dashboard/src/lib/run-status.ts: `notEvaluated - preSatisfied > 0`).
+// The CLI never learned: `scoreFromFinalizeResponse` counted every `skipped`
+// result with no exemption, so a run the dashboard renders PASS came out
+// `can_pass: false` → `incomplete` → exit 1 in CI. These tests pin the fix
+// AND its narrowness: only the one named reason is exempt.
+function finalizeResponse(
+  criteria_results: FinalizeResponse["criteria_results"],
+  score = 100,
+): FinalizeResponse {
+  return {
+    run_id: "run_x",
+    score,
+    dashboard_url: "https://app.pome.sh/runs/run_x",
+    criteria_results,
+  };
+}
+
+describe("scoreFromFinalizeResponse — the seed-pre-satisfied exemption (F-1392)", () => {
+  it("yields can_pass: true and scoreStatus 'pass' when the only non-passing criterion is pre-satisfied", () => {
+    const finalized = finalizeResponse([
+      {
+        criterion: { type: "code", text: "No unsupported endpoint was called" },
+        passed: true,
+        skipped: false,
+        reason: "matched",
+      },
+      {
+        criterion: { type: "code", text: "github.no-new-issues" },
+        passed: false,
+        skipped: true,
+        reason: "already_true_in_seed",
+      },
+    ]);
+
+    const score = scoreFromFinalizeResponse(finalized);
+    expect(score.preSatisfied).toBe(1);
+    expect(score.skipped).toBe(1);
+    expect(score.can_pass).toBe(true);
+    expect(scoreStatus(score, 100)).toBe("pass");
+  });
+
+  it("STILL calls the run incomplete when a DIFFERENT skip reason is present (no loosening)", () => {
+    const finalized = finalizeResponse([
+      {
+        criterion: { type: "code", text: "No unsupported endpoint was called" },
+        passed: true,
+        skipped: false,
+        reason: "matched",
+      },
+      {
+        criterion: { type: "code", text: "some other criterion" },
+        passed: false,
+        skipped: true,
+        reason: "cloud could not evaluate this criterion",
+      },
+    ]);
+
+    const score = scoreFromFinalizeResponse(finalized);
+    expect(score.preSatisfied).toBe(0);
+    expect(score.can_pass).toBe(false);
+    expect(scoreStatus(score, 100)).toBe("incomplete");
+  });
+
+  it("STILL calls the run incomplete when an ERRORED criterion is present, even alongside a pre-satisfied one", () => {
+    // `outcome` is evalResultView's own additive/optional discriminator
+    // (FDRS-591/611) — the wire contract's `criterionResultSchema`
+    // (contract/run.ts) doesn't carry it yet, so it never survives a real
+    // /finalize response. Cast past that gap here to exercise the defensive
+    // `errored` branch `outcomeOf` already supports.
+    const finalized = finalizeResponse(
+      [
+        {
+          criterion: { type: "code", text: "github.no-new-issues" },
+          passed: false,
+          skipped: true,
+          reason: "already_true_in_seed",
+        },
+        {
+          criterion: { type: "model", text: "Severity is set correctly" },
+          outcome: "errored",
+          passed: false,
+          skipped: true,
+          reason: "judge_unavailable",
+          confidence: 0,
+          judge_model: "test-judge",
+        },
+      ] as WireCriterionResult[] as FinalizeResponse["criteria_results"],
+    );
+
+    const score = scoreFromFinalizeResponse(finalized);
+    expect(score.preSatisfied).toBe(1);
+    expect(score.errored).toBe(1);
+    expect(score.can_pass).toBe(false);
+    expect(scoreStatus(score, 100)).toBe("incomplete");
+  });
+
+  it("a run with ONLY pre-satisfied criteria and nothing else evaluated is still incomplete (nothing was actually graded)", () => {
+    // total_required stays 0 and can_pass stays false — the pre-existing A5
+    // guard (`totalRequired > 0`) is untouched by this exemption. F-1392
+    // narrows what counts as an ABSTENTION; it does not relax the older rule
+    // that a run with nothing passed or failed at all cannot pass regardless.
+    const finalized = finalizeResponse([
+      {
+        criterion: { type: "code", text: "github.no-new-issues" },
+        passed: false,
+        skipped: true,
+        reason: "already_true_in_seed",
+      },
+    ]);
+
+    const score = scoreFromFinalizeResponse(finalized);
+    expect(score.can_pass).toBe(false);
+    expect(score.evaluated).toBe(false);
+    expect(scoreStatus(score, 100)).toBe("incomplete");
+  });
+
+  it("keeps the FDRS-618 compat: no criteria_results at all still means can_pass true", () => {
+    const finalized: FinalizeResponse = {
+      run_id: "run_x",
+      score: 100,
+      dashboard_url: "https://app.pome.sh/runs/run_x",
+    };
+    const score = scoreFromFinalizeResponse(finalized);
+    expect(score.can_pass).toBe(true);
+    expect(score.preSatisfied).toBe(0);
   });
 });

--- a/cli/test/unit/run-default-task.test.ts
+++ b/cli/test/unit/run-default-task.test.ts
@@ -50,6 +50,7 @@ vi.mock("../../src/runner/runTaskHosted.js", () => ({
       failed: 0,
       skipped: 0,
       errored: 0,
+      preSatisfied: 0,
       total_required: 1,
       evaluated: true,
       can_pass: true,

--- a/cli/test/unit/run-n-flag.test.ts
+++ b/cli/test/unit/run-n-flag.test.ts
@@ -40,6 +40,7 @@ vi.mock("../../src/runner/runTaskHosted.js", () => ({
       failed: 0,
       skipped: 0,
       errored: 0,
+      preSatisfied: 0,
       total_required: 1,
       evaluated: true,
       can_pass: true,

--- a/cli/test/unit/runner/runTrialGroup.test.ts
+++ b/cli/test/unit/runner/runTrialGroup.test.ts
@@ -169,6 +169,7 @@ function scoreOf(satisfaction: number, failedTexts: string[] = []): Score {
     failed: failedTexts.length,
     skipped: 0,
     errored: 0,
+    preSatisfied: 0,
     total_required: 2,
     evaluated: true,
     can_pass: true,


### PR DESCRIPTION
## Problem

A criterion the seed already satisfied was out of the abstention denominator on the dashboard and in it on the CLI. pome-cloud's `isRunIncomplete` (`apps/dashboard/src/lib/run-status.ts`) subtracts a criterion stamped `already_true_in_seed` before deciding a run is incomplete; the CLI's `scoreFromFinalizeResponse` counted every `skipped` result as an abstention with no exemption. A run whose only unresolved criterion had already been true before the agent ran showed PASS on the dashboard and printed `INCOMPLETE` / exit 1 in CI.

## Fix

- `PRE_SATISFIED_REASON` / `isPreSatisfied` in `evalResultView.ts` define the shared reason string once instead of repeating it inline at each call site.
- `scoreFromFinalizeResponse` (`uploadAndFinalize.ts`) now excludes a `skipped` result stamped `already_true_in_seed` from the abstentions that block `can_pass`. Any other skip reason, and every `errored` result, still blocks it — only the one named exemption is narrowed.
- `runScoreLine` names a pre-satisfied criterion apart from genuine abstentions instead of folding it into "not evaluated". For the all-excluded run it says `nothing was at risk (N criteria already true in the seed)` rather than the self-contradicting `0 of N criteria not evaluated`, which is the dashboard's wording for the same shape.
- `pome fix-prompt` stops filing a seed-excluded criterion under "not uniformly evaluated (skipped or errored in some trials)" — that sent the reader's coding agent hunting for a grader gap that does not exist. It gets its own note, off the same `isPreSatisfied` predicate.
- The comment above `scoreStatus` restates the shared rule as it now holds on both sides, including where it does not.
- `groupRunSets`'s `anyFailed` needed no separate change: it reads `verdict.passed`, derived from the same `scoreStatus` call at write time, so a trial whose only non-passing criterion is pre-satisfied already writes `passed: true` and stops being misrouted to `pome fix-prompt` as an agent defect.
- Bumped `cli/package.json` to 0.23.1 (patch) with a changelog entry, per this repo's version-diff release model (no changesets).

## Agreement is checked, not assumed

`cli/test/unit/hosted/cross-surface-agreement.test.ts` walks the CLI's shipped predicate and a line-by-line transcription of `run-status.ts` over one table of wire fixtures — pass, fail, one abstention, all abstained, seed-excluded beside passes / beside an abstention / beside a failure, and all-excluded. Every row asserts both surfaces' words, and separately asserts they never split on the only bit a CI caller can act on: did this run pass.

One row diverges and is marked as such. A run whose criteria are ALL seed-excluded has no denominator: the CLI calls it `incomplete` (the older A5 guard, `total_required > 0`), and pome-cloud — verified by running `deriveRunStatus` against that payload — exempts every abstention, falls through to `satisfaction_score === 100`, gets 0 from the empty denominator, and renders **Failed** while its own `verdictLine` on the same page says "nothing was at risk". Neither surface passes it and both exit non-zero, so nothing acts on the difference. The word belongs to pome-cloud's `deriveRunStatus`, not to a CLI that would then have to blame the agent for a run in which nothing was ever at risk; filed as F-1399. A second test pins that this is the *only* divergence, so marking a new row is not a way to silence the file.

## Two review notes worth recording

- **The `errored` fixture that needed a cast.** `outcome` is `evalResultView`'s own additive discriminator (FDRS-591/611); it is on no `criterionResultSchema` in either repo, and `finalizeResponseSchema` is a tolerant reader that strips unknown keys. So `errored` has no wire producer, and a finalize fixture claiming one describes a state the system cannot reach. Replaced with a test that pins the stripping, plus the `judge_unavailable` shape a real abstention actually arrives in. The `errored` term stays in `can_pass` as a guard for a producer that does not exist yet, and now says so.
- **`incompleteVerdict.test.ts` re-derived `can_pass` locally**, so every assertion in it could stay green while the shipped predicate said something else — a second implementation of the exact predicate whose two implementations disagreeing is this ticket. It now builds its Score with `scoreFromFinalizeResponse`.

## Verification

- `cd cli && npm run typecheck` — clean
- `cd cli && npm test` — 108 files, 1052 passed
- `cd cli && npm run test:e2e` — 9 files, 21 passed, including a case that spawns the real CLI against a fake cloud and asserts PASS / exit 0 when the only skipped criterion is pre-satisfied
- Reverted the one-line predicate to its pre-fix form and re-ran: 5 unit tests across 3 files fail, and the e2e case fails. The tests catch the original bug rather than describing the new code.
- `npm run gate:no-eval`, `gate:no-native`, `gate:mcp-tools-list`, `lint:no-cloud-imports`, `lint:dead-code`, `lint:copy-markers`, `lint:code-health`, `lint:legacy-markers`, `lint:parent-vocab`, `lint:task-class`, `lint:skill-manifest`, `no-catch-and-continue` — all clean
- `node scripts/ci/check-version-bump-required.mjs <merge-base>` — OK (0.23.0 → 0.23.1, no conflict with `origin/main`)
