### PR TITLE
A corrupt current-version verdict.json is a named, counted skip (F-1411)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,10 +43,13 @@ live at **https://docs.pome.sh**.
   could no longer fire. Such a file is still RECOGNIZED as one of ours and
   `pome fix-prompt` names the skip (`staleVersionCount`) rather than dropping
   it silently. F-1411 gives the same treatment to a verdict.json that EXISTS
-  at the current version but is truncated, hand-edited, or otherwise damaged
-  — a different fact (nothing wrote this file correctly, vs. an older CLI
-  that did) — counted and path-named separately as `unreadableCount` /
-  `unreadablePaths`, never folded into `staleVersionCount`.
+  on disk but cannot be read at all — truncated, hand-edited into an
+  unexpected `state`, or valid JSON that is not one of our artifacts (the
+  version check never even reaches such a file) — a different fact (nothing
+  wrote this file correctly, vs. an older CLI that did) — counted and
+  path-named separately as `unreadableCount` / `unreadablePaths`, never
+  folded into `staleVersionCount`. A run dir with NO verdict.json is neither,
+  and stays silently skipped.
 - **The CLI (`cli/`) IS a root workspace member** — `workspaces: ["packages/*",
   "cli"]`, one `package-lock.json`, one `npm ci`. Use `npm run -w @pome-sh/cli
   ...` from the root. The former `cli/package-lock.json` and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,11 @@ live at **https://docs.pome.sh**.
   spelling could matter — so the normalize step was a dual-format reader that
   could no longer fire. Such a file is still RECOGNIZED as one of ours and
   `pome fix-prompt` names the skip (`staleVersionCount`) rather than dropping
-  it silently.
+  it silently. F-1411 gives the same treatment to a verdict.json that EXISTS
+  at the current version but is truncated, hand-edited, or otherwise damaged
+  — a different fact (nothing wrote this file correctly, vs. an older CLI
+  that did) — counted and path-named separately as `unreadableCount` /
+  `unreadablePaths`, never folded into `staleVersionCount`.
 - **The CLI (`cli/`) IS a root workspace member** — `workspaces: ["packages/*",
   "cli"]`, one `package-lock.json`, one `npm ci`. Use `npm run -w @pome-sh/cli
   ...` from the root. The former `cli/package-lock.json` and

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,31 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.23.11
+
+### Patch Changes
+
+- `pome fix-prompt` names a corrupt current-version `verdict.json` instead of
+  dropping it silently (F-1411). A v2 artifact that is truncated, hand-edited,
+  or carries an unexpected `state` read as `{status: "unreadable"}` and
+  vanished from every count `RunSetDiscovery` exposes — not `totalSets`, not
+  `staleVersionCount` — so a `runs/` holding one readable trial beside a
+  damaged one built a prompt from a fraction of the run set and said nothing
+  about the rest, the same silent drop F-1195 closed for a prior-version
+  file. `RunSetDiscovery` now carries `unreadableCount` and the paths behind
+  it (`unreadablePaths`), and fix-prompt discovery prints a distinct line
+  naming them — capped at 5, "N more omitted" beyond that — every time it
+  happens, not only when nothing else was found. Kept separate from
+  `staleVersionCount` on purpose: a file an older CLI wrote correctly and a
+  file nothing wrote correctly are different facts and want different fixes.
+  A run dir with no verdict.json at all (a run still in progress) is neither,
+  and stays silently skipped as before.
+- `evalResultCache.ts` split `loadTrialEvents` into `hosted/trialEvents.ts`
+  and the run-set grouping (`RunSet`, `groupRunSets`,
+  `latestFailedRunSet`/`latestIncompleteRunSet`) into `hosted/runSets.ts`, to
+  stay under the file-size gate after the above. No behavior change; callers
+  now import from the new paths.
+
 ## 0.23.10
 
 ### Patch Changes

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,14 +9,16 @@ packaging restructure: bump `version` here and in `package.json`, and merging to
 ### Patch Changes
 
 - `pome fix-prompt` names a corrupt current-version `verdict.json` instead of
-  dropping it silently (F-1411). A v2 artifact that is truncated, hand-edited,
-  or carries an unexpected `state` read as `{status: "unreadable"}` and
+  dropping it silently (F-1411). A verdict.json that is truncated,
+  hand-edited into an unexpected `state`, or valid JSON that is not one of
+  our artifacts at all read as `{status: "unreadable"}` and
   vanished from every count `RunSetDiscovery` exposes — not `totalSets`, not
   `staleVersionCount` — so a `runs/` holding one readable trial beside a
   damaged one built a prompt from a fraction of the run set and said nothing
   about the rest, the same silent drop F-1195 closed for a prior-version
   file. `RunSetDiscovery` now carries `unreadableCount` and the paths behind
-  it (`unreadablePaths`), and fix-prompt discovery prints a distinct line
+  it (`unreadablePaths`, sorted so the trimmed list does not depend on
+  `readdir` order), and fix-prompt discovery prints a distinct line
   naming them — capped at 5, "N more omitted" beyond that — every time it
   happens, not only when nothing else was found. Kept separate from
   `staleVersionCount` on purpose: a file an older CLI wrote correctly and a

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.23.10",
+  "version": "0.23.11",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -94,6 +94,10 @@ const DEFAULT_AGENT_FILE = "examples/agents/scripted-triage-agent.ts";
 // with no error pointing at the real cause.
 const DEFAULT_AGENT_COMMAND = `node ${DEFAULT_AGENT_FILE}`;
 const MANIFEST_SCHEMA_URL = "https://pome.sh/schemas/v1/pome.json";
+// F-1411 — cap on how many unreadable verdict.json paths `fix-prompt`
+// discovery names individually, same "kept first N" convention as
+// `fix-prompt/prompt.ts`'s MAX_EVENTS trim.
+const MAX_UNREADABLE_PATHS_SHOWN = 5;
 
 // Injected by tsup (`define: { PKG_VERSION }`) so the bundled CLI never has to
 // locate its own package.json at runtime. Undeclared under `tsx src/cli/main.ts`,
@@ -1220,8 +1224,26 @@ export function createProgram() {
           `${discovery.staleVersionCount} verdict.json file(s) under ${root} are not artifact version ${VERDICT_ARTIFACT_VERSION} (the only version this CLI reads) and were skipped — re-run \`pome run\` to record those trials again.`,
         );
       }
+      // F-1411 — a verdict.json that EXISTS but is truncated, hand-edited, or
+      // otherwise damaged is a different fact from a prior-version file (an
+      // older CLI wrote that one correctly) and gets its own line, naming the
+      // path(s) — a count alone would tell the user something was skipped but
+      // not which trial to go look at. Reported every time it happens, same
+      // as stale-version above, never only when nothing else was found.
+      if (discovery.unreadableCount > 0) {
+        console.error(
+          `${discovery.unreadableCount} verdict.json file(s) under ${root} could not be read (truncated, hand-edited, or not a verdict artifact) and were skipped:`,
+        );
+        for (const path of discovery.unreadablePaths.slice(0, MAX_UNREADABLE_PATHS_SHOWN)) {
+          console.error(`  - ${path}`);
+        }
+        const omitted = discovery.unreadablePaths.length - MAX_UNREADABLE_PATHS_SHOWN;
+        if (omitted > 0) {
+          console.error(`  (${omitted} more omitted — kept first ${MAX_UNREADABLE_PATHS_SHOWN})`);
+        }
+      }
       if (discovery.totalSets === 0) {
-        if (discovery.staleVersionCount === 0) {
+        if (discovery.staleVersionCount === 0 && discovery.unreadableCount === 0) {
           console.error(
             `No finalized run sets under ${root} — hosted \`pome run\` records a verdict.json per trial; run one first (or point fix-prompt at your artifacts dir).`,
           );

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -72,9 +72,9 @@ import {
 } from "../fix-prompt/index.js";
 import {
   discoverRunSet,
-  loadTrialEvents,
   VERDICT_ARTIFACT_VERSION,
 } from "../hosted/evalResultCache.js";
+import { loadTrialEvents } from "../hosted/trialEvents.js";
 import type { Task } from "../task/taskSchema.js";
 import { parseTaskFile } from "../task/parseTask.js";
 import type { RecorderEvent } from "../types/shared.js";

--- a/cli/src/hosted/evalResultCache.ts
+++ b/cli/src/hosted/evalResultCache.ts
@@ -26,6 +26,12 @@ import { readdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { CriterionResult } from "../types/shared.js";
 import type { ScoreStatus } from "./evalResultView.js";
+import {
+  groupRunSets,
+  latestFailedRunSet,
+  latestIncompleteRunSet,
+  type RunSet,
+} from "./runSets.js";
 
 // F-1195 — bumped 1 → 2: the artifact gained `state` (the run's three-state
 // verdict, by name) and the `evaluated`/`not_evaluated`/`pre_satisfied`/
@@ -286,96 +292,6 @@ export async function scanVerdictArtifacts(
   return (await scanVerdictArtifactsDetailed(artifactsRoot)).trials;
 }
 
-// F-1404 — the three-way verdict a run SET can carry, named like
-// `ScoreStatus` (the per-trial word) because it is built from it: "fail" =
-// at least one trial genuinely failed (graded, unsatisfied) — the only
-// outcome that asserts an agent defect. "incomplete" = no trial failed, but
-// at least one trial's grading never finished — a grader/seed gap, not
-// evidence the agent did anything wrong; "fail" wins when a set has both,
-// since a real failure is signal worth naming over a sibling's gap.
-// "pass" = EVERY trial's state is exactly "pass", tested that way round on
-// purpose: "pass" is the one outcome claiming a verified result, so it is
-// never the fallthrough. An unrecognized state reads "incomplete", not green
-// (`isVerdictArtifact` already refuses such a file — second line of defense).
-export type RunSetOutcome = "fail" | "incomplete" | "pass";
-
-export interface RunSet {
-  /** null = a single run that never had a group. */
-  groupId: string | null;
-  taskName: string;
-  /** The task path recorded at run time (first trial's). */
-  taskPath: string;
-  /** Trials sorted by finalized_at ascending. */
-  trials: TrialVerdict[];
-  latestFinalizedAt: string;
-  /** F-1404 — derived from the on-disk `state` (see `RunSetOutcome`), never
-   *  from `passed` alone: `passed` is false for BOTH a genuine failure and a
-   *  trial the grader never finished, so it can't tell "agent defect" from
-   *  "never graded" apart. The ONE computation both the routing decision
-   *  (`latestFailedRunSet` / `latestIncompleteRunSet`) and the message shown
-   *  to the user read, so they cannot disagree. */
-  outcome: RunSetOutcome;
-}
-
-/** Group trials into run sets: trials sharing a group_id form one set; a
- *  null group_id is its own single-run set.
- *
- *  F-1404 — `outcome` reads the on-disk `state` (F-1195), not `!passed`
- *  (F-1392's finding: `!passed` is true for both a genuine failure and an
- *  incomplete trial, so a set holding only incomplete trials used to trip
- *  the old `anyFailed` and get handed to `pome fix-prompt` as an agent
- *  defect). `evalResultCache.test.ts` pins all three outcomes against the
- *  written artifact. */
-export function groupRunSets(trials: TrialVerdict[]): RunSet[] {
-  const byKey = new Map<string, TrialVerdict[]>();
-  for (const trial of trials) {
-    const key = trial.verdict.group_id ?? `solo:${trial.verdict.session_id}`;
-    const bucket = byKey.get(key);
-    if (bucket) bucket.push(trial);
-    else byKey.set(key, [trial]);
-  }
-  const sets: RunSet[] = [];
-  for (const bucket of byKey.values()) {
-    bucket.sort((a, b) =>
-      a.verdict.finalized_at.localeCompare(b.verdict.finalized_at),
-    );
-    const last = bucket[bucket.length - 1]!;
-    const hasFailed = bucket.some((t) => t.verdict.state === "fail");
-    const allPassed = bucket.every((t) => t.verdict.state === "pass");
-    sets.push({
-      groupId: bucket[0]!.verdict.group_id,
-      taskName: bucket[0]!.verdict.task_name,
-      taskPath: bucket[0]!.verdict.task_path,
-      trials: bucket,
-      latestFinalizedAt: last.verdict.finalized_at,
-      outcome: hasFailed ? "fail" : allPassed ? "pass" : "incomplete",
-    });
-  }
-  sets.sort((a, b) => a.latestFinalizedAt.localeCompare(b.latestFinalizedAt));
-  return sets;
-}
-
-/** The newest run set with at least one genuinely FAILED (graded, not
- *  satisfied) trial — the only outcome `pome fix-prompt` may hand to a
- *  coding agent as an agent defect. */
-export function latestFailedRunSet(sets: RunSet[]): RunSet | null {
-  for (let i = sets.length - 1; i >= 0; i -= 1) {
-    if (sets[i]!.outcome === "fail") return sets[i]!;
-  }
-  return null;
-}
-
-/** F-1404 — the newest run set whose worst outcome is INCOMPLETE: no trial
- *  failed, but at least one trial's grading never finished. Callers use this
- *  to name the gap distinctly from both "fix this" (a fail set exists) and
- *  "nothing to fix" (every set passed) — never silently folded into either. */
-export function latestIncompleteRunSet(sets: RunSet[]): RunSet | null {
-  for (let i = sets.length - 1; i >= 0; i -= 1) {
-    if (sets[i]!.outcome === "incomplete") return sets[i]!;
-  }
-  return null;
-}
-
 export interface RunSetDiscovery {
   kind: "trial-dir" | "root";
   /** The set to build a fix prompt from (per `kind` semantics: a trial dir
@@ -470,29 +386,4 @@ export async function discoverRunSet(target: string): Promise<RunSetDiscovery> {
     totalSets: sets.length,
     staleVersionCount: staleVersionDirs.length,
   };
-}
-
-/** Load a trial's captured events.jsonl (raw trace) for prompt assembly.
- *  Missing/corrupt lines are skipped — the prompt degrades, never throws. */
-export async function loadTrialEvents(runDir: string): Promise<unknown[]> {
-  let raw: string;
-  try {
-    raw = await readFile(join(runDir, "events.jsonl"), "utf8");
-  } catch {
-    return [];
-  }
-  const events: unknown[] = [];
-  for (const line of raw.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    try {
-      const parsed: unknown = JSON.parse(trimmed);
-      // Valid JSON but not an event object (`null`, `3`, `"x"`) is corrupt
-      // for our purposes — renderEvent dereferences fields on it.
-      if (typeof parsed === "object" && parsed !== null) events.push(parsed);
-    } catch {
-      // skip corrupt row
-    }
-  }
-  return events;
 }

--- a/cli/src/hosted/evalResultCache.ts
+++ b/cli/src/hosted/evalResultCache.ts
@@ -247,10 +247,18 @@ export async function readVerdictArtifact(
 /** F-1195 — the detailed scan behind `scanVerdictArtifacts`: also collects
  *  the dirs whose verdict.json was recognizable but a prior artifact version,
  *  so `discoverRunSet` can name that skip instead of it looking identical to
- *  "no run happened here". */
+ *  "no run happened here".
+ *
+ *  F-1411 — likewise for `unreadableDirs`: a verdict.json that EXISTS but is
+ *  truncated, hand-edited, or otherwise damaged. Kept out of `staleVersionDirs`
+ *  on purpose — a prior-version file and a corrupt one are different facts
+ *  (upgrade vs. damage) and want different fixes. A run dir with no
+ *  verdict.json at all (no run finished there yet) is neither: `existsSync`
+ *  below is what tells "never written" apart from "written, then damaged". */
 export interface VerdictScanResult {
   trials: TrialVerdict[];
   staleVersionDirs: string[];
+  unreadableDirs: string[];
 }
 
 export async function scanVerdictArtifactsDetailed(
@@ -258,11 +266,12 @@ export async function scanVerdictArtifactsDetailed(
 ): Promise<VerdictScanResult> {
   const trials: TrialVerdict[] = [];
   const staleVersionDirs: string[] = [];
+  const unreadableDirs: string[] = [];
   let slugs: string[];
   try {
     slugs = await readdir(artifactsRoot);
   } catch {
-    return { trials, staleVersionDirs };
+    return { trials, staleVersionDirs, unreadableDirs };
   }
   for (const slug of slugs) {
     const slugDir = join(artifactsRoot, slug);
@@ -277,9 +286,12 @@ export async function scanVerdictArtifactsDetailed(
       const result = await readVerdictArtifactDetailed(runDir);
       if (result.status === "ok") trials.push(result.trial);
       else if (result.status === "stale-version") staleVersionDirs.push(runDir);
+      else if (result.status === "unreadable" && existsSync(join(runDir, VERDICT_FILENAME))) {
+        unreadableDirs.push(runDir);
+      }
     }
   }
-  return { trials, staleVersionDirs };
+  return { trials, staleVersionDirs, unreadableDirs };
 }
 
 /** Scan an artifacts root for finalized trials — exactly the two-level
@@ -316,6 +328,18 @@ export interface RunSetDiscovery {
    *  happened here" — a v1 file dropped silently is the exact shape this
    *  milestone exists to remove. */
   staleVersionCount: number;
+  /** F-1411 — verdict.json files that EXIST under the scanned root (or, for
+   *  `kind: "trial-dir"`, at the target itself) but could not be read: a
+   *  truncated file, one hand-edited into an unexpected `state`, or valid
+   *  JSON that isn't a verdict artifact at all. Never folded into
+   *  `staleVersionCount` (an older CLI wrote that file; nothing wrote this
+   *  one correctly) or `totalSets` — a damaged current-version file is not a
+   *  usable run set. Reported even when other sets under the same root
+   *  parsed fine, same lesson as `staleVersionCount`. */
+  unreadableCount: number;
+  /** The paths behind `unreadableCount`, so the caller can name them instead
+   *  of only counting them. */
+  unreadablePaths: string[];
 }
 
 /**
@@ -340,6 +364,29 @@ export async function discoverRunSet(target: string): Promise<RunSetDiscovery> {
       incompleteSet: null,
       totalSets: 0,
       staleVersionCount: 1,
+      unreadableCount: 0,
+      unreadablePaths: [],
+    };
+  }
+  // F-1411 — same reasoning as the stale-version branch above, for a target
+  // whose verdict.json exists but is damaged: name it as a trial-dir skip
+  // rather than falling through to the "root" branch, which would scan
+  // `target` itself (two levels too shallow) and find nothing. The
+  // `existsSync` check is what tells this apart from a target that is
+  // actually an artifacts root (which has no verdict.json of its own either,
+  // and must fall through).
+  if (
+    anchorResult.status === "unreadable" &&
+    existsSync(join(target, VERDICT_FILENAME))
+  ) {
+    return {
+      kind: "trial-dir",
+      set: null,
+      incompleteSet: null,
+      totalSets: 0,
+      staleVersionCount: 0,
+      unreadableCount: 1,
+      unreadablePaths: [target],
     };
   }
   if (anchorResult.status === "ok") {
@@ -347,7 +394,8 @@ export async function discoverRunSet(target: string): Promise<RunSetDiscovery> {
     // Trial dir → its set. Layout is <root>/<slug>/<runId>, so the root is
     // two levels up; a moved/isolated dir degrades to a set of one.
     const root = join(target, "..", "..");
-    const { trials, staleVersionDirs } = await scanVerdictArtifactsDetailed(root);
+    const { trials, staleVersionDirs, unreadableDirs } =
+      await scanVerdictArtifactsDetailed(root);
     const sets = groupRunSets(trials);
     const own =
       sets.find(
@@ -364,6 +412,8 @@ export async function discoverRunSet(target: string): Promise<RunSetDiscovery> {
       incompleteSet: null,
       totalSets: Math.max(sets.length, 1),
       staleVersionCount: staleVersionDirs.length,
+      unreadableCount: unreadableDirs.length,
+      unreadablePaths: unreadableDirs,
     };
   }
 
@@ -374,9 +424,12 @@ export async function discoverRunSet(target: string): Promise<RunSetDiscovery> {
       incompleteSet: null,
       totalSets: 0,
       staleVersionCount: 0,
+      unreadableCount: 0,
+      unreadablePaths: [],
     };
   }
-  const { trials, staleVersionDirs } = await scanVerdictArtifactsDetailed(target);
+  const { trials, staleVersionDirs, unreadableDirs } =
+    await scanVerdictArtifactsDetailed(target);
   const sets = groupRunSets(trials);
   const failedSet = latestFailedRunSet(sets);
   return {
@@ -385,5 +438,7 @@ export async function discoverRunSet(target: string): Promise<RunSetDiscovery> {
     incompleteSet: failedSet ? null : latestIncompleteRunSet(sets),
     totalSets: sets.length,
     staleVersionCount: staleVersionDirs.length,
+    unreadableCount: unreadableDirs.length,
+    unreadablePaths: unreadableDirs,
   };
 }

--- a/cli/src/hosted/evalResultCache.ts
+++ b/cli/src/hosted/evalResultCache.ts
@@ -254,7 +254,14 @@ export async function readVerdictArtifact(
  *  on purpose — a prior-version file and a corrupt one are different facts
  *  (upgrade vs. damage) and want different fixes. A run dir with no
  *  verdict.json at all (no run finished there yet) is neither: `existsSync`
- *  below is what tells "never written" apart from "written, then damaged". */
+ *  below is what tells "never written" apart from "written, then damaged".
+ *
+ *  `unreadableDirs` is SORTED, unlike the other two: it is the only one whose
+ *  order reaches a user, via the path list `pome fix-prompt` prints and trims
+ *  to the first few. `readdir` promises no order — APFS hands back names
+ *  sorted, ext4 hands back hash order — so without this the WHICH of "kept
+ *  first 5" would differ between a dev's machine and CI, and a test pinning
+ *  the trim would pass locally and flake on Linux. */
 export interface VerdictScanResult {
   trials: TrialVerdict[];
   staleVersionDirs: string[];
@@ -291,6 +298,7 @@ export async function scanVerdictArtifactsDetailed(
       }
     }
   }
+  unreadableDirs.sort();
   return { trials, staleVersionDirs, unreadableDirs };
 }
 
@@ -338,7 +346,9 @@ export interface RunSetDiscovery {
    *  parsed fine, same lesson as `staleVersionCount`. */
   unreadableCount: number;
   /** The paths behind `unreadableCount`, so the caller can name them instead
-   *  of only counting them. */
+   *  of only counting them. Sorted (see `scanVerdictArtifactsDetailed`) —
+   *  callers trim this list for display, so which ones survive the trim must
+   *  not depend on the filesystem's `readdir` order. */
   unreadablePaths: string[];
 }
 

--- a/cli/src/hosted/runSets.ts
+++ b/cli/src/hosted/runSets.ts
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// F-1411 — split out of evalResultCache.ts to keep that module under the
+// file-size tripwire: grouping trials into run sets and deriving their
+// outcome is a distinct concern from reading/writing/scanning the
+// verdict.json artifact itself, and depends on nothing but `TrialVerdict`.
+
+import type { TrialVerdict } from "./evalResultCache.js";
+
+// F-1404 — the three-way verdict a run SET can carry, named like
+// `ScoreStatus` (the per-trial word) because it is built from it: "fail" =
+// at least one trial genuinely failed (graded, unsatisfied) — the only
+// outcome that asserts an agent defect. "incomplete" = no trial failed, but
+// at least one trial's grading never finished — a grader/seed gap, not
+// evidence the agent did anything wrong; "fail" wins when a set has both,
+// since a real failure is signal worth naming over a sibling's gap.
+// "pass" = EVERY trial's state is exactly "pass", tested that way round on
+// purpose: "pass" is the one outcome claiming a verified result, so it is
+// never the fallthrough. An unrecognized state reads "incomplete", not green
+// (`isVerdictArtifact` already refuses such a file — second line of defense).
+export type RunSetOutcome = "fail" | "incomplete" | "pass";
+
+export interface RunSet {
+  /** null = a single run that never had a group. */
+  groupId: string | null;
+  taskName: string;
+  /** The task path recorded at run time (first trial's). */
+  taskPath: string;
+  /** Trials sorted by finalized_at ascending. */
+  trials: TrialVerdict[];
+  latestFinalizedAt: string;
+  /** F-1404 — derived from the on-disk `state` (see `RunSetOutcome`), never
+   *  from `passed` alone: `passed` is false for BOTH a genuine failure and a
+   *  trial the grader never finished, so it can't tell "agent defect" from
+   *  "never graded" apart. The ONE computation both the routing decision
+   *  (`latestFailedRunSet` / `latestIncompleteRunSet`) and the message shown
+   *  to the user read, so they cannot disagree. */
+  outcome: RunSetOutcome;
+}
+
+/** Group trials into run sets: trials sharing a group_id form one set; a
+ *  null group_id is its own single-run set.
+ *
+ *  F-1404 — `outcome` reads the on-disk `state` (F-1195), not `!passed`
+ *  (F-1392's finding: `!passed` is true for both a genuine failure and an
+ *  incomplete trial, so a set holding only incomplete trials used to trip
+ *  the old `anyFailed` and get handed to `pome fix-prompt` as an agent
+ *  defect). `evalResultCache.test.ts` pins all three outcomes against the
+ *  written artifact. */
+export function groupRunSets(trials: TrialVerdict[]): RunSet[] {
+  const byKey = new Map<string, TrialVerdict[]>();
+  for (const trial of trials) {
+    const key = trial.verdict.group_id ?? `solo:${trial.verdict.session_id}`;
+    const bucket = byKey.get(key);
+    if (bucket) bucket.push(trial);
+    else byKey.set(key, [trial]);
+  }
+  const sets: RunSet[] = [];
+  for (const bucket of byKey.values()) {
+    bucket.sort((a, b) =>
+      a.verdict.finalized_at.localeCompare(b.verdict.finalized_at),
+    );
+    const last = bucket[bucket.length - 1]!;
+    const hasFailed = bucket.some((t) => t.verdict.state === "fail");
+    const allPassed = bucket.every((t) => t.verdict.state === "pass");
+    sets.push({
+      groupId: bucket[0]!.verdict.group_id,
+      taskName: bucket[0]!.verdict.task_name,
+      taskPath: bucket[0]!.verdict.task_path,
+      trials: bucket,
+      latestFinalizedAt: last.verdict.finalized_at,
+      outcome: hasFailed ? "fail" : allPassed ? "pass" : "incomplete",
+    });
+  }
+  sets.sort((a, b) => a.latestFinalizedAt.localeCompare(b.latestFinalizedAt));
+  return sets;
+}
+
+/** The newest run set with at least one genuinely FAILED (graded, not
+ *  satisfied) trial — the only outcome `pome fix-prompt` may hand to a
+ *  coding agent as an agent defect. */
+export function latestFailedRunSet(sets: RunSet[]): RunSet | null {
+  for (let i = sets.length - 1; i >= 0; i -= 1) {
+    if (sets[i]!.outcome === "fail") return sets[i]!;
+  }
+  return null;
+}
+
+/** F-1404 — the newest run set whose worst outcome is INCOMPLETE: no trial
+ *  failed, but at least one trial's grading never finished. Callers use this
+ *  to name the gap distinctly from both "fix this" (a fail set exists) and
+ *  "nothing to fix" (every set passed) — never silently folded into either. */
+export function latestIncompleteRunSet(sets: RunSet[]): RunSet | null {
+  for (let i = sets.length - 1; i >= 0; i -= 1) {
+    if (sets[i]!.outcome === "incomplete") return sets[i]!;
+  }
+  return null;
+}

--- a/cli/src/hosted/trialEvents.ts
+++ b/cli/src/hosted/trialEvents.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// F-1411 — split out of evalResultCache.ts to keep that module under the
+// file-size tripwire: this loads a trial's raw HTTP trace (events.jsonl),
+// which shares no shape or helper with the verdict.json artifact that file
+// reads/writes. Same behavior, just filed under its own concern.
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+/** Load a trial's captured events.jsonl (raw trace) for prompt assembly.
+ *  Missing/corrupt lines are skipped — the prompt degrades, never throws. */
+export async function loadTrialEvents(runDir: string): Promise<unknown[]> {
+  let raw: string;
+  try {
+    raw = await readFile(join(runDir, "events.jsonl"), "utf8");
+  } catch {
+    return [];
+  }
+  const events: unknown[] = [];
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      // Valid JSON but not an event object (`null`, `3`, `"x"`) is corrupt
+      // for our purposes — renderEvent dereferences fields on it.
+      if (typeof parsed === "object" && parsed !== null) events.push(parsed);
+    } catch {
+      // skip corrupt row
+    }
+  }
+  return events;
+}

--- a/cli/test/unit/fix-prompt-command.test.ts
+++ b/cli/test/unit/fix-prompt-command.test.ts
@@ -352,6 +352,78 @@ describe("pome fix-prompt command (FDRS-644)", () => {
     });
   });
 
+  // F-1411 — a verdict.json that EXISTS but is damaged (truncated,
+  // hand-edited, or an unexpected `state`) is a different fact from a
+  // stale-version file (an older CLI wrote that one correctly) and gets its
+  // own line, naming the path — never folded into the stale-version count,
+  // "no finalized run sets", or silently dropped.
+  describe("a corrupt current-version verdict.json is a named skip that points at the path (F-1411)", () => {
+    async function writeCorruptTrial(root: string, sid: string): Promise<string> {
+      const runDir = join(root, "runs", "scn", sid);
+      await mkdir(runDir, { recursive: true });
+      await writeFile(
+        join(runDir, "verdict.json"),
+        JSON.stringify(verdict({ session_id: sid, state: "bogus" as never })),
+        "utf8",
+      );
+      return runDir;
+    }
+
+    it("a root holding only a corrupt trial names the path, not 'no runs', and not the stale-version wording", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "fixcmd-unreadable-only-"));
+      const runDir = await writeCorruptTrial(dir, "ses_bad");
+      process.chdir(dir);
+
+      await run();
+      expect(process.exitCode).toBe(5);
+      const err = stderr.join("\n");
+      expect(err).toContain("1 verdict.json file(s)");
+      expect(err).toContain("could not be read");
+      expect(err).toContain(runDir);
+      expect(err).not.toContain("No finalized run sets");
+      expect(err).not.toContain("artifact version");
+    });
+
+    it("a root holding a corrupt trial beside a readable failed one still names the corrupt path AND prints the prompt", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "fixcmd-unreadable-mixed-"));
+      const runDir = await writeCorruptTrial(dir, "ses_bad");
+      await writeTrial(dir, "ses_2", {
+        passed: false,
+        state: "fail",
+        score: 50,
+        criteria_results: [
+          {
+            criterion: { type: "model", text: "Severity is set correctly" },
+            passed: false,
+            skipped: false,
+            reason: "under-rated",
+          },
+        ],
+      });
+      process.chdir(dir);
+
+      await run();
+      expect(process.exitCode ?? 0).toBe(0);
+      expect(stdout.join("\n")).toContain("## Grouped failure signatures");
+      const err = stderr.join("\n");
+      expect(err).toContain("1 verdict.json file(s)");
+      expect(err).toContain("could not be read");
+      expect(err).toContain(runDir);
+    });
+
+    it("a trial dir pointed straight at a corrupt verdict.json names it as unreadable, not as an empty root", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "fixcmd-unreadable-trialdir-"));
+      const runDir = await writeCorruptTrial(dir, "ses_bad");
+
+      await run(runDir);
+      expect(process.exitCode).toBe(5);
+      const err = stderr.join("\n");
+      expect(err).toContain("1 verdict.json file(s)");
+      expect(err).toContain("could not be read");
+      expect(err).toContain(runDir);
+    });
+  });
+
   it("a trial run dir targets that trial's set", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fixcmd-trial-"));
     await writeTrial(dir, "ses_1", {

--- a/cli/test/unit/fix-prompt-command.test.ts
+++ b/cli/test/unit/fix-prompt-command.test.ts
@@ -14,9 +14,9 @@
 // see "an incomplete-only root ..." below. `groupRunSets`'s `outcome` is the
 // one computation both the routing decision and this wording read.
 
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createProgram } from "../../src/cli/main.js";
 import {
@@ -409,6 +409,55 @@ describe("pome fix-prompt command (FDRS-644)", () => {
       expect(err).toContain("1 verdict.json file(s)");
       expect(err).toContain("could not be read");
       expect(err).toContain(runDir);
+    });
+
+    // The trim is the one part of this output with arithmetic in it, and it
+    // only fires past five paths — untested, an off-by-one (or a tail line
+    // that never prints) is invisible to CI. Five is the last count that
+    // prints every path; six is the first that omits one.
+    it("names every path up to five, and trims with a count past that", async () => {
+      const five = await mkdtemp(join(tmpdir(), "fixcmd-unreadable-five-"));
+      const fiveDirs: string[] = [];
+      for (let i = 1; i <= 5; i += 1) {
+        fiveDirs.push(await writeCorruptTrial(five, `ses_bad_${i}`));
+      }
+      process.chdir(five);
+      await run();
+      const fiveErr = stderr.join("\n");
+      expect(fiveErr).toContain("5 verdict.json file(s)");
+      for (const d of fiveDirs) expect(fiveErr).toContain(d);
+      expect(fiveErr).not.toContain("more omitted");
+
+      stderr = [];
+      const six = await mkdtemp(join(tmpdir(), "fixcmd-unreadable-six-"));
+      const sixDirs: string[] = [];
+      for (let i = 1; i <= 6; i += 1) {
+        sixDirs.push(await writeCorruptTrial(six, `ses_bad_${i}`));
+      }
+      process.chdir(six);
+      await run();
+      const sixErr = stderr.join("\n");
+      expect(sixErr).toContain("6 verdict.json file(s)");
+      expect(sixErr).toContain("(1 more omitted — kept first 5)");
+      // WHICH five survive the trim is pinned, not just how many: the scan
+      // sorts `unreadablePaths` so this holds on ext4 (hash-ordered readdir)
+      // as well as APFS. Asserting only the count would let that sort rot.
+      const listed = sixErr
+        .split("\n")
+        .filter((l) => l.startsWith("  - "))
+        .map((l) => l.slice(4));
+      // Compared against the REALPATH of the tmp root: discovery resolves the
+      // root against `process.cwd()`, which on macOS reports
+      // /private/var/... for a /var/... tmpdir. The `toContain` assertions
+      // elsewhere in this describe survive that by substring luck; an
+      // order-sensitive equality cannot.
+      const sixRoot = await realpath(six);
+      expect(listed).toEqual(
+        sixDirs
+          .map((d) => join(sixRoot, relative(six, d)))
+          .sort()
+          .slice(0, 5),
+      );
     });
 
     it("a trial dir pointed straight at a corrupt verdict.json names it as unreadable, not as an empty root", async () => {

--- a/cli/test/unit/hosted/evalResultCache.test.ts
+++ b/cli/test/unit/hosted/evalResultCache.test.ts
@@ -600,4 +600,142 @@ describe("verdict artifact (FDRS-644)", () => {
       expect(discovery.staleVersionCount).toBe(1);
     });
   });
+
+  // F-1411 — a v2 verdict.json that is truncated, hand-edited into an
+  // unexpected `state`, or valid JSON that isn't a verdict artifact at all
+  // used to read as `{status: "unreadable"}` and vanish from every count:
+  // not `totalSets`, not `staleVersionCount`. Unlike a stale-version file
+  // (a REAL trial an older CLI wrote correctly), this is a file nothing wrote
+  // correctly — a different fact, so it gets its own count and its own named
+  // paths, never folded into either existing one.
+  describe("a corrupt current-version verdict.json is a named, counted 'unreadable' skip (F-1411)", () => {
+    it("a truncated verdict.json reads as unreadable", async () => {
+      const tmp = await mkdtemp(join(tmpdir(), "verdict-truncated-"));
+      const dir = join(tmp, "scn", "ses_truncated");
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, "verdict.json"), '{"version": 2, "source":', "utf8");
+      expect(await readVerdictArtifactDetailed(dir)).toEqual({ status: "unreadable" });
+    });
+
+    it("a v2 verdict.json with an unexpected `state` value reads as unreadable, not stale-version", async () => {
+      const tmp = await mkdtemp(join(tmpdir(), "verdict-badstate-"));
+      const dir = join(tmp, "scn", "ses_badstate");
+      await mkdir(dir, { recursive: true });
+      await writeFile(
+        join(dir, "verdict.json"),
+        JSON.stringify(verdict({ session_id: "ses_badstate", state: "bogus" as never })),
+        "utf8",
+      );
+      expect(await readVerdictArtifactDetailed(dir)).toEqual({ status: "unreadable" });
+    });
+
+    it("valid JSON that isn't a verdict artifact at all reads as unreadable", async () => {
+      const tmp = await mkdtemp(join(tmpdir(), "verdict-notartifact-"));
+      const dir = join(tmp, "scn", "ses_notartifact");
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, "verdict.json"), JSON.stringify({ hello: "world", count: 3 }), "utf8");
+      expect(await readVerdictArtifactDetailed(dir)).toEqual({ status: "unreadable" });
+    });
+
+    it("scanVerdictArtifactsDetailed separates unreadable dirs from readable trials AND from stale-version dirs, without flagging a run dir that has no verdict.json at all", async () => {
+      const tmp = await mkdtemp(join(tmpdir(), "verdict-unreadable-scan-"));
+      await writeTrial(tmp, "scn", "ses_ok", {});
+      const staleDir = join(tmp, "scn", "ses_v1");
+      await mkdir(staleDir, { recursive: true });
+      await writeFile(join(staleDir, "verdict.json"), JSON.stringify(v1OnDiskArtifact("ses_v1")), "utf8");
+      const truncatedDir = join(tmp, "scn", "ses_truncated");
+      await mkdir(truncatedDir, { recursive: true });
+      await writeFile(join(truncatedDir, "verdict.json"), '{"version": 2, "source":', "utf8");
+      const badStateDir = join(tmp, "scn", "ses_badstate");
+      await mkdir(badStateDir, { recursive: true });
+      await writeFile(
+        join(badStateDir, "verdict.json"),
+        JSON.stringify(verdict({ session_id: "ses_badstate", state: "bogus" as never })),
+        "utf8",
+      );
+      const notArtifactDir = join(tmp, "scn", "ses_notartifact");
+      await mkdir(notArtifactDir, { recursive: true });
+      await writeFile(join(notArtifactDir, "verdict.json"), JSON.stringify({ hello: "world" }), "utf8");
+      // A run dir that never got a verdict.json at all (e.g. an in-progress
+      // or crashed run) is neither stale nor unreadable — it is simply not
+      // finalized yet, and must stay silently skipped as before.
+      await mkdir(join(tmp, "scn", "ses_never_finalized"), { recursive: true });
+
+      const { trials, staleVersionDirs, unreadableDirs } = await scanVerdictArtifactsDetailed(tmp);
+      expect(trials.map((t) => t.verdict.session_id)).toEqual(["ses_ok"]);
+      expect(staleVersionDirs).toEqual([staleDir]);
+      expect(unreadableDirs.slice().sort()).toEqual(
+        [truncatedDir, badStateDir, notArtifactDir].sort(),
+      );
+    });
+
+    // F-1195's own lesson, replayed for `unreadable`: the count must survive
+    // to the caller even when a real, readable run set exists beside it — a
+    // "only report it when there's nothing else" guard is exactly the silent
+    // drop this milestone exists to remove.
+    it("discoverRunSet(root) reports unreadableCount and names the path even when another run set parsed fine", async () => {
+      const tmp = await mkdtemp(join(tmpdir(), "verdict-unreadable-mixed-"));
+      await writeTrial(tmp, "scn", "ses_fail", {
+        group_id: "grp_mixed",
+        passed: false,
+        state: "fail",
+      });
+      const corruptDir = join(tmp, "scn", "ses_badstate");
+      await mkdir(corruptDir, { recursive: true });
+      await writeFile(
+        join(corruptDir, "verdict.json"),
+        JSON.stringify(verdict({ session_id: "ses_badstate", state: "bogus" as never })),
+        "utf8",
+      );
+
+      const discovery = await discoverRunSet(tmp);
+      expect(discovery.totalSets).toBe(1);
+      expect(discovery.set?.trials.map((t) => t.verdict.session_id)).toEqual(["ses_fail"]);
+      expect(discovery.unreadableCount).toBe(1);
+      expect(discovery.unreadablePaths).toEqual([corruptDir]);
+      // Never folded into the stale-version count — different fact.
+      expect(discovery.staleVersionCount).toBe(0);
+    });
+
+    it("discoverRunSet(root) with ONLY a corrupt file reports unreadableCount, distinct from an empty runs/ and from stale-version", async () => {
+      const tmp = await mkdtemp(join(tmpdir(), "verdict-unreadable-only-"));
+      const corruptDir = join(tmp, "scn", "ses_truncated");
+      await mkdir(corruptDir, { recursive: true });
+      await writeFile(join(corruptDir, "verdict.json"), '{"version": 2, "source":', "utf8");
+
+      const discovery = await discoverRunSet(tmp);
+      expect(discovery.kind).toBe("root");
+      expect(discovery.totalSets).toBe(0);
+      expect(discovery.set).toBeNull();
+      expect(discovery.unreadableCount).toBe(1);
+      expect(discovery.unreadablePaths).toEqual([corruptDir]);
+      expect(discovery.staleVersionCount).toBe(0);
+
+      // A truly empty runs/ still reports unreadableCount: 0 — "nothing here"
+      // and "something here is damaged" stay distinguishable.
+      const empty = await mkdtemp(join(tmpdir(), "verdict-unreadable-empty-"));
+      const emptyDiscovery = await discoverRunSet(empty);
+      expect(emptyDiscovery.totalSets).toBe(0);
+      expect(emptyDiscovery.unreadableCount).toBe(0);
+    });
+
+    it("discoverRunSet(trial dir) pointed straight at a corrupt verdict.json names the skip as unreadable", async () => {
+      const tmp = await mkdtemp(join(tmpdir(), "verdict-unreadable-trialdir-"));
+      const corruptDir = join(tmp, "scn", "ses_badstate");
+      await mkdir(corruptDir, { recursive: true });
+      await writeFile(
+        join(corruptDir, "verdict.json"),
+        JSON.stringify(verdict({ session_id: "ses_badstate", state: "bogus" as never })),
+        "utf8",
+      );
+
+      const discovery = await discoverRunSet(corruptDir);
+      expect(discovery.kind).toBe("trial-dir");
+      expect(discovery.set).toBeNull();
+      expect(discovery.totalSets).toBe(0);
+      expect(discovery.unreadableCount).toBe(1);
+      expect(discovery.unreadablePaths).toEqual([corruptDir]);
+      expect(discovery.staleVersionCount).toBe(0);
+    });
+  });
 });

--- a/cli/test/unit/hosted/evalResultCache.test.ts
+++ b/cli/test/unit/hosted/evalResultCache.test.ts
@@ -609,32 +609,59 @@ describe("verdict artifact (FDRS-644)", () => {
   // correctly — a different fact, so it gets its own count and its own named
   // paths, never folded into either existing one.
   describe("a corrupt current-version verdict.json is a named, counted 'unreadable' skip (F-1411)", () => {
-    it("a truncated verdict.json reads as unreadable", async () => {
-      const tmp = await mkdtemp(join(tmpdir(), "verdict-truncated-"));
-      const dir = join(tmp, "scn", "ses_truncated");
+    // Each of the three damage shapes the ticket names is asserted TWICE, and
+    // the second assertion is the one that matters: `readVerdictArtifactDetailed`
+    // already returned `unreadable` for all three before this change, so a test
+    // that stops there passes against the unfixed code and pins nothing (the
+    // exact shape F-1375 exists to remove). The read status is stated as the
+    // premise; `discoverRunSet` counting and NAMING the dir is the claim.
+    async function discoverOne(prefix: string, sid: string, body: string) {
+      const tmp = await mkdtemp(join(tmpdir(), prefix));
+      const dir = join(tmp, "scn", sid);
       await mkdir(dir, { recursive: true });
-      await writeFile(join(dir, "verdict.json"), '{"version": 2, "source":', "utf8");
-      expect(await readVerdictArtifactDetailed(dir)).toEqual({ status: "unreadable" });
-    });
+      await writeFile(join(dir, "verdict.json"), body, "utf8");
+      return { dir, discovery: await discoverRunSet(tmp) };
+    }
 
-    it("a v2 verdict.json with an unexpected `state` value reads as unreadable, not stale-version", async () => {
-      const tmp = await mkdtemp(join(tmpdir(), "verdict-badstate-"));
-      const dir = join(tmp, "scn", "ses_badstate");
-      await mkdir(dir, { recursive: true });
-      await writeFile(
-        join(dir, "verdict.json"),
-        JSON.stringify(verdict({ session_id: "ses_badstate", state: "bogus" as never })),
-        "utf8",
+    it("a truncated verdict.json is counted and named, not dropped", async () => {
+      const { dir, discovery } = await discoverOne(
+        "verdict-truncated-",
+        "ses_truncated",
+        '{"version": 2, "source":',
       );
       expect(await readVerdictArtifactDetailed(dir)).toEqual({ status: "unreadable" });
+      expect(discovery.unreadableCount).toBe(1);
+      expect(discovery.unreadablePaths).toEqual([dir]);
+      expect(discovery.staleVersionCount).toBe(0);
+      expect(discovery.totalSets).toBe(0);
     });
 
-    it("valid JSON that isn't a verdict artifact at all reads as unreadable", async () => {
-      const tmp = await mkdtemp(join(tmpdir(), "verdict-notartifact-"));
-      const dir = join(tmp, "scn", "ses_notartifact");
-      await mkdir(dir, { recursive: true });
-      await writeFile(join(dir, "verdict.json"), JSON.stringify({ hello: "world", count: 3 }), "utf8");
+    it("a v2 verdict.json with an unexpected `state` value is counted as unreadable, not as stale-version", async () => {
+      const { dir, discovery } = await discoverOne(
+        "verdict-badstate-",
+        "ses_badstate",
+        JSON.stringify(verdict({ session_id: "ses_badstate", state: "bogus" as never })),
+      );
       expect(await readVerdictArtifactDetailed(dir)).toEqual({ status: "unreadable" });
+      expect(discovery.unreadableCount).toBe(1);
+      expect(discovery.unreadablePaths).toEqual([dir]);
+      // The file CLAIMS the current version, so the stale-version count must
+      // stay at zero: "an older CLI wrote this correctly" would be false.
+      expect(discovery.staleVersionCount).toBe(0);
+      expect(discovery.totalSets).toBe(0);
+    });
+
+    it("valid JSON that isn't a verdict artifact at all is counted and named", async () => {
+      const { dir, discovery } = await discoverOne(
+        "verdict-notartifact-",
+        "ses_notartifact",
+        JSON.stringify({ hello: "world", count: 3 }),
+      );
+      expect(await readVerdictArtifactDetailed(dir)).toEqual({ status: "unreadable" });
+      expect(discovery.unreadableCount).toBe(1);
+      expect(discovery.unreadablePaths).toEqual([dir]);
+      expect(discovery.staleVersionCount).toBe(0);
+      expect(discovery.totalSets).toBe(0);
     });
 
     it("scanVerdictArtifactsDetailed separates unreadable dirs from readable trials AND from stale-version dirs, without flagging a run dir that has no verdict.json at all", async () => {
@@ -664,9 +691,13 @@ describe("verdict artifact (FDRS-644)", () => {
       const { trials, staleVersionDirs, unreadableDirs } = await scanVerdictArtifactsDetailed(tmp);
       expect(trials.map((t) => t.verdict.session_id)).toEqual(["ses_ok"]);
       expect(staleVersionDirs).toEqual([staleDir]);
-      expect(unreadableDirs.slice().sort()).toEqual(
-        [truncatedDir, badStateDir, notArtifactDir].sort(),
-      );
+      // Asserted in SORTED order, not "sort both sides and compare": the
+      // scan sorts on purpose so the trimmed path list fix-prompt prints is
+      // the same on APFS (readdir hands back names sorted) and ext4 (hash
+      // order). Sorting the actual before comparing would hide a regression
+      // there and let the display test flake on Linux only.
+      expect(unreadableDirs).toEqual([badStateDir, notArtifactDir, truncatedDir]);
+      expect(unreadableDirs).toEqual([...unreadableDirs].sort());
     });
 
     // F-1195's own lesson, replayed for `unreadable`: the count must survive

--- a/cli/test/unit/hosted/evalResultCache.test.ts
+++ b/cli/test/unit/hosted/evalResultCache.test.ts
@@ -16,10 +16,6 @@ import { describe, expect, it } from "vitest";
 import {
   VERDICT_ARTIFACT_VERSION,
   discoverRunSet,
-  groupRunSets,
-  latestFailedRunSet,
-  latestIncompleteRunSet,
-  loadTrialEvents,
   readVerdictArtifact,
   readVerdictArtifactDetailed,
   scanVerdictArtifacts,
@@ -27,6 +23,11 @@ import {
   writeVerdictArtifact,
   type VerdictArtifact,
 } from "../../../src/hosted/evalResultCache.js";
+import {
+  groupRunSets,
+  latestFailedRunSet,
+  latestIncompleteRunSet,
+} from "../../../src/hosted/runSets.js";
 
 function verdict(over: Partial<VerdictArtifact>): VerdictArtifact {
   return {
@@ -447,29 +448,6 @@ describe("verdict artifact (FDRS-644)", () => {
     expect(d.kind).toBe("trial-dir");
     expect(d.set?.groupId).toBe("grp_t");
     expect(d.set?.trials.map((t) => t.verdict.session_id)).toEqual(["t1", "t2"]);
-  });
-
-  it("loadTrialEvents skips corrupt rows and tolerates a missing file", async () => {
-    const tmp = await mkdtemp(join(tmpdir(), "verdict-events-"));
-    await writeFile(
-      join(tmp, "events.jsonl"),
-      '{"kind":"twin_http","path":"/a"}\nnot json\n\n{"kind":"twin_http","path":"/b"}\n',
-      "utf8",
-    );
-    const events = await loadTrialEvents(tmp);
-    expect(events).toHaveLength(2);
-    expect(await loadTrialEvents(join(tmp, "missing"))).toEqual([]);
-  });
-
-  it("loadTrialEvents drops valid-JSON non-object rows (null, numbers, strings)", async () => {
-    const tmp = await mkdtemp(join(tmpdir(), "verdict-events2-"));
-    await writeFile(
-      join(tmp, "events.jsonl"),
-      'null\n3\n"x"\n{"kind":"twin_http","path":"/a"}\n',
-      "utf8",
-    );
-    const events = await loadTrialEvents(tmp);
-    expect(events).toHaveLength(1);
   });
 
   // F-1195 — a v1 artifact is RECOGNIZABLE (it has every field a verdict.json

--- a/cli/test/unit/hosted/trialEvents.test.ts
+++ b/cli/test/unit/hosted/trialEvents.test.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// F-1411 — moved out of evalResultCache.test.ts alongside the source split
+// (trialEvents.ts): loadTrialEvents shares no shape or helper with the
+// verdict.json artifact tests in that file.
+
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { loadTrialEvents } from "../../../src/hosted/trialEvents.js";
+
+describe("loadTrialEvents", () => {
+  it("skips corrupt rows and tolerates a missing file", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "verdict-events-"));
+    await writeFile(
+      join(tmp, "events.jsonl"),
+      '{"kind":"twin_http","path":"/a"}\nnot json\n\n{"kind":"twin_http","path":"/b"}\n',
+      "utf8",
+    );
+    const events = await loadTrialEvents(tmp);
+    expect(events).toHaveLength(2);
+    expect(await loadTrialEvents(join(tmp, "missing"))).toEqual([]);
+  });
+
+  it("drops valid-JSON non-object rows (null, numbers, strings)", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "verdict-events2-"));
+    await writeFile(
+      join(tmp, "events.jsonl"),
+      'null\n3\n"x"\n{"kind":"twin_http","path":"/a"}\n',
+      "utf8",
+    );
+    const events = await loadTrialEvents(tmp);
+    expect(events).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
<!-- Closes F-1411 -->

## What
Gives a corrupt current-version `verdict.json` (truncated, hand-edited, or carrying an unexpected `state`) the same named/counted treatment F-1195 gave a stale-version file: `RunSetDiscovery` now carries `unreadableCount` and `unreadablePaths`, and `pome fix-prompt` prints a distinct line naming the path(s), every time it happens — never folded into `staleVersionCount` or `totalSets`.

## Why
Such a file used to read as `{status: "unreadable"}` and vanish from every count discovery exposes. A `runs/` holding one readable trial beside a damaged one built a prompt from a fraction of the run set and said nothing about the rest — the exact silent drop F-1195 closed for a prior-version file, just left open for a damaged current-version one.

## Notes for reviewer
- `evalResultCache.ts` was one line under the file-size gate; first commit splits `loadTrialEvents` into `hosted/trialEvents.ts` and the run-set grouping helpers into `hosted/runSets.ts` (pure extraction, no behavior change) to make room. Second commit adds the actual feature.
- A run dir with no `verdict.json` at all (a run still in progress) is deliberately NOT counted as unreadable — only a file that exists on disk but fails to parse/validate is. `scanVerdictArtifactsDetailed` uses `existsSync` to tell the two apart.
- Path list is capped at 5 with a "N more omitted" tail, matching `fix-prompt/prompt.ts`'s existing `MAX_EVENTS` convention.
- Hand-bumped `cli/package.json` to 0.23.11 and added a `cli/CHANGELOG.md` entry (changesets are retired).

## Test plan
- [x] `npm run typecheck -w @pome-sh/cli`
- [x] `npx vitest run test/unit test/integration test/e2e` (931 tests, all green)
- [x] `npm run lint:code-health` (evalResultCache.ts: 498 → 444 lines after the split + feature; still well under the 500-line gate)
- [x] `npm run gate:no-eval`, `lint:no-catch`, `lint:no-cloud-imports`, `lint:dead-code`, `lint:parent-vocab`, `lint:legacy-markers`
- [x] `node scripts/ci/check-version-bump-required.mjs $(git merge-base HEAD origin/main)`
- [x] New tests cover: a truncated file, a v2 file with an unexpected `state`, valid JSON that isn't a verdict artifact at all, a run dir with no `verdict.json` at all (must NOT be flagged), and the F-1195 lesson replayed — the count/path survive even when another run set parsed fine.