### PR TITLE
twin-gmail records the seven divergences its first real Gmail capture found

### DIFF
--- a/packages/twin-gmail/FIDELITY.md
+++ b/packages/twin-gmail/FIDELITY.md
@@ -47,6 +47,84 @@ _(empty)_
 - Do not fake success for watch/stop, resumable upload, or filter `action.forward`.
 - Gate 1 expands the MCP launch set from 10 → 13 to match the live Developer Preview `tools/list`.
 
+## Known divergences from real Gmail
+
+These are the places where the twin's answer differs from what real Gmail
+answered. Each bullet has a structured entry in the Twin Fidelity Watch's
+`known-divergences/gmail.yaml` (maintained in pome-cloud); a lint keeps the two
+1:1.
+
+**These numbers are stable identifiers, not positions**, on the same convention
+twin-github's list uses: a retired divergence leaves its number behind rather
+than renumbering the ones after it, so a gap here means a retirement. The lint
+matches on each bullet's bold title and never on its number.
+
+Unlike the other four twins' lists, every bullet below was **measured, not read
+off the twin's source**. The upstream half is a real human-attended capture
+against a throwaway Gmail mailbox on 2026-08-11 (F-1377), committed as
+`sandboxes/gmail/fixtures/upstream-golden.json` in pome-cloud; the twin half is
+the twin's own answer to the same 14 L1 read surfaces. So
+`verified_against_upstream_at` carries a real date on all seven rather than the
+honest `null` the unmeasured registries carry.
+
+**All seven are registered pending triage (F-1463), which is a disposition and
+not a verdict.** Registration is what stops an unregistered divergence reporting
+as new drift every day; it does not say the twin is right. Which of these get a
+real twin fix — bullets 1 and 2 are the substantial candidates, since an agent
+that walks `payload.parts` for an HTML body or reads `Received` / `DKIM-Signature`
+to make a decision sees a structurally different object here than in Gmail — is a
+later ruling on F-1463. Each fix deletes its entry and its bullet together.
+
+1. **Message payloads are single-part where Gmail returns `payload.parts`.** A
+   delivered Gmail message is `multipart/alternative` with a `text/plain` and a
+   `text/html` part under `payload.parts`; the twin emits one `text/plain`
+   payload and no `parts` key at all. Measured on the seeded welcome message,
+   on both messages of a thread, and on a draft. An agent that reaches for the
+   HTML alternative finds nothing to reach into.
+
+2. **The twin synthesizes a fixed eight-header set, so its header count is
+   wrong in both directions.** The twin always emits the same eight
+   (`From`, `To`, `Date`, `Message-ID`, `Subject`, `MIME-Version`,
+   `Content-Type`, `Content-Transfer-Encoding`). A message Gmail actually
+   delivered carries **26** — the transport and authentication record the twin
+   models none of: `Received` ×3, `Received-SPF`, `Authentication-Results`,
+   `ARC-Seal` / `ARC-Message-Signature` / `ARC-Authentication-Results` ×2,
+   `DKIM-Signature`, `X-Google-DKIM-Signature`, `Return-Path`, `Delivered-To`,
+   the `X-Gm-*` family. An unsent draft carries **7**, where the twin still
+   emits its eight (`Content-Transfer-Encoding` is the extra). The divergence
+   is one fact — a uniform synthesized set — with two opposite consequences.
+
+3. **`messages.list` does not count drafts.** The mailbox holds one unsent
+   draft. Gmail's `users.messages.list` returns 5 message ids; the twin returns
+   4, omitting the draft's. An agent that lists a mailbox and expects to see its
+   own unsent drafts sees a shorter list here than in Gmail.
+
+4. **`threads.list` does not count a draft's thread.** The same fact one level
+   up: Gmail returns 4 threads, the twin 3.
+
+5. **The label set omits Gmail's `CHAT` system label.** Gmail returns 16 labels
+   to the twin's 15. The system-label gap is exactly one — `CHAT`, which Gmail
+   still returns on every mailbox and the twin does not model. The remaining
+   difference is identity, not modelling: the user labels are Gmail-minted
+   opaque ids (`Label_8665618256210763520`) upstream and the twin's own readable
+   ids (`Label_build`) here, which is inherent to a seeded twin and not
+   something a fix would change.
+
+6. **A thread message's `labelIds` carries the twin's own labels and its own
+   read state.** On the captured thread, Gmail's first message is
+   `["Label_8665618256210763520", "INBOX"]` (2) and the twin's is
+   `["INBOX", "Label_build", "UNREAD"]` (3). Two differences sit behind the one
+   count: the label id (see bullet 5) and `UNREAD`, which the twin sets on a
+   seeded inbox message where the captured mailbox's had been read. Seed state,
+   not a serializer gap.
+
+7. **`sendAs` entries omit `replyToAddress`.** Gmail returns `replyToAddress` on
+   every send-as entry — present and empty (`""`) when no reply-to is
+   configured, which is the case on the captured mailbox. The twin omits the key
+   entirely, on both `settings/sendAs` and `settings/sendAs/{sendAsEmail}`. The
+   twin's own `verificationStatus` and `treatAsAlias`, which Gmail did not
+   return, are the twin-adds direction and are informational, not drift.
+
 ## Declared input surface (F-1179)
 
 Fidelity is not only about what a surface *answers*; it is also about what it


### PR DESCRIPTION
## What

Adds a `## Known divergences from real Gmail` section to `packages/twin-gmail/FIDELITY.md` — seven bullets, covering all twelve findings on the eight surfaces that drifted the first time twin-gmail was compared against real Gmail.

Docs only. **No package version bump** — `scripts/ci/check-version-bump-required.mjs` exempts `packages/twin-*/*.md` by design, same as #372.

## Why now

pome-cloud PR #664 (F-1377) ran the human-attended Gmail capture on 2026-08-11 and put a real upstream golden behind twin-gmail's 14 L1 read surfaces for the first time. Coverage went 0 → 14 and the verdicts came back **6 green, 8 drift**. `known-divergences/gmail.yaml`'s own header had anticipated exactly this moment:

> Entries land here once F-1101 lands, `capture-gmail-upstream-golden.ts` is run for the first time, and any real divergences from real Gmail are found and documented in FIDELITY.md.

Until each of the eight has a disposition, the daily `fidelity-watch.yml` cron reports `8 CRITICAL new-drift surface(s)` for twin-gmail and every step after the publish is `skipped` — including the fidelity-history commit and the baseline-expiry tracker.

## Seven bullets, eight surfaces, twelve findings

The unit of registration is the **divergence**, not the surface. One fact drifts on three surfaces (bullets 1 and 2 do); one surface carries three separate facts (`threads/{id}` does).

| # | bullet | surfaces | findings |
|---|---|---|---|
| 1 | single-part payload where Gmail returns `payload.parts` | messages/{id}, threads/{id}, drafts/{id} | 3 × `field-removed` |
| 2 | fixed eight-header set (26 upstream on a delivered message, 7 on a draft) | same three | 3 × `array-length-changed` |
| 3 | `messages.list` does not count drafts (5 → 4) | messages | 1 |
| 4 | `threads.list` does not count a draft's thread (4 → 3) | threads | 1 |
| 5 | label set omits `CHAT` (16 → 15) | labels | 1 |
| 6 | a thread message's `labelIds` carries the twin's labels + `UNREAD` (2 → 3) | threads/{id} | 1 |
| 7 | `sendAs` omits `replyToAddress` | settings/sendAs ×2 | 2 |

**Bullet 6 is not in the originating ticket's read-out.** F-1463 groups the eight into three classes (thin message model / collection membership / one omitted field) and `messages[].labelIds` is in none of them. It was found by reading the finding paths rather than the surface list.

## These are measured, not read off the twin

Every other twin's `Known divergences` list is derived from its own serializers, which is why their registry entries all carry `verified_against_upstream_at: null`. These seven carry a real date (2026-08-11): each is the difference between two committed bodies, one of which is what Gmail actually answered. The bullets quote the real values — the 26 header names, `["Label_8665618256210763520", "INBOX"]` vs `["INBOX", "Label_build", "UNREAD"]`, `replyToAddress: ""`.

## Registration is a disposition, not a verdict

Registering stops the daily cron reporting these as *new* drift. It does not say the twin is right, and the section says so in as many words. Bullets 1 and 2 are the twin-fix candidates — an agent that walks `payload.parts` for an HTML body, or reads `Received` / `DKIM-Signature` / `Received-SPF` to decide whether to trust a message, sees a structurally different object here than in Gmail. Which of the seven get real fixes is a later ruling on F-1463; each fix deletes its bullet and its registry entry together.

Bullets 5 and 6 are the ones that most likely never get "fixed": what is behind them is seed identity (Gmail-minted label ids, a read-vs-unread seeded message), not a modelling gap.

## Ordering — this PR merges FIRST

pome-cloud's `lint-known-divergences.ts` binds each bullet 1:1 to an entry in `known-divergences/gmail.yaml`, and **both** directions are errors. One intermediate state has to be worn; which one was decided by running the real lint on both, not by reasoning:

| State | pome-cloud PR CI (pinned, ADR-023) | fidelity-watch cron (unpinned main) |
|---|---|---|
| **This PR first** (bullets present, no entries) | **green** — an open PR reads the tree at `.github/twins-ref`, which has no bullets, against an empty registry: 0:0 | unaffected — that lane does not run the 1:1 lint, and its run still reports gmail's 8 exactly as it does today |
| pome-cloud first (entries present, no bullets) | **red on its own CI** — `orphan entry` ×7 | red |
| both landed | green | green |

```
lint @ c857b16 (old pin) + new gmail.yaml  → FAILED, orphan entry ×7
lint @ this branch       + old gmail.yaml  → FAILED, missing entry ×7
lint @ this branch       + new gmail.yaml  → OK, 7 entries 1:1
```

## Paired change

A pome-cloud PR adds the seven `known-divergences/gmail.yaml` entries and moves `.github/twins-ref` onto this commit; it closes F-1463. Verified against a pinned worktree of this branch with no `node_modules` (CI's `.twin-src` shape):

```
tools/fidelity-watch  bun test --preload ./fidelity-leg-preload.ts
  → 2634 pass / 2 fail — the documented floor (twin-linear projection,
    Level-2 tool coverage), both worktree artifacts, unchanged by this PR

POME_TWIN_SRC=<this branch> bun run tools/fidelity-watch/run.ts --offline
  → twin-gmail surfaces=59 drifted=[0 of 59 compared]  overall=green
    (was: drifted=[8 of 59 compared], overall=drift)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)