### PR TITLE
`status` in the error envelope is a string, as GitHub sends it (F-1490)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.23.29",
+  "version": "0.23.30",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.23.28",
+  "version": "0.23.29",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/packages/twin-github/CHANGELOG.md
+++ b/packages/twin-github/CHANGELOG.md
@@ -1,5 +1,54 @@
 # @pome-sh/twin-github — CHANGELOG
 
+## 0.10.10 — 2026-08-12
+
+`status` in the error envelope is a **string**, the way real GitHub sends it, and
+the two envelope gaps that cannot be fixed here are registered (F-1490).
+
+**⚠️ Wire change on every 4xx/5xx this twin emits.** `githubError` now renders
+`status: "422"` where it rendered `status: 422`. An examinee that type-checks the
+field, or a grader comparing envelopes leaf by leaf, saw a difference on every
+single error before this. Measured live against `api.github.com` on 2026-08-12:
+**59 of 59** error responses across 400 / 401 / 403 / 404 / 409 / 422 sent it
+quoted — zero exceptions, zero absences — and GitHub's own published OpenAPI
+description declares it independently (`basic-error` has
+`status: {type: string}`). The ticket asked for exactly this re-measurement
+because a quoted numeric is odd enough to distrust from one surface; it held on
+every class.
+
+The HTTP status stays a number. Only the body leaf is a string, and a test
+asserts the two are deliberately different types, because stringifying the wrong
+one would break every response.
+
+**Teeth on the helper, not on a route**, since `githubError` builds the body for
+every envelope that flows through `githubErrorEnvelope` — TwinError, the zod
+branch, the unknown-tool branch, the JSON-parse branch and the 500 fallback. The
+new `test/error-envelope-status.test.ts` asserts the helper directly *and* on the
+wire across every error class the twin can be provoked into, so it cannot pass by
+agreeing with itself.
+
+**Two things measured and deliberately NOT fixed, now registered as divergences
+31 and 32** rather than left invisible:
+
+- **The 401/403 envelopes** carry `documentation_url: ""` and **no `status` leaf
+  at all**, where GitHub sends the generic-but-real url and `"401"`. Three of the
+  four envelope-building sites never reach `githubError`, and two of those live in
+  **`@pome-sh/sdk`** — shared by all five twins, so fixing them there moves slack,
+  stripe, gmail and linear too and needs its own cross-twin measurement.
+- **`documentation_url` is generic** where GitHub names the operation (45 of 59).
+  The SDK hook is `(err) => {status, body}`: it cannot see the entry point, and
+  `notFound()` in `requireRepo` is reachable from ~40 routes and ~30 tools, so the
+  url depends on which door was knocked on rather than where the throw happened.
+
+Divergence 32 records the **boundary** as well as the rule, because "operation
+everywhere" would be a new divergence in the other direction: GitHub is generic
+on every 401 (8/8), on unrouted paths (4/4), and on `GET /users/:username` (2/2,
+a one-off — `/users/:u/repos`, `/orgs/:o` and `/gists/:id` are all specific).
+
+Three test files migrated off the numeric literal: `contents-base64.test.ts` and
+`contents-sha-semantics.test.ts` (whose whole-envelope assertions carried nine of
+them), plus a stray backtick in F-1491's own divergence-30 prose.
+
 ## 0.10.9 — 2026-08-12
 
 A wrong `sha` on the contents door is a **409**, not a 422, and a missing one

--- a/packages/twin-github/FIDELITY.md
+++ b/packages/twin-github/FIDELITY.md
@@ -541,7 +541,7 @@ on each bullet's bold title and never on its number, so gaps cost it nothing.
 30. **A missing required body field says `Validation Failed` where GitHub names
     the field.** Real GitHub answers a required body field the caller did not
     send with `422 Invalid request.\n\n"<field>" wasn't supplied.` and **no
-    `errors` array`**. Measured live 2026-08-12 on four unrelated surfaces —
+    `errors` array**. Measured live 2026-08-12 on four unrelated surfaces —
     `PUT /contents/*` and `DELETE /contents/*` (`sha`), `POST /issues` (`title`),
     `POST /pulls` (`head`) — so it is GitHub's general answer, not one route's
     quirk. This twin instead answers the generic `Validation Failed` plus a
@@ -569,6 +569,88 @@ on each bullet's bold title and never on its number, so gaps cost it nothing.
     Pinned by `test/contents-sha-semantics.test.ts`, whose last test asserts the
     unfixed shape on `POST /issues` deliberately — when the global change lands,
     that test fails, and failing is the signal.
+
+31. **The 401 and 403 envelopes carry an empty `documentation_url` and no
+    `status` leaf at all.** Real GitHub answers `401` with
+    `{message, documentation_url: "https://docs.github.com/rest", status: "401"}`
+    — the generic url, but a *real* one, and the `status` leaf present. Measured
+    live 2026-08-12 (F-1490): 8 of 8 401s across five route shapes (`/user`,
+    `/repos/:o/:r`, `/search/repositories`, `/users/:u`,
+    `/repos/:o/:r/contents/*`), with a bad token and with no `Authorization`
+    header at all. 403 is the same but with an operation-specific url (3 of 3).
+
+    This twin answers `{message, documentation_url: ""}` — empty string, and the
+    `status` leaf **missing entirely**. Three of the four envelope-building sites
+    in play never reach `githubError`, which is why F-1490's global `status` fix
+    does not cover them: the 401 bodies are written by hand in `src/twin.ts`
+    (`auth.unauthorized` / `auth.sidMismatch`), and the admin-gate 403 body comes
+    from **`@pome-sh/sdk`** (`admin-gate.ts`, defaulted in `auth.ts`).
+
+    **Registered rather than fixed because two of the three are not
+    twin-github's to change.** `packages/sdk` is shared by all five twins, so an
+    empty-url or missing-`status` fix there moves slack, stripe, gmail and linear
+    at the same time and needs its own ticket with its own cross-twin
+    measurement — twin-github's numbers say nothing about what Slack's 401 looks
+    like. Doing it inside a github envelope ticket would be the same
+    smuggling F-1490 was spawned to avoid.
+
+    One smaller difference in the same family, measured and not fixed here:
+    GitHub distinguishes a **bad** credential (`Bad credentials`) from a
+    **missing** one (`Requires authentication`); this twin says `Bad credentials`
+    for both.
+
+    Pinned by `test/error-envelope-status.test.ts`, which asserts the *absent*
+    `status` leaf and the empty url on purpose — so this reads as a gap rather
+    than as coverage, and closing it makes the test fail.
+
+32. **`documentation_url` is the generic `https://docs.github.com/rest` where
+    GitHub names the operation.** Measured live 2026-08-12 (F-1490): real GitHub
+    is operation-specific on **45 of 59** error responses —
+    `https://docs.github.com/rest/repos/contents#create-or-update-file-contents`,
+    `…/rest/branches/branches#get-a-branch`, `…/rest/commits/commits#list-commits`
+    and so on. This twin sends the generic url everywhere except the four
+    contents-door `sha` sites and the invalid-base64 site, which can name their
+    operation because a `sha` or base64 refusal can only be raised BY that
+    operation.
+
+    **The boundary matters as much as the rule, because "operation everywhere"
+    would be a NEW divergence in the opposite direction.** GitHub itself sends
+    the generic url on the remaining **14 of 59**, and the cases are crisp:
+
+    * **every 401 — 8 of 8**, on all five route shapes probed and with no
+      `Authorization` header at all. Authentication fails before dispatch, so
+      there is no operation to name.
+    * **unrouted paths — 4 of 4** (`/this-route-does-not-exist`, `/zzz-not-a-route`,
+      `/repos`, `DELETE /user`).
+    * **`GET /users/:username` — 2 of 2.** A genuine GitHub one-off, not a
+      pattern: `GET /users/:u/repos` *is* operation-specific, so is `GET /orgs/:o`,
+      and so is `GET /gists/:id`. Only the single-user read is generic.
+
+    So a faithful fix has to reproduce GitHub's genericness too. The twin is
+    already accidentally right on two of those three classes — its 401s and its
+    unrouted 501 catch-all do not name an operation either.
+
+    **Registered rather than fixed because the envelope builder structurally
+    cannot know the answer.** The SDK hook is `errorEnvelope?: (err: unknown) =>
+    {status, body}` — the error, and nothing else. That is not an oversight to
+    route around: `notFound()` raised inside `domain.requireRepo()` is reachable
+    from ~40 REST routes *and* ~30 MCP tools, and the right url depends on which
+    door was knocked on rather than on where the throw happened. Naming the
+    operation means putting a url on all **65 REST surfaces**
+    (`route-inputs.json`) **and 40 MCP tools**; the MCP door emits this same
+    envelope.
+
+    The data for it is not guesswork and that is worth recording: GitHub's
+    published OpenAPI description carries `externalDocs.url` per operation,
+    byte-identical to what was measured on the wire, and 63 of the 65 REST
+    surfaces map mechanically onto a GitHub operation. The two that do not —
+    `GET /pulls/:n/diff` and `GET /pulls/:n/status` — are twin-only routes GitHub
+    would answer generically anyway, so they are already right. What the fix
+    needs decided rather than guessed is the 40-tool mapping, where a tool like
+    `push_files` spans several REST operations.
+
+    Pinned by `test/error-envelope-status.test.ts`, which asserts the generic url
+    on a 404 deliberately.
 
 ## How fidelity is verified
 

--- a/packages/twin-github/package.json
+++ b/packages/twin-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/twin-github",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "description": "Deterministic GitHub-shaped twin for agent testing \u2014 REST + MCP, SQLite-backed state.",
   "private": true,
   "type": "module",

--- a/packages/twin-github/src/errors.ts
+++ b/packages/twin-github/src/errors.ts
@@ -16,11 +16,25 @@ export class TwinError extends Error {
   }
 }
 
+/**
+ * Build GitHub's error body: `{message, documentation_url, status, errors?}`.
+ *
+ * `status` is rendered as a **STRING**, which looks like a bug and is not.
+ * Measured live against `api.github.com` on 2026-08-12 (F-1490): **59 of 59**
+ * error responses across 400 / 401 / 403 / 404 / 409 / 422 sent it quoted, with
+ * no exceptions and no absences, and GitHub's own published OpenAPI description
+ * declares it that way too — `basic-error` has `status: {type: string}`. Two
+ * independent sources, so the twin quotes it as well.
+ *
+ * ⚠️ The `status` here is the BODY LEAF, not the HTTP status. `twin.ts`'s
+ * `githubErrorEnvelope` returns `{status, body}` and the outer one stays a
+ * number, because that is what the engine writes to the status line.
+ */
 export function githubError(message: string, status: number, errors?: unknown[], documentationUrl?: string) {
   return {
     message,
     documentation_url: documentationUrl ?? "https://docs.github.com/rest",
-    status,
+    status: String(status),
     ...(errors ? { errors } : {})
   };
 }

--- a/packages/twin-github/test/contents-base64.test.ts
+++ b/packages/twin-github/test/contents-base64.test.ts
@@ -162,7 +162,7 @@ describe("F-1460 — REST `PUT /contents/*` takes base64, the way GitHub does", 
       message: "content is not valid Base64",
       documentation_url:
         "https://docs.github.com/rest/repos/contents#create-or-update-file-contents",
-      status: 422
+      status: "422"
     });
 
     // Refused, not half-written.

--- a/packages/twin-github/test/contents-sha-semantics.test.ts
+++ b/packages/twin-github/test/contents-sha-semantics.test.ts
@@ -32,14 +32,17 @@
 // Neither body carries an `errors` array. `DELETE` answers the same two shapes
 // against its own doc anchor (`#delete-a-file`).
 //
-// Two things in those bodies are DELIBERATELY still wrong here and belong to
-// F-1490, which is a global envelope question and has its own decision:
-// `status` is a number where GitHub sends a string, and every envelope this twin
-// builds outside the four sites below carries the generic
-// `https://docs.github.com/rest`. This file pins the operation-specific url
-// because the sha errors can only come FROM the contents operations, so the
-// throw site knows the operation — which is exactly the subset F-1490 cannot
-// generalise. Do not widen it here.
+// `status` is a quoted string in the assertions below because F-1490 closed
+// that half globally in `githubError` — 59 of 59 measured GitHub error responses
+// send it quoted, and GitHub's own `basic-error` schema types it `string`. The
+// numbers this file shipped with were the divergence, not the claim.
+//
+// The OTHER half of F-1490 is still open and deliberately not widened here:
+// every envelope this twin builds outside the four sites below carries the
+// generic `https://docs.github.com/rest` where GitHub names the operation
+// (divergence 32). This file pins the operation-specific url because a sha
+// conflict can only come FROM the contents operations, so the throw site knows
+// which one — exactly the subset F-1490 could not generalise.
 //
 // ── WHY THIS DID NOT GO IN `validationFailed` ─────────────────────────────
 //
@@ -118,7 +121,7 @@ describe("F-1491 — a wrong `sha` on the contents door is a 409, as GitHub answ
     // Whole-envelope equality, so an `errors` array coming back is a failure.
     expect(put).toEqual({
       status: 409,
-      body: { message: "probe.txt does not match deadbeef", documentation_url: PUT_DOC, status: 409 }
+      body: { message: "probe.txt does not match deadbeef", documentation_url: PUT_DOC, status: "409" }
     });
   });
 
@@ -136,7 +139,7 @@ describe("F-1491 — a wrong `sha` on the contents door is a 409, as GitHub answ
 
     expect(put).toEqual({
       status: 409,
-      body: { message: `probe.txt does not match ${ghost}`, documentation_url: PUT_DOC, status: 409 }
+      body: { message: `probe.txt does not match ${ghost}`, documentation_url: PUT_DOC, status: "409" }
     });
   });
 
@@ -154,7 +157,7 @@ describe("F-1491 — a wrong `sha` on the contents door is a 409, as GitHub answ
 
     expect(put).toEqual({
       status: 409,
-      body: { message: `probe.txt does not match ${otherSha}`, documentation_url: PUT_DOC, status: 409 }
+      body: { message: `probe.txt does not match ${otherSha}`, documentation_url: PUT_DOC, status: "409" }
     });
   });
 
@@ -171,7 +174,7 @@ describe("F-1491 — a wrong `sha` on the contents door is a 409, as GitHub answ
 
     expect(put).toEqual({
       status: 409,
-      body: { message: "dir/sub/file.txt does not match deadbeef", documentation_url: PUT_DOC, status: 409 }
+      body: { message: "dir/sub/file.txt does not match deadbeef", documentation_url: PUT_DOC, status: "409" }
     });
   });
 
@@ -187,7 +190,7 @@ describe("F-1491 — a wrong `sha` on the contents door is a 409, as GitHub answ
 
     expect(del).toEqual({
       status: 409,
-      body: { message: "dir/sub/file.txt does not match deadbeef", documentation_url: DELETE_DOC, status: 409 }
+      body: { message: "dir/sub/file.txt does not match deadbeef", documentation_url: DELETE_DOC, status: "409" }
     });
   });
 
@@ -224,7 +227,7 @@ describe("F-1491 — a wrong `sha` on the contents door is a 409, as GitHub answ
 
     expect(called).toEqual({
       status: 409,
-      body: { message: "probe.txt does not match deadbeef", documentation_url: PUT_DOC, status: 409 }
+      body: { message: "probe.txt does not match deadbeef", documentation_url: PUT_DOC, status: "409" }
     });
   });
 
@@ -243,7 +246,7 @@ describe("F-1491 — a wrong `sha` on the contents door is a 409, as GitHub answ
 
     expect(called).toEqual({
       status: 409,
-      body: { message: "probe.txt does not match deadbeef", documentation_url: DELETE_DOC, status: 409 }
+      body: { message: "probe.txt does not match deadbeef", documentation_url: DELETE_DOC, status: "409" }
     });
   });
 });
@@ -264,7 +267,7 @@ describe("F-1491 — a MISSING `sha` is still a 422, but GitHub's 422, not the g
       body: {
         message: 'Invalid request.\n\n"sha" wasn\'t supplied.',
         documentation_url: PUT_DOC,
-        status: 422
+        status: "422"
       }
     });
   });
@@ -286,7 +289,7 @@ describe("F-1491 — a MISSING `sha` is still a 422, but GitHub's 422, not the g
       body: {
         message: 'Invalid request.\n\n"sha" wasn\'t supplied.',
         documentation_url: PUT_DOC,
-        status: 422
+        status: "422"
       }
     });
   });
@@ -309,7 +312,7 @@ describe("F-1491 — a MISSING `sha` is still a 422, but GitHub's 422, not the g
       body: {
         message: 'Invalid request.\n\n"sha" wasn\'t supplied.',
         documentation_url: PUT_DOC,
-        status: 422
+        status: "422"
       }
     });
   });

--- a/packages/twin-github/test/error-envelope-status.test.ts
+++ b/packages/twin-github/test/error-envelope-status.test.ts
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+// F-1490 — `status` in the error envelope is a STRING, the way real GitHub sends it.
+//
+// ── THE MEASUREMENT THIS FILE PINS ────────────────────────────────────────
+//
+// Probed live against `api.github.com` on 2026-08-12 (two throwaway private
+// repos, both deleted; `.context/probe-*.sh` are the transcripts). **59 of 59**
+// error responses carried `status` as a JSON string. Zero exceptions, zero
+// absences:
+//
+//   | HTTP | responses | `status` |
+//   |------|-----------|----------|
+//   | 400  | 1         | `"400"`  |
+//   | 401  | 8         | `"401"`  |
+//   | 403  | 3         | `"403"`  |
+//   | 404  | 24        | `"404"`  |
+//   | 409  | 9         | `"409"`  |
+//   | 422  | 14        | `"422"`  |
+//
+// GitHub's own published OpenAPI description says the same thing out loud —
+// `basic-error` declares `status: {type: string}`. Wire and vendor schema were
+// obtained independently and agree, which is why this is a FIX and not a
+// registered divergence: the ticket asked for exactly this re-measurement
+// ("odd enough that it is worth re-measuring across several error classes")
+// and it held on every class.
+//
+// ⚠️ NOT MEASURED, INFERRED: 5xx and 429. Neither can be provoked safely
+// against live GitHub, so their string-ness rests on `basic-error` alone. The
+// twin sends a string there for consistency; if it ever matters, probe it.
+//
+// ── WHY THE TEETH ARE ON THE HELPER ───────────────────────────────────────
+//
+// `githubError` builds the body for every envelope that flows through
+// `githubErrorEnvelope` — TwinError, the zod branch, the unknown-tool branch,
+// the JSON-parse branch and the 500 fallback — so one assertion on the helper
+// covers all of them, and the wire tests below stop it being a unit test that
+// agrees with itself.
+//
+// ⚠️ IT DOES NOT COVER EVERY ENVELOPE THE TWIN EMITS, and F-1490 measured
+// exactly which ones it misses: the 401 sites in `twin.ts`, the SDK's admin-gate
+// 403, and the 501 catch-all all build their bodies by hand and carry NO
+// `status` leaf at all. Those are registered as divergences 31 and 32 rather
+// than fixed here, because two of the three live in `@pome-sh/sdk` and are
+// shared by all five twins. The last test in this file pins that gap so it
+// cannot be mistaken for coverage.
+
+import { describe, expect, it } from "vitest";
+import { createGitHubCloneApp } from "../src/twin.js";
+import { githubError } from "../src/errors.js";
+import { TEST_AUTH_SECRET, TEST_SID, signTestToken, withAuth } from "./_authHelper.js";
+
+const base = `/s/${TEST_SID}`;
+process.env.TWIN_AUTH_SECRET = TEST_AUTH_SECRET;
+
+const b64 = (text: string) => Buffer.from(text, "utf8").toString("base64");
+
+async function rest(app: ReturnType<typeof createGitHubCloneApp>, method: string, path: string, body?: unknown) {
+  const token = await signTestToken();
+  const init: RequestInit = { method, headers: { "content-type": "application/json" } };
+  if (body !== undefined) init.body = typeof body === "string" ? body : JSON.stringify(body);
+  const response = await app.request(`${base}${path}`, withAuth(token, init));
+  const text = await response.text();
+  return { status: response.status, body: text ? JSON.parse(text) : null };
+}
+
+async function mcp(app: ReturnType<typeof createGitHubCloneApp>, tool: string, args: unknown) {
+  const token = await signTestToken();
+  const response = await app.request(
+    `${base}/mcp/call`,
+    withAuth(token, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ tool, arguments: args }) })
+  );
+  const text = await response.text();
+  return { status: response.status, body: text ? JSON.parse(text) : null };
+}
+
+describe("F-1490 — the envelope builder always renders `status` as a string", () => {
+  it("stringifies every status it is handed", () => {
+    // The teeth, on the helper rather than on one route. Written as data so a
+    // status class the twin gains is covered without editing an assertion.
+    for (const code of [400, 401, 403, 404, 409, 422, 500, 501, 503]) {
+      expect(githubError("x", code)).toMatchObject({ status: String(code) });
+      expect(typeof githubError("x", code).status).toBe("string");
+    }
+  });
+
+  it("does not disturb the other three leaves", () => {
+    expect(githubError("Not Found", 404)).toEqual({
+      message: "Not Found",
+      documentation_url: "https://docs.github.com/rest",
+      status: "404"
+    });
+    expect(githubError("Validation Failed", 422, [{ resource: "Request", field: "q", code: "missing" }], "https://docs.github.com/rest/search/search#search-code")).toEqual({
+      message: "Validation Failed",
+      documentation_url: "https://docs.github.com/rest/search/search#search-code",
+      status: "422",
+      errors: [{ resource: "Request", field: "q", code: "missing" }]
+    });
+  });
+
+  it("keeps the HTTP status a NUMBER — only the body leaf is a string", async () => {
+    // The one way this change could go wrong is by stringifying the wrong
+    // `status`: `githubErrorEnvelope` returns {status, body} where the outer one
+    // is what the engine writes to the status line. A string there would break
+    // every response, so this asserts the two are deliberately different types.
+    const app = createGitHubCloneApp();
+    const got = await rest(app, "GET", "/repos/acme/nope");
+
+    expect(got.status).toBe(404);
+    expect(typeof got.status).toBe("number");
+    expect((got.body as { status: unknown }).status).toBe("404");
+  });
+});
+
+describe("F-1490 — on the wire, across every error class the twin can be made to emit", () => {
+  it("404 from a read", async () => {
+    const app = createGitHubCloneApp();
+    expect(await rest(app, "GET", "/repos/acme/nope")).toEqual({
+      status: 404,
+      body: { message: "Not Found", documentation_url: "https://docs.github.com/rest", status: "404" }
+    });
+  });
+
+  it("422 from the zod branch — a missing required body field", async () => {
+    const app = createGitHubCloneApp();
+    const got = await rest(app, "POST", "/repos/acme/api/issues", { body: "no title" });
+    expect(got.status).toBe(422);
+    expect(got.body).toMatchObject({ message: "Validation Failed", status: "422" });
+  });
+
+  it("422 from the domain — a duplicate label", async () => {
+    const app = createGitHubCloneApp();
+    const got = await rest(app, "POST", "/repos/acme/api/labels", { name: "bug", color: "ffffff" });
+    expect(got.status).toBe(422);
+    expect(got.body).toMatchObject({ message: "Validation Failed", status: "422" });
+  });
+
+  it("409 from the contents door's optimistic locking (F-1491's shape, now with a string)", async () => {
+    const app = createGitHubCloneApp();
+    const seeded = await rest(app, "PUT", "/repos/acme/api/contents/probe.txt", { message: "seed", content: b64("hello\n"), branch: "main" });
+    expect(seeded.status).toBe(201);
+
+    expect(await rest(app, "PUT", "/repos/acme/api/contents/probe.txt", { message: "again", content: b64("x\n"), branch: "main", sha: "deadbeef" })).toEqual({
+      status: 409,
+      body: {
+        message: "probe.txt does not match deadbeef",
+        documentation_url: "https://docs.github.com/rest/repos/contents#create-or-update-file-contents",
+        status: "409"
+      }
+    });
+  });
+
+  it("400 from the JSON-parse branch", async () => {
+    const app = createGitHubCloneApp();
+    const got = await rest(app, "POST", "/repos/acme/api/issues", "{");
+    expect(got.status).toBe(400);
+    expect(got.body).toMatchObject({ message: "Problems parsing JSON", status: "400" });
+  });
+
+  it("422 from the unknown-tool branch on the MCP door", async () => {
+    const app = createGitHubCloneApp();
+    const got = await mcp(app, "no_such_tool_at_all", { owner: "acme", repo: "api" });
+    expect(got.status).toBe(422);
+    expect(got.body).toMatchObject({ message: "Validation Failed", status: "422" });
+  });
+
+  it("422 from the MCP door's own validation", async () => {
+    const app = createGitHubCloneApp();
+    const got = await mcp(app, "create_issue", { owner: "acme", repo: "api" });
+    expect(got.status).toBe(422);
+    expect(got.body).toMatchObject({ status: "422" });
+  });
+});
+
+describe("F-1490 — the envelopes this fix does NOT reach, pinned as gaps", () => {
+  it("401 carries an empty documentation_url and NO status leaf — divergence 31", async () => {
+    const app = createGitHubCloneApp();
+
+    // ⚠️ A GAP, not a fidelity claim. Real GitHub answers
+    // `{message:"Bad credentials", documentation_url:"https://docs.github.com/rest", status:"401"}`
+    // — measured 8/8 across five route shapes. This body is built by hand in
+    // `src/twin.ts` (and defaulted in `@pome-sh/sdk`'s `auth.ts`), never reaching
+    // `githubError`, which is the whole reason the ticket's "githubError builds
+    // every envelope" premise was wrong. Fixing it touches the SDK and therefore
+    // all five twins, so it is registered and ticketed instead.
+    const got = await app.request(`${base}/repos/acme/api`, { headers: { authorization: "Bearer ghp_pome_not_a_real_token" } });
+    expect(got.status).toBe(401);
+
+    const body = await got.json() as Record<string, unknown>;
+    expect(body).toEqual({ message: "Bad credentials", documentation_url: "" });
+    expect("status" in body).toBe(false);
+  });
+
+  it("the 501 catch-all carries no status leaf either", async () => {
+    const app = createGitHubCloneApp();
+    const got = await rest(app, "GET", "/repos/acme/api/actions/runs");
+    expect(got.status).toBe(501);
+    expect("status" in (got.body as object)).toBe(false);
+  });
+
+  it("every reached envelope still carries the GENERIC documentation_url — divergence 32", async () => {
+    const app = createGitHubCloneApp();
+
+    // ⚠️ Also a gap. Real GitHub names the operation on 45 of the 59 measured
+    // errors. The twin cannot: `errorEnvelope` receives the error and nothing
+    // else, and `notFound()` in `requireRepo` is reachable from ~40 routes and
+    // ~30 tools, so the throw site does not know which door was knocked on.
+    // The contents-door sha errors are the exception (F-1491) precisely because
+    // they can only come from one operation.
+    const got = await rest(app, "GET", "/repos/acme/nope");
+    expect((got.body as { documentation_url: string }).documentation_url).toBe("https://docs.github.com/rest");
+  });
+});


### PR DESCRIPTION
## What

`githubError` rendered `status: 422`. Real GitHub sends `status: "422"`, quoted. Since `githubError` builds the body for every envelope that flows through `githubErrorEnvelope`, that was a leaf-by-leaf difference on **every 4xx and 5xx this twin emits**.

Closes F-1490.

## The measurement

Live against `api.github.com`, 2026-08-12, two throwaway private repos (both deleted). **59 of 59** error responses sent `status` as a JSON string — zero exceptions, zero absences:

| HTTP | responses | `status` |
|---|---|---|
| 400 | 1 | `"400"` |
| 401 | 8 | `"401"` |
| 403 | 3 | `"403"` |
| 404 | 24 | `"404"` |
| 409 | 9 | `"409"` |
| 422 | 14 | `"422"` |

GitHub's own published OpenAPI description says it independently — `basic-error` declares `status: {type: string}`. Two sources obtained separately, agreeing.

The ticket asked for this re-measurement by name ("odd enough that it is worth re-measuring across several error classes"), because a quoted numeric from one surface is exactly the kind of thing that turns out to be a per-route quirk. It wasn't. That is what makes this a **fix** rather than a registered divergence.

⚠️ **Not measured, inferred:** 5xx and 429 — neither can be provoked safely against live GitHub, so their string-ness rests on `basic-error` alone. Stated in the source comment rather than glossed.

## The one way this could go wrong

`githubErrorEnvelope` returns `{status, body}` — the outer one is what the engine writes to the status line. Stringifying *that* would break every response. The HTTP status stays a number, the body leaf becomes a string, and a test asserts the two are deliberately different types. That test is mutation-verified below.

## Two gaps registered, not fixed — divergences 31 and 32

The ticket's premise was that `githubError` builds every envelope, so teeth on the helper would cover everything. Measurement says otherwise: there are **four** envelope-building sites and three bypass the helper.

**Divergence 31 — the 401/403 envelopes** carry `documentation_url: ""` and **no `status` leaf at all**, where GitHub sends the generic-but-real url plus `"401"` (8/8 across five route shapes, bad token and no header alike). The 401 bodies are hand-written in `src/twin.ts`; the admin-gate 403 comes from **`@pome-sh/sdk`**. Not fixed here because `packages/sdk` is shared by all five twins — twin-github's numbers say nothing about what Slack's 401 looks like, and changing it inside a github envelope ticket is the same smuggling F-1490 was spawned to avoid. Ticketed separately.

Also measured, same family, not fixed: GitHub distinguishes `Bad credentials` (bad token) from `Requires authentication` (no header); the twin says `Bad credentials` for both.

**Divergence 32 — `documentation_url` stays generic** where GitHub names the operation (45 of 59). The SDK hook is `errorEnvelope?: (err: unknown) => {status, body}` — the error and nothing else — and `notFound()` in `requireRepo` is reachable from ~40 routes and ~30 tools, so the right url depends on which door was knocked on, not where the throw happened. Naming it means data on all 65 REST surfaces and 40 MCP tools.

**The boundary is registered as carefully as the rule**, because "operation everywhere" would be a *new* divergence in the opposite direction. GitHub is itself generic on:

- **every 401 — 8/8**, on all five route shapes probed
- **unrouted paths — 4/4** (`/this-route-does-not-exist`, `/zzz-not-a-route`, `/repos`, `DELETE /user`)
- **`GET /users/:username` — 2/2**, a genuine one-off: `/users/:u/repos`, `/orgs/:o` and `/gists/:id` are all operation-specific

The twin is already accidentally right on two of those three classes. The follow-up ticket carries this boundary too, and notes the data is *not* guesswork — GitHub's OpenAPI has `externalDocs.url` per operation, byte-identical to the wire, and 63 of 65 REST surfaces map mechanically. What needs deciding rather than guessing is the 40-tool mapping.

## Reviewer notes

- **Version bumps:** `@pome-sh/cli` 0.23.28 → **0.23.29**, `@pome-sh/twin-github` 0.10.9 → **0.10.10**. `package-lock.json` untouched. Re-checkable at merge time — the train re-bumped #400 from .27 to .28 tonight.
- **Branched off merged `main` (`92d8904`)**, which contains #400's F-1491 changes to this same error machinery.
- **The literal to migrate was re-located, not trusted.** The ticket named `contents-base64.test.ts:165`; on merged main that is still right, but #400 added `contents-sha-semantics.test.ts` with **nine more** whole-envelope `status` literals. Eleven in total, migrated by distinguishing the body leaf (no trailing comma) from the outer HTTP status (always followed by one).
- **Numbering:** bullet 30 / `GH-DIV-031` are F-1491's, so these take **31 / 32** and `GH-DIV-032 / 033`. Nothing renumbered.
- Also fixes a stray backtick that landed in F-1491's divergence-30 prose (`array\`**` → `array**`) — my own typo in #400, same file and section.
- **Mutation-tested two ways.** Reverting the stringify reds 10 tests. Stringifying the HTTP status *as well* — the plausible wrong fix — reds 4, which is what proves the suite distinguishes the two. Restored tree: 579 pass.

## Verification

twin-github 579 tests, monorepo 3500, all green. `build`, `typecheck`, `test:contract` green. Gates green: `mcp-tools-list`, `route-inputs`, `bundled-deps`, `checks-manifest`, `wire-manifest`, `no-eval`, `no-native`, `no-cloud-imports`, `no-catch`, `code-health`, `dead-code`, `import-meta-main`, `twin-chunks`, `twin-leaves`, `legacy-markers`, `copy-markers`, `skill-manifest`. `probe:twins` 128 probes, `validate:mcp`, `typecheck:examples`, `smoke:examples` 8/8, `probe:examples` 20/20 seeds green.

⚠️ **pome-cloud follow required.** `FIDELITY.md` gains bullets 31 and 32, and the 1:1 lint binds bullets to `known-divergences/github.yaml` at the `.github/twins-ref` pin — so pome-cloud needs `GH-DIV-032` and `GH-DIV-033` plus the pin move in one atomic commit. It also **stacks on pome-cloud#706** (F-1491's follow, which adds `GH-DIV-031`); that must land first or the numbering has a hole. No pome-cloud oracle pins the envelope `status` leaf — `rest-writes.mock.ts` builds error bodies with `message` only — so no leg or mock migration is expected this time, and that was checked rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)