### PR TITLE
Repin support-triage's adapter to the published 0.3.4 (F-1483 follow-through)

### DIFF
--- a/examples/support-triage/package-lock.json
+++ b/examples/support-triage/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.215",
-        "@pome-sh/adapter-claude-sdk": "0.3.3"
+        "@pome-sh/adapter-claude-sdk": "0.3.4"
       },
       "devDependencies": {
         "@types/node": "^25.9.5",
@@ -890,9 +890,9 @@
       }
     },
     "node_modules/@pome-sh/adapter-claude-sdk": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@pome-sh/adapter-claude-sdk/-/adapter-claude-sdk-0.3.3.tgz",
-      "integrity": "sha512-GcDUm3YebAG96FA/u6fNh34jP3rvkKHywgz2sNDYgpnykIDlhrR0CX+ZbKeqK4OlNnYL/5xnx3UZF0QyM50Ssg==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@pome-sh/adapter-claude-sdk/-/adapter-claude-sdk-0.3.4.tgz",
+      "integrity": "sha512-f7Y/doinwAhaDZxJTzSp3a7NTkexPnma4+Qwx/X0Ot3unGCryxLkt4cWB9pwh+HyMqqaIgPAD7R9Sde9ozN9Mg==",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.221.0",

--- a/examples/support-triage/package.json
+++ b/examples/support-triage/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.215",
-    "@pome-sh/adapter-claude-sdk": "0.3.3"
+    "@pome-sh/adapter-claude-sdk": "0.3.4"
   },
   "devDependencies": {
     "@types/node": "^25.9.5",


### PR DESCRIPTION
`main` is red. F-1488 (#393) bumped `@pome-sh/adapter-claude-sdk` to 0.3.4 and `release.yml` published it, but `examples/support-triage` still pins `0.3.3` — so F-1483's registry-parity gate fires, exactly as designed.

This is the per-release re-pin F-1483 records as its own cost ("one follow-up re-pin PR per adapter release"), not a defect in the gate. Filing it as its own PR rather than absorbing it into #394, because it is #393's fallout and it blocks every branch cut from `main`.

## Verification

- `examples/support-triage/package.json` pin `0.3.3` → `0.3.4`; lockfile regenerated with `npm install --package-lock-only`.
- Pin-parity gate now reports `1 matched, 0 skipped (unpublished), 0 drifted, 0 errored (of 1 exact pin(s) checked); 3 file:/link: workspace link(s) out of scope, 0 unwatchable`.
- `grep -c shared-types package-lock.json` → **0**. The retired `@pome-sh/shared-types` stays out of the hero example's tree, which was F-1483's substantive concern.
- Diff is the pin plus its lockfile entries; nothing else touched.