### PR TITLE
The three list routes honour GitHub's state=open default (F-1427)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,22 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.23.9
+
+### Patch Changes
+
+- Carries twin-github 0.10.4 (F-1427) into the bundled twin.
+  `GET /repos/:o/:r/issues`, `GET /repos/:o/:r/pulls` and
+  `GET /repos/:o/:r/milestones` now default `state` to `open`, the way real
+  GitHub documents them; they previously returned closed items too whenever the
+  caller sent no `state`. **This moves results**: an agent that lists issues
+  under `pome twin start github` and counts them gets a different answer than it
+  did on 0.23.8 — the answer real GitHub gives, but a different one.
+  `state=all` and `state=closed` are unchanged, and `GET /search/issues` is
+  deliberately excluded (GitHub's search API has no such default). A seed asking
+  for a closed pull request also gets one now; the field was accepted and
+  silently dropped before. No CLI source changed.
+
 ## 0.23.8
 
 ### Patch Changes

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.23.8",
+  "version": "0.23.9",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/packages/twin-github/CHANGELOG.md
+++ b/packages/twin-github/CHANGELOG.md
@@ -1,6 +1,65 @@
 # @pome-sh/twin-github — CHANGELOG
 
 
+## 0.10.4 — 2026-08-11
+
+An absent `state` means `open` on the three list routes, the way real GitHub
+documents them (F-1427).
+
+`GET /repos/:o/:r/issues`, `GET /repos/:o/:r/pulls` and
+`GET /repos/:o/:r/milestones` each filtered only when `state` was PRESENT:
+
+```js
+if (input.state && input.state !== "all") rows = rows.filter(...)
+```
+
+so a caller who sent none — the common case, and the one real GitHub answers with
+open items only — got everything, closed included.
+
+⚠️ **This changes what the twin SERVES.** A task whose agent lists issues and
+counts them gets a different answer from 0.10.4 on. That answer is the one real
+GitHub gives, but it is a moved result, not a silent correction. `state=all`
+returns everything and an explicit `state=closed` returns the closed items; both
+are unchanged.
+
+It stayed invisible for one reason on all three surfaces: every seeded issue,
+pull request and milestone was open, so `all` and `open` named the same set and
+no fixture could tell them apart. pome-cloud's upstream seeder had already met
+the milestone half and worked around it in the SEED rather than the twin — its
+milestone is kept open on purpose, commented "GitHub defaults that list to
+`state=open` — a closed milestone would leave the golden empty again". The issue
+half surfaced the moment pome-cloud's fidelity seed closed an issue, as
+`[].state` constant-mismatch and `[].closed_at` type-changed against real GitHub,
+both CRITICAL on a `semantic`-tier read surface.
+
+`GET /search/issues` is deliberately excluded and now says so in the code.
+GitHub's search API has no `state` default — `is:open` is a query qualifier, not
+a default — so the twin's search keeps filtering only on an explicit `state`.
+Imposing the list default there would be a new divergence in the other direction,
+and a worse one: the twin's search is substring matching over the seeded world,
+so a query whose only match is closed would answer `[]`, replacing a value
+mismatch with an empty-array one.
+
+Seeding the closed side of these surfaces works now, too. `seedSchema` had
+accepted `pull_requests[].state` for as long as the field existed, but nothing
+ever applied it — `createPullRequest` hardcodes `'open'` in its INSERT — so a
+seed asking for a closed pull request got an open one and
+`GET /pulls?state=closed` could not be made non-empty by any seed. That is the
+same shape of invisibility F-1421 fixed for the five entities the seed could not
+express at all, and it is why the pull-request half of this fix was untestable
+until now. The seed applies it last, after every child is seeded: the review and
+update-branch write paths refuse a non-open pull request, so closing first would
+make a seeded child fail against the state the seed itself asked for.
+
+`test/list-state-default.test.ts` seeds one open and one closed of each kind and
+compares SETS of numbers, never counts — a count matches for the wrong reason as
+easily as the right one, since two items is what `state=all` returns AND what an
+open default would return from a world with two open items. The absent case is
+asserted equal to the explicit `open` case and, separately, NOT equal to the
+`all` case, so a future change that reverts the default fails on the assertion
+that names the cause.
+
+
 ## 0.10.3 — 2026-08-10
 
 `GET /repos/:o/:r/pulls/:n/comments` serves the review-comment object, not six

--- a/packages/twin-github/FIDELITY.md
+++ b/packages/twin-github/FIDELITY.md
@@ -4,7 +4,7 @@
 universal clone. This page documents exactly which surfaces are faithful to
 GitHub today, at what tier, and how fidelity is verified.
 
-Last verified: 2026-08-10.
+Last verified: 2026-08-11.
 
 ## What "fidelity" means here
 
@@ -58,11 +58,11 @@ in the package README. Changing any of those is a breaking change for
 | `create_branch` | SQLite branches/files | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts`, `concurrency.test.ts` | Branch protection is not modeled. |
 | `push_files` | SQLite files/commits | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | Multi-file pushes are one local commit; Git object APIs are simplified. |
 | `search_issues` | SQLite issues | hot | semantic | `mcp-contract.test.ts`, `performance.test.ts`, `fixture-endpoints.test.ts` | Query syntax is substring based. |
-| `list_issues` | SQLite issues | hot | semantic | `mcp-contract.test.ts`, `performance.test.ts`, `fixture-endpoints.test.ts` | Only state, labels, assignee, and pagination filters are supported. |
+| `list_issues` | SQLite issues | hot | semantic | `mcp-contract.test.ts`, `performance.test.ts`, `fixture-endpoints.test.ts`, `list-state-default.test.ts` | Only state, labels, assignee, and pagination filters are supported. An absent `state` means `open`, as on real GitHub (F-1427). |
 | `add_issue_comment` | SQLite issue comments | hot | semantic | `mcp-contract.test.ts`, `state-export.test.ts` | Comment edit/delete APIs are not implemented. |
 | `create_issue` | SQLite issues | hot | semantic | `mcp-contract.test.ts` | Issue templates and milestones are not modeled. |
 | `create_pull_request_review` | SQLite PR reviews | hot | semantic | `mcp-contract.test.ts`, `state-export.test.ts` | Inline review comments are not created by this tool. |
-| `list_pull_requests` | SQLite pull requests | hot | semantic | `mcp-contract.test.ts`, `v2-hot-paths-rest.test.ts` | Sorting and advanced filters are simplified. `stack` is derived from the base chain (divergence #11). |
+| `list_pull_requests` | SQLite pull requests | hot | semantic | `mcp-contract.test.ts`, `v2-hot-paths-rest.test.ts`, `list-state-default.test.ts` | Sorting and advanced filters are simplified. `stack` is derived from the base chain (divergence #11). An absent `state` means `open`, as on real GitHub (F-1427). |
 | `merge_pull_request` | SQLite merge mutation | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | Merge methods are simplified to one deterministic local merge. |
 | `update_pull_request_branch` | SQLite merge of base into head | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts`, `m5-hot-gaps.test.ts` | Merge commit carries a single parent; conflicting paths resolve head-wins (no 422 merge-conflict); 202-shaped no-op instead of GitHub's 422 when base has no new commits or when its changes are already contained on head (merge commits are only created when files change); no async update job. |
 | `create_pull_request` | SQLite pull requests/files | hot | semantic | `mcp-contract.test.ts`, `concurrency.test.ts` | Cross-repo forks are supported only when the fork exists in the clone. |
@@ -112,6 +112,44 @@ Twin-only fields are namespaced under `_twin.*`, matching `twin-slack` and
 
 If you hit this envelope and the route is one your agent needs, that's a
 fidelity gap worth filing — open an issue or a PR adding the route.
+
+### An absent `state` means `open` on the three list routes (F-1427)
+
+`GET /repos/:o/:r/issues`, `GET /repos/:o/:r/pulls` and
+`GET /repos/:o/:r/milestones` each default `state` to `open`, the way real
+GitHub documents them. `state=all` returns every item and an explicit
+`state=closed` returns the closed ones; both are unchanged.
+
+**This is a change to what the twin SERVES, not only to what it documents.**
+Until 0.10.4 the filter applied only when `state` was present, so a caller who
+sent none got closed items too — a task whose agent lists issues and counts them
+gets a different answer from 0.10.4 on. That answer is the one real GitHub gives,
+but it is a moved result, not a silent correction.
+
+It stayed invisible for one reason on all three surfaces: every seeded issue,
+pull request and milestone was open, so `all` and `open` named the same set and
+no fixture could tell them apart. pome-cloud's upstream seeder had already met
+the milestone half and worked around it in the SEED — its milestone is kept open
+on purpose, commented "GitHub defaults that list to `state=open` — a closed
+milestone would leave the golden empty again" — which is what kept the twin's own
+missing default hidden. The issue half surfaced the moment that seed closed an
+issue, as `[].state` constant-mismatch and `[].closed_at` type-changed against
+real GitHub, both CRITICAL.
+
+`GET /search/issues` is deliberately NOT part of this. GitHub's search API has no
+`state` default — `is:open` is a query qualifier, not a default — so the twin's
+search keeps filtering only on an explicit `state`. Imposing the list default
+there would be a new divergence in the other direction, and a worse one: the
+twin's search is substring matching over the seeded world, so a query whose only
+match is closed would answer `[]`, replacing a value mismatch with an
+empty-array one. Any residual `state` / `closed_at` finding on `/search/issues`
+is a property of that surface's upstream comparison, not of this default.
+
+Seeding the closed side of these surfaces works now, too: `seedSchema` had
+accepted `pull_requests[].state` for as long as the field existed while
+`createPullRequest` hardcoded `'open'` in its INSERT, so a seed asking for a
+closed pull request got an open one and `GET /pulls?state=closed` could not be
+made non-empty by any seed. It is applied from 0.10.4.
 
 ## Tier-mismatch ledger
 

--- a/packages/twin-github/package.json
+++ b/packages/twin-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-github",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Deterministic GitHub-shaped twin for agent testing — REST + MCP, SQLite-backed state.",
   "private": true,
   "type": "module",

--- a/packages/twin-github/src/domain/github-domain.ts
+++ b/packages/twin-github/src/domain/github-domain.ts
@@ -233,6 +233,20 @@ export class GitHubDomain {
               { actor: author }
             );
           }
+          // F-1427 — LAST, after every child is seeded. `seedSchema` has taken
+          // `pull_requests[].state` since the field was added, but nothing ever
+          // applied it: `createPullRequest` hardcodes `'open'` in its INSERT, so
+          // a seed asking for a closed PR got an open one and
+          // `GET /pulls?state=closed` could not be made non-empty by any seed —
+          // the same shape of invisibility F-1421 fixed for the five entities
+          // the seed could not express at all. Ordering is the reason this sits
+          // here rather than beside `createPullRequest`: the review and
+          // update-branch write paths refuse a non-open PR, so closing first
+          // would make a seeded child fail against the state the seed itself
+          // asked for.
+          if (pull.state === "closed") {
+            this.updatePullRequest({ owner: repo.owner, repo: repo.name, pull_number: prNumber, state: "closed" });
+          }
         }
         // F-1421 — tags and releases last: both name a commit, so every branch
         // and commit the seed can point them at exists by now. Tags first, so a

--- a/packages/twin-github/src/domain/issues.ts
+++ b/packages/twin-github/src/domain/issues.ts
@@ -98,7 +98,13 @@ export function createIssue(domain: GitHubDomain, input: { owner: string; repo: 
 export function listIssues(domain: GitHubDomain, input: { owner: string; repo: string; state?: "open" | "closed" | "all"; labels?: string; assignee?: string } & PageOptions) {
   const repo = domain.requireRepo(input.owner, input.repo);
   let rows = domain.listIssuesRows(repo.id);
-  if (input.state && input.state !== "all") rows = rows.filter((issue) => issue.state === input.state);
+  // Real GitHub defaults this route to `state=open` (F-1427). The filter used to
+  // apply only when `state` was PRESENT, so a caller who sent none — the common
+  // case — got closed issues too. Invisible while every seeded issue was open;
+  // the moment pome-cloud's fidelity seed closed one it showed up as `[].state`
+  // constant-mismatch and `[].closed_at` type-changed against real GitHub.
+  const state = input.state ?? "open";
+  if (state !== "all") rows = rows.filter((issue) => issue.state === state);
   if (input.labels) {
     const wanted = input.labels.split(",").map((label) => label.trim()).filter(Boolean);
     rows = rows.filter((issue) => {
@@ -312,7 +318,13 @@ export function deleteIssueComment(domain: GitHubDomain, input: { owner: string;
 export function listMilestones(domain: GitHubDomain, input: { owner: string; repo: string; state?: "open" | "closed" | "all" } & PageOptions) {
   const repo = domain.requireRepo(input.owner, input.repo);
   let rows = domain.db.prepare("SELECT * FROM milestones WHERE repo_id = ? ORDER BY number ASC").all(repo.id) as MilestoneRow[];
-  if (input.state && input.state !== "all") rows = rows.filter((milestone) => milestone.state === input.state);
+  // `state=open` by default, as on real GitHub (F-1427). pome-cloud's upstream
+  // seeder had already met this one and worked around it in the SEED rather than
+  // the twin — its milestone is kept open on purpose, commented "GitHub defaults
+  // that list to `state=open` — a closed milestone would leave the golden empty
+  // again". That workaround is what kept the twin's own missing default hidden.
+  const state = input.state ?? "open";
+  if (state !== "all") rows = rows.filter((milestone) => milestone.state === state);
   return paginate(rows, input.page, input.per_page ?? input.perPage).map((milestone) => milestoneJson(milestone, repo));
 }
 

--- a/packages/twin-github/src/domain/pulls.ts
+++ b/packages/twin-github/src/domain/pulls.ts
@@ -113,7 +113,12 @@ export function listPullRequests(domain: GitHubDomain, input: { owner: string; r
   const repo = domain.requireRepo(input.owner, input.repo);
   const all = domain.listPullRequestRows(repo.id);
   let rows = all;
-  if (input.state && input.state !== "all") rows = rows.filter((pr) => pr.state === input.state);
+  // `state=open` by default, as on real GitHub (F-1427). Same missing default
+  // the issue list had, hidden the same way: every seeded pull request was open,
+  // so "all" and "open" named one set. `all` below is deliberately the UNFILTERED
+  // rows — see the note on the stack read.
+  const state = input.state ?? "open";
+  if (state !== "all") rows = rows.filter((pr) => pr.state === state);
   // `all`, not `rows`: a PR's stack is a fact about the whole repo, so the state
   // filter and the page must not change it. Reading it once here is also what
   // keeps serializing a page of N from re-reading the table N times (F-1178).

--- a/packages/twin-github/src/domain/search.ts
+++ b/packages/twin-github/src/domain/search.ts
@@ -140,6 +140,13 @@ export function searchIssues(domain: GitHubDomain, input: { query?: string; q?: 
   let filtered = rows.filter((issue) => !query || issue.title.toLowerCase().includes(query) || issue.body.toLowerCase().includes(query) || issue.full_name.toLowerCase().includes(query));
   if (input.owner) filtered = filtered.filter((issue) => issue.owner === input.owner);
   if (input.repo) filtered = filtered.filter((issue) => issue.name === input.repo);
+  // NO `state=open` default here, deliberately (F-1427). The three repo LIST
+  // surfaces gained one because real GitHub defaults them; GitHub's SEARCH API
+  // does not — a search returns what the query asks for, and `is:open` is a
+  // query qualifier, not a default. Adding one to match the lists would be a new
+  // divergence in the other direction, and a worse one: this search is substring
+  // matching over the seeded world, so any query whose only match is closed would
+  // answer `[]` — an empty-array divergence in place of a value one.
   if (input.state && input.state !== "all") filtered = filtered.filter((issue) => issue.state === input.state);
   return {
     total_count: filtered.length,

--- a/packages/twin-github/test/list-state-default.test.ts
+++ b/packages/twin-github/test/list-state-default.test.ts
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-1427 — the three LIST surfaces real GitHub defaults to `state=open`, and
+// the one search surface it does not.
+//
+// `listIssues`, `listPullRequests` and `listMilestones` each filtered only when
+// a `state` query param was PRESENT:
+//
+//     if (input.state && input.state !== "all") rows = rows.filter(...)
+//
+// so a caller who sent no `state` — the overwhelmingly common case, and the one
+// real GitHub answers with open items only — got everything, closed included.
+//
+// This was invisible rather than merely wrong, and it stayed invisible for the
+// same reason on all three: every seeded issue, pull request and milestone was
+// OPEN, so "all" and "open" named the same set and no fixture could tell them
+// apart. pome-cloud's upstream seeder had already met the milestone half of it
+// and worked around it in the SEED rather than the twin — its `PlannedMilestone`
+// is kept open on purpose, commented "GitHub defaults that list to `state=open`
+// — a closed milestone would leave the golden empty again". F-1424 closed issue
+// #2 in `FIDELITY_SEED` and the issue half surfaced immediately as
+// `[].state` constant-mismatch + `[].closed_at` type-changed, both CRITICAL.
+//
+// Every assertion below compares a SET of numbers, never a count. A count
+// matches for the wrong reason as easily as the right one: two items is what
+// `state=all` returns AND what an open-default would return from a world with
+// two open items, so a count assertion passes against the bug it is meant to
+// catch. The world therefore seeds one open and one closed of each kind, and
+// the four cases (absent / open / closed / all) must name exactly which.
+//
+// `GET /search/issues` is the deliberate exception and is asserted as one.
+// GitHub's search API has no `state=open` default — a search returns what the
+// query asks for — so `searchIssues` keeps filtering only on an explicit
+// `state`. That is not an oversight the next reader should "fix": the twin's
+// search is substring-based over the seeded world, so imposing an open default
+// would answer `[]` for any query whose only match is closed, turning a
+// value mismatch into an empty-array divergence in the other direction.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createGitHubCloneApp } from "../src/twin.js";
+import type { GitHubStateSeed } from "../src/types.js";
+import { TEST_AUTH_SECRET, TEST_SID, signTestToken, withAuth } from "./_authHelper.js";
+
+const previousSecret = process.env.TWIN_AUTH_SECRET;
+let token: string;
+
+beforeAll(async () => {
+  process.env.TWIN_AUTH_SECRET = TEST_AUTH_SECRET;
+  token = await signTestToken();
+});
+afterAll(() => {
+  if (previousSecret === undefined) delete process.env.TWIN_AUTH_SECRET;
+  else process.env.TWIN_AUTH_SECRET = previousSecret;
+});
+
+const base = `/s/${TEST_SID}`;
+
+// Issues and pull requests draw numbers from ONE per-repo counter, so the seed
+// order below is what fixes them: issue #1, issue #2, then PR #3, PR #4.
+const OPEN_ISSUE = 1;
+const CLOSED_ISSUE = 2;
+const OPEN_PULL = 3;
+const CLOSED_PULL = 4;
+// Milestones have their own counter, so these are #1 and #2 independently.
+const OPEN_MILESTONE = 1;
+const CLOSED_MILESTONE = 2;
+
+/** One open and one closed of every kind whose list surface takes `state`. */
+const WORLD: GitHubStateSeed = {
+  users: [
+    { login: "acme", type: "Organization", name: "Acme" },
+    { login: "alice", type: "User", name: "Alice" },
+    { login: "pome-agent", type: "User", name: "Pome Agent" }
+  ],
+  repositories: [
+    {
+      owner: "acme",
+      name: "api",
+      description: "State-default fixture for the three list surfaces.",
+      default_branch: "main",
+      collaborators: ["alice", "pome-agent"],
+      labels: [{ name: "bug", color: "d73a4a", description: "Something is not working" }],
+      files: [
+        { path: "README.md", content: "# Acme API\n" },
+        { path: "src/feature.ts", content: "export const feature = true;\n", branch: "feature" },
+        { path: "src/hotfix.ts", content: "export const hotfix = true;\n", branch: "hotfix" }
+      ],
+      milestones: [
+        { number: OPEN_MILESTONE, title: "v1.0 — checkout hardening", state: "open" },
+        { number: CLOSED_MILESTONE, title: "v0.9 — shipped", state: "closed" }
+      ],
+      issues: [
+        { number: OPEN_ISSUE, title: "Seeded bug: 500 on POST /orders", state: "open", labels: ["bug"] },
+        // The only "idempotency" match in the world, and it is CLOSED — which is
+        // what makes the search assertion below load-bearing.
+        { number: CLOSED_ISSUE, title: "Seeded feature: add idempotency keys", state: "closed" }
+      ],
+      pull_requests: [
+        { number: OPEN_PULL, title: "Add feature flag", head: "feature", base: "main", state: "open", author: "pome-agent" },
+        { number: CLOSED_PULL, title: "Abandoned hotfix", head: "hotfix", base: "main", state: "closed", author: "pome-agent" }
+      ]
+    }
+  ]
+};
+
+const app = createGitHubCloneApp({ seed: WORLD });
+
+async function numbersAt(path: string): Promise<number[]> {
+  const response = await app.request(`${base}${path}`, withAuth(token));
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as Array<{ number: number }>;
+  return body.map((row) => row.number).sort((a, b) => a - b);
+}
+
+/**
+ * The one table this ticket is measured in: for each surface, what each of the
+ * four `state` spellings must name. The absent case is the fix — it must equal
+ * the explicit `open` case and NOT the `all` case.
+ */
+const SURFACES = [
+  {
+    name: "GET /repos/:o/:r/issues",
+    path: "/repos/acme/api/issues",
+    open: [OPEN_ISSUE],
+    closed: [CLOSED_ISSUE],
+    all: [OPEN_ISSUE, CLOSED_ISSUE]
+  },
+  {
+    name: "GET /repos/:o/:r/pulls",
+    path: "/repos/acme/api/pulls",
+    open: [OPEN_PULL],
+    closed: [CLOSED_PULL],
+    all: [OPEN_PULL, CLOSED_PULL]
+  },
+  {
+    name: "GET /repos/:o/:r/milestones",
+    path: "/repos/acme/api/milestones",
+    open: [OPEN_MILESTONE],
+    closed: [CLOSED_MILESTONE],
+    all: [OPEN_MILESTONE, CLOSED_MILESTONE]
+  }
+] as const;
+
+describe("list surfaces default `state` to open, the way real GitHub does (F-1427)", () => {
+  for (const surface of SURFACES) {
+    describe(surface.name, () => {
+      it("serves the OPEN set when no `state` is given", async () => {
+        expect(await numbersAt(surface.path)).toEqual([...surface.open]);
+      });
+
+      it("serves the same set for an absent `state` as for an explicit `state=open`", async () => {
+        expect(await numbersAt(surface.path)).toEqual(await numbersAt(`${surface.path}?state=open`));
+      });
+
+      it("does NOT serve the `state=all` set when no `state` is given", async () => {
+        // The regression this ticket exists for. Stated as its own assertion so
+        // a future change that reverts the default fails HERE, naming the cause,
+        // rather than only in the set assertion above.
+        expect(await numbersAt(surface.path)).not.toEqual(await numbersAt(`${surface.path}?state=all`));
+      });
+
+      it("keeps `state=closed` serving the closed set", async () => {
+        expect(await numbersAt(`${surface.path}?state=closed`)).toEqual([...surface.closed]);
+      });
+
+      it("keeps `state=all` serving everything", async () => {
+        expect(await numbersAt(`${surface.path}?state=all`)).toEqual([...surface.all]);
+      });
+    });
+  }
+
+  describe("GET /search/issues is the exception and keeps no default", () => {
+    async function searchNumbers(path: string): Promise<number[]> {
+      const response = await app.request(`${base}${path}`, withAuth(token));
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { items: Array<{ number: number }> };
+      return body.items.map((item) => item.number).sort((a, b) => a - b);
+    }
+
+    it("still returns a closed match when no `state` is given", async () => {
+      // GitHub's search API has no `state=open` default. The only match for this
+      // query in the seeded world is the CLOSED issue, so an open default here
+      // would answer `[]` — the reverse divergence, not a fix.
+      expect(await searchNumbers("/search/issues?q=idempotency")).toEqual([CLOSED_ISSUE]);
+    });
+
+    it("still honours an explicit `state`", async () => {
+      expect(await searchNumbers("/search/issues?q=idempotency&state=closed")).toEqual([CLOSED_ISSUE]);
+      expect(await searchNumbers("/search/issues?q=idempotency&state=open")).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
`GET /repos/:o/:r/issues`, `GET /repos/:o/:r/pulls` and `GET /repos/:o/:r/milestones` each filtered only when `state` was PRESENT:

```js
if (input.state && input.state !== "all") rows = rows.filter(...)
```

so a caller who sent none — the common case, and the one real GitHub answers with open items only — got everything, closed included.

## ⚠️ This changes what the twin SERVES

A task whose agent lists issues and counts them gets a different answer from 0.10.4 on. That answer is the one real GitHub gives, but it is a moved result, not a silent correction. `state=all` returns everything and an explicit `state=closed` returns the closed items; both are unchanged.

## Why it was invisible

One reason on all three surfaces: every seeded issue, pull request and milestone was open, so `all` and `open` named the same set and no fixture could tell them apart.

pome-cloud's upstream seeder had already met the milestone half and worked around it **in the seed** rather than the twin — its milestone is kept open on purpose, commented *"GitHub defaults that list to `state=open` — a closed milestone would leave the golden empty again"*. That workaround is what kept the twin's own missing default hidden. The issue half surfaced the moment F-1424's seed closed an issue, as `[].state` constant-mismatch and `[].closed_at` type-changed against real GitHub, both CRITICAL on a `semantic`-tier read surface.

## `GET /search/issues` is deliberately excluded, and now says so in the code

The ticket assumed one fix would clear this surface too. It does not: `searchIssues` is a **separate function that never calls `listIssues`**, and GitHub's search API has no `state` default — `is:open` is a query qualifier. Imposing the list default there would be a new divergence in the other direction, and a worse one: the twin's search is substring matching over the seeded world, so a query whose only match is closed would answer `[]`, replacing a value mismatch with an empty-array one. That surface is now tracked separately (F-1428).

## The seed could not express a closed pull request

`seedSchema` had accepted `pull_requests[].state` for as long as the field existed, but nothing ever applied it — `createPullRequest` hardcodes `'open'` in its INSERT — so a seed asking for a closed PR got an open one and `GET /pulls?state=closed` could not be made non-empty by any seed. Same shape of invisibility F-1421 fixed for the five entities the seed could not express at all, and it is why the pull-request half of this fix was untestable until now.

Applied last in the seed block: the review and update-branch write paths refuse a non-open PR, so closing first would make a seeded child fail against the state the seed itself asked for.

## Tests

`test/list-state-default.test.ts` seeds one open and one closed of each kind and compares **SETS** of numbers, never counts — a count matches for the wrong reason as easily as the right one, since two items is what `state=all` returns AND what an open default would return from a world with two open items. The absent case is asserted equal to the explicit `open` case and, separately, NOT equal to the `all` case, so a revert fails on the assertion that names the cause.

## Docs

The `FIDELITY.md` record is a REST-surfaces subsection, **not** a numbered "Known divergences" bullet: that list is lint-bound 1:1 to pome-cloud's `known-divergences/github.yaml` on `md_bullet_title`, so an unbacked bullet reds pome-cloud, and a YAML entry would paper over the gap this fix exists to close.

## Verification

- 3,339 tests green across the monorepo, typecheck clean, all eight lint/gate scripts pass, contract suite 104 pass / 5 skip.
- Measured with pome-cloud's `run.ts --offline` against this branch: `twin-github drifted` goes **9 → 8 of 72**, with `GET /repos/:o/:r/issues` dropping off the list entirely (both `constant-mismatch` and `type-changed` cleared).

## ⚠️ Paired pome-cloud PR follows

The twin's `GET /issues` capture moves 2 → 1, so `sandbox-capture.json` needs a re-capture and two fidelity tests need real fixes (not just a moved number). Landing that immediately after this one. The exposure is the **daily `fidelity-watch` run**, which reads twins main unpinned — open pome-cloud PRs never run that suite (`ci.yml` has no fidelity leg).

Version bumps: `@pome-sh/twin-github` 0.10.3 → 0.10.4, `@pome-sh/cli` 0.23.8 → 0.23.9 (twin-github is bundled into the CLI tarball, so the version-bump gate needs both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)