### PR TITLE
The seed can name a milestone, a tag, a release and a comment (F-1421)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,26 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.23.7
+
+### Patch Changes
+
+- Carries twin-github 0.10.2 (F-1421) into the bundled twin. A task seed may now
+  name a milestone, a tag, a release, an issue comment and a pull-request review
+  comment; before this, `seedSchema` had no field for any of them, zod stripped
+  them, and the five routes the twin serves them from could only ever answer
+  `[]`. No CLI source changed — the twins are inlined into this tarball, so a
+  twin change is a change to what `pome twin start github` boots.
+- The task-file path picks the new fields up for free: `cli/src/task/taskSchema.ts`
+  imports `@pome-sh/twin-github/seed`'s own `seedSchema` rather than restating it,
+  which is exactly why it does not have to be edited here. `cli/src/contract/seed-state.ts`'s
+  `githubSeedStateSchema` — the published-contract description of the same world
+  — is a hand-copy and does NOT gain them, so it goes one step further out of
+  date. It narrows nothing on the runtime seed path (`contract/rest.ts` forwards
+  a seed as a shape-blind `z.record`, deliberately, for this exact reason), and
+  it already lagged on `assignee` vs `assignees[]`. Reconciling the two is its
+  own change, not a rider on this one.
+
 ## 0.23.6
 
 ### Patch Changes

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.23.6",
+  "version": "0.23.7",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/packages/checks/CHANGELOG.md
+++ b/packages/checks/CHANGELOG.md
@@ -1,5 +1,31 @@
 # @pome-sh/checks
 
+## 0.1.4
+
+Carries twin-github's widened seed schema to the grader (F-1421). One thing
+moves in `dist/`: `@pome-sh/checks/github`'s re-exported `seedSchema` — and with
+it `parseSeed` — now accepts five entity types it used to strip silently.
+
+- `repositories[].milestones[]`, `repositories[].tags[]`,
+  `repositories[].releases[]`
+- `repositories[].issues[].comments[]` and
+  `repositories[].pull_requests[].comments[]`
+- `repositories[].pull_requests[].review_comments[]`
+
+Every one is optional with a `[]` default, so a seed that parsed before parses
+to the same value now. This is a widening, not a tightening: nothing a consumer
+already sends can start failing.
+
+Why it is owed a release rather than left to the twin: this package's job is to
+carry the twins' seed schemas to a consumer that has no twin, and a consumer
+validating a seed against 0.1.3 would strip exactly the keys twin-github 0.10.2
+now honors — reporting a seed as accepted and a world as seeded while five
+entities were dropped on the way. The two halves have to move together or the
+copy on the grader's side becomes the one that decides what a seed may say.
+
+No check declaration, template, polarity or vacuity sentinel changed, so no
+existing criterion's verdict moves.
+
 ## 0.1.3
 
 No change to the published surface — `dist/` is byte-identical to 0.1.2, so no

--- a/packages/checks/package.json
+++ b/packages/checks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/checks",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Pome's grading vocabulary — the check declarations, seed schemas and default seeds of all five digital twins, plus the check DSL they are written in. Declarations only: no twin server, no database, no routes, no tools.",
   "private": false,
   "type": "module",

--- a/packages/twin-github/CHANGELOG.md
+++ b/packages/twin-github/CHANGELOG.md
@@ -1,6 +1,85 @@
 # @pome-sh/twin-github — CHANGELOG
 
 
+## 0.10.2 — 2026-08-10
+
+The seed can name a milestone, a tag, a release and a comment, and the twin
+serves them (F-1421). No route, tool, handler or response shape changed.
+
+`seedSchema` had no field for five of the entities this twin SERVES —
+milestones, tags, releases, issue comments and pull-request review comments —
+and zod strips unknown keys, so a seed naming one arrived at the domain as
+nothing at all. `GET /repos/:o/:r/milestones`, `/tags`, `/releases`,
+`/issues/:n/comments` and `/pulls/:n/comments` could only ever answer `[]`, on
+every seed anyone could write. The tables, the domain operations and the routes
+were all already there; the seed was the only thing that could not reach them.
+
+That is worse than wrong, it is invisible: a shape-diff returns before the
+per-element comparison when EITHER side is empty, so `[] vs []` compares zero
+elements and publishes green. Those five surfaces had been publishing green
+against an equally empty golden since 2026-05-31, and F-1420 — which seeds the
+upstream half — would have turned that vacuous green into an equally vacuous
+`array-length-changed` red without this change.
+
+New seed fields, every one optional and defaulting to `[]`, so an existing seed
+parses to the same value it did before and the default world does not move:
+
+- `repositories[].milestones[]` — `{number?, title, description?, state?,
+  due_on?}`. `number` is honored when given and assigned sequentially from 1
+  otherwise.
+- `repositories[].tags[]` — `{name, target?}`, `target` being any ref the twin
+  resolves (a branch name or a SHA), defaulting to the default branch's head.
+- `repositories[].releases[]` — `{tag_name, name?, body?, target_commitish?,
+  draft?, prerelease?, author?}`. A release naming a seeded tag reuses it rather
+  than minting a second.
+- `repositories[].issues[].comments[]` and
+  `repositories[].pull_requests[].comments[]` — `{body, author?}`. One shape,
+  because it is one table and one route: GitHub serves a pull request's
+  conversation through the issue-comment endpoints (F-1151).
+- `repositories[].pull_requests[].review_comments[]` — `{body, path, line?,
+  side?, author?}`, the inline surface.
+
+Two things worth knowing about how they are applied.
+
+**Review comments go through the domain's write path**, not a raw INSERT. So
+`path` must name a file the pull request changes and `line` must exist in that
+file: a seeded review comment is one `POST /pulls/:n/comments` could have
+produced, and a seed planting one it could not FAILS rather than creating a row
+only the seeder can make.
+
+**Comment authors are seeded honestly.** `addIssueComment` stamps `user_login =
+"pome-agent"` unconditionally, and an issue whose only commenter is the agent
+under test is not an issue worth handing that agent — so the seed writes the
+author directly, the same bargain the seeded PR reviews already struck for the
+same reason.
+
+`GET /releases/latest` and `GET /releases/tags/:tag` answer 200 from a seed as
+of this version. Both are registered exceptions in pome-cloud's Level-1 coverage
+list whose stated reason is "the seed schema cannot seed a release"; that reason
+is now false, and the exceptions are retired alongside this change. An exception
+list that outlives its reason starts lying.
+
+`test/seed-entities.test.ts` runs each of the seven surfaces against TWO worlds
+that differ only in the value the seed plants, asserting that the served element
+carries THIS world's value and that the other world's differs. Asserting the
+array came back non-empty would have been the same mistake one level up — it
+passes against a twin answering a constant.
+
+Two things this version does NOT change, named because it is what makes them
+observable for the first time:
+
+- `GET /pulls/:number/comments` serves a leaner element than the twin's own
+  review-comment object — no `line`, `side`, `commit_id` or `pull_request_url` —
+  while `POST` to the same route serves all of them from the same row.
+- `pull_request_read`'s `get_comments` still answers from the review-comment
+  table, on a comment says the twin "stores one comment thread per PR". F-1151
+  gave the conversation its own table and `exportState` keeps the three apart,
+  so that comment is stale and the method is pointed at the wrong one.
+
+Both are served-shape questions with their own fidelity accounting, not the
+modelling gap this version closes.
+
+
 ## 0.10.1 — 2026-08-09
 
 `fidelity.inventory.json`'s `rest` half is now compared to the routes the twin

--- a/packages/twin-github/FIDELITY.md
+++ b/packages/twin-github/FIDELITY.md
@@ -337,6 +337,31 @@ upstream so a divergence that upstream "heals" becomes a tier-upgrade signal.
     seeded sandbox's smaller label set and different collaborator set, not a serializer
     bug. On these L1 read surfaces the item-count difference is an accepted divergence
     (INFO), not drift.
+21. **The review-comment LIST serves a leaner object than the review-comment CREATE
+    (open gap, not accepted).** `GET /repos/:o/:r/pulls/:n/comments` builds its
+    elements inline — `{id, path, body, user, created_at, updated_at}` — while
+    `POST` to the same route serves the same row through
+    `pullRequestReviewCommentJson`, which adds `line`, `side`, `commit_id`,
+    `original_*`, `in_reply_to_id`, `pull_request_url`, `html_url`, `diff_hunk`
+    and the rest. One row, two shapes, one route family. This is NOT an accepted
+    INFO divergence like the omission bullets above: the twin already has the
+    faithful serializer and the list simply does not call it. It went unmeasured
+    because the surface answered `[]` on every seed anyone could write until
+    F-1421 made a review comment seedable — the first real element on this
+    surface is what makes the gap visible. Fixing it widens a served shape, so it
+    is owed its own change and its own fidelity accounting.
+22. **`pull_request_read`'s `get_comments` answers from the wrong table (open gap,
+    not accepted).** GitHub distinguishes the issue-level `get_comments` from the
+    diff-level `get_review_comments`; the twin answers BOTH from
+    `pull_request_review_comments`, on a comment that says it "stores one comment
+    thread per PR and answers both from it rather than inventing a split it does
+    not model". That was true when it was written and F-1151 made it false: a PR's
+    conversation has its own table (`issue_comments`, keyed on the PR's number),
+    `exportState` keeps the three comment surfaces apart, and the REST routes
+    already serve them separately. So `get_comments` returns inline review
+    comments to a caller asking for the timeline. Same visibility story as bullet
+    21 — F-1421 makes both surfaces seedable, so the two now have different
+    contents to tell apart.
 
 ## How fidelity is verified
 

--- a/packages/twin-github/README.md
+++ b/packages/twin-github/README.md
@@ -189,19 +189,46 @@ curl -s -X POST http://127.0.0.1:3333/admin/seed \
           { "path": "README.md", "content": "# My App\n" },
           { "path": "src/index.ts", "content": "export const ok = true;\n" }
         ],
+        "milestones": [
+          { "number": 1, "title": "v1.0", "description": "Ship checkout", "due_on": "2026-09-30T00:00:00Z" }
+        ],
+        "tags": [{ "name": "v1.0.0", "target": "main" }],
+        "releases": [
+          { "tag_name": "v1.0.0", "name": "v1.0.0", "body": "First cut.", "author": "agent-user" }
+        ],
         "issues": [
           {
             "number": 1,
             "title": "Fix checkout error",
             "body": "Users see a 500 after submitting checkout.",
             "labels": ["bug"],
-            "assignees": []
+            "assignees": [],
+            "comments": [
+              { "body": "Reproduced on staging.", "author": "agent-user" }
+            ]
           }
         ]
       }
     ]
   }'
 ```
+
+Notes on the less obvious fields:
+
+- **`milestones[].number`, `issues[].number`, `pull_requests[].number`** are
+  honored when given. Issues and pull requests draw from ONE per-repo counter,
+  so two seeded issues put the first seeded PR at `#3`.
+- **`tags[].target`** is any ref the twin resolves — a branch name or a SHA —
+  and defaults to the default branch's head. A `releases[]` entry whose
+  `tag_name` matches a seeded tag reuses it; one whose tag is not seeded mints
+  it from `target_commitish`.
+- **`comments[]`** is the conversation timeline, and it hangs off a
+  `pull_requests[]` entry as readily as an `issues[]` one — GitHub serves both
+  through `/issues/:number/comments`. The inline review surface is
+  `pull_requests[].review_comments[]`, whose `path` must name a file the pull
+  request changes and whose `line` must exist in it.
+- **`author` / `assignees` / `collaborators`** logins that are not in `users[]`
+  are created as plain users rather than rejected.
 
 3. Give your agent these inputs:
 

--- a/packages/twin-github/package.json
+++ b/packages/twin-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-github",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Deterministic GitHub-shaped twin for agent testing — REST + MCP, SQLite-backed state.",
   "private": true,
   "type": "module",

--- a/packages/twin-github/src/domain/github-domain.ts
+++ b/packages/twin-github/src/domain/github-domain.ts
@@ -116,6 +116,23 @@ export class GitHubDomain {
         for (const label of repoSeed.labels ?? []) {
           this.createLabel(repo, label.name, label.color ?? "ededed", label.description ?? "");
         }
+        // F-1421 — milestones sit beside labels: repository-level, and in
+        // existence before any issue points at one.
+        for (const milestone of repoSeed.milestones ?? []) {
+          const created = this.createMilestone({
+            owner: repo.owner,
+            repo: repo.name,
+            title: milestone.title,
+            description: milestone.description ?? "",
+            due_on: milestone.due_on,
+            state: milestone.state ?? "open"
+          });
+          if (milestone.number && milestone.number !== created.number) {
+            // A single UPDATE, unlike the issue renumber below: nothing in the
+            // schema references a milestone by number.
+            this.db.prepare("UPDATE milestones SET number = ? WHERE repo_id = ? AND number = ?").run(milestone.number, repo.id, created.number);
+          }
+        }
         this.createBranchInternal(repo, repo.default_branch, null);
         const files = repoSeed.files?.filter((file) => (file.branch ?? repo.default_branch) === repo.default_branch) ?? [];
         this.commitFiles(repo, repo.default_branch, "Initial seed commit", files, "pome-agent");
@@ -139,6 +156,11 @@ export class GitHubDomain {
             this.bumpEntityCounter(repo.id, to);
           }
           if (issue.state === "closed") this.updateIssue({ owner: repo.owner, repo: repo.name, issue_number: issue.number ?? created.number, state: "closed" });
+          // F-1421 — after the renumber, so a comment lands on the number the
+          // seed asked for rather than the one `createIssue` handed out.
+          for (const comment of issue.comments ?? []) {
+            this.seedComment(repo, issue.number ?? created.number, comment);
+          }
         }
         for (const pull of repoSeed.pull_requests ?? []) {
           const createdPr = this.createPullRequest({ owner: repo.owner, repo: repo.name, title: pull.title, body: pull.body ?? "", head: pull.head, base: pull.base ?? repo.default_branch, actor: pull.author });
@@ -183,6 +205,61 @@ export class GitHubDomain {
               });
             }
           }
+          // F-1421 — the PR's conversation timeline. The shared per-repo
+          // `entity_counter` is what lets one table hold both: within a repo a
+          // number names an issue or a pull request, never both, so `prNumber`
+          // selects this PR's comments and no issue's.
+          for (const comment of pull.comments ?? []) {
+            this.seedComment(repo, prNumber, comment);
+          }
+          // F-1421 — inline review comments, through the write path rather than
+          // a raw INSERT: it is what checks that `path` names a file this PR
+          // changes, that `line` exists in that file, and that the resolved
+          // commit is one of the PR's. A seeded comment that skipped those
+          // would be a row `POST /pulls/:n/comments` could not have produced.
+          for (const comment of pull.review_comments ?? []) {
+            const author = comment.author ?? "pome-agent";
+            this.upsertUser(author, "User", author);
+            this.createPullRequestReviewComment(
+              {
+                owner: repo.owner,
+                repo: repo.name,
+                pull_number: prNumber,
+                body: comment.body,
+                path: comment.path,
+                line: comment.line ?? 1,
+                side: comment.side ?? "RIGHT"
+              },
+              { actor: author }
+            );
+          }
+        }
+        // F-1421 — tags and releases last: both name a commit, so every branch
+        // and commit the seed can point them at exists by now. Tags first, so a
+        // release naming a seeded tag reuses it instead of minting a second.
+        for (const tag of repoSeed.tags ?? []) {
+          if (this.db.prepare("SELECT 1 FROM tags WHERE repo_id = ? AND name = ?").get(repo.id, tag.name)) {
+            conflict(`Seed declares tag ${tag.name} twice in ${repo.full_name}`);
+          }
+          const sha = this.resolveRefToSha(repo, tag.target ?? repo.default_branch);
+          this.db.prepare("INSERT INTO tags (repo_id, name, commit_sha, created_at) VALUES (?, ?, ?, ?)").run(repo.id, tag.name, sha, nowIso());
+        }
+        for (const release of repoSeed.releases ?? []) {
+          const author = release.author ?? "pome-agent";
+          this.upsertUser(author, "User", author);
+          this.createRelease(
+            {
+              owner: repo.owner,
+              repo: repo.name,
+              tag_name: release.tag_name,
+              target_commitish: release.target_commitish,
+              name: release.name,
+              body: release.body ?? "",
+              draft: release.draft ?? false,
+              prerelease: release.prerelease ?? false
+            },
+            { actor: author }
+          );
         }
       }
       this.audit("seed", null, { repositories: parsedSeed.repositories.length });
@@ -192,6 +269,31 @@ export class GitHubDomain {
       before: { repositories: before },
       after: { repositories: this.summarizeRepositories() }
     });
+  }
+
+  /**
+   * F-1421 — plant one conversation comment on an issue or a pull request.
+   *
+   * A direct INSERT, for the same reason the seeded reviews above bypass
+   * `createPullRequestReview`: `addIssueComment` stamps `user_login =
+   * "pome-agent"` unconditionally, and a seeded world where the agent under
+   * test wrote every comment it is being asked to read has nothing to read.
+   * The one check the write path does that matters here is kept — the comment
+   * must hang off an issue or a pull request that exists (F-1151).
+   */
+  seedComment(repo: RepoRow, number: number, comment: { body: string; author?: string }) {
+    this.requireCommentTarget(repo.id, number);
+    const author = comment.author ?? "pome-agent";
+    this.upsertUser(author, "User", author);
+    const now = nowIso();
+    this.db.prepare("INSERT INTO issue_comments (repo_id, issue_number, body, user_login, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)").run(
+      repo.id,
+      number,
+      comment.body,
+      author,
+      now,
+      now
+    );
   }
 
 

--- a/packages/twin-github/src/seed.ts
+++ b/packages/twin-github/src/seed.ts
@@ -30,6 +30,56 @@ export const seedSchema = z.object({
         )
         .default([]),
       files: z.array(z.object({ path: z.string().min(1), content: z.string(), branch: z.string().optional() })).default([]),
+      // F-1421 — milestones, tags and releases are repository-level entities the
+      // twin already SERVES (`GET /milestones`, `/tags`, `/releases`,
+      // `/releases/latest`, `/releases/tags/:tag`) and the seed could not
+      // express. Zod strips unknown keys, so a seed naming one reached the
+      // domain as nothing at all and those routes could only ever answer `[]`
+      // — a shape of infidelity no shape-diff can see, because an empty array
+      // on both sides compares zero elements.
+      milestones: z
+        .array(
+          z.object({
+            // Assigned sequentially from 1 in seed order when omitted, the way
+            // `nextMilestoneNumber` hands them out. Honored when given, so a
+            // seed that pins `PATCH /milestones/2` addresses the milestone it
+            // named rather than one silently renumbered under it.
+            number: z.number().int().positive().optional(),
+            title: z.string().min(1),
+            description: z.string().default(""),
+            state: z.enum(["open", "closed"]).default("open"),
+            // GitHub's own spelling: an ISO 8601 timestamp. Absent means the
+            // milestone has no due date (`due_on: null` on the wire).
+            due_on: z.string().optional()
+          })
+        )
+        .default([]),
+      // A tag names a commit. `target` is any ref the twin resolves — a branch
+      // name or a SHA — and defaults to the repository's default-branch head. A
+      // release whose `tag_name` matches an entry here reuses that tag rather
+      // than minting a second one: `createRelease` looks the tag up first.
+      tags: z
+        .array(
+          z.object({
+            name: z.string().min(1),
+            target: z.string().min(1).optional()
+          })
+        )
+        .default([]),
+      releases: z
+        .array(
+          z.object({
+            tag_name: z.string().min(1),
+            // Nullable upstream, so an absent `name` means `null` — not `""`.
+            name: z.string().optional(),
+            body: z.string().default(""),
+            target_commitish: z.string().min(1).optional(),
+            draft: z.boolean().default(false),
+            prerelease: z.boolean().default(false),
+            author: z.string().min(1).optional()
+          })
+        )
+        .default([]),
       issues: z
         .array(
           z.object({
@@ -38,7 +88,21 @@ export const seedSchema = z.object({
             body: z.string().default(""),
             state: z.enum(["open", "closed"]).default("open"),
             labels: z.array(z.string().min(1)).default([]),
-            assignees: z.array(z.string().min(1)).default([])
+            assignees: z.array(z.string().min(1)).default([]),
+            // The issue's conversation timeline, served at
+            // `GET /repos/:o/:r/issues/:n/comments` (F-1421). `author` is
+            // seeded honestly rather than taken from the write path, which
+            // stamps every comment `pome-agent`: a world in which the agent
+            // under test wrote every comment on the issue it is being asked to
+            // read is not one worth testing against.
+            comments: z
+              .array(
+                z.object({
+                  body: z.string().min(1),
+                  author: z.string().min(1).optional()
+                })
+              )
+              .default([])
           })
         )
         .default([]),
@@ -72,6 +136,38 @@ export const seedSchema = z.object({
                   context: z.string().min(1).default("ci/build"),
                   state: z.enum(["error", "failure", "pending", "success"]).default("success"),
                   description: z.string().default("")
+                })
+              )
+              .default([]),
+            // F-1421 — the PR's CONVERSATION timeline. Same table, same route
+            // and same number space as an issue's comments, because GitHub
+            // models a pull request as an issue (F-1151). This is the third
+            // thing a reader could call "a comment on the PR" and the seed
+            // keeps all three apart: `reviews[].body` is the prose on a review
+            // verdict, `review_comments[]` below is anchored to a file and
+            // line, and THIS one is the timeline.
+            comments: z
+              .array(
+                z.object({
+                  body: z.string().min(1),
+                  author: z.string().min(1).optional()
+                })
+              )
+              .default([]),
+            // F-1421 — inline review comments, served at
+            // `GET /repos/:o/:r/pulls/:n/comments`. Seeded through the domain's
+            // own write path, so `path` must name a file the PR changes and
+            // `line` must exist in it: a seeded review comment is one
+            // `POST /pulls/:n/comments` could have produced, not a row only the
+            // seeder can make.
+            review_comments: z
+              .array(
+                z.object({
+                  body: z.string().min(1),
+                  path: z.string().min(1),
+                  line: z.number().int().positive().default(1),
+                  side: z.enum(["LEFT", "RIGHT"]).default("RIGHT"),
+                  author: z.string().min(1).optional()
                 })
               )
               .default([])

--- a/packages/twin-github/src/types.ts
+++ b/packages/twin-github/src/types.ts
@@ -32,6 +32,24 @@ export type SeedRepository = {
   collaborators?: string[];
   labels?: Array<{ name: string; color?: string; description?: string }>;
   files?: Array<{ path: string; content: string; branch?: string }>;
+  // F-1421 — the five entities the twin serves but the seed used to strip.
+  milestones?: Array<{
+    number?: number;
+    title: string;
+    description?: string;
+    state?: "open" | "closed";
+    due_on?: string;
+  }>;
+  tags?: Array<{ name: string; target?: string }>;
+  releases?: Array<{
+    tag_name: string;
+    name?: string;
+    body?: string;
+    target_commitish?: string;
+    draft?: boolean;
+    prerelease?: boolean;
+    author?: string;
+  }>;
   issues?: Array<{
     number?: number;
     title: string;
@@ -39,6 +57,7 @@ export type SeedRepository = {
     state?: "open" | "closed";
     labels?: string[];
     assignees?: string[];
+    comments?: SeedComment[];
   }>;
   pull_requests?: Array<{
     number?: number;
@@ -58,7 +77,24 @@ export type SeedRepository = {
       state?: "error" | "failure" | "pending" | "success";
       description?: string;
     }>;
+    comments?: SeedComment[];
+    review_comments?: Array<{
+      body: string;
+      path: string;
+      line?: number;
+      side?: "LEFT" | "RIGHT";
+      author?: string;
+    }>;
   }>;
+};
+
+/**
+ * A conversation comment on an issue OR a pull request — one shape, because
+ * they are one table and one route on GitHub too (F-1151).
+ */
+export type SeedComment = {
+  body: string;
+  author?: string;
 };
 
 export type RepoRow = {

--- a/packages/twin-github/test/seed-entities.test.ts
+++ b/packages/twin-github/test/seed-entities.test.ts
@@ -1,0 +1,510 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-1421 — the five entities twin-github SERVES but its seed could not express:
+// milestones, tags, releases, issue comments and pull-request review comments.
+// `seedSchema` had no field for any of them and zod strips unknown keys, so a
+// seed naming one reached the domain as nothing at all and `GET /milestones`,
+// `/tags`, `/releases`, `/issues/:n/comments` and `/pulls/:n/comments` could
+// only ever answer `[]`.
+//
+// That is invisible to a shape-diff rather than merely wrong: the diff engine
+// returns before the per-element shape union when EITHER side is empty, so
+// `[] vs []` compares zero elements and publishes green, and `[1] vs []`
+// compares zero elements and publishes an array-length red. Only a seeded
+// element gets a real comparison.
+//
+// The two surfaces that were already reachable — a PR's reviews and an issue
+// the seed closes — are asserted here beside the five, because the unit this
+// ticket is measured in is the seven-surface set.
+//
+// EVERY assertion below runs against two worlds that differ only in the value
+// the seed plants. Asserting "the array came back non-empty" would repeat the
+// original mistake one level up: it passes against a twin answering a constant.
+// Asserting the planted value AND that the other world answers differently is
+// what makes the element load-bearing — a wrong value in it produces drift.
+//
+// The world is shaped like pome-cloud's `FIDELITY_SEED` (acme/api, issues #1
+// and #2, PR #3 off `feature`) so this doubles as a rehearsal of the seed the
+// fidelity watch will run. Note the trap it encodes: issues and pull requests
+// draw numbers from ONE per-repo counter, so the closed issue is issue #2
+// flipped rather than a third issue — a third would move the PR to #4 and break
+// every `/pulls/3/...` handle downstream.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { openGitHubCloneDatabase } from "../src/db.js";
+import { GitHubDomain } from "../src/domain/index.js";
+import { createGitHubCloneApp } from "../src/twin.js";
+import { defaultSeedState, parseSeed } from "../src/seed.js";
+import type { GitHubStateSeed } from "../src/types.js";
+import { TEST_AUTH_SECRET, TEST_SID, signTestToken, withAuth } from "./_authHelper.js";
+
+const previousSecret = process.env.TWIN_AUTH_SECRET;
+let token: string;
+
+beforeAll(async () => {
+  process.env.TWIN_AUTH_SECRET = TEST_AUTH_SECRET;
+  token = await signTestToken();
+});
+afterAll(() => {
+  if (previousSecret === undefined) delete process.env.TWIN_AUTH_SECRET;
+  else process.env.TWIN_AUTH_SECRET = previousSecret;
+});
+
+const base = `/s/${TEST_SID}`;
+
+/** The values the seed plants — one per surface, different in each world. */
+type Planted = {
+  milestoneTitle: string;
+  tagName: string;
+  releaseBody: string;
+  issueCommentBody: string;
+  reviewCommentBody: string;
+  reviewBody: string;
+  closedIssueTitle: string;
+};
+
+const WORLD_A: Planted = {
+  milestoneTitle: "v1.0 — checkout hardening",
+  tagName: "v1.0.0",
+  releaseBody: "First cut of the ordering API.",
+  issueCommentBody: "Reproduced on staging at 14:07.",
+  reviewCommentBody: "This flag needs a default.",
+  reviewBody: "Looks right to me.",
+  closedIssueTitle: "Seeded closed: retry storm on 429"
+};
+
+const WORLD_B: Planted = {
+  milestoneTitle: "v2.0 — regional failover",
+  tagName: "v2.3.1",
+  releaseBody: "Adds the failover path.",
+  issueCommentBody: "Only reproduces under the read replica.",
+  reviewCommentBody: "Drop the sleep, it hides the race.",
+  reviewBody: "One blocker before this lands.",
+  closedIssueTitle: "Seeded closed: duplicate webhook delivery"
+};
+
+function world(planted: Planted): GitHubStateSeed {
+  return {
+    users: [
+      { login: "acme", type: "Organization", name: "Acme" },
+      { login: "alice", type: "User", name: "Alice" },
+      { login: "bob", type: "User", name: "Bob" },
+      { login: "pome-agent", type: "User", name: "Pome Agent" }
+    ],
+    repositories: [
+      {
+        owner: "acme",
+        name: "api",
+        description: "Fidelity sandbox repository for twin-github capture.",
+        default_branch: "main",
+        collaborators: ["alice", "bob", "pome-agent"],
+        labels: [
+          { name: "bug", color: "d73a4a", description: "Something is not working" },
+          { name: "feature", color: "a2eeef", description: "New feature or request" }
+        ],
+        files: [
+          { path: "README.md", content: "# Acme API\n\nFidelity sandbox.\n" },
+          { path: "src/index.ts", content: "export const ok = true;\n" },
+          { path: "src/feature.ts", content: "export const feature = true;\n", branch: "feature" }
+        ],
+        milestones: [
+          {
+            number: 1,
+            title: planted.milestoneTitle,
+            description: "Everything blocking the next tag.",
+            state: "open",
+            due_on: "2026-09-30T00:00:00Z"
+          }
+        ],
+        tags: [{ name: planted.tagName, target: "main" }],
+        releases: [
+          {
+            tag_name: planted.tagName,
+            name: `Release ${planted.tagName}`,
+            body: planted.releaseBody,
+            author: "alice"
+          }
+        ],
+        issues: [
+          {
+            number: 1,
+            title: "Seeded bug: 500 on POST /orders",
+            body: "Started failing after the 14:00 deploy.",
+            state: "open",
+            labels: ["bug"],
+            assignees: ["alice"],
+            comments: [{ body: planted.issueCommentBody, author: "bob" }]
+          },
+          {
+            number: 2,
+            title: planted.closedIssueTitle,
+            body: "Fixed by the backoff change.",
+            state: "closed",
+            labels: ["bug"],
+            assignees: []
+          }
+        ],
+        pull_requests: [
+          {
+            title: "Add feature flag",
+            body: "Introduces a feature branch.",
+            head: "feature",
+            base: "main",
+            author: "pome-agent",
+            reviews: [{ author: "alice", state: "APPROVED", body: planted.reviewBody }],
+            review_comments: [
+              { body: planted.reviewCommentBody, path: "src/feature.ts", line: 1, author: "bob" }
+            ]
+          }
+        ]
+      }
+    ]
+  };
+}
+
+async function get(app: ReturnType<typeof createGitHubCloneApp>, path: string) {
+  const response = await app.request(`${base}${path}`, withAuth(token));
+  const text = await response.text();
+  return { status: response.status, body: text ? (JSON.parse(text) as any) : null };
+}
+
+function appFor(planted: Planted) {
+  return createGitHubCloneApp({ seed: world(planted) });
+}
+
+/**
+ * The seven surfaces the ticket is measured in, each with the field the seed
+ * plants and where the served element carries it.
+ */
+const SURFACES: Array<{
+  id: string;
+  path: string;
+  planted: (world: Planted) => string;
+  served: (body: any) => unknown;
+}> = [
+  {
+    id: "GET /repos/:o/:r/milestones",
+    path: "/repos/acme/api/milestones",
+    planted: (w) => w.milestoneTitle,
+    served: (body) => body[0]?.title
+  },
+  {
+    id: "GET /repos/:o/:r/tags",
+    path: "/repos/acme/api/tags",
+    planted: (w) => w.tagName,
+    served: (body) => body[0]?.name
+  },
+  {
+    id: "GET /repos/:o/:r/releases",
+    path: "/repos/acme/api/releases",
+    planted: (w) => w.releaseBody,
+    served: (body) => body[0]?.body
+  },
+  {
+    id: "GET /repos/:o/:r/issues/:n/comments",
+    path: "/repos/acme/api/issues/1/comments",
+    planted: (w) => w.issueCommentBody,
+    served: (body) => body[0]?.body
+  },
+  {
+    id: "GET /repos/:o/:r/pulls/:n/comments",
+    path: "/repos/acme/api/pulls/3/comments",
+    planted: (w) => w.reviewCommentBody,
+    served: (body) => body[0]?.body
+  },
+  {
+    id: "GET /repos/:o/:r/pulls/:n/reviews",
+    path: "/repos/acme/api/pulls/3/reviews",
+    planted: (w) => w.reviewBody,
+    served: (body) => body[0]?.body
+  },
+  {
+    id: "GET /repos/:o/:r/issues?state=closed",
+    path: "/repos/acme/api/issues?state=closed",
+    planted: (w) => w.closedIssueTitle,
+    served: (body) => body[0]?.title
+  }
+];
+
+describe("F-1421 — seeded surfaces serve an element a diff can compare", () => {
+  it.each(SURFACES)(
+    "$id serves the value THIS seed planted, and a different seed a different one",
+    async ({ path, planted, served }) => {
+      const a = await get(appFor(WORLD_A), path);
+      const b = await get(appFor(WORLD_B), path);
+
+      expect(a.status).toBe(200);
+      expect(b.status).toBe(200);
+      expect(Array.isArray(a.body)).toBe(true);
+      // ≥1 element is the precondition for the comparison, not the assertion.
+      expect(a.body.length).toBeGreaterThanOrEqual(1);
+      expect(b.body.length).toBeGreaterThanOrEqual(1);
+
+      expect(served(a.body)).toBe(planted(WORLD_A));
+      expect(served(b.body)).toBe(planted(WORLD_B));
+      // The element is load-bearing: plant a different value and it shows up.
+      // Without this the two assertions above would also pass against a twin
+      // that answers a constant, which is the mistake one level up.
+      expect(served(a.body)).not.toBe(served(b.body));
+    }
+  );
+});
+
+describe("F-1421 — a seeded element is a whole GitHub object, not a stub", () => {
+  it("serves the seeded milestone with every field the seed set", async () => {
+    const { body } = await get(appFor(WORLD_A), "/repos/acme/api/milestones");
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({
+      number: 1,
+      title: WORLD_A.milestoneTitle,
+      description: "Everything blocking the next tag.",
+      state: "open",
+      due_on: "2026-09-30T00:00:00Z",
+      creator: { login: "pome-agent" },
+      open_issues: 0,
+      closed_issues: 0
+    });
+    expect(body[0].html_url).toBe("https://github.com/acme/api/milestone/1");
+  });
+
+  it("serves the seeded tag pointed at the ref the seed named", async () => {
+    const app = appFor(WORLD_A);
+    const { body } = await get(app, "/repos/acme/api/tags");
+    const main = await get(app, "/repos/acme/api/branches/main");
+
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({
+      name: WORLD_A.tagName,
+      commit: { sha: main.body.commit.sha }
+    });
+  });
+
+  it("serves the seeded release, authored by the seeded user and published", async () => {
+    const { body } = await get(appFor(WORLD_A), "/repos/acme/api/releases");
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({
+      tag_name: WORLD_A.tagName,
+      name: `Release ${WORLD_A.tagName}`,
+      body: WORLD_A.releaseBody,
+      draft: false,
+      prerelease: false,
+      target_commitish: "main",
+      author: { login: "alice" }
+    });
+    expect(body[0].published_at).toEqual(expect.any(String));
+  });
+
+  it("serves the seeded issue comment under its seeded author", async () => {
+    const { body } = await get(appFor(WORLD_A), "/repos/acme/api/issues/1/comments");
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({
+      body: WORLD_A.issueCommentBody,
+      // Not "pome-agent": the write path stamps its own actor, the seed does
+      // not, and an issue whose only commenter is the agent under test is not
+      // an issue worth handing that agent.
+      user: { login: "bob" },
+      issue_url: "https://api.github.com/repos/acme/api/issues/1"
+    });
+  });
+
+  it("serves the seeded review comment anchored to the file the seed named", async () => {
+    const { body } = await get(appFor(WORLD_A), "/repos/acme/api/pulls/3/comments");
+    expect(body).toHaveLength(1);
+    // This LIST route serves a leaner element than the twin's own review-comment
+    // object — no `line`, `side`, `commit_id`, `pull_request_url` — while
+    // `POST /pulls/:n/comments` on the same row serves all of them
+    // (`pullRequestReviewCommentJson`). That predates this change and is left
+    // alone by it: widening a served shape is a wire change with its own
+    // fidelity accounting, and this ticket's subject is the modelling gap that
+    // made the array empty. Asserted as it is rather than as it should be.
+    expect(body[0]).toMatchObject({
+      body: WORLD_A.reviewCommentBody,
+      path: "src/feature.ts",
+      user: { login: "bob" }
+    });
+  });
+
+  // The two below are what pin `path` and `line`: the seed goes through the
+  // domain's own write path, so a review comment the API could not have made is
+  // a seed that FAILS rather than a row only the seeder can produce. They are
+  // also how `line` is asserted at all — the list route above does not serve it.
+  it("refuses a seeded review comment on a file the pull request does not change", async () => {
+    const bad = world(WORLD_A);
+    // `README.md` is on both branches unchanged, so it is not in the PR's diff.
+    bad.repositories[0]!.pull_requests![0]!.review_comments = [
+      { body: "nope", path: "README.md", line: 1 }
+    ];
+    expect(() => createGitHubCloneApp({ seed: bad })).toThrow(/Validation Failed/);
+  });
+
+  it("refuses a seeded review comment on a line past the end of the file", async () => {
+    const bad = world(WORLD_A);
+    // src/feature.ts is one line long.
+    bad.repositories[0]!.pull_requests![0]!.review_comments = [
+      { body: "nope", path: "src/feature.ts", line: 99 }
+    ];
+    expect(() => createGitHubCloneApp({ seed: bad })).toThrow(/Validation Failed/);
+  });
+});
+
+describe("F-1421 — the release surfaces that had no seedable state", () => {
+  // `releases/latest` and `releases/tags/:tag` were registered exceptions in
+  // pome-cloud's L1 coverage list, reason: "the seed schema cannot seed a
+  // release". Both now answer 200 from a seed, so those two exceptions are
+  // false and are retired with this change.
+  it("serves releases/latest from the seed", async () => {
+    const { status, body } = await get(appFor(WORLD_A), "/repos/acme/api/releases/latest");
+    expect(status).toBe(200);
+    expect(body).toMatchObject({ tag_name: WORLD_A.tagName, body: WORLD_A.releaseBody });
+  });
+
+  it("serves releases/tags/:tag from the seed", async () => {
+    const { status, body } = await get(
+      appFor(WORLD_A),
+      `/repos/acme/api/releases/tags/${WORLD_A.tagName}`
+    );
+    expect(status).toBe(200);
+    expect(body).toMatchObject({ tag_name: WORLD_A.tagName, body: WORLD_A.releaseBody });
+  });
+
+  it("mints no second tag for a release naming a tag the seed already declared", async () => {
+    const { body } = await get(appFor(WORLD_A), "/repos/acme/api/tags");
+    expect(body.map((tag: { name: string }) => tag.name)).toEqual([WORLD_A.tagName]);
+  });
+
+  it("mints the tag for a release whose tag the seed did not declare", async () => {
+    const untagged = world(WORLD_A);
+    untagged.repositories[0]!.tags = [];
+    const { body } = await get(createGitHubCloneApp({ seed: untagged }), "/repos/acme/api/tags");
+    expect(body.map((tag: { name: string }) => tag.name)).toEqual([WORLD_A.tagName]);
+  });
+});
+
+describe("F-1421 — the schema keeps the keys it used to strip", () => {
+  it("carries all five entity types through parseSeed", () => {
+    const parsed = parseSeed(world(WORLD_A));
+    const repo = parsed.repositories[0]!;
+
+    expect(repo.milestones).toHaveLength(1);
+    expect(repo.tags).toHaveLength(1);
+    expect(repo.releases).toHaveLength(1);
+    expect(repo.issues[0]?.comments).toHaveLength(1);
+    expect(repo.pull_requests[0]?.review_comments).toHaveLength(1);
+  });
+
+  it("keeps a pull request's conversation comments apart from its review comments", async () => {
+    // Three things a reader could call "a comment on the PR" (F-1151), and the
+    // seed can now express all three separately: the review verdict's prose,
+    // the inline comment, and the timeline.
+    const seed = world(WORLD_A);
+    seed.repositories[0]!.pull_requests![0]!.comments = [
+      { body: "Rebased onto main.", author: "alice" }
+    ];
+    const app = createGitHubCloneApp({ seed });
+
+    const timeline = await get(app, "/repos/acme/api/issues/3/comments");
+    const inline = await get(app, "/repos/acme/api/pulls/3/comments");
+    const reviews = await get(app, "/repos/acme/api/pulls/3/reviews");
+
+    expect(timeline.body).toHaveLength(1);
+    expect(timeline.body[0]).toMatchObject({
+      body: "Rebased onto main.",
+      user: { login: "alice" },
+      // A PR is an issue: GitHub browses its comment at /pull/N while the API
+      // pointer stays on the issues path.
+      html_url: expect.stringContaining("/acme/api/pull/3#issuecomment-")
+    });
+    expect(inline.body[0].body).toBe(WORLD_A.reviewCommentBody);
+    expect(reviews.body[0].body).toBe(WORLD_A.reviewBody);
+  });
+
+  it("leaves the default world alone — the change is additive", () => {
+    const parsed = parseSeed(defaultSeedState());
+    const repo = parsed.repositories[0]!;
+    expect(repo.milestones).toEqual([]);
+    expect(repo.tags).toEqual([]);
+    expect(repo.releases).toEqual([]);
+    expect(repo.issues[0]?.comments).toEqual([]);
+  });
+});
+
+describe("F-1421 — how the new entities are numbered, scoped and reseeded", () => {
+  it("honors milestone numbers the seed pins, in whatever order it pins them", () => {
+    // The identity case (`number: 1` first) never exercises the renumber, so
+    // this one asks for numbers `nextMilestoneNumber` would not have handed out.
+    const seed = world(WORLD_A);
+    seed.repositories[0]!.milestones = [
+      { number: 7, title: "Later" },
+      { number: 2, title: "Earlier" }
+    ];
+    const domain = new GitHubDomain(openGitHubCloneDatabase());
+    domain.seed(seed);
+
+    expect(domain.listMilestones({ owner: "acme", repo: "api" })).toMatchObject([
+      { number: 2, title: "Earlier" },
+      { number: 7, title: "Later" }
+    ]);
+  });
+
+  it("scopes milestones, tags and releases to the repository that declared them", () => {
+    const seed = world(WORLD_A);
+    seed.repositories.push({
+      owner: "acme",
+      name: "web",
+      default_branch: "main",
+      files: [{ path: "README.md", content: "# Web\n" }],
+      milestones: [{ title: "web milestone" }],
+      tags: [{ name: "web-v0.1.0" }],
+      releases: [{ tag_name: "web-v0.1.0", body: "web release" }]
+    });
+    const domain = new GitHubDomain(openGitHubCloneDatabase());
+    domain.seed(seed);
+
+    const names = (owner: string, repo: string) => ({
+      milestones: domain.listMilestones({ owner, repo }).map((m: any) => m.title),
+      tags: domain.listTags({ owner, repo }).map((t: any) => t.name),
+      releases: domain.listReleases({ owner, repo }).map((r: any) => r.tag_name)
+    });
+
+    expect(names("acme", "api")).toEqual({
+      milestones: [WORLD_A.milestoneTitle],
+      tags: [WORLD_A.tagName],
+      releases: [WORLD_A.tagName]
+    });
+    expect(names("acme", "web")).toEqual({
+      milestones: ["web milestone"],
+      tags: ["web-v0.1.0"],
+      releases: ["web-v0.1.0"]
+    });
+  });
+
+  it("refuses a seed that declares one tag name twice in a repository", () => {
+    const bad = world(WORLD_A);
+    bad.repositories[0]!.tags = [{ name: "v1.0.0" }, { name: "v1.0.0", target: "feature" }];
+    expect(() => new GitHubDomain(openGitHubCloneDatabase()).seed(bad)).toThrow(
+      /declares tag v1\.0\.0 twice/
+    );
+  });
+
+  it("reseeds from scratch — the counts do not grow across repeated seeds", () => {
+    // `/admin/seed` is reseed-from-scratch, and pome-cloud's fidelity sandbox
+    // leans on that: it reseeds before every capture and expects the same world.
+    // The five new entity types have to be wiped by `resetDatabase` like the
+    // rest, or a second capture would run against a doubled world.
+    const domain = new GitHubDomain(openGitHubCloneDatabase());
+    const counts = () => ({
+      milestones: domain.listMilestones({ owner: "acme", repo: "api" }).length,
+      tags: domain.listTags({ owner: "acme", repo: "api" }).length,
+      releases: domain.listReleases({ owner: "acme", repo: "api" }).length,
+      issueComments: domain.listIssueComments({ owner: "acme", repo: "api", issue_number: 1 }).length,
+      reviewComments: domain.getPullRequestComments({ owner: "acme", repo: "api", pull_number: 3 }).length
+    });
+
+    domain.seed(world(WORLD_A));
+    const first = counts();
+    domain.seed(world(WORLD_A));
+
+    expect(first).toEqual({ milestones: 1, tags: 1, releases: 1, issueComments: 1, reviewComments: 1 });
+    expect(counts()).toEqual(first);
+  });
+});


### PR DESCRIPTION
Executive summary: `twin-github`'s `seedSchema` had no field for five entities the twin *serves* — milestones, tags, releases, issue comments and PR review comments — and zod strips unknown keys, so five advertised routes could only ever answer `[]` on any seed anyone could write. The tables, domain operations and routes all already existed; the seed was the only thing that could not reach them. This is additive: every new field is optional with a `[]` default, and no route, tool, handler or response shape changed.

## What

`seedSchema` gains five entity types on `repositories[]`:

| new field | the surface it makes reachable |
| -- | -- |
| `milestones[]` | `GET /repos/:o/:r/milestones` |
| `tags[]` | `GET /repos/:o/:r/tags` |
| `releases[]` | `GET /repos/:o/:r/releases`, `/releases/latest`, `/releases/tags/:tag` |
| `issues[].comments[]`, `pull_requests[].comments[]` | `GET /repos/:o/:r/issues/:n/comments` |
| `pull_requests[].review_comments[]` | `GET /repos/:o/:r/pulls/:n/comments` |

`GitHubDomain.seed()` applies them, `types.ts`'s hand-written `SeedRepository` keeps up, and `test/seed-entities.test.ts` (25 tests) covers it. README documents the new fields and the non-obvious constraints.

## Why

A shape-diff returns before the per-element comparison when **either** side is empty, so `[] vs []` compares zero elements and publishes green. Those five surfaces had been publishing green against an equally empty golden since 2026-05-31 while comparing nothing at all — a twin that serves a route and can only answer `[]` is precisely the shape of infidelity this project exists to catch. Seeding the upstream half alone would only have converted a vacuous green into an equally vacuous `array-length-changed` red; a real comparison needs an element on both sides.

## Notes for reviewer

**Two application choices, both deliberate:**

- **Review comments go through the domain's write path**, not a raw INSERT. So `path` must name a file the pull request changes and `line` must exist in it: a seeded review comment is one `POST /pulls/:n/comments` could have produced, and a seed planting one it could not **fails** rather than creating a row only the seeder can make. Two tests pin both refusals — and they are also the only place `line` is asserted, because the list route does not serve it.
- **Comment authors are seeded directly** rather than through `addIssueComment`, which stamps `user_login = "pome-agent"` unconditionally. An issue whose only commenter is the agent under test has nothing for that agent to read. The seeded PR reviews already bypass `createPullRequestReview` for exactly this reason; this follows that precedent, and keeps the one check that matters (`requireCommentTarget`).

**The test's shape is the point.** Every surface is asserted against **two** worlds that differ only in the value the seed plants: the served element must carry *this* world's value, and the other world's must differ. Asserting the array came back non-empty would repeat the original mistake one level up — it passes against a twin answering a constant. The seven surfaces are the five above plus the two that were already seedable (a PR's reviews, an issue the seed closes).

**The test world mirrors the fidelity sandbox on purpose** — `acme/api`, issues #1 and #2, PR #3 off `feature` — so it doubles as a rehearsal of the seed the fidelity watch will run, including the trap that issues and pull requests draw from one per-repo counter (the closed-issue surface is issue #2 flipped, not a third issue, which would move the PR to #4).

**Two gaps documented rather than fixed** (FIDELITY.md divergences 21 and 22). Both are pre-existing and both become observable for the first time here, because until now these surfaces had no element to inspect:

1. `GET /pulls/:n/comments` builds its elements inline — `{id, path, body, user, created_at, updated_at}` — while `POST` to the same route serves the same row through `pullRequestReviewCommentJson`, which adds `line`, `side`, `commit_id`, `pull_request_url` and the rest. One row, two shapes, one route family.
2. `pull_request_read`'s `get_comments` answers from the review-comment table on a comment claiming the twin "does not split" the two — true when written, falsified by F-1151, which gave the conversation its own table.

Both widen a served shape, which is a wire change owed its own review and its own fidelity accounting, so neither is a rider on this one. The first will surface as field-level findings on the fidelity watch's first real comparison of that surface.

**`GET /releases/latest` and `/releases/tags/:tag` answer 200 from a seed now**, which falsifies the stated reason of two registered read-surface exceptions in pome-cloud's Level-1 coverage list ("the seed schema cannot seed a release"). They are retired on that side, which must land *after* this ships and the twin snapshot is promoted — retiring them against a deployed twin that still strips the seed would red the lane.

**Version bumps:** `twin-github` 0.10.2, `cli` 0.23.7 (bundled twin), `checks` 0.1.4 — `seed.ts` is in the checks tarball's publish-relevant paths, and a grader validating against 0.1.3 would strip exactly the keys 0.10.2 honors.

## Tests / CI

Local, all green:

- `npm test` — 3081 tests across 10 workspaces (twin-github 458 → 483; 25 new)
- `npm run typecheck` — all workspaces
- `lint:code-health`, `lint:route-inputs`, `gate:route-inputs`, `lint:dead-code`, `gate:mcp-tools-list`, `lint:no-cloud-imports`, `gate:no-eval`, `lint:copy-markers`, `lint:legacy-markers`, `lint:parent-vocab`, `lint:skill-manifest`
- `check-version-bump-required.mjs origin/main`, `check-checks-tarball.mjs --manifest-only`
- `probe:twins` — 128 probes across all 5 twins

`probe:examples` fails identically on a clean tree in this environment (a local install gap under `examples/`), unrelated to this change.

## Review required

Yes — this touches the twin fidelity contract (FIDELITY.md divergences 21/22) and a public OSS API (`@pome-sh/checks/github`'s re-exported `seedSchema`, published to npm). The widening cannot break an existing consumer, but the published seed vocabulary is a contract worth a second pair of eyes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)