### PR TITLE
twin-gmail's search_threads serves the resultCountEstimate it advertises (F-1417)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,27 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.23.31
+
+### Patch Changes
+
+- **twin-gmail's `search_threads` serves `resultCountEstimate`** (F-1417). The
+  tool's own `outputSchema` has always advertised the field as an
+  int64-as-string, and the handler never produced it. No lane could report that:
+  twin-gmail's `mcp_diff` compares the served table against the upstream golden
+  and since F-1400 those are the same bytes, so the field is identical on both
+  sides and the comparison is silent by construction; the MCP read leg's oracle
+  names only what the seed fixes, so an omitted field it never mentioned is not
+  a `field-removed`. It was found by walking every tool's advertised
+  `outputSchema` against a live call — the only one of the thirteen with an
+  advertised field the handlers never produce.
+
+  The count is the whole match set rather than the returned page, and exact
+  rather than estimated: the domain computes the full match list before it
+  paginates, and Google documents the field as a lower bound, so an exact count
+  satisfies the contract. Emitted unconditionally, including `"0"` — an absent
+  field must not mean both "no matches" and "this twin does not serve it".
+
 ## 0.23.27
 
 ### Patch Changes

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.23.30",
+  "version": "0.23.31",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/packages/twin-gmail/fixtures/README.md
+++ b/packages/twin-gmail/fixtures/README.md
@@ -54,17 +54,6 @@ it can ever report is capture staleness. Whether the twin behaves like the tools
 by pome-cloud's read leg and write round trip
 ([F-1397](https://linear.app/pome-sh/issue/F-1397)).
 
-#### One advertised field is still unserved, and it is named rather than missing
-
-`search_threads` declares `resultCountEstimate` (int64-as-string, "treated as a lower bound") and
-this twin never returns it. That is **not** part of F-1400's adoption: the 2026-07-20 capture declared
-it too, so it is a gap this twin has always had and no comparison between the two captures reports.
-It is cheap to close — the domain knows the exact match count before it paginates — and deliberately
-left out of the change that moved the capture, so the adoption's behavioural surface is only the
-three claims that actually moved. Every other field either of the two schemas declares is served
-whenever the data exists; `nextPageToken` only when there is another page, and `color` / `htmlBody` /
-`attachments` only when the record carries one.
-
 ### Provenance notes
 
 - `tools/list` was captured live without OAuth on **2026-08-10** against `https://gmailmcp.googleapis.com/mcp/v1`; `initialize` on 2026-07-20 against the same endpoint (protocolVersion `2025-03-26`, unchanged).

--- a/packages/twin-gmail/src/mcp.ts
+++ b/packages/twin-gmail/src/mcp.ts
@@ -173,6 +173,14 @@ const implementations: Record<ToolName, ToolImplementation> = {
             input.view === "THREAD_VIEW_METADATA_ONLY" ? "metadata" : "minimal"
           )
         ),
+        // `threads` above is the PAGE; this is the whole match set, which is
+        // why the count is exact rather than an estimate. Google documents the
+        // field as a lower bound, so an exact count satisfies the contract —
+        // and the advertised type is int64-as-STRING, not a number (F-1417).
+        // Unconditional: it is the answer to "how many matched", and 0 matches
+        // is an answer. Emitting it only when non-zero would make an absent
+        // field mean two different things.
+        resultCountEstimate: String(threads.length),
         ...(page.nextPageToken ? { nextPageToken: page.nextPageToken } : {}),
       };
     },

--- a/packages/twin-gmail/test/mcp.test.ts
+++ b/packages/twin-gmail/test/mcp.test.ts
@@ -717,6 +717,74 @@ describe("the adopted listing's claims are behaviours", () => {
     });
   });
 
+  it("answers every field the search_threads root advertises, resultCountEstimate included", async () => {
+    // Read out of the fixture rather than named here (F-1400's pattern): if
+    // Google adds a fourth root field, this reds instead of the twin quietly
+    // never serving it. Naming `resultCountEstimate` in the assertion would
+    // close exactly one gap and leave the class open.
+    expect(advertisedFields("search_threads")).toContain("resultCountEstimate");
+
+    // Two threads, because this file's `seed()` has exactly one: with a single
+    // match, pageSize 1 returns the whole result set and `nextPageToken` can
+    // never appear, so the root could not show its full advertised shape.
+    const base = seed();
+    const app = createGmailTwinApp({
+      seed: {
+        ...base,
+        primaryMailbox: {
+          ...base.primaryMailbox,
+          messages: [
+            ...base.primaryMailbox.messages,
+            {
+              ...base.primaryMailbox.messages[0]!,
+              id: "msg_seed_2",
+              threadId: "thread_seed_2",
+              subject: "Second seed message",
+              messageId: "seed2@example.com",
+              date: "2026-07-19T13:00:00.000Z",
+            },
+          ],
+        },
+      },
+    });
+
+    // pageSize 1 against a multi-thread mailbox so `nextPageToken` is present
+    // too — otherwise the root can never show its full advertised set and the
+    // comparison below would be asserting a shape the tool cannot produce.
+    const page = await call(app, 1, "search_threads", { query: "", pageSize: 1 });
+    expect(page.result.isError).toBe(false);
+    expect(Object.keys(page.result.structuredContent ?? {}).sort()).toEqual(
+      advertisedFields("search_threads")
+    );
+
+    // int64-as-string, as the outputSchema declares — a number here would
+    // satisfy "present" while diverging from the advertised type.
+    const estimate = (page.result.structuredContent as { resultCountEstimate?: unknown })
+      .resultCountEstimate;
+    expect(typeof estimate).toBe("string");
+
+    // The WHOLE match set, not the page. This is the assertion with teeth:
+    // returning `page.items.length` would also be a string and also be present,
+    // and would be wrong by exactly the amount that matters.
+    const all = await call(app, 2, "search_threads", { query: "" });
+    const total = (all.result.structuredContent as { threads: unknown[] }).threads.length;
+    expect((page.result.structuredContent as { threads: unknown[] }).threads.length).toBe(1);
+    expect(estimate).toBe(String(total));
+    expect(total).toBeGreaterThan(1);
+  });
+
+  it("reports a zero match count rather than omitting the field", async () => {
+    // 0 is an answer to "how many matched". If the field were emitted only when
+    // non-zero, an absent field would mean both "no matches" and "this twin
+    // does not serve it" — which is the gap F-1417 closed.
+    const app = createGmailTwinApp({ seed: fullyPopulatedSeed() });
+    const none = await call(app, 1, "search_threads", { query: "is:unread from:nobody@example.invalid" });
+    expect(none.result.isError).toBe(false);
+    const body = none.result.structuredContent as { threads: unknown[]; resultCountEstimate?: unknown };
+    expect(body.threads).toEqual([]);
+    expect(body.resultCountEstimate).toBe("0");
+  });
+
   it("takes no page arguments on list_labels, because the listing declares none", async () => {
     const app = createGmailTwinApp({ seed: fullyPopulatedSeed() });
 


### PR DESCRIPTION
## What

`search_threads` now returns `resultCountEstimate` on every successful call, as the int64-as-string its own `outputSchema` declares, carrying the number of matching threads. `@pome-sh/cli` → **0.23.31**.

## Why

The tool has always advertised the field and the handler never produced it. It was the only one of twin-gmail's thirteen tools with an advertised field the handlers never produce — found by walking every tool's advertised `outputSchema` against a live call.

**No lane could report this, and none can.** `mcp_diff` compares the served table against the upstream golden, and since F-1400 those are the same bytes — the 2026-07-20 capture declared `resultCountEstimate` too — so the field is identical on both sides and the comparison is silent by construction. The MCP read leg does not catch it either: its oracle names only what the seed fixes, so a field the twin *omits* that the oracle never mentioned is not a `field-removed`.

## Notes

**Exact, not estimated, and the whole match set rather than the page.** The handler already computes the full match list before `paginate` slices it, so the count is in hand. Google documents the field as a lower bound, so an exact count satisfies the contract. `threads` in the same response is the *page* — returning `page.items.length` would also be a string and also be present, and wrong by exactly the amount that matters.

**Unconditional, including `"0"`.** Zero is an answer to "how many matched". A field emitted only when non-zero would make its absence mean both "no matches" and "this twin does not serve it" — which is the gap this closes.

**`gmail.mcp.yaml` stays `[]`.** This was a twin gap to close, not a divergence to accept. ⚠️ One follow-up for whoever moves the pome-cloud twins-ref pin past this commit: that file's commentary still says *"⚠️ ONE THING IS STILL UNSERVED and is named rather than registered: search_threads.resultCountEstimate"*. It becomes false at the pin move and should be dropped in the same PR.

**README subsection deleted, not edited** — "One advertised field is still unserved" existed only to name this gap.

## Review

**The test does not name the field.** It reads the advertised property set out of the fixture and compares it to the response's own keys, the way F-1400's Message and Label tests do, so `search_threads`'s root joins the two shapes already covered and the next field Google adds to it is a red rather than a silent absence.

Two cases, both verified to fail with the single handler line reverted (2 failed / 13 passed) and pass with it (15/15):

- the full advertised root shape — run against a **two-thread** mailbox so `nextPageToken` is present too. This file's `seed()` holds a single thread, where pageSize 1 returns the whole result set and the token can never appear, so the comparison would have been asserting a shape the tool cannot produce.
- the zero-match case returns `"0"` rather than omitting the field.

The first also pins that the value is a `string` and equals the **total**, not the page length.

Green: `npm test -w @pome-sh/twin-gmail` 14 files / 147 tests, `node --test` gate0 fixtures, `typecheck` clean, and `gate:mcp-fixture` still reports *13 tools, all three files match the upstream golden* — the served table is untouched, only the behaviour behind it.

`package-lock.json` untouched.