### PR TITLE
verdict.json names the run state and its denominator (F-1195)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,13 @@ live at **https://docs.pome.sh**.
   them. F-933 renamed the two artifact keys that had no such contract:
   `runs/latest.json` now writes `task` (was `scenario`) and
   `runs/<task>/<session>/verdict.json` writes `task_path` (was
-  `scenario_path`); the verdict READ path still accepts `scenario_path` so
-  `pome fix-prompt` can read trials recorded by `@pome-sh/cli` <= 0.8.x.
+  `scenario_path`). F-1195 retired the verdict READ path's `scenario_path`
+  tolerance: `verdict.json` is at artifact version 2, every file spelling it
+  the old way is version 1, and the version check refuses those before the
+  spelling could matter — so the normalize step was a dual-format reader that
+  could no longer fire. Such a file is still RECOGNIZED as one of ours and
+  `pome fix-prompt` names the skip (`staleVersionCount`) rather than dropping
+  it silently.
 - **The CLI (`cli/`) IS a root workspace member** — `workspaces: ["packages/*",
   "cli"]`, one `package-lock.json`, one `npm ci`. Use `npm run -w @pome-sh/cli
   ...` from the root. The former `cli/package-lock.json` and

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -19,11 +19,22 @@ packaging restructure: bump `version` here and in `package.json`, and merging to
   `not_evaluated` / `pre_satisfied` / `total` counts, computed by one shared
   helper (`evaluationCounts` in `evalResultView.ts`) so the artifact and the
   terminal's "N of M criteria not evaluated" line can't drift apart.
-  `VERDICT_ARTIFACT_VERSION` bumps 1 → 2 with the new fields required; a v1
-  file on disk is refused (no dual-format reader) but `pome fix-prompt`
-  discovery now names that skip explicitly instead of reporting it exactly
-  like an empty `runs/`. `cli/README.md`'s exit-code contract now points CI
-  at `state` instead of "read the verdict word printed beside the score".
+  `cli/README.md`'s exit-code contract now points CI at `state` instead of
+  "read the verdict word printed beside the score". `state` is the CLI's
+  word, and the two run shapes where the dashboard words the same run
+  differently are named in `VerdictArtifact`'s own doc comment (an
+  all-pre-satisfied run, filed as F-1399; and a task whose `pass_threshold`
+  is not 100) rather than left for a reader to find as a mismatch.
+- `verdict.json` is at artifact version 2, and a file at any other version is
+  a NAMED skip rather than a silent one (F-1195). The new fields are
+  required, so a version-1 file is refused outright — there is no
+  dual-format reader — but `pome fix-prompt` now reports every skipped file
+  and its version instead of reporting a `runs/` full of them exactly like an
+  empty one, including when readable trials sit beside them (that case used
+  to build a prompt from part of a run set and say nothing about the rest).
+  The read path's pre-F-933 `scenario_path` tolerance is gone with it: every
+  file spelling the path that way is version 1, so the version check refuses
+  it first and the normalize step could no longer fire.
 
 ## 0.23.1
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,27 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.23.2
+
+### Patch Changes
+
+- `verdict.json` now names the run's third state and carries the counts
+  `score` is computed over (F-1195). Before this, a hosted run whose criteria
+  couldn't all be graded wrote `score: 100, pass_threshold: 100, passed:
+  false` with no denominator and no field naming the third state anywhere in
+  the artifact — a CI script trusting `score >= pass_threshold` read `true`
+  on a run where a third of the criteria never ran. `verdict.json` now
+  carries `state` (`"pass"` / `"fail"` / `"incomplete"`, the same word
+  `scoreStatus` gives the terminal and the dashboard) plus `evaluated` /
+  `not_evaluated` / `pre_satisfied` / `total` counts, computed by one shared
+  helper (`evaluationCounts` in `evalResultView.ts`) so the artifact and the
+  terminal's "N of M criteria not evaluated" line can't drift apart.
+  `VERDICT_ARTIFACT_VERSION` bumps 1 → 2 with the new fields required; a v1
+  file on disk is refused (no dual-format reader) but `pome fix-prompt`
+  discovery now names that skip explicitly instead of reporting it exactly
+  like an empty `runs/`. `cli/README.md`'s exit-code contract now points CI
+  at `state` instead of "read the verdict word printed beside the score".
+
 ## 0.23.1
 
 ### Patch Changes

--- a/cli/README.md
+++ b/cli/README.md
@@ -85,9 +85,13 @@ Three rules CI must honor:
   with nothing in those two fields alone saying so. Read `state` in the
   `verdict.json` a hosted `pome run` writes to
   `<artifacts-dir>/<task-slug>/<session-id>/verdict.json`: `"pass"`, `"fail"`,
-  or `"incomplete"` — the same word the terminal prints beside the score. The
-  `evaluated` / `not_evaluated` / `pre_satisfied` / `total` counts alongside
-  `score` show what fraction of criteria that number is actually over.
+  or `"incomplete"` — the same word the terminal prints beside the score, and
+  the field to gate on. The `evaluated` / `not_evaluated` / `pre_satisfied` /
+  `total` counts alongside it say how much of the task `score` covers:
+  **`score` is a percentage over `evaluated` alone**, so `not_evaluated > 0`
+  means `score` is silent about part of the run, and `evaluated: 0` means it
+  scored nothing at all (the cloud sends `0` there for want of a denominator
+  — "nothing was scored", not "nothing was correct").
 - **Trial groups map as a whole.** `pome run -n k` (k>1) collapses the whole
   group to one code: `0` = at least one trial completed and every completed
   trial passed; `1` = at least one completed trial failed its threshold **or was

--- a/cli/README.md
+++ b/cli/README.md
@@ -79,8 +79,15 @@ Three rules CI must honor:
   whose criteria could not all be graded exits `1` rather than mapping its
   partial score to a code — a run whose checks never ran is not a green CI
   signal. The cost is stated rather than hidden: **`1` cannot tell "the agent
-  regressed" from "we could not grade it."** Read the verdict word printed
-  beside the score (`INCOMPLETE` vs a sub-threshold number) to separate them.
+  regressed" from "we could not grade it."** To separate them programmatically,
+  do not compare `score` against `pass_threshold` yourself — a run with a third
+  of its criteria unevaluated can still read `score: 100, pass_threshold: 100`
+  with nothing in those two fields alone saying so. Read `state` in the
+  `verdict.json` a hosted `pome run` writes to
+  `<artifacts-dir>/<task-slug>/<session-id>/verdict.json`: `"pass"`, `"fail"`,
+  or `"incomplete"` — the same word the terminal prints beside the score. The
+  `evaluated` / `not_evaluated` / `pre_satisfied` / `total` counts alongside
+  `score` show what fraction of criteria that number is actually over.
 - **Trial groups map as a whole.** `pome run -n k` (k>1) collapses the whole
   group to one code: `0` = at least one trial completed and every completed
   trial passed; `1` = at least one completed trial failed its threshold **or was

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -1208,20 +1208,24 @@ export function createProgram() {
       // no network and no local judging — the verdicts were the cloud's.
       const root = target ?? "runs";
       const discovery = await discoverRunSet(resolve(root));
-      if (discovery.totalSets === 0) {
-        // F-1195 — a v1 verdict.json is a RECOGNIZABLE prior artifact
-        // version, not a foreign file: name the skip instead of reporting
-        // the same "no runs" a truly empty runs/ would get.
-        if (discovery.staleVersionCount > 0) {
-          console.error(
-            `${discovery.staleVersionCount} verdict.json file(s) under ${root} were written by an older CLI (artifact version < ${VERDICT_ARTIFACT_VERSION}) and can't be read by this version — re-run \`pome run\` to produce trials fix-prompt can use.`,
-          );
-          process.exitCode = 5;
-          return;
-        }
+      // F-1195 — a verdict.json this CLI can't read is a RECOGNIZABLE prior
+      // artifact version, not a foreign file, and the skip is named EVERY
+      // time it happens — not only when nothing else was found. A runs/ that
+      // holds one readable trial beside two stale ones would otherwise build
+      // a prompt from a third of the run set and say nothing about the rest,
+      // which is the same silent drop as reporting "no runs" for a dir full
+      // of them.
+      if (discovery.staleVersionCount > 0) {
         console.error(
-          `No finalized run sets under ${root} — hosted \`pome run\` records a verdict.json per trial; run one first (or point fix-prompt at your artifacts dir).`,
+          `${discovery.staleVersionCount} verdict.json file(s) under ${root} are not artifact version ${VERDICT_ARTIFACT_VERSION} (the only version this CLI reads) and were skipped — re-run \`pome run\` to record those trials again.`,
         );
+      }
+      if (discovery.totalSets === 0) {
+        if (discovery.staleVersionCount === 0) {
+          console.error(
+            `No finalized run sets under ${root} — hosted \`pome run\` records a verdict.json per trial; run one first (or point fix-prompt at your artifacts dir).`,
+          );
+        }
         process.exitCode = 5;
         return;
       }

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -73,6 +73,7 @@ import {
 import {
   discoverRunSet,
   loadTrialEvents,
+  VERDICT_ARTIFACT_VERSION,
 } from "../hosted/evalResultCache.js";
 import type { Task } from "../task/taskSchema.js";
 import { parseTaskFile } from "../task/parseTask.js";
@@ -1208,6 +1209,16 @@ export function createProgram() {
       const root = target ?? "runs";
       const discovery = await discoverRunSet(resolve(root));
       if (discovery.totalSets === 0) {
+        // F-1195 — a v1 verdict.json is a RECOGNIZABLE prior artifact
+        // version, not a foreign file: name the skip instead of reporting
+        // the same "no runs" a truly empty runs/ would get.
+        if (discovery.staleVersionCount > 0) {
+          console.error(
+            `${discovery.staleVersionCount} verdict.json file(s) under ${root} were written by an older CLI (artifact version < ${VERDICT_ARTIFACT_VERSION}) and can't be read by this version — re-run \`pome run\` to produce trials fix-prompt can use.`,
+          );
+          process.exitCode = 5;
+          return;
+        }
         console.error(
           `No finalized run sets under ${root} — hosted \`pome run\` records a verdict.json per trial; run one first (or point fix-prompt at your artifacts dir).`,
         );

--- a/cli/src/hosted/evalResultCache.ts
+++ b/cli/src/hosted/evalResultCache.ts
@@ -62,14 +62,35 @@ export interface VerdictArtifact {
   cloud_run_id: string;
   cloud_dashboard_url: string;
   judge_model: string | null;
-  /** Cloud-authoritative satisfaction score, 0-100. */
+  /** Cloud-authoritative satisfaction score, 0-100 — the percentage over
+   *  `evaluated` ALONE, never over `total`. F-1195 shipped `evaluated`
+   *  beside it for that reason: `score` on its own does not say how much of
+   *  the task it covers, and `score >= pass_threshold` is not the gate on a
+   *  run where `not_evaluated > 0` (`state` and `passed` are). When
+   *  `evaluated` is 0 the cloud sends 0 for want of a denominator — that is
+   *  "nothing was scored", not "nothing was correct". */
   score: number;
   pass_threshold: number;
   /** F-1195 — the run's three-state verdict, BY NAME, taken from
    *  `RunTaskHostedResult.verdict` (itself `scoreStatus(score,
-   *  passThreshold)`) rather than re-derived here — the same word the
-   *  terminal prints and the dashboard renders. `passed` alone told a reader
-   *  "not a pass" with no reason; `state` says which of the two reasons. */
+   *  passThreshold)`) rather than re-derived here. `passed` alone told a
+   *  reader "not a pass" with no reason; `state` says which of the two
+   *  reasons.
+   *
+   *  It is the word the TERMINAL prints, always — one local, one derivation.
+   *  It is the word the DASHBOARD renders (`deriveRunStatus`, pome-cloud
+   *  `apps/dashboard/src/lib/run-status.ts`) on the same three words and on
+   *  every shape `cross-surface-agreement.test.ts` walks EXCEPT two, named
+   *  here rather than left for a reader to discover from a mismatch:
+   *    - a run whose criteria were ALL pre-satisfied: `incomplete` here (no
+   *      denominator, so no verified pass — the A5 guard), `fail` on the
+   *      dashboard, which exempts every abstention and then reads a
+   *      satisfaction of 0 off an empty denominator. Neither passes it and
+   *      both exit non-zero; filed as F-1399 against pome-cloud.
+   *    - a task whose `pass_threshold` is not 100: the dashboard's pass bar
+   *      is a hard `satisfaction_score === 100` and it has no field to learn
+   *      the task's threshold from. `pass_threshold` is in this artifact
+   *      beside `state` precisely so a reader can see which bar was used. */
   state: ScoreStatus;
   passed: boolean;
   /** F-1195 — `EvaluationCounts` from `evalResultView.ts`, so `score` is
@@ -99,19 +120,6 @@ export async function writeVerdictArtifact(
   );
 }
 
-/** F-933 — the on-disk shape, which may predate the `scenario_path` →
- *  `task_path` rename. `@pome-sh/cli` <= 0.8.x wrote `scenario_path`; unlike
- *  latest.json (rewritten by every run), verdict.json files accumulate under
- *  runs/ and outlive a CLI upgrade, so the READ path accepts either spelling
- *  and normalizes to `task_path` before anything downstream sees it. The
- *  WRITE path emits `task_path` only. Drop the legacy branch once pre-0.9 run
- *  dirs are no longer worth reading. */
-type OnDiskVerdictArtifact = Omit<VerdictArtifact, "task_path"> & {
-  task_path?: string;
-  /** Retired pre-F-933 spelling of `task_path`. */
-  scenario_path?: string;
-};
-
 /** Read one trial's verdict.json. Returns null when absent or when the file
  *  isn't a recognizable verdict artifact (foreign/corrupt files are skipped,
  *  never thrown on — fix-prompt discovery must survive a messy runs/). */
@@ -119,10 +127,13 @@ type OnDiskVerdictArtifact = Omit<VerdictArtifact, "task_path"> & {
  *  shape, or the FILE is rejected — discovery treats a half-recognizable
  *  verdict.json as foreign rather than crashing downstream on it.
  *
- *  F-1195 — this is the shape shared by EVERY artifact version (v1 included):
- *  used on its own it answers "is this a verdict.json at all?", which is what
- *  tells a v1 file apart from a foreign/corrupt one so the stale-version skip
- *  below can be named rather than folded into "not a verdict file". */
+ *  F-1195 — this is RECOGNITION, not reading: the shape shared by every
+ *  artifact version this repo has ever written, so a prior-version file can
+ *  be told apart from a foreign/corrupt one and its skip NAMED rather than
+ *  folded into "not a verdict file". Deliberately more generous than
+ *  `isVerdictArtifact` below — including the pre-F-933 `scenario_path`
+ *  spelling, which no reader accepts any more (see `isVerdictArtifact`) but
+ *  which still identifies the file as one of ours worth naming. */
 function looksLikeVerdictArtifactBase(parsed: unknown): parsed is Record<string, unknown> {
   if (typeof parsed !== "object" || parsed === null) return false;
   const v = parsed as Record<string, unknown>;
@@ -152,13 +163,21 @@ function looksLikeVerdictArtifactBase(parsed: unknown): parsed is Record<string,
 
 /** F-1195 — the CURRENT version's shape: the base fields plus `version ===
  *  VERDICT_ARTIFACT_VERSION`, the named `state`, and the four counts. A file
- *  that passes `looksLikeVerdictArtifactBase` but fails this is a PRIOR
- *  version, not a foreign file — callers that need to tell the two apart use
- *  `readVerdictArtifactDetailed` instead of this function directly. */
-function isVerdictArtifact(parsed: unknown): parsed is OnDiskVerdictArtifact {
+ *  that passes `looksLikeVerdictArtifactBase` but fails this is a prior
+ *  version or a corrupt current one — `readVerdictArtifactDetailed` tells
+ *  those two apart.
+ *
+ *  F-1195 also retired the pre-F-933 `scenario_path` tolerance the read path
+ *  used to carry: `task_path` is required here. Every file spelling it the
+ *  old way was written by `@pome-sh/cli` <= 0.8.x at artifact version 1, so
+ *  the version check refuses it before the spelling could matter — the
+ *  normalize step was a dual-format reader that could no longer fire, and
+ *  this repo keeps no back-compat it cannot exercise. */
+function isVerdictArtifact(parsed: unknown): parsed is VerdictArtifact {
   if (!looksLikeVerdictArtifactBase(parsed)) return false;
   const v = parsed;
   if (v.version !== VERDICT_ARTIFACT_VERSION) return false;
+  if (typeof v.task_path !== "string") return false;
   if (typeof v.state !== "string" || !VALID_STATES.has(v.state)) return false;
   if (typeof v.evaluated !== "number") return false;
   if (typeof v.not_evaluated !== "number") return false;
@@ -167,21 +186,19 @@ function isVerdictArtifact(parsed: unknown): parsed is OnDiskVerdictArtifact {
   return true;
 }
 
-/** F-933 — collapse the legacy `scenario_path` onto `task_path` so callers
- *  only ever deal with one spelling. Validation ran first, so at least one of
- *  the two is a string. */
-function normalizeVerdictArtifact(parsed: OnDiskVerdictArtifact): VerdictArtifact {
-  const { scenario_path: legacyPath, task_path: taskPath, ...rest } = parsed;
-  return { ...rest, task_path: taskPath ?? legacyPath! };
-}
-
 /** F-1195 — the detailed read: distinguishes "current-version artifact",
- *  "recognizable but a PRIOR version" (a real trial fix-prompt can no longer
- *  read), and "not a verdict file at all" (foreign/corrupt/missing). Callers
- *  that only care about usable trials (`readVerdictArtifact`,
- *  `scanVerdictArtifacts`) collapse the last two together, same as before
- *  F-1195; discovery callers that need to NAME a stale-version skip instead
- *  of silently reporting "no runs" use this directly. */
+ *  "recognizable, but written at a DIFFERENT artifact version" (a real trial
+ *  this CLI can no longer read), and "not a verdict file at all"
+ *  (foreign/corrupt/missing). Callers that only care about usable trials
+ *  (`readVerdictArtifact`, `scanVerdictArtifacts`) collapse the last two
+ *  together, same as before F-1195; discovery callers that need to NAME a
+ *  version skip instead of silently reporting "no runs" use this directly.
+ *
+ *  `stale-version` is keyed on the version NUMBER differing, never on the
+ *  new fields being absent, so the status never claims more than it checked:
+ *  a file that says `version: 2` and is malformed is a corrupt CURRENT file
+ *  (`unreadable`), not a prior version. `version` is null when the file
+ *  carries no numeric `version` at all. */
 export type VerdictReadResult =
   | { status: "ok"; trial: TrialVerdict }
   | { status: "stale-version"; version: number | null }
@@ -204,14 +221,10 @@ export async function readVerdictArtifactDetailed(
     return { status: "unreadable" };
   }
   if (!looksLikeVerdictArtifactBase(parsed)) return { status: "unreadable" };
-  if (!isVerdictArtifact(parsed)) {
-    const v = parsed;
-    return {
-      status: "stale-version",
-      version: typeof v.version === "number" ? v.version : null,
-    };
-  }
-  return { status: "ok", trial: { runDir, verdict: normalizeVerdictArtifact(parsed) } };
+  const version = typeof parsed.version === "number" ? parsed.version : null;
+  if (version !== VERDICT_ARTIFACT_VERSION) return { status: "stale-version", version };
+  if (!isVerdictArtifact(parsed)) return { status: "unreadable" };
+  return { status: "ok", trial: { runDir, verdict: parsed } };
 }
 
 export async function readVerdictArtifact(
@@ -297,7 +310,16 @@ export interface RunSet {
  *  reporting it as a criterion nobody evaluated, `fix-prompt/prompt.ts`.)
  *  Nothing to change here — the fix lives upstream, and
  *  `evalResultCache.test.ts` pins the group-level behavior directly against
- *  the written artifact. */
+ *  the written artifact.
+ *
+ *  F-1195 note: `state` is now on the artifact, so `anyFailed` COULD read
+ *  `state === "fail"` and stop routing a merely INCOMPLETE trial to
+ *  `pome fix-prompt` as an agent defect. Deliberately not done here — it is
+ *  not a one-liner: with no failed set, `main.ts` falls to its `!discovery.set`
+ *  branch and prints "the latest run sets under runs all passed", which is
+ *  false about an incomplete run and is the same defect pointed the other way.
+ *  That needs a third message, so it is F-1404, not a drive-by in a ticket
+ *  about what the artifact SAYS. */
 export function groupRunSets(trials: TrialVerdict[]): RunSet[] {
   const byKey = new Map<string, TrialVerdict[]>();
   for (const trial of trials) {

--- a/cli/src/hosted/evalResultCache.ts
+++ b/cli/src/hosted/evalResultCache.ts
@@ -25,10 +25,28 @@ import { existsSync } from "node:fs";
 import { readdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { CriterionResult } from "../types/shared.js";
+import type { ScoreStatus } from "./evalResultView.js";
 
-export const VERDICT_ARTIFACT_VERSION = 1;
+// F-1195 — bumped 1 → 2: the artifact gained `state` (the run's three-state
+// verdict, by name) and the `evaluated`/`not_evaluated`/`pre_satisfied`/
+// `total` counts `score` is computed over. Before this, a CI script reading
+// `score >= pass_threshold` on an incomplete run read `true`, because
+// `verdict.json` carried no denominator and no name for the third state —
+// `passed: false` was the only signal, and it carries no reason. A v1 file
+// on disk is a RECOGNIZABLE prior version, not garbage: `readVerdictArtifact`
+// refuses it (the new fields are required, not optional-with-a-default — zero
+// customers, no dual-format reader) but `scanVerdictArtifactsDetailed` /
+// `discoverRunSet` name the skip instead of making it indistinguishable from
+// "no run happened here" (see `looksLikeVerdictArtifactBase` below).
+export const VERDICT_ARTIFACT_VERSION = 2;
 
 export const VERDICT_FILENAME = "verdict.json";
+
+const VALID_STATES: ReadonlySet<string> = new Set<ScoreStatus>([
+  "pass",
+  "fail",
+  "incomplete",
+]);
 
 export interface VerdictArtifact {
   version: number;
@@ -47,7 +65,19 @@ export interface VerdictArtifact {
   /** Cloud-authoritative satisfaction score, 0-100. */
   score: number;
   pass_threshold: number;
+  /** F-1195 — the run's three-state verdict, BY NAME, taken from
+   *  `RunTaskHostedResult.verdict` (itself `scoreStatus(score,
+   *  passThreshold)`) rather than re-derived here — the same word the
+   *  terminal prints and the dashboard renders. `passed` alone told a reader
+   *  "not a pass" with no reason; `state` says which of the two reasons. */
+  state: ScoreStatus;
   passed: boolean;
+  /** F-1195 — `EvaluationCounts` from `evalResultView.ts`, so `score` is
+   *  legible as "N of what" instead of a bare number beside a threshold. */
+  evaluated: number;
+  not_evaluated: number;
+  pre_satisfied: number;
+  total: number;
   criteria_results: CriterionResult[];
   duration_ms: number;
   finalized_at: string;
@@ -87,8 +117,13 @@ type OnDiskVerdictArtifact = Omit<VerdictArtifact, "task_path"> & {
  *  never thrown on — fix-prompt discovery must survive a messy runs/). */
 /** Every field the fix-prompt pipeline dereferences must hold its declared
  *  shape, or the FILE is rejected — discovery treats a half-recognizable
- *  verdict.json as foreign rather than crashing downstream on it. */
-function isVerdictArtifact(parsed: unknown): parsed is OnDiskVerdictArtifact {
+ *  verdict.json as foreign rather than crashing downstream on it.
+ *
+ *  F-1195 — this is the shape shared by EVERY artifact version (v1 included):
+ *  used on its own it answers "is this a verdict.json at all?", which is what
+ *  tells a v1 file apart from a foreign/corrupt one so the stale-version skip
+ *  below can be named rather than folded into "not a verdict file". */
+function looksLikeVerdictArtifactBase(parsed: unknown): parsed is Record<string, unknown> {
   if (typeof parsed !== "object" || parsed === null) return false;
   const v = parsed as Record<string, unknown>;
   if (v.source !== "cloud-finalize") return false;
@@ -115,6 +150,23 @@ function isVerdictArtifact(parsed: unknown): parsed is OnDiskVerdictArtifact {
   });
 }
 
+/** F-1195 — the CURRENT version's shape: the base fields plus `version ===
+ *  VERDICT_ARTIFACT_VERSION`, the named `state`, and the four counts. A file
+ *  that passes `looksLikeVerdictArtifactBase` but fails this is a PRIOR
+ *  version, not a foreign file — callers that need to tell the two apart use
+ *  `readVerdictArtifactDetailed` instead of this function directly. */
+function isVerdictArtifact(parsed: unknown): parsed is OnDiskVerdictArtifact {
+  if (!looksLikeVerdictArtifactBase(parsed)) return false;
+  const v = parsed;
+  if (v.version !== VERDICT_ARTIFACT_VERSION) return false;
+  if (typeof v.state !== "string" || !VALID_STATES.has(v.state)) return false;
+  if (typeof v.evaluated !== "number") return false;
+  if (typeof v.not_evaluated !== "number") return false;
+  if (typeof v.pre_satisfied !== "number") return false;
+  if (typeof v.total !== "number") return false;
+  return true;
+}
+
 /** F-933 — collapse the legacy `scenario_path` onto `task_path` so callers
  *  only ever deal with one spelling. Validation ran first, so at least one of
  *  the two is a string. */
@@ -123,37 +175,71 @@ function normalizeVerdictArtifact(parsed: OnDiskVerdictArtifact): VerdictArtifac
   return { ...rest, task_path: taskPath ?? legacyPath! };
 }
 
-export async function readVerdictArtifact(
+/** F-1195 — the detailed read: distinguishes "current-version artifact",
+ *  "recognizable but a PRIOR version" (a real trial fix-prompt can no longer
+ *  read), and "not a verdict file at all" (foreign/corrupt/missing). Callers
+ *  that only care about usable trials (`readVerdictArtifact`,
+ *  `scanVerdictArtifacts`) collapse the last two together, same as before
+ *  F-1195; discovery callers that need to NAME a stale-version skip instead
+ *  of silently reporting "no runs" use this directly. */
+export type VerdictReadResult =
+  | { status: "ok"; trial: TrialVerdict }
+  | { status: "stale-version"; version: number | null }
+  | { status: "unreadable" };
+
+export async function readVerdictArtifactDetailed(
   runDir: string,
-): Promise<TrialVerdict | null> {
+): Promise<VerdictReadResult> {
   const path = join(runDir, VERDICT_FILENAME);
   let raw: string;
   try {
     raw = await readFile(path, "utf8");
   } catch {
-    return null;
+    return { status: "unreadable" };
   }
+  let parsed: unknown;
   try {
-    const parsed: unknown = JSON.parse(raw);
-    if (!isVerdictArtifact(parsed)) return null;
-    return { runDir, verdict: normalizeVerdictArtifact(parsed) };
+    parsed = JSON.parse(raw);
   } catch {
-    return null;
+    return { status: "unreadable" };
   }
+  if (!looksLikeVerdictArtifactBase(parsed)) return { status: "unreadable" };
+  if (!isVerdictArtifact(parsed)) {
+    const v = parsed;
+    return {
+      status: "stale-version",
+      version: typeof v.version === "number" ? v.version : null,
+    };
+  }
+  return { status: "ok", trial: { runDir, verdict: normalizeVerdictArtifact(parsed) } };
 }
 
-/** Scan an artifacts root for finalized trials — exactly the two-level
- *  layout `<root>/<task-slug>/<session-id>/verdict.json`. Anything
- *  unreadable is skipped. */
-export async function scanVerdictArtifacts(
+export async function readVerdictArtifact(
+  runDir: string,
+): Promise<TrialVerdict | null> {
+  const result = await readVerdictArtifactDetailed(runDir);
+  return result.status === "ok" ? result.trial : null;
+}
+
+/** F-1195 — the detailed scan behind `scanVerdictArtifacts`: also collects
+ *  the dirs whose verdict.json was recognizable but a prior artifact version,
+ *  so `discoverRunSet` can name that skip instead of it looking identical to
+ *  "no run happened here". */
+export interface VerdictScanResult {
+  trials: TrialVerdict[];
+  staleVersionDirs: string[];
+}
+
+export async function scanVerdictArtifactsDetailed(
   artifactsRoot: string,
-): Promise<TrialVerdict[]> {
-  const found: TrialVerdict[] = [];
+): Promise<VerdictScanResult> {
+  const trials: TrialVerdict[] = [];
+  const staleVersionDirs: string[] = [];
   let slugs: string[];
   try {
     slugs = await readdir(artifactsRoot);
   } catch {
-    return found;
+    return { trials, staleVersionDirs };
   }
   for (const slug of slugs) {
     const slugDir = join(artifactsRoot, slug);
@@ -164,11 +250,23 @@ export async function scanVerdictArtifacts(
       continue;
     }
     for (const runId of runIds) {
-      const trial = await readVerdictArtifact(join(slugDir, runId));
-      if (trial) found.push(trial);
+      const runDir = join(slugDir, runId);
+      const result = await readVerdictArtifactDetailed(runDir);
+      if (result.status === "ok") trials.push(result.trial);
+      else if (result.status === "stale-version") staleVersionDirs.push(runDir);
     }
   }
-  return found;
+  return { trials, staleVersionDirs };
+}
+
+/** Scan an artifacts root for finalized trials — exactly the two-level
+ *  layout `<root>/<task-slug>/<session-id>/verdict.json`. Anything
+ *  unreadable (including a prior artifact version — see
+ *  `scanVerdictArtifactsDetailed`) is skipped. */
+export async function scanVerdictArtifacts(
+  artifactsRoot: string,
+): Promise<TrialVerdict[]> {
+  return (await scanVerdictArtifactsDetailed(artifactsRoot)).trials;
 }
 
 export interface RunSet {
@@ -244,6 +342,12 @@ export interface RunSetDiscovery {
   /** Total finalized run sets seen — lets the caller distinguish "no runs
    *  at all" from "runs exist but none failed". */
   totalSets: number;
+  /** F-1195 — verdict.json files recognized as a PRIOR artifact version under
+   *  the scanned root (or, for `kind: "trial-dir"`, at the target itself).
+   *  Named so a stale-version skip never renders identically to "no runs
+   *  happened here" — a v1 file dropped silently is the exact shape this
+   *  milestone exists to remove. */
+  staleVersionCount: number;
 }
 
 /**
@@ -253,12 +357,21 @@ export interface RunSetDiscovery {
  * - `target` = an artifacts root: the latest failed set under it.
  */
 export async function discoverRunSet(target: string): Promise<RunSetDiscovery> {
-  const anchor = await readVerdictArtifact(target);
-  if (anchor) {
+  const anchorResult = await readVerdictArtifactDetailed(target);
+  if (anchorResult.status === "stale-version") {
+    // The user pointed fix-prompt directly at a trial dir whose verdict.json
+    // is a prior version — name it rather than falling through to the "root"
+    // branch below, which would scan `target` as if it were an artifacts
+    // root (two levels too shallow) and report a plain "no runs".
+    return { kind: "trial-dir", set: null, totalSets: 0, staleVersionCount: 1 };
+  }
+  if (anchorResult.status === "ok") {
+    const anchor = anchorResult.trial;
     // Trial dir → its set. Layout is <root>/<slug>/<runId>, so the root is
     // two levels up; a moved/isolated dir degrades to a set of one.
     const root = join(target, "..", "..");
-    const sets = groupRunSets(await scanVerdictArtifacts(root));
+    const { trials, staleVersionDirs } = await scanVerdictArtifactsDetailed(root);
+    const sets = groupRunSets(trials);
     const own =
       sets.find(
         (s) =>
@@ -268,15 +381,24 @@ export async function discoverRunSet(target: string): Promise<RunSetDiscovery> {
             s.trials.length === 1 &&
             s.trials[0]!.verdict.session_id === anchor.verdict.session_id),
       ) ?? groupRunSets([anchor])[0]!;
-    return { kind: "trial-dir", set: own, totalSets: Math.max(sets.length, 1) };
+    return {
+      kind: "trial-dir",
+      set: own,
+      totalSets: Math.max(sets.length, 1),
+      staleVersionCount: staleVersionDirs.length,
+    };
   }
 
-  if (!existsSync(target)) return { kind: "root", set: null, totalSets: 0 };
-  const sets = groupRunSets(await scanVerdictArtifacts(target));
+  if (!existsSync(target)) {
+    return { kind: "root", set: null, totalSets: 0, staleVersionCount: 0 };
+  }
+  const { trials, staleVersionDirs } = await scanVerdictArtifactsDetailed(target);
+  const sets = groupRunSets(trials);
   return {
     kind: "root",
     set: latestFailedRunSet(sets),
     totalSets: sets.length,
+    staleVersionCount: staleVersionDirs.length,
   };
 }
 

--- a/cli/src/hosted/evalResultView.ts
+++ b/cli/src/hosted/evalResultView.ts
@@ -220,6 +220,39 @@ function criteriaWord(n: number): string {
   return n === 1 ? "criterion" : "criteria";
 }
 
+// F-1195 — the completeness arithmetic, factored out of `runScoreLine` so
+// `verdict.json` (runTaskHosted.ts) can carry the SAME counts the terminal
+// line already prints instead of a second, hand-rolled computation. Before
+// this existed, `verdict.json` wrote `score: 100, pass_threshold: 100,
+// passed: false` with no denominator anywhere in the file — a CI script that
+// trusted `score >= pass_threshold` read `true` on a run where a third of the
+// criteria never ran, because nothing in the artifact said so.
+export interface EvaluationCounts {
+  /** passed + failed — the satisfaction denominator (`score.total_required`). */
+  evaluated: number;
+  /** skipped + errored − preSatisfied — abstentions that actually block
+   *  `can_pass`. Zero on a fully-evaluated OR fully-pre-satisfied run. */
+  notEvaluated: number;
+  /** Excluded from the denominator because the seed already satisfied them
+   *  (`PRE_SATISFIED_REASON`) — not an abstention, so not counted in
+   *  `notEvaluated`. */
+  preSatisfied: number;
+  /** evaluated + notEvaluated + preSatisfied — every criterion the run
+   *  considered, so `score` (over `evaluated`) is legible as "N of total". */
+  total: number;
+}
+
+export function evaluationCounts(score: Score): EvaluationCounts {
+  const evaluated = score.total_required;
+  const notEvaluated = score.skipped + score.errored - score.preSatisfied;
+  return {
+    evaluated,
+    notEvaluated,
+    preSatisfied: score.preSatisfied,
+    total: evaluated + notEvaluated + score.preSatisfied,
+  };
+}
+
 export function scoreCountsSummary(score: Score): string {
   return `${score.passed ?? 0} passed, ${score.failed ?? 0} failed, ${score.skipped ?? 0} skipped, ${score.errored ?? 0} errored`;
 }
@@ -240,9 +273,7 @@ export function runScoreLine(
     // instead of folded into "not evaluated", the way the dashboard's
     // `verdictLine` does (run-status.ts:173-199): a pre-satisfied criterion
     // reached a verdict (the grader wasn't gapped), it just tested nothing.
-    const allExcluded = score.skipped + score.errored;
-    const unreached = allExcluded - score.preSatisfied;
-    const total = score.total_required + allExcluded;
+    const { notEvaluated: unreached, total } = evaluationCounts(score);
     // The all-excluded run: nothing passed, nothing failed, and every
     // criterion that left the denominator left it because the seed already
     // satisfied it. `unreached` is 0, so the sentence below would read "0 of 2

--- a/cli/src/runner/runTaskHosted.ts
+++ b/cli/src/runner/runTaskHosted.ts
@@ -32,6 +32,7 @@ import type { CriterionDefWire } from "../hosted/client.js";
 import type { RecorderEvent as LegacyGithubRecorderEvent } from "@pome-sh/wire";
 import type { Task } from "../task/taskSchema.js";
 import {
+  evaluationCounts,
   scoreStatus,
   type Score,
   type ScoreStatus,
@@ -674,6 +675,13 @@ export async function runTaskHosted(
     //     effort: a disk failure degrades to "fix-prompt won't see this
     //     trial", never fails a finalized run.
     try {
+      // F-1195 — `counts` is the SAME arithmetic `runScoreLine` prints beside
+      // the terminal's verdict word, so the artifact's "N of total" can never
+      // drift from what the terminal already said. `state` is the `verdict`
+      // local computed above (`scoreStatus`), not a second derivation — the
+      // one place F-1392 shipped a bug was two call sites disagreeing on this
+      // exact word.
+      const counts = evaluationCounts(score);
       await writeVerdictArtifact(artifacts.runDir, {
         version: VERDICT_ARTIFACT_VERSION,
         source: "cloud-finalize",
@@ -686,7 +694,12 @@ export async function runTaskHosted(
         judge_model: score.judge_model,
         score: finalized.score,
         pass_threshold: scenario.config.passThreshold,
+        state: verdict,
         passed: exitCode === 0,
+        evaluated: counts.evaluated,
+        not_evaluated: counts.notEvaluated,
+        pre_satisfied: counts.preSatisfied,
+        total: counts.total,
         criteria_results: score.results,
         duration_ms: durationMs,
         finalized_at: new Date().toISOString(),

--- a/cli/test/e2e/runTaskHosted.test.ts
+++ b/cli/test/e2e/runTaskHosted.test.ts
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url";
 import { serve, type ServerType } from "@hono/node-server";
 import { Hono } from "hono";
 import { sign as signJwt } from "hono/jwt";
+import { readVerdictArtifact } from "../../src/hosted/evalResultCache.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLI_ENTRY = resolve(__dirname, "../../src/cli/main.ts");
@@ -282,6 +283,25 @@ describe("pome run --hosted (e2e via spawn)", () => {
     expect(stderr).toContain("1 of 1 criteria not evaluated");
     expect(stderr).not.toContain("cannot pass");
     expect(stderr).toContain("cloud score: 100/100");
+
+    // F-1195 — the bug this test guards: `verdict.json` used to write
+    // `score: 100, pass_threshold: 100, passed: false` with no denominator
+    // and no name for the third state, so a CI script trusting
+    // `score >= pass_threshold` read `true` on this exact run. Assert the
+    // artifact directly: `state` must name it `incomplete` (never `pass`,
+    // even though score >= pass_threshold), and the counts must show the one
+    // criterion was never evaluated.
+    const v = await readVerdictArtifact(join(tmp, "runs", "scn", "ses_e2e"));
+    expect(v).not.toBeNull();
+    expect(v?.verdict.score).toBe(100);
+    expect(v?.verdict.pass_threshold).toBe(100);
+    expect(v?.verdict.state).toBe("incomplete");
+    expect(v?.verdict.state).not.toBe("pass");
+    expect(v?.verdict.passed).toBe(false);
+    expect(v?.verdict.evaluated).toBe(0);
+    expect(v?.verdict.not_evaluated).toBe(1);
+    expect(v?.verdict.pre_satisfied).toBe(0);
+    expect(v?.verdict.total).toBe(1);
   }, 90_000);
 
   // F-1392 — the sibling of the INCOMPLETE test above. pome-cloud's F-1296
@@ -364,6 +384,21 @@ describe("pome run --hosted (e2e via spawn)", () => {
     expect(stderr).toMatch(/PASS/);
     expect(stderr).not.toMatch(/INCOMPLETE/);
     expect(stderr).not.toContain("score: incomplete —");
+
+    // F-1195 — this is the row the dashboard and the CLI have to agree on
+    // (`cross-surface-agreement.test.ts`'s "seed-excluded criterion beside
+    // three passes"). `verdict.json` must record the same `pass` the
+    // terminal just printed, and the counts must show the pre-satisfied
+    // criterion excluded from the denominator without being folded into
+    // `not_evaluated` (it reached a verdict — the seed already satisfied it).
+    const v = await readVerdictArtifact(join(tmp, "runs", "scn", "ses_e2e"));
+    expect(v).not.toBeNull();
+    expect(v?.verdict.state).toBe("pass");
+    expect(v?.verdict.passed).toBe(true);
+    expect(v?.verdict.evaluated).toBe(1);
+    expect(v?.verdict.not_evaluated).toBe(0);
+    expect(v?.verdict.pre_satisfied).toBe(1);
+    expect(v?.verdict.total).toBe(2);
   }, 90_000);
 
   // F-768 (M1 "Turn-usage into the main ledger") — the whole point of the

--- a/cli/test/integration/run-group-e2e.test.ts
+++ b/cli/test/integration/run-group-e2e.test.ts
@@ -271,9 +271,26 @@ describe("pome run -n k end-to-end against a stub cloud (FDRS-636)", () => {
       session_id: "ses_1",
       passed: true,
       score: 100,
+      // F-1195 — a full pass: the one criterion evaluated, nothing left out.
+      state: "pass",
+      evaluated: 1,
+      not_evaluated: 0,
+      pre_satisfied: 0,
+      total: 1,
     });
     expect(v3?.verdict.passed).toBe(false);
     expect(v3?.verdict.criteria_results[0]?.reason).toBe("under-rated");
+    // F-1195 — a genuine fail (the criterion ran and was judged unsatisfied,
+    // not skipped): `state` names it `fail`, distinct from `incomplete`, and
+    // the denominator shows the criterion WAS evaluated.
+    expect(v3?.verdict).toMatchObject({
+      state: "fail",
+      score: 58,
+      evaluated: 1,
+      not_evaluated: 0,
+      pre_satisfied: 0,
+      total: 1,
+    });
     expect(await readVerdictArtifact(join(tmp, "runs", "scn", "ses_2"))).toBeNull();
 
     // FDRS-644 — the fix & green handoff renders (a completed trial failed):

--- a/cli/test/unit/fix-prompt-command.test.ts
+++ b/cli/test/unit/fix-prompt-command.test.ts
@@ -178,6 +178,70 @@ describe("pome fix-prompt command (FDRS-644)", () => {
     expect(stderr.join("\n")).toContain("No finalized run sets");
   });
 
+  // F-1195 — a verdict.json this CLI can't read must never render as an
+  // absence. Both halves are pinned: the root that holds ONLY stale files
+  // must not read like an empty `runs/`, and the root that holds stale files
+  // BESIDE readable ones must say so even though it has a prompt to print.
+  describe("a verdict.json at another artifact version is a named skip (F-1195)", () => {
+    async function writeStaleTrial(root: string, sid: string): Promise<void> {
+      const runDir = join(root, "runs", "scn", sid);
+      await mkdir(runDir, { recursive: true });
+      const {
+        state: _s,
+        evaluated: _e,
+        not_evaluated: _n,
+        pre_satisfied: _p,
+        total: _t,
+        ...v1
+      } = verdict({ session_id: sid });
+      await writeFile(
+        join(runDir, "verdict.json"),
+        JSON.stringify({ ...v1, version: 1 }),
+        "utf8",
+      );
+      await writeFile(join(runDir, "events.jsonl"), EVENT, "utf8");
+    }
+
+    it("a root holding only stale trials names the version, not 'no runs'", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "fixcmd-stale-only-"));
+      await writeStaleTrial(dir, "ses_v1");
+      process.chdir(dir);
+
+      await run();
+      expect(process.exitCode).toBe(5);
+      const err = stderr.join("\n");
+      expect(err).toContain("1 verdict.json file(s)");
+      expect(err).toContain(`artifact version ${VERDICT_ARTIFACT_VERSION}`);
+      // The distinct-state requirement: this must NOT be the message a truly
+      // empty runs/ gets.
+      expect(err).not.toContain("No finalized run sets");
+    });
+
+    it("a root holding stale trials beside readable ones still names the skip AND prints the prompt", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "fixcmd-stale-mixed-"));
+      await writeStaleTrial(dir, "ses_v1");
+      await writeTrial(dir, "ses_2", {
+        passed: false,
+        state: "fail",
+        score: 50,
+        criteria_results: [
+          {
+            criterion: { type: "model", text: "Severity is set correctly" },
+            passed: false,
+            skipped: false,
+            reason: "under-rated",
+          },
+        ],
+      });
+      process.chdir(dir);
+
+      await run();
+      expect(process.exitCode ?? 0).toBe(0);
+      expect(stdout.join("\n")).toContain("## Grouped failure signatures");
+      expect(stderr.join("\n")).toContain("1 verdict.json file(s)");
+    });
+  });
+
   it("a trial run dir targets that trial's set", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fixcmd-trial-"));
     await writeTrial(dir, "ses_1", {

--- a/cli/test/unit/fix-prompt-command.test.ts
+++ b/cli/test/unit/fix-prompt-command.test.ts
@@ -38,7 +38,12 @@ function verdict(over: Partial<VerdictArtifact>): VerdictArtifact {
     judge_model: "test-judge",
     score: 100,
     pass_threshold: 100,
+    state: "pass",
     passed: true,
+    evaluated: 1,
+    not_evaluated: 0,
+    pre_satisfied: 0,
+    total: 1,
     criteria_results: [
       {
         criterion: { type: "model", text: "Severity is set correctly" },

--- a/cli/test/unit/fix-prompt-group.test.ts
+++ b/cli/test/unit/fix-prompt-group.test.ts
@@ -29,6 +29,8 @@ function trial(
   n: number,
   opts: { passed: boolean; results: CriterionResult[] },
 ): TrialFixInput {
+  const skippedCount = opts.results.filter((r) => r.skipped).length;
+  const evaluatedCount = opts.results.length - skippedCount;
   const verdict: VerdictArtifact = {
     version: VERDICT_ARTIFACT_VERSION,
     source: "cloud-finalize",
@@ -41,7 +43,12 @@ function trial(
     judge_model: "test-judge",
     score: opts.passed ? 100 : 50,
     pass_threshold: 100,
+    state: opts.passed ? "pass" : "fail",
     passed: opts.passed,
+    evaluated: evaluatedCount,
+    not_evaluated: skippedCount,
+    pre_satisfied: 0,
+    total: opts.results.length,
     criteria_results: opts.results,
     duration_ms: 1000,
     finalized_at: `2026-07-06T00:0${n}:00.000Z`,

--- a/cli/test/unit/hosted/cross-surface-agreement.test.ts
+++ b/cli/test/unit/hosted/cross-surface-agreement.test.ts
@@ -22,9 +22,28 @@
 // The one row where the two surfaces still differ is in the table too, marked
 // `divergence`, with the reason. A known divergence with a test on it is a
 // fact; the same divergence with no test on it is the F-1392 defect again.
+//
+// F-1195 — there is now a THIRD surface answering the same question: the
+// `state` field of the `verdict.json` a hosted run writes, which is what CI
+// reads instead of scraping stderr. It answers with the CLI's word by
+// construction (`runTaskHosted.ts` passes the one `verdict` local it already
+// computed into the artifact; `test/e2e/runTaskHosted.test.ts` pins that end
+// to end). What this file adds is the VOCABULARY claim — that the artifact
+// spells the answer in the dashboard's three words and no others — and the
+// artifact's side of the known divergence, so `verdict.json` is never found
+// to have quietly picked a side of F-1399 that nothing wrote down.
 
+import { mkdir, mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import type { CriterionResult } from "../../../src/contract/index.js";
+import {
+  readVerdictArtifact,
+  VERDICT_ARTIFACT_VERSION,
+  writeVerdictArtifact,
+  type VerdictArtifact,
+} from "../../../src/hosted/evalResultCache.js";
 import { PRE_SATISFIED_REASON, scoreStatus } from "../../../src/hosted/evalResultView.js";
 import { scoreFromFinalizeResponse } from "../../../src/hosted/uploadAndFinalize.js";
 
@@ -203,6 +222,85 @@ describe("CLI and dashboard answer `what state is this run in?` the same way (F-
       );
     });
   }
+
+  // ── The third surface: verdict.json's `state` (F-1195) ───────────────────
+  //
+  // `runTaskHosted.ts` writes `state: verdict` — the same local that produced
+  // the terminal's word — so agreement between the artifact and the terminal
+  // is structural, and the e2e tests prove the wiring. The risk this block
+  // covers is the OTHER one: that the artifact spells the answer in a
+  // vocabulary of its own, which would be the F-1392 defect reappearing in a
+  // new file.
+  describe("verdict.json spells the state in the same three words (F-1195)", () => {
+    async function roundtripState(state: string): Promise<string | undefined> {
+      const dir = join(await mkdtemp(join(tmpdir(), "xsurface-")), "scn", "ses_1");
+      await mkdir(dir, { recursive: true });
+      await writeVerdictArtifact(dir, {
+        version: VERDICT_ARTIFACT_VERSION,
+        source: "cloud-finalize",
+        task_name: "scn",
+        task_path: "tasks/scn.md",
+        group_id: null,
+        session_id: "ses_1",
+        cloud_run_id: "run_x",
+        cloud_dashboard_url: "https://app.pome.sh/runs/run_x",
+        judge_model: null,
+        score: 100,
+        pass_threshold: 100,
+        state: state as VerdictArtifact["state"],
+        passed: state === "pass",
+        evaluated: 1,
+        not_evaluated: 0,
+        pre_satisfied: 0,
+        total: 1,
+        criteria_results: [passing("a")],
+        duration_ms: 1,
+        finalized_at: "2026-08-10T00:00:00.000Z",
+      });
+      return (await readVerdictArtifact(dir))?.verdict.state;
+    }
+
+    // The dashboard's `RunStatus` is these three plus `in_progress`
+    // (run-status.ts) — a state no finalized artifact can be in, and one the
+    // artifact must therefore refuse rather than store.
+    const dashboardWords: DashboardStatus[] = ["pass", "fail", "incomplete"];
+
+    for (const word of dashboardWords) {
+      it(`accepts the dashboard's "${word}" verbatim`, async () => {
+        expect(await roundtripState(word)).toBe(word);
+      });
+    }
+
+    for (const notAWord of ["in_progress", "INCOMPLETE", "passed", "unevaluated", ""]) {
+      it(`refuses "${notAWord}" — a fourth word is a fourth vocabulary`, async () => {
+        expect(await roundtripState(notAWord)).toBeUndefined();
+      });
+    }
+
+    it("records the CLI's word on the F-1399 divergence, and the divergence is stated in the artifact's own doc", async () => {
+      const row = table.find((r) => r.divergence)!;
+      const cliWord = cliRunStatus(row.results, row.satisfaction);
+      // The all-pre-satisfied run: the artifact says `incomplete` (the CLI's
+      // A5 guard) while the dashboard renders Failed. Both refuse to pass it,
+      // so `passed` — the only bit CI can act on — agrees. The artifact does
+      // not get to pick this side silently: `VerdictArtifact.state`'s doc
+      // comment names F-1399 and this row.
+      expect(cliWord).toBe("incomplete");
+      expect(dashboardRunStatus(row.results, row.satisfaction)).toBe("fail");
+      expect(await roundtripState(cliWord)).toBe("incomplete");
+
+      // And the claim in this test's name is checked, not asserted: the field
+      // a CI reader meets first is `VerdictArtifact.state`, so the divergence
+      // has to be legible from there. Delete the mention and this goes red
+      // rather than the artifact quietly going back to implying agreement it
+      // does not have.
+      const artifactSource = await readFile(
+        new URL("../../../src/hosted/evalResultCache.ts", import.meta.url),
+        "utf8",
+      );
+      expect(artifactSource).toContain("F-1399");
+    });
+  });
 
   it("has exactly one known divergence, and it is the empty-denominator row", () => {
     // A guard on the guard: adding a `divergence` to a row is how this file

--- a/cli/test/unit/hosted/evalResultCache.test.ts
+++ b/cli/test/unit/hosted/evalResultCache.test.ts
@@ -120,7 +120,7 @@ describe("verdict artifact (FDRS-644)", () => {
     expect(await readVerdictArtifact(join(tmp, "scn", "nope"))).toBeNull();
   });
 
-  it("writes `task_path` and still reads pre-F-933 `scenario_path` trials (normalized)", async () => {
+  it("writes `task_path`; the retired `scenario_path` spelling is refused BY NAME, not normalized (F-1195)", async () => {
     const tmp = await mkdtemp(join(tmpdir(), "verdict-legacy-"));
 
     // Write path: the retired spelling never lands on disk again.
@@ -133,25 +133,31 @@ describe("verdict artifact (FDRS-644)", () => {
     expect(onDisk.task_path).toBe("tasks/scn.md");
     expect(onDisk).not.toHaveProperty("scenario_path");
 
-    // Read path: a run dir written by cli <= 0.8.x still resolves, and the
-    // legacy key is surfaced to callers as `task_path`.
+    // Read path: F-933's normalize branch is gone. Every file spelling the
+    // path the old way was written by `@pome-sh/cli` <= 0.8.x at artifact
+    // version 1, so the version gate refuses it first — but it is still
+    // RECOGNIZED as ours, so the skip is named rather than silently dropped
+    // the way a foreign file is.
     const legacyDir = join(tmp, "scn", "ses_old");
     await mkdir(legacyDir, { recursive: true });
     const { task_path: _tp, ...withoutTaskPath } = verdict({ session_id: "ses_old" });
     await writeFile(
       join(legacyDir, "verdict.json"),
-      JSON.stringify({ ...withoutTaskPath, scenario_path: "scenarios/scn.md" }),
+      JSON.stringify({ ...withoutTaskPath, version: 1, scenario_path: "scenarios/scn.md" }),
       "utf8",
     );
-    const legacy = await readVerdictArtifact(legacyDir);
-    expect(legacy?.verdict.task_path).toBe("scenarios/scn.md");
-    expect(groupRunSets([legacy!])[0]!.taskPath).toBe("scenarios/scn.md");
+    expect(await readVerdictArtifact(legacyDir)).toBeNull();
+    expect(await readVerdictArtifactDetailed(legacyDir)).toEqual({
+      status: "stale-version",
+      version: 1,
+    });
 
-    // Neither spelling present → still foreign.
+    // Neither spelling present → not recognizable as a verdict.json at all,
+    // which is a different answer from "a version we can't read".
     const neither = join(tmp, "scn", "ses_none");
     await mkdir(neither, { recursive: true });
     await writeFile(join(neither, "verdict.json"), JSON.stringify(withoutTaskPath), "utf8");
-    expect(await readVerdictArtifact(neither)).toBeNull();
+    expect(await readVerdictArtifactDetailed(neither)).toEqual({ status: "unreadable" });
   });
 
   it("rejects half-recognizable files instead of crashing downstream (adversarial fix)", async () => {
@@ -349,6 +355,53 @@ describe("verdict artifact (FDRS-644)", () => {
       expect(await readVerdictArtifactDetailed(foreignDir)).toEqual({ status: "unreadable" });
     });
 
+    it("`stale-version` is keyed on the version number, never on the new fields being absent", async () => {
+      const tmp = await mkdtemp(join(tmpdir(), "verdict-version-key-"));
+
+      // A file that CLAIMS the current version but is missing `state` is a
+      // corrupt current-version file, not a prior version — saying
+      // "stale-version" about it would be the artifact stating more than it
+      // checked, one layer down.
+      const corruptCurrent = join(tmp, "scn", "ses_corrupt");
+      await mkdir(corruptCurrent, { recursive: true });
+      const { state: _state, ...withoutState } = verdict({ session_id: "ses_corrupt" });
+      await writeFile(
+        join(corruptCurrent, "verdict.json"),
+        JSON.stringify(withoutState),
+        "utf8",
+      );
+      expect(await readVerdictArtifactDetailed(corruptCurrent)).toEqual({
+        status: "unreadable",
+      });
+
+      // A file with no `version` key at all (the very first writers) is a
+      // version we can't read, reported with `version: null` rather than a
+      // guessed number.
+      const noVersion = join(tmp, "scn", "ses_nover");
+      await mkdir(noVersion, { recursive: true });
+      const { version: _v, ...withoutVersion } = verdict({ session_id: "ses_nover" });
+      await writeFile(join(noVersion, "verdict.json"), JSON.stringify(withoutVersion), "utf8");
+      expect(await readVerdictArtifactDetailed(noVersion)).toEqual({
+        status: "stale-version",
+        version: null,
+      });
+
+      // And a FUTURE version (a newer CLI wrote it) is the same named skip —
+      // the check is `!== VERDICT_ARTIFACT_VERSION`, and no surface claims it
+      // was "older".
+      const future = join(tmp, "scn", "ses_future");
+      await mkdir(future, { recursive: true });
+      await writeFile(
+        join(future, "verdict.json"),
+        JSON.stringify(verdict({ session_id: "ses_future", version: 99 })),
+        "utf8",
+      );
+      expect(await readVerdictArtifactDetailed(future)).toEqual({
+        status: "stale-version",
+        version: 99,
+      });
+    });
+
     it("scanVerdictArtifactsDetailed separates stale-version dirs from readable trials", async () => {
       const tmp = await mkdtemp(join(tmpdir(), "verdict-v1-scan-"));
       await writeTrial(tmp, "scn", "ses_current", {});
@@ -383,6 +436,27 @@ describe("verdict artifact (FDRS-644)", () => {
       const emptyDiscovery = await discoverRunSet(empty);
       expect(emptyDiscovery.totalSets).toBe(0);
       expect(emptyDiscovery.staleVersionCount).toBe(0);
+    });
+
+    it("discoverRunSet(root) still counts stale trials when readable ones exist beside them", async () => {
+      // The realistic upgrade shape, and the one a "only report it when
+      // there's nothing else" guard would drop: a group half-written by the
+      // old CLI. The set fix-prompt builds is SHORT, so the count has to
+      // survive to the caller or the prompt silently covers fewer trials
+      // than the dir holds.
+      const tmp = await mkdtemp(join(tmpdir(), "verdict-v1-mixed-"));
+      await writeTrial(tmp, "scn", "ses_current", {
+        group_id: "grp_mixed",
+        passed: false,
+      });
+      const staleDir = join(tmp, "scn", "ses_v1");
+      await mkdir(staleDir, { recursive: true });
+      await writeFile(join(staleDir, "verdict.json"), JSON.stringify(v1OnDiskArtifact("ses_v1")), "utf8");
+
+      const discovery = await discoverRunSet(tmp);
+      expect(discovery.totalSets).toBe(1);
+      expect(discovery.set?.trials.map((t) => t.verdict.session_id)).toEqual(["ses_current"]);
+      expect(discovery.staleVersionCount).toBe(1);
     });
 
     it("discoverRunSet(trial dir) pointed straight at a v1 verdict.json names the skip", async () => {

--- a/cli/test/unit/hosted/evalResultCache.test.ts
+++ b/cli/test/unit/hosted/evalResultCache.test.ts
@@ -15,7 +15,9 @@ import {
   latestFailedRunSet,
   loadTrialEvents,
   readVerdictArtifact,
+  readVerdictArtifactDetailed,
   scanVerdictArtifacts,
+  scanVerdictArtifactsDetailed,
   writeVerdictArtifact,
   type VerdictArtifact,
 } from "../../../src/hosted/evalResultCache.js";
@@ -33,7 +35,12 @@ function verdict(over: Partial<VerdictArtifact>): VerdictArtifact {
     judge_model: "test-judge",
     score: 100,
     pass_threshold: 100,
+    state: "pass",
     passed: true,
+    evaluated: 1,
+    not_evaluated: 0,
+    pre_satisfied: 0,
+    total: 1,
     criteria_results: [
       {
         criterion: { type: "model", text: "Severity is set correctly" },
@@ -45,6 +52,36 @@ function verdict(over: Partial<VerdictArtifact>): VerdictArtifact {
     duration_ms: 1000,
     finalized_at: "2026-07-06T00:00:00.000Z",
     ...over,
+  };
+}
+
+/** F-1195 — a verdict.json exactly as a pre-F-1195 CLI wrote it: recognizable
+ *  (source/session_id/task_name/task_path/criteria_results all present and
+ *  shaped) but missing `state` and the four counts, at `version: 1`. */
+function v1OnDiskArtifact(sessionId: string): Record<string, unknown> {
+  return {
+    version: 1,
+    source: "cloud-finalize",
+    task_name: "scn",
+    task_path: "tasks/scn.md",
+    group_id: null,
+    session_id: sessionId,
+    cloud_run_id: "run_v1",
+    cloud_dashboard_url: "https://app.pome.sh/runs/run_v1",
+    judge_model: "test-judge",
+    score: 100,
+    pass_threshold: 100,
+    passed: false,
+    criteria_results: [
+      {
+        criterion: { type: "model", text: "Severity is set correctly" },
+        passed: true,
+        skipped: false,
+        reason: "ok",
+      },
+    ],
+    duration_ms: 1000,
+    finalized_at: "2026-07-06T00:00:00.000Z",
   };
 }
 
@@ -278,5 +315,87 @@ describe("verdict artifact (FDRS-644)", () => {
     );
     const events = await loadTrialEvents(tmp);
     expect(events).toHaveLength(1);
+  });
+
+  // F-1195 — a v1 artifact is RECOGNIZABLE (it has every field a verdict.json
+  // has always had), just missing `state` and the four counts this ticket
+  // added. `readVerdictArtifact` still refuses it (no dual-format reader —
+  // zero customers), but the detailed API must say WHY, distinctly from a
+  // foreign/corrupt file, so a v1 run never looks identical to "no run
+  // happened here" to fix-prompt discovery.
+  describe("v1 verdict.json is a named stale-version skip, not a silent drop (F-1195)", () => {
+    it("readVerdictArtifact still returns null for a v1 file (no dual-format reader)", async () => {
+      const tmp = await mkdtemp(join(tmpdir(), "verdict-v1-"));
+      const dir = join(tmp, "scn", "ses_v1");
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, "verdict.json"), JSON.stringify(v1OnDiskArtifact("ses_v1")), "utf8");
+      expect(await readVerdictArtifact(dir)).toBeNull();
+    });
+
+    it("readVerdictArtifactDetailed names it stale-version with the on-disk version number", async () => {
+      const tmp = await mkdtemp(join(tmpdir(), "verdict-v1-detail-"));
+      const dir = join(tmp, "scn", "ses_v1");
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, "verdict.json"), JSON.stringify(v1OnDiskArtifact("ses_v1")), "utf8");
+      expect(await readVerdictArtifactDetailed(dir)).toEqual({
+        status: "stale-version",
+        version: 1,
+      });
+      // A genuinely foreign file is still a plain "unreadable", not confused
+      // for a stale version.
+      const foreignDir = join(tmp, "scn", "foreign");
+      await mkdir(foreignDir, { recursive: true });
+      await writeFile(join(foreignDir, "verdict.json"), '{"hello":"world"}', "utf8");
+      expect(await readVerdictArtifactDetailed(foreignDir)).toEqual({ status: "unreadable" });
+    });
+
+    it("scanVerdictArtifactsDetailed separates stale-version dirs from readable trials", async () => {
+      const tmp = await mkdtemp(join(tmpdir(), "verdict-v1-scan-"));
+      await writeTrial(tmp, "scn", "ses_current", {});
+      const staleDir = join(tmp, "scn", "ses_v1");
+      await mkdir(staleDir, { recursive: true });
+      await writeFile(join(staleDir, "verdict.json"), JSON.stringify(v1OnDiskArtifact("ses_v1")), "utf8");
+
+      const { trials, staleVersionDirs } = await scanVerdictArtifactsDetailed(tmp);
+      expect(trials.map((t) => t.verdict.session_id)).toEqual(["ses_current"]);
+      expect(staleVersionDirs).toEqual([staleDir]);
+      // The plain (non-detailed) scan still only returns readable trials.
+      expect((await scanVerdictArtifacts(tmp)).map((t) => t.verdict.session_id)).toEqual([
+        "ses_current",
+      ]);
+    });
+
+    it("discoverRunSet(root) reports staleVersionCount alongside totalSets:0 instead of looking like an empty runs/", async () => {
+      const tmp = await mkdtemp(join(tmpdir(), "verdict-v1-root-"));
+      const staleDir = join(tmp, "scn", "ses_v1");
+      await mkdir(staleDir, { recursive: true });
+      await writeFile(join(staleDir, "verdict.json"), JSON.stringify(v1OnDiskArtifact("ses_v1")), "utf8");
+
+      const discovery = await discoverRunSet(tmp);
+      expect(discovery.kind).toBe("root");
+      expect(discovery.totalSets).toBe(0);
+      expect(discovery.set).toBeNull();
+      expect(discovery.staleVersionCount).toBe(1);
+
+      // A truly empty runs/ still reports staleVersionCount: 0 — the two
+      // "nothing to read" cases stay distinguishable.
+      const empty = await mkdtemp(join(tmpdir(), "verdict-v1-empty-"));
+      const emptyDiscovery = await discoverRunSet(empty);
+      expect(emptyDiscovery.totalSets).toBe(0);
+      expect(emptyDiscovery.staleVersionCount).toBe(0);
+    });
+
+    it("discoverRunSet(trial dir) pointed straight at a v1 verdict.json names the skip", async () => {
+      const tmp = await mkdtemp(join(tmpdir(), "verdict-v1-trialdir-"));
+      const staleDir = join(tmp, "scn", "ses_v1");
+      await mkdir(staleDir, { recursive: true });
+      await writeFile(join(staleDir, "verdict.json"), JSON.stringify(v1OnDiskArtifact("ses_v1")), "utf8");
+
+      const discovery = await discoverRunSet(staleDir);
+      expect(discovery.kind).toBe("trial-dir");
+      expect(discovery.set).toBeNull();
+      expect(discovery.totalSets).toBe(0);
+      expect(discovery.staleVersionCount).toBe(1);
+    });
   });
 });

--- a/cli/test/unit/hosted/incompleteVerdict.test.ts
+++ b/cli/test/unit/hosted/incompleteVerdict.test.ts
@@ -21,6 +21,7 @@
 import { describe, expect, it } from "vitest";
 import type { CriterionResult } from "../../../src/contract/index.js";
 import {
+  evaluationCounts,
   isPreSatisfied,
   PRE_SATISFIED_REASON,
   runScoreLine,
@@ -250,5 +251,68 @@ describe("runScoreLine — pre-satisfied criteria are named apart from abstentio
     const line = runScoreLine(s, 100, "cloud score");
     expect(line).toContain("1 of 2 criteria not evaluated (1 already true in the seed)");
     expect(line).not.toContain("nothing was at risk");
+  });
+});
+
+// F-1195 — `evaluationCounts` is the ONE place this arithmetic exists, so
+// `verdict.json` and `runScoreLine`'s "N of M criteria not evaluated" cannot
+// drift apart. These pin the four counts directly against the shapes
+// `verdict.json` needs to name: a full pass, an unevaluated criterion (the
+// original bug — a bare `score`/`pass_threshold` pair with no denominator),
+// and a pre-satisfied exclusion (must agree with the dashboard).
+describe("evaluationCounts — the counts verdict.json and the terminal both read", () => {
+  it("a fully-evaluated run: evaluated = total, nothing left out", () => {
+    const s = score([ok("a"), ok("b")], 100);
+    expect(evaluationCounts(s)).toEqual({
+      evaluated: 2,
+      notEvaluated: 0,
+      preSatisfied: 0,
+      total: 2,
+    });
+  });
+
+  it("an abstained criterion counts as not-evaluated, not folded into evaluated", () => {
+    // This is the F-1195 bug shape: 100/100 over what DID run, with a third
+    // criterion that never did.
+    const s = score([ok("a"), ok("b"), abstained("c")], 100);
+    expect(evaluationCounts(s)).toEqual({
+      evaluated: 2,
+      notEvaluated: 1,
+      preSatisfied: 0,
+      total: 3,
+    });
+  });
+
+  it("a pre-satisfied criterion is excluded from evaluated AND from notEvaluated", () => {
+    const s = score([ok("a"), preSatisfied("github.no-new-issues")], 100);
+    expect(evaluationCounts(s)).toEqual({
+      evaluated: 1,
+      notEvaluated: 0,
+      preSatisfied: 1,
+      total: 2,
+    });
+  });
+
+  it("a genuine abstention beside a pre-satisfied exclusion counts them separately", () => {
+    const s = score(
+      [ok("a"), abstained("b"), preSatisfied("github.no-new-issues")],
+      100,
+    );
+    expect(evaluationCounts(s)).toEqual({
+      evaluated: 1,
+      notEvaluated: 1,
+      preSatisfied: 1,
+      total: 3,
+    });
+  });
+
+  it("every criterion pre-satisfied: no denominator, everything in preSatisfied", () => {
+    const s = score([preSatisfied("github.no-new-issues")], 0);
+    expect(evaluationCounts(s)).toEqual({
+      evaluated: 0,
+      notEvaluated: 0,
+      preSatisfied: 1,
+      total: 1,
+    });
   });
 });


### PR DESCRIPTION
## Problem

`pome run` prints the right thing to the terminal and exits with the
documented CI contract, but the `verdict.json` it caches next to the trace
carries none of that. On an incomplete run it wrote:

```json
{ "score": 100, "pass_threshold": 100, "passed": false, ... }
```

`passed: false` is correct but carries no reason, and nothing in the file
names the third state or says how many criteria the score is actually over.
A CI script that trusts the obvious arithmetic (`score >= pass_threshold`)
reads `true` on a run where a third of the criteria never ran.

## Fix

`verdict.json` now writes:

- `state`: `"pass"` / `"fail"` / `"incomplete"` — the same word the terminal
  prints, taken from the `verdict` local `runTaskHosted.ts` already computes
  (`scoreStatus`), not re-derived.
- `evaluated` / `not_evaluated` / `pre_satisfied` / `total`: the counts
  `score` is computed over, from one new exported helper
  (`evaluationCounts` in `evalResultView.ts`) that `runScoreLine` now also
  uses, so the terminal's "N of M criteria not evaluated" line and the
  artifact's counts can't drift apart the way the artifact drifted from the
  terminal before this.

`score` itself is unchanged and still comparable to `pass_threshold` — the
ticket rules on that explicitly ("keep `passed`, add `state`, add the counts;
don't remove `score`"). What makes it legible instead is naming its
denominator: `score` is a percentage over `evaluated` ALONE, said at the
field and in the README, so `not_evaluated > 0` visibly means `score` is
silent about part of the run and `evaluated: 0` means it scored nothing at
all. The three signals a CI caller can gate on — the exit code, `passed`, and
`state` — all agree, and the README now points at `state` instead of "read
the verdict word printed beside the score", which only ever worked for a
human reading stderr.

### Agreement with the other surfaces

`state` uses the CLI's `ScoreStatus`, which is pome-cloud's `RunStatus` minus
`in_progress` — no third vocabulary. `cross-surface-agreement.test.ts` now
walks the artifact as a third surface beside the CLI and the dashboard: it
pins that the artifact accepts exactly those three words and refuses a fourth,
and that on the one known divergence (an all-pre-satisfied run: `incomplete`
here, Failed on the dashboard, F-1399) the artifact records the CLI's word
rather than picking a side silently. Both surfaces still refuse to pass that
run, so `passed` — the only bit CI can act on — agrees. The divergence and the
non-100 `pass_threshold` case are both named in `VerdictArtifact.state`'s doc
comment, and a test fails if that mention disappears.

### Versioning, and what happens to an older file

`VERDICT_ARTIFACT_VERSION` bumps 1 → 2 with the new fields required. There is
no dual-format reader: a version-1 file is refused outright, and the read
path's pre-F-933 `scenario_path` tolerance went with it (every file spelling
the path that way is version 1, so the version gate refused it before the
spelling could matter — a back-compat branch that could no longer fire).

What the bump adds is a NAMED skip, not a compatibility shim.
`readVerdictArtifactDetailed` distinguishes "current", "recognizable but at
another artifact version", and "not a verdict file at all", keyed on the
version number rather than on the new fields being absent — so a corrupt
version-2 file is reported as corrupt and a file from a newer writer is not
called older. `pome fix-prompt` names that skip every time it happens,
including when readable trials sit beside stale ones (that case used to build
a prompt from part of a run set and say nothing about the rest), and the
"no finalized run sets" message is now reserved for a root that really is
empty.

### Consumers

Every producer and consumer of `verdict.json` is in this repo and in this PR:
the single writer (`runTaskHosted.ts`), the validator and discovery
(`evalResultCache.ts`), the fix-prompt CLI surface (`main.ts`), and every test
fixture that constructs a `VerdictArtifact`. Nothing outside `cli/` reads it —
no workflow, script, example, skill or doc; `eval-roundtrip.sh` reads
`latest.json` only, nothing reads run dirs by glob, and `VerdictArtifact` is
not exported from `@pome-sh/shared-types` and has no published JSON schema.
`AGENTS.md`'s prose about the artifact is updated.

## Not fixed here

`groupRunSets`' `anyFailed` reads `!verdict.passed`, so a merely INCOMPLETE
trial still routes to `pome fix-prompt` as an agent defect. Now that `state`
is on disk the predicate can be `state === "fail"`, but with no failed set the
caller prints "the latest run sets under runs all passed", which is false
about an incomplete run — it needs a third message. Filed as F-1404 under the
same milestone.

## How verified

- `cd cli && npm run typecheck` — clean.
- `cd cli && npm test` — 108 files / 1075 tests passing.
- `cd cli && npm run test:e2e` — 9 files / 21 tests passing.
- Root gates: `lint:dead-code`, `lint:code-health`, `lint:no-catch`,
  `lint:copy-markers`, `lint:legacy-markers`, `lint:parent-vocab`,
  `lint:task-class`, `lint:skill-manifest`, `lint:no-cloud-imports`,
  `gate:no-eval`, `gate:no-native`, and `cli`'s `gate:no-eval` all pass.
- `node scripts/ci/check-version-bump-required.mjs <merge-base>` passes
  against the bumped `cli/package.json` (0.23.1 → 0.23.2) and CHANGELOG entry.
- The regression tests were proved against the bug, not just written beside
  it. Reverting `evalResultCache.ts` / `evalResultView.ts` /
  `runTaskHosted.ts` to their pre-PR state reproduces the exact reported
  artifact and turns the e2e INCOMPLETE test red on `expected undefined to be
  'incomplete'`. Separately, writing a plausible WRONG derivation
  (`state: exitCode === 0 ? "pass" : "fail"`, which loses the third state)
  turns it red on `expected 'fail' to be 'incomplete'`. The two review fixes
  were mutation-checked the same way: restoring the "only report a stale skip
  when nothing else was found" guard fails the mixed-root fix-prompt test, and
  keying `stale-version` off the missing fields instead of the version number
  fails the corrupt-current-file test.