### PR TITLE
Patch triage-agent lockfile advisories (F-1450)

### DIFF
--- a/examples/triage-agent/package-lock.json
+++ b/examples/triage-agent/package-lock.json
@@ -25,17 +25,18 @@
     },
     "../../packages/adapter-claude-sdk": {
       "name": "@pome-sh/adapter-claude-sdk",
-      "version": "0.3.0",
+      "version": "0.3.3",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.221.0",
         "@opentelemetry/resources": "^2.10.0",
-        "@opentelemetry/sdk-trace-base": "^2.10.0",
-        "@pome-sh/shared-types": "0.14.0"
+        "@opentelemetry/sdk-trace-base": "^2.10.0"
       },
       "devDependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.221",
+        "@pome-sh/wire": "*",
         "@types/node": "^26.1.2",
+        "tsup": "^8.5.0",
         "typescript": "^5.9.3",
         "vitest": "^4.1.10"
       },
@@ -699,13 +700,13 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -1738,9 +1739,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -1972,9 +1973,9 @@
       "peer": true
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -2382,9 +2383,9 @@
       "peer": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2539,9 +2540,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2559,7 +2560,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
<!-- Closes F-1450 -->

## What
Re-resolves four `examples/triage-agent` transitive lockfile deps to close eight open Dependabot advisories. Lockfile-only — no `package.json` range changed and no `overrides` entry was needed.

| Package | Before | Required | Resolved | Advisory |
|---|---|---|---|---|
| `fast-uri` | 3.1.3 | 3.1.5 | 3.1.5 | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7), [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx) |
| `ip-address` | 10.2.0 | 10.3.1 | 10.5.0 | [GHSA-mwp4-54f8-5fhr](https://github.com/advisories/GHSA-mwp4-54f8-5fhr), [GHSA-4xrf-jv44-h6hh](https://github.com/advisories/GHSA-4xrf-jv44-h6hh), [GHSA-22jq-vg5j-6vgg](https://github.com/advisories/GHSA-22jq-vg5j-6vgg) |
| `postcss` | 8.5.16 | 8.5.23 | 8.5.26 | [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849), [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) |
| `@hono/node-server` | 1.19.14 | >= 2.0.5 | 2.1.0 | [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9) |

`npm update` also re-snapshotted the `file:` link entry for `@pome-sh/adapter-claude-sdk`: version 0.3.0 → 0.3.3, `@pome-sh/shared-types@0.14.0` dropped from `dependencies`, `@pome-sh/wire` + `tsup` added to `devDependencies`. That is the lockfile catching up to a manifest already on `main` since the shared-types dissolution — the stale entry still named a package the repo no longer has. Also unremarkable: `postcss`'s recorded `nanoid` range `^3.3.12` → `^3.3.17`, and `@hono/node-server`'s `engines.node` `>=18.14.1` → `>=20`, under this example's own `>=24`. No package entry was added or removed and `lockfileVersion` stays 3.

## Why
`@hono/node-server` is a forced major — GHSA-frvp-7c67-39w9 has no 1.x remediation — but it needs no manifest change here, because `@modelcontextprotocol/sdk@1.30.0` already declares `"@hono/node-server": "^1.19.9 || ^2.0.5"`. The root lockfile resolves that same SDK version to 2.1.0, so 2.x is already proven against it in this repo.

## Test plan
Precondition for all local runs: the workspace dists must exist first (`npm run build -w @pome-sh/wire -w @pome-sh/adapter-claude-sdk` from the repo root). Without them this example's `npm ci`, `npm test` and `npm run typecheck` all fail on `Cannot find module '@pome-sh/adapter-claude-sdk'` — pre-existing, and what `quickstart-smoke.yml` builds around.

- [x] `npm ci` in `examples/triage-agent` — succeeds
- [x] `npm test` in `examples/triage-agent` — `Test Files 1 passed (1)`, `Tests 4 passed (4)`
- [x] `npm run typecheck` in `examples/triage-agent` — no errors
- [x] Resolved-version check over `package-lock.json` — all four packages at or above target
- [x] `quickstart-smoke.yml` green in CI, including the "Quickstart preflight" step this change cannot exercise locally: CI does a root `npm ci`, builds the adapter, runs this example's own `npm ci` + `npm test`, builds the CLI, boots the GitHub twin and mints an env-secret JWT against it
