### PR TITLE
Releases carry updated_at, and four measured divergences get written down

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,29 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.23.16
+
+### Patch Changes
+
+- twin-github release objects carry `updated_at` (F-1459). Real GitHub returns
+  it on every release and the twin omitted the key, so all three release
+  surfaces — `GET /releases`, `/releases/latest`, `/releases/tags/:tag` —
+  differed from real GitHub on a field an agent reading "when did this release
+  last change" would ask for. A release served by the twin has never been edited
+  (there is no release-update route), so its update instant is its creation
+  instant and the value is exact rather than approximated. Existing twin
+  databases migrate and backfill on boot.
+
+- Four twin-github divergences are now on the public record as FIDELITY.md
+  bullets 25-28, recorded rather than fixed: issue-comment objects omit
+  `author_association` / `reactions` / `performed_via_github_app` / `pin` /
+  `minimized`; review objects omit `author_association`; release objects omit
+  GitHub's `immutable` flag; and a review comment's `pull_request_review_id` is
+  always `null`. None is new behaviour — seven of this twin's collections had
+  been published as `green` against an empty array on both sides since
+  2026-05-31, and seeding the upstream half made the comparison real for the
+  first time.
+
 ## 0.23.15
 
 ### Patch Changes

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.23.15",
+  "version": "0.23.16",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/packages/twin-github/CHANGELOG.md
+++ b/packages/twin-github/CHANGELOG.md
@@ -1,5 +1,43 @@
 # @pome-sh/twin-github — CHANGELOG
 
+## 0.10.7 — 2026-08-12
+
+`updated_at` appears on release objects, and four divergences the first real
+comparison of the seeded collections found get written down (F-1459).
+
+**Releases carry `updated_at`.** Real GitHub returns it on every release and this
+twin omitted the key entirely, so all three release surfaces —
+`GET /releases`, `/releases/latest`, `/releases/tags/:tag` — reported
+`field-removed` against the real-GitHub golden. A release here has never been
+edited (there is no release-update route on this twin), so its update instant is
+its creation instant and the honest value was already in hand; omitting it was a
+gap, not a modelling decision. `updated_at` is a real column rather than
+`created_at` aliased in the serializer, so that a release-update route added
+later has somewhere to write and cannot silently leave this field frozen.
+Databases written by an earlier build migrate through `ensureColumn` and are
+backfilled from `created_at`, which is exact rather than approximate for the
+same reason.
+
+**Four divergences recorded, not fixed** — bullets 25–28 in FIDELITY.md. None of
+these is new behaviour. Seven of this twin's collections published `green` from
+2026-05-31 while both sides of the comparison were empty arrays, which bound no
+key, no leaf type and no element; seeding the upstream half made the comparison
+real, and this is what it found.
+
+- **25** — issue-comment objects omit `author_association`, `reactions`,
+  `performed_via_github_app`, `pin` and `minimized`.
+- **26** — review objects omit `author_association`.
+- **27** — release objects omit GitHub's `immutable` flag. Unlike its neighbour
+  `updated_at` there is no honest value to emit: this twin does not model
+  immutable releases, and a hard-coded `false` would claim it had evaluated
+  something it cannot.
+- **28** — a review comment's `pull_request_review_id` is always `null`. The
+  faithful fix is for this twin to mint the implicit `COMMENTED` review GitHub
+  makes for a standalone review comment, but the fidelity harness already works
+  around the gap by declaring that review in its seed — so minting one here
+  would serve three reviews where GitHub serves two. Both moves have to land
+  together, across two repos, and that is its own change.
+
 ## 0.10.6 — 2026-08-11
 
 Nine route inputs GitHub does not declare come out of `route-inputs.ts`, and

--- a/packages/twin-github/FIDELITY.md
+++ b/packages/twin-github/FIDELITY.md
@@ -478,6 +478,71 @@ on each bullet's bold title and never on its number, so gaps cost it nothing.
     across both doors, with the fixture regeneration and saved-task audit that
     implies, tracked separately.
 
+25. **Issue-comment objects omit moderation and social metadata.** The twin's
+    issue-comment object carries what an agent reads a comment for — id, body,
+    user, `created_at`/`updated_at`, the html and issue urls — and omits five
+    leaves real GitHub always returns: `author_association` and `reactions` (the
+    same social metadata divergence 9 records on the issue object and 21 on
+    review comments), `performed_via_github_app` (null unless a GitHub App wrote
+    the comment), and two moderation slots this twin has no model for at all —
+    `pin` and `minimized`, GitHub's pinned-comment and hidden-comment state,
+    both null on an ordinary comment. `pin` is the counterpart of the issue
+    object's `pinned_comment`, which divergence 9 already records; registering
+    one half of a pinned-comment model and not the other would have been the
+    odder choice.
+
+    First observed on 2026-08-11. Not new behaviour: `GET /issues/:n/comments`
+    published green from 2026-05-31 while both sides of the comparison were
+    empty arrays, which bound no key and no leaf type. Seeding the upstream half
+    made the comparison real and this is what it found.
+
+26. **Review objects omit `author_association`.** Real GitHub returns the
+    reviewer's relationship to the repository (`OWNER`, `COLLABORATOR`, `NONE`,
+    …) on every review; this twin does not model it. One leaf, and deliberately
+    not folded into divergence 21 — that one is about review *comments*, a
+    different object served by a different route, and one bullet naming two
+    claims is how a registration ends up covering something nobody verified.
+
+    What is **not** here is this surface's item count. `GET /pulls/:n/reviews`
+    did serve one review where GitHub served two, because posting a standalone
+    review comment makes GitHub wrap it in an empty-bodied `COMMENTED` review to
+    hang it off and this twin writes the comment without touching the review
+    table. That was fixed on the harness side by declaring the implicit review
+    in the fidelity seed, so a count divergence reappearing here is a
+    regression and must go red rather than land in a bullet widened to absorb
+    it.
+
+27. **Release objects omit GitHub's `immutable` flag.** Real GitHub returns
+    `immutable` on every release — the flag for its immutable-releases feature,
+    which pins a release's tag and assets against being moved or replaced after
+    publication. This twin does not model the feature, so it omits the key
+    rather than emitting a hard-coded `false`, which would claim it had
+    evaluated something it cannot.
+
+    Its neighbour `updated_at` was the same kind of omission and is **fixed**,
+    not recorded, in 0.10.7: a release does have an update instant, this twin
+    already knows the instant it was created, and there is no release-update
+    route here that could ever move the two apart — so the honest value was
+    available and omitting it was a gap rather than a modelling decision.
+
+28. **A review comment's `pull_request_review_id` is always `null`.** Real
+    GitHub returns the id of the review the comment hangs off — every review
+    comment belongs to one, because posting a standalone comment via
+    `POST /pulls/:n/comments` makes GitHub mint an empty-bodied `COMMENTED`
+    review for it. This twin writes `pull_request_review_comments` and never
+    touches the review table, so it has no review to point at and answers
+    `null`. Measured 2026-08-11: GitHub `4907749377`, twin `null`.
+
+    Recorded rather than fixed, and the reason is a collision rather than
+    difficulty. The faithful fix is for this twin to mint the implicit review
+    the way GitHub does — but the fidelity harness already works around the gap by
+    declaring that review explicitly in its seed, so a twin that also minted one
+    would serve **three** reviews where GitHub serves two, and
+    `GET /pulls/:n/reviews` would start failing on a count. Making both moves at
+    once is a coordinated two-repo change that also moves the result of every
+    task asserting on a review list, and it needs its own ticket rather than a
+    line in this one.
+
 ## How fidelity is verified
 
 Three independent checks back the tier classifications above. Each is a

--- a/packages/twin-github/package.json
+++ b/packages/twin-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-github",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "Deterministic GitHub-shaped twin for agent testing — REST + MCP, SQLite-backed state.",
   "private": true,
   "type": "module",

--- a/packages/twin-github/src/db.ts
+++ b/packages/twin-github/src/db.ts
@@ -128,6 +128,7 @@ CREATE TABLE IF NOT EXISTS releases (
   prerelease INTEGER NOT NULL DEFAULT 0,
   author_login TEXT NOT NULL DEFAULT 'pome-agent',
   created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT '',
   published_at TEXT,
   UNIQUE (repo_id, tag_name),
   FOREIGN KEY (repo_id) REFERENCES repositories(id) ON DELETE CASCADE
@@ -326,6 +327,11 @@ export function migrate(db: GitHubCloneDatabase) {
   ensureColumn(db, "pull_request_review_comments", "commit_sha", "TEXT");
   ensureColumn(db, "pull_request_review_comments", "in_reply_to_id", "INTEGER");
   ensureColumn(db, "collaborators", "invitation_state", "TEXT NOT NULL DEFAULT 'accepted'");
+  // F-1459 — real GitHub returns `updated_at` on every release and the twin
+  // omitted the key entirely. Defaulted to '' rather than NULL so an older
+  // database migrates without a rewrite; `hydrateDerivedColumns` backfills it
+  // from `created_at` for rows written before the column existed.
+  ensureColumn(db, "releases", "updated_at", "TEXT NOT NULL DEFAULT ''");
   ensureIssueNumberCascade(db);
   ensureCommentsAllowPullRequests(db);
   hydrateDerivedColumns(db);
@@ -450,5 +456,14 @@ UPDATE pull_requests
 SET
   head_sha = COALESCE(head_sha, (SELECT head_sha FROM branches WHERE branches.repo_id = pull_requests.head_repo_id AND branches.name = pull_requests.head_ref)),
   base_sha = COALESCE(base_sha, (SELECT head_sha FROM branches WHERE branches.repo_id = pull_requests.base_repo_id AND branches.name = pull_requests.base_ref));
+
+-- F-1459. \`updated_at\` arrived after \`releases\` existed, so a database written
+-- by an earlier build has it at the column default (''). A release this twin
+-- serves has never been edited — there is no release-update route — so its
+-- update instant IS its creation instant, and backfilling is exact rather than
+-- an approximation. Guarded on '' so a real value is never overwritten.
+UPDATE releases
+SET updated_at = created_at
+WHERE updated_at = '';
 `);
 }

--- a/packages/twin-github/src/domain/releases.ts
+++ b/packages/twin-github/src/domain/releases.ts
@@ -135,7 +135,7 @@ export function createRelease(domain: GitHubDomain,
     const draft = input.draft ? 1 : 0;
     const prerelease = input.prerelease ? 1 : 0;
     const now = nowIso();
-    const result = domain.db.prepare("INSERT INTO releases (repo_id, tag_name, target_commitish, name, body, draft, prerelease, author_login, created_at, published_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(
+    const result = domain.db.prepare("INSERT INTO releases (repo_id, tag_name, target_commitish, name, body, draft, prerelease, author_login, created_at, updated_at, published_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(
       repo.id,
       input.tag_name,
       target,
@@ -144,6 +144,11 @@ export function createRelease(domain: GitHubDomain,
       draft,
       prerelease,
       options.actor ?? "pome-agent",
+      now,
+      // F-1459 — `updated_at` on creation IS `created_at`. There is no release
+      // update route on this twin, so nothing can ever move it apart; when one
+      // is added it must set this column, which is why it is a real column and
+      // not `created_at` aliased in the serializer.
       now,
       draft ? null : now
     );

--- a/packages/twin-github/src/serializers.ts
+++ b/packages/twin-github/src/serializers.ts
@@ -591,6 +591,10 @@ export function releaseJson(release: ReleaseRow, repo: RepoRow) {
     prerelease: Boolean(release.prerelease),
     author: userJson(release.author_login),
     created_at: release.created_at,
+    // F-1459 — real GitHub returns this on every release; the twin used to omit
+    // the key, which read as `field-removed` on all three release surfaces.
+    // Falls back to `created_at` for a row written before the column existed.
+    updated_at: release.updated_at || release.created_at,
     published_at: release.published_at,
     html_url: `https://github.com/${repo.full_name}/releases/tag/${release.tag_name}`,
     url: `https://api.github.com/repos/${repo.full_name}/releases/${release.id}`,

--- a/packages/twin-github/src/types.ts
+++ b/packages/twin-github/src/types.ts
@@ -261,6 +261,10 @@ export type ReleaseRow = {
   prerelease: 0 | 1;
   author_login: string;
   created_at: string;
+  /** F-1459 — GitHub's release `updated_at`. Equal to `created_at` on a release
+   * that has never been edited, which is every release this twin serves: it has
+   * no release-update route. */
+  updated_at: string;
   published_at: string | null;
 };
 


### PR DESCRIPTION
## Why now

pome-cloud's F-1430 seeded the upstream half of twin-github's fidelity comparison. Seven of this twin's collections had published `green` since 2026-05-31 while **both sides were empty arrays** — `diffArray` returns before the per-element union when either side is empty, so those greens bound no key, no leaf type and no element. The element union now runs for the first time, and it is finding things.

Nothing here is a regression. Every divergence below has been true for as long as the surface has existed; what changed is that anything is measuring it.

## Fixed: `updated_at` on release objects

Real GitHub returns `updated_at` on every release; this twin omitted the key, so `GET /releases`, `/releases/latest` and `/releases/tags/:tag` each reported `field-removed` against the real-GitHub golden.

Fixed rather than recorded because **the honest value was already in hand**. A release served by this twin has never been edited — there is no release-update route here — so its update instant *is* its creation instant. That is exact, not an approximation.

Three details that are deliberate:

- **A real column, not `created_at` aliased in the serializer.** A release-update route added later must have somewhere to write; an alias would leave this field silently frozen at creation forever, which is a subtler version of the bug being fixed.
- **`ensureColumn` + a guarded backfill.** A database written by an earlier build gets the column by migration and `updated_at = created_at` where it is still `''`. Guarded on `''` so a real value is never overwritten.
- **The serializer falls back to `created_at`** for any row that reaches it without the backfill.

## Recorded, not fixed: bullets 25–28

| # | divergence | why not a fix |
|---|---|---|
| 25 | issue-comment objects omit `author_association`, `reactions`, `performed_via_github_app`, `pin`, `minimized` | `pin`/`minimized` are moderation state this twin has no model for; the other three are the same social metadata bullets 9 and 21 already record on neighbouring objects |
| 26 | review objects omit `author_association` | not modelled |
| 27 | release objects omit GitHub's `immutable` flag | no honest value — a hard-coded `false` would claim it had evaluated a feature it does not model |
| 28 | a review comment's `pull_request_review_id` is always `null` | see below |

### ⚠️ Bullet 28 is the one that looks like a fix and is not

Real GitHub returns the id of the review a comment hangs off, because *every* review comment belongs to one: posting a standalone comment via `POST /pulls/:n/comments` makes GitHub mint an empty-bodied `COMMENTED` review to hang it off. This twin writes `pull_request_review_comments` and never touches the review table, so it answers `null`. Measured 2026-08-11: GitHub `4907749377`, twin `null`.

The faithful fix is for this twin to mint that implicit review. **It cannot land alone.** pome-cloud's `FIDELITY_SEED` already works around the gap by declaring the implicit review explicitly (`upstream_implicit: true`, so the *upstream* seeder skips it) — which is exactly what makes `GET /pulls/:n/reviews` compare 2 against 2 today. A twin that also minted one would serve **three** reviews against GitHub's two and break that surface on a count.

So both moves have to land together, across two repos, and they move the result of every task that asserts on a review list plus seven test files in this package. That is the same class of coordinated behaviour migration bullet 24 was deferred for, and it gets its own ticket rather than being smuggled in here.

Bullet 26 says the same thing from the other side: the count divergence on `/pulls/:n/reviews` is **fixed** and must go red if it reappears, so it is deliberately *not* absorbed into that bullet.

## Version

`0.10.6` → **`0.10.7`**. Not docs-only — `src/db.ts`, `src/types.ts`, `src/domain/releases.ts` and `src/serializers.ts` all move, so `check-version-bump-required.mjs` requires the bump.

## Ordering — this PR merges FIRST

Same discipline as #372 → pome-cloud#663 and #373 → pome-cloud#669. The 1:1 lint binds each FIDELITY.md bullet to a `known-divergences/github.yaml` entry and errors in **both** directions, so one intermediate state has to be worn:

| State | pome-cloud PR CI (pinned, ADR-023) | fidelity-watch cron (unpinned main) |
|---|---|---|
| **This PR first** (bullets present, no entries) | **green** — an open PR reads the tree at `.github/twins-ref`, which has 23 bullets against 23 entries | red, `missing entry` ×4 — already red on twin-github's twelve drift surfaces |
| pome-cloud first (entries present, no bullets) | **red on its own CI** — `orphan entry` ×4 | red |
| both landed | green | green |

## Verification

```
npm run build       → 10 packages, build success
npm run typecheck   → exit 0
npm test -w packages/twin-github
                    → 40 files, 527 tests, all passing
```

## Paired change

A pome-cloud PR adds `GH-DIV-026/027/028/029`, extends the surface lists of `GH-DIV-006/009/014/018` onto the newly-compared surfaces, fixes three stale MCP read oracles, and moves `.github/twins-ref` onto this commit. It closes F-1459.

🤖 Generated with [Claude Code](https://claude.com/claude-code)