### PR TITLE
fix-prompt names an incomplete run set instead of routing it as a failure (F-1404)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,29 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.23.5
+
+### Patch Changes
+
+- `pome fix-prompt` no longer routes an INCOMPLETE trial to your coding agent
+  as an agent defect (F-1404). A run set's `outcome` (`groupRunSets` in
+  `evalResultCache.ts`) was computed from `!verdict.passed`, which is false
+  for a genuine failure and for a trial the grader never finished alike — so
+  a `runs/` whose only non-passing trials were incomplete got picked by
+  `latestFailedRunSet` and handed to `pome fix-prompt` as if the agent had a
+  defect, when nothing had established that: a criterion just never got
+  graded. `outcome` now reads the on-disk `state` (`"fail"` / `"incomplete"`
+  / `"pass"`, from F-1195's verdict.json field) instead, so it can tell the
+  two apart.
+
+  A root whose only non-passing run set is incomplete now gets a third,
+  distinct message instead of either the old misroute or a false "the latest
+  run sets under runs all passed": it names the gap as incomplete, says it is
+  a grading gap rather than an agent defect, and tells you to re-run the
+  task. Pointing `fix-prompt` straight at a trial directory is unchanged — it
+  still targets that trial's whole set regardless of outcome, since the user
+  pointed at it directly.
+
 ## 0.23.4
 
 ### Patch Changes

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -21,11 +21,37 @@ packaging restructure: bump `version` here and in `package.json`, and merging to
 
   A root whose only non-passing run set is incomplete now gets a third,
   distinct message instead of either the old misroute or a false "the latest
-  run sets under runs all passed": it names the gap as incomplete, says it is
-  a grading gap rather than an agent defect, and tells you to re-run the
-  task. Pointing `fix-prompt` straight at a trial directory is unchanged — it
-  still targets that trial's whole set regardless of outcome, since the user
-  pointed at it directly.
+  run sets under runs all passed": it names which set (a newer one may have
+  passed, so it is the most recent NON-PASSING set, not "the latest"), says
+  how many trials were left ungraded, and tells you to re-run the task.
+  Pointing `fix-prompt` straight at a trial directory is unchanged — it still
+  targets that trial's whole set regardless of outcome, since the user
+  pointed at it directly. `pome fix-prompt`'s exit codes are now written down
+  in the README beside `pome run`'s: `1` is only ever the incomplete case,
+  and it means the same thing there as it does for `pome run`.
+
+  That third message does not absolve the agent blindly, either. A trial's
+  `state` is `incomplete` for ANY ungraded criterion, so an incomplete set can
+  still hold criteria the judge did grade and did fail; saying "a grading gap,
+  not an agent defect" over those would understate exactly as badly as the old
+  misroute overstated. The message now counts the graded failures, says they
+  are real, and points at the trial-directory form when you want a prompt
+  built from the part that was graded.
+
+- The run-set fix prompt itself stops describing an ungraded trial as a
+  failing one (F-1404). A set reaches the prompt builder holding an
+  `INCOMPLETE` trial whenever a genuine failure sits beside one, or when you
+  point `fix-prompt` at a trial directory yourself — and the prompt handed to
+  your coding agent used to list that trial under "Other failing trials",
+  count it as a non-pass in a fraction labelled "completed trials", and let it
+  win the "most-failing trial" heading that anchors the one trace. All three
+  asserted an outcome the grading never reached. Every fraction is now over
+  graded trials only, per-criterion counts read "failed in N of M trials that
+  graded it" (the old denominator could exceed its own numerator once a set
+  held an incomplete trial), a set with nothing graded end to end says so
+  instead of printing "0 of 0 completed trials passed", and the ungraded
+  trials get their own closing section stating that no pass and no failure is
+  claimed for them.
 
 ## 0.23.4
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -99,6 +99,16 @@ Three rules CI must honor:
   excluded from the verdict fraction (`3 of 4 passed · 1 incomplete`) so neither
   is counted as a pass nor charged to the agent as a loss — but a group holding
   one cannot exit `0`.
+- **`pome fix-prompt` uses the same codes, and its `1` is only ever
+  INCOMPLETE.** Building a prompt for a failed run set exits `0` (the prompt is
+  on stdout, and stdout being non-empty is the signal that there was something
+  to fix); an all-green root exits `0` with nothing on stdout; a bad argument or
+  a root with no readable run sets exits `5`. `1` is reserved for the one case
+  where the newest non-passing set was never fully graded: no prompt is built,
+  because a run whose checks never ran is not evidence of an agent defect. This
+  matches `pome run`, where `1` also covers INCOMPLETE — the two commands do not
+  disagree about what an ungraded run exits, and `verdict.json`'s `state` stays
+  the field to read when a script needs the reason rather than the code.
 
 ## Development
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.23.4",
+  "version": "0.23.5",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -1230,6 +1230,24 @@ export function createProgram() {
         return;
       }
       if (!discovery.set) {
+        // F-1404 — a root whose only non-passing run set is INCOMPLETE (a
+        // criterion was never graded) is neither "all passed" nor a failure
+        // to hand to a coding agent: routing it as a fix-prompt would assert
+        // an agent defect nothing here established, and "all passed" would
+        // be false about it. `incompleteSet` is only ever populated when no
+        // set actually failed (see `discoverRunSet`), so this branch and the
+        // routing decision above read the same computation and cannot
+        // disagree.
+        if (discovery.incompleteSet) {
+          const incompleteTrials = discovery.incompleteSet.trials.filter(
+            (t) => t.verdict.state === "incomplete",
+          ).length;
+          console.error(
+            `Not routed to fix-prompt: the latest run set under ${root} is INCOMPLETE, not failed — ${incompleteTrials} of ${discovery.incompleteSet.trials.length} trial(s) have criteria that were never graded. That is a grader/seed gap, not an agent defect, so fix-prompt will not hand it to your coding agent. Re-run \`pome run\` for this task so those criteria are actually evaluated, then run fix-prompt again.`,
+          );
+          process.exitCode = 1;
+          return;
+        }
         console.error(
           `Nothing to fix: the latest run sets under ${root} all passed.`,
         );

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -19,7 +19,7 @@ import {
 import { runTask } from "../runner/runTask.js";
 import { runTaskHosted } from "../runner/runTaskHosted.js";
 import { effectiveTrialCount, parseTrialsFlag } from "../runner/trialCount.js";
-import { runScoreLine, scoreStatus } from "../hosted/evalResultView.js";
+import { outcomeOf, runScoreLine, scoreStatus } from "../hosted/evalResultView.js";
 import { HostedUsageError, exitCodeFor } from "../hosted/errors.js";
 import { resolveCredentials, clearLocalCredentials } from "./credentials.js";
 import { loginWithClerk } from "./login.js";
@@ -1230,21 +1230,49 @@ export function createProgram() {
         return;
       }
       if (!discovery.set) {
-        // F-1404 — a root whose only non-passing run set is INCOMPLETE (a
-        // criterion was never graded) is neither "all passed" nor a failure
-        // to hand to a coding agent: routing it as a fix-prompt would assert
-        // an agent defect nothing here established, and "all passed" would
-        // be false about it. `incompleteSet` is only ever populated when no
-        // set actually failed (see `discoverRunSet`), so this branch and the
-        // routing decision above read the same computation and cannot
-        // disagree.
-        if (discovery.incompleteSet) {
-          const incompleteTrials = discovery.incompleteSet.trials.filter(
+        // F-1404 — a root whose only non-passing run set is INCOMPLETE (the
+        // grader never reached some criterion) is neither "all passed" nor a
+        // failure to hand to a coding agent: routing it would assert an agent
+        // defect nothing here established, and "all passed" would be false
+        // about it. `incompleteSet` is only ever populated when no set failed
+        // (see `discoverRunSet`), so this branch and the routing decision
+        // above read the one computation and cannot disagree.
+        //
+        // What this message may NOT say is "just a grading gap" unread: a
+        // trial's `state` is `incomplete` for ANY ungraded criterion
+        // (`scoreStatus`'s A5 guard outranks everything else), so such a set
+        // can still hold criteria that WERE graded and did fail. Claiming
+        // "not an agent defect" over those would be this ticket's own defect
+        // pointed the other way — understating instead of overstating. Count
+        // them and say which case this is.
+        const incomplete = discovery.incompleteSet;
+        if (incomplete) {
+          const ungradedTrials = incomplete.trials.filter(
             (t) => t.verdict.state === "incomplete",
           ).length;
-          console.error(
-            `Not routed to fix-prompt: the latest run set under ${root} is INCOMPLETE, not failed — ${incompleteTrials} of ${discovery.incompleteSet.trials.length} trial(s) have criteria that were never graded. That is a grader/seed gap, not an agent defect, so fix-prompt will not hand it to your coding agent. Re-run \`pome run\` for this task so those criteria are actually evaluated, then run fix-prompt again.`,
+          const gradedFailures = incomplete.trials.reduce(
+            (n, t) =>
+              n +
+              t.verdict.criteria_results.filter((r) => outcomeOf(r) === "failed")
+                .length,
+            0,
           );
+          const which = `task ${incomplete.taskName}${incomplete.groupId ? ` · group ${incomplete.groupId}` : ""}`;
+          // "the most recent NON-PASSING set", never "the latest run set":
+          // a newer set may have passed — `latestIncompleteRunSet` scans for
+          // an outcome, not for the newest set.
+          console.error(
+            `Not routed to fix-prompt: no run set under ${root} failed outright. The most recent non-passing one (${which}) is INCOMPLETE — ${ungradedTrials} of ${incomplete.trials.length} trial(s) have criteria the grader never graded.`,
+          );
+          if (gradedFailures > 0) {
+            console.error(
+              `${gradedFailures} criterion result(s) in that set WERE graded and did fail, so this is not only a grading gap — but no trial in it was graded end to end, and a fix prompt built from a partial grading would claim more than was checked. Re-run \`pome run ${incomplete.taskPath}\` to grade the rest, or point fix-prompt straight at one trial (\`pome fix-prompt ${incomplete.trials[0]!.runDir}\`) to build one from the partial grading anyway.`,
+            );
+          } else {
+            console.error(
+              `Nothing in that set was graded and failed, so it is a grader/seed gap, not an agent defect, and fix-prompt will not hand it to your coding agent. Re-run \`pome run ${incomplete.taskPath}\` to grade those criteria; if they come back ungraded, the gap is in the task's checks or its seed, not in your prompt.`,
+            );
+          }
           process.exitCode = 1;
           return;
         }

--- a/cli/src/fix-prompt/prompt.ts
+++ b/cli/src/fix-prompt/prompt.ts
@@ -157,6 +157,34 @@ function failedResults(verdict: VerdictArtifact): CriterionResult[] {
   return verdict.criteria_results.filter((r) => outcomeOf(r) === "failed");
 }
 
+/** F-1404 — a trial whose grading FINISHED: the only kind whose pass/fail
+ *  this prompt may count. A trial's `state` is `"incomplete"` whenever the
+ *  grader never reached some criterion (`scoreStatus`'s A5 guard), and such a
+ *  trial is neither a pass nor a failure — it belongs in no numerator and no
+ *  denominator here. Read off `state`, the same field `groupRunSets` routes
+ *  on, so the routing decision and this prompt cannot disagree about which
+ *  trials were graded.
+ *
+ *  This is why the partition below is NOT `verdict.passed`: `passed` is false
+ *  for a graded failure and for an ungraded trial alike, which listed an
+ *  ungraded trial under "Other failing trials" and counted it as a non-pass
+ *  in a fraction labelled "completed trials". Both stated more than the
+ *  artifact checked. */
+function isGraded(t: TrialFixInput): boolean {
+  return t.verdict.state !== "incomplete";
+}
+
+/** Criteria the grader never reached in this trial — neither graded pass nor
+ *  graded failure, and not a seed exclusion (which IS a verdict). */
+function ungradedCount(verdict: VerdictArtifact): number {
+  return verdict.criteria_results.filter(
+    (r) =>
+      !isPreSatisfied(r) &&
+      outcomeOf(r) !== "passed" &&
+      outcomeOf(r) !== "failed",
+  ).length;
+}
+
 /** Judge reasons and criterion text are DATA rendered into prompt prose —
  *  flatten to one line so a crafted (or just verbose) string can never open
  *  a new markdown heading/section inside the prompt structure. */
@@ -189,10 +217,19 @@ function renderGroupedSignatures(trials: TrialFixInput[]): string {
   // under, and "the seed already satisfied it" is a different note from "the
   // grader never reached it".
   const outcomesSeen = new Map<string, Set<string>>();
+  // F-1404 — per-criterion denominator: how many trials actually GRADED this
+  // criterion (reached a pass or a fail on it). The old denominator was
+  // `trials.length`, which counted trials that never graded the criterion at
+  // all — and once a set may hold an INCOMPLETE trial, a criterion can be
+  // failed in more trials than that count admits, printing "failed in 2 of 1".
+  const gradedFor = new Map<string, number>();
   for (const trial of trials) {
     for (const result of trial.verdict.criteria_results) {
       const key = result.criterion.text;
       const outcome = isPreSatisfied(result) ? "excluded" : outcomeOf(result);
+      if (outcome === "passed" || outcome === "failed") {
+        gradedFor.set(key, (gradedFor.get(key) ?? 0) + 1);
+      }
       if (outcome === "failed") {
         const entry = byCriterion.get(key) ?? {
           marker: criterionMarker(result.criterion),
@@ -217,14 +254,14 @@ function renderGroupedSignatures(trials: TrialFixInput[]): string {
     else notUniformlyEvaluated.push(key);
   }
 
-  const completed = trials.length;
   const blocks = [...byCriterion.entries()]
     .sort((a, b) => b[1].hits.length - a[1].hits.length)
     .map(([text, { marker, hits }], idx) => {
       const lines = hits.map(
         (h) => `   - ${h.label}: ${flattenLine(h.reason)}`,
       );
-      return `${idx + 1}. ${marker} ${flattenLine(text)} — failed in ${hits.length} of ${completed} completed trials\n${lines.join("\n")}`;
+      const graded = gradedFor.get(text) ?? hits.length;
+      return `${idx + 1}. ${marker} ${flattenLine(text)} — failed in ${hits.length} of ${graded} trials that graded it\n${lines.join("\n")}`;
     });
   if (
     blocks.length === 0 &&
@@ -261,11 +298,15 @@ function renderGroupedSignatures(trials: TrialFixInput[]): string {
 }
 
 /** The failing trial with the most failed criteria — the representative
- *  whose full trace anchors the prompt. */
+ *  whose full trace anchors the prompt.
+ *
+ *  F-1404 — `state === "fail"`, not `!passed`: an INCOMPLETE trial is not a
+ *  failing one, and anchoring the prompt's one trace on it under the heading
+ *  "the most-failing trial" asserted a failure the grading never reached. */
 export function representativeFailingTrial(
   trials: TrialFixInput[],
 ): TrialFixInput | null {
-  const failing = trials.filter((t) => !t.verdict.passed);
+  const failing = trials.filter((t) => t.verdict.state === "fail");
   if (failing.length === 0) return null;
   return failing.reduce((worst, t) =>
     failedResults(t.verdict).length > failedResults(worst.verdict).length
@@ -275,11 +316,15 @@ export function representativeFailingTrial(
 }
 
 export function buildGroupFixUserPrompt(ctx: GroupFixPromptContext): string {
-  const completed = ctx.trials.length;
-  const passed = ctx.trials.filter((t) => t.verdict.passed).length;
+  // F-1404 — every fraction below is over GRADED trials only. An INCOMPLETE
+  // trial gets its own named section instead of being counted as a non-pass
+  // in a denominator labelled "completed".
+  const incomplete = ctx.trials.filter((t) => !isGraded(t));
+  const completed = ctx.trials.length - incomplete.length;
+  const passed = ctx.trials.filter((t) => t.verdict.state === "pass").length;
   const representative = representativeFailingTrial(ctx.trials);
   const otherFailing = ctx.trials.filter(
-    (t) => !t.verdict.passed && t !== representative,
+    (t) => t.verdict.state === "fail" && t !== representative,
   );
 
   const signatures = redactSecrets(
@@ -299,11 +344,24 @@ export function buildGroupFixUserPrompt(ctx: GroupFixPromptContext): string {
     ? (redactSecrets(ctx.task.prompt) as string)
     : `(task file not found at ${ctx.trials[0]?.verdict.task_path ?? "?"} — criteria above come from the cloud verdicts)`;
 
+  // "0 of 0 completed trials passed" would be a fraction over an empty
+  // denominator — the A5 sin this milestone exists to remove. Name the state
+  // instead. (Reachable: `pome fix-prompt <trial-dir>` deliberately targets
+  // the trial the user pointed at whatever its outcome.)
+  const tally =
+    completed === 0
+      ? "no trial in this set was graded end to end"
+      : `${passed} of ${completed} completed trials passed`;
+  const gapNote =
+    incomplete.length > 0
+      ? ` · ${incomplete.length} INCOMPLETE (counted in nothing below — see the last section)`
+      : "";
+
   const sections: string[] = [];
   sections.push(`## Run set (cloud-judged)
 task ${redactSecrets(ctx.taskName) as string} · ${
     ctx.groupId ? `group ${ctx.groupId}` : "single run"
-  } · ${passed} of ${completed} completed trials passed`);
+  } · ${tally}${gapNote}`);
 
   sections.push(`## Grouped failure signatures (from the cloud judge)
 ${escapeTagContent(signatures)}`);
@@ -332,6 +390,24 @@ ${escapeTagContent(trace)}
       return `- ${t.label} — failed: ${failed || "(see verdict)"} — trace at ${join(t.runDir, "events.jsonl")}`;
     });
     sections.push(`## Other failing trials (traces on disk)
+${escapeTagContent(redactSecrets(lines.join("\n")) as string)}`);
+  }
+
+  // F-1404 — the gap, named, as the LAST thing the reading agent sees before
+  // it starts work. The prompt is allowed to be built over a set holding an
+  // ungraded trial (a genuine failure alongside it, or a trial dir the user
+  // pointed at directly); it is not allowed to let that trial read as
+  // evidence. Nothing above counts these, and this says so.
+  if (incomplete.length > 0) {
+    const lines = incomplete.map(
+      (t) =>
+        `- ${t.label} — ${ungradedCount(t.verdict)} criterion(s) never graded — trace at ${join(t.runDir, "events.jsonl")}`,
+    );
+    sections.push(`## Trials the grader never finished (INCOMPLETE)
+The grader never reached every criterion in these trials, so they are neither
+passes nor failures and are counted in no fraction above. Do NOT treat them as
+evidence for or against any fix: a criterion that never ran is a grader or seed
+gap, not something the agent did wrong.
 ${escapeTagContent(redactSecrets(lines.join("\n")) as string)}`);
   }
 

--- a/cli/src/hosted/evalResultCache.ts
+++ b/cli/src/hosted/evalResultCache.ts
@@ -282,20 +282,14 @@ export async function scanVerdictArtifacts(
   return (await scanVerdictArtifactsDetailed(artifactsRoot)).trials;
 }
 
-// F-1404 — the three-way verdict a run SET can carry, named the same as
-// `ScoreStatus` (the per-trial word) because it is built from that word:
-//   "fail"       — at least one trial genuinely failed (state === "fail"):
-//                  it was graded and did not satisfy a criterion. This is
-//                  the ONLY outcome that asserts an agent defect.
-//   "incomplete" — no trial failed, but at least one trial's grading never
-//                  finished (state === "incomplete"). Nothing here says the
-//                  agent did anything wrong — a criterion was never
-//                  evaluated, which is a grader/seed gap, not evidence of a
-//                  bug in the run. "fail" wins over "incomplete" when a set
-//                  has both: a trial that DID fail is real signal, and
-//                  naming it takes priority over naming the gap in a
-//                  sibling trial.
-//   "pass"       — every trial's state is "pass".
+// F-1404 — the three-way verdict a run SET can carry, named like
+// `ScoreStatus` (the per-trial word) because it is built from it: "fail" =
+// at least one trial genuinely failed (graded, unsatisfied) — the only
+// outcome that asserts an agent defect. "incomplete" = no trial failed, but
+// at least one trial's grading never finished — a grader/seed gap, not
+// evidence the agent did anything wrong; "fail" wins when a set has both,
+// since a real failure is signal worth naming over a sibling's gap. "pass" =
+// every trial's state is "pass".
 export type RunSetOutcome = "fail" | "incomplete" | "pass";
 
 export interface RunSet {
@@ -309,11 +303,10 @@ export interface RunSet {
   latestFinalizedAt: string;
   /** F-1404 — derived from the on-disk `state` (see `RunSetOutcome`), never
    *  from `passed` alone: `passed` is false for BOTH a genuine failure and a
-   *  trial the grader never finished, so a predicate built on it can't tell
-   *  "the agent has a defect" from "something was never graded" apart. This
-   *  is the ONE computation both the routing decision (`latestFailedRunSet`
-   *  / `latestIncompleteRunSet`) and the message shown to the user read, so
-   *  they cannot disagree about what a set is. */
+   *  trial the grader never finished, so it can't tell "agent defect" from
+   *  "never graded" apart. The ONE computation both the routing decision
+   *  (`latestFailedRunSet` / `latestIncompleteRunSet`) and the message shown
+   *  to the user read, so they cannot disagree. */
   outcome: RunSetOutcome;
 }
 
@@ -324,8 +317,7 @@ export interface RunSet {
  *  (F-1392's finding: `!passed` is true for both a genuine failure and an
  *  incomplete trial, so a set holding only incomplete trials used to trip
  *  the old `anyFailed` and get handed to `pome fix-prompt` as an agent
- *  defect — routing a grader gap as if it were proof the agent misbehaved).
- *  `evalResultCache.test.ts` pins all three outcomes directly against the
+ *  defect). `evalResultCache.test.ts` pins all three outcomes against the
  *  written artifact. */
 export function groupRunSets(trials: TrialVerdict[]): RunSet[] {
   const byKey = new Map<string, TrialVerdict[]>();
@@ -387,11 +379,10 @@ export interface RunSetDiscovery {
    *  agent. */
   set: RunSet | null;
   /** F-1404 — `kind: "root"` only, and only populated when `set` is null:
-   *  the newest run set whose outcome is `"incomplete"` (no trial failed,
-   *  but at least one was never graded). Distinct from `set` so a caller
-   *  can never conflate "route this to fix-prompt" with "tell the user
-   *  something was never graded" — the two must be named separately, or the
-   *  routing decision and the message it prints can end up disagreeing. */
+   *  the newest run set whose outcome is `"incomplete"`. Kept distinct from
+   *  `set` so a caller can never conflate "route this to fix-prompt" with
+   *  "something was never graded" — the routing decision and the message it
+   *  prints must never disagree. */
   incompleteSet: RunSet | null;
   /** Total finalized run sets seen — lets the caller distinguish "no runs
    *  at all" from "runs exist but none failed". */

--- a/cli/src/hosted/evalResultCache.ts
+++ b/cli/src/hosted/evalResultCache.ts
@@ -288,8 +288,11 @@ export async function scanVerdictArtifacts(
 // outcome that asserts an agent defect. "incomplete" = no trial failed, but
 // at least one trial's grading never finished — a grader/seed gap, not
 // evidence the agent did anything wrong; "fail" wins when a set has both,
-// since a real failure is signal worth naming over a sibling's gap. "pass" =
-// every trial's state is "pass".
+// since a real failure is signal worth naming over a sibling's gap.
+// "pass" = EVERY trial's state is exactly "pass", tested that way round on
+// purpose: "pass" is the one outcome claiming a verified result, so it is
+// never the fallthrough. An unrecognized state reads "incomplete", not green
+// (`isVerdictArtifact` already refuses such a file — second line of defense).
 export type RunSetOutcome = "fail" | "incomplete" | "pass";
 
 export interface RunSet {
@@ -334,14 +337,14 @@ export function groupRunSets(trials: TrialVerdict[]): RunSet[] {
     );
     const last = bucket[bucket.length - 1]!;
     const hasFailed = bucket.some((t) => t.verdict.state === "fail");
-    const hasIncomplete = bucket.some((t) => t.verdict.state === "incomplete");
+    const allPassed = bucket.every((t) => t.verdict.state === "pass");
     sets.push({
       groupId: bucket[0]!.verdict.group_id,
       taskName: bucket[0]!.verdict.task_name,
       taskPath: bucket[0]!.verdict.task_path,
       trials: bucket,
       latestFinalizedAt: last.verdict.finalized_at,
-      outcome: hasFailed ? "fail" : hasIncomplete ? "incomplete" : "pass",
+      outcome: hasFailed ? "fail" : allPassed ? "pass" : "incomplete",
     });
   }
   sets.sort((a, b) => a.latestFinalizedAt.localeCompare(b.latestFinalizedAt));

--- a/cli/src/hosted/evalResultCache.ts
+++ b/cli/src/hosted/evalResultCache.ts
@@ -282,6 +282,22 @@ export async function scanVerdictArtifacts(
   return (await scanVerdictArtifactsDetailed(artifactsRoot)).trials;
 }
 
+// F-1404 — the three-way verdict a run SET can carry, named the same as
+// `ScoreStatus` (the per-trial word) because it is built from that word:
+//   "fail"       — at least one trial genuinely failed (state === "fail"):
+//                  it was graded and did not satisfy a criterion. This is
+//                  the ONLY outcome that asserts an agent defect.
+//   "incomplete" — no trial failed, but at least one trial's grading never
+//                  finished (state === "incomplete"). Nothing here says the
+//                  agent did anything wrong — a criterion was never
+//                  evaluated, which is a grader/seed gap, not evidence of a
+//                  bug in the run. "fail" wins over "incomplete" when a set
+//                  has both: a trial that DID fail is real signal, and
+//                  naming it takes priority over naming the gap in a
+//                  sibling trial.
+//   "pass"       — every trial's state is "pass".
+export type RunSetOutcome = "fail" | "incomplete" | "pass";
+
 export interface RunSet {
   /** null = a single run that never had a group. */
   groupId: string | null;
@@ -291,35 +307,26 @@ export interface RunSet {
   /** Trials sorted by finalized_at ascending. */
   trials: TrialVerdict[];
   latestFinalizedAt: string;
-  anyFailed: boolean;
+  /** F-1404 — derived from the on-disk `state` (see `RunSetOutcome`), never
+   *  from `passed` alone: `passed` is false for BOTH a genuine failure and a
+   *  trial the grader never finished, so a predicate built on it can't tell
+   *  "the agent has a defect" from "something was never graded" apart. This
+   *  is the ONE computation both the routing decision (`latestFailedRunSet`
+   *  / `latestIncompleteRunSet`) and the message shown to the user read, so
+   *  they cannot disagree about what a set is. */
+  outcome: RunSetOutcome;
 }
 
 /** Group trials into run sets: trials sharing a group_id form one set; a
  *  null group_id is its own single-run set.
  *
- *  F-1392 note on `anyFailed` below: it reads `!t.verdict.passed`, which is
- *  `runTaskHosted.ts`'s `exitCode === 0` at write time — itself derived from
- *  `scoreStatus(scoreFromFinalizeResponse(finalized), passThreshold)`. Once
- *  that root predicate stopped treating a pre-satisfied `skipped` as an
- *  abstention, a trial whose only non-passing criterion is pre-satisfied gets
- *  `passed: true` on disk, so a group holding it no longer trips `anyFailed`
- *  and is no longer misrouted to `pome fix-prompt` as an agent defect. (A
- *  trial where EVERY criterion was pre-satisfied still writes `passed: false`
- *  — no denominator, no verified pass — and still routes there; what it now
- *  gets when it arrives is a prompt that names the exclusion instead of
- *  reporting it as a criterion nobody evaluated, `fix-prompt/prompt.ts`.)
- *  Nothing to change here — the fix lives upstream, and
- *  `evalResultCache.test.ts` pins the group-level behavior directly against
- *  the written artifact.
- *
- *  F-1195 note: `state` is now on the artifact, so `anyFailed` COULD read
- *  `state === "fail"` and stop routing a merely INCOMPLETE trial to
- *  `pome fix-prompt` as an agent defect. Deliberately not done here — it is
- *  not a one-liner: with no failed set, `main.ts` falls to its `!discovery.set`
- *  branch and prints "the latest run sets under runs all passed", which is
- *  false about an incomplete run and is the same defect pointed the other way.
- *  That needs a third message, so it is F-1404, not a drive-by in a ticket
- *  about what the artifact SAYS. */
+ *  F-1404 — `outcome` reads the on-disk `state` (F-1195), not `!passed`
+ *  (F-1392's finding: `!passed` is true for both a genuine failure and an
+ *  incomplete trial, so a set holding only incomplete trials used to trip
+ *  the old `anyFailed` and get handed to `pome fix-prompt` as an agent
+ *  defect — routing a grader gap as if it were proof the agent misbehaved).
+ *  `evalResultCache.test.ts` pins all three outcomes directly against the
+ *  written artifact. */
 export function groupRunSets(trials: TrialVerdict[]): RunSet[] {
   const byKey = new Map<string, TrialVerdict[]>();
   for (const trial of trials) {
@@ -334,23 +341,38 @@ export function groupRunSets(trials: TrialVerdict[]): RunSet[] {
       a.verdict.finalized_at.localeCompare(b.verdict.finalized_at),
     );
     const last = bucket[bucket.length - 1]!;
+    const hasFailed = bucket.some((t) => t.verdict.state === "fail");
+    const hasIncomplete = bucket.some((t) => t.verdict.state === "incomplete");
     sets.push({
       groupId: bucket[0]!.verdict.group_id,
       taskName: bucket[0]!.verdict.task_name,
       taskPath: bucket[0]!.verdict.task_path,
       trials: bucket,
       latestFinalizedAt: last.verdict.finalized_at,
-      anyFailed: bucket.some((t) => !t.verdict.passed),
+      outcome: hasFailed ? "fail" : hasIncomplete ? "incomplete" : "pass",
     });
   }
   sets.sort((a, b) => a.latestFinalizedAt.localeCompare(b.latestFinalizedAt));
   return sets;
 }
 
-/** The newest run set with at least one failed (completed) trial. */
+/** The newest run set with at least one genuinely FAILED (graded, not
+ *  satisfied) trial — the only outcome `pome fix-prompt` may hand to a
+ *  coding agent as an agent defect. */
 export function latestFailedRunSet(sets: RunSet[]): RunSet | null {
   for (let i = sets.length - 1; i >= 0; i -= 1) {
-    if (sets[i]!.anyFailed) return sets[i]!;
+    if (sets[i]!.outcome === "fail") return sets[i]!;
+  }
+  return null;
+}
+
+/** F-1404 — the newest run set whose worst outcome is INCOMPLETE: no trial
+ *  failed, but at least one trial's grading never finished. Callers use this
+ *  to name the gap distinctly from both "fix this" (a fail set exists) and
+ *  "nothing to fix" (every set passed) — never silently folded into either. */
+export function latestIncompleteRunSet(sets: RunSet[]): RunSet | null {
+  for (let i = sets.length - 1; i >= 0; i -= 1) {
+    if (sets[i]!.outcome === "incomplete") return sets[i]!;
   }
   return null;
 }
@@ -358,9 +380,19 @@ export function latestFailedRunSet(sets: RunSet[]): RunSet | null {
 export interface RunSetDiscovery {
   kind: "trial-dir" | "root";
   /** The set to build a fix prompt from (per `kind` semantics: a trial dir
-   *  targets ITS set regardless of outcome; a root targets the latest
-   *  FAILED set). Null when nothing matches. */
+   *  targets ITS set regardless of outcome; a root targets the latest set
+   *  whose outcome is `"fail"`). Null when nothing matches — for `kind:
+   *  "root"` that means either every set passed, or the newest non-passing
+   *  set is `incompleteSet` below rather than a failure to hand to an
+   *  agent. */
   set: RunSet | null;
+  /** F-1404 — `kind: "root"` only, and only populated when `set` is null:
+   *  the newest run set whose outcome is `"incomplete"` (no trial failed,
+   *  but at least one was never graded). Distinct from `set` so a caller
+   *  can never conflate "route this to fix-prompt" with "tell the user
+   *  something was never graded" — the two must be named separately, or the
+   *  routing decision and the message it prints can end up disagreeing. */
+  incompleteSet: RunSet | null;
   /** Total finalized run sets seen — lets the caller distinguish "no runs
    *  at all" from "runs exist but none failed". */
   totalSets: number;
@@ -376,7 +408,10 @@ export interface RunSetDiscovery {
  * Resolve what `pome fix-prompt [target]` should read.
  * - `target` = a trial run dir (has verdict.json): that trial's whole set —
  *   the user pointed at it, outcome doesn't matter.
- * - `target` = an artifacts root: the latest failed set under it.
+ * - `target` = an artifacts root: the latest set with a genuine FAILURE
+ *   under it; if none, the newest INCOMPLETE set is surfaced separately
+ *   (`incompleteSet`) so the caller can name the gap instead of either
+ *   routing it to an agent or claiming everything passed.
  */
 export async function discoverRunSet(target: string): Promise<RunSetDiscovery> {
   const anchorResult = await readVerdictArtifactDetailed(target);
@@ -385,7 +420,13 @@ export async function discoverRunSet(target: string): Promise<RunSetDiscovery> {
     // is a prior version — name it rather than falling through to the "root"
     // branch below, which would scan `target` as if it were an artifacts
     // root (two levels too shallow) and report a plain "no runs".
-    return { kind: "trial-dir", set: null, totalSets: 0, staleVersionCount: 1 };
+    return {
+      kind: "trial-dir",
+      set: null,
+      incompleteSet: null,
+      totalSets: 0,
+      staleVersionCount: 1,
+    };
   }
   if (anchorResult.status === "ok") {
     const anchor = anchorResult.trial;
@@ -406,19 +447,28 @@ export async function discoverRunSet(target: string): Promise<RunSetDiscovery> {
     return {
       kind: "trial-dir",
       set: own,
+      incompleteSet: null,
       totalSets: Math.max(sets.length, 1),
       staleVersionCount: staleVersionDirs.length,
     };
   }
 
   if (!existsSync(target)) {
-    return { kind: "root", set: null, totalSets: 0, staleVersionCount: 0 };
+    return {
+      kind: "root",
+      set: null,
+      incompleteSet: null,
+      totalSets: 0,
+      staleVersionCount: 0,
+    };
   }
   const { trials, staleVersionDirs } = await scanVerdictArtifactsDetailed(target);
   const sets = groupRunSets(trials);
+  const failedSet = latestFailedRunSet(sets);
   return {
     kind: "root",
-    set: latestFailedRunSet(sets),
+    set: failedSet,
+    incompleteSet: failedSet ? null : latestIncompleteRunSet(sets),
     totalSets: sets.length,
     staleVersionCount: staleVersionDirs.length,
   };

--- a/cli/test/unit/fix-prompt-command.test.ts
+++ b/cli/test/unit/fix-prompt-command.test.ts
@@ -7,6 +7,12 @@
 //     prompt; all-green roots print "nothing to fix" (exit 0); empty roots
 //     are a usage error (exit 5);
 //   - a trial run dir targets that set.
+//
+// F-1404 — a root whose only non-passing run set is INCOMPLETE (no trial
+// genuinely failed; something was never graded) is a THIRD outcome, distinct
+// from both "route it to fix-prompt as an agent defect" and "all passed":
+// see "an incomplete-only root ..." below. `groupRunSets`'s `outcome` is the
+// one computation both the routing decision and this wording read.
 
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -132,6 +138,7 @@ describe("pome fix-prompt command (FDRS-644)", () => {
     });
     await writeTrial(dir, "ses_2", {
       passed: false,
+      state: "fail",
       score: 50,
       finalized_at: "2026-07-06T00:02:00.000Z",
       criteria_results: [
@@ -168,6 +175,50 @@ describe("pome fix-prompt command (FDRS-644)", () => {
     expect(process.exitCode ?? 0).toBe(0);
     expect(stdout.join("\n")).toBe("");
     expect(stderr.join("\n")).toContain("Nothing to fix");
+  });
+
+  // F-1404 — the ticket's own reproduction: a root whose only non-passing
+  // run set is INCOMPLETE (a criterion was never graded, nothing genuinely
+  // failed). This must be neither routed to fix-prompt as an agent defect
+  // (the original defect) nor reported as "all passed" (the reversed
+  // defect a naive `state === "fail"` flip would produce).
+  it("an incomplete-only root names the gap distinctly (exit 1, no prompt, not 'all passed')", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fixcmd-incomplete-"));
+    await writeTrial(dir, "ses_1", {
+      passed: false,
+      state: "incomplete",
+      score: 0,
+      evaluated: 0,
+      not_evaluated: 1,
+      total: 1,
+      criteria_results: [
+        {
+          criterion: { type: "model", text: "Severity is set correctly" },
+          passed: false,
+          skipped: true,
+          reason: "tool_not_recorded",
+        },
+      ],
+    });
+    process.chdir(dir);
+
+    await run();
+    // Not routed to an agent: no prompt is printed at all.
+    expect(stdout.join("\n")).toBe("");
+    const err = stderr.join("\n");
+    // Distinct from the "all passed" wording — the reversed defect a naive
+    // `state === "fail"` flip (with no third message) would produce here.
+    expect(err).not.toContain("all passed");
+    expect(err).not.toContain("Nothing to fix:");
+    // Names the gap by kind and what to do about it, without blaming the
+    // agent's prompt.
+    expect(err).toContain("INCOMPLETE");
+    expect(err).toContain("never graded");
+    expect(err).toContain("not an agent defect");
+    expect(err).toContain("Re-run");
+    // Non-zero: there is something worth acting on, even though it isn't a
+    // fix-prompt-worthy failure.
+    expect(process.exitCode).toBe(1);
   });
 
   it("an empty root is a usage error naming what to do", async () => {

--- a/cli/test/unit/fix-prompt-command.test.ts
+++ b/cli/test/unit/fix-prompt-command.test.ts
@@ -219,6 +219,65 @@ describe("pome fix-prompt command (FDRS-644)", () => {
     // Non-zero: there is something worth acting on, even though it isn't a
     // fix-prompt-worthy failure.
     expect(process.exitCode).toBe(1);
+    // Names WHICH set, and does not call it "the latest run set" — the
+    // newest set may have passed; this one is the newest NON-PASSING one.
+    expect(err).toContain("most recent non-passing");
+    expect(err).toContain("task scn");
+  });
+
+  // F-1404 — the understating twin of the original defect. A trial's `state`
+  // is "incomplete" for ANY ungraded criterion (`scoreStatus`'s A5 guard), so
+  // an incomplete set can still hold criteria the judge DID grade and DID
+  // fail. Telling the user "a grading gap, not an agent defect" over those
+  // would state more than was checked in the opposite direction — and would
+  // silently bin real judge reasons.
+  it("an incomplete set holding GRADED failures says so instead of calling it only a grading gap", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fixcmd-incomplete-failed-"));
+    await writeTrial(dir, "ses_1", {
+      passed: false,
+      state: "incomplete",
+      score: 0,
+      evaluated: 2,
+      not_evaluated: 1,
+      total: 3,
+      criteria_results: [
+        {
+          criterion: { type: "model", text: "Severity is set correctly" },
+          passed: false,
+          skipped: false,
+          reason: "under-rated",
+        },
+        {
+          criterion: { type: "model", text: "An assignee is set" },
+          passed: false,
+          skipped: false,
+          reason: "never set",
+        },
+        {
+          criterion: { type: "model", text: "Exactly one comment" },
+          passed: false,
+          skipped: true,
+          reason: "tool_not_recorded",
+        },
+      ],
+    });
+    process.chdir(dir);
+
+    await run();
+    const err = stderr.join("\n");
+    // Still not routed (no trial was graded end to end), still exit 1, still
+    // never "all passed".
+    expect(stdout.join("\n")).toBe("");
+    expect(process.exitCode).toBe(1);
+    expect(err).not.toContain("all passed");
+    // But it must NOT absolve the agent: two criteria were graded and failed.
+    expect(err).not.toContain("not an agent defect");
+    expect(err).toContain("2 criterion result(s)");
+    expect(err).toContain("WERE graded and did fail");
+    // And it names the escape hatch that DOES build a prompt from what was
+    // graded — the trial-dir form, which targets its set whatever the outcome.
+    expect(err).toContain("pome fix-prompt");
+    expect(err).toContain(join("runs", "scn", "ses_1"));
   });
 
   it("an empty root is a usage error naming what to do", async () => {

--- a/cli/test/unit/fix-prompt-group.test.ts
+++ b/cli/test/unit/fix-prompt-group.test.ts
@@ -27,7 +27,7 @@ function result(text: string, passed: boolean, reason: string): CriterionResult 
 
 function trial(
   n: number,
-  opts: { passed: boolean; results: CriterionResult[] },
+  opts: { passed: boolean; results: CriterionResult[]; incomplete?: boolean },
 ): TrialFixInput {
   const skippedCount = opts.results.filter((r) => r.skipped).length;
   const evaluatedCount = opts.results.length - skippedCount;
@@ -43,7 +43,7 @@ function trial(
     judge_model: "test-judge",
     score: opts.passed ? 100 : 50,
     pass_threshold: 100,
-    state: opts.passed ? "pass" : "fail",
+    state: opts.incomplete ? "incomplete" : opts.passed ? "pass" : "fail",
     passed: opts.passed,
     evaluated: evaluatedCount,
     not_evaluated: skippedCount,
@@ -270,6 +270,105 @@ describe("run-set fix prompt (FDRS-644)", () => {
     expect(prompt).not.toContain(
       `passed in every completed trial: "${CRITERIA.comment}"`,
     );
+  });
+
+  // F-1404 — a set reaches this builder holding an INCOMPLETE trial two ways:
+  // "fail wins over incomplete" routes a mixed set here, and a trial dir the
+  // user points at directly targets its set whatever the outcome. Either way
+  // the prompt is handed to a coding agent as grounds for a fix, so it may not
+  // state anything about the ungraded trial that the grading never checked.
+  describe("an INCOMPLETE trial in the set (F-1404)", () => {
+    const ungraded: CriterionResult = {
+      criterion: { type: "model", text: CRITERIA.comment },
+      passed: false,
+      skipped: true,
+      reason: "tool_not_recorded",
+    };
+
+    function mixedWithIncomplete(): TrialFixInput[] {
+      return [
+        trial(1, {
+          passed: false,
+          results: [result(CRITERIA.severity, false, "under-rated")],
+        }),
+        trial(2, {
+          passed: false,
+          incomplete: true,
+          results: [ungraded],
+        }),
+      ];
+    }
+
+    it("is never listed as a failing trial, nor counted as a non-pass", () => {
+      const prompt = buildGroupFixUserPrompt({
+        taskName: "scn",
+        groupId: "grp_test",
+        task,
+        trials: mixedWithIncomplete(),
+      });
+      // The denominator is the GRADED trials — trial 2 was never graded, so
+      // "0 of 2 completed trials passed" would charge it as a loss.
+      expect(prompt).toContain("0 of 1 completed trials passed");
+      expect(prompt).not.toContain("of 2 completed trials passed");
+      // The old output said `trial 2 · ses_2 — failed: (see verdict)`.
+      expect(prompt).not.toContain("## Other failing trials");
+      expect(prompt).not.toContain("trial 2 · ses_2 — failed");
+    });
+
+    it("gets its own named section saying no claim is made about it", () => {
+      const prompt = buildGroupFixUserPrompt({
+        taskName: "scn",
+        groupId: "grp_test",
+        task,
+        trials: mixedWithIncomplete(),
+      });
+      expect(prompt).toContain("· 1 INCOMPLETE");
+      expect(prompt).toContain("## Trials the grader never finished (INCOMPLETE)");
+      expect(prompt).toContain("neither\npasses nor failures");
+      expect(prompt).toContain("trial 2 · ses_2 — 1 criterion(s) never graded");
+      expect(prompt).toContain("runs/scn/ses_2/events.jsonl");
+    });
+
+    it("never anchors the representative trace on an ungraded trial", () => {
+      // The incomplete trial holds a graded FAILURE too, and comes first — the
+      // old `!passed` predicate made it eligible, and the tie on failed-count
+      // handed it the "most-failing trial" heading.
+      const trials = [
+        trial(1, {
+          passed: false,
+          incomplete: true,
+          results: [result(CRITERIA.severity, false, "under-rated"), ungraded],
+        }),
+        trial(2, {
+          passed: false,
+          results: [result(CRITERIA.severity, false, "under-rated too")],
+        }),
+      ];
+      expect(representativeFailingTrial(trials)?.label).toBe("trial 2 · ses_2");
+      const prompt = buildGroupFixUserPrompt({
+        taskName: "scn",
+        groupId: "grp_test",
+        task,
+        trials,
+      });
+      expect(prompt).toContain("## Trace of the most-failing trial (trial 2 · ses_2)");
+      // Per-criterion denominator is the trials that GRADED it (both here) —
+      // never a count that can exceed the number of hits.
+      expect(prompt).toContain(`${CRITERIA.severity} — failed in 2 of 2 trials that graded it`);
+    });
+
+    it("an all-incomplete set claims no fraction at all (no 0-of-0)", () => {
+      const prompt = buildGroupFixUserPrompt({
+        taskName: "scn",
+        groupId: null,
+        task,
+        trials: [trial(1, { passed: false, incomplete: true, results: [ungraded] })],
+      });
+      expect(prompt).toContain("no trial in this set was graded end to end");
+      expect(prompt).not.toContain("0 of 0");
+      expect(prompt).not.toContain("## Trace of the most-failing trial");
+      expect(prompt).toContain("## Trials the grader never finished (INCOMPLETE)");
+    });
   });
 
   it("flattens hostile judge reasons — no markdown-heading injection (adversarial fix)", () => {

--- a/cli/test/unit/hosted/evalResultCache.test.ts
+++ b/cli/test/unit/hosted/evalResultCache.test.ts
@@ -358,6 +358,27 @@ describe("verdict artifact (FDRS-644)", () => {
     expect(latestIncompleteRunSet(sets)).toBeNull();
   });
 
+  // F-1404 — "pass" is the one outcome that asserts a verified result, so it
+  // must never be what an unrecognized `state` falls through to. The read path
+  // already refuses such a file (`isVerdictArtifact` checks `state` against
+  // the three words), so this pins the SECOND line of defense: a `state` this
+  // build does not know reads "incomplete", the claim that checks least — an
+  // ungraded run must not become an invisible one.
+  it("groupRunSets never reports an unrecognized state as a pass", () => {
+    const sets = groupRunSets([
+      {
+        runDir: "x1",
+        verdict: verdict({
+          group_id: "grp_x",
+          session_id: "x1",
+          state: "who-knows" as never,
+        }),
+      },
+    ]);
+    expect(sets[0]!.outcome).toBe("incomplete");
+    expect(latestFailedRunSet(sets)).toBeNull();
+  });
+
   it("discoverRunSet(root): latest failed set; all-green roots return set=null with totalSets>0", async () => {
     const tmp = await mkdtemp(join(tmpdir(), "verdict-root-"));
     await writeTrial(tmp, "scn", "g1", { group_id: "grp_g", finalized_at: "2026-07-06T05:00:00Z" });

--- a/cli/test/unit/hosted/evalResultCache.test.ts
+++ b/cli/test/unit/hosted/evalResultCache.test.ts
@@ -3,6 +3,11 @@
 // roundtrip, the two-level scan, run-set grouping, latest-FAILED selection,
 // and the fix-prompt discovery semantics (trial dir → its set regardless of
 // outcome; root → latest failed set). Foreign/corrupt files never throw.
+//
+// F-1404 — `outcome` (fail / incomplete / pass) is derived from the on-disk
+// `state`, not `!passed`: `passed` alone can't tell a genuine failure apart
+// from a trial the grader never finished, and both used to trip the old
+// `anyFailed` boolean the same way.
 
 import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -13,6 +18,7 @@ import {
   discoverRunSet,
   groupRunSets,
   latestFailedRunSet,
+  latestIncompleteRunSet,
   loadTrialEvents,
   readVerdictArtifact,
   readVerdictArtifactDetailed,
@@ -209,32 +215,34 @@ describe("verdict artifact (FDRS-644)", () => {
       // group A: newer, all passed
       { runDir: "a1", verdict: verdict({ group_id: "grp_a", session_id: "a1", finalized_at: "2026-07-06T03:00:00Z" }) },
       { runDir: "a2", verdict: verdict({ group_id: "grp_a", session_id: "a2", finalized_at: "2026-07-06T03:01:00Z" }) },
-      // group B: older, one failed
+      // group B: older, one genuinely failed
       { runDir: "b1", verdict: verdict({ group_id: "grp_b", session_id: "b1", finalized_at: "2026-07-06T01:00:00Z" }) },
-      { runDir: "b2", verdict: verdict({ group_id: "grp_b", session_id: "b2", passed: false, score: 40, finalized_at: "2026-07-06T01:01:00Z" }) },
+      { runDir: "b2", verdict: verdict({ group_id: "grp_b", session_id: "b2", passed: false, state: "fail", score: 40, finalized_at: "2026-07-06T01:01:00Z" }) },
       // solo run, failed, oldest
-      { runDir: "s1", verdict: verdict({ session_id: "s1", passed: false, finalized_at: "2026-07-06T00:00:00Z" }) },
+      { runDir: "s1", verdict: verdict({ session_id: "s1", passed: false, state: "fail", finalized_at: "2026-07-06T00:00:00Z" }) },
     ];
     const sets = groupRunSets(trials);
     expect(sets).toHaveLength(3);
     // Sorted by latest finalize ascending; trials inside sorted ascending.
     expect(sets.map((s) => s.groupId)).toEqual([null, "grp_b", "grp_a"]);
-    expect(sets[2]!.anyFailed).toBe(false);
-    expect(sets[1]!.anyFailed).toBe(true);
+    expect(sets[2]!.outcome).toBe("pass");
+    expect(sets[1]!.outcome).toBe("fail");
     expect(sets[1]!.trials.map((t) => t.verdict.session_id)).toEqual(["b1", "b2"]);
 
     // Latest FAILED ≠ latest overall: grp_a is newest but green.
     expect(latestFailedRunSet(sets)?.groupId).toBe("grp_b");
+    // No set is incomplete-only in this table.
+    expect(latestIncompleteRunSet(sets)).toBeNull();
   });
 
-  // F-1392 — `anyFailed` reads `!t.verdict.passed`, so a group holding a
-  // trial whose only non-passing criterion was pre-satisfied must NOT trip
-  // `anyFailed`, or it gets misrouted to `pome fix-prompt` as an agent
-  // defect. This is resolved upstream in `scoreFromFinalizeResponse` (the
-  // trial's `passed` is written correctly at verdict.json write time); this
-  // test pins the group-level behavior against the artifact directly rather
-  // than re-deriving it.
-  it("a group holding a pre-satisfied-only trial (passed: true) is NOT anyFailed", async () => {
+  // F-1392 — the old `anyFailed` read `!t.verdict.passed`, so a group holding
+  // a trial whose only non-passing criterion was pre-satisfied must NOT trip
+  // it, or it gets misrouted to `pome fix-prompt` as an agent defect. This is
+  // resolved upstream in `scoreFromFinalizeResponse` (the trial's `passed`
+  // and `state` are written correctly at verdict.json write time); this test
+  // pins the group-level behavior against the artifact directly rather than
+  // re-deriving it.
+  it("a group holding a pre-satisfied-only trial (state: pass) has outcome pass, not fail", async () => {
     const trials = [
       {
         runDir: "p1",
@@ -242,6 +250,7 @@ describe("verdict artifact (FDRS-644)", () => {
           group_id: "grp_p",
           session_id: "p1",
           passed: true,
+          state: "pass",
           criteria_results: [
             {
               criterion: { type: "code", text: "github.no-new-issues" },
@@ -260,24 +269,120 @@ describe("verdict artifact (FDRS-644)", () => {
     ];
     const sets = groupRunSets(trials);
     expect(sets).toHaveLength(1);
-    expect(sets[0]!.anyFailed).toBe(false);
+    expect(sets[0]!.outcome).toBe("pass");
+  });
+
+  // F-1404 — the defect as filed: a set holding ONLY an incomplete trial (no
+  // trial genuinely failed) must not read as `outcome: "fail"`. Both trials
+  // here have `passed: false` (the old, wrong signal) but neither has
+  // `state: "fail"` — this is the exact shape `!t.verdict.passed` could not
+  // tell apart from group B above.
+  it("a group whose only non-passing trials are INCOMPLETE has outcome incomplete, not fail", async () => {
+    const trials = [
+      {
+        runDir: "i1",
+        verdict: verdict({
+          group_id: "grp_i",
+          session_id: "i1",
+          passed: false,
+          state: "incomplete",
+          score: 0,
+          evaluated: 0,
+          not_evaluated: 1,
+          total: 1,
+          finalized_at: "2026-08-10T01:00:00Z",
+        }),
+      },
+      {
+        runDir: "i2",
+        verdict: verdict({
+          group_id: "grp_i",
+          session_id: "i2",
+          passed: false,
+          state: "incomplete",
+          score: 0,
+          evaluated: 0,
+          not_evaluated: 1,
+          total: 1,
+          finalized_at: "2026-08-10T01:01:00Z",
+        }),
+      },
+    ];
+    const sets = groupRunSets(trials);
+    expect(sets).toHaveLength(1);
+    expect(sets[0]!.outcome).toBe("incomplete");
+    // The reversed defect, pinned directly: an incomplete-only set must
+    // never be picked up as the latest FAILED set either.
+    expect(latestFailedRunSet(sets)).toBeNull();
+    expect(latestIncompleteRunSet(sets)?.groupId).toBe("grp_i");
+  });
+
+  // F-1404 — a set mixing a genuine failure with an incomplete trial: the
+  // failure is real signal and must win. `fix-prompt` should still be told
+  // there is something to fix here, not that the set merely has a grading
+  // gap.
+  it("a group mixing a genuine failure and an incomplete trial has outcome fail (fail wins)", async () => {
+    const trials = [
+      {
+        runDir: "m1",
+        verdict: verdict({
+          group_id: "grp_m",
+          session_id: "m1",
+          passed: false,
+          state: "fail",
+          score: 0,
+          finalized_at: "2026-08-10T02:00:00Z",
+        }),
+      },
+      {
+        runDir: "m2",
+        verdict: verdict({
+          group_id: "grp_m",
+          session_id: "m2",
+          passed: false,
+          state: "incomplete",
+          score: 0,
+          evaluated: 0,
+          not_evaluated: 1,
+          total: 1,
+          finalized_at: "2026-08-10T02:01:00Z",
+        }),
+      },
+    ];
+    const sets = groupRunSets(trials);
+    expect(sets).toHaveLength(1);
+    expect(sets[0]!.outcome).toBe("fail");
+    expect(latestFailedRunSet(sets)?.groupId).toBe("grp_m");
+    // A set already counted as failed is never ALSO reported as the latest
+    // incomplete one — that would be the same set under two names.
+    expect(latestIncompleteRunSet(sets)).toBeNull();
   });
 
   it("discoverRunSet(root): latest failed set; all-green roots return set=null with totalSets>0", async () => {
     const tmp = await mkdtemp(join(tmpdir(), "verdict-root-"));
     await writeTrial(tmp, "scn", "g1", { group_id: "grp_g", finalized_at: "2026-07-06T05:00:00Z" });
-    await writeTrial(tmp, "scn", "f1", { group_id: "grp_f", passed: false, score: 0, finalized_at: "2026-07-06T04:00:00Z" });
+    await writeTrial(tmp, "scn", "f1", {
+      group_id: "grp_f",
+      passed: false,
+      state: "fail",
+      score: 0,
+      finalized_at: "2026-07-06T04:00:00Z",
+    });
 
     const d = await discoverRunSet(tmp);
     expect(d.kind).toBe("root");
     expect(d.totalSets).toBe(2);
     expect(d.set?.groupId).toBe("grp_f");
+    // A genuine failure exists, so the incomplete slot stays empty even
+    // though nothing else checked for an incomplete set here.
+    expect(d.incompleteSet).toBeNull();
 
     const green = await mkdtemp(join(tmpdir(), "verdict-green-"));
     await writeTrial(green, "scn", "g2", { group_id: "grp_h" });
     const dg = await discoverRunSet(green);
     expect(dg.totalSets).toBe(1);
     expect(dg.set).toBeNull();
+    expect(dg.incompleteSet).toBeNull();
 
     const empty = await mkdtemp(join(tmpdir(), "verdict-empty-"));
     const de = await discoverRunSet(empty);
@@ -286,6 +391,29 @@ describe("verdict artifact (FDRS-644)", () => {
 
     const missing = await discoverRunSet(join(empty, "nope"));
     expect(missing.totalSets).toBe(0);
+  });
+
+  // F-1404 — the root-level shape the ticket names directly: a root whose
+  // only non-passing run set is INCOMPLETE. `set` must stay null (nothing
+  // here is proven to be the agent's fault) and `incompleteSet` must name
+  // the gap instead of the caller falling back to "all passed".
+  it("discoverRunSet(root): an incomplete-only root surfaces incompleteSet, not set", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "verdict-incomplete-root-"));
+    await writeTrial(tmp, "scn", "i1", {
+      group_id: "grp_i",
+      passed: false,
+      state: "incomplete",
+      score: 0,
+      evaluated: 0,
+      not_evaluated: 1,
+      total: 1,
+      finalized_at: "2026-08-10T01:00:00Z",
+    });
+
+    const d = await discoverRunSet(tmp);
+    expect(d.kind).toBe("root");
+    expect(d.set).toBeNull();
+    expect(d.incompleteSet?.groupId).toBe("grp_i");
   });
 
   it("discoverRunSet(trial dir): that trial's whole set, even when it passed", async () => {
@@ -448,6 +576,7 @@ describe("verdict artifact (FDRS-644)", () => {
       await writeTrial(tmp, "scn", "ses_current", {
         group_id: "grp_mixed",
         passed: false,
+        state: "fail",
       });
       const staleDir = join(tmp, "scn", "ses_v1");
       await mkdir(staleDir, { recursive: true });


### PR DESCRIPTION
## Problem

`groupRunSets` in `cli/src/hosted/evalResultCache.ts` computed a run set's `anyFailed` as `bucket.some((t) => !t.verdict.passed)`. `passed` is false both for a genuine failure and for an INCOMPLETE trial (one the grader never finished), so a `runs/` whose only non-passing trials were incomplete tripped `anyFailed` the same way a real failure would. `latestFailedRunSet` then picked that set, and `pome fix-prompt` handed it to the user's coding agent as an agent defect — asserting something (a bug in the agent's work) that was never established. What actually happened was a criterion nobody graded: a grader/seed gap, not evidence of anything wrong with the run.

Flipping the predicate to `state === "fail"` (the field F-1195 added to `verdict.json`) isn't enough on its own: with no failed set, `main.ts`'s existing `!discovery.set` branch prints "the latest run sets under runs all passed," which is false about an incomplete run — the same class of defect, pointed the other way.

## Fix

`RunSet` now carries a three-way `outcome: "fail" | "incomplete" | "pass"`, derived from the on-disk `verdict.state` instead of `passed`:
- `"fail"` — at least one trial genuinely failed (graded, unsatisfied). The only outcome that asserts an agent defect.
- `"incomplete"` — no trial failed, but at least one trial's grading never finished. `"fail"` wins when a set has both, since a real failure is signal worth naming over a sibling's gap.
- `"pass"` — EVERY trial's state is exactly `"pass"`, tested that way round rather than as the fallthrough, so a `state` this build does not recognize reads `incomplete` instead of being asserted green.

`discoverRunSet` resolves the newest failed set first; if none exists, it separately surfaces the newest incomplete-only set as `incompleteSet` rather than folding it into "nothing found." `pome fix-prompt`'s root mode now has a third message for that case (exit code 1, no prompt printed). Pointing `fix-prompt` directly at a trial directory is unchanged — it still targets that trial's whole set regardless of outcome, since the user pointed at it.

### Routing was only half of it — the prompt itself was still reading `passed`

Routing fixed *which* sets reach `fix-prompt`. Three surfaces downstream still partitioned trials on `verdict.passed`, which cannot tell a graded failure from an ungraded trial. Two paths put an INCOMPLETE trial in front of them: the "fail wins" mixed set, and a trial dir the user points at directly. In both, the prompt handed to a coding agent as grounds for a fix:

- listed the ungraded trial under **`## Other failing trials`** as `failed: (see verdict)`;
- counted it as a non-pass in a fraction labelled **"completed trials"** (`0 of 2 completed trials passed` for one failure and one ungraded trial);
- let it win the **`## Trace of the most-failing trial`** heading that anchors the prompt's single trace, since `representativeFailingTrial` filtered on `!passed` and ties go to the first trial.

Every fraction is now over graded trials only; per-criterion counts read `failed in N of M trials that graded it` (the old denominator was the trial count, which a set holding an incomplete trial could make *smaller than its own numerator*); a set with nothing graded end to end says so instead of printing `0 of 0 completed trials passed`; and the ungraded trials get their own closing section stating that no pass and no failure is claimed for them.

### The new root message was overstating in the other direction

A trial's `state` is `incomplete` for **any** ungraded criterion (`scoreStatus`'s A5 guard outranks everything else), so an incomplete set can still hold criteria the judge *did* grade and *did* fail. Telling the user "a grader/seed gap, not an agent defect" over those understates exactly as badly as the original misroute overstated, and bins real judge reasons silently. The message now counts the graded failures, says they are real, and points at the trial-dir form when you want a prompt built from the part that was graded. It also no longer calls the set "the latest run set" — `latestIncompleteRunSet` scans for an outcome, not for the newest set, so a newer set may have passed — and it names which task it means.

### Exit codes

Ruled explicitly rather than left implicit. `fix-prompt`'s `1` is *only ever* the incomplete case: building a prompt for a failed set exits `0` (stdout is the signal), an all-green root exits `0`, usage errors and unreadable roots exit `5`. So `1` does not collide with "your agent failed" inside this command, and it agrees with `pome run`, where `1` also covers INCOMPLETE and the README already documents the cost and names `verdict.json`'s `state` as the machine-readable discriminator. Introducing a distinct code here would make the two commands disagree about what an ungraded run exits. `cli/README.md` now writes the contract down.

Bumps `@pome-sh/cli` to 0.23.5.

## How verified

- `cli/test/unit/hosted/evalResultCache.test.ts` covers all three `outcome` values (fail-only, incomplete-only, mixed fail+incomplete, all-pass), `discoverRunSet`'s `set`/`incompleteSet` split, and that an unrecognized `state` reads `incomplete` rather than `pass`.
- `cli/test/unit/fix-prompt-command.test.ts` drives an incomplete-only `runs/` through the actual command (no prompt, exit 1, names INCOMPLETE/never graded/not an agent defect/re-run, never "all passed"), plus a second root whose incomplete set holds two graded failures — asserting the message does *not* say "not an agent defect" there and does name the trial-dir escape hatch.
- `cli/test/unit/fix-prompt-group.test.ts` adds an `INCOMPLETE`-in-the-set block: never listed as failing, never counted in the denominator, never the representative trace, its own named section, and no `0 of 0` for an all-incomplete set.
- Verified empirically with direct file edits (never `git stash`): reverted the `outcome` fallthrough to `"pass"`, the prompt partition to `!passed`, and the graded-failure branch in `main.ts`, one at a time — confirmed 3, 3 and 1 tests went red respectively, then restored and confirmed green.
- Gates run serially, one at a time: `npm run typecheck -w cli`, `npm run lint:code-health`, `gate:no-eval`, `lint:no-catch`, `lint:parent-vocab`, `lint:legacy-markers`, `lint:copy-markers`, `node scripts/ci/check-version-bump-required.mjs <merge-base>`, `npm run lint:dead-code` (knip), and the full cli vitest suite (108 files / 1094 tests). All green.

## Not in this PR

`cli/test/unit/hosted/cross-surface-agreement.test.ts` still records the all-seed-pre-satisfied divergence (CLI `incomplete` vs dashboard `fail`) as a divergence. pome-cloud PR #632 (F-1399) would close it, but it is still **open** — `mergedAt: null`, and no F-1399 commit on pome-cloud `origin/main`. Updating this file now would assert a behavior that is not on main yet, which is the same defect in the other direction, so it stays as-is and follows #632.
