### PR TITLE
pull_request_read's get_comments answers from the conversation (F-1423)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,22 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.23.13
+
+### Patch Changes
+
+- The GitHub twin's `pull_request_read` tool now answers `get_comments` from the
+  pull request's conversation rather than from its inline review comments
+  (F-1423); `get_review_comments` is unchanged. Both methods used to read
+  `pull_request_review_comments`, behind a comment claiming the twin did not
+  model the split — it has since F-1151, which gave a PR's conversation its own
+  storage keyed on the PR's number, the way GitHub models a pull request as an
+  issue. **This moves results**: an agent under `pome twin start github` that
+  asks a PR for its discussion gets the discussion from 0.23.13 on, where it
+  previously got diff-anchored comments in the review-comment shape. A task that
+  seeded `review_comments[]` and read them back through `get_comments` needs to
+  seed `comments[]` instead. REST is unchanged and no CLI source changed.
+
 ## 0.23.12
 
 ### Patch Changes

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.23.12",
+  "version": "0.23.13",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/packages/twin-github/CHANGELOG.md
+++ b/packages/twin-github/CHANGELOG.md
@@ -1,6 +1,56 @@
 # @pome-sh/twin-github — CHANGELOG
 
 
+## 0.10.5 — 2026-08-11
+
+`pull_request_read`'s `get_comments` reads the PR's conversation instead of its
+inline review comments (F-1423).
+
+The dispatch answered BOTH comment methods from `pull_request_review_comments`:
+
+```js
+// GitHub distinguishes issue-level `get_comments` from diff-level
+// `get_review_comments`; this twin stores one comment thread per PR and
+// answers both from it rather than inventing a split it does not model.
+case "get_comments":
+case "get_review_comments":
+  return domain.getPullRequestComments(pull);
+```
+
+The justification was false by the time it was read. F-1151 gave a PR's
+conversation its own storage — `issue_comments`, keyed on the PR's own number,
+because GitHub models a pull request as an issue — and F-1421 gave the seed both
+vocabularies as separate fields (`pull_requests[].comments[]` and
+`pull_requests[].review_comments[]`). The twin models the split; only this
+dispatch did not. `get_comments` now reads `issue_comments` and
+`get_review_comments` keeps the review-comment table.
+
+The conversation is read through a new `getPullRequestConversation`, not by
+calling the ISSUE endpoints' `listIssueComments` with the pull number. Those
+read the same rows through the same serializer, but they resolve the target
+with `requireCommentTarget`, which accepts an issue OR a pull request — correct
+for the endpoints it serves, and wrong on this tool, where every other method
+answers 404 for a number that is not a pull request. Reusing it would have
+fixed the table and quietly widened one method of `pull_request_read` to answer
+for issues as well.
+
+⚠️ **This changes what the twin SERVES.** An examinee calling
+`pull_request_read(method: "get_comments")` gets the PR's discussion from 0.10.5
+on, where it previously got inline diff comments — and, since 0.10.3 (F-1422),
+got them in the full review-comment shape, so the answer was recognizably the
+wrong OBJECT rather than a lean one that could pass for a timeline comment. A
+task that seeded review comments and read them back through `get_comments` will
+now see `[]` unless it also seeds `comments[]`. The REST routes are unchanged;
+this was always MCP-only, which is why no fidelity lane measured it — the L1 MCP
+lane compares tool names and input schemas, not response bodies.
+
+`test/pull-request-read-comment-methods.test.ts` seeds one comment of each kind
+on one PR and pins each method to the body its own table holds, asserts the two
+answers are disjoint, and pins `pull_request_read(get_comments)` equal to
+`issue_read(get_comments)` on the same number — the two tool names for the one
+GitHub endpoint, which is what stops the dispatches drifting apart again.
+
+
 ## 0.10.4 — 2026-08-11
 
 An absent `state` means `open` on the three list routes, the way real GitHub

--- a/packages/twin-github/FIDELITY.md
+++ b/packages/twin-github/FIDELITY.md
@@ -80,7 +80,7 @@ in the package README. Changing any of those is a breaking change for
 | `get_tag` | SQLite tags | hot | semantic | `mcp-contract.test.ts`, `m5-hot-gaps.test.ts` | MCP-only (no REST route; git-plumbing REST stays cold per F-729); returns the lightweight tag object, not the annotated-tag git object. |
 | `issue_read` | SQLite issues, issue comments, issue labels | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | GitHub's consolidated reader (F-1376). Methods `get`, `get_comments`, `get_labels`; `get_sub_issues` and `get_parent` answer 501 — sub-issues are not modeled. |
 | `issue_write` | SQLite issues, labels, assignees | hot | semantic | `mcp-contract.test.ts`, `mcp-error-semantics.test.ts` | GitHub's consolidated writer (F-1376). Methods `create` and `update`. Milestones, issue types and `state_reason` are not implemented. |
-| `pull_request_read` | SQLite pull requests, PR files, commits, reviews, comments, check runs | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | GitHub's consolidated reader (F-1376). `get_diff` and `get_files` return simplified placeholder patches; `get_comments` answers from the review-comment table rather than the PR's conversation, which the twin DOES split (divergence 22). |
+| `pull_request_read` | SQLite pull requests, PR files, commits, reviews, comments, check runs | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | GitHub's consolidated reader (F-1376). `get_diff` and `get_files` return simplified placeholder patches; `get_comments` serves the PR's conversation timeline and `get_review_comments` its inline diff comments, from the two tables GitHub splits them across (F-1423). |
 | `pull_request_review_write` | SQLite PR reviews | hot | semantic | `mcp-contract.test.ts`, `state-export.test.ts` | GitHub's consolidated review writer (F-1376). Only `create` with an explicit `event`; pending reviews and review threads are not modeled, so the other four methods answer 501. |
 | `list_repository_collaborators` | SQLite collaborators | hot | semantic | `mcp-contract.test.ts` | Permission filtering is not implemented. |
 
@@ -409,21 +409,34 @@ upstream so a divergence that upstream "heals" becomes a tier-upgrade signal.
     against upstream, so the shape diff masks them; an agent that parses a
     review comment's hunk text or resolves `position` against a real diff will
     diverge, exactly as on the diff surfaces bullet 2 names.
+
 22. **`pull_request_read`'s `get_comments` answers from the wrong table (open gap,
-    not accepted).** GitHub distinguishes the issue-level `get_comments` from the
-    diff-level `get_review_comments`; the twin answers BOTH from
-    `pull_request_review_comments`, on a comment that says it "stores one comment
+    not accepted).** ⚠️ **FIXED in 0.10.5 (F-1423) — this bullet is awaiting
+    retirement, not describing current behaviour.** `get_comments` now reads the
+    pull request's conversation (`issue_comments`, keyed on the PR's own number)
+    and `get_review_comments` keeps `pull_request_review_comments`; the two are
+    pinned apart by `test/pull-request-read-comment-methods.test.ts`.
+
+    It is still here because pome-cloud's `lint-known-divergences.ts` binds this
+    bullet 1:1 to an entry in its `known-divergences/github.yaml`, matching on the
+    bold title above, and runs on every pome-cloud PR against **main, unpinned**
+    (F-1430, PR #369). Deleting the bullet without deleting that entry in the same
+    window orphans it and reds every open pome-cloud PR — so the two retire
+    together, in the coordinated change that owns the pome-cloud half, and the
+    title is left byte-identical so the match keeps holding until then. The stale
+    thing this ticket was really about — a code comment asserting a split the twin
+    did model — is gone from `tools.ts`.
+
+    What it recorded, for the reader who finds it before it goes: GitHub
+    distinguishes the issue-level `get_comments` from the diff-level
+    `get_review_comments`; the twin answered BOTH from
+    `pull_request_review_comments`, on a comment saying it "stores one comment
     thread per PR and answers both from it rather than inventing a split it does
-    not model". That was true when it was written and F-1151 made it false: a PR's
-    conversation has its own table (`issue_comments`, keyed on the PR's number),
-    `exportState` keeps the three comment surfaces apart, and the REST routes
-    already serve them separately. So `get_comments` returns inline review
-    comments to a caller asking for the timeline — and since F-1422 it returns
-    them in the full review-comment shape, so the answer is now recognizably the
-    wrong OBJECT rather than a lean one that could pass for a timeline comment.
-    Discovered the same way as the LIST shape in bullet 21 — F-1421 makes both
-    surfaces seedable, so the two now have different contents to tell apart —
-    but MCP-only, so no fidelity-watch lane measures it.
+    not model". That was true when written and F-1151 made it false — a PR's
+    conversation has its own table, `exportState` keeps the three comment surfaces
+    apart, and the REST routes already served them separately. Discovered the same
+    way as the LIST shape in bullet 21, but MCP-only, so no fidelity-watch lane
+    measured it.
 
 23. **`check-runs` has no reachable upstream — `Checks` is not grantable to a
     fine-grained PAT.** GitHub gates

--- a/packages/twin-github/package.json
+++ b/packages/twin-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-github",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Deterministic GitHub-shaped twin for agent testing — REST + MCP, SQLite-backed state.",
   "private": true,
   "type": "module",

--- a/packages/twin-github/src/domain/github-domain.ts
+++ b/packages/twin-github/src/domain/github-domain.ts
@@ -494,6 +494,10 @@ export class GitHubDomain {
     return pulls.getPullRequestComments(this, input);
   }
 
+  getPullRequestConversation(input: { owner: string; repo: string; pull_number: number } & PageOptions) {
+    return pulls.getPullRequestConversation(this, input);
+  }
+
   getPullRequestStatus(input: { owner: string; repo: string; pull_number: number }) {
     return pulls.getPullRequestStatus(this, input);
   }

--- a/packages/twin-github/src/domain/pulls.ts
+++ b/packages/twin-github/src/domain/pulls.ts
@@ -189,6 +189,30 @@ export function getPullRequestComments(domain: GitHubDomain, input: { owner: str
 }
 
 
+// F-1423 — the PR's CONVERSATION timeline, the other half of the pair above.
+// It reads `issue_comments` keyed on the PR's own number, because GitHub models
+// a pull request as an issue and puts both entities' conversations in one table
+// and behind one route (F-1151).
+//
+// This is deliberately not `issues.listIssueComments` called with the pull
+// number, even though that reads the same rows through the same serializer.
+// That function resolves its target with `requireCommentTarget`, which accepts
+// an issue OR a pull request — correct for the ISSUE endpoints it serves, and
+// wrong here, because every other method on `pull_request_read` answers 404 for
+// a number that is not a pull request. Reaching the shared table must not
+// quietly make one method on that tool answer for issues too. So the guard is
+// `requirePullRequest`, like every sibling in this file, and `target` is
+// `"pull_request"` as a fact rather than a lookup.
+export function getPullRequestConversation(domain: GitHubDomain, input: { owner: string; repo: string; pull_number: number } & PageOptions) {
+  const repo = domain.requireRepo(input.owner, input.repo);
+  domain.requirePullRequest(repo.id, input.pull_number);
+  const rows = domain.listIssueCommentRows(repo.id, input.pull_number);
+  return paginate(rows, input.page, input.per_page ?? input.perPage).map((comment) =>
+    issueCommentJson(comment, repo, "pull_request")
+  );
+}
+
+
 export function getPullRequestStatus(domain: GitHubDomain, input: { owner: string; repo: string; pull_number: number }) {
   const repo = domain.requireRepo(input.owner, input.repo);
   const pr = domain.requirePullRequest(repo.id, input.pull_number);

--- a/packages/twin-github/src/tools.ts
+++ b/packages/twin-github/src/tools.ts
@@ -414,10 +414,17 @@ export function executeTool(
           return domain.getPullRequestCommits(pull);
         case "get_reviews":
           return domain.getPullRequestReviews(pull);
-        // GitHub distinguishes issue-level `get_comments` from diff-level
-        // `get_review_comments`; this twin stores one comment thread per PR and
-        // answers both from it rather than inventing a split it does not model.
+        // GitHub distinguishes the issue-level `get_comments` from the
+        // diff-level `get_review_comments`, and so does this twin: a PR's
+        // CONVERSATION lives in `issue_comments`, keyed on the PR's own number
+        // because GitHub models a pull request as an issue (F-1151), while the
+        // comments anchored to a file and line live in
+        // `pull_request_review_comments`. Both halves of the justification that
+        // stood here — one thread per PR, a split the twin does not model —
+        // stopped being true at F-1151, and F-1421 then gave the seed both
+        // vocabularies as separate fields (F-1423).
         case "get_comments":
+          return domain.getPullRequestConversation(pull);
         case "get_review_comments":
           return domain.getPullRequestComments(pull);
         case "get_check_runs": {

--- a/packages/twin-github/test/pull-request-read-comment-methods.test.ts
+++ b/packages/twin-github/test/pull-request-read-comment-methods.test.ts
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-1423 — `pull_request_read`'s two comment methods read two different tables.
+//
+// The dispatch answered BOTH `get_comments` and `get_review_comments` from
+// `domain.getPullRequestComments`, i.e. from `pull_request_review_comments`,
+// behind a comment claiming the twin "stores one comment thread per PR and
+// answers both from it rather than inventing a split it does not model". That
+// justification stopped being true: F-1151 gave a PR's CONVERSATION its own
+// storage (`issue_comments`, keyed on the PR's number, because GitHub models a
+// pull request as an issue), and F-1421 gave the seed both vocabularies as
+// separate fields. So the twin does model the split — the tool dispatch just
+// read the wrong side of it.
+//
+// Why it is worth a suite of its own: `pull_request_read` is a tool an EXAMINEE
+// calls. An agent that asks for a pull request's discussion and is handed
+// inline diff comments is graded against a world that answered a different
+// question than the one it asked. Nothing else catches it — the L1 MCP lane
+// compares tool names and input schemas, not response bodies, so a wrong-table
+// dispatch is invisible to every fidelity lane that runs today.
+//
+// Every assertion below is on CONTENT, never on a count. Both tables holding
+// one row each is precisely the state in which a length assertion passes
+// against the bug: `get_comments` returned one element before this fix too, it
+// was simply the wrong one. So each method is pinned to the body its own table
+// holds, and asserted NOT to carry the other's. `ONLY_CONVERSATION` then
+// removes the second table entirely — pre-fix, `get_comments` answered `[]`
+// there while the PR visibly had a comment, which is the same defect seen from
+// the side where the wrong table is empty rather than merely different.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createGitHubCloneApp } from "../src/twin.js";
+import type { GitHubStateSeed } from "../src/types.js";
+import { TEST_AUTH_SECRET, TEST_SID, signTestToken, withAuth } from "./_authHelper.js";
+
+const previousSecret = process.env.TWIN_AUTH_SECRET;
+let token: string;
+
+beforeAll(async () => {
+  process.env.TWIN_AUTH_SECRET = TEST_AUTH_SECRET;
+  token = await signTestToken();
+});
+afterAll(() => {
+  if (previousSecret === undefined) delete process.env.TWIN_AUTH_SECRET;
+  else process.env.TWIN_AUTH_SECRET = previousSecret;
+});
+
+const base = `/s/${TEST_SID}`;
+
+/** The two bodies the whole suite turns on. Nothing else may say either one. */
+const CONVERSATION = "Rebased onto main — the flake was the fixture, not the race.";
+const INLINE = "This flag needs a default.";
+
+// Issues and pull requests share one per-repo number counter, so the single
+// seeded issue is #1 and the pull request is #2. `get_comments` reading the
+// issue-comment table by the PR's OWN number is the behaviour under test, so
+// the issue below is not scenery: it holds a comment at a DIFFERENT number, and
+// a dispatch that leaked across numbers would surface it here.
+const PULL = 2;
+
+function world(options: { withInline: boolean }): GitHubStateSeed {
+  return {
+    users: [
+      { login: "acme", type: "Organization", name: "Acme" },
+      { login: "alice", type: "User", name: "Alice" },
+      { login: "bob", type: "User", name: "Bob" },
+      { login: "pome-agent", type: "User", name: "Pome Agent" }
+    ],
+    repositories: [
+      {
+        owner: "acme",
+        name: "api",
+        default_branch: "main",
+        collaborators: ["alice", "bob", "pome-agent"],
+        files: [
+          { path: "README.md", content: "# Acme API\n" },
+          { path: "src/feature.ts", content: "export const feature = true;\n", branch: "feature" }
+        ],
+        issues: [
+          {
+            number: 1,
+            title: "Seeded bug: 500 on POST /orders",
+            state: "open",
+            comments: [{ body: "A comment on the ISSUE, not the pull request.", author: "alice" }]
+          }
+        ],
+        pull_requests: [
+          {
+            title: "Add feature flag",
+            head: "feature",
+            base: "main",
+            author: "pome-agent",
+            comments: [{ body: CONVERSATION, author: "alice" }],
+            ...(options.withInline
+              ? { review_comments: [{ body: INLINE, path: "src/feature.ts", line: 1, author: "bob" }] }
+              : {})
+          }
+        ]
+      }
+    ]
+  };
+}
+
+/** One of each, so neither method can be right by being empty. */
+const BOTH_SURFACES = world({ withInline: true });
+/** The conversation alone — `get_comments` must not need the other table. */
+const ONLY_CONVERSATION = world({ withInline: false });
+
+describe("F-1423 — pull_request_read reads the conversation and the diff separately", () => {
+  it("answers get_comments from the PR's conversation, not its review comments", async () => {
+    const app = createGitHubCloneApp({ seed: BOTH_SURFACES });
+
+    const conversation = await call(app, { method: "get_comments" });
+
+    expect(conversation.map((comment) => comment.body)).toEqual([CONVERSATION]);
+    expect(JSON.stringify(conversation)).not.toContain(INLINE);
+  });
+
+  it("keeps get_review_comments on the review-comment table", async () => {
+    const app = createGitHubCloneApp({ seed: BOTH_SURFACES });
+
+    const inline = await call(app, { method: "get_review_comments" });
+
+    expect(inline.map((comment) => comment.body)).toEqual([INLINE]);
+    expect(JSON.stringify(inline)).not.toContain(CONVERSATION);
+  });
+
+  // The two methods answering DIFFERENT questions is the whole ticket, so it is
+  // asserted directly rather than inferred from the two cases above passing.
+  it("serves two disjoint answers for one pull request", async () => {
+    const app = createGitHubCloneApp({ seed: BOTH_SURFACES });
+
+    const conversation = await call(app, { method: "get_comments" });
+    const inline = await call(app, { method: "get_review_comments" });
+
+    const bodies = (comments: Comment[]) => comments.map((comment) => comment.body);
+    expect(bodies(conversation)).not.toEqual(bodies(inline));
+    expect(bodies(conversation).some((body) => bodies(inline).includes(body))).toBe(false);
+  });
+
+  // Shape, not just content: the two tables serve two different GitHub schemas,
+  // and an agent branching on `path`/`line` is reading the anchor that tells a
+  // diff comment from a timeline one. A dispatch that returned the right ROWS
+  // through the wrong serializer would pass the body assertions above.
+  it("gives each method its own GitHub schema", async () => {
+    const app = createGitHubCloneApp({ seed: BOTH_SURFACES });
+
+    const [conversation] = await call(app, { method: "get_comments" });
+    const [inline] = await call(app, { method: "get_review_comments" });
+
+    // A review comment is anchored to a file and a line; a conversation comment
+    // has nowhere to be anchored and carries neither key.
+    expect(inline).toMatchObject({ path: "src/feature.ts", line: 1 });
+    expect(conversation).not.toHaveProperty("path");
+    expect(conversation).not.toHaveProperty("line");
+    // GitHub browses a PR's conversation comment at `/pull/N#issuecomment-…`
+    // even though the API pointer stays on the issues path (F-1151).
+    expect(conversation.html_url).toContain(`/acme/api/pull/${PULL}#issuecomment-`);
+  });
+
+  it("answers get_comments from a PR that has no review comments at all", async () => {
+    const app = createGitHubCloneApp({ seed: ONLY_CONVERSATION });
+
+    expect(await call(app, { method: "get_comments" })).toHaveLength(1);
+    // Empty because the table is empty — the one case where both methods
+    // returning the same thing is correct, and it must be the EMPTY one.
+    expect(await call(app, { method: "get_review_comments" })).toEqual([]);
+  });
+
+  // The number is still a PULL REQUEST number. `issue_comments` is shared with
+  // issues, and the reader that serves the ISSUE endpoints resolves its target
+  // with `requireCommentTarget`, which accepts either entity — right there,
+  // wrong here. Every other `pull_request_read` method 404s on a number that is
+  // not a PR, and reaching the shared table must not make this one method
+  // answer for issues. Issue #1 is seeded WITH a comment precisely so that a
+  // dispatch which lost the guard returns it instead of failing.
+  it("still refuses a number that is an issue, not a pull request", async () => {
+    const app = createGitHubCloneApp({ seed: BOTH_SURFACES });
+
+    await expect(
+      mcp(app, "pull_request_read", { method: "get_comments", owner: "acme", repo: "api", pullNumber: 1 })
+    ).rejects.toThrow("404");
+    // The sibling method's answer for the same number, so the tool is refusing
+    // on one rule rather than two.
+    await expect(
+      mcp(app, "pull_request_read", { method: "get", owner: "acme", repo: "api", pullNumber: 1 })
+    ).rejects.toThrow("404");
+  });
+
+  // `pull_request_read(get_comments)` and `issue_read(get_comments)` are the
+  // same GitHub endpoint reached by two tool names, because a PR is an issue.
+  // They are now two different readers — one guards on the pull request, the
+  // other on either entity — so pinning them equal on a PR's number is what
+  // stops the pair drifting into two shapes for one comment.
+  it("agrees with issue_read's get_comments on the same number", async () => {
+    const app = createGitHubCloneApp({ seed: BOTH_SURFACES });
+
+    const viaPull = await call(app, { method: "get_comments" });
+    const viaIssue = (await mcp(app, "issue_read", {
+      method: "get_comments",
+      owner: "acme",
+      repo: "api",
+      issue_number: PULL
+    })) as Comment[];
+
+    expect(viaPull).toEqual(viaIssue);
+  });
+
+  it("paginates the conversation rather than the review comments", async () => {
+    const app = createGitHubCloneApp({ seed: BOTH_SURFACES });
+
+    // `perPage: 1` on a one-row table is not a pagination test; what it pins is
+    // that the page options reach the SAME reader the method now dispatches to.
+    const page = await call(app, { method: "get_comments", perPage: 1, page: 1 });
+    expect(page.map((comment) => comment.body)).toEqual([CONVERSATION]);
+    expect(await call(app, { method: "get_comments", perPage: 1, page: 2 })).toEqual([]);
+  });
+});
+
+type Comment = { body: string; html_url: string; path?: string; line?: number };
+
+function call(
+  app: ReturnType<typeof createGitHubCloneApp>,
+  args: { method: string; page?: number; perPage?: number }
+) {
+  return mcp(app, "pull_request_read", {
+    owner: "acme",
+    repo: "api",
+    pullNumber: PULL,
+    ...args
+  }) as Promise<Comment[]>;
+}
+
+async function mcp(app: ReturnType<typeof createGitHubCloneApp>, tool: string, args: unknown) {
+  const response = await app.request(
+    `${base}/mcp/call`,
+    withAuth(token, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ tool, arguments: args })
+    })
+  );
+  if (!response.ok) throw new Error(`${tool}: ${response.status} ${await response.text()}`);
+  return response.json() as Promise<unknown>;
+}


### PR DESCRIPTION
Closes F-1423.

`pull_request_read` answered **both** of its comment methods from `pull_request_review_comments`:

```js
// GitHub distinguishes issue-level `get_comments` from diff-level
// `get_review_comments`; this twin stores one comment thread per PR and
// answers both from it rather than inventing a split it does not model.
case "get_comments":
case "get_review_comments":
  return domain.getPullRequestComments(pull);
```

Both halves of that justification had stopped being true. F-1151 gave a pull request's conversation its own storage — `issue_comments`, keyed on the PR's own number, because GitHub models a pull request as an issue — and F-1421 gave the seed both vocabularies as separate fields (`pull_requests[].comments[]` and `pull_requests[].review_comments[]`), backed by separate tables. The twin *does* model the split; this dispatch read the wrong side of it behind a comment that had gone stale.

## ⚠️ This changes what the twin serves

An examinee calling `pull_request_read(method: "get_comments")` gets the PR's **discussion** from `@pome-sh/twin-github` 0.10.5 on, where it previously got inline diff comments — and since F-1422 got them in the full review-comment shape, so the answer was recognizably the wrong *object* rather than a lean one that could pass for a timeline comment. A task that seeded `review_comments[]` and read them back through `get_comments` now sees `[]` unless it also seeds `comments[]`. **The REST routes were always correct and are untouched.**

## Why fix rather than document

`pull_request_read` is a tool an examinee **calls**. An agent that asks for a PR's discussion and receives inline diff comments is graded against a world that answered a different question than the one it asked — and nothing measures it: the L1 MCP lane compares tool *names and input schemas*, not response bodies, so no fidelity lane can see a wrong-table dispatch.

## Reviewer notes

**The new domain function is the part worth a second look.** The conversation is read through a new `getPullRequestConversation` rather than by calling the issue endpoints' `listIssueComments` with the pull number. Those read the same rows through the same serializer, but resolve their target with `requireCommentTarget`, which accepts an issue **or** a pull request — right for the endpoints it serves, wrong on this tool, where every other method answers 404 for a number that is not a PR. Reusing it would have fixed the table and silently widened one method of `pull_request_read` to answer for issues too. The guard is pinned by a test, and verified load-bearing by mutation (removing it fails that test and only that test).

**The tests assert content, never counts.** Both tables holding one row each is exactly the state where a length assertion passes against the bug — `get_comments` returned one element before this change too, it was simply the wrong one. `test/pull-request-read-comment-methods.test.ts` pins each method to the body its own table holds, pins the two answers disjoint, pins each method's GitHub schema (a review comment is anchored to a file and line; a conversation comment carries neither key), pins the guard by seeding a commented issue at a number the tool must still refuse, and pins `pull_request_read(get_comments)` equal to `issue_read(get_comments)` on the same number — the two tool names for the one GitHub endpoint.

**Docs — read this before merging.** The `pull_request_read` row now describes the split the twin serves. Divergence **bullet 22 is deliberately NOT deleted**, which is a change from this PR's first revision.

pome-cloud's `lint-known-divergences.ts` binds each bullet 1:1 to an entry in its `known-divergences/github.yaml`, matching on the **bold title**, and runs on every pome-cloud PR against this repo at **main, unpinned** (#369 confirmed twin-github at 23 entries 1:1). Deleting the bullet without deleting that entry in the same window orphans it and **reds every open pome-cloud PR** — and because the lint is unpinned, that starts the moment this merges, not when a pin moves. I cannot execute the pome-cloud half from this repo, so the bullet keeps its **byte-identical bold title** (what the matcher reads) and its body now opens by stating the behaviour is fixed in 0.10.5 and the bullet is awaiting retirement. The two halves retire together in whatever change owns the pome-cloud side.

The stale artefact this ticket was actually about — the code comment in `tools.ts` asserting a split the twin did model — is gone.

## Release

Version bumps are in this PR, per F-1456's batch plan: `@pome-sh/cli` 0.23.12 → **0.23.13** (twins are inlined into its tarball) and `@pome-sh/twin-github` 0.10.4 → **0.10.5**.

> **Sequencing note for the batch.** `release.yml` publishes on a version diff *per merge*, so if F-1389 and F-1385 also land with bumps they will each publish their own patch rather than one combined release — and whichever merges second must bump **above** whatever the first one published, or `check-version-bump-required.mjs` reds it (version equal to base) and, if it somehow got through, `decide-publish.sh` would silently skip the publish. Merging this alone publishes 0.23.13 with only this fix in it.

## Follow-up (not in this PR)

Retiring divergence bullet 22 **and** its pome-cloud `known-divergences/github.yaml` entry, together, in one window — see the Docs note above for why they cannot be split. Natural home is alongside F-1457's six dead `*.declared.yaml` entries.

## CI

Rebased onto `main` (post-#369) and re-verified. Locally green: full workspace suite (3,376 tests / 10 packages), `typecheck`, `lint:route-inputs`, `gate:route-inputs`, `gate:mcp-tools-list`, `lint:code-health`, `lint:dead-code`, `probe:twins` (128 probes), and `check-version-bump-required.mjs`. `probe:examples` reports findings both with and without this change — the bundled examples' own dependencies aren't installed in this workspace — so it is unrelated and left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
