### PR TITLE
The reactions guard moves into twin-slack, where the state lives (F-1159)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,18 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.23.10
+
+### Patch Changes
+
+- Carries twin-slack's reactions guard (F-1159) into the bundled twin.
+  `slack.no-reaction-added` now refuses (`state_incomplete`) instead of scoring
+  a free pass when a state export carries no `reactions` section at all — its
+  `(final.reactions ?? []).some(…)` used to filter that absence to zero rows and
+  pass the criterion, the same way an unresolved-field trap already closed on
+  twin-github's `pull.reviews`/`pull.comments`. No route, tool or check id
+  changed under `pome twin start slack`.
+
 ## 0.23.9
 
 ### Patch Changes

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.23.9",
+  "version": "0.23.10",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/packages/checks/CHANGELOG.md
+++ b/packages/checks/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @pome-sh/checks
 
+## 0.1.5
+
+`slack.no-reaction-added` now refuses instead of scoring a free pass (F-1159).
+Its predicate filtered the exported `reactions` collection with `(final.reactions
+?? []).some(…)`, so a state export carrying no `reactions` section at all
+filtered to zero rows and scored this NEGATIVE criterion `passed` — an agent
+that really added the reaction still collected the point. It now checks
+`final.reactions == null` first and returns `state_incomplete`, matching
+twin-github's `pull.reviews == null` / `pull.comments == null` skips: absent is
+not the same as none.
+
+This closes the gap the same class of criterion in twin-github never had, and
+it is why pome-cloud's `STATE_SECTION_GUARDS` carried a stopgap row for this one
+check (F-1156) — that row is now redundant and is deleted in a follow-up
+pome-cloud PR once this version is pinned there. No check id, template or
+polarity changed, so no criterion moves from bound to unbound; this only
+affects the verdict on the one export shape (`reactions` absent) that used to
+be misgraded.
+
 ## 0.1.4
 
 Carries twin-github's widened seed schema to the grader (F-1421). One thing

--- a/packages/checks/CHANGELOG.md
+++ b/packages/checks/CHANGELOG.md
@@ -13,11 +13,33 @@ not the same as none.
 
 This closes the gap the same class of criterion in twin-github never had, and
 it is why pome-cloud's `STATE_SECTION_GUARDS` carried a stopgap row for this one
-check (F-1156) — that row is now redundant and is deleted in a follow-up
-pome-cloud PR once this version is pinned there. No check id, template or
-polarity changed, so no criterion moves from bound to unbound; this only
-affects the verdict on the one export shape (`reactions` absent) that used to
-be misgraded.
+check (F-1156) — that row is now redundant. No check id, template or polarity
+changed, so no criterion moves from bound to unbound; this only affects the
+verdict on the one export shape (`reactions` absent) that used to be misgraded,
+and on that shape the cloud already returned `state_incomplete` via the stopgap.
+The grade a real run receives does not move.
+
+**What pome-cloud must do, and it is TWO edits, not one.** Pinning `0.1.5`
+turns `declared-pin.test.ts` red on its own, before anybody touches the guard
+table, so a follow-up that only deletes the row will not go green:
+
+1. Delete the `slack.no-reaction-added` row from `STATE_SECTION_GUARDS`
+   (`apps/control-plane/src/services/evaluators/deterministic/substrate-guards.ts`).
+   The arm that asserts every vacuous reader has a row —
+   `findVacuousStateSectionReaders(allDeclared(), STATE_SECTION_GUARDS)` — stays
+   `[]` with the row present or absent, because the twin now refuses on its own.
+2. Re-point the NEGATIVE CONTROL beside it, `names the shipped reader when the
+   table is empty`. It asserts
+   `findVacuousStateSectionReaders(allDeclared(), [])` equals
+   `["slack.no-reaction-added:reactions"]` — the detector's only firing case in
+   the shipped vocabulary, and this release is what removes it. Measured against
+   the built `0.1.5` declarations it now returns `[]`. Give that arm a synthetic
+   declaration that still reads absence as a pass, the way the three arms below
+   it already build one inline, so the detector keeps a firing case nobody has
+   to ship a defect to preserve.
+
+Both `apps/control-plane` and `apps/mcp` pin this package exactly and must move
+together, or `save_task` accepts criteria the grader cannot bind.
 
 ## 0.1.4
 

--- a/packages/checks/package.json
+++ b/packages/checks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/checks",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Pome's grading vocabulary — the check declarations, seed schemas and default seeds of all five digital twins, plus the check DSL they are written in. Declarations only: no twin server, no database, no routes, no tools.",
   "private": false,
   "type": "module",

--- a/packages/twin-slack/src/check-messages.ts
+++ b/packages/twin-slack/src/check-messages.ts
@@ -142,7 +142,8 @@ export const noReactionAdded: Check<{ reaction: string; channel: string }> = def
     "Resolves the named channel, then filters the TOP-LEVEL reactions list by that channel's id " +
     "and this emoji name, asserting no row matches. Reactions are not nested under their channel " +
     "in the export, so this is a join the predicate performs itself. It asserts nothing about " +
-    "which message was reacted to, or by whom.",
+    "which message was reacted to, or by whom. An export carrying no `reactions` collection at " +
+    "all is SKIPPED, because absent is not the same as none.",
   template: 'No "{reaction}" reaction was added in the "{channel}" channel',
   params: { reaction: emojiName, channel: channelName },
   substrate: "final",
@@ -179,35 +180,33 @@ export const noReactionAdded: Check<{ reaction: string; channel: string }> = def
   evaluate({ reaction, channel }, { final }) {
     const found = resolveChannel(final, channel);
     if ("missing" in found) return missSkip(found);
-    // ⚠️ `?? []` IS A KNOWN GAP, AND F-1157's subject declaration above did not
-    // close it. An export carrying no `reactions` collection at all filters to
-    // zero rows and scores this negative criterion `passed` — an agent that did
-    // react collects the point. Same direction of failure as the redaction case,
-    // different cause: that one is a masked VALUE, this one an absent SECTION.
-    //
-    // F-1159 is the ticket, and the guard for it lives in the consuming engine's
-    // `STATE_SECTION_GUARDS` today rather than here, which is the wrong repo for
-    // a guard whose state is this file's. Moving it costs a twins release plus a
-    // cloud pin bump, so it is deliberately not folded into F-1157's diff. The
-    // shape it wants is twin-github's, where `pull.reviews == null` and
-    // `pull.comments == null` each skip with "absent is not the same as none"
-    // beside them.
-    const hit = (final.reactions ?? []).some(
+    // F-1159. `?? []` used to read a MISSING `reactions` collection the same as
+    // an EMPTY one: the filter fell through to zero rows either way, and this
+    // negative criterion scored `passed` over an export it never actually
+    // observed — an agent that did react still collected the point. Same
+    // direction of failure as the redaction case above, different cause: that
+    // one is a masked VALUE, this one an absent SECTION. The guard used to live
+    // at arm's length in the consuming engine's `STATE_SECTION_GUARDS`, which
+    // could drift from the state it inspects silently because that state lives
+    // here; it is now here instead, matching twin-github's `pull.reviews ==
+    // null` and `pull.comments == null`: absent is not the same as none.
+    if (final.reactions == null) return STATE_INCOMPLETE;
+    const hit = final.reactions.some(
       (row) => row.channel_id === found.found.id && row.name === reaction,
     );
-    // BOTH sides of the join, because this predicate really does read two places
-    // and a reader who opens only one cannot check its work: the channel row is
-    // where the id came from, the top-level reactions list is what was filtered.
-    // Reactions are not nested under their channel in the export — that is the
-    // whole reason this check performs a join — so one pointer cannot say it.
-    const joined = [found.path];
-    if (final.reactions !== undefined) joined.push(statePath("reactions"));
     return {
       passed: !hit,
       reason: hit
         ? `reaction "${reaction}" found in channel "${channel}"`
         : `no reaction "${reaction}" in channel "${channel}"`,
-      evidenceStatePaths: joined,
+      // BOTH sides of the join, because this predicate really does read two
+      // places and a reader who opens only one cannot check its work: the
+      // channel row is where the id came from, the top-level reactions list is
+      // what was filtered. Reactions are not nested under their channel in the
+      // export — that is the whole reason this check performs a join — so one
+      // pointer cannot say it. The guard above already proved `reactions` is
+      // present, so both pointers always resolve.
+      evidenceStatePaths: [found.path, statePath("reactions")],
     };
   },
 });

--- a/packages/twin-slack/src/check-state.ts
+++ b/packages/twin-slack/src/check-state.ts
@@ -66,6 +66,26 @@ export interface SlackCheckStateChannel {
   is_im?: number | boolean | null;
   is_mpim?: number | boolean | null;
   members?: string[] | null;
+  // NULLABLE IN THE TYPE, UNCONDITIONAL IN THE EXPORT — and that gap is why the
+  // predicates that read this one may default it with `?? []` while the
+  // TOP-LEVEL `reactions` may not (F-1159).
+  //
+  // `exportState()` builds every channel row as
+  // `{ ...channel, members, messages: SELECT * FROM messages WHERE channel_id = ? }`
+  // (`domain/slack-domain.ts:243`), so a channel that arrived at all arrived with
+  // its `messages` array — empty when nobody posted. `?? []` on this field is
+  // therefore a REAL-ZERO default and not the absent-section trap: there is no
+  // export shape where it substitutes for evidence nobody gathered. The `| null`
+  // is here for hand-written fixtures and for the file-wide rule that every
+  // export field is optional, not because a whole export can drop it.
+  //
+  // That is a claim about the exporter, so it is pinned as one:
+  // `fidelity-contract.test.ts` asserts an exported channel row carries this
+  // field, and `state-export.test.ts` asserts it of EVERY row over the live
+  // `_pome/state` surface. If the export ever becomes conditional, four `?? []`
+  // sites across `check-messages.ts` and `check-secrets.ts` — two of them
+  // NEGATIVE criteria — start reading absence as a clean bill, and those tests
+  // go red first.
   messages?: SlackCheckStateMessage[] | null;
 }
 

--- a/packages/twin-slack/test/check-messages.test.ts
+++ b/packages/twin-slack/test/check-messages.test.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-1159 — the reactions absence guard, at the twin whose state it reads.
+//
+// `slack.no-reaction-added` filters the top-level `reactions` list with
+// `(final.reactions ?? []).some(…)`. An export carrying no `reactions`
+// collection at all used to filter to zero rows and score this NEGATIVE
+// criterion `passed` — an agent that really added the reaction still collected
+// the point. `checks-contract.test.ts`'s redaction-survival ledger names the
+// shape; this is the executable proof, matching twin-github's
+// `pull.reviews == null` / `pull.comments == null` skips: absent is not the
+// same as none.
+
+import { describe, expect, it } from "vitest";
+import { noReactionAdded } from "../src/check-messages.js";
+import type { SlackCheckState } from "../src/check-state.js";
+import { publicChannel } from "../src/check-worlds.js";
+
+const args = { reaction: "white_check_mark", channel: "general" };
+
+describe("slack.no-reaction-added", () => {
+  it("passes when the named channel carries no matching reaction", () => {
+    const final: SlackCheckState = { channels: [publicChannel("general")], reactions: [] };
+    const outcome = noReactionAdded.evaluate(args, { seed: null, tape: null, final });
+    expect(outcome.passed).toBe(true);
+    expect(outcome.status).toBeUndefined();
+  });
+
+  it("fails when the reaction is present in the channel", () => {
+    const channel = publicChannel("general");
+    const final: SlackCheckState = {
+      channels: [channel],
+      reactions: [{ channel_id: channel.id, message_ts: "1.0", name: "white_check_mark", user_id: "U1" }],
+    };
+    const outcome = noReactionAdded.evaluate(args, { seed: null, tape: null, final });
+    expect(outcome.passed).toBe(false);
+    expect(outcome.status).toBeUndefined();
+  });
+
+  it("SKIPS on an absent reactions section — absent is not the same as none", () => {
+    // The defect F-1159 closes. `?? []` used to read a missing `reactions`
+    // collection the same as an empty one, so a negative criterion scored a
+    // free pass over a world it never actually observed. It must refuse
+    // instead, the way twin-github's `pull.reviews == null` and
+    // `pull.comments == null` do.
+    const final: SlackCheckState = { channels: [publicChannel("general")] };
+    const outcome = noReactionAdded.evaluate(args, { seed: null, tape: null, final });
+    expect(outcome.passed).toBe(false);
+    expect(outcome.status).toBe("skipped");
+    expect(outcome.reason).toContain("state_incomplete");
+  });
+
+  it("SKIPS on an absent channel — resolveChannel's own guard, unchanged by this fix", () => {
+    const final: SlackCheckState = { channels: [] };
+    const outcome = noReactionAdded.evaluate(args, { seed: null, tape: null, final });
+    expect(outcome.status).toBe("skipped");
+    expect(outcome.reason).toContain("channel_not_found");
+  });
+});

--- a/packages/twin-slack/test/checks-contract.test.ts
+++ b/packages/twin-slack/test/checks-contract.test.ts
@@ -426,24 +426,28 @@ describe("declared state citations", () => {
 // declares its subject now, so the row below reads `declared_subject` and the
 // engine skips the criterion at the door.
 //
-// ⚠️ THAT IS NOT THE ONLY WAY `slack.no-reaction-added` PASSES VACUOUSLY, and
-// declaring its subject did not close the other one. F-1159: its predicate reads
-// `(final.reactions ?? []).some(…)`, so an export carrying NO `reactions`
-// collection filters to zero rows and scores the same negative criterion
-// `passed` — an agent that did react collects the point. Same direction of
-// failure, different cause: this ledger's question is "what if the VALUE was
-// masked", F-1159's is "what if the SECTION is absent". This probe only ever
-// replaces strings and never deletes a collection, so it is structurally unable
-// to see it and a green row above is not evidence about it.
+// THAT WAS NOT THE ONLY WAY `slack.no-reaction-added` PASSED VACUOUSLY, and
+// declaring its subject did not close the other one on its own. F-1157's
+// predicate read `(final.reactions ?? []).some(…)`, so an export carrying NO
+// `reactions` collection filtered to zero rows and scored the same negative
+// criterion `passed` — an agent that did react collected the point. Same
+// direction of failure, different cause: this ledger's question is "what if
+// the VALUE was masked", F-1159's was "what if the SECTION is absent". This
+// probe only ever replaces strings and never deletes a collection, so it is
+// structurally unable to see that class and a green row above was never
+// evidence about it.
 //
-// It is guarded in the consuming engine's `STATE_SECTION_GUARDS` today, which is
-// the wrong repo for a guard whose state lives here — that is F-1159's whole
-// point, and moving it costs a twins release plus a cloud pin bump, so it stays
-// its own ticket. Its neighbours in twin-github already have the shape this one
-// wants: `pull.reviews == null`, `pull.comments == null` and `pull.merged ==
-// null` each skip with "absent is not the same as none" written beside them.
-// `packages/twin-slack/src/check-messages.ts` is the only place across all five
-// twins' declarations that reaches for `?? []` on a top-level section.
+// F-1159 closed it, directly in `check-messages.ts`'s `evaluate`, the way its
+// neighbours in twin-github already do: `pull.reviews == null`, `pull.comments
+// == null` and `pull.merged == null` each skip with "absent is not the same as
+// none" written beside them. `noReactionAdded` now returns `STATE_INCOMPLETE`
+// (this file's own name for the same idiom, already used by
+// `noMessageContaining` for the `channels` section) when `final.reactions ==
+// null`, before the join runs — see `check-messages.test.ts` for the executable
+// proof. It used to be guarded at arm's length in the consuming engine's
+// `STATE_SECTION_GUARDS`, which could drift from the state it inspects silently
+// because that state lives here; that row is now redundant and pome-cloud
+// deletes it once this fix is published and pinned.
 //
 // The `abstains` rows are `resolveChannel`'s `missSkip`, which is what a
 // channel-name slot has always done with a miss, and the reason slack's other

--- a/packages/twin-slack/test/checks-contract.test.ts
+++ b/packages/twin-slack/test/checks-contract.test.ts
@@ -446,8 +446,17 @@ describe("declared state citations", () => {
 // null`, before the join runs — see `check-messages.test.ts` for the executable
 // proof. It used to be guarded at arm's length in the consuming engine's
 // `STATE_SECTION_GUARDS`, which could drift from the state it inspects silently
-// because that state lives here; that row is now redundant and pome-cloud
-// deletes it once this fix is published and pinned.
+// because that state lives here; that row is now redundant.
+//
+// Deleting it is NOT the whole of the follow-up, and assuming it is buys a red
+// pipeline in the other repo. `declared-pin.test.ts` keeps a negative control —
+// `names the shipped reader when the table is empty` — that asserts the
+// arrival-direction detector still NAMES `slack.no-reaction-added:reactions`
+// when handed an empty guard table. This release is precisely what stops it
+// naming anything, so that arm goes red on the pin bump alone, before the row
+// is touched, and it needs a synthetic reader of its own. The two edits are
+// spelled out in `packages/checks/CHANGELOG.md` under 0.1.5, which is the file
+// whoever does the bump will actually read.
 //
 // The `abstains` rows are `resolveChannel`'s `missSkip`, which is what a
 // channel-name slot has always done with a miss, and the reason slack's other

--- a/packages/twin-slack/test/state-export.test.ts
+++ b/packages/twin-slack/test/state-export.test.ts
@@ -111,4 +111,64 @@ describe("state export", () => {
     expect(state.workspace.id).toBe("T_CUSTOM");
     expect(state.channels[0]!.id).toBe("C_HELP");
   });
+
+  // F-1159 — the premise the reactions guard rests on, made falsifiable.
+  //
+  // `slack.no-reaction-added` refuses (`state_incomplete`) when the export
+  // carries no `reactions` key, because absent is not the same as none. That is
+  // only SAFE while a zero-reaction workspace still emits `reactions: []`: the
+  // day this export starts omitting empty collections, every one of those
+  // criteria stops being graded and silently leaves the denominator on runs
+  // where the agent behaved perfectly — a false SKIP replacing a false pass,
+  // just as quiet and rather harder to notice.
+  //
+  // `exportState()` runs `SELECT * FROM reactions` unconditionally today, so the
+  // guard's trigger is unreachable on a whole export.
+  //
+  // `fidelity-contract.test.ts` already asserts the KEY survives, but it asks
+  // the domain method directly and only that the property exists. Two gaps this
+  // closes: the value must be `[]` rather than any present-but-falsy stand-in,
+  // and the question is asked of `/_pome/state` — the surface pome-cloud
+  // actually reads — so the SDK's state pipeline sits inside the assertion
+  // instead of beside it.
+  it("a zero-reaction workspace exports `reactions: []`, never an absent key (F-1159)", async () => {
+    const a = build();
+    const token = await signTestToken();
+    const state = (await (
+      await a.app.request(`/s/${TEST_SID}/_pome/state`, withAuth(token, {}))
+    ).json()) as Record<string, unknown>;
+
+    expect(Object.hasOwn(state, "reactions")).toBe(true);
+    expect(state.reactions).toEqual([]);
+
+    // The same promise one level down, and the reason the nested
+    // `channel.messages ?? []` in `check-messages.ts` is a real-zero default
+    // rather than an unguarded absence: a channel row always carries its
+    // `messages` array, empty or not.
+    const channels = state.channels as Array<Record<string, unknown>>;
+    expect(channels.length).toBeGreaterThan(0);
+    for (const channel of channels) {
+      expect(Object.hasOwn(channel, "messages"), `channel ${String(channel.id)}`).toBe(true);
+      expect(Array.isArray(channel.messages)).toBe(true);
+    }
+  });
+
+  it("a workspace that HAS a reaction still exports the same key, populated", async () => {
+    const a = build();
+    const token = await signTestToken();
+    const posted = a.domain.chatPostMessage(
+      { channel: "C_GENERAL", text: "please approve" },
+      { login: "pome-agent" },
+    ) as { ts: string };
+    a.domain.reactionsAdd(
+      { channel: "C_GENERAL", timestamp: posted.ts, name: "white_check_mark" },
+      { login: "bob" },
+    );
+    const state = (await (
+      await a.app.request(`/s/${TEST_SID}/_pome/state`, withAuth(token, {}))
+    ).json()) as { reactions: Array<{ name: string }> };
+    // The populated arm exists so the empty-arm assertion above cannot be
+    // satisfied by an export that emits `[]` for everything.
+    expect(state.reactions.map((row) => row.name)).toContain("white_check_mark");
+  });
 });


### PR DESCRIPTION
## Problem

`slack.no-reaction-added` is a negative-polarity check — it asserts a reaction was **not** added — implemented as `(final.reactions ?? []).some(...)` returning `passed: !hit`. A state export carrying no `reactions` section at all filtered to zero rows, so the check scored `passed` — an agent that really added the reaction still collected the point.

Its neighbours in twin-github don't have this gap: `pull.reviews == null`, `pull.comments == null` and `pull.merged == null` each get an explicit skip with "absent is not the same as none" written beside them. This was the one place across all five twins' declarations that reached for `?? []` on a top-level exported section — F-1157 named the exact shape of the gap in a comment left in place on purpose, pointing at this ticket.

It was guarded cloud-side, at arm's length, in `STATE_SECTION_GUARDS` (F-1156, a stopgap because a negative criterion false-passing in production couldn't wait on an npm release). That guard can drift from the state it inspects silently, because the state lives here.

## Fix

`packages/twin-slack/src/check-messages.ts`'s `noReactionAdded.evaluate` now checks `final.reactions == null` and returns `state_incomplete` before the join runs — reusing this file's own `STATE_INCOMPLETE` constant, already used by `noMessageContaining` for the identical situation on the `channels` section, rather than inventing a second idiom. Absent section ⇒ refuse, never fabricate a pass or a fail.

TDD: `packages/twin-slack/test/check-messages.test.ts` is new and asserts the absence case reds first — see verification below for the red-then-green transcript and the mutation check (re-removing the guard reds the same test).

`packages/twin-slack/test/checks-contract.test.ts`'s redaction-survival ledger carried a long comment documenting this exact gap as open; it's updated to describe the fix instead.

## Audit (the ticket's other half)

Every check in twin-slack that filters a top-level exported list (`channels`, `reactions` — the only two root fields `SlackCheckState` has):

| Check | Reads | Disposition |
|---|---|---|
| `slack.no-message-containing` | `final.channels` directly | Already guarded — `if (final.channels == null) return STATE_INCOMPLETE;` |
| `slack.no-reaction-added` | `final.reactions` directly | **Was the gap — now guarded, this PR** |
| `slack.no-secret-newly-exposed` | `seed.channels` / `final.channels`, via `publicChannels()` | Already guarded — `publicChannels` checks `state.channels == null` internally |
| `slack.no-message-posted` | resolves one channel via `resolveChannel`, then `channel.messages` (nested, not top-level) | Guarded upstream — top-level `channels` absence routes through `resolveChannel`'s own `state_incomplete`. The nested `messages ?? []` is a real-zero default on a resolved row; **that reason is now written into `check-state.ts` beside the field and pinned by a test**, per the ticket's "or has a written reason it doesn't need to" |
| `slack.message-contains` | same shape as above | Same disposition |

`resolveChannel` itself (the resolver all channel-scoped checks share) already guards `state.channels == null` before scanning.

## The other twins (report only, not fixed here)

- **twin-github** — already correct (the ticket's own reference point).
- **twin-stripe** — clean. A shared `requireList()` helper explicitly guards every top-level collection (`payment_intents`, `charges`, `events`) before any `.some()`/`.filter()`, and `refundsOnCharge` checks `state.refunds == null` explicitly.
- **twin-linear** — clean. Every top-level list is read through a guarded resolver (`resolveLabelNames`, `resolveComments`, etc.) that checks `state.<field> == null` first; nested defaults like `issue.labelIds ?? []` are real zeros on a resolved row, the same shape as twin-github's per-entity fields.
- **twin-gmail** — one real finding of the same class, **confirmed by execution**, not fixed here (own ticket). `labelIdsFor` (`packages/twin-gmail/src/check-state.ts:197`) reads `state.labels ?? []` with no `state.labels == null` guard, unlike its sibling resolvers in the same file. It backs `gmail.mailbox-label-count`, whose polarity flips to **negative** at count `0` (`check-messages.ts:119`). Run against the built `@pome-sh/checks` declarations, on one world differing only in whether `labels` is present:

  ```
  polarity at count 0    : negative
  labels PRESENT, agent labelled the message : passed=false   ← correct
  labels ABSENT,  same world                 : passed=true    ← free point
  ```

  It is not a theoretical undercount. The default seed ships `{ id: "Label_follow_up", name: "Follow Up" }`, so a user label's minted id differs from its display name by construction; with `labels` gone, `labelIdsFor` degrades to the bare display name, no `messageLabels` row carries it, the total is `0`, and `0 === 0` passes a NEGATIVE criterion over an export where the agent did apply the label. Two aggravating details: `labelIdsFor`'s own comment justifies the `?? []` with "a `messageLabels` row carries the bare id regardless", which holds only for SYSTEM labels (`id === name`); and `mailboxLabelCount` guards `isTruncated` for `messages` and `messageLabels` but **not** for `labels`, even though `resolveLabelByName` in the same file does — so a capped `labels` collection reaches it too. `messageHasLabel` and `oneMessagePerRecipient` also use it but are both positive, so the same absence there fails closed (false-fail) rather than vacuous-pass. Also `draftRecipients` (`check-state.ts:268`) has the same unguarded `state.messages ?? []` shape, but its only caller already checks `final.messages == null` first, so it's dead-code-safe today. Worth its own ticket; not touched here to keep this PR to twin-slack.

## Release

Per `RELEASING.md`'s current model (version-diff on push to `main`; Changesets and the batch-PR flow it replaced no longer exist in this repo — `check-cli-pins-match-workspace.mjs` and `PACKAGE_RELEASE.md` referenced by the ticket are both gone): `check-messages.ts` is a checks-declaration path AND a CLI-bundled twin path, so both `@pome-sh/checks` (0.1.4 → 0.1.5) and `@pome-sh/cli` (0.23.9 → 0.23.10) are bumped, with `CHANGELOG.md` entries in each. Both are **patch**: no check id, template, polarity or seed schema changed — this is an internal `evaluate()` fix behind an unchanged public surface, and the CLI's `CONTRACT.md` is untouched.

Publishing itself (merge to `main`, which triggers `release.yml`) and the follow-up pome-cloud PR are out of scope for this PR — but see **The pome-cloud follow-up is TWO edits** below before doing it.

## The pome-cloud follow-up is TWO edits, not one

The Done-when is "delete the `STATE_SECTION_GUARDS` row and `declared-pin.test.ts` stays green". Deleting the row is necessary but **not sufficient**, and the missing half fails on the pin bump alone — before the row is touched.

`declared-pin.test.ts` holds a negative control beside the guard assertion:

```ts
it("names the shipped reader when the table is empty", () => {
  expect(findVacuousStateSectionReaders(allDeclared(), [])).toEqual([
    "slack.no-reaction-added:reactions",
  ]);
});
```

That arm exists because "a detector whose firing case has never been seen is one nobody has checked". Its firing case *is* this defect — and this release removes it. I ran the cloud's own detector verbatim against the locally built `0.1.5` declarations (all 46, five twins):

| declarations | guard table | `findVacuousStateSectionReaders` |
|---|---|---|
| pre-fix (`0.1.4`) | `STATE_SECTION_GUARDS` | `[]` |
| pre-fix (`0.1.4`) | `[]` | `["slack.no-reaction-added:reactions"]` |
| **post-fix (`0.1.5`)** | `STATE_SECTION_GUARDS` | `[]` |
| **post-fix (`0.1.5`)** | `[]` | **`[]`** ← the negative control goes red |

So the follow-up needs:

1. **Delete** the `slack.no-reaction-added` row from `STATE_SECTION_GUARDS`. The `has a row for every declared check that reads absence of a section as a pass` arm stays `[]` either way — the twin refuses on its own now, which is the thing this PR was for.
2. **Re-point the negative control** at a synthetic declaration that still reads absence as a pass, the way the three arms directly below it already build one inline with `as unknown as`. Otherwise the detector keeps a firing case only for as long as a real defect is shipped, which is the wrong thing to depend on.

Also: `apps/control-plane` and `apps/mcp` both pin `@pome-sh/checks` exactly (`0.1.4` today) and per pome-cloud's `AGENTS.md` **must move together**, or `save_task` accepts criteria the grader cannot bind. Bump both.

Both edits are written into `packages/checks/CHANGELOG.md` under 0.1.5 and into the `checks-contract.test.ts` comment, so whoever does the bump reads them without needing this PR.

## Semantic equivalence with the cloud stopgap

| | cloud `absentStateSection` | twin `noReactionAdded` |
|---|---|---|
| trigger | `state["reactions"] != null` is false | `final.reactions == null` |
| verdict | `{ passed: false, status: "skipped", reason: "state_incomplete" }` | identical — the shared `STATE_INCOMPLETE` constant |
| `[]` (real zero) | evaluates normally | evaluates normally |

Same trigger, same verdict, and `state_incomplete` is scored the way it must be: `score-merge.ts` excludes `skipped` from **both** numerator and denominator, so this withholds the point without recording a failure. It does not trade a false pass for a false fail.

The fix reaches the tarball: `npm pack packages/checks` → `pome-sh-checks-0.1.5.tgz`, and `package/dist/chunk-MJOHK2NI.js:212` is `if (final.reactions == null)`. `@pome-sh/checks` is the right and sufficient vehicle — it inlines the twin's compiled declarations, and the `@pome-sh/twin-*` pins in pome-cloud are the twin RUNTIME on a separate axis that grading never reads.

## Why `reactions: []` vs an omitted key is safe (and now pinned)

The guard is only correct while a zero-reaction workspace still exports `reactions: []`. `exportState()` runs `SELECT * FROM reactions` unconditionally (`domain/slack-domain.ts:247`), so it does — but nothing asserted that at the surface pome-cloud reads, and an "omit empty collections" tidy-up would look harmless while silently turning every one of these criteria into `state_incomplete` on runs where the agent behaved perfectly. `state-export.test.ts` now asserts over `/_pome/state` that the key is present and the value is `[]`, with a populated arm so an export emitting `[]` for everything could not satisfy it. Mutation-checked: making the exporter omit the empty collection reds it.

## Verification

- `npm ci`, `npm run build` (full workspace) — clean
- `npm run typecheck` — clean across all 11 workspaces
- `npm test` — all packages green (twin-slack: 32 files / 301 tests)
- `npm run lint:no-cloud-imports`, `lint:code-health`, `lint:copy-markers`, `lint:no-catch`, `lint:legacy-markers`, `lint:parent-vocab`, `lint:task-class`, `lint:twin-chunks`, `lint:twin-leaves`, `lint:dead-code` — all pass
- `node scripts/ci/check-version-bump-required.mjs origin/main` — pass
- `npm run gate:checks-manifest`, `gate:checks-tarball`, `gate:bundled-deps`, `npm run test:pack` (clean-room pack test, both npm tarballs, boots all five twins) — all pass
