### PR TITLE
The review-comment LIST serves the object the CREATE serves (F-1422)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,18 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.23.8
+
+### Patch Changes
+
+- Carries twin-github 0.10.3 (F-1422) into the bundled twin.
+  `GET /repos/:o/:r/pulls/:n/comments` now serves the review-comment object
+  `POST` to the same route already served — `line`, `side`, `commit_id`,
+  `pull_request_url` and the rest — instead of six columns of a row that held
+  more. An agent reading a PR's inline comments through `pome twin start github`
+  can now tell WHERE each comment is anchored; before, it got the prose and the
+  filename and had to guess the line. No CLI source changed.
+
 ## 0.23.7
 
 ### Patch Changes

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.23.7",
+  "version": "0.23.8",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/packages/twin-github/CHANGELOG.md
+++ b/packages/twin-github/CHANGELOG.md
@@ -1,6 +1,61 @@
 # @pome-sh/twin-github — CHANGELOG
 
 
+## 0.10.3 — 2026-08-10
+
+`GET /repos/:o/:r/pulls/:n/comments` serves the review-comment object, not six
+columns of it (F-1422).
+
+The LIST route built its elements inline — `{id, path, body, user, created_at,
+updated_at}` — while `POST` to the same route served the SAME ROW through
+`pullRequestReviewCommentJson`, which carries `line`, `side`, `commit_id`,
+`pull_request_url`, `position`, `html_url`, the `original_*` twins and the rest.
+The write path validates `line` against the target file's real line count and
+refuses one past the end; the read path then dropped the value it had just
+checked. One row had two shapes depending on which verb you used, and the read
+side — the one a fidelity lane measures and an agent reads — was the lean one.
+
+The fix is one line of routing: the LIST maps through the same serializer the
+CREATE uses. `listPullRequestReviewCommentRows` also stops casting a `SELECT *`
+to a six-key structural subset of `PullRequestReviewCommentRow` — that cast is
+what made the omission look deliberate to every reader after it.
+
+What this means for a caller:
+
+- `GET /repos/:o/:r/pulls/:n/comments` elements gain `url`, `node_id`,
+  `pull_request_review_id`, `diff_hunk`, `position`, `original_position`,
+  `commit_id`, `original_commit_id`, `in_reply_to_id`, `side`, `line`,
+  `original_line`, `start_line`, `original_start_line`, `start_side`,
+  `html_url` and `pull_request_url`. The six they already had are unchanged.
+- `pull_request_read`'s `get_review_comments` and `get_comments` answer from the
+  same domain call, so both widen with it.
+- Nothing narrows, and no other route, tool or handler moved.
+
+This was invisible rather than merely wrong, which is why it survived: the
+surface answered `[]` on every seed anyone could write until 0.10.2 (F-1421)
+made a review comment seedable, and a shape-diff compares no elements when
+either side is empty. The first real element on this surface is what makes an
+omitted field a `field-removed` finding — drift, on a `semantic`-tier read
+surface.
+
+`test/review-comment-list-shape.test.ts` states the property that was violated
+rather than a field checklist: the LIST element and the CREATE response are the
+same object for the same comment. A checklist goes stale the next time the
+serializer grows a leaf; the property does not. It also plants a wrong `line` —
+two worlds differing only in the seeded anchor — so the new fields are shown to
+be COMPARED and not merely present. A field that is serialized but never
+compared publishes green whatever it holds, which is the same defect one level
+over.
+
+FIDELITY.md divergence 21 changes subject accordingly: it recorded the two
+shapes as an open gap and now records what is genuinely absent from the one
+shape versus real GitHub — `author_association`, `reactions`, `subject_type` —
+plus the two the twin serves as placeholders rather than measurements
+(`diff_hunk`, `position`). The matching `read_subset` entry lives in pome-cloud's
+`known-divergences/github.yaml`; without that cloud-side half the daily cron
+still reds, because a `FIDELITY.md` bullet alone relaxes no verdict.
+
+
 ## 0.10.2 — 2026-08-10
 
 The seed can name a milestone, a tag, a release and a comment, and the twin

--- a/packages/twin-github/FIDELITY.md
+++ b/packages/twin-github/FIDELITY.md
@@ -4,7 +4,7 @@
 universal clone. This page documents exactly which surfaces are faithful to
 GitHub today, at what tier, and how fidelity is verified.
 
-Last verified: 2026-08-08.
+Last verified: 2026-08-10.
 
 ## What "fidelity" means here
 
@@ -80,7 +80,7 @@ in the package README. Changing any of those is a breaking change for
 | `get_tag` | SQLite tags | hot | semantic | `mcp-contract.test.ts`, `m5-hot-gaps.test.ts` | MCP-only (no REST route; git-plumbing REST stays cold per F-729); returns the lightweight tag object, not the annotated-tag git object. |
 | `issue_read` | SQLite issues, issue comments, issue labels | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | GitHub's consolidated reader (F-1376). Methods `get`, `get_comments`, `get_labels`; `get_sub_issues` and `get_parent` answer 501 — sub-issues are not modeled. |
 | `issue_write` | SQLite issues, labels, assignees | hot | semantic | `mcp-contract.test.ts`, `mcp-error-semantics.test.ts` | GitHub's consolidated writer (F-1376). Methods `create` and `update`. Milestones, issue types and `state_reason` are not implemented. |
-| `pull_request_read` | SQLite pull requests, PR files, commits, reviews, comments, check runs | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | GitHub's consolidated reader (F-1376). `get_diff` and `get_files` return simplified placeholder patches; `get_comments` and `get_review_comments` answer from one comment thread, which this twin does not split. |
+| `pull_request_read` | SQLite pull requests, PR files, commits, reviews, comments, check runs | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | GitHub's consolidated reader (F-1376). `get_diff` and `get_files` return simplified placeholder patches; `get_comments` answers from the review-comment table rather than the PR's conversation, which the twin DOES split (divergence 22). |
 | `pull_request_review_write` | SQLite PR reviews | hot | semantic | `mcp-contract.test.ts`, `state-export.test.ts` | GitHub's consolidated review writer (F-1376). Only `create` with an explicit `event`; pending reviews and review threads are not modeled, so the other four methods answer 501. |
 | `list_repository_collaborators` | SQLite collaborators | hot | semantic | `mcp-contract.test.ts` | Permission filtering is not implemented. |
 
@@ -337,19 +337,40 @@ upstream so a divergence that upstream "heals" becomes a tier-upgrade signal.
     seeded sandbox's smaller label set and different collaborator set, not a serializer
     bug. On these L1 read surfaces the item-count difference is an accepted divergence
     (INFO), not drift.
-21. **The review-comment LIST serves a leaner object than the review-comment CREATE
-    (open gap, not accepted).** `GET /repos/:o/:r/pulls/:n/comments` builds its
-    elements inline — `{id, path, body, user, created_at, updated_at}` — while
-    `POST` to the same route serves the same row through
-    `pullRequestReviewCommentJson`, which adds `line`, `side`, `commit_id`,
-    `original_*`, `in_reply_to_id`, `pull_request_url`, `html_url`, `diff_hunk`
-    and the rest. One row, two shapes, one route family. This is NOT an accepted
-    INFO divergence like the omission bullets above: the twin already has the
-    faithful serializer and the list simply does not call it. It went unmeasured
-    because the surface answered `[]` on every seed anyone could write until
-    F-1421 made a review comment seedable — the first real element on this
-    surface is what makes the gap visible. Fixing it widens a served shape, so it
-    is owed its own change and its own fidelity accounting.
+21. **Review-comment objects omit `author_association`, `reactions` and
+    `subject_type`.** The twin's review-comment object serves the anchor
+    (`path`, `line`, `side`, `commit_id`, `position` and their `original_*`
+    twins), the identity (`id`, `node_id`, `user`, `in_reply_to_id`), the prose
+    (`body`) and the timestamps, and omits the leaves that belong to features it
+    does not model: `author_association` (no org-membership model — bullets 8 and
+    11 omit the same leaf on issues and pull requests), `reactions` (no reaction
+    model) and `subject_type` (no file-level comments; every twin review comment
+    is a line comment). `_links` is omitted under the categorical hypermedia
+    exemption, and `body_text` / `body_html` are gated behind media types the
+    twin does not serve, so neither is on this list. On the L1 read surface
+    `GET /repos/:o/:r/pulls/:n/comments` these upstream-only omissions are
+    accepted (INFO), not drift.
+
+    **`line`, `side`, `commit_id` and `pull_request_url` are served, not omitted
+    (F-1422).** They had been dropped by the LIST route alone: it built its
+    elements inline out of six columns while `POST` to the same route served the
+    same row through `pullRequestReviewCommentJson`. One row, two shapes, and the
+    read side — the measured one — was the lean one. That went unmeasured rather
+    than unnoticed: the surface answered `[]` on every seed anyone could write
+    until F-1421 made a review comment seedable, and a shape-diff compares no
+    elements when either side is empty. Both verbs now serve the one serializer,
+    which is asserted as that property — the LIST element and the CREATE response
+    are the same object for the same comment — in
+    `test/review-comment-list-shape.test.ts`, rather than as a field checklist
+    that goes stale the next time the serializer grows a leaf.
+
+    **`diff_hunk` and `position` are served as placeholders, not measurements.**
+    `diff_hunk` is `""` and `position` mirrors the row's `line` rather than
+    counting lines from the `@@` header, because the twin's patches are
+    placeholders (bullet 2). Both are string-vs-string and number-vs-number
+    against upstream, so the shape diff masks them; an agent that parses a
+    review comment's hunk text or resolves `position` against a real diff will
+    diverge, exactly as on the diff surfaces bullet 2 names.
 22. **`pull_request_read`'s `get_comments` answers from the wrong table (open gap,
     not accepted).** GitHub distinguishes the issue-level `get_comments` from the
     diff-level `get_review_comments`; the twin answers BOTH from
@@ -359,9 +380,12 @@ upstream so a divergence that upstream "heals" becomes a tier-upgrade signal.
     conversation has its own table (`issue_comments`, keyed on the PR's number),
     `exportState` keeps the three comment surfaces apart, and the REST routes
     already serve them separately. So `get_comments` returns inline review
-    comments to a caller asking for the timeline. Same visibility story as bullet
-    21 — F-1421 makes both surfaces seedable, so the two now have different
-    contents to tell apart.
+    comments to a caller asking for the timeline — and since F-1422 it returns
+    them in the full review-comment shape, so the answer is now recognizably the
+    wrong OBJECT rather than a lean one that could pass for a timeline comment.
+    Discovered the same way as the LIST shape in bullet 21 — F-1421 makes both
+    surfaces seedable, so the two now have different contents to tell apart —
+    but MCP-only, so no fidelity-watch lane measures it.
 
 ## How fidelity is verified
 

--- a/packages/twin-github/package.json
+++ b/packages/twin-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-github",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Deterministic GitHub-shaped twin for agent testing — REST + MCP, SQLite-backed state.",
   "private": true,
   "type": "module",

--- a/packages/twin-github/src/domain/github-domain.ts
+++ b/packages/twin-github/src/domain/github-domain.ts
@@ -1361,15 +1361,13 @@ export class GitHubDomain {
   }
 
 
+  // F-1422 — `PullRequestReviewCommentRow`, not a six-key structural subset of
+  // it. The query is `SELECT *` and always was, so the narrow cast described
+  // less than the reader was handed and every caller inherited that description
+  // as its ceiling: `getPullRequestComments` served exactly the six keys named
+  // here while `line`, `side` and `commit_sha` sat unreachable in the same row.
   listPullRequestReviewCommentRows(repoId: number, pullNumber: number) {
-    return this.db.prepare("SELECT * FROM pull_request_review_comments WHERE repo_id = ? AND pull_number = ? ORDER BY id ASC").all(repoId, pullNumber) as Array<{
-      id: number;
-      path: string;
-      body: string;
-      user_login: string;
-      created_at: string;
-      updated_at: string;
-    }>;
+    return this.db.prepare("SELECT * FROM pull_request_review_comments WHERE repo_id = ? AND pull_number = ? ORDER BY id ASC").all(repoId, pullNumber) as PullRequestReviewCommentRow[];
   }
 
 

--- a/packages/twin-github/src/domain/pulls.ts
+++ b/packages/twin-github/src/domain/pulls.ts
@@ -59,7 +59,6 @@ import {
   reviewJson,
   statusJson,
   tagJson,
-  userJson,
 } from "../serializers.js";
 import type { GitHubDomain } from "./github-domain.js";
 import { contentLineCount, normalizePath } from "./helpers.js";
@@ -173,14 +172,15 @@ export function getPullRequestComments(domain: GitHubDomain, input: { owner: str
   const repo = domain.requireRepo(input.owner, input.repo);
   domain.requirePullRequest(repo.id, input.pull_number);
   const rows = domain.listPullRequestReviewCommentRows(repo.id, input.pull_number);
-  return paginate(rows, input.page, input.per_page ?? input.perPage).map((comment) => ({
-    id: comment.id,
-    path: comment.path,
-    body: comment.body,
-    user: userJson(comment.user_login),
-    created_at: comment.created_at,
-    updated_at: comment.updated_at
-  }));
+  // F-1422 — the same serializer `POST` to this route uses. It built its
+  // elements inline out of six columns while the row already held `line`,
+  // `side` and `commit_sha`, all validated on the way in: one row, two shapes,
+  // and the read side was the lean one. Real GitHub serves the `review-comment`
+  // schema from both verbs, so anything this list omits that the CREATE serves
+  // is a field-removed finding against upstream.
+  return paginate(rows, input.page, input.per_page ?? input.perPage).map((comment) =>
+    pullRequestReviewCommentJson(comment, repo)
+  );
 }
 
 

--- a/packages/twin-github/test/review-comment-list-shape.test.ts
+++ b/packages/twin-github/test/review-comment-list-shape.test.ts
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-1422 — one row, one shape.
+//
+// `GET /repos/:o/:r/pulls/:n/comments` built its elements inline out of six
+// columns — `{id, path, body, user, created_at, updated_at}` — while `POST` to
+// the same route served the SAME ROW through `pullRequestReviewCommentJson`,
+// which carries `line`, `side`, `commit_id`, `pull_request_url` and the rest.
+// The write path validates `line` against the file's real line count and then
+// the read path dropped it. One row had two shapes depending on which verb you
+// used, and the read side was the lean one.
+//
+// It went unmeasured rather than unnoticed: the surface answered `[]` on every
+// seed anyone could write until F-1421 made a review comment seedable, and a
+// shape-diff returns before the per-element comparison when either side is
+// empty. The first real element on this surface is what makes the gap visible —
+// as a `field-removed` finding per omitted field, which on a `semantic`-tier
+// read surface is drift.
+//
+// The property under test is stated as the property, not as a field checklist:
+// the LIST element and the CREATE response are the same object for the same
+// comment. A checklist drifts the moment the serializer gains a field; this
+// does not.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createGitHubCloneApp } from "../src/twin.js";
+import type { GitHubStateSeed } from "../src/types.js";
+import { TEST_AUTH_SECRET, TEST_SID, signTestToken, withAuth } from "./_authHelper.js";
+
+const previousSecret = process.env.TWIN_AUTH_SECRET;
+let token: string;
+
+beforeAll(async () => {
+  process.env.TWIN_AUTH_SECRET = TEST_AUTH_SECRET;
+  token = await signTestToken();
+});
+afterAll(() => {
+  if (previousSecret === undefined) delete process.env.TWIN_AUTH_SECRET;
+  else process.env.TWIN_AUTH_SECRET = previousSecret;
+});
+
+const base = `/s/${TEST_SID}`;
+
+/**
+ * `src/app.ts` exists on BOTH branches and the pull request changes it, so a
+ * review comment resolves on either side: `RIGHT` against the four-line head,
+ * `LEFT` against the three-line base. The one-line file F-1421's world uses
+ * cannot express a wrong line at all — every line in it is line 1.
+ */
+const BASE_APP_TS = "const a = 1;\nconst b = 2;\nconst c = 3;\n";
+const HEAD_APP_TS = "const a = 1;\nconst b = 22;\nconst c = 3;\nconst d = 4;\n";
+
+/** What the seed plants on the one review comment. */
+type Planted = { line: number; side: "LEFT" | "RIGHT" };
+
+function world(planted: Planted): GitHubStateSeed {
+  return {
+    users: [
+      { login: "acme", type: "Organization", name: "Acme" },
+      { login: "bob", type: "User", name: "Bob" },
+      { login: "pome-agent", type: "User", name: "Pome Agent" }
+    ],
+    repositories: [
+      {
+        owner: "acme",
+        name: "api",
+        default_branch: "main",
+        collaborators: ["bob", "pome-agent"],
+        files: [
+          { path: "README.md", content: "# Acme API\n" },
+          { path: "src/app.ts", content: BASE_APP_TS },
+          { path: "src/app.ts", content: HEAD_APP_TS, branch: "feature" }
+        ],
+        pull_requests: [
+          {
+            title: "Tune the constants",
+            body: "Bumps b and adds d.",
+            head: "feature",
+            base: "main",
+            author: "pome-agent",
+            review_comments: [
+              {
+                body: "This constant needs a name.",
+                path: "src/app.ts",
+                line: planted.line,
+                side: planted.side,
+                author: "bob"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  };
+}
+
+/** No issues in this world, so the pull request is the repo's first number. */
+const PR = 1;
+
+function appFor(planted: Planted) {
+  return createGitHubCloneApp({ seed: world(planted) });
+}
+
+async function req(
+  app: ReturnType<typeof createGitHubCloneApp>,
+  method: string,
+  path: string,
+  body?: unknown
+) {
+  const init: RequestInit = { method, headers: { "content-type": "application/json" } };
+  if (body !== undefined) init.body = JSON.stringify(body);
+  const response = await app.request(`${base}${path}`, withAuth(token, init));
+  const text = await response.text();
+  return { status: response.status, body: text ? (JSON.parse(text) as any) : null };
+}
+
+const listComments = (app: ReturnType<typeof createGitHubCloneApp>) =>
+  req(app, "GET", `/repos/acme/api/pulls/${PR}/comments`);
+
+describe("F-1422 — the review-comment LIST and CREATE serve one shape", () => {
+  it("serves the CREATE response's own field set back from the LIST, for the same comment", async () => {
+    const app = appFor({ line: 2, side: "RIGHT" });
+
+    const post = await req(app, "POST", `/repos/acme/api/pulls/${PR}/comments`, {
+      body: "Same row, both verbs.",
+      path: "src/app.ts",
+      line: 4
+    });
+    expect(post.status).toBe(201);
+
+    const list = await listComments(app);
+    expect(list.status).toBe(200);
+    const element = list.body.find((comment: { id: number }) => comment.id === post.body.id);
+    expect(element).toBeDefined();
+
+    // THE assertion of this ticket. Stated as the property that was violated —
+    // one row, one shape — rather than as a list of field names, which would go
+    // stale the next time the serializer grows a leaf.
+    expect(Object.keys(element).sort()).toEqual(Object.keys(post.body).sort());
+    // Same row, same serializer, so the values match too: a LIST that agreed on
+    // the key set while answering a different `line` would be the same defect
+    // wearing the right shape.
+    expect(element).toEqual(post.body);
+  });
+
+  it("serves a SEEDED comment through that same shape, not only a POSTed one", async () => {
+    // The fidelity lane never POSTs — it seeds and reads. A fix that only held
+    // for comments this process created would leave the measured path lean.
+    const app = appFor({ line: 2, side: "RIGHT" });
+    const post = await req(app, "POST", `/repos/acme/api/pulls/${PR}/comments`, {
+      body: "Second comment.",
+      path: "src/app.ts",
+      line: 4
+    });
+
+    const list = await listComments(app);
+    expect(list.body).toHaveLength(2);
+    const [seeded, posted] = list.body;
+    expect(posted.id).toBe(post.body.id);
+    expect(Object.keys(seeded).sort()).toEqual(Object.keys(post.body).sort());
+  });
+
+  it("carries the four fields the row already held and the read used to drop", async () => {
+    const app = appFor({ line: 2, side: "RIGHT" });
+    const head = await req(app, "GET", "/repos/acme/api/branches/feature");
+    const list = await listComments(app);
+
+    expect(list.body[0]).toMatchObject({
+      // The named four (ticket F-1422).
+      line: 2,
+      side: "RIGHT",
+      commit_id: head.body.commit.sha,
+      pull_request_url: `https://api.github.com/repos/acme/api/pulls/${PR}`,
+      // The six that were already there stay there — this widened the shape, it
+      // did not swap it.
+      path: "src/app.ts",
+      body: "This constant needs a name.",
+      user: { login: "bob" }
+    });
+    expect(list.body[0].created_at).toEqual(expect.any(String));
+    expect(list.body[0].updated_at).toEqual(expect.any(String));
+    expect(list.body[0].id).toEqual(expect.any(Number));
+  });
+
+  it("anchors a LEFT-side comment to the base file's line", async () => {
+    // `side` is not decoration: it selects which file the write path measures
+    // `line` against. Serving it is what lets a reader know which side of the
+    // diff the comment sits on.
+    const list = await listComments(appFor({ line: 3, side: "LEFT" }));
+    expect(list.body[0]).toMatchObject({ line: 3, side: "LEFT" });
+  });
+});
+
+describe("F-1422 — a wrong line is drift, not a field nobody reads", () => {
+  // A field that is serialized but never COMPARED is the same defect one level
+  // over: it publishes green whatever it holds. These two worlds differ in one
+  // planted value and nothing else, so the served element has to move with it.
+  it("serves the line THIS seed planted, and a different seed a different one", async () => {
+    const right = await listComments(appFor({ line: 2, side: "RIGHT" }));
+    // Line 4 exists only on the head file (the base is three lines long), so
+    // this is a value the other world could not have produced by accident.
+    const wrong = await listComments(appFor({ line: 4, side: "RIGHT" }));
+
+    expect(right.body[0].line).toBe(2);
+    expect(wrong.body[0].line).toBe(4);
+    expect(right.body[0].line).not.toBe(wrong.body[0].line);
+
+    // `position` and `original_line` are resolved from the same row column, so
+    // a comparison catches the wrong line through all three.
+    expect(wrong.body[0]).toMatchObject({ line: 4, original_line: 4, position: 4 });
+  });
+
+  it("serves the side THIS seed planted, and a different seed a different one", async () => {
+    const right = await listComments(appFor({ line: 3, side: "RIGHT" }));
+    const left = await listComments(appFor({ line: 3, side: "LEFT" }));
+
+    expect(right.body[0].side).toBe("RIGHT");
+    expect(left.body[0].side).toBe("LEFT");
+    expect(right.body[0].side).not.toBe(left.body[0].side);
+  });
+
+  it("refuses a seeded line past the end of the side it names", async () => {
+    // The write path's own guard, restated here because it is what makes the
+    // served `line` worth comparing: the twin cannot hold a line the file does
+    // not have, so a served `line` is a fact about the diff and not a free
+    // integer. `LEFT` is the three-line base; line 4 exists only on the head.
+    expect(() => appFor({ line: 4, side: "LEFT" })).toThrow(/Validation Failed/);
+  });
+});

--- a/packages/twin-github/test/seed-entities.test.ts
+++ b/packages/twin-github/test/seed-entities.test.ts
@@ -310,24 +310,28 @@ describe("F-1421 — a seeded element is a whole GitHub object, not a stub", () 
   it("serves the seeded review comment anchored to the file the seed named", async () => {
     const { body } = await get(appFor(WORLD_A), "/repos/acme/api/pulls/3/comments");
     expect(body).toHaveLength(1);
-    // This LIST route serves a leaner element than the twin's own review-comment
-    // object — no `line`, `side`, `commit_id`, `pull_request_url` — while
-    // `POST /pulls/:n/comments` on the same row serves all of them
-    // (`pullRequestReviewCommentJson`). That predates this change and is left
-    // alone by it: widening a served shape is a wire change with its own
-    // fidelity accounting, and this ticket's subject is the modelling gap that
-    // made the array empty. Asserted as it is rather than as it should be.
+    // F-1422 closed the gap this assertion used to record: the LIST served six
+    // columns of a row whose `line`, `side` and `commit_id` the CREATE on the
+    // same route already served. Both verbs now go through
+    // `pullRequestReviewCommentJson`, so the anchor the seed planted is
+    // readable from the surface the fidelity lane measures — asserted here on
+    // the seeded element, and as the shared-shape property itself in
+    // `review-comment-list-shape.test.ts`.
     expect(body[0]).toMatchObject({
       body: WORLD_A.reviewCommentBody,
       path: "src/feature.ts",
-      user: { login: "bob" }
+      user: { login: "bob" },
+      line: 1,
+      side: "RIGHT",
+      pull_request_url: "https://api.github.com/repos/acme/api/pulls/3"
     });
   });
 
   // The two below are what pin `path` and `line`: the seed goes through the
   // domain's own write path, so a review comment the API could not have made is
-  // a seed that FAILS rather than a row only the seeder can produce. They are
-  // also how `line` is asserted at all — the list route above does not serve it.
+  // a seed that FAILS rather than a row only the seeder can produce. That guard
+  // is what makes the served `line` above a fact about the diff rather than a
+  // free integer.
   it("refuses a seeded review comment on a file the pull request does not change", async () => {
     const bad = world(WORLD_A);
     // `README.md` is on both branches unchanged, so it is not in the PR's diff.


### PR DESCRIPTION
Executive summary: `GET /repos/:o/:r/pulls/:n/comments` built its elements inline out of six columns while `POST` to the same route served the *same row* through `pullRequestReviewCommentJson` — `line`, `side`, `commit_id`, `pull_request_url` and the rest. The write path validates `line` against the file's real line count and refuses one past the end; the read path then dropped the value it had just checked. One row, two shapes, and the read side — the one a fidelity lane measures and an agent reads — was the lean one. The fix is one line of routing plus the type cast that hid it. Nothing narrows.

## What

`getPullRequestComments` maps through `pullRequestReviewCommentJson` instead of building a six-key object. The element gains `url`, `node_id`, `pull_request_review_id`, `diff_hunk`, `position`, `original_position`, `commit_id`, `original_commit_id`, `in_reply_to_id`, `side`, `line`, `original_line`, `start_line`, `original_start_line`, `start_side`, `html_url`, `pull_request_url`. `listPullRequestReviewCommentRows` stops casting a `SELECT *` to a six-key structural subset of `PullRequestReviewCommentRow`. `pull_request_read`'s `get_review_comments` and `get_comments` share the domain call and widen with it. No other route, tool or handler moved.

## Why

Every field real GitHub returns and the twin omits is a `field-removed` finding, which is drift on a `semantic`-tier read surface, with `FIDELITY_FAIL_ON_DRIFT=1` on the daily schedule. This was invisible rather than merely wrong, which is why it survived as long as the route has existed: the surface answered `[]` on every seed anyone could write until 0.10.2 (F-1421) made a review comment seedable, and a shape-diff compares no elements when either side is empty. The first real element on this surface is what makes the gap measurable — and what would have reded the cron.

The alternative was a `read_subset` waiver, i.e. registering "our twin returns less" for fields the twin already had in the row. That is a written excuse for an omission, which is the shape this milestone exists to eliminate. A `read_subset` entry is for a leaf the twin genuinely cannot model; this was not one.

## Notes for reviewer

**The test states the property, not a checklist.** `test/review-comment-list-shape.test.ts` asserts that the LIST element and the CREATE response are the same object for the same comment — key-set equality *and* deep equality — rather than listing the field names that ought to be there. A checklist goes stale the next time the serializer grows a leaf; the property does not. It is asserted for a POSTed comment *and* for a seeded one, because the fidelity lane never POSTs — it seeds and reads, so a fix that only held for comments this process created would leave the measured path lean.

**It plants a wrong `line` and demands the served element move with it.** Two worlds differing only in the seeded anchor, on a file whose head side is four lines and base side three (F-1421's world has a one-line file, where every line is line 1 and a wrong line cannot be expressed). A field that is serialized but never *compared* publishes green whatever it holds, which is the same defect one level over.

**The type cast is half the bug and is why this is two files.** `listPullRequestReviewCommentRows` ran `SELECT *` and cast the result to six keys. The columns were always there; the cast is what made the omission read as deliberate to everyone after it.

**FIDELITY.md divergence 21 changes subject rather than disappearing.** It recorded the two shapes as an open gap; it now records what is genuinely absent from the one shape versus real GitHub — `author_association`, `reactions`, `subject_type` — plus two the twin serves as placeholders rather than measurements (`diff_hunk` is `""`, `position` mirrors `line` instead of counting from the `@@` header). Both are masked by the shape diff, so neither produces a finding, but an agent parsing a hunk or resolving a position against a real diff will diverge, exactly as on the diff surfaces divergence 2 names. Divergence 22 and the `pull_request_read` table cell also stopped asserting the comment split the twin *does* model (F-1151).

**One risk that no cloud-side registry entry can cover, flagged rather than guessed.** The twin serves `in_reply_to_id`, `start_line`, `original_start_line` and `start_side` as `null` on a top-level single-line comment. If real GitHub returns them as null too, they match. If it *omits* any of them, the diff is twin-only — a `field-added`, which the subset relaxation never touches in any direction. `in_reply_to_id` is the likely one: the upstream schema marks it optional while marking `start_line` / `start_side` present-and-nullable. There is no captured review comment anywhere to check against, because this surface has answered `[]` since May, so the first capture is the arbiter. The remedy, if it shows, is one conditional key in `pullRequestReviewCommentJson`, the way `contentDirectoryEntryJson` already omits `git_url` on directories rather than emitting a null. Shipping that pre-emptively would be a wire change on a guess about a vendor response — the same class of mistake as registering a divergence nobody measured.

**The cloud-side half is still owed.** A `read_subset` entry for the three genuinely-absent leaves must land in the fidelity watch's known-divergences registry, sequenced after this ships and the twin snapshot is promoted. A FIDELITY.md bullet alone relaxes no verdict.

**Version bumps:** `twin-github` 0.10.3, `cli` 0.23.8 (bundled twin). `checks` is untouched — `src/domain/*.ts` is not in its tarball's publish-relevant paths.

## Tests / CI

Local, all green:

- `npm test` — 3322 tests across 10 workspaces; twin-github 462 → 469 (7 new, 1 new file)
- `npm run typecheck` — all workspaces
- `npm run test:contract` — 104 passed, 5 skipped
- `lint:code-health`, `lint:route-inputs`, `gate:route-inputs`, `lint:dead-code`, `gate:mcp-tools-list`, `lint:no-cloud-imports`, `gate:no-eval`, `gate:no-native`, `lint:copy-markers`, `lint:legacy-markers`, `lint:parent-vocab`, `lint:skill-manifest`, `lint:twin-chunks`, `lint:twin-leaves`, `lint:task-class`, `gate:checks-manifest`, `gate:wire-manifest`
- `check-version-bump-required.mjs`
- `probe:twins` — 128 probes across all 5 twins

`probe:examples` fails identically on a clean tree in this environment (`ERR_MODULE_NOT_FOUND` for example-local deps under `examples/`, which this diff does not touch) — verified by stashing and re-running.

## Review required

Yes — this touches the twin fidelity contract (FIDELITY.md divergences 21/22) and widens a served response shape on a `semantic`-tier hot surface. The widening cannot break a consumer reading the six fields it already served, but "what the twin puts on the wire" is worth a second pair of eyes, and the `in_reply_to_id` question above is a judgement call worth confirming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)