### PR TITLE
Patch fast-uri, ip-address, and @hono/node-server lockfile advisories (F-1452)

### DIFF
--- a/examples/pr-summary-review/package-lock.json
+++ b/examples/pr-summary-review/package-lock.json
@@ -24,17 +24,18 @@
     },
     "../../packages/adapter-claude-sdk": {
       "name": "@pome-sh/adapter-claude-sdk",
-      "version": "0.3.0",
+      "version": "0.3.3",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.221.0",
         "@opentelemetry/resources": "^2.10.0",
-        "@opentelemetry/sdk-trace-base": "^2.10.0",
-        "@pome-sh/shared-types": "0.14.0"
+        "@opentelemetry/sdk-trace-base": "^2.10.0"
       },
       "devDependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.221",
+        "@pome-sh/wire": "*",
         "@types/node": "^26.1.2",
+        "tsup": "^8.5.0",
         "typescript": "^5.9.3",
         "vitest": "^4.1.10"
       },
@@ -664,13 +665,13 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -1183,9 +1184,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -1399,9 +1400,9 @@
       "peer": true
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "peer": true,
       "engines": {


### PR DESCRIPTION
<!-- Closes F-1452 -->

## What
Closes five open Dependabot alerts against `examples/pr-summary-review/package-lock.json`. Lockfile-only; no `package.json` change and no new `overrides` entry.

| Package | Before | Required | Resolved | Advisory |
|---|---|---|---|---|
| `fast-uri` | 3.1.4 | 3.1.5 | 3.1.5 | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) |
| `ip-address` | 10.2.0 | 10.3.1 | 10.5.0 | [GHSA-mwp4-54f8-5fhr](https://github.com/advisories/GHSA-mwp4-54f8-5fhr), [GHSA-4xrf-jv44-h6hh](https://github.com/advisories/GHSA-4xrf-jv44-h6hh), [GHSA-22jq-vg5j-6vgg](https://github.com/advisories/GHSA-22jq-vg5j-6vgg) |
| `@hono/node-server` | 1.19.14 | >= 2.0.5 | 2.1.0 | [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9) |

This lockfile started at `fast-uri@3.1.4`, one patch ahead of the sibling examples, so it carries only one of the two fast-uri advisories.

`npm update` also re-snapshotted the `file:` link entry for `@pome-sh/adapter-claude-sdk` (0.3.0 → 0.3.3, `@pome-sh/shared-types` dropped, `@pome-sh/wire` + `tsup` added) — it re-reads the linked workspace package's current manifest. No `node_modules` entries were added or removed.

## Why
`@hono/node-server` is a forced major: GHSA-frvp-7c67-39w9 has no 1.x remediation, so 2.x is the only way to close it. It needs no manifest change because `@modelcontextprotocol/sdk@1.30.0` declares `"@hono/node-server": "^1.19.9 || ^2.0.5"` — upstream supports both majors, and v2's `engines.node: >=20` sits under this example's own `>=24`.

## Test plan
- [x] `npm ci` in the example — installs cleanly, `found 0 vulnerabilities`
- [x] `npm run typecheck` in the example — passes, after building `@pome-sh/adapter-claude-sdk` first. That mirrors the repo's own gate: the root `npm run typecheck` does not cover `examples/` (they are standalone packages, not workspaces), so `npm run typecheck:examples` builds the adapter and then typechecks each example.
- [x] `typecheck-test` green in CI, which additionally runs `smoke:examples` and `probe:examples` — those `npm ci` this lockfile and boot the example from its own installed tree, so the new tree was executed, not just typechecked
- [x] Resolved versions confirmed at or above target: `fast-uri 3.1.5`, `ip-address 10.5.0`, `@hono/node-server 2.1.0`

This example has no `test` script.
