### PR TITLE
Five route inputs the twins accept that their vendors do not (F-1389)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,24 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.23.14
+
+### Patch Changes
+
+- Four route inputs the twins accepted but their vendors do not declare are gone
+  from the twins' published input surface (F-1389). The GitHub twin no longer
+  declares `owner` on `POST /user/repos` (that surface creates a repository for
+  the authenticated user, and the body copy reached the domain) or `encoding` on
+  `PUT /contents/*`; the Slack twin no longer declares a singular `channel` on
+  `files.upload` (Slack takes `channels`, plural), and its domain no longer
+  falls back to it; the Stripe twin no longer accepts `created` on
+  `GET /v1/customers/:id/payment_methods`. **Only the Stripe one changes what a
+  caller is told** — that twin refuses undeclared inputs, matching Stripe, which
+  publishes `parameter_unknown` for exactly this parameter, so a request the
+  real API declines is now declined here too. GitHub and Slack ignore undeclared
+  inputs, so those three are discarded rather than refused, as on the real
+  vendors. No CLI source changed.
+
 ## 0.23.13
 
 ### Patch Changes

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,19 +8,33 @@ packaging restructure: bump `version` here and in `package.json`, and merging to
 
 ### Patch Changes
 
-- Four route inputs the twins accepted but their vendors do not declare are gone
-  from the twins' published input surface (F-1389). The GitHub twin no longer
-  declares `owner` on `POST /user/repos` (that surface creates a repository for
-  the authenticated user, and the body copy reached the domain) or `encoding` on
-  `PUT /contents/*`; the Slack twin no longer declares a singular `channel` on
-  `files.upload` (Slack takes `channels`, plural), and its domain no longer
-  falls back to it; the Stripe twin no longer accepts `created` on
-  `GET /v1/customers/:id/payment_methods`. **Only the Stripe one changes what a
-  caller is told** — that twin refuses undeclared inputs, matching Stripe, which
-  publishes `parameter_unknown` for exactly this parameter, so a request the
-  real API declines is now declined here too. GitHub and Slack ignore undeclared
-  inputs, so those three are discarded rather than refused, as on the real
-  vendors. No CLI source changed.
+- Eleven route inputs the twins accepted but their vendors do not declare are
+  gone from the twins' published input surface (F-1389). The GitHub twin no
+  longer declares `owner` on `POST /user/repos` (that surface creates a
+  repository for the authenticated user, and the body copy reached the domain),
+  `encoding` on `PUT /contents/*`, or `owner`/`repo`/`state` on `/search/code`,
+  `/search/commits` and `/search/issues`; the Slack twin no longer declares a
+  singular `channel` on `files.upload` (Slack takes `channels`, plural), and its
+  domain no longer falls back to it; the Stripe twin no longer accepts `created`
+  on `GET /v1/customers/:id/payment_methods`. **Only the Stripe one changes what
+  a caller is told** — that twin refuses undeclared inputs, matching Stripe,
+  which publishes `parameter_unknown` for exactly this parameter, so a request
+  the real API declines is now declined here too. GitHub and Slack ignore
+  undeclared inputs, so the rest are discarded rather than refused, as on the
+  real vendors. No CLI source changed.
+- The GitHub twin's three search routes now parse GitHub's scope qualifiers out
+  of `q` — `repo:owner/name`, `user:`, `org:`, and `state:` on `/search/issues`
+  (F-1389). This ships with the removal above rather than after it, because the
+  removal alone would have left the surface punishing correct requests: `q` was
+  matched as one substring, so `q=idempotency repo:acme/api` — the request
+  GitHub documents — answered ZERO, and dropping `?owner=`/`?repo=` without
+  teaching the twin the qualifier spelling would have left an agent with no way
+  to scope a search at all. Qualifiers this twin does not parse stay in the
+  free-text term rather than being dropped, so an unrecognised one narrows the
+  answer instead of widening it past what GitHub would return. ⚠️ `?state=` on
+  `/search/issues` is now ignored rather than filtering; the qualifier
+  `q=… state:closed` is the spelling that works. See the twin's FIDELITY.md
+  divergence 1 for exactly which qualifiers are parsed. No CLI source changed.
 
 ## 0.23.13
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.23.13",
+  "version": "0.23.14",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/packages/twin-github/CHANGELOG.md
+++ b/packages/twin-github/CHANGELOG.md
@@ -1,5 +1,28 @@
 # @pome-sh/twin-github — CHANGELOG
 
+## 0.10.6 — 2026-08-11
+
+Two route inputs GitHub does not declare come out of `route-inputs.ts` (F-1389).
+
+- `owner` off the `POST /user/repos` body. That surface creates a repository for
+  the AUTHENTICATED USER, which is its whole meaning, and
+  `repos/create-for-authenticated-user` declares 23 body properties without it.
+  `routes.ts` passed the body straight to `domain.createRepository`, so the one
+  surface defined not to take an owner could be made to create a repository
+  under an arbitrary one. It stays declared on `POST /orgs/:org/repos`, where
+  the handler overwrites it from the path and nothing observable differs.
+- `encoding` off `PUT /repos/:owner/:repo/contents/*`. GitHub declares `content`
+  as base64 and takes no `encoding` parameter.
+
+Both are now undeclared, so github's measured `ignore` disposition (F-1372)
+discards them instead of the handler acting on them. Neither is a 4xx: real
+GitHub answers 200 to a parameter it does not know.
+
+⚠️ `encoding`'s BEHAVIOURAL half is recorded, not fixed — the twin still treats
+`content` as plain text where GitHub treats it as base64. New FIDELITY.md
+divergence 24 says so, with the measurement that deferred it: 47 call sites send
+`content` and zero send base64, and the MCP door still declares `encoding`.
+
 
 ## 0.10.5 — 2026-08-11
 

--- a/packages/twin-github/CHANGELOG.md
+++ b/packages/twin-github/CHANGELOG.md
@@ -2,7 +2,48 @@
 
 ## 0.10.6 — 2026-08-11
 
-Two route inputs GitHub does not declare come out of `route-inputs.ts` (F-1389).
+Nine route inputs GitHub does not declare come out of `route-inputs.ts`, and
+the search routes learn the `q` qualifiers GitHub puts them in instead (F-1389).
+The published input surface goes 295 → 286.
+
+**`GET /search/code`, `/search/commits` and `/search/issues` take `q` and
+nothing but `q`.** GitHub's search API has ONE scoping input and encodes every
+filter as a qualifier inside it (`repo:octocat/hello-world`, `state:open`); its
+OpenAPI declares `q, sort, order, per_page, page`. This twin also took `?owner=`,
+`?repo=` and `?state=` — seven inputs across the three routes — and scoped by
+them, so the same request was scoped here and unscoped on GitHub.
+
+Both halves of that had to move together, because the second one is worse than
+the first. `q` was matched as ONE case-insensitive substring, so an agent writing
+the request GitHub actually documents:
+
+```
+GET /search/issues?q=idempotency repo:acme/api
+```
+
+got **zero results** — no issue's title or body contains that literal string.
+The surface did not merely let a wrong scoping habit pass; it punished the
+correct one, and deleting the three parameters alone would have left that
+standing. So `domain/search.ts` now lifts four qualifiers out of `q` —
+`repo:owner/name`, `user:login`, `org:login`, and `state:open|closed` on
+`/search/issues` — scopes by them, ORs several together the way GitHub does,
+and matches whatever free text is left as the substring term. The parser sits in
+the domain, so the MCP tools get it too.
+
+A qualifier this twin does not parse (`in:`, `language:`, `path:`, `is:`, a
+typo) stays in the free-text term rather than being dropped: dropping it would
+answer a BROADER set than GitHub for a request GitHub narrows, and breadth is
+the direction that scores a call the real API would not have served. Same for a
+recognised qualifier carrying a value the surface cannot honour — `repo:api`
+with no owner, `state:merged`. FIDELITY.md divergence 1 lists what is and is not
+parsed; `test/search-query-qualifiers.test.ts` pins it.
+
+⚠️ **`?state=` on `/search/issues` no longer filters.** It is ignored, not
+refused. A caller who relied on it gets the unfiltered answer — spell it
+`q=… state:closed` instead. Nothing changed about the absence of a `state=open`
+DEFAULT on that route (F-1427); only the spelling of the explicit filter moved.
+
+Two more, unrelated to search:
 
 - `owner` off the `POST /user/repos` body. That surface creates a repository for
   the AUTHENTICATED USER, which is its whole meaning, and
@@ -14,14 +55,20 @@ Two route inputs GitHub does not declare come out of `route-inputs.ts` (F-1389).
 - `encoding` off `PUT /repos/:owner/:repo/contents/*`. GitHub declares `content`
   as base64 and takes no `encoding` parameter.
 
-Both are now undeclared, so github's measured `ignore` disposition (F-1372)
-discards them instead of the handler acting on them. Neither is a 4xx: real
-GitHub answers 200 to a parameter it does not know.
+All nine are now undeclared, so github's measured `ignore` disposition (F-1372)
+discards them instead of the handler acting on them. None is a 4xx: real GitHub
+answers 200 to a parameter it does not know.
 
 ⚠️ `encoding`'s BEHAVIOURAL half is recorded, not fixed — the twin still treats
 `content` as plain text where GitHub treats it as base64. New FIDELITY.md
 divergence 24 says so, with the measurement that deferred it: 47 call sites send
 `content` and zero send base64, and the MCP door still declares `encoding`.
+
+The MCP door keeps `owner` / `repo` on `search_code` and `search_commits` and
+`state` on `search_issues`. Those are a separate published surface with their
+own frozen tool fixture, and they are left alone here on the same line the
+`encoding` amendment drew — the qualifier parser reaches both doors, so an MCP
+caller writing `repo:acme/api` inside `query` is served correctly either way.
 
 
 ## 0.10.5 — 2026-08-11

--- a/packages/twin-github/FIDELITY.md
+++ b/packages/twin-github/FIDELITY.md
@@ -50,14 +50,14 @@ in the package README. Changing any of those is a breaking change for
 | `search_repositories` | SQLite repositories | hot | semantic | `mcp-contract.test.ts`, `fixture-endpoints.test.ts` | Search query support is intentionally smaller than GitHub search syntax. |
 | `create_repository` | SQLite repositories, branches, commits, files | hot | semantic | `mcp-contract.test.ts`, `concurrency.test.ts` | Creates a deterministic README and main branch. |
 | `fork_repository` | SQLite repository/file/commit copy | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | Fork permissions and network metadata are simplified. |
-| `search_code` | SQLite default-branch files | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts`, `performance.test.ts` | Query syntax is substring based; search is scoped to the default branch. |
+| `search_code` | SQLite default-branch files | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts`, `performance.test.ts`, `search-query-qualifiers.test.ts` | Free text is substring based and scoped to the default branch; `repo:`/`user:`/`org:` are parsed, other qualifiers are not (divergence #1). |
 | `search_users` | SQLite users | hot | semantic | `mcp-contract.test.ts` | Organization/user scoring is simplified. |
 | `get_file_contents` | SQLite files/directories | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts`, `fixture-endpoints.test.ts` | Symlinks, submodules, and media/raw modes are not implemented. |
 | `list_commits` | SQLite commit graph | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts`, `fixture-endpoints.test.ts` | Commit listing follows the selected branch ancestry only. |
 | `create_or_update_file` | SQLite files/commits | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | Requires `sha` for updates to preserve optimistic locking. |
 | `create_branch` | SQLite branches/files | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts`, `concurrency.test.ts` | Branch protection is not modeled. |
 | `push_files` | SQLite files/commits | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | Multi-file pushes are one local commit; Git object APIs are simplified. |
-| `search_issues` | SQLite issues | hot | semantic | `mcp-contract.test.ts`, `performance.test.ts`, `fixture-endpoints.test.ts` | Query syntax is substring based. |
+| `search_issues` | SQLite issues | hot | semantic | `mcp-contract.test.ts`, `performance.test.ts`, `fixture-endpoints.test.ts`, `search-query-qualifiers.test.ts` | Free text is substring based; `repo:`/`user:`/`org:`/`state:` are parsed, other qualifiers are not (divergence #1). No `state=open` default, deliberately (F-1427). |
 | `list_issues` | SQLite issues | hot | semantic | `mcp-contract.test.ts`, `performance.test.ts`, `fixture-endpoints.test.ts`, `list-state-default.test.ts` | Only state, labels, assignee, and pagination filters are supported. An absent `state` means `open`, as on real GitHub (F-1427). |
 | `add_issue_comment` | SQLite issue comments | hot | semantic | `mcp-contract.test.ts`, `state-export.test.ts` | Comment edit/delete APIs are not implemented. |
 | `create_issue` | SQLite issues | hot | semantic | `mcp-contract.test.ts` | Issue templates and milestones are not modeled. |
@@ -75,7 +75,7 @@ in the package README. Changing any of those is a breaking change for
 | `list_releases` | SQLite releases | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | Newest-first; includes drafts and prereleases. |
 | `get_latest_release` | SQLite releases | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | Skips drafts and prereleases; 404 if none. |
 | `get_me` | SQLite users + JWT actor | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | Returns the JWT-claimed `login` (default `pome-agent`). |
-| `search_commits` | SQLite commit graph (default branches) | hot | semantic | `mcp-contract.test.ts`, `m5-hot-gaps.test.ts` | Substring match over commit message/author on default-branch ancestry; GitHub search qualifiers are not parsed. |
+| `search_commits` | SQLite commit graph (default branches) | hot | semantic | `mcp-contract.test.ts`, `m5-hot-gaps.test.ts`, `search-query-qualifiers.test.ts` | Substring match over commit message/author on default-branch ancestry; `repo:`/`user:`/`org:` are parsed, other qualifiers are not (divergence #1). |
 | `get_release_by_tag` | SQLite releases | hot | semantic | `mcp-contract.test.ts`, `m5-hot-gaps.test.ts` | 404 for unknown tag. |
 | `get_tag` | SQLite tags | hot | semantic | `mcp-contract.test.ts`, `m5-hot-gaps.test.ts` | MCP-only (no REST route; git-plumbing REST stays cold per F-729); returns the lightweight tag object, not the annotated-tag git object. |
 | `issue_read` | SQLite issues, issue comments, issue labels | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | GitHub's consolidated reader (F-1376). Methods `get`, `get_comments`, `get_labels`; `get_sub_issues` and `get_parent` answer 501 — sub-issues are not modeled. |
@@ -137,13 +137,21 @@ issue, as `[].state` constant-mismatch and `[].closed_at` type-changed against
 real GitHub, both CRITICAL.
 
 `GET /search/issues` is deliberately NOT part of this. GitHub's search API has no
-`state` default — `is:open` is a query qualifier, not a default — so the twin's
-search keeps filtering only on an explicit `state`. Imposing the list default
+`state` default — state is a query qualifier, not a default — so the twin's
+search keeps filtering only on an explicit state. Imposing the list default
 there would be a new divergence in the other direction, and a worse one: the
 twin's search is substring matching over the seeded world, so a query whose only
 match is closed would answer `[]`, replacing a value mismatch with an
 empty-array one. Any residual `state` / `closed_at` finding on `/search/issues`
 is a property of that surface's upstream comparison, not of this default.
+
+Where that explicit state is SPELLED moved in 0.10.6 (F-1389): it is a `q`
+qualifier, `?q=idempotency state:closed`, not a `?state=` query parameter.
+GitHub's search API declares `q, sort, order, per_page, page` and encodes every
+filter inside `q`, so `?state=` came off this route's declaration and is now
+discarded like any other input GitHub does not declare — it is ignored, not
+refused. The absence of a default is unchanged; only the spelling of the filter
+moved.
 
 Seeding the closed side of these surfaces works now, too: `seedSchema` had
 accepted `pull_requests[].state` for as long as the field existed while
@@ -196,10 +204,21 @@ the Twin Fidelity Watch's `known-divergences/github.yaml` (maintained in
 pome-cloud); a lint keeps the two 1:1. The fidelity watchdog reverse-tests each one against
 upstream so a divergence that upstream "heals" becomes a tier-upgrade signal.
 
-1. **Search query syntax is substring-based.** `search_repositories`,
-   `search_code`, and `search_issues` use substring matching scoped to the
-   default branch — GitHub's search qualifiers (`in:`, `language:`, `path:`,
-   boolean operators) are not parsed.
+1. **Search query syntax is substring-based.** The free text left in `q` is
+   matched as one case-insensitive substring, scoped to the default branch —
+   not as GitHub's ranked, tokenised, boolean-aware index. Four SCOPE
+   qualifiers are lifted out of `q` and honoured on `/search/code`,
+   `/search/commits` and `/search/issues` (F-1389): `repo:owner/name`,
+   `user:login`, `org:login`, and `state:open|closed` on `/search/issues` only,
+   several of them OR-ing together the way GitHub's do. Everything else GitHub
+   has — `in:`, `language:`, `path:`, `is:`, `label:`, `author:`, the boolean
+   operators — is **not parsed**, and an unparsed qualifier stays in the
+   free-text term rather than being dropped, so it narrows the answer to nothing
+   instead of silently widening it past what GitHub would return. Three further
+   simplifications, each deliberate: `user:` and `org:` both resolve to the
+   repository's owner login with no account-type check; `search_repositories`
+   and `search_users` parse no qualifiers at all and still match the whole `q`;
+   and quoted qualifier values (`repo:"a/b"`) are not unquoted.
 2. **PR diffs and patches are simplified placeholders.** `get_pull_request_diff`
    and `get_pull_request_files` return a unified-diff-shaped envelope whose
    `patch` bodies are placeholders, not byte-accurate GitHub patches.
@@ -567,8 +586,8 @@ the declaration with, and
 [`scripts/lint-route-input-declarations.mjs`](../../scripts/lint-route-input-declarations.mjs)
 fails the build if any module a route registrar reaches reads one imperatively.
 
-**This twin declares 295 inputs across 65 published surfaces**
-(157 path, 56 query, 82 body), 182 of them required. Each carries its name, location,
+**This twin declares 286 inputs across 65 published surfaces**
+(157 path, 49 query, 80 body), 182 of them required. Each carries its name, location,
 requiredness and best-effort type, all *derived from the schemas that validate* —
 requiredness by asking the validator whether the input may be absent, and type by
 way of JSON Schema. Nothing here is hand-written, so nothing here can drift from
@@ -608,6 +627,33 @@ the exam recorded a failure the agent did not commit.
 
 Nothing above this heading changes. The handler still sees only what the
 declaration names — `parse()` returns declared names and nothing else in either
-disposition — and the 295 published inputs are byte-identical, so what this
+disposition — and the 286 published inputs are byte-identical, so what this
 twin is short of GitHub's real surface is still the declared-fidelity lane's
 finding to report. The disposition decides only what the CALLER is told.
+
+### Nine inputs GitHub does not declare, removed (F-1389)
+
+The declared lane compares in both directions, and the direction that had gone
+unmeasured was ours: inputs this twin ACCEPTED that GitHub's OpenAPI does not
+declare. Nine came off in 0.10.6, taking the published surface from 295 to 286.
+
+- **`owner` on the `POST /user/repos` body.** That surface creates a repository
+  for the authenticated user, which is its whole meaning, and
+  `repos/create-for-authenticated-user` declares 23 body properties without it.
+  It stays declared on `POST /orgs/:org/repos`, where the handler overwrites it
+  from the path and nothing observable differs.
+- **`encoding` on `PUT /repos/:owner/:repo/contents/*`.** GitHub declares
+  `content` as base64 and takes no encoding switch. The BEHAVIOURAL half of that
+  finding is deferred and recorded as divergence 24, not fixed here.
+- **`owner`, `repo` and `state` on `/search/code`, `/search/commits` and
+  `/search/issues`** — seven inputs across three routes. GitHub's search API
+  takes one scoping input, `q`, and encodes every filter as a qualifier inside
+  it; its OpenAPI declares `q, sort, order, per_page, page`. The scoping moved
+  into `q` in the same change rather than simply disappearing — see divergence 1
+  for which qualifiers are parsed and which are not, and
+  `test/search-query-qualifiers.test.ts` for the behaviour.
+
+All nine are now undeclared, which under the `ignore` ruling above means
+discarded rather than refused: a request still sending one gets the answer it
+would have got without it, the way real GitHub answers. None of the three
+surfaces 4xx's.

--- a/packages/twin-github/FIDELITY.md
+++ b/packages/twin-github/FIDELITY.md
@@ -453,6 +453,30 @@ upstream so a divergence that upstream "heals" becomes a tier-upgrade signal.
     until F-1430 was an empty `check_runs` array diffed against the twin's empty
     one, which published green while binding no key, no leaf type and no element.
 
+24. **`PUT /contents/*` treats `content` as plain text; GitHub treats it as
+    base64.** GitHub declares `content` as "the new file content, using Base64
+    encoding" — base64 is the only encoding the surface has. This twin writes
+    `content` through verbatim unless an `encoding: "base64"` flag asks it not
+    to, so the same request writes readable text here and base64-decoded garbage
+    on GitHub. An agent cannot see the difference until it reads the file back
+    from the real API.
+
+    The *declared* half of this is fixed: F-1389 removed `encoding` from
+    `route-inputs.ts`, so the twin no longer advertises a parameter GitHub does
+    not have, and github's `ignore` disposition discards it if sent. What
+    remains is the behaviour, and it is recorded rather than fixed in that PR
+    for a measured reason: **47 call sites send `content`, and zero of them send
+    base64** — the default seed, `config/twin-endpoint-probes.json`, and the
+    whole twin-github suite among them. Flipping the decode is a result-moving
+    change for every existing task, so it carries its own migration.
+
+    It is also wider than this route. The MCP door — `create_or_update_file` and
+    `push_files` — still declares `encoding` in its tool schema, and that is the
+    door an examinee actually calls; a REST-only decode would migrate all 47
+    sites while leaving the reachable path unchanged. So the fix is one change
+    across both doors, with the fixture regeneration and saved-task audit that
+    implies, tracked separately.
+
 ## How fidelity is verified
 
 Three independent checks back the tier classifications above. Each is a

--- a/packages/twin-github/FIDELITY_MATRIX.md
+++ b/packages/twin-github/FIDELITY_MATRIX.md
@@ -65,9 +65,9 @@ Last verified: 2026-08-08
 | `POST /repos/:owner/:repo/releases` | warm | semantic | Auto-creates tag from `target_commitish` if missing. |
 | `GET /user` | hot | semantic | Returns JWT-claimed `login`. |
 | `GET /search/repositories` | hot | semantic | Searches clone state. Result-set counts reflect the local seed, not GitHub's global index (divergence #18). |
-| `GET /search/code` | hot | semantic | Searches clone state (divergence #18). |
-| `GET /search/commits` | hot | semantic | Searches clone state; added by F-735 (divergence #18). |
-| `GET /search/issues` | hot | semantic | Searches clone state (divergence #18). |
+| `GET /search/code` | hot | semantic | Searches clone state (divergence #18). Takes `q` only; `repo:`/`user:`/`org:` are parsed out of it, other qualifiers are not (divergence #1, F-1389). |
+| `GET /search/commits` | hot | semantic | Searches clone state; added by F-735 (divergence #18). Takes `q` only; `repo:`/`user:`/`org:` are parsed out of it (divergence #1, F-1389). |
+| `GET /search/issues` | hot | semantic | Searches clone state (divergence #18). Takes `q` only; `repo:`/`user:`/`org:`/`state:` are parsed out of it and `?state=` is ignored (divergence #1, F-1389). No `state=open` default (F-1427). |
 | `GET /search/users` | hot | semantic | Searches clone state; `type` is not modelled (divergence #15, #18). |
 | `POST /mcp/call` and `POST /mcp/tools/:name` | unclassified | semantic | MCP tools mutate the same state as REST routes. Engine introspection — outside the rubric's inventory scope; rows retained until the post-F-440 surface-count reconcile. |
 | `GET /repos/:owner/:repo/actions/*` | cold | unsupported | Named cold (F-729): loud 501, test-backed (`m5-hot-gaps.test.ts`); top post-M5 promotion candidate. |

--- a/packages/twin-github/package.json
+++ b/packages/twin-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-github",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Deterministic GitHub-shaped twin for agent testing — REST + MCP, SQLite-backed state.",
   "private": true,
   "type": "module",

--- a/packages/twin-github/route-inputs.json
+++ b/packages/twin-github/route-inputs.json
@@ -7,7 +7,7 @@
     "packages/twin-github/src/route-inputs.ts"
   ],
   "surface_count": 65,
-  "input_count": 293,
+  "input_count": 286,
   "surfaces": [
     {
       "method": "DELETE",
@@ -1046,12 +1046,6 @@
       "surface": "GET /search/code",
       "inputs": [
         {
-          "name": "owner",
-          "location": "query",
-          "required": false,
-          "type": "string"
-        },
-        {
           "name": "page",
           "location": "query",
           "required": false,
@@ -1065,12 +1059,6 @@
         },
         {
           "name": "q",
-          "location": "query",
-          "required": false,
-          "type": "string"
-        },
-        {
-          "name": "repo",
           "location": "query",
           "required": false,
           "type": "string"
@@ -1083,12 +1071,6 @@
       "surface": "GET /search/commits",
       "inputs": [
         {
-          "name": "owner",
-          "location": "query",
-          "required": false,
-          "type": "string"
-        },
-        {
           "name": "page",
           "location": "query",
           "required": false,
@@ -1102,12 +1084,6 @@
         },
         {
           "name": "q",
-          "location": "query",
-          "required": false,
-          "type": "string"
-        },
-        {
-          "name": "repo",
           "location": "query",
           "required": false,
           "type": "string"
@@ -1120,12 +1096,6 @@
       "surface": "GET /search/issues",
       "inputs": [
         {
-          "name": "owner",
-          "location": "query",
-          "required": false,
-          "type": "string"
-        },
-        {
           "name": "page",
           "location": "query",
           "required": false,
@@ -1139,18 +1109,6 @@
         },
         {
           "name": "q",
-          "location": "query",
-          "required": false,
-          "type": "string"
-        },
-        {
-          "name": "repo",
-          "location": "query",
-          "required": false,
-          "type": "string"
-        },
-        {
-          "name": "state",
           "location": "query",
           "required": false,
           "type": "string"

--- a/packages/twin-github/route-inputs.json
+++ b/packages/twin-github/route-inputs.json
@@ -7,7 +7,7 @@
     "packages/twin-github/src/route-inputs.ts"
   ],
   "surface_count": 65,
-  "input_count": 295,
+  "input_count": 294,
   "surfaces": [
     {
       "method": "DELETE",
@@ -2064,12 +2064,6 @@
           "name": "name",
           "location": "body",
           "required": true,
-          "type": "string"
-        },
-        {
-          "name": "owner",
-          "location": "body",
-          "required": false,
           "type": "string"
         },
         {

--- a/packages/twin-github/route-inputs.json
+++ b/packages/twin-github/route-inputs.json
@@ -7,7 +7,7 @@
     "packages/twin-github/src/route-inputs.ts"
   ],
   "surface_count": 65,
-  "input_count": 294,
+  "input_count": 293,
   "surfaces": [
     {
       "method": "DELETE",
@@ -2138,12 +2138,6 @@
           "name": "content",
           "location": "body",
           "required": true,
-          "type": "string"
-        },
-        {
-          "name": "encoding",
-          "location": "body",
-          "required": false,
           "type": "string"
         },
         {

--- a/packages/twin-github/src/domain/search.ts
+++ b/packages/twin-github/src/domain/search.ts
@@ -65,6 +65,99 @@ import type { GitHubDomain } from "./github-domain.js";
 import type { FileChange, MutatingOptions, PageOptions, StateDeltaCallback } from "./types.js";
 
 
+/**
+ * F-1389 — GitHub's search API takes ONE scoping input, `q`, and encodes every
+ * filter as a qualifier inside it. Its OpenAPI declares `q, sort, order,
+ * per_page, page` and nothing else.
+ *
+ * This twin used to take `?owner=`, `?repo=` and `?state=` alongside `q` and
+ * scope by them, which is two failures rather than one. The named one is that
+ * an agent taught to scope a search that way passes the exam and fails in
+ * production. The MIRROR is worse and is what makes this a parser rather than a
+ * deletion: the free-text match ran against the WHOLE `q` string, so an agent
+ * writing the request GitHub actually documents — `q=idempotency repo:acme/api`
+ * — got zero results, because no issue's title or body contains that literal
+ * string. The surface did not merely let a wrong habit pass; it punished the
+ * correct one, and dropping the three parameters alone would have left that
+ * standing.
+ *
+ * Four qualifiers are lifted out. Everything else GitHub has — `in:`,
+ * `language:`, `path:`, `is:`, the boolean operators — stays in the free-text
+ * term (FIDELITY.md divergence 1).
+ */
+const QUALIFIER = /(^|\s)(repo|user|org|state):(\S+)/gi;
+
+interface ParsedSearchQuery {
+  /** What is left of `q` once the qualifiers are lifted out, lowercased. */
+  readonly text: string;
+  /** `user:` / `org:` values — repository owner logins, lowercased. */
+  readonly owners: readonly string[];
+  /** `repo:` values — repository FULL names (`owner/name`), lowercased. */
+  readonly fullNames: readonly string[];
+  /** `state:`, on the surfaces that have one. */
+  readonly state?: "open" | "closed";
+}
+
+/**
+ * `q` split into the scope it names and the text it searches for.
+ *
+ * An unrecognised qualifier is left in the term rather than dropped, and so is
+ * a recognised one carrying a value the surface cannot honour (`repo:api` with
+ * no owner, `state:merged`). Both choices point the same way: a qualifier this
+ * twin discarded would answer a BROADER set than GitHub for a request GitHub
+ * narrows, and breadth is the direction that scores a call the real API would
+ * not have served. Narrowing is the safe failure.
+ *
+ * `state` is a qualifier only where the surface has one — `/search/issues`.
+ * Lifting `state:` out of a code search would filter by nothing and widen the
+ * answer for the same reason.
+ */
+function parseSearchQuery(raw: string, options: { state?: boolean } = {}): ParsedSearchQuery {
+  const owners: string[] = [];
+  const fullNames: string[] = [];
+  let state: "open" | "closed" | undefined;
+  const text = raw.replace(QUALIFIER, (whole, lead: string, key: string, rawValue: string) => {
+    const value = rawValue.toLowerCase();
+    switch (key.toLowerCase()) {
+      case "repo":
+        // GitHub's `repo:` names a repository in full. A bare name is not a
+        // scope it would honour, so it is not one here either.
+        if (!value.includes("/")) return whole;
+        fullNames.push(value);
+        return lead;
+      case "user":
+      case "org":
+        // Both resolve to the repository's owner login, with no account-type
+        // check — GitHub documents `org:` for organizations and `user:` for
+        // accounts, and this twin does not tell them apart. Refusing
+        // `user:<an org>` would answer `[]` to a request real GitHub serves,
+        // which is this ticket's own failure pointed the other way.
+        owners.push(value);
+        return lead;
+      case "state":
+        if (!options.state || (value !== "open" && value !== "closed")) return whole;
+        state = value;
+        return lead;
+      default:
+        return whole;
+    }
+  });
+  return { text: text.replace(/\s+/g, " ").trim().toLowerCase(), owners, fullNames, state };
+}
+
+/**
+ * Whether a repository is in `q`'s scope. Several scope qualifiers OR together,
+ * the way GitHub's do — `repo:a/b user:c` is everything in `a/b` plus
+ * everything `c` owns, not the empty intersection.
+ */
+function inScope(parsed: ParsedSearchQuery, owner: string, fullName: string): boolean {
+  if (parsed.owners.length === 0 && parsed.fullNames.length === 0) return true;
+  return (
+    parsed.fullNames.includes(fullName.toLowerCase()) || parsed.owners.includes(owner.toLowerCase())
+  );
+}
+
+
 export function searchRepositories(domain: GitHubDomain, input: { query?: string; q?: string } & PageOptions) {
   const query = (input.query ?? input.q ?? "").toLowerCase();
   const repos = (domain.db.prepare("SELECT * FROM repositories ORDER BY full_name ASC").all() as RepoRow[]).filter(
@@ -83,8 +176,16 @@ export function searchUsers(domain: GitHubDomain, input: { query?: string; q?: s
 }
 
 
+/**
+ * `owner` / `repo` survive on the DOMAIN signature after F-1389 took them off
+ * the REST declaration, because the MCP door still declares them on
+ * `search_code` and `search_commits`. That door is a separate published surface
+ * with its own frozen tool fixture, and it is out of this ticket's scope on the
+ * same line the `encoding` amendment drew — the qualifier parser below reaches
+ * both doors, so the behaviour half is fixed for MCP callers regardless.
+ */
 export function searchCode(domain: GitHubDomain, input: { query?: string; q?: string; owner?: string; repo?: string } & PageOptions) {
-  const query = (input.query ?? input.q ?? "").toLowerCase();
+  const parsed = parseSearchQuery(input.query ?? input.q ?? "");
   let rows = domain.db
     .prepare(
       "SELECT files.*, repositories.owner, repositories.name, repositories.full_name, repositories.description, repositories.private, repositories.default_branch, repositories.fork, repositories.parent_full_name, repositories.entity_counter, repositories.created_at, repositories.updated_at FROM files INNER JOIN repositories ON files.repo_id = repositories.id WHERE files.branch = repositories.default_branch ORDER BY repositories.full_name, files.path"
@@ -92,7 +193,8 @@ export function searchCode(domain: GitHubDomain, input: { query?: string; q?: st
     .all() as Array<FileRow & RepoRow>;
   if (input.owner) rows = rows.filter((row) => row.owner === input.owner);
   if (input.repo) rows = rows.filter((row) => row.name === input.repo);
-  rows = rows.filter((row) => !query || row.path.toLowerCase().includes(query) || row.content.toLowerCase().includes(query));
+  rows = rows.filter((row) => inScope(parsed, row.owner, row.full_name));
+  rows = rows.filter((row) => !parsed.text || row.path.toLowerCase().includes(parsed.text) || row.content.toLowerCase().includes(parsed.text));
   return {
     total_count: rows.length,
     incomplete_results: false,
@@ -110,16 +212,17 @@ export function searchCode(domain: GitHubDomain, input: { query?: string; q?: st
 
 
 export function searchCommits(domain: GitHubDomain, input: { query?: string; q?: string; owner?: string; repo?: string } & PageOptions) {
-  const query = (input.query ?? input.q ?? "").toLowerCase();
+  const parsed = parseSearchQuery(input.query ?? input.q ?? "");
   let repos = domain.db.prepare("SELECT * FROM repositories ORDER BY full_name ASC").all() as RepoRow[];
   if (input.owner) repos = repos.filter((repo) => repo.owner === input.owner);
   if (input.repo) repos = repos.filter((repo) => repo.name === input.repo);
+  repos = repos.filter((repo) => inScope(parsed, repo.owner, repo.full_name));
   const matches: Array<{ commit: CommitRow; repo: RepoRow }> = [];
   for (const repo of repos) {
     const branch = domain.db.prepare("SELECT * FROM branches WHERE repo_id = ? AND name = ?").get(repo.id, repo.default_branch) as BranchRow | undefined;
     if (!branch?.head_sha) continue;
     for (const commit of domain.commitAncestry(repo.id, branch.head_sha)) {
-      if (!query || commit.message.toLowerCase().includes(query) || commit.author_login.toLowerCase().includes(query)) matches.push({ commit, repo });
+      if (!parsed.text || commit.message.toLowerCase().includes(parsed.text) || commit.author_login.toLowerCase().includes(parsed.text)) matches.push({ commit, repo });
     }
   }
   return {
@@ -131,23 +234,30 @@ export function searchCommits(domain: GitHubDomain, input: { query?: string; q?:
 
 
 export function searchIssues(domain: GitHubDomain, input: { query?: string; q?: string; owner?: string; repo?: string; state?: "open" | "closed" | "all" } & PageOptions) {
-  const query = (input.query ?? input.q ?? "").toLowerCase();
+  const parsed = parseSearchQuery(input.query ?? input.q ?? "", { state: true });
   const rows = domain.db
     .prepare(
       "SELECT issues.*, repositories.owner, repositories.name, repositories.full_name, repositories.description, repositories.private, repositories.default_branch, repositories.fork, repositories.parent_full_name, repositories.entity_counter, repositories.created_at AS repo_created_at, repositories.updated_at AS repo_updated_at FROM issues INNER JOIN repositories ON issues.repo_id = repositories.id ORDER BY issues.updated_at DESC"
     )
     .all() as Array<IssueRow & { owner: string; name: string; full_name: string; description: string; private: 0 | 1; default_branch: string; fork: 0 | 1; parent_full_name: string | null; entity_counter: number; repo_created_at: string; repo_updated_at: string }>;
-  let filtered = rows.filter((issue) => !query || issue.title.toLowerCase().includes(query) || issue.body.toLowerCase().includes(query) || issue.full_name.toLowerCase().includes(query));
+  let filtered = rows.filter((issue) => !parsed.text || issue.title.toLowerCase().includes(parsed.text) || issue.body.toLowerCase().includes(parsed.text) || issue.full_name.toLowerCase().includes(parsed.text));
+  filtered = filtered.filter((issue) => inScope(parsed, issue.owner, issue.full_name));
   if (input.owner) filtered = filtered.filter((issue) => issue.owner === input.owner);
   if (input.repo) filtered = filtered.filter((issue) => issue.name === input.repo);
   // NO `state=open` default here, deliberately (F-1427). The three repo LIST
   // surfaces gained one because real GitHub defaults them; GitHub's SEARCH API
-  // does not — a search returns what the query asks for, and `is:open` is a
+  // does not — a search returns what the query asks for, and `state:open` is a
   // query qualifier, not a default. Adding one to match the lists would be a new
   // divergence in the other direction, and a worse one: this search is substring
   // matching over the seeded world, so any query whose only match is closed would
   // answer `[]` — an empty-array divergence in place of a value one.
-  if (input.state && input.state !== "all") filtered = filtered.filter((issue) => issue.state === input.state);
+  //
+  // `state:` in `q` is GitHub's own spelling and wins over `input.state`, which
+  // only an MCP caller can still set (F-1389 took `?state=` off the REST
+  // declaration). A request naming both has already contradicted itself; the
+  // qualifier is the half GitHub would have read.
+  const state = parsed.state ?? (input.state === "all" ? undefined : input.state);
+  if (state) filtered = filtered.filter((issue) => issue.state === state);
   return {
     total_count: filtered.length,
     incomplete_results: false,

--- a/packages/twin-github/src/route-inputs.ts
+++ b/packages/twin-github/src/route-inputs.ts
@@ -90,6 +90,22 @@ const commentBody = { body: z.string().min(1) };
 
 export const GITHUB_ROUTES = {
   // ----- search -----
+  //
+  // GH-DECL-IN-001 / GH-DECL-IN-002 (F-1389) — all five take `q` and nothing but
+  // `q`. GitHub's search API has ONE scoping input and encodes every filter as a
+  // qualifier inside it (`repo:octocat/hello-world`, `state:open`); its OpenAPI
+  // declares `q, sort, order, per_page, page`. `/search/code`,
+  // `/search/commits` and `/search/issues` used to declare `owner` / `repo`
+  // (and `state`) alongside and scope by them, so the same request was scoped
+  // here and unscoped on GitHub.
+  //
+  // They are undeclared rather than refused, per github's measured `ignore`
+  // ruling — a request still sending them gets the answer it would have got
+  // without them, which is what real GitHub does. The scoping moved into `q`:
+  // `domain/search.ts` parses `repo:` / `user:` / `org:` / `state:` out of it.
+  // Both halves had to land together — deleting the parameters alone would have
+  // left `q=idempotency repo:acme/api` still answering zero, which is the
+  // mirror defect and the worse one.
   searchRepositories: declareInputs({
     method: "GET",
     path: "/search/repositories",
@@ -98,23 +114,12 @@ export const GITHUB_ROUTES = {
   searchCode: declareInputs({
     method: "GET",
     path: "/search/code",
-    query: {
-      q: z.string().optional(),
-      owner: z.string().optional(),
-      repo: z.string().optional(),
-      ...pageQuery,
-    },
+    query: { q: z.string().optional(), ...pageQuery },
   }),
   searchIssues: declareInputs({
     method: "GET",
     path: "/search/issues",
-    query: {
-      q: z.string().optional(),
-      owner: z.string().optional(),
-      repo: z.string().optional(),
-      state: stateFilter,
-      ...pageQuery,
-    },
+    query: { q: z.string().optional(), ...pageQuery },
   }),
   searchUsers: declareInputs({
     method: "GET",
@@ -124,12 +129,7 @@ export const GITHUB_ROUTES = {
   searchCommits: declareInputs({
     method: "GET",
     path: "/search/commits",
-    query: {
-      q: z.string().optional(),
-      owner: z.string().optional(),
-      repo: z.string().optional(),
-      ...pageQuery,
-    },
+    query: { q: z.string().optional(), ...pageQuery },
   }),
 
   // ----- repositories -----

--- a/packages/twin-github/src/route-inputs.ts
+++ b/packages/twin-github/src/route-inputs.ts
@@ -142,15 +142,22 @@ export const GITHUB_ROUTES = {
     method: "POST",
     path: "/user/repos",
     bodyEncoding: "json",
-    body: { ...repositoryBody, owner: z.string().min(1).optional() },
+    // F-1389 (GH-DECL-IN-003) — no `owner`. This surface creates a repository
+    // for the AUTHENTICATED USER, which is its whole meaning;
+    // `repos/create-for-authenticated-user` declares 23 body properties and
+    // `owner` is not one. `routes.ts` passed the body straight to
+    // `domain.createRepository`, so the one surface defined not to take an
+    // owner could be made to create a repository under an arbitrary one.
+    // Undeclared now, so `parse()` never hands it to the handler, and github's
+    // measured disposition (`ignore`) discards it rather than 422-ing a request
+    // real GitHub accepts and ignores.
+    body: { ...repositoryBody },
   }),
-  // `owner` is declared in BOTH locations, because the twin accepts it in both.
-  //
-  // The handler spreads the body schema and then overwrites `owner` with the
-  // path value, so the body copy is read and discarded. Declaring only the path
-  // one would turn that into a 422 for a request the twin has always accepted —
-  // a divergence this ticket invented rather than found. The declaration records
-  // what is true: two locations, one of which the handler ignores.
+  // `owner` stays declared on the ORG surface, and the contrast is the whole
+  // argument: there the handler overwrites it with the path value, so the body
+  // copy is read and discarded and nothing observable differs. That one is
+  // registered `accepted` (GH-DECL-IN-004); the `/user/repos` one above was
+  // registered `open-defect` because there the body copy reached the domain.
   createOrgRepository: declareInputs({
     method: "POST",
     path: "/orgs/:owner/repos",

--- a/packages/twin-github/src/route-inputs.ts
+++ b/packages/twin-github/src/route-inputs.ts
@@ -196,7 +196,15 @@ export const GITHUB_ROUTES = {
       content: z.string(),
       branch: z.string().optional(),
       sha: z.string().optional(),
-      encoding: z.enum(["utf-8", "base64"]).optional(),
+      // F-1389 (GH-DECL-IN-005) — no `encoding`. GitHub declares `content` as
+      // "the new file content, using Base64 encoding" and takes no `encoding`
+      // parameter: base64 is the only encoding this surface has. Undeclared
+      // now, so github's measured disposition (`ignore`) discards it.
+      //
+      // ⚠️ This closes the DECLARED drift, not the behavioural one. The twin
+      // still treats `content` as plain text rather than base64 — recorded as
+      // divergence 24, and unified across both doors in the follow-up ticket
+      // that owns the 47-call-site migration.
     },
   }),
   listCommits: declareInputs({

--- a/packages/twin-github/test/list-state-default.test.ts
+++ b/packages/twin-github/test/list-state-default.test.ts
@@ -30,11 +30,20 @@
 //
 // `GET /search/issues` is the deliberate exception and is asserted as one.
 // GitHub's search API has no `state=open` default — a search returns what the
-// query asks for — so `searchIssues` keeps filtering only on an explicit
-// `state`. That is not an oversight the next reader should "fix": the twin's
-// search is substring-based over the seeded world, so imposing an open default
-// would answer `[]` for any query whose only match is closed, turning a
-// value mismatch into an empty-array divergence in the other direction.
+// query asks for — so `searchIssues` keeps filtering only on an explicit state.
+// That is not an oversight the next reader should "fix": the twin's search is
+// substring-based over the seeded world, so imposing an open default would
+// answer `[]` for any query whose only match is closed, turning a value
+// mismatch into an empty-array divergence in the other direction.
+//
+// Where that explicit state is SPELLED moved in F-1389: `state` is a `q`
+// qualifier (`q=idempotency state:closed`), not a query parameter. GitHub's
+// search API declares `q, sort, order, per_page, page` and encodes every filter
+// inside `q`, so `?state=` came off the declaration and is now discarded like
+// any other input GitHub does not declare. Both spellings are asserted below —
+// the qualifier because it is the one that filters, and the parameter because
+// "ignored" is a claim about what the twin SERVES, not only about what it
+// declares. `search-query-qualifiers.test.ts` covers the rest of that move.
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createGitHubCloneApp } from "../src/twin.js";
@@ -184,9 +193,20 @@ describe("list surfaces default `state` to open, the way real GitHub does (F-142
       expect(await searchNumbers("/search/issues?q=idempotency")).toEqual([CLOSED_ISSUE]);
     });
 
-    it("still honours an explicit `state`", async () => {
-      expect(await searchNumbers("/search/issues?q=idempotency&state=closed")).toEqual([CLOSED_ISSUE]);
-      expect(await searchNumbers("/search/issues?q=idempotency&state=open")).toEqual([]);
+    it("still honours an explicit state, now spelled as a `q` qualifier (F-1389)", async () => {
+      expect(await searchNumbers("/search/issues?q=idempotency state:closed")).toEqual([CLOSED_ISSUE]);
+      expect(await searchNumbers("/search/issues?q=idempotency state:open")).toEqual([]);
+    });
+
+    it("ignores `?state=`, which GitHub's search API does not declare (F-1389)", async () => {
+      // The parameter is gone from the declaration, and github's measured
+      // undeclared disposition is `ignore` — so this is not a 4xx, it is the
+      // same answer as without it. Asserted against `state=open`, the value
+      // that USED to change the answer: a twin still scoping by the parameter
+      // would answer `[]` here and fail loudly.
+      const unfiltered = await searchNumbers("/search/issues?q=idempotency");
+      expect(await searchNumbers("/search/issues?q=idempotency&state=open")).toEqual(unfiltered);
+      expect(await searchNumbers("/search/issues?q=idempotency&state=closed")).toEqual(unfiltered);
     });
   });
 });

--- a/packages/twin-github/test/search-query-qualifiers.test.ts
+++ b/packages/twin-github/test/search-query-qualifiers.test.ts
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-1389 — GitHub's search API takes ONE scoping input, `q`, and encodes every
+// filter as a qualifier inside it (`repo:octocat/hello-world`, `state:open`).
+// Its OpenAPI declares `q, sort, order, per_page, page` and nothing else.
+//
+// This twin used to take `?owner=`, `?repo=` and `?state=` as query parameters
+// on `/search/code`, `/search/commits` and `/search/issues` and scope by them
+// (GH-DECL-IN-001, GH-DECL-IN-002). Deleting those three declarations alone
+// would have been the smaller half of the fix, and on its own it would have
+// left the surface worse than it looks: `searchIssues` matched the WHOLE `q`
+// string as a case-insensitive substring, so an agent writing the request
+// GitHub actually documents —
+//
+//     GET /search/issues?q=idempotency repo:acme/api
+//
+// — got ZERO results here, because no issue's title or body contains that
+// literal string. The surface did not merely let a wrong scoping habit pass; it
+// PUNISHED the correct one. Both halves therefore land together: the qualifiers
+// are parsed out of `q` and scoped by, and the three query parameters are gone
+// from the declaration.
+//
+// Every assertion below compares a SET of results, never a count — the
+// discipline `list-state-default.test.ts` sets out and the reason for it: a
+// count matches for the wrong reason as easily as the right one. Results are
+// keyed by `full_name` AND number/path, because issue numbers are drawn from a
+// PER-REPO counter, so "issue #1" names three different issues in this world.
+//
+// The world seeds THREE repositories under three different owners, two of them
+// sharing the repository name `api`. Both facts are load-bearing: a `repo:`
+// scope has to be shown EXCLUDING the other repositories, and `repo:acme/api`
+// has to be shown resolving on the full name rather than on `api`.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createGitHubCloneApp } from "../src/twin.js";
+import type { GitHubStateSeed } from "../src/types.js";
+import { TEST_AUTH_SECRET, TEST_SID, signTestToken, withAuth } from "./_authHelper.js";
+
+const previousSecret = process.env.TWIN_AUTH_SECRET;
+let token: string;
+
+beforeAll(async () => {
+  process.env.TWIN_AUTH_SECRET = TEST_AUTH_SECRET;
+  token = await signTestToken();
+});
+afterAll(() => {
+  if (previousSecret === undefined) delete process.env.TWIN_AUTH_SECRET;
+  else process.env.TWIN_AUTH_SECRET = previousSecret;
+});
+
+const base = `/s/${TEST_SID}`;
+
+/**
+ * One search term — `idempotency` — planted in all three repositories, in an
+ * issue title, a file and a file path. Scoping is only demonstrable against a
+ * world where the unscoped answer is bigger than the scoped one.
+ *
+ * `acme` and `globex` are Organizations and `alice` is a User, so `org:` and
+ * `user:` have something to tell apart (and this suite pins that this twin
+ * deliberately does NOT tell them apart — see the `org:`/`user:` case).
+ */
+const WORLD: GitHubStateSeed = {
+  users: [
+    { login: "acme", type: "Organization", name: "Acme" },
+    { login: "globex", type: "Organization", name: "Globex" },
+    { login: "alice", type: "User", name: "Alice" },
+    { login: "pome-agent", type: "User", name: "Pome Agent" },
+  ],
+  repositories: [
+    {
+      owner: "acme",
+      name: "api",
+      description: "Acme's API.",
+      default_branch: "main",
+      files: [
+        { path: "README.md", content: "# Acme API\n" },
+        { path: "src/idempotency.ts", content: "export const idempotencyKey = 'acme';\n" },
+      ],
+      issues: [
+        { number: 1, title: "Add idempotency keys to POST /orders", state: "open" },
+        { number: 2, title: "Retry storm from a missing idempotency token", state: "closed" },
+      ],
+    },
+    {
+      // Same repository NAME as acme's, different owner. `repo:acme/api` must
+      // exclude this one, which a scope resolved on the bare name would not.
+      owner: "globex",
+      name: "api",
+      description: "Globex's API.",
+      default_branch: "main",
+      files: [
+        { path: "README.md", content: "# Globex API\n" },
+        { path: "src/idempotency.ts", content: "export const idempotencyKey = 'globex';\n" },
+      ],
+      issues: [{ number: 1, title: "idempotency keys for billing", state: "open" }],
+    },
+    {
+      owner: "alice",
+      name: "tools",
+      description: "Alice's scripts.",
+      default_branch: "main",
+      files: [{ path: "idempotency.md", content: "Notes on retry safety.\n" }],
+      issues: [{ number: 1, title: "idempotency helper script", state: "open" }],
+    },
+  ],
+};
+
+const app = createGitHubCloneApp({ seed: WORLD });
+
+async function search(path: string): Promise<{ status: number; items: any[] }> {
+  const response = await app.request(`${base}${path}`, withAuth(token));
+  const body = (await response.json()) as { items?: unknown[] };
+  return { status: response.status, items: (body.items ?? []) as any[] };
+}
+
+/**
+ * `acme/api#2` — repo-qualified, because issue numbers are per-repo.
+ *
+ * Read off `repository_url`, which is where an issue carries its repository:
+ * GitHub's `/search/issues` items are issue objects and have no `repository`
+ * field, unlike the code and commit results below.
+ */
+async function issues(query: string): Promise<string[]> {
+  const { status, items } = await search(`/search/issues?q=${encodeURIComponent(query)}`);
+  expect(status).toBe(200);
+  return items
+    .map((item) => `${item.repository_url.replace("https://api.github.com/repos/", "")}#${item.number}`)
+    .sort();
+}
+
+/** `acme/api:src/idempotency.ts`. */
+async function code(query: string): Promise<string[]> {
+  const { status, items } = await search(`/search/code?q=${encodeURIComponent(query)}`);
+  expect(status).toBe(200);
+  return items.map((item) => `${item.repository.full_name}:${item.path}`).sort();
+}
+
+/** `acme/api@Initial seed commit` — every seeded repo gets exactly one. */
+async function commits(query: string): Promise<string[]> {
+  const { status, items } = await search(`/search/commits?q=${encodeURIComponent(query)}`);
+  expect(status).toBe(200);
+  return items.map((item) => `${item.repository.full_name}@${item.commit.message}`).sort();
+}
+
+const ALL_IDEMPOTENCY_ISSUES = ["acme/api#1", "acme/api#2", "alice/tools#1", "globex/api#1"];
+const ACME_IDEMPOTENCY_ISSUES = ["acme/api#1", "acme/api#2"];
+
+describe("search `q` qualifiers (F-1389)", () => {
+  describe("the request GitHub documents", () => {
+    it("scopes `/search/issues` by `repo:` and excludes the other repositories", async () => {
+      // THE case that returned zero before this ticket. It is stated against
+      // the unscoped answer as well, so a regression that broke scoping
+      // altogether (returning everything) fails here too.
+      expect(await issues("idempotency repo:acme/api")).toEqual(ACME_IDEMPOTENCY_ISSUES);
+      expect(await issues("idempotency")).toEqual(ALL_IDEMPOTENCY_ISSUES);
+    });
+
+    it("scopes `/search/code` by `repo:`", async () => {
+      expect(await code("idempotency repo:acme/api")).toEqual(["acme/api:src/idempotency.ts"]);
+      expect(await code("idempotency")).toEqual([
+        "acme/api:src/idempotency.ts",
+        "alice/tools:idempotency.md",
+        "globex/api:src/idempotency.ts",
+      ]);
+    });
+
+    it("scopes `/search/commits` by `repo:`", async () => {
+      expect(await commits("seed repo:acme/api")).toEqual(["acme/api@Initial seed commit"]);
+      expect(await commits("seed")).toEqual([
+        "acme/api@Initial seed commit",
+        "alice/tools@Initial seed commit",
+        "globex/api@Initial seed commit",
+      ]);
+    });
+
+    it("resolves `repo:` on the FULL name, not the bare repository name", async () => {
+      // `acme/api` and `globex/api` share the name `api`. A scope resolved on
+      // the bare name would answer both and still look like it worked.
+      expect(await issues("idempotency repo:globex/api")).toEqual(["globex/api#1"]);
+    });
+
+    it("matches `repo:` case-insensitively, the way GitHub resolves a repository", async () => {
+      expect(await issues("idempotency repo:ACME/API")).toEqual(ACME_IDEMPOTENCY_ISSUES);
+    });
+  });
+
+  describe("a qualifier with no free text is a scope on its own", () => {
+    it("answers every issue in the repository", async () => {
+      expect(await issues("repo:acme/api")).toEqual(ACME_IDEMPOTENCY_ISSUES);
+    });
+
+    it("answers every file in the repository", async () => {
+      expect(await code("repo:acme/api")).toEqual([
+        "acme/api:README.md",
+        "acme/api:src/idempotency.ts",
+      ]);
+    });
+  });
+
+  describe("`org:` and `user:` scope by owner", () => {
+    it("scopes to an organization's repositories", async () => {
+      expect(await issues("idempotency org:acme")).toEqual(ACME_IDEMPOTENCY_ISSUES);
+    });
+
+    it("scopes to a user's repositories", async () => {
+      expect(await issues("idempotency user:alice")).toEqual(["alice/tools#1"]);
+    });
+
+    it("does not distinguish an organization from a user — a deliberate simplification", async () => {
+      // GitHub documents `org:` for organizations and `user:` for accounts.
+      // This twin resolves BOTH to the repository's owner login and checks no
+      // account type. Stated as its own assertion because it is a divergence
+      // (FIDELITY.md divergence 1), not an accident: the alternative — refusing
+      // `user:acme` because `acme` is an Organization — would answer `[]` to a
+      // request real GitHub serves, which is the failure this whole ticket is
+      // about, pointed the other way.
+      expect(await issues("idempotency user:acme")).toEqual(ACME_IDEMPOTENCY_ISSUES);
+      expect(await issues("idempotency org:alice")).toEqual(["alice/tools#1"]);
+    });
+
+    it("ORs several scope qualifiers together, the way GitHub does", async () => {
+      expect(await issues("idempotency repo:acme/api user:alice")).toEqual([
+        "acme/api#1",
+        "acme/api#2",
+        "alice/tools#1",
+      ]);
+    });
+  });
+
+  describe("`state:` on `/search/issues`", () => {
+    it("filters to the open issues", async () => {
+      expect(await issues("idempotency repo:acme/api state:open")).toEqual(["acme/api#1"]);
+    });
+
+    it("filters to the closed issues", async () => {
+      expect(await issues("idempotency repo:acme/api state:closed")).toEqual(["acme/api#2"]);
+    });
+
+    it("keeps NO open default when `state:` is absent (F-1427)", async () => {
+      // GitHub's search API has no `state=open` default — `is:open` is a query
+      // qualifier, not a default — so the closed issue must still be in the
+      // answer. F-1427 gave the three LIST routes an open default and
+      // deliberately left this surface without one; parsing `state:` as a
+      // qualifier must not quietly introduce one.
+      expect(await issues("idempotency repo:acme/api")).toContain("acme/api#2");
+    });
+
+    it("is NOT a qualifier on `/search/code`, so it stays free text", async () => {
+      // `state:` is an issue-search qualifier on GitHub; code search has no such
+      // filter. Lifting it out of `q` here would answer a BROADER set than
+      // GitHub, which is the direction this ticket exists to close.
+      expect(await code("idempotency state:open")).toEqual([]);
+    });
+  });
+
+  describe("a qualifier this twin does not parse stays in the free-text term", () => {
+    it("does not silently drop an unknown qualifier", async () => {
+      // GitHub treats an unrecognised `word:word` as part of the search text.
+      // Dropping it would answer a BROADER set than GitHub for a typo'd
+      // qualifier — an agent would pass here and lose results in production.
+      // Narrowing is the safe direction, so `bogus:x` stays in the term and
+      // matches nothing.
+      expect(await issues("idempotency")).toEqual(ALL_IDEMPOTENCY_ISSUES);
+      expect(await issues("idempotency bogus:x")).toEqual([]);
+    });
+
+    it("leaves the qualifiers GitHub has that this twin does not parse in the term", async () => {
+      // `in:`, `language:`, `path:`, `is:` and the boolean operators are named
+      // in FIDELITY.md divergence 1 as unparsed. They are unparsed the same way
+      // `bogus:` is — left in the term — rather than dropped.
+      expect(await issues("idempotency is:open")).toEqual([]);
+      expect(await code("idempotency language:ts")).toEqual([]);
+    });
+
+    it("leaves a `repo:` with no owner in the term — GitHub takes `owner/name`", async () => {
+      expect(await issues("idempotency repo:api")).toEqual([]);
+    });
+
+    it("leaves a `state:` value the surface does not have in the term", async () => {
+      // `state:merged` is not a state `/search/issues` can answer. Honouring it
+      // as "no filter" is the failure the strict `stateFilter` enum in
+      // `route-inputs.ts` was introduced to prevent — `?state=merged` silently
+      // listing everything.
+      expect(await issues("idempotency repo:acme/api state:merged")).toEqual([]);
+    });
+  });
+
+  describe("the three query parameters GitHub does not declare are gone", () => {
+    // github's measured undeclared disposition is `ignore` (F-1372), so these
+    // are discarded rather than refused: real GitHub answers 200 to a query
+    // parameter it does not know. The claim is therefore that the answer is
+    // UNCHANGED, not that the request is rejected.
+    const IGNORED = [
+      { name: "?owner=", suffix: "&owner=acme" },
+      { name: "?repo=", suffix: "&repo=api" },
+      { name: "?state=", suffix: "&state=closed" },
+      { name: "all three at once", suffix: "&owner=acme&repo=api&state=closed" },
+    ] as const;
+
+    for (const surface of [
+      { name: "/search/issues", path: "/search/issues?q=idempotency" },
+      { name: "/search/code", path: "/search/code?q=idempotency" },
+      { name: "/search/commits", path: "/search/commits?q=seed" },
+    ]) {
+      for (const ignored of IGNORED) {
+        it(`${surface.name} ignores ${ignored.name}`, async () => {
+          const bare = await search(surface.path);
+          const probed = await search(`${surface.path}${ignored.suffix}`);
+          expect(bare.status).toBe(200);
+          expect(probed.status, `${surface.name} refused ${ignored.name}`).toBe(200);
+          expect(
+            probed.items,
+            `${surface.name} scoped its answer by ${ignored.name}, which GitHub does not declare`
+          ).toEqual(bare.items);
+        });
+      }
+    }
+
+    it("does not publish them in the declared input surface", async () => {
+      const { GITHUB_ROUTE_INPUTS } = await import("../src/route-inputs.js");
+      for (const path of ["/search/code", "/search/commits", "/search/issues"]) {
+        const declaration = GITHUB_ROUTE_INPUTS.find((entry) => entry.path === path);
+        expect(declaration, `${path} is not declared at all`).toBeDefined();
+        expect(
+          declaration!.inputs.filter((input) => input.location === "query").map((input) => input.name).sort(),
+          `${path} declares an input GitHub's OpenAPI does not`
+        ).toEqual(["page", "per_page", "q"]);
+      }
+    });
+  });
+});

--- a/packages/twin-slack/CHANGELOG.md
+++ b/packages/twin-slack/CHANGELOG.md
@@ -1,6 +1,18 @@
 # @pome-sh/twin-slack — CHANGELOG
 
 
+## 0.4.1 — 2026-08-11
+
+`files.upload` takes `channels` only (F-1389).
+
+Slack documents `channels` — plural, comma-separated — and has never documented
+a singular `channel`; the vendored `slack_web_openapi_v2` snapshot agrees,
+declaring `channels` and eight other real arguments, so it is not thin here. The
+twin declared both and the domain fell back `args.channels ?? args.channel`, so
+an upload addressed `channel=C123` landed in that channel here and in no channel
+at all on Slack. The declaration and the domain fallback are both gone; slack's
+measured `ignore` disposition discards `channel` if sent.
+
 ## 0.4.0 — 2026-08-10
 
 **Breaking.** It serves the tools Slack declares. Every tool name and almost

--- a/packages/twin-slack/package.json
+++ b/packages/twin-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-slack",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Deterministic Slack Web API twin for agent testing \u2014 REST + MCP, SQLite-backed state.",
   "private": true,
   "type": "module",

--- a/packages/twin-slack/route-inputs.json
+++ b/packages/twin-slack/route-inputs.json
@@ -7,7 +7,7 @@
     "packages/twin-slack/src/route-inputs.ts"
   ],
   "surface_count": 62,
-  "input_count": 242,
+  "input_count": 241,
   "surfaces": [
     {
       "method": "GET",
@@ -1466,12 +1466,6 @@
       "path": "/files.upload",
       "surface": "POST /files.upload",
       "inputs": [
-        {
-          "name": "channel",
-          "location": "body",
-          "required": false,
-          "type": "string"
-        },
         {
           "name": "channels",
           "location": "body",

--- a/packages/twin-slack/src/domain/files.ts
+++ b/packages/twin-slack/src/domain/files.ts
@@ -36,13 +36,19 @@ import { clampLimit, filetypeMimetype } from "./helpers.js";
 // ───────────────────────────────────────────────────────────────────────────
 
 export function filesUpload(domain: SlackDomain, 
-  args: { channels?: string; channel?: string; filename?: string; title?: string; filetype?: string; content?: string; initial_comment?: string; thread_ts?: string },
+  args: { channels?: string; filename?: string; title?: string; filetype?: string; content?: string; initial_comment?: string; thread_ts?: string },
   actor: Actor,
   onDelta: DeltaHook = NOOP
 ): Record<string, unknown> {
   const workspace = domain.requireWorkspace();
   const acting = domain.resolveActorUser(actor);
-  const channelsRaw = args.channels ?? args.channel ?? "";
+  // F-1389 (SLACK-DECL-IN-003) — `channels` only. The singular `channel`
+  // fallback that stood here is what made an upload addressed `channel=C123`
+  // land in that channel on the twin and in no channel at all on Slack, which
+  // documents no singular form on this method. Dropping the fallback as well as
+  // the declaration matters: leaving it would keep the wrong behaviour reachable
+  // from any caller that reaches the domain without going through `parse()`.
+  const channelsRaw = args.channels ?? "";
   const channelIds = channelsRaw
     .split(",")
     .map((s) => s.trim())

--- a/packages/twin-slack/src/route-inputs.ts
+++ b/packages/twin-slack/src/route-inputs.ts
@@ -375,8 +375,14 @@ export const SLACK_WRITES = {
   }),
 
   filesUpload: slackWrite("/files.upload", {
+    // F-1389 (SLACK-DECL-IN-003) — `channels` (plural, comma-separated) only.
+    // Slack has never documented a singular `channel` here, and the vendored
+    // `slack_web_openapi_v2` snapshot agrees: it declares `channels` and eight
+    // other real arguments, so it is not thin on this method. An upload
+    // addressed `channel=C123` landed in that channel here and in no channel at
+    // all on Slack. Undeclared now, so slack's measured disposition (`ignore`)
+    // discards it instead of the handler forwarding it to `domain.filesUpload`.
     channels: absentIfEmpty(),
-    channel: absentIfEmpty(),
     filename: absentIfEmpty(),
     title: absentIfEmpty(),
     filetype: absentIfEmpty(),

--- a/packages/twin-slack/src/routes.ts
+++ b/packages/twin-slack/src/routes.ts
@@ -361,7 +361,6 @@ export function registerSlackRoutes(app: Hono, { domain, recorder }: RouteContex
     domain.filesUpload(
       {
         channels: args.channels,
-        channel: args.channel,
         filename: args.filename,
         title: args.title,
         filetype: args.filetype,

--- a/packages/twin-stripe/CHANGELOG.md
+++ b/packages/twin-stripe/CHANGELOG.md
@@ -1,6 +1,20 @@
 # @pome-sh/twin-stripe — CHANGELOG
 
 
+## 0.4.7 — 2026-08-11
+
+`GET /v1/customers/:id/payment_methods` no longer accepts `created` (F-1389).
+
+The route shared the twin's `LIST_QUERY`, which carries `created`.
+`GetCustomersCustomerPaymentMethods` declares `allow_redisplay, ending_before,
+expand, limit, starting_after, type` and no `created`, and Stripe's measured
+disposition is `refuse` — it publishes `parameter_unknown`. So a request Stripe
+rejects outright used to succeed here, and an exam scored a call the real API
+declined. The route's query is now spelled out rather than spread from
+`LIST_QUERY`, so a future edit to that shared shape cannot put `created` back by
+inheritance. This twin REFUSES undeclared inputs, so the parameter is now a 400
+naming it — which is the point, not a side effect.
+
 ## 0.4.6 — 2026-08-06
 
 Its MCP tool table is now derived from `fixtures/mcp-tools-list.raw.json`

--- a/packages/twin-stripe/package.json
+++ b/packages/twin-stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-stripe",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Deterministic test double for Stripe x402 machine payments \u2014 stateful clone agents can drive without burning sandbox quota or real chain gas.",
   "private": true,
   "type": "module",

--- a/packages/twin-stripe/route-inputs.json
+++ b/packages/twin-stripe/route-inputs.json
@@ -7,7 +7,7 @@
     "packages/twin-stripe/src/route-inputs.ts"
   ],
   "surface_count": 38,
-  "input_count": 128,
+  "input_count": 127,
   "surfaces": [
     {
       "method": "DELETE",
@@ -188,12 +188,6 @@
           "location": "path",
           "required": true,
           "type": "string"
-        },
-        {
-          "name": "created",
-          "location": "query",
-          "required": false,
-          "type": "object|string"
         },
         {
           "name": "ending_before",

--- a/packages/twin-stripe/src/route-inputs.ts
+++ b/packages/twin-stripe/src/route-inputs.ts
@@ -285,11 +285,27 @@ export const STRIPE_ROUTES = {
     body: CUSTOMER_FIELDS_BODY,
   }),
 
+  // F-1389 (ST-DECL-IN-001) — NOT `LIST_QUERY`. This is the one list surface
+  // that does not take `created`: `GetCustomersCustomerPaymentMethods` declares
+  // `allow_redisplay, ending_before, expand, limit, starting_after, type` and
+  // nothing else, and Stripe's measured disposition is `refuse` — it publishes
+  // `parameter_unknown`. Sharing `LIST_QUERY` here meant a request Stripe
+  // rejects outright succeeded, so an exam scored a call the real API declined.
+  // Leaving it undeclared is what makes the twin refuse it too: the declaration
+  // IS the validator, and this twin's declarer is `refuse`. That is why this
+  // one is spelled out rather than fixed by spreading a narrower shared shape —
+  // the point is the absence, and a future `LIST_QUERY` edit must not put
+  // `created` back by inheritance.
   listCustomerPaymentMethods: declareInputs({
     method: "GET",
     path: "/v1/customers/:id/payment_methods",
     pathParams: ID_PATH,
-    query: { ...LIST_QUERY, type: z.string().optional() },
+    query: {
+      limit: LIST_QUERY.limit,
+      starting_after: LIST_QUERY.starting_after,
+      ending_before: LIST_QUERY.ending_before,
+      type: z.string().optional(),
+    },
   }),
 
   retrieveCustomer: declareInputs({


### PR DESCRIPTION
Closes F-1389 (sub-issue of F-1456, the C3 batch release).

Five findings from pome-cloud's declared-fidelity lane, all pointing the same
way: **the twin ACCEPTS an input its vendor does not declare.** All five are
fixed in the twin — none is recorded as an accepted divergence — and each one's
`input_drift` entry in pome-cloud's `known-divergences/<twin>.declared.yaml` goes
dead, which is what the declared lane's dead-entry check fails on until F-1457
retires them at the pin bump.

The rule applied to each (F-1372): the twin's handling of an input its vendor
does not declare must equal that vendor's **measured** undeclared disposition —
github and slack `ignore`, stripe `refuses` — and in every case the parameter
comes out of `route-inputs.ts`, because the declaration is the half that teaches
an agent the wrong shape.

`route-inputs.json`: **990 → 979.**

| Commit | Finding | What |
|---|---|---|
| `b71b96b` | `GH-DECL-IN-003` | `owner` off the `POST /user/repos` body |
| `b71b96b` | `SLACK-DECL-IN-003` | singular `channel` off `files.upload` |
| `b71b96b` | `ST-DECL-IN-001` | `created` off `GET /v1/customers/:id/payment_methods` |
| `6789d4d` | `GH-DECL-IN-005` | `encoding` off `PUT /contents/*` |
| `3912648` | `GH-DECL-IN-001` / `-002` | `owner`/`repo`/`state` off the three search routes — **plus the `q` qualifier parser** |

---

## The argument the registry entries do not make

The entries say the twin accepts inputs GitHub does not declare. Working
`GH-DECL-IN-001`/`-002` turned up the **mirror defect, which is worse**.

`searchIssues` matched the WHOLE `q` string as one case-insensitive substring
against title/body/full_name. So an agent writing the request GitHub actually
documents:

```
GET /search/issues?q=idempotency repo:acme/api
```

got **zero results** from the twin — no issue's title or body contains that
literal string. The surface did not merely let a wrong scoping habit pass; it
**punished the correct one.**

That is why this is a parser and not a deletion. Dropping `?owner=`/`?repo=`/
`?state=` on their own would have left the correct request still answering zero,
and left an agent with no way to scope a search at all. Both halves land
together, deliberately enlarging the ticket's `hitl` framing.

**What is parsed:** `repo:owner/name`, `user:login`, `org:login`, and
`state:open|closed` on `/search/issues` only. Several scope qualifiers OR
together, the way GitHub's do. Whatever free text is left is the substring term.
The parser sits in the **domain**, so the MCP tools get it too.

**What is not, and why that is safe:** an unparsed qualifier (`in:`,
`language:`, `path:`, `is:`, a typo) stays in the free-text term rather than
being dropped — as does a recognised one carrying a value the surface cannot
honour (`repo:api` with no owner, `state:merged`). Dropping would answer a
**broader** set than GitHub for a request GitHub narrows, and breadth is the
direction that scores a call the real API would not have served. Narrowing is
the safe failure.

## ⚠️ Behaviour changes a caller can see

- **`?state=` on `/search/issues` no longer filters.** It is ignored, not
  refused (github's `ignore` ruling — real GitHub answers 200 to a parameter it
  does not know). `q=… state:closed` is the spelling that works.
  `list-state-default.test.ts` now pins both halves.
- **The absence of a `state=open` DEFAULT there is unchanged** (F-1427). Only
  the spelling of the explicit filter moved.
- `encoding`'s **behavioural** half is recorded, not fixed — the twin still
  treats `content` as plain text where GitHub treats it as base64. FIDELITY.md
  divergence 24, and **F-1460** for the fix across both doors.

## Judgement calls — flagged rather than buried

Four of these the `[DECISION]` does not settle. Each is pinned by a named test,
so reversing one is an edit to an assertion and not a silent drift.

1. **Unknown qualifiers stay in the free-text term.** GitHub treats an
   unrecognised `word:word` as search text. Dropping it would let a typo'd
   qualifier pass here and lose results in production.
2. **`user:` and `org:` do not distinguish account type.** Both resolve to the
   repository's owner login. Refusing `user:<an org>` would answer `[]` to a
   request real GitHub serves — this ticket's own failure, pointed the other
   way.
3. **`/search/repositories` and `/search/users` parse no qualifiers.** They
   already declared `q` only, so they are outside the registry entries — but
   `q=api org:acme` still answers zero there. The obvious next candidate; not
   taken here because it is scope the decision did not name.
4. **The MCP door keeps `owner`/`repo` on `search_code`/`search_commits` and
   `state` on `search_issues`.** Separate published surface, own frozen tool
   fixture — left alone on the same line the `encoding` amendment drew. The
   parser reaches both doors regardless, so an MCP caller writing
   `repo:acme/api` inside `query` is served correctly either way.

## FIDELITY.md divergence 1

Its **bold title** is unchanged — it is bound 1:1 to a pome-cloud
`known-divergences/github.yaml` entry on that title, and that lint runs against
this repo at `main`, unpinned, on every pome-cloud PR. Only the body is
rewritten, to say which four qualifiers are parsed and which are not.

## Verification

`npm test` (10 packages), `typecheck`, `lint:route-inputs`, `gate:route-inputs`,
`gate:mcp-tools-list`, `lint:twin-leaves`, `lint:twin-chunks`,
`lint:code-health`, `lint:dead-code`, and `check-version-bump-required.mjs`
against `origin/main` — all green at `3912648`. The new
`test/search-query-qualifiers.test.ts` (32 cases) asserts on **sets of results,
never counts**, over a world of three repositories under three owners, two of
them sharing the name `api` — so `repo:` is shown resolving on the full name and
**excluding**, not merely returning something.

## Sequencing (F-1456 batch release) — resolved

**#368 (F-1423) merged first** (`65d6266`), so this branch was rebased onto it and
re-bumped. `check-version-bump-required.mjs` against the new `origin/main` is what
picked the numbers, not a hand-choice — and it was verified to still BITE (setting
`cli` back to 0.23.13 makes it fail, naming the package).

| Package | on `main` | here |
|---|---|---|
| `@pome-sh/cli` | 0.23.13 | **0.23.14** |
| `@pome-sh/twin-github` | 0.10.5 | **0.10.6** |
| `@pome-sh/twin-slack` | 0.4.0 | **0.4.1** |
| `@pome-sh/twin-stripe` | 0.4.6 | **0.4.7** |

All four publish-relevant packages are strictly above `main`, so `decide-publish.sh`
has a version diff on each and none is silently skipped. The CHANGELOG entries moved
with them: `twin-github` 0.10.6 and `cli` 0.23.14 are new sections above #368's
0.10.5 / 0.23.13, which are untouched.

Re-verified green after the rebase: `npm test` (10 packages, `twin-github` now 40
files / 527 tests including #368's), `typecheck`, `emit`+`gate:route-inputs`
(295 → 286 on twin-github, 979 total), `lint:route-inputs`, `gate:mcp-tools-list`,
`lint:twin-leaves`, `lint:twin-chunks`, `lint:code-health`, `lint:copy-markers`,
`lint:no-catch`, `lint:dead-code`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
