### PR TITLE
users.profile.set takes `profile` as an object, the way Slack does

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.23.21",
+  "version": "0.23.22",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/packages/twin-slack/route-inputs.json
+++ b/packages/twin-slack/route-inputs.json
@@ -1867,7 +1867,7 @@
           "name": "profile",
           "location": "body",
           "required": false,
-          "type": "string"
+          "type": "object|string"
         },
         {
           "name": "token",

--- a/packages/twin-slack/src/domain/slack-domain.ts
+++ b/packages/twin-slack/src/domain/slack-domain.ts
@@ -421,7 +421,7 @@ export class SlackDomain {
     return users.usersProfileGet(this, args, actor);
   }
 
-  usersProfileSet(args: { user?: string; profile?: string; name?: string; value?: string }, actor: Actor, onDelta: DeltaHook = NOOP): Record<string, unknown> {
+  usersProfileSet(args: { user?: string; profile?: string | Record<string, unknown>; name?: string; value?: string }, actor: Actor, onDelta: DeltaHook = NOOP): Record<string, unknown> {
     return users.usersProfileSet(this, args, actor, onDelta);
   }
 

--- a/packages/twin-slack/src/domain/users.ts
+++ b/packages/twin-slack/src/domain/users.ts
@@ -84,7 +84,7 @@ export function usersProfileGet(domain: SlackDomain, args: { user?: string; incl
 }
 
 
-export function usersProfileSet(domain: SlackDomain, args: { user?: string; profile?: string; name?: string; value?: string }, actor: Actor, onDelta: DeltaHook = NOOP): Record<string, unknown> {
+export function usersProfileSet(domain: SlackDomain, args: { user?: string; profile?: string | Record<string, unknown>; name?: string; value?: string }, actor: Actor, onDelta: DeltaHook = NOOP): Record<string, unknown> {
   const target = args.user ? domain.resolveUser(args.user) : domain.resolveActorUser(actor);
   if (!target) slackError("user_not_found", 404);
   const acting = domain.resolveActorUser(actor);
@@ -93,7 +93,11 @@ export function usersProfileSet(domain: SlackDomain, args: { user?: string; prof
     const before = domain.db.prepare(`SELECT * FROM users WHERE id = ?`).get(target!.id) as UserRow;
     let profile = safeParseJson(before.profile_json);
     if (args.profile) {
-      const incoming = safeParseJson(args.profile);
+      // F-1462 — Slack takes `profile` as a JSON string OR as an object, so the
+      // parse only runs on the branch that needs it. `safeParseJson` over an
+      // object would be a category error, not a no-op: it would swallow the
+      // fields and write nothing, which is a silent partial success.
+      const incoming = typeof args.profile === "string" ? safeParseJson(args.profile) : args.profile;
       profile = { ...(profile as object), ...(incoming as object) };
     } else if (args.name) {
       profile = { ...(profile as object), [args.name]: args.value ?? "" };

--- a/packages/twin-slack/src/route-inputs.ts
+++ b/packages/twin-slack/src/route-inputs.ts
@@ -163,6 +163,29 @@ const zeroIfAbsent = (): z.ZodType<number> => integerInput().default(0);
 /** A value the handler forwards without inspecting (canvas document bodies). */
 const opaque = (): z.ZodType<unknown> => z.unknown().optional();
 
+/**
+ * `users.profile.set`'s `profile`, which real Slack takes in TWO shapes (F-1462).
+ *
+ * Slack documents the JSON-STRING form, which is what form encoding forces, and
+ * it also accepts a bare OBJECT when the request body is `application/json`.
+ * That second half is documented nowhere and this twin refused it until F-1462
+ * called `users.profile.set` on the sandbox workspace and measured all three
+ * combinations — form+string, json+string and json+object all answered `ok:true`,
+ * and the object's fields were APPLIED, not merely tolerated. An examinee that
+ * sent the natural JSON shape used to fail here and pass in production.
+ *
+ * ⚠️ IT IS A UNION, NOT A SWAP. Both forms are real; swapping which one is
+ * accepted would move the divergence rather than close it. And it is NOT
+ * `z.unknown()` — the accepted set widened by exactly one shape, so
+ * `profile: 12345` is still refused, which is what keeps the declaration a
+ * statement about Slack rather than a hole.
+ */
+const jsonStringOrObject = (): z.ZodType<string | Record<string, unknown> | undefined> =>
+  z
+    .union([z.string(), z.record(z.string(), z.unknown())])
+    .optional()
+    .transform((value) => (value ? value : undefined));
+
 // ─── Reads: mounted on GET and POST ──────────────────────────────────────────
 
 export const SLACK_READS = {
@@ -359,7 +382,7 @@ export const SLACK_WRITES = {
 
   usersProfileSet: slackWrite("/users.profile.set", {
     user: absentIfEmpty(),
-    profile: absentIfEmpty(),
+    profile: jsonStringOrObject(),
     name: absentIfEmpty(),
     value: absentIfEmpty(),
   }),

--- a/packages/twin-slack/test/users-profile-set-shapes.test.ts
+++ b/packages/twin-slack/test/users-profile-set-shapes.test.ts
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// `users.profile.set` takes `profile` as a JSON STRING *or* an object (F-1462).
+//
+// ── WHAT WAS MEASURED, AND AGAINST WHOM ────────────────────────────────────
+//
+// The twin declared `profile` as `z.string()` and ran `safeParseJson` over it,
+// so an object under `application/json` failed the route parse and the method
+// answered `{ok:false, error:"invalid_arguments"}` at HTTP 200 — the shape a
+// status-code-only check reads as success. F-1406's REST write leg hit it on its
+// first run against the booted twin and WORKED AROUND it by sending the string
+// form, which is why that row is green and nothing was fixed.
+//
+// Whether real Slack accepts the object was unknown and undocumented, so F-1462
+// refused to rule it from the docs. It was called on 2026-08-12 against the
+// `pome-twin-sandbox` workspace with a one-shot user token:
+//
+//   C  form-encoded + string profile   ok:true     (Slack's documented shape)
+//   B  application/json + string       ok:true     (so JSON bodies are fine here)
+//   A  application/json + OBJECT       ok:true     and status_text came back as
+//                                                  the value nested INSIDE the
+//                                                  object — applied, not merely
+//                                                  tolerated
+//
+// B is what makes A readable: without it, a refusal could have meant "Slack
+// takes no JSON body on this method", which is a different ticket. Slack accepts
+// BOTH forms, so the twin refusing one is a false FAILURE — an examinee's agent
+// that sends the natural JSON shape fails here and passes in production.
+//
+// ⚠️ THE STRING FORM IS NOT DEPRECATED BY THIS. Both are real; C and B both
+// answered `ok:true`. A fix that swapped one for the other would move the
+// divergence rather than close it, so every case below is asserted in both
+// shapes, and the assertions read the WRITTEN STATE back through
+// `users.profile.get` rather than trusting the echo.
+import { beforeEach, describe, expect, it } from "vitest";
+import { createSlackTwinApp } from "../src/twin.js";
+import { openSlackTwinDatabase } from "../src/db.js";
+import { SlackDomain } from "../src/domain/index.js";
+import { defaultSeedState } from "../src/seed.js";
+import { signTestToken, TEST_SID, withAuth } from "./_authHelper.js";
+
+const base = `/s/${TEST_SID}`;
+
+function freshApp() {
+  const db = openSlackTwinDatabase(":memory:");
+  const domain = new SlackDomain(db);
+  domain.seed(defaultSeedState());
+  return createSlackTwinApp({ db, domain, runId: "profile-shapes" });
+}
+
+type App = ReturnType<typeof createSlackTwinApp>;
+
+async function post(app: App, token: string, path: string, body: unknown, contentType = "application/json") {
+  const init: RequestInit = { method: "POST", headers: { "content-type": contentType } };
+  init.body = contentType.startsWith("application/json")
+    ? JSON.stringify(body)
+    : new URLSearchParams(body as Record<string, string>).toString();
+  const response = await app.request(`${base}${path}`, withAuth(token, init));
+  return { status: response.status, body: (await response.json()) as Record<string, any> };
+}
+
+/** The written state, read back — never the echo off the write itself. */
+async function displayName(app: App, token: string, user: string): Promise<string> {
+  const got = await post(app, token, "/users.profile.get", { user });
+  expect(got.body.ok, JSON.stringify(got.body)).toBe(true);
+  return got.body.profile.display_name as string;
+}
+
+describe("users.profile.set — `profile` as an object, the way Slack takes it", () => {
+  let token: string;
+  beforeEach(async () => {
+    token = await signTestToken();
+  });
+
+  it("accepts an OBJECT profile under application/json and APPLIES it", async () => {
+    const app = freshApp();
+
+    const set = await post(app, token, "/users.profile.set", {
+      user: "alice",
+      profile: { display_name: "object-form" },
+    });
+
+    expect(set.status).toBe(200);
+    expect(set.body.ok, JSON.stringify(set.body)).toBe(true);
+    // ⚠️ NOT just `ok:true`. The twin answered `{ok:false}` at HTTP 200 before
+    // this change, so a status-only assertion passes on the bug. And a twin that
+    // accepted the object and then dropped it would also answer ok:true — only
+    // reading the state back separates the two.
+    expect(await displayName(app, token, "alice")).toBe("object-form");
+  });
+
+  it("still accepts the JSON-STRING profile — both forms are real", async () => {
+    // Slack answered ok:true to the string form on both transports. This is the
+    // half a "fix" that merely swapped the accepted type would have broken, and
+    // it is the form F-1406's leg has been sending all along.
+    const app = freshApp();
+
+    const set = await post(app, token, "/users.profile.set", {
+      user: "alice",
+      profile: JSON.stringify({ display_name: "string-form" }),
+    });
+
+    expect(set.body.ok, JSON.stringify(set.body)).toBe(true);
+    expect(await displayName(app, token, "alice")).toBe("string-form");
+  });
+
+  it("takes the string form form-encoded too — the shape Slack documents", async () => {
+    const app = freshApp();
+
+    const set = await post(
+      app,
+      token,
+      "/users.profile.set",
+      { user: "alice", profile: JSON.stringify({ display_name: "form-encoded" }) },
+      "application/x-www-form-urlencoded",
+    );
+
+    expect(set.body.ok, JSON.stringify(set.body)).toBe(true);
+    expect(await displayName(app, token, "alice")).toBe("form-encoded");
+  });
+
+  it("merges into the existing profile rather than replacing it, in either shape", async () => {
+    // `usersProfileSet` spreads the incoming keys over the stored profile. The
+    // object branch reaches that spread by a different path than the string
+    // branch (no `safeParseJson`), so "does the merge still happen" is a real
+    // question about the new branch and not a restatement of the old one.
+    const app = freshApp();
+
+    await post(app, token, "/users.profile.set", { user: "alice", profile: { display_name: "merged" } });
+    await post(app, token, "/users.profile.set", { user: "alice", profile: { status_text: "in a meeting" } });
+
+    const got = await post(app, token, "/users.profile.get", { user: "alice" });
+    expect(got.body.profile.display_name).toBe("merged");
+    expect(got.body.profile.status_text).toBe("in a meeting");
+  });
+
+  it("still refuses a profile that is neither — a number is not a shape Slack takes", async () => {
+    // The tightening this must NOT become: `z.unknown()` would accept anything
+    // and quietly write nothing legible. The accepted set widened by exactly one
+    // shape, and this is the assertion that says so.
+    const app = freshApp();
+
+    const set = await post(app, token, "/users.profile.set", { user: "alice", profile: 12345 });
+
+    expect(set.body.ok).toBe(false);
+    expect(String(JSON.stringify(set.body))).toContain("profile");
+    // And nothing was written — the seeded display name is untouched.
+    expect(await displayName(app, token, "alice")).toBe("Alice");
+  });
+
+  it("leaves the name/value pair form working", async () => {
+    // The third way in. It shares the handler with both `profile` branches, so a
+    // union that widened the parse could have broken it without anything else
+    // noticing.
+    const app = freshApp();
+
+    const set = await post(app, token, "/users.profile.set", {
+      user: "alice",
+      name: "display_name",
+      value: "pair-form",
+    });
+
+    expect(set.body.ok, JSON.stringify(set.body)).toBe(true);
+    expect(await displayName(app, token, "alice")).toBe("pair-form");
+  });
+});


### PR DESCRIPTION
## What

The twin declared `profile` as `z.string()` and ran `safeParseJson` over it, so
an object under `application/json` failed the route parse and the method
answered `{"ok":false,"error":"invalid_arguments"}` at **HTTP 200** — the shape
a status-code-only check reads as a success.

F-1406's REST write leg hit this on its first run against the booted twin and
**worked around it** by sending the string form, which is why that row is green
and nothing was fixed. The finding lived only in a merged PR description and one
source comment.

## The vendor was called, not read

Whether real Slack takes the object was undocumented and had never been tried,
so it was deliberately not ruled from the docs. Called 2026-08-12 against the
`pome-twin-sandbox` workspace with a one-shot user token, since revoked:

| | content-type | `profile` | result |
| --- | --- | --- | --- |
| **C** | `x-www-form-urlencoded` | string | `ok:true` — Slack's documented shape |
| **B** | `application/json` | string | `ok:true` — so JSON bodies are fine here |
| **A** | `application/json` | **object** | `ok:true`, and `status_text` came back as the value nested **inside** the object |

**B is what makes A readable.** Without it, a refusal could have meant *"Slack
takes no JSON body on this method"* — a different finding. With it, both forms
are confirmed real, and the twin was refusing a call the vendor answers: a false
**FAILURE**, the opposite direction from the five entries F-1389 registered, and
the direction nothing currently measures. An examinee's agent that sent the
natural JSON shape failed here and passed in production.

## ⚠️ A union, not a swap

Both shapes work at Slack. Accepting the object and dropping the string would
move the divergence rather than close it — and the string form is what F-1406's
leg has been sending all along. Every case in the new suite is asserted in
**both** shapes.

## ⚠️ Not `z.unknown()`

The accepted set widens by exactly **one** shape. `profile: 12345` is still
refused and still writes nothing — asserted. A declaration that took anything
would be a hole rather than a statement about Slack.

## Reviewer notes

- **The parse follows the type rather than running unconditionally.**
  `safeParseJson` over an object is a category error, not a no-op: it swallows
  the fields and writes nothing, which is a silent partial success and strictly
  worse than the refusal it replaces.
- **The assertions read state back through `users.profile.get`**, never the
  write's own echo. Both halves matter — the old bug answered HTTP 200, so a
  status-only check passes on it; and a twin that accepted the object then
  dropped it would answer `ok:true` too.
- **`cli/package.json` 0.23.21 → 0.23.22**, since the CLI bundles the twins.
  `package-lock.json` is independently stale and deliberately untouched.
- The pome-cloud half adds the object step to `sandboxes/slack/rest-writes.ts`
  so the capture leg proves this fix instead of continuing to route around it.

## Verification

```
twin-slack 307 (was 301)   full workspace 3457 green   typecheck clean   knip clean
probe:twins 128 probes     gate:route-inputs 981 inputs (unchanged)
gate:mcp-tools-list OK     version-bump + workspace-pin gates OK
```

## Tracking

Linear [F-1462](https://linear.app/pome-sh/issue/F-1462/twin-slacks-usersprofileset-rejects-a-json-profile-object-verify) —
the identifier is deliberately **not** in this title. The ticket needs two PRs
(this one, then pome-cloud's leg step), and a linked title here would flip it
`Done` on *this* merge with the half that proves it still unwritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)