### PR TITLE
Five known-divergence bullets, and a twin's docs stop demanding a CLI republish

### DIFF
--- a/packages/twin-github/FIDELITY.md
+++ b/packages/twin-github/FIDELITY.md
@@ -425,6 +425,21 @@ upstream so a divergence that upstream "heals" becomes a tier-upgrade signal.
     surfaces seedable, so the two now have different contents to tell apart —
     but MCP-only, so no fidelity-watch lane measures it.
 
+23. **`check-runs` has no reachable upstream — `Checks` is not grantable to a
+    fine-grained PAT.** GitHub gates
+    `GET /repos/{owner}/{repo}/commits/{ref}/check-runs` on the `Checks`
+    permission, which it offers to a GitHub App and **not** to a fine-grained
+    personal access token, so the fidelity capture answers HTTP 403 at every
+    scope its credential can hold (measured 2026-08-11, on the first credentialed
+    live dispatch). Note what this bullet does and does not claim: the twin's
+    answer has never been compared to GitHub's, so this is not an observed
+    difference — the surface is UNMEASURABLE under the credential model the
+    watchdog is permitted to use. It is registered in pome-cloud with a written
+    `verification_opt_out` so the promotion gate reads it as waived-with-a-reason
+    rather than never-checked, and it holds no committed golden: the one it held
+    until F-1430 was an empty `check_runs` array diffed against the twin's empty
+    one, which published green while binding no key, no leaf type and no element.
+
 ## How fidelity is verified
 
 Three independent checks back the tier classifications above. Each is a

--- a/packages/twin-slack/FIDELITY.md
+++ b/packages/twin-slack/FIDELITY.md
@@ -321,6 +321,16 @@ _Shape-anchoring divergences (compile-time anchor to `@slack/web-api`):_
     `@slack/web-api`'s `ChatScheduledMessagesListResponse` item, so it is held out of
     the anchored `base` and spread back.
 
+22. **`users.list` member count reflects the seeded world, not the live sandbox
+    workspace.** The twin serves the users its seed declares;
+    `pome-twin-sandbox.slack.com` holds whoever is installed in it, and it gained
+    a bot user on 2026-08-10 when a second Slack app was installed. The L1
+    upstream oracle fires `array-length-changed` on any exact count mismatch, so
+    those two numbers can only ever agree by coincidence — and they did, until
+    the 2026-08-11 re-baseline removed the coincidence. The COUNT is accepted in
+    pome-cloud's registry and the per-member SHAPE is still compared; the same
+    reasoning already covers `conversations.members`. F-1434.
+
 ## Shape anchoring (compile-time, `@slack/web-api@7.16.0`)
 
 The serializers are pinned to Slack's official response types at compile time

--- a/packages/twin-stripe/FIDELITY.md
+++ b/packages/twin-stripe/FIDELITY.md
@@ -366,6 +366,28 @@ not exposed at the root mount — those remain at `/s/:sid/_pome/*` and
     the shape tier carries no billing-cycle arithmetic, so no period is
     fabricated. Cancellation is an immediate status flip with no proration.
 
+17. **`/v1/payment_intents` row count is the empty seeded world against a live
+    test account.** The twin serves `data: []`; the live Stripe TEST account has
+    held payment intents since 2026-08-10. `array-length-changed` fires on the
+    exact count, so the two sides can only agree by coincidence — and they did
+    until the 2026-08-11 re-baseline, when both were empty and the comparison
+    bound nothing at all. The count is accepted in pome-cloud's registry; the
+    per-object shape is still compared, so a wrong `object`, a wrong `status` or
+    a changed leaf type still drifts. F-1434.
+
+18. **`/v1/charges` row count is the empty seeded world against a live test
+    account.** Same class as bullet 17 on the charges list. The PII redaction
+    pass masks free-text leaves by VALUE only — it never changes a key set, an
+    array length or a leaf type — so accepting the count here does not compound
+    with it. F-1434.
+
+19. **`/v1/balance_transactions` row count is the empty seeded world against a
+    live test account.** Same class as bullet 17, and the clearest illustration
+    of why seeding the upstream to match the twin is not a maintainable answer:
+    balance transactions are minted by Stripe as a side effect of charge
+    activity rather than created directly, so this surface would drift again on
+    an account emptied today. F-1434.
+
 > Pagination is **not** a divergence: `GET /v1/payment_intents` (and the
 > other list surfaces) use real cursor pagination keyed on `(created, id)`
 > via `starting_after` / `ending_before`, matching Stripe's cursor model.

--- a/scripts/ci/check-version-bump-required.mjs
+++ b/scripts/ci/check-version-bump-required.mjs
@@ -68,13 +68,42 @@ function isTwinExamplePath(file) {
   return /^packages\/twin-[^/]+\/examples\//.test(file);
 }
 
+/**
+ * A twin's own TOP-LEVEL markdown ships in no tarball either, for exactly the
+ * reason above: every `packages/twin-*` package is `private: true`, and
+ * release.yml publishes only cli, adapter-claude-sdk, checks and wire. Their
+ * `files` arrays do name `README.md` / `FIDELITY.md` / `LIMITS.md`, and that is
+ * as inert as the `dist/examples` case — a `files` array on a package nothing
+ * publishes describes a tarball nobody builds. The CLI's tarball inlines twin
+ * SOURCE through tsup, and tsup cannot inline a markdown file.
+ *
+ * Same shape of over-match as F-1455, one directory over: `packages/twin-` is a
+ * plain prefix, so documentation that cannot change one byte of any published
+ * artifact was demanding a `@pome-sh/cli` bump — i.e. a republish that would be
+ * byte-identical. RELEASING.md's advice ("if your change doesn't warrant a
+ * release it shouldn't be touching a publish-relevant path") has no answer here:
+ * a twin's FIDELITY.md has nowhere else to live.
+ *
+ * Found on the docs-only PR that added the FIDELITY.md bullets pome-cloud's
+ * `lint-known-divergences.ts` binds its registry entries to 1:1.
+ *
+ * `[^/]+\/[^/]+\.md` is two single path segments on purpose: this exempts
+ * `packages/twin-github/FIDELITY.md` and NOT `packages/twin-github/src/x.md`
+ * or any nested docs directory, so it cannot widen to cover something the
+ * bundler might actually read.
+ */
+function isTwinTopLevelDocPath(file) {
+  return /^packages\/twin-[^/]+\/[^/]+\.md$/.test(file);
+}
+
 const changedFiles = execFileSync("git", ["diff", "--name-only", baseSha, "HEAD"], {
   encoding: "utf8",
 })
   .split("\n")
   .filter(Boolean)
   .filter((file) => !isUnpublishableTestPath(file))
-  .filter((file) => !isTwinExamplePath(file));
+  .filter((file) => !isTwinExamplePath(file))
+  .filter((file) => !isTwinTopLevelDocPath(file));
 
 function versionAt(ref, manifestPath) {
   try {

--- a/scripts/ci/check-version-bump-required.test.mjs
+++ b/scripts/ci/check-version-bump-required.test.mjs
@@ -161,6 +161,36 @@ console.log("check-version-bump-required.mjs");
 }
 
 {
+  // Same over-match as F-1455, one directory over: a twin's own top-level
+  // markdown ships in no tarball (every twin-* is `private: true`), and tsup
+  // cannot inline a markdown file into the CLI's bundle either way. Demanding a
+  // bump here demands a byte-identical republish, and RELEASING.md's "don't
+  // touch a publish-relevant path" has no answer — a twin's FIDELITY.md has
+  // nowhere else to live.
+  const r = run({
+    changes: { "packages/twin-github/FIDELITY.md": "## Known divergences\n\n1. **A.** b\n" },
+  });
+  check("a change confined to a twin's top-level docs needs no bump", r.status === 0, r.out);
+}
+
+{
+  // Anchoring check, single path segment: `[^/]+\/[^/]+\.md` must not loosen.
+  // Nothing under a twin's src/ is exempt, markdown or otherwise — the point of
+  // the exemption is "documentation at the package root", not "any .md".
+  const r = run({
+    changes: {
+      "packages/twin-github/FIDELITY.md": "# doc\n",
+      "packages/twin-github/src/index.ts": "export const a = 1;\n",
+    },
+  });
+  check(
+    "a doc change RIDING ALONG with a src change still demands a bump",
+    r.status === 1 && r.out.includes("@pome-sh/cli"),
+    r.out,
+  );
+}
+
+{
   // Anchoring check: a twin's src/ is very much publish-relevant (it's what
   // tsup inlines into the CLI's tarball), so the new exemption must not have
   // widened to cover it.


### PR DESCRIPTION
Two commits, no source and **no version bump** — merging this publishes nothing.

1. Five numbered bullets under `## Known divergences` in three `FIDELITY.md` files.
2. A carve-out in `scripts/ci/check-version-bump-required.mjs`, because commit 1 tripped it.

## Why this has to merge before the pome-cloud PR

pome-cloud's `lint-known-divergences.ts` binds every entry in its `known-divergences/<twin>.yaml` **1:1** to a numbered bullet under this repo's `## Known divergences` heading, matching on the bullet's bold title (`md_bullet_title`). `ci-fidelity-leg.ts` runs that lint on **every pome-cloud PR**, against a checkout of this repo at **main, unpinned**.

So the five registry entries pome-cloud is adding need these five bullets to already exist. An entry without a bullet is an "orphan entry" and reds every open pome-cloud PR; a bullet without an entry is a "missing entry" and does the same. No ordering avoids a brief red window on pome-cloud `main` — the sequence below keeps it to minutes.

**This repo's CI is unaffected either way**: nothing here reads that registry, and there is no copy of the lint in this repo.

## The five bullets

| Twin | Bullet | What it records |
|---|---|---|
| twin-github | 23 | `check-runs` has no reachable upstream — `Checks` is grantable to a GitHub App and not to a fine-grained PAT, so the capture credential answers **403 at any scope** (measured 2026-08-11) |
| twin-slack | 22 | `users.list` member count — seeded world vs a workspace that gained a bot on 2026-08-10 |
| twin-stripe | 17 | `/v1/payment_intents` row count — empty seeded world vs a live test account |
| twin-stripe | 18 | `/v1/charges` row count — same |
| twin-stripe | 19 | `/v1/balance_transactions` row count — same |

**The github bullet is careful about what it does *not* claim.** twin-github's `check-runs` answer has never been compared to GitHub's, so the bullet says the surface is **unmeasurable**, not that it diverges. Its counterpart entry is the first anywhere to carry a written `verification_opt_out`.

**The other four are one class.** The L1 upstream oracle fires `array-length-changed` on any exact count mismatch, and a deliberately-seeded twin's row count can only ever agree with a live vendor account's by coincidence. They agreed until 2026-08-11 because both sides were empty — which is worse than it sounds: the diff returns before the per-element union when either side is empty, so that green compared nothing at all. The re-baseline did not create these divergences, it removed what was hiding them. Each counterpart entry accepts only the **count**; per-element shape stays under comparison on all four.

## The second commit, and why it is not scope creep

Commit 1 failed `typecheck-test`:

```
Version bump required:
  - @pome-sh/cli: publish-relevant paths changed but cli/package.json's
    version is still 0.23.12.
```

`@pome-sh/cli`'s publish-relevant paths include the plain prefix `packages/twin-`, so a twin's `FIDELITY.md` matched. It cannot change one byte of that tarball: tsup inlines twin **source** and cannot inline markdown, and every `packages/twin-*` package is `private: true`, so its own `files: [..., "FIDELITY.md"]` describes a tarball nobody builds.

This is **F-1455's over-match one directory over**. That ticket carved out a twin's top-level `examples/` on identical evidence (PR #366 was told to bump the CLI for a byte-identical republish); the argument transfers unchanged, and the carve-out is written next to it citing it.

The alternative was to bump `cli/package.json`, which would publish a real `@pome-sh/cli` release carrying whatever else is on `main` at that moment — a live release triggered by a documentation change.

RELEASING.md's rule of thumb ("if your change doesn't warrant a release it shouldn't be touching a publish-relevant path in the first place") has no answer here: a twin's `FIDELITY.md` has nowhere else to live, because the cross-repo lint binds to exactly that path.

Scoped to **two single path segments** — `packages/twin-github/FIDELITY.md` is exempt, `packages/twin-github/src/anything.md` is not. Two new tests: docs alone need no bump, and a doc change **riding along with** a src change still demands one.

## Verification

`scripts/ci/check-version-bump-required.test.mjs` — 13 checks, all pass, including the two new ones and the three pre-existing anchoring checks that the exemption must not have widened.

The 1:1 lint, run from a pome-cloud checkout carrying the new registry entries against this branch's files:

```
known-divergences lint OK — 23 entries 1:1 (packages/twin-github/FIDELITY.md)
known-divergences lint OK — 22 entries 1:1 (packages/twin-slack/FIDELITY.md)
known-divergences lint OK — 19 entries 1:1 (packages/twin-stripe/FIDELITY.md)
```

## Merge sequence

1. **Merge this PR.** pome-cloud `main` goes red (five bullets, no entries).
2. Re-run CI on pome-sh/pome-cloud#660 — it carries the entries, so it goes green.
3. Merge it. Window closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)