### PR TITLE
Stop the version-bump gate matching a twin's examples/ (F-1455)

### DIFF
--- a/scripts/ci/check-version-bump-required.mjs
+++ b/scripts/ci/check-version-bump-required.mjs
@@ -41,12 +41,40 @@ function isUnpublishableTestPath(file) {
   return /(^|\/)tests?\//.test(file) || /\.test\.[cm]?[jt]sx?$/.test(file);
 }
 
+/**
+ * A twin's own top-level examples/ ships in no tarball — but not because of
+ * its `files` array. Some twins' `files` DO name it: twin-github and
+ * twin-slack's tsconfig.build.json compile `examples/**\/*.ts` into
+ * `dist/examples/*.js` (rootDir "."), and `files: ["dist", ...]` names
+ * `dist`. The actual load-bearing fact is `private: true` — release.yml
+ * (F-1308, F-949) publishes only cli, adapter-claude-sdk, checks and wire,
+ * and no twin is any of those. Nothing in this repo currently asserts a
+ * twin stays private, so if one were ever unprivated this exemption would
+ * need re-checking; today it holds for all five. The CLI's own `files`
+ * entry "examples" is cli/examples (cli/tsconfig.json's `include`), a
+ * different directory, not a twin's.
+ *
+ * `[^/]+` is deliberately one path segment, so only a twin's TOP-LEVEL
+ * examples/ is exempt — `packages/twin-stripe/src/examples/handler.ts`
+ * does not match, because that file compiles into the twin's `dist` same as
+ * any other `src/` module and is publish-relevant if the CLI bundle imports
+ * it.
+ *
+ * F-1455, reproduced by PR #366 (F-1453): a PR touching only
+ * packages/twin-stripe/examples/buyer-agent/ was told to bump @pome-sh/cli
+ * for a republish that would be byte-identical.
+ */
+function isTwinExamplePath(file) {
+  return /^packages\/twin-[^/]+\/examples\//.test(file);
+}
+
 const changedFiles = execFileSync("git", ["diff", "--name-only", baseSha, "HEAD"], {
   encoding: "utf8",
 })
   .split("\n")
   .filter(Boolean)
-  .filter((file) => !isUnpublishableTestPath(file));
+  .filter((file) => !isUnpublishableTestPath(file))
+  .filter((file) => !isTwinExamplePath(file));
 
 function versionAt(ref, manifestPath) {
   try {

--- a/scripts/ci/check-version-bump-required.test.mjs
+++ b/scripts/ci/check-version-bump-required.test.mjs
@@ -13,6 +13,18 @@
  * that shouldn't happen; the prefix match didn't know it. A test path is now
  * dropped before the match, EXCEPT under `examples/`, `assets/` and `tasks/`,
  * which the CLI's `files` array really does publish verbatim.
+ *
+ * F-1455 (reproduced by PR #366 / F-1453) found the same shape of bug one
+ * prefix over: `packages/twin-` is also a plain string prefix, so it matched
+ * a twin's own top-level `examples/` even though those files ship in no
+ * tarball — not because of `files` (twin-github and twin-slack's `files`
+ * DOES name `dist`, and their examples compile into `dist/examples/`), but
+ * because every twin-* package is `private: true` and release.yml publishes
+ * only cli, adapter-claude-sdk, checks and wire. The `examples/` carve-back
+ * above does not apply here — that one exists because `cli/examples` really
+ * does ship — so this needed a second, separately anchored exemption, one
+ * scoped to a single path segment so a twin's `src/examples/` (which DOES
+ * compile into that twin's `dist`) stays caught.
  */
 import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -135,6 +147,42 @@ console.log("check-version-bump-required.mjs");
     versions: { "cli/package.json": "0.9.0" },
   });
   check("a BEHIND version still fails", r.status === 1 && r.out.includes("BEHIND"), r.out);
+}
+
+{
+  // F-1455 (PR #366 / F-1453): `packages/twin-` is a plain prefix, so it
+  // over-matched a twin's own top-level examples/ — files that ship in no
+  // tarball because every twin-* package is `private: true` and release.yml
+  // publishes only cli, adapter-claude-sdk, checks and wire.
+  const r = run({
+    changes: { "packages/twin-stripe/examples/buyer-agent/package-lock.json": "{}\n" },
+  });
+  check("a change confined to a twin's examples/ needs no bump", r.status === 0, r.out);
+}
+
+{
+  // Anchoring check: a twin's src/ is very much publish-relevant (it's what
+  // tsup inlines into the CLI's tarball), so the new exemption must not have
+  // widened to cover it.
+  const r = run({
+    changes: { "packages/twin-stripe/src/index.ts": "export const a = 1;\n" },
+  });
+  check(
+    "a twin's src/ change with no bump still fails",
+    r.status === 1 && r.out.includes("@pome-sh/cli"),
+    r.out,
+  );
+}
+
+{
+  // Anchoring check, single path segment: `[^/]+` must not loosen to `.+`.
+  // packages/twin-stripe/src/examples/handler.ts compiles into that twin's
+  // own dist/ same as any other src/ module — a real publish-relevant file
+  // that a looser regex would wrongly exempt.
+  const r = run({
+    changes: { "packages/twin-stripe/src/examples/handler.ts": "export const a = 1;\n" },
+  });
+  check("a twin's src/examples/ change with no bump still fails", r.status === 1, r.out);
 }
 
 if (failures > 0) {


### PR DESCRIPTION
<!-- Closes F-1455 -->

## What
The version-bump gate no longer demands a `@pome-sh/cli` bump for a PR that only touches a twin's own top-level `examples/` directory.

## Why
`@pome-sh/cli`'s `pathPrefixes` includes `"packages/twin-"` as a plain string prefix (twins are inlined into the CLI bundle by tsup), so it also matched `packages/twin-stripe/examples/buyer-agent/**`. But a twin's `examples/` ships in no tarball — and not because of its `files` array: twin-github and twin-slack's `tsconfig.build.json` compiles `examples/**/*.ts` into `dist/examples/*.js`, and their `files` array does name `dist`. The actual load-bearing fact is `private: true` — `.github/workflows/release.yml` publishes only `cli`, `adapter-claude-sdk`, `checks` and `wire`, and no twin is any of those. Nothing in the repo currently asserts a twin stays private, so this exemption would need re-checking if one ever were. The CLI's own `files` entry `"examples"` is `cli/examples` (named in `cli/tsconfig.json`'s `include`), a different directory, not a twin's — `isUnpublishableTestPath`'s `examples/` carve-back exists for that reason and doesn't apply here, so this needed its own, separately anchored exemption (`isTwinExamplePath`), scoped to a single path segment so a twin's own `src/examples/` (which does compile into that twin's `dist`) stays caught.

No commit on `main` has previously touched `packages/twin-*/examples/`, so this is the first PR to trip it: F-1453 / PR #366 (branch `gagan/f-1453-buyer-agent-hono-v2`), whose only changed files are `packages/twin-stripe/examples/buyer-agent/package.json` and `packages/twin-stripe/examples/buyer-agent/package-lock.json`, was failing the gate over a CLI republish that would be byte-identical.

## Test plan
- [x] `node scripts/ci/check-version-bump-required.test.mjs` — all 11 checks pass, including the 3 new cases added here (a change confined to a twin's `examples/` needs no bump; a twin's `src/` change with no bump still fails; a twin's `src/examples/` change with no bump still fails).
- [x] Mutation-tested the new predicate by hand: deleting `isTwinExamplePath` reds the first new case; loosening `/^packages\/twin-[^/]+\/examples\//` to `/^packages\/twin-.+\/examples\//` reds exactly the third new case (`a twin's src/examples/ change with no bump still fails`) with all others still green — confirms the single-path-segment anchoring is load-bearing, not decorative. Reverted the mutation after confirming.
- [x] `node scripts/ci/check-version-bump-required.mjs "$(git merge-base HEAD origin/main)"` — exits 0 on this branch.
- [x] Confirmed against the real repro: `git fetch origin gagan/f-1453-buyer-agent-hono-v2 && git diff --name-only origin/main FETCH_HEAD` shows only the two `packages/twin-stripe/examples/buyer-agent/*` files above, both matched by the new `isTwinExamplePath` regex, so they're filtered out of the changed-file set before the `@pome-sh/cli` prefix match runs. Not checked out or modified, per repo policy for that branch.