### PR TITLE
Bump postcss to 8.5.26 in minimal-viktor examples (F-1454)

### DIFF
--- a/examples/minimal-viktor-langgraph/package-lock.json
+++ b/examples/minimal-viktor-langgraph/package-lock.json
@@ -1902,9 +1902,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2046,9 +2046,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2066,7 +2066,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/examples/minimal-viktor/package-lock.json
+++ b/examples/minimal-viktor/package-lock.json
@@ -1580,9 +1580,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -1636,9 +1636,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -1656,7 +1656,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
<!-- Closes F-1454 -->

## What
Re-resolve the `vite`-declared `postcss` dev dependency in two examples to a version that closes the advisory below.

| Lockfile | `postcss` before | Required | Resolved | Advisory |
|---|---|---|---|---|
| `examples/minimal-viktor/package-lock.json` | 8.5.18 | 8.5.23 | 8.5.26 | [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) |
| `examples/minimal-viktor-langgraph/package-lock.json` | 8.5.19 | 8.5.23 | 8.5.26 | [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) |

Lockfile-only — `vite@7.3.6` declares `postcss@^8.5.6`, which 8.5.26 satisfies. `nanoid` 3.3.16 → 3.3.18 rides along in both, because postcss tightened its own range to `^3.3.17`; nothing else changed.

## Test plan
`examples/minimal-viktor`:
- [x] `npm ci` — added 82 packages, 0 vulnerabilities
- [x] `npm test` — 1 file, 8 tests passed
- [x] `npm run typecheck` — no errors
- [x] resolved `postcss` >= 8.5.23 — confirmed 8.5.26

`examples/minimal-viktor-langgraph`:
- [x] `npm ci` — added 121 packages, 0 vulnerabilities
- [x] `npm test` — 2 files, 19 tests passed
- [x] `npm run typecheck` — no errors
- [x] resolved `postcss` >= 8.5.23 — confirmed 8.5.26

Note: `typecheck-test` covers these lockfiles via `typecheck:examples` / `smoke:examples` / `probe:examples`. The `npm test` runs above are local only — CI does not run the examples' vitest suites.
