### PR TITLE
Two green tests stop pinning the defects F-1211 and F-1014 own (F-1375)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
       # the PR's actual base (a push to main has already merged).
       - if: github.event_name == 'pull_request'
         run: node scripts/ci/check-version-bump-required.mjs "${{ github.event.pull_request.base.sha }}"
+      - run: node scripts/ci/check-version-bump-required.test.mjs
       # F-949 — @pome-sh/wire publishes to GitHub Packages, and the two ways that
       # silently stops working are both readable straight from its package.json:
       # `private: true` makes `npm publish -w` skip the workspace and EXIT 0 (a

--- a/cli/test/integration/runTaskHosted.test.ts
+++ b/cli/test/integration/runTaskHosted.test.ts
@@ -937,8 +937,18 @@ describe("runTaskHosted single-twin old-cloud (no per_twin) env parity", () => {
     expect(agentEnv.ghm).toBe(`${twinUrl}/mcp`);
     expect(agentEnv.ghr).toBe(twinUrl);
     expect(agentEnv.base).toBe(twinUrl);
-    // Provider github token flows through (origin/main parity).
-    expect(agentEnv.ght).toBe("ght_provider");
+    // F-1211: `POME_GITHUB_TOKEN` is currently
+    // `provider_credentials.github.token ?? agent_token` — here the PAT
+    // `"ght_provider"`, which the twin proxy 404s on because it verifies
+    // bearers only against `agent_token`. Asserting that exact value pinned
+    // the defect (F-1375: a test that pins a known defect is the defect with
+    // a second lock on it), so the value is not asserted; F-1211 owns the
+    // fix, after which this becomes `agentEnv.auth` unconditionally, matching
+    // the stripe/slack/gmail bearers. What is true on BOTH sides of that fix
+    // is that the agent is handed one of the two bearers this session
+    // actually carries — never a third, empty or absent one.
+    expect(agentEnv.ght).toBeTruthy();
+    expect([agentEnv.auth, "ght_provider"]).toContain(agentEnv.ght);
     // Stripe vars injected UNCONDITIONALLY even on a github-only run.
     expect(agentEnv.sb).toBe(twinUrl);
     expect(agentEnv.sk).toBe(agentEnv.auth);

--- a/cli/test/unit/runner/buildAgentEnv.test.ts
+++ b/cli/test/unit/runner/buildAgentEnv.test.ts
@@ -8,9 +8,11 @@ import { rawBodyHadPerTwin } from "../../../src/hosted/client.js";
 
 // Regression: single-twin runs against an OLD cloud (no `per_twin` in the wire
 // body) must stay BYTE-IDENTICAL to origin/main's hosted env, with ONE
-// deliberate exception: POME_GITHUB_TOKEN (see the F-1211 comment at its
-// assertions below — that key is a known defect, not a byte-identity
-// property, so this file does not pin its value). The schema synthesizes a
+// deliberate exception: the VALUE of POME_GITHUB_TOKEN (see the F-1211
+// comment at its assertions below — that value is a known defect, not a
+// byte-identity property, so this file does not pin it; the key's presence
+// and its slot in the insertion order are still asserted). The schema
+// synthesizes a
 // `per_twin` entry whose `mcp_url` host-rewrites api.pome.sh→mcp.pome.sh with
 // NO `/mcp` suffix; the fan-out must NOT trust that synthesized value and
 // must fall back to `${twin_url}/mcp`, exactly as main did. It must also keep
@@ -67,13 +69,24 @@ function originMainEnv(session: CreateSessionResponse): Record<string, string> {
   };
 }
 
-/** Drop `POME_GITHUB_TOKEN` from an env object while preserving the order of
- *  the remaining keys, so the byte-identity checks below can compare
- *  everything ELSE against `originMainEnv()` without re-asserting F-1211's
- *  defective value. */
+/** Drop `POME_GITHUB_TOKEN` so the value-level byte-identity checks below can
+ *  compare every OTHER key against `originMainEnv()` without re-asserting
+ *  F-1211's defective value. Key ORDER is checked separately, over the full
+ *  env — see `expectedKeyOrder`. */
 function withoutGithubToken(env: Record<string, string>): Record<string, string> {
   const { POME_GITHUB_TOKEN: _omitted, ...rest } = env;
   return rest;
+}
+
+/** `originMainEnv()`'s key order with `POME_GITHUB_TOKEN` put back in main's
+ *  slot for it — directly after `POME_GITHUB_MCP_URL`. The fixture omits the
+ *  key because its VALUE is F-1211's defect; its POSITION is ordinary
+ *  byte-identity coverage that F-1211 will not move, so the key-order check
+ *  keeps asserting it. */
+function expectedKeyOrder(expected: Record<string, string>): string[] {
+  return Object.keys(expected).flatMap((key) =>
+    key === "POME_GITHUB_MCP_URL" ? [key, "POME_GITHUB_TOKEN"] : [key],
+  );
 }
 
 function oldCloudBody(extra: Record<string, unknown> = {}): Record<string, unknown> {
@@ -132,7 +145,10 @@ describe("buildAgentEnv — single-twin old-cloud byte-identity", () => {
     const envWithoutGithubToken = withoutGithubToken(env);
     expect(envWithoutGithubToken).toEqual(expected);
     // Insertion order matters for byte-identity of any serialized env dump.
-    expect(Object.keys(envWithoutGithubToken)).toEqual(Object.keys(expected));
+    // POME_GITHUB_TOKEN's VALUE is F-1211's defect, but its SLOT in main's
+    // literal is not — the fix changes what the key holds, never where it
+    // sits — so the key-order check still covers the full env including it.
+    expect(Object.keys(env)).toEqual(expectedKeyOrder(expected));
     // Stripe vars injected unconditionally even for a github-only session.
     expect(env.POME_STRIPE_API_BASE).toBe(TWIN_URL);
     expect(env.POME_STRIPE_API_KEY).toBe(AGENT_TOKEN);
@@ -145,15 +161,21 @@ describe("buildAgentEnv — single-twin old-cloud byte-identity", () => {
     // (`GITHUB_PROVIDER_TOKEN`) as part of the "byte-identity acceptance
     // bar" above — that was pinning the defect, not protecting a real
     // property, so the assertion was deleted rather than flipped (F-1211
-    // owns the fix, not this ticket). When F-1211 lands, `buildAgentEnv`
-    // will set POME_GITHUB_TOKEN to `session.agent_token` unconditionally,
-    // matching stripe/slack/gmail elsewhere in this file — at which point
-    // this value will differ from `GITHUB_PROVIDER_TOKEN`. The only
-    // invariant that holds true both before AND after that fix, and so is
-    // safe to assert here, is that the key exists and carries some bearer
-    // string:
+    // owns the fix, not this ticket). F-1211 offers two fixes and has not
+    // picked one: set POME_GITHUB_TOKEN to `session.agent_token`
+    // unconditionally, matching how `buildAgentEnv`'s per-twin overlay
+    // already derives the stripe, slack and gmail bearers — or teach the
+    // proxy to accept the github provider credential, leaving this value the
+    // PAT. So there is no single "correct" value to flip this to yet.
+    //
+    // What holds under BOTH of those fixes — and so is what gets asserted —
+    // is that the key is present and carries one of the two bearers this
+    // session actually contains. That is deliberately stronger than a
+    // `typeof === "string"` check: it still reds if the key is dropped, and
+    // it ALSO reds if the value becomes a third bearer that is neither the
+    // PAT nor the JWT, which is the realistic way this line breaks.
     expect(typeof env.POME_GITHUB_TOKEN).toBe("string");
-    expect(env.POME_GITHUB_TOKEN.length).toBeGreaterThan(0);
+    expect([GITHUB_PROVIDER_TOKEN, AGENT_TOKEN]).toContain(env.POME_GITHUB_TOKEN);
   });
 
   it("empty per_twin ({}): FULL env is byte-identical to the omitted-per_twin case", () => {

--- a/cli/test/unit/runner/buildAgentEnv.test.ts
+++ b/cli/test/unit/runner/buildAgentEnv.test.ts
@@ -7,12 +7,15 @@ import { buildAgentEnv } from "../../../src/runner/runTaskHosted.js";
 import { rawBodyHadPerTwin } from "../../../src/hosted/client.js";
 
 // Regression: single-twin runs against an OLD cloud (no `per_twin` in the wire
-// body) must stay BYTE-IDENTICAL to origin/main's hosted env. The schema
-// synthesizes a `per_twin` entry whose `mcp_url` host-rewrites
-// api.pome.sh→mcp.pome.sh with NO `/mcp` suffix; the fan-out must NOT trust
-// that synthesized value and must fall back to `${twin_url}/mcp`, exactly as
-// main did. It must also keep injecting the github + stripe vars unconditionally
-// (main set them on every hosted run regardless of twin).
+// body) must stay BYTE-IDENTICAL to origin/main's hosted env, with ONE
+// deliberate exception: POME_GITHUB_TOKEN (see the F-1211 comment at its
+// assertions below — that key is a known defect, not a byte-identity
+// property, so this file does not pin its value). The schema synthesizes a
+// `per_twin` entry whose `mcp_url` host-rewrites api.pome.sh→mcp.pome.sh with
+// NO `/mcp` suffix; the fan-out must NOT trust that synthesized value and
+// must fall back to `${twin_url}/mcp`, exactly as main did. It must also keep
+// injecting the github + stripe vars unconditionally (main set them on every
+// hosted run regardless of twin).
 
 const AGENT_TOKEN = "edt_fake.jwt.token";
 const GITHUB_PROVIDER_TOKEN = "ght_provider_x";
@@ -32,8 +35,17 @@ const ENV_SCAFFOLD = {
 } as const;
 
 /** Reproduce the env origin/main produced for a single-twin github session —
- *  the acceptance bar for byte-identity. Mirrors main's env object literal
- *  (keys AND insertion order) exactly. */
+ *  the acceptance bar for byte-identity over every key EXCEPT
+ *  `POME_GITHUB_TOKEN`. Mirrors main's env object literal (keys AND insertion
+ *  order) exactly for everything else.
+ *
+ *  `POME_GITHUB_TOKEN` is deliberately omitted here: main computes it as
+ *  `session.provider_credentials.github?.token ?? session.agent_token`, which
+ *  is F-1211 — the twin proxy verifies bearers only against `agent_token`, so
+ *  that provider-credential PAT 404s against every real hosted twin. Pinning
+ *  it as part of a "byte-identity" fixture would assert the bug is the
+ *  correct behaviour; see the F-1211 comment at this fixture's call sites for
+ *  what is actually asserted about that key instead. */
 function originMainEnv(session: CreateSessionResponse): Record<string, string> {
   const { agentId, runId } = ENV_SCAFFOLD;
   return {
@@ -46,8 +58,6 @@ function originMainEnv(session: CreateSessionResponse): Record<string, string> {
     POME_TWIN_BASE_URL: session.twin_url,
     POME_GITHUB_REST_URL: session.twin_url,
     POME_GITHUB_MCP_URL: `${session.twin_url}/mcp`,
-    POME_GITHUB_TOKEN:
-      session.provider_credentials.github?.token ?? session.agent_token,
     POME_STRIPE_API_BASE: session.twin_url,
     POME_STRIPE_API_KEY: session.agent_token,
     POME_AUTH_TOKEN: session.agent_token,
@@ -55,6 +65,15 @@ function originMainEnv(session: CreateSessionResponse): Record<string, string> {
     POME_ARTIFACTS_DIR: `runs/scn/${runId}`,
     POME_ADAPTER_SIGNALS_PATH: ENV_SCAFFOLD.signalsPath,
   };
+}
+
+/** Drop `POME_GITHUB_TOKEN` from an env object while preserving the order of
+ *  the remaining keys, so the byte-identity checks below can compare
+ *  everything ELSE against `originMainEnv()` without re-asserting F-1211's
+ *  defective value. */
+function withoutGithubToken(env: Record<string, string>): Record<string, string> {
+  const { POME_GITHUB_TOKEN: _omitted, ...rest } = env;
+  return rest;
 }
 
 function oldCloudBody(extra: Record<string, unknown> = {}): Record<string, unknown> {
@@ -110,12 +129,31 @@ describe("buildAgentEnv — single-twin old-cloud byte-identity", () => {
     });
 
     const expected = originMainEnv(session);
-    expect(env).toEqual(expected);
+    const envWithoutGithubToken = withoutGithubToken(env);
+    expect(envWithoutGithubToken).toEqual(expected);
     // Insertion order matters for byte-identity of any serialized env dump.
-    expect(Object.keys(env)).toEqual(Object.keys(expected));
+    expect(Object.keys(envWithoutGithubToken)).toEqual(Object.keys(expected));
     // Stripe vars injected unconditionally even for a github-only session.
     expect(env.POME_STRIPE_API_BASE).toBe(TWIN_URL);
     expect(env.POME_STRIPE_API_KEY).toBe(AGENT_TOKEN);
+
+    // F-1211: main computes POME_GITHUB_TOKEN as
+    // `session.provider_credentials.github?.token ?? session.agent_token`,
+    // which is the exact expression that hands the twin proxy a
+    // provider-credential PAT it 404s on (the proxy verifies bearers only
+    // against `agent_token`). This test used to assert that PAT
+    // (`GITHUB_PROVIDER_TOKEN`) as part of the "byte-identity acceptance
+    // bar" above — that was pinning the defect, not protecting a real
+    // property, so the assertion was deleted rather than flipped (F-1211
+    // owns the fix, not this ticket). When F-1211 lands, `buildAgentEnv`
+    // will set POME_GITHUB_TOKEN to `session.agent_token` unconditionally,
+    // matching stripe/slack/gmail elsewhere in this file — at which point
+    // this value will differ from `GITHUB_PROVIDER_TOKEN`. The only
+    // invariant that holds true both before AND after that fix, and so is
+    // safe to assert here, is that the key exists and carries some bearer
+    // string:
+    expect(typeof env.POME_GITHUB_TOKEN).toBe("string");
+    expect(env.POME_GITHUB_TOKEN.length).toBeGreaterThan(0);
   });
 
   it("empty per_twin ({}): FULL env is byte-identical to the omitted-per_twin case", () => {
@@ -140,8 +178,12 @@ describe("buildAgentEnv — single-twin old-cloud byte-identity", () => {
       ...ENV_SCAFFOLD,
     });
 
+    // Both sides come from the SAME buildAgentEnv code path (including
+    // whatever POME_GITHUB_TOKEN it currently computes, F-1211 included) —
+    // this is a self-consistency check between two actual outputs, not a
+    // comparison against a fixed "correct" value, so it is not a defect pin.
     expect(envEmpty).toEqual(envOmitted);
-    expect(envEmpty).toEqual(originMainEnv(sessionEmpty));
+    expect(withoutGithubToken(envEmpty)).toEqual(originMainEnv(sessionEmpty));
   });
 
   it("new cloud with real per_twin: trusts mcp_url + applies ensureMcpSuffix", () => {

--- a/packages/adapter-claude-sdk/test/genaiSpans.test.ts
+++ b/packages/adapter-claude-sdk/test/genaiSpans.test.ts
@@ -341,6 +341,45 @@ describe("withGenAiSpans → gen_ai.usage.output_tokens is the message_delta tru
     event: { type: "message_delta", delta: { stop_reason: stopReason }, usage: { output_tokens: outputTokens } },
   });
 
+  // The two numbers the main agent's turn reports in the sub-agent tapes
+  // below: its `message_delta` truth, and its ~5x-low `message_start`
+  // snapshot. Named so the sub-agent assertions can say "none of the main
+  // turn's numbers" without re-spelling literals the fixtures own.
+  const MAIN_DELTA = 517;
+  const MAIN_SNAPSHOT = 8;
+
+  /**
+   * A sub-agent span must carry the SUB-AGENT's own output count.
+   *
+   * Deliberately does not assert what that count IS. It is the 4-token
+   * `message_start` snapshot today — that is F-1014's defect — and becomes the
+   * real total once F-1014 reads `system/task_notification`; asserting either
+   * would pin a value an open ticket is going to change (F-1375).
+   *
+   * What is asserted is that the span carries a real count and that no
+   * main-turn number leaked into it. The finiteness check is load-bearing
+   * rather than ceremony: `outputTokensOf` yields NaN for a span that carries
+   * no `gen_ai.usage.output_tokens` attribute at all, and NaN satisfies every
+   * `not.toBe` silently, so without it a regression that drops sub-agent usage
+   * entirely leaves this whole file green (verified by mutation).
+   *
+   * Caveat for whoever takes F-1014: this holds under the ticket's approach 1
+   * (derive the split, keep `gen_ai.usage.output_tokens`), which the ticket
+   * says to try first. Approaches 2 and 3 deliberately stop putting a
+   * sub-agent output count on a `gen_ai` span at all — leaving `gen_ai.usage.*`
+   * unset, or not emitting these spans. Those change the span's SHAPE, not
+   * just this value, so they should rewrite this test rather than find it
+   * already permissive: a test still claiming these spans carry sub-agent
+   * output tokens would be wrong, not merely outdated.
+   */
+  function expectSubagentOwnCount(span: ExportedSpan): void {
+    const tokens = outputTokensOf(span);
+    expect(Number.isFinite(tokens)).toBe(true);
+    expect(tokens).toBeGreaterThan(0);
+    expect(tokens).not.toBe(MAIN_DELTA);
+    expect(tokens).not.toBe(MAIN_SNAPSHOT);
+  }
+
   it("prefers the message_delta count over the snapshot on the assistant message", async () => {
     await drive([
       streamStart("msg_A"),
@@ -408,17 +447,18 @@ describe("withGenAiSpans → gen_ai.usage.output_tokens is the message_delta tru
   // emits a `message_delta` for it and nothing yet reads the real total from
   // `system/task_notification`. Asserting `4` here as the expected span value
   // would pin that defect a second time (F-1375), so this test does NOT
-  // assert what the sub-agent spans' token count equals — only that they are
-  // NOT the main turn's delta (517), which is the actual regression this test
-  // guards against ("must not leak onto it," above) and will remain true
-  // after F-1014 lands, whatever the corrected sub-agent number turns out to
-  // be (`system/task_notification`'s `total_tokens`, or `total - input`, per
-  // the ticket's ordered approach).
+  // assert what the sub-agent spans' token count equals. It asserts every
+  // property of that count which survives F-1014 — see
+  // `expectSubagentOwnCount`: a real, positive number carrying none of the
+  // main turn's numbers, which is the regression this test guards against
+  // ("must not leak onto it," above) and stays true whatever the corrected
+  // sub-agent number turns out to be (`system/task_notification`'s
+  // `total_tokens`, or `total - input`, per the ticket's ordered approach).
   it("keeps the snapshot on a subagent turn and does not leak the main delta onto it", async () => {
     await drive([
       streamStart("msg_main"),
-      { type: "assistant", message: { id: "msg_main", model: "claude-opus-4-8", usage: { input_tokens: 2, output_tokens: 8 } } },
-      streamDelta(517, "tool_use"),
+      { type: "assistant", message: { id: "msg_main", model: "claude-opus-4-8", usage: { input_tokens: 2, output_tokens: MAIN_SNAPSHOT } } },
+      streamDelta(MAIN_DELTA, "tool_use"),
       // Subagent turns: assistant messages only, no stream events of their own.
       {
         type: "assistant",
@@ -436,11 +476,11 @@ describe("withGenAiSpans → gen_ai.usage.output_tokens is the message_delta tru
     const spans = collectSpans();
     expect(spans.length).toBe(3);
     // Main-agent turn: unaffected by F-1014, still the exact message_delta count.
-    expect(outputTokensOf(spans[0]!)).toBe(517);
-    // Sub-agent turns must carry their OWN number, not the main turn's delta —
-    // see the F-1014 comment above for why that number itself is not asserted.
-    expect(outputTokensOf(spans[1]!)).not.toBe(outputTokensOf(spans[0]!));
-    expect(outputTokensOf(spans[2]!)).not.toBe(outputTokensOf(spans[0]!));
+    expect(outputTokensOf(spans[0]!)).toBe(MAIN_DELTA);
+    // Sub-agent turns keep their own count with nothing from the main turn in
+    // it — see `expectSubagentOwnCount` for why the count itself is not pinned.
+    expectSubagentOwnCount(spans[1]!);
+    expectSubagentOwnCount(spans[2]!);
   });
 
   // The lanes keep ONE `pending` turn, not one per stream, so a subagent's
@@ -463,9 +503,9 @@ describe("withGenAiSpans → gen_ai.usage.output_tokens is the message_delta tru
 
     await drive([
       streamStart("msg_main1"),
-      { type: "assistant", message: { id: "msg_main1", model: "claude-opus-4-8", usage: { input_tokens: 2, output_tokens: 8 } } },
-      { type: "assistant", message: { id: "msg_main1", model: "claude-opus-4-8", usage: { input_tokens: 2, output_tokens: 8 } } },
-      streamDelta(517, "tool_use"),
+      { type: "assistant", message: { id: "msg_main1", model: "claude-opus-4-8", usage: { input_tokens: 2, output_tokens: MAIN_SNAPSHOT } } },
+      { type: "assistant", message: { id: "msg_main1", model: "claude-opus-4-8", usage: { input_tokens: 2, output_tokens: MAIN_SNAPSHOT } } },
+      streamDelta(MAIN_DELTA, "tool_use"),
       messageStop(),
       sub("msg_sub_a", "toolu_alpha"),
       sub("msg_sub_b", "toolu_beta"),
@@ -481,18 +521,18 @@ describe("withGenAiSpans → gen_ai.usage.output_tokens is the message_delta tru
     expect(spans.length).toBe(4);
     // Main-agent turns, in stream order, survive the interleaved sub-agent
     // turns untouched.
-    expect(outputTokensOf(spans[0]!)).toBe(517);
+    expect(outputTokensOf(spans[0]!)).toBe(MAIN_DELTA);
     expect(outputTokensOf(spans[3]!)).toBe(7);
-    // spans[1] and spans[2] are the interleaved sub-agent turns — see the
-    // F-1014 comment on the previous test for why their token count is not
-    // asserted here (that number, currently a 4-token snapshot, is F-1014's
-    // defect, not a byte we should pin). The invariant that matters — the
-    // interleaving does not corrupt the main turn's boundary — is what
-    // spans[0]/spans[3] above and the total below prove.
-    expect(outputTokensOf(spans[1]!)).not.toBe(outputTokensOf(spans[0]!));
-    expect(outputTokensOf(spans[2]!)).not.toBe(outputTokensOf(spans[0]!));
-    // Main-agent turns alone reproduce SDKResultMessage.usage.output_tokens.
-    expect(517 + 7).toBe(524);
+    // spans[1] and spans[2] are the interleaved sub-agent turns — see
+    // `expectSubagentOwnCount` for why their count is not pinned (that number,
+    // currently a 4-token snapshot, is F-1014's defect) and what is checked
+    // instead.
+    expectSubagentOwnCount(spans[1]!);
+    expectSubagentOwnCount(spans[2]!);
+    // Main-agent turns ALONE reproduce SDKResultMessage.usage.output_tokens —
+    // read off the exported spans, so the interleaved sub-agent turns
+    // provably neither joined this total nor stole from it.
+    expect(outputTokensOf(spans[0]!) + outputTokensOf(spans[3]!)).toBe(524);
   });
 
   // The span window is measured from the previously yielded message. Injected

--- a/packages/adapter-claude-sdk/test/genaiSpans.test.ts
+++ b/packages/adapter-claude-sdk/test/genaiSpans.test.ts
@@ -402,6 +402,18 @@ describe("withGenAiSpans → gen_ai.usage.output_tokens is the message_delta tru
   // usage, so the exactness invariant holds over MAIN-AGENT turns. Live
   // two-subagent run: main deltas 517 + 7 == result 524, with the subagent turns'
   // 4 + 4 sitting outside that total on both sides.
+  //
+  // F-1014: that "4" snapshot is the defect this ticket tracks — a real
+  // sub-agent turn doing ~22k tokens of work reports 4, because the SDK never
+  // emits a `message_delta` for it and nothing yet reads the real total from
+  // `system/task_notification`. Asserting `4` here as the expected span value
+  // would pin that defect a second time (F-1375), so this test does NOT
+  // assert what the sub-agent spans' token count equals — only that they are
+  // NOT the main turn's delta (517), which is the actual regression this test
+  // guards against ("must not leak onto it," above) and will remain true
+  // after F-1014 lands, whatever the corrected sub-agent number turns out to
+  // be (`system/task_notification`'s `total_tokens`, or `total - input`, per
+  // the ticket's ordered approach).
   it("keeps the snapshot on a subagent turn and does not leak the main delta onto it", async () => {
     await drive([
       streamStart("msg_main"),
@@ -422,7 +434,13 @@ describe("withGenAiSpans → gen_ai.usage.output_tokens is the message_delta tru
     ]);
 
     const spans = collectSpans();
-    expect(spans.map(outputTokensOf)).toEqual([517, 4, 4]);
+    expect(spans.length).toBe(3);
+    // Main-agent turn: unaffected by F-1014, still the exact message_delta count.
+    expect(outputTokensOf(spans[0]!)).toBe(517);
+    // Sub-agent turns must carry their OWN number, not the main turn's delta —
+    // see the F-1014 comment above for why that number itself is not asserted.
+    expect(outputTokensOf(spans[1]!)).not.toBe(outputTokensOf(spans[0]!));
+    expect(outputTokensOf(spans[2]!)).not.toBe(outputTokensOf(spans[0]!));
   });
 
   // The lanes keep ONE `pending` turn, not one per stream, so a subagent's
@@ -460,7 +478,19 @@ describe("withGenAiSpans → gen_ai.usage.output_tokens is the message_delta tru
     ]);
 
     const spans = collectSpans();
-    expect(spans.map(outputTokensOf)).toEqual([517, 4, 4, 7]);
+    expect(spans.length).toBe(4);
+    // Main-agent turns, in stream order, survive the interleaved sub-agent
+    // turns untouched.
+    expect(outputTokensOf(spans[0]!)).toBe(517);
+    expect(outputTokensOf(spans[3]!)).toBe(7);
+    // spans[1] and spans[2] are the interleaved sub-agent turns — see the
+    // F-1014 comment on the previous test for why their token count is not
+    // asserted here (that number, currently a 4-token snapshot, is F-1014's
+    // defect, not a byte we should pin). The invariant that matters — the
+    // interleaving does not corrupt the main turn's boundary — is what
+    // spans[0]/spans[3] above and the total below prove.
+    expect(outputTokensOf(spans[1]!)).not.toBe(outputTokensOf(spans[0]!));
+    expect(outputTokensOf(spans[2]!)).not.toBe(outputTokensOf(spans[0]!));
     // Main-agent turns alone reproduce SDKResultMessage.usage.output_tokens.
     expect(517 + 7).toBe(524);
   });

--- a/scripts/ci/check-version-bump-required.mjs
+++ b/scripts/ci/check-version-bump-required.mjs
@@ -21,11 +21,32 @@ if (!baseSha) {
   throw new Error("usage: check-version-bump-required.mjs <base-sha>");
 }
 
+/**
+ * A test file cannot change one byte of any tarball this gate guards: no
+ * package's `files` array names a test directory, tsup builds from `src/`, and
+ * no `src/` module imports out of one. Demanding a version bump for a
+ * test-only PR therefore demands a release that republishes an identical
+ * artifact — which is what RELEASING.md already says should not happen ("If
+ * your change doesn't warrant a release (docs, tests, CI-only), it shouldn't
+ * be touching a publish-relevant path in the first place"), and is the same
+ * pointless-bump noise the `@pome-sh/checks` entry below argues a gate must
+ * not generate if it wants to keep being read.
+ *
+ * `examples/`, `assets/` and `tasks/` are carved back IN because the CLI's
+ * `files` array publishes them verbatim — a file named `*.test.ts` inside one
+ * of those really does ship, so it must still demand a bump.
+ */
+function isUnpublishableTestPath(file) {
+  if (/(^|\/)(examples|assets|tasks)\//.test(file)) return false;
+  return /(^|\/)tests?\//.test(file) || /\.test\.[cm]?[jt]sx?$/.test(file);
+}
+
 const changedFiles = execFileSync("git", ["diff", "--name-only", baseSha, "HEAD"], {
   encoding: "utf8",
 })
   .split("\n")
-  .filter(Boolean);
+  .filter(Boolean)
+  .filter((file) => !isUnpublishableTestPath(file));
 
 function versionAt(ref, manifestPath) {
   try {

--- a/scripts/ci/check-version-bump-required.test.mjs
+++ b/scripts/ci/check-version-bump-required.test.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+/**
+ * Regression coverage for scripts/ci/check-version-bump-required.mjs.
+ *
+ * Stands up a throwaway git repo with the manifests the gate knows about, then
+ * drives it over real commits so the `git diff --name-only base HEAD` path is
+ * exercised rather than mocked.
+ *
+ * The case that motivated this file (F-1375): `cli/` is a publish-relevant
+ * PREFIX, so a PR touching only `cli/test/**` used to be told to bump
+ * `@pome-sh/cli` — publishing a tarball whose bytes are identical, because no
+ * package's `files` array names a test directory. RELEASING.md already said
+ * that shouldn't happen; the prefix match didn't know it. A test path is now
+ * dropped before the match, EXCEPT under `examples/`, `assets/` and `tasks/`,
+ * which the CLI's `files` array really does publish verbatim.
+ */
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const SCRIPT = join(ROOT, "scripts/ci/check-version-bump-required.mjs");
+
+let failures = 0;
+function check(label, condition, detail = "") {
+  if (condition) {
+    console.log(`  ✓ ${label}`);
+    return;
+  }
+  failures += 1;
+  console.error(`  ✗ ${label}${detail ? `\n      ${detail}` : ""}`);
+}
+
+function git(cwd, ...args) {
+  const r = spawnSync("git", args, { cwd, encoding: "utf8" });
+  if (r.status !== 0) throw new Error(`git ${args.join(" ")}\n${r.stderr}`);
+  return r.stdout.trim();
+}
+
+function write(dir, relPath, contents) {
+  mkdirSync(join(dir, dirname(relPath)), { recursive: true });
+  writeFileSync(join(dir, relPath), contents);
+}
+
+/**
+ * Build a repo whose base commit carries the given manifest versions, apply
+ * `changes` as a second commit, and run the gate against the base sha.
+ */
+function run({ changes, versions = {} }) {
+  const dir = mkdtempSync(join(tmpdir(), "version-bump-gate-"));
+  try {
+    git(dir, "init", "-q", "-b", "main");
+    git(dir, "config", "user.email", "ci@example.com");
+    git(dir, "config", "user.name", "ci");
+    write(dir, "cli/package.json", JSON.stringify({ name: "@pome-sh/cli", version: "1.0.0" }));
+    write(
+      dir,
+      "packages/adapter-claude-sdk/package.json",
+      JSON.stringify({ name: "@pome-sh/adapter-claude-sdk", version: "1.0.0" }),
+    );
+    git(dir, "add", "-A");
+    git(dir, "commit", "-qm", "base");
+    const baseSha = git(dir, "rev-parse", "HEAD");
+
+    for (const [relPath, contents] of Object.entries(changes)) write(dir, relPath, contents);
+    for (const [manifest, version] of Object.entries(versions)) {
+      const name = manifest.startsWith("cli") ? "@pome-sh/cli" : "@pome-sh/adapter-claude-sdk";
+      write(dir, manifest, JSON.stringify({ name, version }));
+    }
+    git(dir, "add", "-A");
+    git(dir, "commit", "-qm", "change");
+
+    const r = spawnSync("node", [SCRIPT, baseSha], { cwd: dir, encoding: "utf8" });
+    return { status: r.status, out: `${r.stdout}${r.stderr}` };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+console.log("check-version-bump-required.mjs");
+
+{
+  const r = run({ changes: { "cli/test/unit/thing.test.ts": "// test only\n" } });
+  check("test-only change under cli/test/ needs no bump", r.status === 0, r.out);
+}
+
+{
+  const r = run({ changes: { "packages/adapter-claude-sdk/test/spans.test.ts": "// test\n" } });
+  check("test-only change in the adapter needs no bump", r.status === 0, r.out);
+}
+
+{
+  const r = run({ changes: { "cli/src/thing.ts": "export const a = 1;\n" } });
+  check(
+    "src change with no bump still fails",
+    r.status === 1 && r.out.includes("@pome-sh/cli"),
+    r.out,
+  );
+}
+
+{
+  const r = run({
+    changes: { "cli/src/thing.ts": "export const a = 1;\n" },
+    versions: { "cli/package.json": "1.0.1" },
+  });
+  check("src change WITH a bump passes", r.status === 0, r.out);
+}
+
+{
+  // A test file mixed in with a src change must not mask the src change.
+  const r = run({
+    changes: { "cli/src/thing.ts": "export const a = 1;\n", "cli/test/thing.test.ts": "// t\n" },
+  });
+  check("src + test change with no bump still fails", r.status === 1, r.out);
+}
+
+{
+  // `files: ["examples", ...]` publishes these verbatim, so they are not
+  // exempt just because of the filename.
+  const r = run({ changes: { "cli/examples/demo/smoke.test.ts": "// shipped\n" } });
+  check("a *.test.ts under cli/examples/ still demands a bump", r.status === 1, r.out);
+}
+
+{
+  const r = run({ changes: { "cli/tasks/thing/test/fixture.json": "{}\n" } });
+  check("a test/ dir under cli/tasks/ still demands a bump", r.status === 1, r.out);
+}
+
+{
+  // The downgrade guard is independent of the test filter.
+  const r = run({
+    changes: { "cli/src/thing.ts": "export const a = 1;\n" },
+    versions: { "cli/package.json": "0.9.0" },
+  });
+  check("a BEHIND version still fails", r.status === 1 && r.out.includes("BEHIND"), r.out);
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("all checks passed");


### PR DESCRIPTION
## Summary

F-1375's audit found three open tickets each locked in place by a green test asserting the buggy value: fix the defect and you turn a green suite red on purpose. Two of the three live in this repo (the third, F-1314, was already fixed in pome-cloud#650).

Three sites, not two — the sweep's prose blind spot hid one:

- `cli/test/unit/runner/buildAgentEnv.test.ts` reproduced `session.provider_credentials.github?.token ?? session.agent_token` as part of a "byte-identity acceptance bar" against origin/main — that expression is F-1211: the twin proxy verifies bearers only against `agent_token`, so the provider-credential PAT this line hands the agent 404s on every real hosted run.
- `cli/test/integration/runTaskHosted.test.ts` asserted `expect(agentEnv.ght).toBe("ght_provider")` — the same F-1211 defect, reached through an abbreviated key and a different fixture literal, which is why a grep for `POME_GITHUB_TOKEN` did not surface it. Simulating F-1211's fix across the **whole** cli workspace rather than just the edited files is what caught it.
- `packages/adapter-claude-sdk/test/genaiSpans.test.ts` asserted `[517, 4, 4]` (and `[517, 4, 4, 7]`) — the `4`s are F-1014: a sub-agent turn doing ~22k tokens of real work reports 4, because the SDK never emits a `message_delta` for it and nothing yet reads the real total from `system/task_notification`.

Neither F-1211 nor F-1014 is fixed here — that's each ticket's own scope. This PR only removes the pins, and replaces each with the strongest invariant that survives the fix rather than the weakest one that merely passes:

- **F-1211 sites** assert the bearer is one of the two the session actually carries. That holds under *both* fixes F-1211 lists (make it `agent_token`, or teach the proxy to accept the PAT), and unlike a `typeof === "string"` check it reds when the agent is handed a third, wrong bearer. `POME_GITHUB_TOKEN`'s slot in the insertion order stays inside the byte-identity key check: the fix changes what the key holds, never where it sits.
- **F-1014 sites** assert each sub-agent span carries a real, positive count that is none of the main turn's numbers. The finiteness check is load-bearing: `outputTokensOf` returns `NaN` for a span with no `gen_ai.usage.output_tokens` attribute, and `NaN` satisfies every `not.toBe` silently — a mutation dropping sub-agent usage entirely left all 15 tests green without it, while the pre-PR file failed two with `[517, NaN, NaN]`. `expect(517 + 7).toBe(524)` was arithmetic on literals proving nothing; it now sums the two exported main-turn spans.

Each site carries a comment naming the owning ticket, what the value becomes once it lands, and why the assertion was deleted rather than flipped (neither fix is settled, so there is no correct value to flip to yet). The F-1014 helper also names that ticket's approaches 2 and 3, which change the span's *shape* rather than this value and so should rewrite that test rather than find it already permissive.

### Also: the version-bump gate no longer demands a release for a test-only PR

`check-version-bump-required.mjs` matched `cli/` as a prefix, so this PR was told to bump `@pome-sh/cli` and `@pome-sh/adapter-claude-sdk` and publish two byte-identical tarballs. No package's `files` array names a test directory, tsup builds from `src/`, and no `src/` module imports out of one — and RELEASING.md already says a test change should not warrant a release. Test paths are now dropped before the prefix match, except under `examples/`, `assets/` and `tasks/`, which the CLI's `files` array publishes verbatim. New `scripts/ci/check-version-bump-required.test.mjs` covers both directions and is wired into `ci.yml`, matching how every other gate script in `scripts/ci/` is tested.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (all workspaces green)
- [x] `npm run test --workspace cli` (108 files, 1096 tests)
- [x] `npm run test --workspace packages/adapter-claude-sdk` (11 files, 134 tests)
- [x] `npm run lint:no-cloud-imports && npm run lint:code-health && npm run lint:copy-markers && npm run lint:no-catch`
- [x] `node scripts/ci/check-version-bump-required.mjs <base>` → OK, no bump required
- [x] `node scripts/ci/check-version-bump-required.test.mjs` → 8/8
- [x] Simulated F-1211's fix (`POME_GITHUB_TOKEN = session.agent_token` unconditionally) over the **full cli workspace**: 108 files / 1096 tests green, no test edits
- [x] Simulated F-1014's fix (sub-agent turns report a real total instead of the 4-token snapshot) over the **full adapter workspace**: 11 files / 134 tests green, no test edits
- [x] Mutation-verified every replacement assertion reds when the thing it protects breaks: main delta leaking onto sub-agent turns; sub-agent usage dropped entirely; sub-agent turn inheriting the main turn's snapshot; `POME_GITHUB_TOKEN` removed; `POME_GITHUB_TOKEN` set to a wrong bearer
