### PR TITLE
twin-github retires divergence 22, and the numbers become stable ids (F-1457)

### DIFF
--- a/packages/twin-github/FIDELITY.md
+++ b/packages/twin-github/FIDELITY.md
@@ -204,6 +204,16 @@ the Twin Fidelity Watch's `known-divergences/github.yaml` (maintained in
 pome-cloud); a lint keeps the two 1:1. The fidelity watchdog reverse-tests each one against
 upstream so a divergence that upstream "heals" becomes a tier-upgrade signal.
 
+**These numbers are stable identifiers, not positions.** A retired divergence
+leaves its number behind rather than renumbering the ones after it — code
+comments, CHANGELOG entries and tickets cite divergences by number ("recorded as
+divergence 24"), and renumbering would silently repoint every one of them, including
+entries in an append-only changelog that cannot be corrected without falsifying
+the record. So a gap in this list means a divergence was retired, and the first
+one is 22: `pull_request_read`'s `get_comments` answered from the review-comment
+table until F-1423 gave the conversation its own read in 0.10.5. The lint matches
+on each bullet's bold title and never on its number, so gaps cost it nothing.
+
 1. **Search query syntax is substring-based.** The free text left in `q` is
    matched as one case-insensitive substring, scoped to the default branch —
    not as GitHub's ranked, tokenised, boolean-aware index. Four SCOPE
@@ -428,34 +438,6 @@ upstream so a divergence that upstream "heals" becomes a tier-upgrade signal.
     against upstream, so the shape diff masks them; an agent that parses a
     review comment's hunk text or resolves `position` against a real diff will
     diverge, exactly as on the diff surfaces bullet 2 names.
-
-22. **`pull_request_read`'s `get_comments` answers from the wrong table (open gap,
-    not accepted).** ⚠️ **FIXED in 0.10.5 (F-1423) — this bullet is awaiting
-    retirement, not describing current behaviour.** `get_comments` now reads the
-    pull request's conversation (`issue_comments`, keyed on the PR's own number)
-    and `get_review_comments` keeps `pull_request_review_comments`; the two are
-    pinned apart by `test/pull-request-read-comment-methods.test.ts`.
-
-    It is still here because pome-cloud's `lint-known-divergences.ts` binds this
-    bullet 1:1 to an entry in its `known-divergences/github.yaml`, matching on the
-    bold title above, and runs on every pome-cloud PR against **main, unpinned**
-    (F-1430, PR #369). Deleting the bullet without deleting that entry in the same
-    window orphans it and reds every open pome-cloud PR — so the two retire
-    together, in the coordinated change that owns the pome-cloud half, and the
-    title is left byte-identical so the match keeps holding until then. The stale
-    thing this ticket was really about — a code comment asserting a split the twin
-    did model — is gone from `tools.ts`.
-
-    What it recorded, for the reader who finds it before it goes: GitHub
-    distinguishes the issue-level `get_comments` from the diff-level
-    `get_review_comments`; the twin answered BOTH from
-    `pull_request_review_comments`, on a comment saying it "stores one comment
-    thread per PR and answers both from it rather than inventing a split it does
-    not model". That was true when written and F-1151 made it false — a PR's
-    conversation has its own table, `exportState` keeps the three comment surfaces
-    apart, and the REST routes already served them separately. Discovered the same
-    way as the LIST shape in bullet 21, but MCP-only, so no fidelity-watch lane
-    measured it.
 
 23. **`check-runs` has no reachable upstream — `Checks` is not grantable to a
     fine-grained PAT.** GitHub gates


### PR DESCRIPTION
## What

Deletes twin-github FIDELITY.md's **bullet 22** (`pull_request_read`'s `get_comments` answers from the wrong table), which F-1423 fixed in 0.10.5 and which has been carrying a "FIXED — awaiting retirement" banner since.

Adds a short convention note to the `## Known divergences from real GitHub` heading: **the numbers are stable identifiers, not positions.**

Docs only. No package version bump — `scripts/ci/check-version-bump-required.mjs` exempts `packages/twin-*/*.md` by design.

## Why the numbers do not close up

Divergences are cited **by number** from three places that a renumber would silently repoint:

| Citation | Where |
|---|---|
| `// … recorded as divergence 24` | `packages/twin-github/src/route-inputs.ts:206` |
| `divergence 24 says so, with the measurement that deferred it` | `packages/twin-github/CHANGELOG.md:64` |
| `(divergence #1)` ×2 | the MCP tool table in this file |

CHANGELOG.md is append-only. Renumbering would either repoint a historical entry or falsify it, and there is no third option. So bullet 22's number stays vacant and the heading now says a gap means a retirement. The pome-cloud lint matches on **bold titles**, never on numbers, so gaps cost it nothing.

## Ordering — this PR merges FIRST

pome-cloud's `lint-known-divergences.ts` binds each bullet 1:1 to an entry in `known-divergences/github.yaml`, and **both** directions are errors (`missing entry` / `orphan entry`). So one of the two intermediate states has to be worn, and which one was determined by simulating both against the real lint rather than by reasoning:

| State | pome-cloud PR CI (pinned, ADR-023) | fidelity-watch cron (unpinned main) |
|---|---|---|
| **This PR first** (bullet gone, entry still present) | **green** — open PRs read `.github/twins-ref`, a tree that still has bullet 22 | red, `orphan entry` |
| pome-cloud first (entry gone, bullet still present) | **red on its own CI** — `missing entry` | red |
| both landed | green | green |

The banner on bullet 22 predicted the opposite ("deleting the bullet … reds every open pome-cloud PR"). **ADR-023 falsified that** — pome-cloud's `ci.yml` now checks digital-twins out *at* `.github/twins-ref`, so open PRs read a pinned tree, not `main`. The bullet was written before that landed.

The exposed lane is the unpinned `fidelity-watch` cron, and it is **already red** independently: `main` carries the new bullet 24 (`PUT /contents/*` … base64) and pome-cloud has no entry for it until the paired PR lands. That PR adds it.

## Paired change

pome-cloud PR (bumps `.github/twins-ref` → this commit, deletes `GH-DIV-023`, adds `GH-DIV-025` for bullet 24, retires the six dead F-1389 `input_drift` entries). Linked on F-1457.

🤖 Generated with [Claude Code](https://claude.com/claude-code)