### PR TITLE
The CLI stops asserting a run-state divergence F-1399 closed (F-1413)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,21 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.23.6
+
+### Patch Changes
+
+- `cross-surface-agreement.test.ts`'s transcription of the dashboard's
+  run-state predicate no longer asserts a shape pome-cloud PR #632 (F-1399)
+  retired (F-1413). pome-cloud moved the incomplete-run arithmetic into
+  `@pome-cloud/contract`'s `isIncompleteTally`, which adds an
+  `evaluated === 0` clause: a run whose every criterion was excluded as
+  already true in the seed now reads `incomplete` on the dashboard instead
+  of `fail`, matching the word the CLI already used. The transcription's
+  seed-excluded row is updated to `incomplete`, its `divergence` marker is
+  gone, and the "exactly one known divergence" assertion is now a
+  zero-divergence guard. Test-only; no runtime behavior changes.
+
 ## 0.23.5
 
 ### Patch Changes

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,16 +8,31 @@ packaging restructure: bump `version` here and in `package.json`, and merging to
 
 ### Patch Changes
 
-- `cross-surface-agreement.test.ts`'s transcription of the dashboard's
-  run-state predicate no longer asserts a shape pome-cloud PR #632 (F-1399)
-  retired (F-1413). pome-cloud moved the incomplete-run arithmetic into
-  `@pome-cloud/contract`'s `isIncompleteTally`, which adds an
-  `evaluated === 0` clause: a run whose every criterion was excluded as
-  already true in the seed now reads `incomplete` on the dashboard instead
-  of `fail`, matching the word the CLI already used. The transcription's
-  seed-excluded row is updated to `incomplete`, its `divergence` marker is
-  gone, and the "exactly one known divergence" assertion is now a
-  zero-divergence guard. Test-only; no runtime behavior changes.
+- The CLI's copies of the dashboard's run-state predicate no longer assert a
+  shape pome-cloud PR #632 (F-1399) retired (F-1413). pome-cloud moved the
+  incomplete-run arithmetic into `@pome-cloud/contract`'s `isIncompleteTally`,
+  which adds an `evaluated === 0` clause: a run whose every criterion was
+  excluded as already true in the seed now reads `incomplete` on the dashboard
+  instead of `fail`, matching the word the CLI already used.
+  `cross-surface-agreement.test.ts`'s transcription is updated clause by
+  clause, its seed-excluded row is `incomplete` with no `divergence` marker,
+  and "exactly one known divergence" is now a zero-divergence guard.
+- Four other places in the CLI asserted the retired behaviour in prose and
+  stayed green while doing it — `scoreStatus`'s comment in
+  `evalResultView.ts` (which claimed the dashboard "renders FAILED"),
+  `VerdictArtifact.state`'s doc, and comments in `incompleteVerdict.test.ts`
+  and `uploadAndFinalize.test.ts` (F-1413). Claims about pome-cloud's
+  run-state behaviour are now stated once, in `evalResultView.ts`, and
+  pointed at from the rest instead of restated — a restated claim about
+  another repo is one that goes false on its own.
+- `isIncompleteTally`'s first clause (`total === 0` is never `incomplete`) is
+  transcribed but was reachable by no row in the table, so deleting it left
+  every test green; it now has its own assertions, alongside why the CLI's
+  `incomplete` for the same wire shape is the A5 guard rather than a
+  cross-surface divergence. The row lookup in the artifact test no longer
+  selects by `divergence` marker, which returned `undefined` the moment the
+  divergence was closed.
+- Test- and comment-only; no runtime behavior changes.
 
 ## 0.23.5
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.23.5",
+  "version": "0.23.6",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/cli/src/hosted/evalResultCache.ts
+++ b/cli/src/hosted/evalResultCache.ts
@@ -80,17 +80,21 @@ export interface VerdictArtifact {
    *  It is the word the TERMINAL prints, always — one local, one derivation.
    *  It is the word the DASHBOARD renders (`deriveRunStatus`, pome-cloud
    *  `apps/dashboard/src/lib/run-status.ts`) on the same three words and on
-   *  every shape `cross-surface-agreement.test.ts` walks EXCEPT two, named
+   *  every shape `cross-surface-agreement.test.ts` walks EXCEPT one, named
    *  here rather than left for a reader to discover from a mismatch:
-   *    - a run whose criteria were ALL pre-satisfied: `incomplete` here (no
-   *      denominator, so no verified pass — the A5 guard), `fail` on the
-   *      dashboard, which exempts every abstention and then reads a
-   *      satisfaction of 0 off an empty denominator. Neither passes it and
-   *      both exit non-zero; filed as F-1399 against pome-cloud.
    *    - a task whose `pass_threshold` is not 100: the dashboard's pass bar
    *      is a hard `satisfaction_score === 100` and it has no field to learn
    *      the task's threshold from. `pass_threshold` is in this artifact
-   *      beside `state` precisely so a reader can see which bar was used. */
+   *      beside `state` precisely so a reader can see which bar was used.
+   *
+   *  F-1399 closed the other one: a run whose criteria were ALL pre-satisfied
+   *  used to read `incomplete` here (no denominator, so no verified pass —
+   *  the A5 guard) against `fail` on the dashboard, which exempted every
+   *  abstention and then read a satisfaction of 0 off an empty denominator.
+   *  Neither passed it and both exited non-zero, so no CI caller could act on
+   *  the difference — but pome-cloud's shared `isIncompleteTally` (`@pome-
+   *  cloud/contract`) now adds an `evaluated === 0` clause, so the dashboard
+   *  reads `incomplete` here too. */
   state: ScoreStatus;
   passed: boolean;
   /** F-1195 — `EvaluationCounts` from `evalResultView.ts`, so `score` is

--- a/cli/src/hosted/evalResultCache.ts
+++ b/cli/src/hosted/evalResultCache.ts
@@ -89,12 +89,12 @@ export interface VerdictArtifact {
    *
    *  F-1399 closed the other one: a run whose criteria were ALL pre-satisfied
    *  used to read `incomplete` here (no denominator, so no verified pass —
-   *  the A5 guard) against `fail` on the dashboard, which exempted every
-   *  abstention and then read a satisfaction of 0 off an empty denominator.
-   *  Neither passed it and both exited non-zero, so no CI caller could act on
-   *  the difference — but pome-cloud's shared `isIncompleteTally` (`@pome-
-   *  cloud/contract`) now adds an `evaluated === 0` clause, so the dashboard
-   *  reads `incomplete` here too. */
+   *  the A5 guard) against `fail` on the dashboard. pome-cloud's shared
+   *  incomplete-run predicate now adds an `evaluated === 0` clause, so both
+   *  surfaces say `incomplete`. The reasoning is in `evalResultView.ts`'s
+   *  `scoreStatus` comment and stated only there: one place to correct when
+   *  pome-cloud changes this again, rather than four that go false
+   *  independently (F-1413). */
   state: ScoreStatus;
   passed: boolean;
   /** F-1195 — `EvaluationCounts` from `evalResultView.ts`, so `score` is

--- a/cli/src/hosted/evalResultView.ts
+++ b/cli/src/hosted/evalResultView.ts
@@ -143,32 +143,39 @@ export type ScoreStatus = "pass" | "fail" | "incomplete";
 // criterion the seed already satisfied (`PRE_SATISFIED_REASON` above) —
 // `uploadAndFinalize.ts`'s `scoreFromFinalizeResponse` subtracts
 // `preSatisfied` out of the `skipped` tally before deciding `can_pass`, and
-// pome-cloud's `isRunIncomplete` subtracts the same `preSatisfied` count out
-// of `notEvaluated` over the same `criteria_results`
-// (apps/dashboard/src/lib/run-status.ts). F-1392 — the CLI used to count
-// every `skipped` result with no exemption, which called a run INCOMPLETE
-// that the dashboard called PASS. ANY OTHER skipped reason, and every
-// `errored`, still fails this guard — only the one named exemption is
+// pome-cloud subtracts the same `preSatisfied` count out of `notEvaluated`
+// over the same `criteria_results`. Since F-1399 that subtraction lives in
+// `@pome-cloud/contract`'s `isIncompleteTally`, which the dashboard's
+// `isRunIncomplete` (apps/dashboard/src/lib/run-status.ts) and the markdown
+// report both CALL rather than each keeping a copy of. F-1392 — the CLI used
+// to count every `skipped` result with no exemption, which called a run
+// INCOMPLETE that the dashboard called PASS. ANY OTHER skipped reason, and
+// every `errored`, still fails this guard — only the one named exemption is
 // narrowed. Deliberately NOT read from the wire's `all_skipped`, which is the
 // narrower every-abstained predicate and would loosen this guard.
 //
-// The one input the two surfaces still word differently, stated so nobody
-// reads the paragraph above as more agreement than there is: a run whose
-// criteria are ALL pre-satisfied (nothing passed, nothing failed, so no
-// denominator). Here it is `incomplete` — `evaluated` is false and the A5
-// guard predates and outranks this exemption. On the dashboard
-// `isRunIncomplete` is false (every abstention is exempt) and
-// `deriveRunStatus` falls through to `satisfaction_score === 100`, which is 0
-// for an empty denominator (`score-merge.ts`), so it renders FAILED while its
-// own `verdictLine` says "nothing was at risk". The two surfaces agree on the
-// only thing a CI caller can act on — neither passes it, both exit non-zero —
-// and disagree on the word. Filed as F-1399 against pome-cloud rather than
-// papered over here: calling it `fail` locally would blame the agent for a run in which
-// nothing was ever at risk, which is the F-925 inversion pointed the other
-// way. `runScoreLine` names this state explicitly instead of printing "0 of N
-// criteria not evaluated".
-// `cross-surface-agreement.test.ts` walks both predicates over one table of
-// wire fixtures so this paragraph cannot quietly stop being true.
+// The all-pre-satisfied run — nothing passed, nothing failed, so no
+// denominator — is `incomplete` here: `evaluated` is false and the A5 guard
+// predates and outranks the exemption. Calling it `fail` locally would blame
+// the agent for a run in which nothing was ever at risk, which is the F-925
+// inversion pointed the other way. `runScoreLine` names this state explicitly
+// instead of printing "0 of N criteria not evaluated".
+//
+// F-1399 — the dashboard used to answer that same run `fail`, and this
+// paragraph used to say so at length. `isIncompleteTally`'s third clause
+// (`evaluated === 0`) closed it: both surfaces read it `incomplete` now, and
+// the last shape they still word differently is a task whose `passThreshold`
+// is not 100 (the dashboard's bar is a hard `satisfaction_score === 100` and
+// it has no field to learn the task's threshold from).
+//
+// F-1413 is what the correction cost, and is why the prose is here and not
+// also somewhere else: pome-cloud shipped the fix and every copy of the old
+// claim in this repo went false while staying green.
+// `cross-surface-agreement.test.ts` pins the two PREDICATES row by row, which
+// is what keeps the arithmetic honest — but it cannot pin a sentence. So
+// claims about pome-cloud's run-state behaviour are stated ONCE, here, and
+// pointed at from the tests and from `VerdictArtifact.state`'s doc rather
+// than restated in each.
 export function scoreStatus(score: Score, passThreshold: number): ScoreStatus {
   if (!score.evaluated || !score.can_pass) return "incomplete";
   return score.satisfaction >= passThreshold ? "pass" : "fail";
@@ -271,7 +278,7 @@ export function runScoreLine(
     //
     // F-1392 — `preSatisfied` criteria are named APART from the abstentions
     // instead of folded into "not evaluated", the way the dashboard's
-    // `verdictLine` does (run-status.ts:173-199): a pre-satisfied criterion
+    // `verdictLine` does (run-status.ts:174-206): a pre-satisfied criterion
     // reached a verdict (the grader wasn't gapped), it just tested nothing.
     const { notEvaluated: unreached, total } = evaluationCounts(score);
     // The all-excluded run: nothing passed, nothing failed, and every

--- a/cli/test/unit/hosted/cross-surface-agreement.test.ts
+++ b/cli/test/unit/hosted/cross-surface-agreement.test.ts
@@ -222,6 +222,20 @@ const table: Row[] = [
   },
 ];
 
+/** Tracked-by-name lookup for the tests below that single a row out.
+ *
+ *  Not `table.find((r) => r.divergence)`: that predicate selected the row only
+ *  while the row was MARKED as a divergence, so closing the divergence handed
+ *  its caller `undefined` and the test kept passing on a `!`-asserted ghost
+ *  (F-1413). Renaming a row must red with a readable message instead. */
+function rowNamed(name: string): Row {
+  const row = table.find((r) => r.name === name);
+  if (row === undefined) {
+    throw new Error(`no table row named "${name}" — a test below tracks it by name`);
+  }
+  return row;
+}
+
 describe("CLI and dashboard answer `what state is this run in?` the same way (F-1392)", () => {
   for (const row of table) {
     const label = row.divergence ? `${row.name} [known divergence]` : row.name;
@@ -237,6 +251,40 @@ describe("CLI and dashboard answer `what state is this run in?` the same way (F-
       );
     });
   }
+
+  // ── isIncompleteTally's FIRST clause, which no row above reaches ─────────
+  //
+  // `total === 0 ⇒ never incomplete` is transcribed above as the `total > 0 &&`
+  // conjunct, and every row in the table has criteria, so nothing exercises
+  // it: delete that conjunct and the whole table stays green. A transcribed
+  // clause with no assertion on it is this file's own defect one level down,
+  // so it gets assertions here.
+  //
+  // It is NOT a table row because the table's third assertion — the two
+  // surfaces never split on `passed` — is false for this input at
+  // satisfaction 100, and that is not a divergence to mark. It is a shape only
+  // ONE surface can be asked about. `taskSchema` (`src/task/taskSchema.ts`:
+  // `criteria: z.array(criterionSchema).min(1)`) refuses a task carrying no
+  // criteria, so a hosted `pome run` always has criteria for /finalize to
+  // answer about; an empty `criteria_results` arriving at the CLI means the
+  // grader returned nothing for criteria that DO exist, which is precisely
+  // what the A5 guard is for. pome-cloud's clause 1 exists for rows the CLI
+  // never produces — a replay run (`replay-run.ts` writes `criteriaResults:
+  // []` by construction and encodes the finding in the score itself) and a
+  // production run not yet scored by online eval.
+  describe("a run that recorded no criteria at all (isIncompleteTally clause 1)", () => {
+    it("is never `incomplete` on the dashboard — it falls through to the score", () => {
+      expect(dashboardRunStatus([], 100)).toBe("pass");
+      expect(dashboardRunStatus([], 0)).toBe("fail");
+    });
+
+    it("is `incomplete` to the CLI, which is the A5 guard and not a divergence", () => {
+      // Same wire shape, different question — see the note above for why the
+      // CLI cannot be handed a run this clause was written for.
+      expect(cliRunStatus([], 100)).toBe("incomplete");
+      expect(cliRunStatus([], 0)).toBe("incomplete");
+    });
+  });
 
   // ── The third surface: verdict.json's `state` (F-1195) ───────────────────
   //
@@ -293,9 +341,7 @@ describe("CLI and dashboard answer `what state is this run in?` the same way (F-
     }
 
     it("records the same word as the dashboard now that F-1399 closed the divergence, and the closure is stated in the artifact's own doc", async () => {
-      const row = table.find(
-        (r) => r.name === "every criterion seed-excluded — no denominator",
-      )!;
+      const row = rowNamed("every criterion seed-excluded — no denominator");
       const cliWord = cliRunStatus(row.results, row.satisfaction);
       // The all-pre-satisfied run: F-1399 added `isIncompleteTally`'s
       // `evaluated === 0` clause, so the dashboard now reads `incomplete`

--- a/cli/test/unit/hosted/cross-surface-agreement.test.ts
+++ b/cli/test/unit/hosted/cross-surface-agreement.test.ts
@@ -13,15 +13,25 @@
 // was a run the CLI called INCOMPLETE and the dashboard called PASS, shipped
 // for as long as it took a human to notice the two screens disagreeing.
 //
-// `dashboardRunStatus` below is a TRANSCRIPTION of run-status.ts, named line by
-// line so a reviewer can diff it against the original, and deliberately NOT a
+// `dashboardRunStatus` below is a TRANSCRIPTION, named clause by clause so a
+// reviewer can diff it against the original, and deliberately NOT a
 // generalization of it. It is the oracle, not an implementation: nothing in
 // `src/` imports it. When pome-cloud changes its predicate, this table is what
 // goes red.
 //
-// The one row where the two surfaces still differ is in the table too, marked
-// `divergence`, with the reason. A known divergence with a test on it is a
-// fact; the same divergence with no test on it is the F-1392 defect again.
+// F-1399 moved the arithmetic out of `run-status.ts` and into
+// `@pome-cloud/contract`'s `isIncompleteTally` (`packages/contract/src/
+// run-completeness.ts`), the shared predicate the dashboard and the control
+// plane's markdown report both now call instead of keeping their own copies —
+// closing the exact defect class this file exists to catch, one repo over.
+// This transcription still cannot import that package (ADR-002: no cloud
+// imports in OSS), so it stays a transcription; see the note at the bottom of
+// this file on what a real fix would take.
+//
+// There is no known divergence between the two surfaces today — F-1399 closed
+// the last one (below). A row CAN still carry a `divergence` marker if the two
+// surfaces disagree again: a known divergence with a test on it is a fact; the
+// same divergence with no test on it is the F-1392 defect again.
 //
 // F-1195 — there is now a THIRD surface answering the same question: the
 // `state` field of the `verdict.json` a hosted run writes, which is what CI
@@ -29,9 +39,7 @@
 // construction (`runTaskHosted.ts` passes the one `verdict` local it already
 // computed into the artifact; `test/e2e/runTaskHosted.test.ts` pins that end
 // to end). What this file adds is the VOCABULARY claim — that the artifact
-// spells the answer in the dashboard's three words and no others — and the
-// artifact's side of the known divergence, so `verdict.json` is never found
-// to have quietly picked a side of F-1399 that nothing wrote down.
+// spells the answer in the dashboard's three words and no others.
 
 import { mkdir, mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -49,11 +57,25 @@ import { scoreFromFinalizeResponse } from "../../../src/hosted/uploadAndFinalize
 
 // ── The oracle: pome-cloud's answer, transcribed ────────────────────────────
 //
+// @pome-cloud/contract's packages/contract/src/run-completeness.ts:
+//   isIncompleteTally (107-109) — three clauses, in order:
+//     1. `total === 0` ⇒ false, never incomplete (no criteria recorded is a
+//        different fact from "recorded and none could be evaluated").
+//     2. `notEvaluated - preSatisfied > 0` ⇒ incomplete (F-925, narrowed by
+//        F-1296's seed-exclusion exemption).
+//     3. `evaluated === 0` ⇒ incomplete (F-1399). Fires for exactly the shape
+//        clause 2 does not already catch: every criterion excluded as already
+//        true in the seed. That run has an empty denominator and used to fall
+//        through to `satisfaction_score === 100 ? pass : fail` and land on
+//        `fail` — a verdict about the agent for a run nothing was ever at
+//        risk in.
+//
 // apps/dashboard/src/lib/run-status.ts:
-//   deriveCriteriaCounts  (75-95)  — skipped ⇒ notEvaluated, +preSatisfied when
-//                                    the reason matches; else evaluated (+passed)
-//   isRunIncomplete      (117-122) — total > 0 && notEvaluated - preSatisfied > 0
-//   deriveRunStatus      (135-141) — incomplete first, then
+//   deriveCriteriaCounts (73-93)   — skipped ⇒ notEvaluated, +preSatisfied
+//                                    when the reason matches; else evaluated
+//                                    (+passed)
+//   isRunIncomplete      (110-114) — isIncompleteTally(deriveCriteriaCounts(results))
+//   deriveRunStatus      (127-133) — incomplete first, then
 //                                    satisfaction_score === 100 ? pass : fail
 //
 // The satisfaction score the dashboard reads is the run row's, which the
@@ -75,7 +97,8 @@ function dashboardRunStatus(
     if (r.reason === PRE_SATISFIED_REASON) preSatisfied += 1;
   }
   const total = results.length;
-  if (total > 0 && notEvaluated - preSatisfied > 0) return "incomplete";
+  const evaluated = total - notEvaluated;
+  if (total > 0 && (notEvaluated - preSatisfied > 0 || evaluated === 0)) return "incomplete";
   return satisfactionScore === 100 ? "pass" : "fail";
 }
 
@@ -186,24 +209,16 @@ const table: Row[] = [
     expected: "fail",
   },
   {
+    // F-1399 added `isIncompleteTally`'s third clause (`evaluated === 0`):
+    // an all-excluded run has an empty denominator, which used to fall
+    // through to `satisfaction_score === 100 ? pass : fail` and land on
+    // `fail` here. Both surfaces now agree it is `incomplete` — the CLI
+    // already read it that way (its own A5 guard), so this row used to be
+    // the one known divergence and is now just another agreement row.
     name: "every criterion seed-excluded — no denominator",
     results: [excluded("github.no-new-issues"), excluded("github.no-new-labels")],
     satisfaction: 0,
-    expected: "fail",
-    divergence: {
-      cli: "incomplete",
-      why:
-        "The dashboard exempts every abstention, falls through to " +
-        "`satisfaction_score === 100`, and gets 0 because the denominator is " +
-        "empty — so it renders FAILED while its own verdictLine says " +
-        '"nothing was at risk". The CLI keeps the older A5 guard ' +
-        "(`total_required > 0` ⇒ not evaluated ⇒ incomplete), which is the " +
-        "honest word for a run in which nothing was ever at risk. Both refuse " +
-        "to pass it and both exit non-zero, so no CI caller can act on the " +
-        "difference; the fix belongs in pome-cloud's deriveRunStatus (F-1399), " +
-        "not in a CLI that would then have to blame the agent for an empty " +
-        "denominator. Retire this row when F-1399 lands.",
-    },
+    expected: "incomplete",
   },
 ];
 
@@ -277,23 +292,25 @@ describe("CLI and dashboard answer `what state is this run in?` the same way (F-
       });
     }
 
-    it("records the CLI's word on the F-1399 divergence, and the divergence is stated in the artifact's own doc", async () => {
-      const row = table.find((r) => r.divergence)!;
+    it("records the same word as the dashboard now that F-1399 closed the divergence, and the closure is stated in the artifact's own doc", async () => {
+      const row = table.find(
+        (r) => r.name === "every criterion seed-excluded — no denominator",
+      )!;
       const cliWord = cliRunStatus(row.results, row.satisfaction);
-      // The all-pre-satisfied run: the artifact says `incomplete` (the CLI's
-      // A5 guard) while the dashboard renders Failed. Both refuse to pass it,
-      // so `passed` — the only bit CI can act on — agrees. The artifact does
-      // not get to pick this side silently: `VerdictArtifact.state`'s doc
-      // comment names F-1399 and this row.
+      // The all-pre-satisfied run: F-1399 added `isIncompleteTally`'s
+      // `evaluated === 0` clause, so the dashboard now reads `incomplete`
+      // here too — the CLI already did, via its own A5 guard. `passed` — the
+      // only bit CI can act on — agreed even before F-1399; now the word
+      // itself does too.
       expect(cliWord).toBe("incomplete");
-      expect(dashboardRunStatus(row.results, row.satisfaction)).toBe("fail");
+      expect(dashboardRunStatus(row.results, row.satisfaction)).toBe("incomplete");
       expect(await roundtripState(cliWord)).toBe("incomplete");
 
-      // And the claim in this test's name is checked, not asserted: the field
-      // a CI reader meets first is `VerdictArtifact.state`, so the divergence
-      // has to be legible from there. Delete the mention and this goes red
-      // rather than the artifact quietly going back to implying agreement it
-      // does not have.
+      // The claim in this test's name is checked, not asserted: the field a
+      // CI reader meets first is `VerdictArtifact.state`, so the F-1399
+      // history has to be legible from there. Delete the mention and this
+      // goes red rather than the artifact quietly losing the only place that
+      // history was written down.
       const artifactSource = await readFile(
         new URL("../../../src/hosted/evalResultCache.ts", import.meta.url),
         "utf8",
@@ -302,12 +319,59 @@ describe("CLI and dashboard answer `what state is this run in?` the same way (F-
     });
   });
 
-  it("has exactly one known divergence, and it is the empty-denominator row", () => {
+  it("has no known divergences between the two surfaces", () => {
     // A guard on the guard: adding a `divergence` to a row is how this file
     // would be silenced, so the count is asserted rather than left to review.
+    // F-1399 closed the last one (the empty-denominator row above); the next
+    // one has to be added deliberately, not slip in unnoticed.
     const diverging = table.filter((row) => row.divergence);
-    expect(diverging.map((row) => row.name)).toEqual([
-      "every criterion seed-excluded — no denominator",
-    ]);
+    expect(diverging.map((row) => row.name)).toEqual([]);
   });
 });
+
+// ── F-1413: why this stays a transcription, and what would stop it drifting
+// again ───────────────────────────────────────────────────────────────────
+//
+// F-1413 is the second time this table has gone stale-green: pome-cloud
+// changed the predicate under it and nothing here noticed until a human read
+// both repos side by side. That is the parallel-copy defect this repo is
+// otherwise trying to close (D3) — one level up, across a repo boundary
+// instead of within one file.
+//
+// This repo cannot import `@pome-cloud/contract` to fix that at the root.
+// Two independent reasons, not one:
+//   1. Policy — `scripts/lint-no-cloud-imports.sh` denies every `pome-cloud/*`
+//      import (bare or scoped) anywhere under `packages/`, `cli/src/`,
+//      `cli/scripts/`, `scripts/`; this file lives under `cli/test/`, which
+//      the gate does not cover, but the module it would need to import does
+//      not reach here regardless of the gate — see (2).
+//   2. Reachability — `@pome-cloud/contract` is a `private` workspace member
+//      of pome-cloud, published to no registry. `@pome-sh/wire` is the one
+//      package this repo publishes FOR pome-cloud to consume (GitHub
+//      Packages, F-949); nothing runs the other direction today.
+//
+// A REAL fix exists but is a cross-repo migration, not a one-file patch:
+// extract `isIncompleteTally` + `PRE_SATISFIED_REASON` out of pome-cloud's
+// private `packages/contract` and into the already-published `@pome-sh/wire`
+// (or a new sibling package built the same way), with the dashboard, the
+// control plane, and the markdown report importing it from there instead of
+// owning the source — the same collapse F-1399 just did for `run-status.ts`
+// and `run-report.ts`, one repo boundary further out. That needs a pome-cloud
+// PR to consume the published package, a `@pome-sh/wire` version bump here,
+// and this file's `dashboardRunStatus`/`cliRunStatus` comparison rewritten
+// against ONE real predicate instead of an oracle transcription — at which
+// point a table like this one still has value (agreement is still worth
+// pinning row by row) but the copy of the ARITHMETIC disappears, and with it
+// the only thing that can go stale.
+//
+// Short of that, there is no self-detecting middle ground available from
+// inside this repo's CI: a job that diffs this transcription against
+// pome-cloud's source would need read access to a private repo, which is
+// exactly the credential the public repo's "zero embedded cloud config"
+// guardrail (AGENTS.md, Public Repo Guardrails) exists to keep out of here.
+// A pinned commit SHA plus a maintainer-run (non-CI) diff script is possible
+// and would be strictly better than today — it turns "silently stale" into
+// "stale unless someone runs the check" — but it is still not automatic, and
+// building it is out of scope for this ticket. Filing the `@pome-sh/wire`
+// extraction as its own ticket is the concrete next step if this drift is
+// worth spending more than a comment on.

--- a/cli/test/unit/hosted/incompleteVerdict.test.ts
+++ b/cli/test/unit/hosted/incompleteVerdict.test.ts
@@ -172,10 +172,11 @@ describe("scoreStatus — a pre-satisfied criterion is not an abstention (F-1392
     // The A5 guard (`total_required > 0`) predates this exemption and
     // outranks it: nothing passed and nothing failed, so there is no score to
     // clear a threshold with. `runScoreLine` names this state rather than
-    // reporting a contradictory count, and
-    // `cross-surface-agreement.test.ts` records that the dashboard words the
-    // same run differently (it renders FAILED at 0/100) — the two agree that
-    // it is not a pass, which is what the exit code encodes.
+    // reporting a contradictory count. The dashboard reads this run the same
+    // way since F-1399 — `cross-surface-agreement.test.ts` is where that
+    // agreement is CHECKED and `evalResultView.ts`'s `scoreStatus` comment is
+    // where it is explained. Neither is restated here: a restated claim about
+    // another repo is one that goes false on its own (F-1413).
     const s = score([preSatisfied("github.no-new-issues")], 0);
     expect(s.preSatisfied).toBe(1);
     expect(s.total_required).toBe(0);

--- a/cli/test/unit/hosted/uploadAndFinalize.test.ts
+++ b/cli/test/unit/hosted/uploadAndFinalize.test.ts
@@ -325,10 +325,10 @@ describe("scoreFromFinalizeResponse — the seed-pre-satisfied exemption (F-1392
     // narrows what counts as an ABSTENTION; it does not relax the older rule
     // that a run with nothing passed or failed at all cannot pass regardless.
     //
-    // This is the one shape where the CLI and the dashboard still word the
-    // same run differently — the dashboard renders FAILED at 0/100 rather
-    // than incomplete. Both refuse to pass it; only the word differs. The
-    // whole table, including this row, is in
+    // The dashboard reads this shape `incomplete` too since F-1399; it used
+    // to render FAILED at 0/100, which is the claim this comment carried
+    // until F-1413 caught it going false. That agreement is checked rather
+    // than restated: the whole table, including this row, is in
     // `cross-surface-agreement.test.ts`.
     const finalized = finalizeResponse([
       {


### PR DESCRIPTION
## Summary

pome-cloud PR #632 (F-1399) moved the incomplete-run predicate into `@pome-cloud/contract`'s `isIncompleteTally` and added an `evaluated === 0` clause: an all-seed-excluded run now reads `incomplete` on the dashboard instead of `fail`. This repo asserted the retired behaviour in **five** places and every one of them was green while doing it.

### The transcription

`cli/test/unit/hosted/cross-surface-agreement.test.ts`'s hand-transcribed oracle is updated to `isIncompleteTally`'s three clauses (verified clause by clause against `origin/main:packages/contract/src/run-completeness.ts` and `apps/dashboard/src/lib/run-status.ts`, including the cited line numbers). The seed-excluded row expects `incomplete`, its `divergence` marker is gone, and "exactly one known divergence" is now a zero-divergence guard.

### The prose that went stale with it

The same claim was written out in four more places, which is the parallel-copy defect the ticket is about. The fix is not four corrections — pome-cloud's run-state behaviour is now stated **once**, in `evalResultView.ts`'s `scoreStatus` comment, and pointed at from the rest:

- `cli/src/hosted/evalResultView.ts` — claimed the dashboard "renders FAILED", that F-1399 was still open, and that `cross-surface-agreement.test.ts` made the paragraph impossible to falsify. It also mis-attributed the `preSatisfied` subtraction to `run-status.ts` (it is `isIncompleteTally` since #632) and cited `run-status.ts:173-199` for `verdictLine`, which moved to `174-206`.
- `cli/src/hosted/evalResultCache.ts` — `VerdictArtifact.state`'s doc.
- `cli/test/unit/hosted/incompleteVerdict.test.ts:171` and `cli/test/unit/hosted/uploadAndFinalize.test.ts:322` — both restated "the dashboard renders FAILED at 0/100".

### Two holes in the guard itself

- **`isIncompleteTally`'s first clause had no test.** `total === 0 ⇒ never incomplete` is transcribed as the `total > 0 &&` conjunct and no table row reaches it — deleting the conjunct left all 19 tests green. It now has its own assertions, deliberately outside the table: the CLI answers the same wire shape `incomplete`, and that is the A5 guard rather than a divergence, because `taskSchema` requires at least one criterion so an empty `criteria_results` means the grader returned nothing for criteria that do exist. pome-cloud's clause 1 exists for rows the CLI never produces (replay runs, unscored production runs).
- **`table.find((r) => r.divergence)!`** selected the artifact test's row only while that row carried the marker, so closing the divergence handed it `undefined`. Replaced with a `rowNamed` helper that throws with the row name.

`@pome-sh/cli` → 0.23.6. Test- and comment-only, but `cli/` is a publish-relevant prefix for the version-bump gate; 0.23.6 is free (main is 0.23.5, npm's latest is 0.23.5).

## Test plan

- [x] `npm run typecheck -w cli`
- [x] `npm test -w cli -- --no-file-parallelism` — 108 files, 1096 tests passed
- [x] `npm run lint:code-health`
- [x] `npm run lint:dead-code`
- [x] `npm run lint:no-cloud-imports`
- [x] `node scripts/ci/check-version-bump-required.mjs $(git merge-base origin/main HEAD)`

Mutation-tested, each reverted after:

- [x] Add a `divergence` marker to a row → `has no known divergences` reds (`expected [ Array(1) ] to deeply equal []`).
- [x] Delete the `total > 0 &&` conjunct → the new clause-1 test reds (`expected 'incomplete' to be 'pass'`). Before this PR nothing red.
- [x] Rename the tracked row → `Error: no table row named "every criterion seed-excluded — no denominator"`, not a TypeError.