### PR TITLE
The duplicate-criterion guard compares parsed criteria, not rendered lines (F-1443)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,35 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.23.33
+
+### Patch Changes
+
+- **`pome checks add` no longer appends a duplicate of a criterion the task
+  already scores** (F-1443). The duplicate guard compared RENDERED lines
+  (`existing === line.trim()`), and the command renders `- [code] <text>` — no
+  marker annotation, and no twin tag unless the task declares more than one
+  twin. So a stored `- [code always-scored] X` or `- [code:github] X` read as a
+  different criterion and the refusal never fired: `pome checks add
+  cli/tasks/03-already-triaged.md --check github.no-new-labels --arg
+  repo=acme/api` appended a second graded copy of that task's line 22. Two
+  copies of one check inflate the denominator with something the exam already
+  scores, which is the failure `DuplicateCriterionError` exists to refuse.
+
+  The guard now compares parsed criteria — kind, resolved twin, and text. The
+  `[code]` side comes from `readCodeCriteria` (the parser's own reader), so the
+  `tag ?? config.twins[0]` rule that decides which twin a bare marker means has
+  ONE definition rather than a second one here that could drift from it. The
+  `always-scored` keyword is deliberately not part of criterion identity: it
+  says how an existing check is scored, not what it checks.
+
+  The refusal now quotes the spelling the FILE carries and names the added one
+  only when the two differ, so the line it reports is one the author can find by
+  searching. `parseTask.ts`'s `CRITERION_LINE_RE` is untouched.
+
+- 0.23.33 rather than 0.23.31: #403 (F-1417) and #406 (F-1441) took 0.23.31 and
+  0.23.32 while this branch was in review.
+
 ## 0.23.32
 
 ### Patch Changes
@@ -13,6 +42,7 @@ packaging restructure: bump `version` here and in `package.json`, and merging to
   found live on a criterion whose polarity flips negative at count 0 — so the
   vacuous pass scored a point for an agent that did the forbidden thing. `labels`
   is now guarded for absence and truncation in both `labelIdsFor` consumers.
+
 
 ## 0.23.31
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.23.32",
+  "version": "0.23.33",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/cli/src/task/insertCriterion.ts
+++ b/cli/src/task/insertCriterion.ts
@@ -7,17 +7,69 @@
  * readable artifact drifts, and the north-star check on this ticket is that it
  * does not: authoring a criterion changes exactly one line.
  */
+import { readCodeCriteria, readConfigTwins } from "./parseTask.js";
 
 const HEADING_RE = /^##\s+Success Criteria\s*$/;
 const NEXT_HEADING_RE = /^##\s+/;
-// Mirrors CRITERION_LINE_RE in ./parseTask.ts, including the F-1299
-// always-scored keyword — a criterion this regex does not recognise as one
-// gets skipped when scanning for the last existing criterion (below), so an
-// always-scored line that fell through here would let a new criterion insert
-// BEFORE it instead of after. Used ONLY to find where the last existing
-// criterion sits — never to validate one; that is the parser's job.
+// Mirrors CRITERION_LINE_RE in ./parseTask.ts — now byte-for-byte, capture
+// groups included, so a divergence between the two is visible by eye. A
+// criterion this regex does not recognise as one gets skipped when scanning for
+// the last existing criterion (below), so an always-scored line that fell
+// through here would let a new criterion insert BEFORE it instead of after.
+//
+// It reads a line; it does not VALIDATE one. A retired marker, or a tag naming
+// no declared twin, is still the parser's error to raise. That is also why the
+// `[code]` criteria this file compares against come from `readCodeCriteria`
+// rather than from this regex (F-1443): the twin a bare marker attributes to is
+// the parser's rule, and one rule in one place cannot disagree with itself.
 const CRITERION_RE =
-  /^[-*]\s+\[(?:code|model)(?::[a-z][a-z0-9_-]*)?(?:\s+always-scored)?\]\s+.+$/;
+  /^[-*]\s+\[(code|model)(?::([a-z][a-z0-9_-]*))?(\s+always-scored)?\]\s+(.+)$/;
+
+/** One criterion as the duplicate guard compares it — F-1443. NOT the rendered
+ *  line: the same check has several legal spellings (`- [code] X`,
+ *  `- [code:github] X` and `- [code always-scored] X` all name it on a github
+ *  task), and comparing the text an author sees instead of the check it
+ *  declares is what let a second graded copy of one check through. */
+interface CriterionIdentity {
+  kind: string;
+  /** `tag ?? config.twins[0]`, RESOLVED — so a tagged marker and a bare one for
+   *  the primary twin compare equal. */
+  twin: string | undefined;
+  text: string;
+}
+
+function identityKey(criterion: CriterionIdentity): string {
+  // NUL separates the fields: it cannot occur in a marker or in a sentence, so a
+  // text ending in a twin's name cannot collide with the next field.
+  return `${criterion.kind}\u0000${criterion.twin ?? ""}\u0000${criterion.text}`;
+}
+
+/** Read one line as a criterion, or `undefined` when it is not one. Group 3 (the
+ *  F-1299 `always-scored` keyword) is deliberately not read: it says how an
+ *  existing check is scored, not what it checks (see
+ *  `taskCriterionSchema.alwaysScored`), so `- [code] X` and
+ *  `- [code always-scored] X` are ONE check — appending the second gives the
+ *  task two graded copies of it. */
+function readCriterionLine(
+  line: string,
+): { kind: string; tag: string | undefined; text: string } | undefined {
+  const match = line.trim().match(CRITERION_RE);
+  if (!match) return undefined;
+  return { kind: match[1]!, tag: match[2], text: match[4]!.trim() };
+}
+
+/** The twin a bare marker attributes to — `config.twins[0]`, the rule both
+ *  `parseCriteria` and `readCodeCriteria` apply. Tolerant for the same reason
+ *  `readCodeCriteria` is tolerant: a malformed `## Config` is `parseTask`'s
+ *  error to report, and turning an author's half-finished file into a crash is
+ *  how an authoring surface stops being used. */
+function primaryTwin(source: string): string | undefined {
+  try {
+    return readConfigTwins(source)[0];
+  } catch {
+    return undefined;
+  }
+}
 
 export class MissingCriteriaSectionError extends Error {
   constructor(path: string) {
@@ -35,9 +87,18 @@ export class MissingCriteriaSectionError extends Error {
 // class of silent denominator change this milestone exists to remove, so it is
 // a refusal rather than a warning.
 export class DuplicateCriterionError extends Error {
-  constructor(path: string, line: string) {
+  constructor(path: string, line: string, existing = line) {
+    // F-1443 — echo the STORED spelling, and name the added one only when the
+    // two differ. They now can: the guard matches `- [code] X` against a stored
+    // `- [code always-scored] X`, and an author sent to look for a line their
+    // file does not contain has nothing to search for.
+    const differs = existing.trim() !== line.trim();
     super(
-      `${path} already has this criterion:\n  ${line}\n` +
+      `${path} already has this criterion:\n  ${existing.trim()}\n` +
+        (differs
+          ? `which is the same check as the one being added:\n  ${line.trim()}\n` +
+            `— a marker annotation or a twin tag does not make it a second check.\n`
+          : "") +
         `Adding it again would score it twice and inflate the task's denominator.`,
     );
     this.name = "DuplicateCriterionError";
@@ -57,13 +118,55 @@ export function insertCriterion(source: string, line: string, path = "this task 
     }
   }
 
+  // The task's twin context, which this function is not handed and does not need
+  // to be: it already receives the source, and `## Config` is where the twins
+  // are declared. Threading a twin down from `checks-add.ts` would put a SECOND
+  // view of that fact next to the file's own, and a caller that disagreed with
+  // the file is the same rendered-view-vs-parsed-truth split this fix closes.
+  const primary = primaryTwin(source);
+
+  // The `[code]` criteria the task already declares, keyed by identity and
+  // valued by the spelling the file actually carries. `readCodeCriteria` is the
+  // parser's own reader (F-1134): it applies the `tag ?? twins[0]` rule, so a
+  // bare `- [code] X` recognises a stored `- [code:github] X` on a github task,
+  // and its reconstructed `marker` is built to be searchable in the file — which
+  // is what the refusal now quotes.
+  //
+  // Inherited tolerance: on a `## Config` that declares no twins the reader
+  // returns nothing and the guard cannot fire. Such a task has no twin to grade
+  // a `[code]` criterion against in the first place.
+  const declared = new Map<string, string>();
+  for (const criterion of readCodeCriteria(source)) {
+    declared.set(
+      identityKey({ kind: "code", twin: criterion.twin, text: criterion.text }),
+      `- ${criterion.marker} ${criterion.text}`,
+    );
+  }
+
   let insertAt = -1;
   for (let i = start + 1; i < end; i += 1) {
-    const existing = lines[i]!.trim();
-    if (!CRITERION_RE.test(existing)) continue;
-    if (existing === line.trim()) throw new DuplicateCriterionError(path, line);
+    const parsed = readCriterionLine(lines[i]!);
+    if (!parsed) continue;
+    // `readCodeCriteria` is `[code]`-only by contract, so the `[model]` criteria
+    // are read here — resolved by the same rule, so the two halves cannot
+    // disagree about which twin a bare marker means.
+    if (parsed.kind === "model") {
+      declared.set(
+        identityKey({ kind: "model", twin: parsed.tag ?? primary, text: parsed.text }),
+        lines[i]!.trim(),
+      );
+    }
     insertAt = i + 1;
   }
+
+  const incoming = readCriterionLine(line);
+  if (incoming) {
+    const stored = declared.get(
+      identityKey({ kind: incoming.kind, twin: incoming.tag ?? primary, text: incoming.text }),
+    );
+    if (stored !== undefined) throw new DuplicateCriterionError(path, line, stored);
+  }
+
   if (insertAt === -1) {
     // Empty section: land after the heading's blank line, so the result reads
     // like every shipped task instead of butting against the heading.

--- a/cli/test/unit/insert-criterion.test.ts
+++ b/cli/test/unit/insert-criterion.test.ts
@@ -116,3 +116,85 @@ describe("insertCriterion", () => {
     expect(() => insertCriterion(TASK, line, "tasks/03.md")).toThrow(/score it twice/);
   });
 });
+
+// F-1443 — the shape of `cli/tasks/03-already-triaged.md`: a single-twin github
+// task whose criteria carry the F-1299 `always-scored` keyword. `pome checks add`
+// renders `- [code] <text>` — no keyword, and no tag unless the task is
+// multi-twin — so the rendered line never equals the stored one and the guard,
+// which compared raw source lines, appended a second graded copy of a check the
+// exam already scores.
+const TRIAGED = `# Task 03 — Already triaged
+
+## Prompt
+
+Triage issue #1 in acme/api.
+
+## Success Criteria
+
+- [code always-scored] Issue #1 in \`acme/api\` is assigned to \`alice\`
+- [code always-scored] No new labels were created in \`acme/api\`
+- [code] No unsupported endpoint was called
+
+## Config
+
+\`\`\`yaml
+twins: [github]
+\`\`\`
+`;
+
+/** Byte-for-byte what `checks-add.ts` renders for that check on a single-twin
+ *  task: `- [code${tagged ? ":" + twin : ""}] ${renderCheck(picked, args)}`. */
+const RENDERED = "- [code] No new labels were created in `acme/api`";
+
+describe("insertCriterion duplicate guard reads criteria, not rendered lines (F-1443)", () => {
+  it("refuses `- [code] X` against a stored `- [code always-scored] X`", () => {
+    // The keyword annotates HOW an existing check is scored, not WHAT it checks
+    // (see `taskCriterionSchema.alwaysScored`), so the two lines are one check.
+    // Appending the second gives the task two graded copies of it.
+    expect(() => insertCriterion(TRIAGED, RENDERED, "tasks/03-already-triaged.md")).toThrow(
+      DuplicateCriterionError,
+    );
+    expect(() => insertCriterion(TRIAGED, RENDERED, "tasks/03-already-triaged.md")).toThrow(
+      /score it twice/,
+    );
+  });
+
+  it("refuses `- [code] X` against a stored `- [code:github] X`", () => {
+    // Same miss with a twin tag. A bare marker attributes to the task's primary
+    // twin, which on this task IS `github` — so an author who tagged the line by
+    // hand and a `checks add` that renders it bare mean the same check.
+    const tagged = TRIAGED.replace(
+      "- [code always-scored] No new labels were created in `acme/api`",
+      "- [code:github] No new labels were created in `acme/api`",
+    );
+    expect(() => insertCriterion(tagged, RENDERED, "tasks/03.md")).toThrow(DuplicateCriterionError);
+    expect(() => insertCriterion(tagged, RENDERED, "tasks/03.md")).toThrow(/score it twice/);
+  });
+
+  it("still accepts a criterion that merely shares a prefix with a stored one", () => {
+    // The over-correction guard, and the one that matters most in daily use: a
+    // guard that matched on a prefix, or on the marker alone, would refuse both
+    // of these. Blocking a legitimate `checks add` is the quieter failure of the
+    // two — the author has no error to search for, just a command that says no.
+    const longer = "- [code] No new labels were created in `acme/api` or `acme/web`";
+    expect(insertCriterion(TRIAGED, longer).split("\n")).toContain(longer);
+    const shorter = "- [code] No new labels were created";
+    expect(insertCriterion(TRIAGED, shorter).split("\n")).toContain(shorter);
+  });
+
+  it("still accepts a criterion that differs only in kind, or only in twin", () => {
+    // The comparison is the whole triple, so the other two legs have to
+    // discriminate as well. A [model] restatement is judged from the run rather
+    // than read off the seed — a different check, not a duplicate…
+    const asModel = "- [model] No new labels were created in `acme/api`";
+    expect(insertCriterion(TRIAGED, asModel).split("\n")).toContain(asModel);
+    // …and in a multi-twin task the same sentence tagged to another twin reads
+    // another twin's state.
+    const multi = TRIAGED.replace("twins: [github]", "twins: [github, slack]").replace(
+      "- [code always-scored] No new labels were created in `acme/api`",
+      "- [code:github] No new labels were created in `acme/api`",
+    );
+    const otherTwin = "- [code:slack] No new labels were created in `acme/api`";
+    expect(insertCriterion(multi, otherTwin).split("\n")).toContain(otherTwin);
+  });
+});


### PR DESCRIPTION
## What was wrong

`DuplicateCriterionError` fired on raw source-line equality — `existing === line.trim()`. `pome checks add` renders a criterion as `` `- [code${tagged ? ":" + twin : ""}] ${renderCheck(picked, args)}` `` (`cli/src/cli/checks-add.ts:259`): no marker annotation, and no twin tag unless the task declares more than one twin. So any stored criterion carrying an annotation read as a *different* criterion and the guard stayed silent.

Reachable on a shipped task. `cli/tasks/03-already-triaged.md:22` is `` - [code always-scored] No new labels were created in `acme/api` ``, and before this change:

```
$ pome checks add cli/tasks/03-already-triaged.md \
    --check github.no-new-labels --arg repo=acme/api
Wrote …:
  - [code] No new labels were created in `acme/api`
```

Two graded copies of one check. The denominator inflates with something the exam already scores, which is the failure the error exists to refuse. `- [code] X` against a stored `- [code:github] X` was the same miss with a twin tag.

After:

```
$ pome checks add /tmp/03-already-triaged.md \
    --check github.no-new-labels --arg repo=acme/api
/tmp/03-already-triaged.md already has this criterion:
  - [code always-scored] No new labels were created in `acme/api`
which is the same check as the one being added:
  - [code] No new labels were created in `acme/api`
— a marker annotation or a twin tag does not make it a second check.
Adding it again would score it twice and inflate the task's denominator.
$ echo $?
2
```

An unrelated check still lands (`--check github.no-new-issues --arg repo=acme/api` writes, exit 0).

## What changed

The guard compares **parsed criteria — kind, resolved twin, text** — instead of rendered lines.

* The `[code]` side comes from **`readCodeCriteria`**, the parser's own reader (F-1134). It already applies the `tag ?? config.twins[0]` rule, so the question "which twin does a bare marker mean" keeps ONE definition instead of gaining a second one in this file that could drift from it. Its reconstructed `marker` is documented as being built so a report can echo a line the author can find by searching — which is now exactly what the refusal quotes.
* `[model]` criteria are read in the section scan that already runs, resolved by the same rule. `readCodeCriteria` is `[code]`-only by contract, so they cannot come from it; the pre-existing `[model]` duplicate refusal is covered by a shipped test and does not regress.
* `always-scored` is **deliberately not part of criterion identity**. It says how an existing check is scored, not what it checks (`taskCriterionSchema.alwaysScored`), so `- [code] X` and `- [code always-scored] X` are one check appended twice — which is the ticket's first case.
* `DuplicateCriterionError` takes an optional stored spelling and names the added line only when the two differ. Without that, the fix would send an author to search their file for a line it does not contain.

### How the guard gets the task's twin context

**Derived from `source`, not threaded down from `checks-add.ts`.** `insertCriterion(source, line, path)` already receives the file, and `## Config` is where the twins are declared — `readConfigTwins` is the same reader `checks-add.ts` calls one line earlier to decide whether to tag the line at all. Threading a `twin` argument would put a second view of that fact beside the file's own, and a caller whose twin disagreed with the file is the same rendered-view-vs-parsed-truth split this PR closes. It also means no signature change: every call site gets the fix and none can forget to pass it.

Resolution is tolerant in the same way `readCodeCriteria` is — a malformed `## Config` falls back rather than crashing, because turning a half-finished file into a stack trace is how an authoring surface stops being used. The inherited limit is noted in the code: a `## Config` declaring no twins yields no `[code]` criteria from the reader and the guard cannot fire, on a task that has no twin to grade a `[code]` criterion against in the first place.

## `CRITERION_LINE_RE` is untouched

`cli/src/task/parseTask.ts` is **not in this diff** (`git diff --name-only origin/main HEAD` lists four files, none of them it). That regex is the registered grammar authority pome-cloud's criterion-grammar check reads from the twins pin and compares against four other copies, so moving it would red a gate in a repo this PR cannot see. `insertCriterion`'s own `CRITERION_RE` is the unregistered mirror and is what changed: it gains capture groups and is now byte-identical to the authority, so a future divergence is visible by eye. `npm run lint:task-format-doc` passes and prints the same grammar.

## Tests (written first, watched fail)

Before the fix: 2 failed, 12 passed — both new refusals silently appended instead.

| Test | Catches |
| --- | --- |
| refuses `- [code] X` against a stored `- [code always-scored] X` | the ticket's named reachable case — the annotation making one check look like two |
| refuses `- [code] X` against a stored `- [code:github] X` | the same miss with a twin tag; requires resolving the bare marker to the primary twin, so it fails if the bare-marker case is quietly dropped |
| still accepts a criterion that merely shares a prefix (both directions) | over-correction. A guard that matched on prefix or on marker alone would block legitimate `checks add` calls — the quieter failure of the two, since the author gets no error to search for |
| still accepts one differing only in kind, or only in twin tag | the other two legs of the triple actually discriminate: a `[model]` restatement is judged from the run, and a differently-tagged criterion reads another twin's state |

`cli/tasks/` is untouched — the fixture reproduces `03-already-triaged.md`'s shape rather than editing it.

## Checks run locally

`@pome-sh/cli` 109 files / 1123 tests green; all workspaces 163 files / 1708 tests green; `npm run typecheck` (all workspaces) clean; `lint:dead-code` (knip), `lint:copy-markers`, `lint:code-health`, `lint:legacy-markers`, `lint:task-format-doc`, `lint:no-catch`, `lint:parent-vocab`, `lint:task-class` all pass; `scripts/ci/check-version-bump-required.mjs` passes.

## Release

`@pome-sh/cli` **0.23.33** (main is 0.23.31; 0.23.32 is claimed by #406). Changelog entry added above the 0.23.31 one. `package-lock.json` untouched.
