### PR TITLE
Bump buyer-agent example's @hono/node-server to v2 (F-1453)

### DIFF
--- a/packages/twin-stripe/examples/buyer-agent/package-lock.json
+++ b/packages/twin-stripe/examples/buyer-agent/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@pome-sh/twin-stripe-buyer-agent-example",
       "version": "0.1.0",
       "dependencies": {
-        "@hono/node-server": "^2.0.5",
+        "@hono/node-server": "^2.1.0",
         "hono": "^4.13.0"
       },
       "devDependencies": {

--- a/packages/twin-stripe/examples/buyer-agent/package-lock.json
+++ b/packages/twin-stripe/examples/buyer-agent/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@pome-sh/twin-stripe-buyer-agent-example",
       "version": "0.1.0",
       "dependencies": {
-        "@hono/node-server": "^1.19.17",
+        "@hono/node-server": "^2.0.5",
         "hono": "^4.13.0"
       },
       "devDependencies": {
@@ -463,12 +463,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.17",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
-      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/packages/twin-stripe/examples/buyer-agent/package.json
+++ b/packages/twin-stripe/examples/buyer-agent/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@hono/node-server": "^2.0.5",
+    "@hono/node-server": "^2.1.0",
     "hono": "^4.13.0"
   },
   "devDependencies": {

--- a/packages/twin-stripe/examples/buyer-agent/package.json
+++ b/packages/twin-stripe/examples/buyer-agent/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@hono/node-server": "^1.19.17",
+    "@hono/node-server": "^2.0.5",
     "hono": "^4.13.0"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- Closes F-1453 -->

## What
Bumps `@hono/node-server` in the twin-stripe buyer-agent example off the vulnerable 1.x line to `^2.1.0`.

| Package | Current | Target | Advisory |
|---|---|---|---|
| `@hono/node-server` | 1.19.17 | >= 2.0.5 | [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9) |

## Why
No 1.x patch exists for this advisory (path traversal in `serve-static` on Windows via an encoded backslash) — the only patched release is 2.0.5. `@hono/node-server` is a direct dependency of the example, so the declared range had to move off 1.x, a genuine major bump. The range is set to `^2.1.0`, not the bare `^2.0.5` minimum: every other manifest on `main` (`cli/`, `twin-slack`, `twin-linear`, `twin-gmail`, `twin-github`, `twin-stripe`, `packages/sdk`) already declares `^2.1.0`, so this example was the repo's last 1.x holdout. v2 has been running elsewhere in this repo for a while, and `serve()`'s shipped `.d.ts` signature is unchanged between 1.19.17 and 2.1.0 — the only API this example uses.

## Test plan
Run inside `packages/twin-stripe/examples/buyer-agent`:
- [x] `npm ci` — installs cleanly, resolves `@hono/node-server@2.1.0` (satisfies `^2.1.0`)
- [x] `npm run typecheck` — passes with no errors (this example has no `test` script; confirmed by inspecting `package.json`)
- [x] Resolved version check: `node -e 'const l=require("./package-lock.json");for(const[k,v]of Object.entries(l.packages))if(/node_modules\/@hono\/node-server$/.test(k))console.log(k,v.version)'` → `node_modules/@hono/node-server 2.1.0`
- [x] Booted for real: started `packages/twin-stripe`'s dev twin (`npm run dev -w @pome-sh/twin-stripe`), then ran `npm start` in the example. Literal stdout:
  ```
  🛒 pome twin-stripe buyer-agent demo

  step twin reachable at http://127.0.0.1:3333 (stripe)
  step seller listening at http://127.0.0.1:4040/paid
  ✓ got 402 challenge: pay 10000 USDC on eip155:84532 to 0xb45f05035b8f3fcb504a4db509f1a07a6f909af0
  ✓ paid + got resource: {"ok":true,"message":"you paid; enjoy this exclusive resource","timestamp":"2026-08-11T14:14:13.402Z"}
  ✓ twin reports 3 PI(s) with status=succeeded (latest: pi_j0BpinwdqkqDUHlPXV5vFsMH)
  ✓ twin emitted all 5 expected events

  ✓ x402 buyer flow completed end-to-end
  ```
  Exit code 0. Scoping the claim to what the script actually asserts: only the 402 challenge (step 1), the `X-PAYMENT` retry returning 200 (step 3), and the PaymentIntent reaching `status === "succeeded"` (step 4) are hard-asserted with `fail()` on mismatch — this is what a clean exit proves. The "twin emitted all 5 expected events" line (step 5) is a soft check in the script itself (mismatches log a warning, not a failure), so the line above is direct observed output, not a script-enforced assertion.

No source changes were needed — `serve()` is the only `@hono/node-server` API used here.

Known CI note: `typecheck-test` fails at ~6s before `setup-node` runs, on a version-bump gate that over-matches `packages/twin-` and incorrectly treats this example as CLI-publish-relevant. That gate bug is unrelated to this change and is being fixed separately (F-1455).