### PR TITLE
gmail.mailbox-label-count refuses what it cannot see (F-1441)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,16 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.23.32
+
+### Patch Changes
+
+- **`gmail.mailbox-label-count` refuses instead of scoring a free pass**
+  (F-1441), via `@pome-sh/checks` 0.1.6. Same class as F-1159's twin-slack fix,
+  found live on a criterion whose polarity flips negative at count 0 — so the
+  vacuous pass scored a point for an agent that did the forbidden thing. `labels`
+  is now guarded for absence and truncation in both `labelIdsFor` consumers.
+
 ## 0.23.31
 
 ### Patch Changes
@@ -24,6 +34,7 @@ packaging restructure: bump `version` here and in `package.json`, and merging to
   paginates, and Google documents the field as a lower bound, so an exact count
   satisfies the contract. Emitted unconditionally, including `"0"` — an absent
   field must not mean both "no matches" and "this twin does not serve it".
+
 
 ## 0.23.27
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.23.31",
+  "version": "0.23.32",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/packages/checks/CHANGELOG.md
+++ b/packages/checks/CHANGELOG.md
@@ -1,5 +1,28 @@
 # @pome-sh/checks
 
+## 0.1.6
+
+`gmail.mailbox-label-count` now refuses instead of scoring a free pass (F-1441)
+— the same class as 0.1.5's `slack.no-reaction-added`, found live in twin-gmail
+on a worse criterion. Its polarity flips NEGATIVE at count 0, so the vacuous
+pass handed a point to an agent that did the forbidden thing.
+
+`labelIdsFor` read `state.labels ?? []` with no absence guard. The bare display
+name is always added to the id set so the join survives a capped collection —
+but that only holds for SYSTEM labels, where `id === name`. A USER label's
+minted id differs from its display name by construction (the default seed ships
+`{ id: "Label_follow_up", name: "Follow Up" }`), so with `labels` absent the
+lookup degraded to a name no `messageLabels` row carries, the total came out 0,
+and `0 === 0` passed over an export in which the agent DID apply the label.
+
+`labels` is now guarded for both absence and truncation alongside `messages` and
+`messageLabels`, in `gmail.mailbox-label-count` and in the second `labelIdsFor`
+consumer (`oneMessagePerRecipient`, positive polarity and fail-closed today —
+guarded anyway, because safe-by-polarity is how this class survives review).
+`labelIdsFor`'s own comment now states that its bare-id fallback is
+system-labels-only and that callers must guard; `draftRecipients` carries the
+written reason its ticket asked for.
+
 ## 0.1.5
 
 `slack.no-reaction-added` now refuses instead of scoring a free pass (F-1159).

--- a/packages/checks/package.json
+++ b/packages/checks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/checks",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Pome's grading vocabulary — the check declarations, seed schemas and default seeds of all five digital twins, plus the check DSL they are written in. Declarations only: no twin server, no database, no routes, no tools.",
   "private": false,
   "type": "module",

--- a/packages/twin-gmail/src/check-messages.ts
+++ b/packages/twin-gmail/src/check-messages.ts
@@ -140,10 +140,29 @@ export const mailboxLabelCount: Check<{ mailbox: string; count: string; label: s
     },
     evaluate({ mailbox, count, label }, { final }) {
       const wanted = Number(count);
-      if (final.messages == null || final.messageLabels == null) {
+      // `labels` is guarded alongside the other two (F-1441). Without it this
+      // check was a live instance of the F-1159 class, and on the worst
+      // possible criterion: polarity flips NEGATIVE at count 0, so a vacuous
+      // pass scores a point for an agent that did the forbidden thing.
+      //
+      // The mechanism is that a USER label's minted id differs from its display
+      // name by construction — the default seed ships
+      // `{ id: "Label_follow_up", name: "Follow Up" }`. With `labels` absent,
+      // `labelIdsFor` degrades to the bare display name, no `messageLabels` row
+      // carries it, the total is 0, and `0 === 0` passes over an export in
+      // which the agent DID apply the label.
+      if (final.messages == null || final.messageLabels == null || final.labels == null) {
         return { passed: false, status: "skipped", reason: "state_incomplete" };
       }
-      if (isTruncated(final, "messages") || isTruncated(final, "messageLabels")) {
+      // Truncation reaches the same vacuous pass without a partial upload at
+      // all: a capped `labels` collection loses the id→name row just as an
+      // absent one does. `resolveLabelByName` in check-state.ts has guarded
+      // both since it was written; this check guarded only two of its three.
+      if (
+        isTruncated(final, "messages") ||
+        isTruncated(final, "messageLabels") ||
+        isTruncated(final, "labels")
+      ) {
         return { passed: false, status: "skipped", reason: "collection_truncated" };
       }
       // A mailboxes collection that is present and omits this mailbox means we
@@ -247,10 +266,19 @@ export const oneMessagePerRecipient: Check<{ label: string; count: string }> = d
   },
   evaluate({ label, count }, { final }) {
     const wanted = parseCount(count);
-    if (final.messages == null || final.messageLabels == null) {
+    // The second `labelIdsFor` consumer, guarded on the same terms (F-1441).
+    // This one's polarity is positive and it fails closed today, so an absent
+    // `labels` section costs the agent a point rather than gifting one — but
+    // safe-by-polarity is exactly how this class survives review, and the
+    // polarity is not this function's to promise.
+    if (final.messages == null || final.messageLabels == null || final.labels == null) {
       return { passed: false, status: "skipped", reason: "state_incomplete" };
     }
-    if (isTruncated(final, "messages") || isTruncated(final, "messageLabels")) {
+    if (
+      isTruncated(final, "messages") ||
+      isTruncated(final, "messageLabels") ||
+      isTruncated(final, "labels")
+    ) {
       return { passed: false, status: "skipped", reason: "collection_truncated" };
     }
     const ids = labelIdsFor(final, label);

--- a/packages/twin-gmail/src/check-state.ts
+++ b/packages/twin-gmail/src/check-state.ts
@@ -193,6 +193,20 @@ export function resolveMessage(
  * The bare `wanted` is always included so the join still works when the `labels`
  * collection was capped away — a `messageLabels` row carries the bare id
  * regardless.
+ *
+ * ⚠️ THAT FALLBACK IS SYSTEM-LABELS-ONLY, and the sentence above used to stop
+ * short of saying so, which is why the gap read as intentional (F-1441). It
+ * holds when `id === name` — `INBOX`, `UNREAD`, `STARRED`. A USER label's
+ * minted id differs from its display name by construction (the default seed
+ * ships `{ id: "Label_follow_up", name: "Follow Up" }`), so with `labels`
+ * absent or capped this degrades to a name no `messageLabels` row carries and
+ * the join silently returns nothing.
+ *
+ * So: this function cannot refuse — it returns a Set, and an empty Set is
+ * indistinguishable from "the label was never applied". **Every caller must
+ * guard `state.labels` absence and truncation itself before calling**, and both
+ * callers in check-messages.ts now do. Adding a third without that guard
+ * reintroduces the F-1159 class.
  */
 export function labelIdsFor(state: GmailCheckState, wanted: string): Set<string> {
   const ids = new Set<string>([lower(wanted)]);
@@ -260,6 +274,14 @@ export function resolveLabelByName(
  * alone would answer "no draft is addressed to anyone", always. A draft whose
  * message did not survive the export contributes nothing rather than throwing;
  * the caller decides whether that emptiness is answerable.
+ *
+ * ⚠️ Same shape as `labelIdsFor`, same rule, and the reason is written down
+ * rather than left to be rediscovered (F-1441): `state.messages ?? []` cannot
+ * tell an absent collection from one that holds no match, so this function
+ * cannot refuse either. It is safe TODAY only because its sole caller
+ * null-checks `final.messages` first (`check-drafts.ts:63`) — safe-by-caller,
+ * which is precisely how this class survives review. A second caller must
+ * guard, or this must be changed to return a `Resolved`.
  */
 export function draftRecipients(
   state: GmailCheckState,

--- a/packages/twin-gmail/test/check-state.test.ts
+++ b/packages/twin-gmail/test/check-state.test.ts
@@ -13,6 +13,7 @@ import {
   resolveMessage,
   type GmailCheckState,
 } from "../src/check-state.js";
+import { mailboxLabelCount, oneMessagePerRecipient } from "../src/check-messages.js";
 
 const MB = "pome-agent@pome-twin.test";
 
@@ -208,5 +209,105 @@ describe("isTruncated", () => {
     // would skip every criterion on them; treating it as "not truncated" is the
     // same answer a pre-cap export would have given honestly.
     expect(isTruncated(state({ exportBounds: null }), "messages")).toBe(false);
+  });
+});
+
+// F-1441 — the F-1159 class, found live in twin-gmail on the worst possible
+// criterion. `gmail.mailbox-label-count`'s polarity flips NEGATIVE at count 0,
+// so a vacuous pass hands a point to an agent that did the forbidden thing.
+//
+// The mechanism is that a USER label's minted id differs from its display name
+// by construction — the default seed ships `{ id: "Label_follow_up", name:
+// "Follow Up" }`. With `labels` absent, `labelIdsFor` degrades to the bare
+// display name, no `messageLabels` row carries it, the total is 0, and
+// `0 === 0` passes over an export in which the agent DID apply the label.
+describe("gmail.mailbox-label-count refuses what it cannot see", () => {
+  const args = { mailbox: MB, count: "0", label: "Follow Up" };
+
+  /** The agent DID apply the user label — so a count-0 prohibition must FAIL. */
+  function applied(overrides: Partial<GmailCheckState> = {}): GmailCheckState {
+    return state({
+      messageLabels: [{ mailboxEmail: MB, messageId: "msg_support", labelId: "Label_follow_up" }],
+      ...overrides,
+    });
+  }
+
+  it("FAILS the prohibition when it can see the labels — the control", () => {
+    // Without this the two skips below could be satisfied by a check that
+    // refuses everything, which would be a different defect wearing the fix.
+    const outcome = mailboxLabelCount.evaluate(args, {
+      seed: null,
+      tape: null,
+      final: applied(),
+    });
+    expect(outcome.passed).toBe(false);
+    expect(outcome.status).toBeUndefined();
+  });
+
+  it("SKIPS on an absent labels section rather than scoring the prohibition", () => {
+    // THE DEFECT. Before F-1441 this returned
+    // {passed:true, reason:'... has 0 message(s) labeled Follow Up (wanted 0)'}
+    // over an export whose messageLabels row says otherwise.
+    const outcome = mailboxLabelCount.evaluate(args, {
+      seed: null,
+      tape: null,
+      final: applied({ labels: undefined }),
+    });
+    expect(outcome.passed).toBe(false);
+    expect(outcome.status).toBe("skipped");
+    expect(outcome.reason).toContain("state_incomplete");
+  });
+
+  it("SKIPS on a CAPPED labels collection — reachable with no partial upload", () => {
+    const outcome = mailboxLabelCount.evaluate(args, {
+      seed: null,
+      tape: null,
+      final: applied({
+        exportBounds: {
+          messageBodiesOmitted: true,
+          largeMailbox: false,
+          truncatedCollections: ["labels"],
+        },
+      }),
+    });
+    expect(outcome.passed).toBe(false);
+    expect(outcome.status).toBe("skipped");
+    expect(outcome.reason).toContain("collection_truncated");
+  });
+
+  it("still skips for the reasons it already knew — messages and messageLabels", () => {
+    for (const missing of ["messages", "messageLabels"] as const) {
+      const outcome = mailboxLabelCount.evaluate(args, {
+        seed: null,
+        tape: null,
+        final: applied({ [missing]: undefined }),
+      });
+      expect(outcome.status).toBe("skipped");
+      expect(outcome.reason).toContain("state_incomplete");
+    }
+  });
+});
+
+// The second `labelIdsFor` consumer. Its polarity is positive and it fails
+// closed today, so an absent section costs the agent a point rather than
+// gifting one — but safe-by-polarity is how this class survives review, and the
+// polarity is not `labelIdsFor`'s to promise.
+describe("the second labelIdsFor consumer guards its labels section too", () => {
+  it("SKIPS rather than answering from a label set it could not resolve", () => {
+    const outcome = oneMessagePerRecipient.evaluate(
+      { label: "Follow Up", count: "1" },
+      {
+        seed: null,
+        tape: null,
+        final: state({
+          labels: undefined,
+          messageLabels: [
+            { mailboxEmail: MB, messageId: "msg_support", labelId: "Label_follow_up" },
+          ],
+        }),
+      },
+    );
+    expect(outcome.status).toBe("skipped");
+    expect(outcome.reason).toContain("state_incomplete");
   });
 });


### PR DESCRIPTION
## What

`gmail.mailbox-label-count` now guards its `labels` section for **absence and truncation**, alongside the `messages` and `messageLabels` it already guarded. `@pome-sh/checks` → **0.1.6**, `@pome-sh/cli` → **0.23.32**.

## Why

This was the F-1159 class live in twin-gmail, on the worst possible criterion: `mailbox-label-count`'s polarity flips **negative** at count 0, so the vacuous pass scored a point for an agent that did the forbidden thing.

`labelIdsFor` read `state.labels ?? []` with no absence guard. It always adds the bare display name to the id set so the join survives a capped collection — and **that only holds for SYSTEM labels, where `id === name`**. A user label's minted id differs from its display name by construction; the default seed ships `{ id: "Label_follow_up", name: "Follow Up" }`. So with `labels` absent the lookup degraded to a name no `messageLabels` row carries, the total came out 0, and `0 === 0` passed over an export whose `messageLabels` row says the label WAS applied.

The function's own comment justified the `?? []` with *"a `messageLabels` row carries the bare id regardless"* and never said that holds only for system labels. That is why the gap read as intentional rather than as a bug — the comment is corrected here, and now says callers must guard.

## Notes

**Truncation is an independent path to the same pass**, and it needs no partial upload: a capped `labels` collection loses the id→name row exactly as an absent one does. `resolveLabelByName` in the same file has guarded both since it was written; this check guarded two of its three collections.

**Both `labelIdsFor` consumers are guarded**, not just the failing one. `oneMessagePerRecipient`'s polarity is positive and it fails closed today, so an absent section costs the agent a point rather than gifting one. Guarded anyway — safe-by-polarity is how this class survives review, and the polarity is not `labelIdsFor`'s to promise.

**`draftRecipients` carries the written reason rather than a change.** Same unguarded shape, safe only because its sole caller null-checks `final.messages` first (`check-drafts.ts:63`). The ticket asked for a guard *or* a written reason; safe-by-caller is exactly the shape that needs the reason recorded.

**Version bumps follow F-1159's precedent exactly.** This changes a declared check's verdict, so it ships through `@pome-sh/checks` — 0.1.5 was F-1159's identical fix for `slack.no-reaction-added`. pome-cloud picks it up at a checks pin bump; nothing here moves that pin.

## Review

Four tests. **Three fail with the guard reverted** (verified: 3 failed / 23 passed, restored 26/26):

- an absent `labels` section SKIPS with `state_incomplete` instead of scoring the prohibition — before this it returned `{passed: true, reason: '… has 0 message(s) labeled Follow Up (wanted 0)'}`;
- a **capped** `labels` collection SKIPS with `collection_truncated`;
- the second consumer skips rather than answering from a label set it could not resolve.

**The fourth is the control and it is the one that matters for honesty:** with the `labels` section present and the label actually applied, the prohibition still **FAILS** (`passed: false`, no `status`). Without it, all three skips above would also be satisfied by a check that had simply started refusing everything — a different defect wearing the fix.

Green: `npm test -w @pome-sh/twin-gmail` 14 files / 150 tests, `npm test -w @pome-sh/checks` 24 tests, `typecheck` clean. `package-lock.json` untouched.