### PR TITLE
A half-written verdict.json is no longer read as a corrupt one (F-1445)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,34 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.23.34
+
+### Patch Changes
+
+- **`verdict.json` is published by tmp-file + `rename`, so a scan can no longer
+  read it half-written** (F-1445). `writeVerdictArtifact` used a plain
+  `writeFile`, which opens the live path with `O_TRUNC` and lands the bytes
+  afterwards — the artifact was observably empty, then partial, for the whole
+  of a write. A `pome fix-prompt` scanning a root while a hosted `pome run`
+  finalized in it read that prefix, and since F-1411 it REPORTED that read:
+  the path named, counted in `unreadableCount`, and described as "truncated,
+  hand-edited, or not a verdict artifact". The bytes were read correctly; the
+  account of the run was wrong, and the suggested action (inspect the file,
+  delete it) is wrong for a file that is complete a moment later. The temp
+  file is a sibling inside the run dir — a directory cannot span a mount, so
+  the rename is the atomic kind by construction; `os.tmpdir()` would put it
+  one `EXDEV` away from a copy, which is the torn window again.
+
+- `readVerdictArtifactDetailed` gained a `missing` status, and both call sites
+  dropped the `existsSync` re-stat they used to need. "There is no verdict.json
+  here" used to collapse into `unreadable`, so the scan and `pome fix-prompt`'s
+  discovery each re-stat'ed the file they had just failed to read in order to
+  recover the distinction — a check-then-read window of their own. No
+  user-visible count moves: `missing` covers every errno for which a `stat`
+  fails too (ENOENT, ENOTDIR, ELOOP, ENAMETOOLONG), so a stray file under a
+  task slug is still silently skipped rather than counted as damage, while
+  EACCES/EISDIR stay `unreadable` exactly as before.
+
 ## 0.23.33
 
 ### Patch Changes
@@ -32,6 +60,7 @@ packaging restructure: bump `version` here and in `package.json`, and merging to
 
 - 0.23.33 rather than 0.23.31: #403 (F-1417) and #406 (F-1441) took 0.23.31 and
   0.23.32 while this branch was in review.
+
 
 ## 0.23.32
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.23.33",
+  "version": "0.23.34",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/cli/src/hosted/evalResultCache.ts
+++ b/cli/src/hosted/evalResultCache.ts
@@ -21,8 +21,8 @@
 // this file itself can't be called that anymore) and grouped under
 // `hosted/` since it caches a CLOUD response, not a recorder concern.
 
-import { existsSync } from "node:fs";
-import { readdir, readFile, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { CriterionResult } from "../types/shared.js";
 import type { ScoreStatus } from "./evalResultView.js";
@@ -119,15 +119,45 @@ export interface TrialVerdict {
   verdict: VerdictArtifact;
 }
 
+/** F-1445 — publish by RENAME, never by writing the live path in place.
+ *  `writeFile` opens with `O_TRUNC` and the bytes land afterwards, so
+ *  `verdict.json` was observably empty and then partial for the whole of a
+ *  write, and a `pome fix-prompt` scanning the root while a `pome run`
+ *  finalized in it read that prefix. Since F-1411 it REPORTED that read: path
+ *  named, counted in `unreadableCount`, described as "truncated, hand-edited,
+ *  or not a verdict artifact" — a correct read of the bytes and a wrong
+ *  account of the run, whose suggested fix (inspect it, delete it) is wrong
+ *  for a file that is complete a moment later. `rename` is atomic within a
+ *  filesystem, so a reader now sees the previous artifact or the complete new
+ *  one, never a prefix.
+ *
+ *  The temp file MUST be a sibling inside `runDir`, and that is the whole of
+ *  the same-filesystem guarantee: a directory cannot span a mount, so this
+ *  rename is always the atomic kind. `os.tmpdir()` is not a substitute — with
+ *  an artifacts root on another mount (container volume, external disk, network
+ *  share) `rename(2)` fails `EXDEV`, and the reflex fix for `EXDEV` is a copy,
+ *  which is exactly the torn window this removes. That would still pass a
+ *  same-machine test, so the constraint is stated here rather than left to CI.
+ *
+ *  Deliberately not fsync'd: the window this closes belongs to a concurrent
+ *  READER, not a power cut, and this file is a cache of a cloud response the
+ *  dashboard holds authoritatively (see the header). */
 export async function writeVerdictArtifact(
   runDir: string,
   verdict: VerdictArtifact,
 ): Promise<void> {
-  await writeFile(
-    join(runDir, VERDICT_FILENAME),
-    `${JSON.stringify(verdict, null, 2)}\n`,
-    "utf8",
-  );
+  const tmpPath = join(runDir, `.${VERDICT_FILENAME}.${process.pid}.${randomUUID()}.tmp`);
+  try {
+    await writeFile(tmpPath, `${JSON.stringify(verdict, null, 2)}\n`, "utf8");
+    await rename(tmpPath, join(runDir, VERDICT_FILENAME));
+  } catch (err) {
+    // No debris in the user's runs/ when the write or the rename fails. The
+    // caller treats that as "fix-prompt won't see this trial" (runTaskHosted
+    // step 11) and must still receive the original error, so a failure to
+    // clean up never replaces it.
+    await rm(tmpPath, { force: true }).catch(() => {});
+    throw err;
+  }
 }
 
 /** Read one trial's verdict.json. Returns null when absent or when the file
@@ -208,11 +238,36 @@ function isVerdictArtifact(parsed: unknown): parsed is VerdictArtifact {
  *  new fields being absent, so the status never claims more than it checked:
  *  a file that says `version: 2` and is malformed is a corrupt CURRENT file
  *  (`unreadable`), not a prior version. `version` is null when the file
- *  carries no numeric `version` at all. */
+ *  carries no numeric `version` at all.
+ *
+ *  F-1445 — `missing` is the fourth: no verdict.json at this path at all (no
+ *  run finished here yet, or the caller pointed at an artifacts root rather
+ *  than a trial dir). It used to collapse into `unreadable`, which is why both
+ *  callers below re-`existsSync`'d the file they had just failed to read — a
+ *  second stat answering what the read already knew, and its own
+ *  check-then-read window. */
 export type VerdictReadResult =
   | { status: "ok"; trial: TrialVerdict }
   | { status: "stale-version"; version: number | null }
-  | { status: "unreadable" };
+  | { status: "unreadable" }
+  | { status: "missing" };
+
+/** F-1445 — the errno set for "this path does not resolve to a file": exactly
+ *  the set `existsSync` answered `false` for, since a `stat` fails the same
+ *  way. ENOENT alone would move a user-visible count — the scan walks every
+ *  entry under a task slug as a run dir, so a stray FILE there yields ENOTDIR
+ *  on `<file>/verdict.json`; ELOOP and ENAMETOOLONG are the same fact for a
+ *  path typed at `pome fix-prompt`. EACCES and EISDIR are NOT here: something
+ *  IS at that path and this process could not read it, which is `unreadable`,
+ *  as before (`existsSync` succeeds on a file whose parent is traversable). */
+const MISSING_ERROR_CODES: ReadonlySet<string> = new Set([
+  "ENOENT", "ENOTDIR", "ELOOP", "ENAMETOOLONG",
+]);
+
+function isMissingFileError(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException | null)?.code;
+  return typeof code === "string" && MISSING_ERROR_CODES.has(code);
+}
 
 export async function readVerdictArtifactDetailed(
   runDir: string,
@@ -221,8 +276,8 @@ export async function readVerdictArtifactDetailed(
   let raw: string;
   try {
     raw = await readFile(path, "utf8");
-  } catch {
-    return { status: "unreadable" };
+  } catch (err) {
+    return isMissingFileError(err) ? { status: "missing" } : { status: "unreadable" };
   }
   let parsed: unknown;
   try {
@@ -253,8 +308,8 @@ export async function readVerdictArtifact(
  *  truncated, hand-edited, or otherwise damaged. Kept out of `staleVersionDirs`
  *  on purpose — a prior-version file and a corrupt one are different facts
  *  (upgrade vs. damage) and want different fixes. A run dir with no
- *  verdict.json at all (no run finished there yet) is neither: `existsSync`
- *  below is what tells "never written" apart from "written, then damaged".
+ *  verdict.json at all is neither (no run finished there yet): F-1445 put that
+ *  distinction in the read's `missing` status, not a re-stat here.
  *
  *  `unreadableDirs` is SORTED, unlike the other two: it is the only one whose
  *  order reaches a user, via the path list `pome fix-prompt` prints and trims
@@ -293,9 +348,7 @@ export async function scanVerdictArtifactsDetailed(
       const result = await readVerdictArtifactDetailed(runDir);
       if (result.status === "ok") trials.push(result.trial);
       else if (result.status === "stale-version") staleVersionDirs.push(runDir);
-      else if (result.status === "unreadable" && existsSync(join(runDir, VERDICT_FILENAME))) {
-        unreadableDirs.push(runDir);
-      }
+      else if (result.status === "unreadable") unreadableDirs.push(runDir);
     }
   }
   unreadableDirs.sort();
@@ -381,14 +434,11 @@ export async function discoverRunSet(target: string): Promise<RunSetDiscovery> {
   // F-1411 — same reasoning as the stale-version branch above, for a target
   // whose verdict.json exists but is damaged: name it as a trial-dir skip
   // rather than falling through to the "root" branch, which would scan
-  // `target` itself (two levels too shallow) and find nothing. The
-  // `existsSync` check is what tells this apart from a target that is
-  // actually an artifacts root (which has no verdict.json of its own either,
-  // and must fall through).
-  if (
-    anchorResult.status === "unreadable" &&
-    existsSync(join(target, VERDICT_FILENAME))
-  ) {
+  // `target` itself (two levels too shallow) and find nothing. F-1445 — what
+  // tells this apart from a target that IS an artifacts root (no verdict.json
+  // of its own either, and must fall through) is the read's own `missing`
+  // status, not a second `existsSync` of the path the read just failed on.
+  if (anchorResult.status === "unreadable") {
     return {
       kind: "trial-dir",
       set: null,
@@ -427,17 +477,11 @@ export async function discoverRunSet(target: string): Promise<RunSetDiscovery> {
     };
   }
 
-  if (!existsSync(target)) {
-    return {
-      kind: "root",
-      set: null,
-      incompleteSet: null,
-      totalSets: 0,
-      staleVersionCount: 0,
-      unreadableCount: 0,
-      unreadablePaths: [],
-    };
-  }
+  // `missing` — no verdict.json at `target`, so it is an artifacts root (or
+  // nothing at all). F-1445 also dropped the `if (!existsSync(target))` early
+  // return that sat here: on a root that isn't there `readdir` throws and is
+  // caught, and the three empty arrays give the same nulls and zeros through
+  // `groupRunSets` / `latestFailedRunSet` / `latestIncompleteRunSet`.
   const { trials, staleVersionDirs, unreadableDirs } =
     await scanVerdictArtifactsDetailed(target);
   const sets = groupRunSets(trials);

--- a/cli/test/unit/hosted/evalResultCache.test.ts
+++ b/cli/test/unit/hosted/evalResultCache.test.ts
@@ -9,7 +9,7 @@
 // from a trial the grader never finished, and both used to trip the old
 // `anyFailed` boolean the same way.
 
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -767,6 +767,176 @@ describe("verdict artifact (FDRS-644)", () => {
       expect(discovery.unreadableCount).toBe(1);
       expect(discovery.unreadablePaths).toEqual([corruptDir]);
       expect(discovery.staleVersionCount).toBe(0);
+    });
+  });
+
+  // F-1445 — the counts above are only honest about DAMAGE if a file that is
+  // merely mid-write can never reach them. `pome fix-prompt` scanning a root
+  // while a `pome run` finalizes in it is an ordinary thing to do, and a
+  // plain `writeFile` publishes the path first (O_TRUNC empties it) and the
+  // bytes second, so the scanner had a real window in which to read a prefix
+  // and report it as "truncated, hand-edited, or not a verdict artifact".
+  describe("verdict.json is published by rename, so a concurrent scan never sees a prefix (F-1445)", () => {
+    /** Big enough that the write is a measurable interval rather than an
+     *  instant: ~4 MB of JSON. On the pre-F-1445 code the artifact path is
+     *  observably empty (or partial) for that whole interval, which is what
+     *  lets this test fail on `origin/main` instead of passing vacuously —
+     *  a small artifact lands in one syscall and the window is too narrow to
+     *  sample reliably. */
+    function largeVerdict(sid: string): VerdictArtifact {
+      return verdict({
+        session_id: sid,
+        criteria_results: Array.from({ length: 3000 }, (_, i) => ({
+          criterion: { type: "model" as const, text: `criterion ${i} ${"c".repeat(320)}` },
+          passed: true,
+          skipped: false,
+          reason: `reason ${i} ${"r".repeat(320)}`,
+        })),
+      });
+    }
+
+    it("a scan running throughout a large write never reports an unreadable count", async () => {
+      const tmp = await mkdtemp(join(tmpdir(), "verdict-atomic-scan-"));
+      const runDir = join(tmp, "scn", "ses_hot");
+      await mkdir(runDir, { recursive: true });
+      const artifact = largeVerdict("ses_hot");
+      // Seed one COMPLETE artifact first: the claim is that a reader sees
+      // either the previous artifact or the new one, which needs a previous
+      // one to exist.
+      await writeVerdictArtifact(runDir, artifact);
+
+      let writing = true;
+      const writer = (async () => {
+        try {
+          for (let i = 0; i < 20; i += 1) {
+            await writeVerdictArtifact(runDir, artifact);
+          }
+        } finally {
+          writing = false;
+        }
+      })();
+      const scans: { unreadable: number; sets: number }[] = [];
+      const scanner = async () => {
+        while (writing) {
+          const d = await discoverRunSet(tmp);
+          scans.push({ unreadable: d.unreadableCount, sets: d.totalSets });
+        }
+      };
+      await Promise.all([writer, scanner(), scanner()]);
+
+      // Sampling proof: an assertion over zero observations is not evidence.
+      expect(scans.length).toBeGreaterThan(10);
+      // The ticket's claim, both halves: no scan accused the run of damage,
+      // and every scan still found the one complete run set — "silently saw
+      // nothing" would be the same race wearing the pre-F-1411 face.
+      expect(scans.filter((s) => s.unreadable > 0)).toEqual([]);
+      expect(scans.filter((s) => s.sets !== 1)).toEqual([]);
+    }, 60_000);
+
+    it("republishing swaps the directory entry (new inode) instead of truncating in place", async () => {
+      const tmp = await mkdtemp(join(tmpdir(), "verdict-atomic-inode-"));
+      const runDir = join(tmp, "scn", "ses_swap");
+      await mkdir(runDir, { recursive: true });
+
+      await writeVerdictArtifact(runDir, verdict({ session_id: "ses_swap" }));
+      const first = await stat(join(runDir, "verdict.json"));
+      await writeVerdictArtifact(runDir, verdict({ session_id: "ses_swap", score: 40 }));
+      const second = await stat(join(runDir, "verdict.json"));
+
+      // The deterministic half of the claim above, which the concurrency test
+      // can only sample: `writeFile` reuses the inode (it opens the SAME file
+      // with O_TRUNC), a rename replaces the directory entry with a different
+      // one. A same-inode second write is an in-place rewrite, i.e. a window.
+      expect(second.ino).not.toBe(first.ino);
+      // And the content is the new artifact, not a stale one left behind.
+      const onDisk = JSON.parse(await readFile(join(runDir, "verdict.json"), "utf8")) as {
+        score: number;
+      };
+      expect(onDisk.score).toBe(40);
+    });
+
+    it("leaves no temp file behind in the run dir", async () => {
+      const tmp = await mkdtemp(join(tmpdir(), "verdict-atomic-tidy-"));
+      const runDir = join(tmp, "scn", "ses_tidy");
+      await mkdir(runDir, { recursive: true });
+      await writeVerdictArtifact(runDir, verdict({ session_id: "ses_tidy" }));
+      await writeVerdictArtifact(runDir, verdict({ session_id: "ses_tidy" }));
+      // The temp file is a SIBLING (same directory ⇒ same filesystem ⇒ the
+      // rename is atomic), so tidiness is this module's problem: a leftover
+      // `.verdict.json.*.tmp` in every run dir would be a visible mess in the
+      // user's runs/ even though no reader looks at it.
+      expect(await readdir(runDir)).toEqual(["verdict.json"]);
+    });
+  });
+
+  // F-1445 — `readVerdictArtifactDetailed` used to collapse "there is no
+  // verdict.json here" into `unreadable`, which is why both call sites
+  // re-`existsSync`'d the path they had just failed to read. The status now
+  // carries the distinction, so the re-stat (and the check-then-read window
+  // it opened) is gone.
+  describe("an absent verdict.json is `missing`, not `unreadable` (F-1445)", () => {
+    it("names the absence directly, for a run dir with no verdict.json and for a dir that isn't there", async () => {
+      const tmp = await mkdtemp(join(tmpdir(), "verdict-missing-"));
+      const empty = join(tmp, "scn", "ses_never_finalized");
+      await mkdir(empty, { recursive: true });
+
+      expect(await readVerdictArtifactDetailed(empty)).toEqual({ status: "missing" });
+      expect(await readVerdictArtifactDetailed(join(tmp, "scn", "nope"))).toEqual({
+        status: "missing",
+      });
+      // The collapsing reader still collapses: callers that only want usable
+      // trials are unaffected.
+      expect(await readVerdictArtifact(empty)).toBeNull();
+    });
+
+    it("every path that does not RESOLVE is `missing`, so the scan's junk-skipping is unchanged", async () => {
+      // The `existsSync` guard this status replaces answered `false` for more
+      // than ENOENT, and each of those is a count that would otherwise move.
+      // ENOTDIR is the one that reaches a real user: the scan walks every
+      // entry under a task slug as a run dir, so `<root>/<slug>/loose.txt`
+      // gets read as `<...>/loose.txt/verdict.json`. Keying `missing` on
+      // ENOENT alone would newly count every stray file under a task slug as
+      // a damaged artifact. ELOOP and ENAMETOOLONG are the same fact for a
+      // path a user typed at `pome fix-prompt`.
+      const tmp = await mkdtemp(join(tmpdir(), "verdict-missing-notdir-"));
+      await writeTrial(tmp, "scn", "ses_ok", {});
+      const loose = join(tmp, "scn", "loose.txt");
+      await writeFile(loose, "not a run dir", "utf8");
+      const loop = join(tmp, "scn", "loop");
+      await symlink(loop, loop); // self-referential → ELOOP on resolve
+      const tooLong = join(tmp, "scn", "n".repeat(5000)); // → ENAMETOOLONG
+
+      expect(await readVerdictArtifactDetailed(loose)).toEqual({ status: "missing" });
+      expect(await readVerdictArtifactDetailed(loop)).toEqual({ status: "missing" });
+      expect(await readVerdictArtifactDetailed(tooLong)).toEqual({ status: "missing" });
+
+      const { trials, unreadableDirs } = await scanVerdictArtifactsDetailed(tmp);
+      expect(trials.map((t) => t.verdict.session_id)).toEqual(["ses_ok"]);
+      expect(unreadableDirs).toEqual([]);
+      const discovery = await discoverRunSet(tmp);
+      expect(discovery.totalSets).toBe(1);
+      expect(discovery.unreadableCount).toBe(0);
+    });
+
+    it("a fix-prompt target with no verdict.json still falls through to the artifacts-root read", async () => {
+      // `discoverRunSet` distinguishes "you pointed me at a damaged trial"
+      // from "you pointed me at a root" — with `missing` that is a status
+      // check rather than a second stat of the same path.
+      const tmp = await mkdtemp(join(tmpdir(), "verdict-missing-root-"));
+      await writeTrial(tmp, "scn", "ses_fail", { passed: false, state: "fail" });
+
+      const discovery = await discoverRunSet(tmp);
+      expect(discovery.kind).toBe("root");
+      expect(discovery.totalSets).toBe(1);
+      expect(discovery.unreadableCount).toBe(0);
+      expect(discovery.set?.trials.map((t) => t.verdict.session_id)).toEqual(["ses_fail"]);
+
+      // A root that does not exist at all is still an empty root, not a
+      // trial dir.
+      const gone = await discoverRunSet(join(tmp, "not-here"));
+      expect(gone.kind).toBe("root");
+      expect(gone.totalSets).toBe(0);
+      expect(gone.unreadableCount).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## What

`verdict.json` is written to a sibling temp file inside the run dir and
`rename`d into place, so a concurrent reader sees either the previous artifact
or the complete new one — never a prefix. `readVerdictArtifactDetailed` gained
a `{status: "missing"}` arm, and the two `existsSync` re-stats that existed
only to recover that distinction are gone.

## Why

F-1445. `writeVerdictArtifact` used a plain `writeFile`, which opens the live
path with `O_TRUNC` and lands the bytes afterwards, so the artifact was
observably empty and then partial for the whole of a write. A `pome fix-prompt`
scanning a root while a hosted `pome run` finalizes in it reads that prefix —
and since F-1411 it *reports* the read: path named, counted in
`unreadableCount`, described as "truncated, hand-edited, or not a verdict
artifact". The bytes were read correctly; the account of the run was wrong, and
the suggested action (inspect the file, delete it) is wrong for a file that is
complete a moment later. The race predates F-1411, which turned it from a
silent drop into a loud misdiagnosis.

## Notes for reviewer

**How the concurrency test was shown to fail on `origin/main`** (tdd-required —
the test went in first). `a scan running throughout a large write never reports
an unreadable count` writes a ~2.4 MB artifact (3000 criteria) in a loop while
two scanners run `discoverRunSet` over the same root. Against the unfixed
`writeVerdictArtifact`, **every** sampled scan was torn — 51/51 in the first
measurement, 67/67 in a later one, each reporting `unreadableCount: 1` and
`totalSets: 0`. Sizing mattered and I measured it rather than guessing: the
same loop with the default ~1.3 KB artifact tore on only 4 of 22 scans (~18%),
which is a test that would pass vacuously often enough to mean nothing. At 2.4
MB the artifact is empty or partial for essentially the whole write, because
`JSON.stringify` of that payload blocks the loop and the scanners only get to
run during the async write. After the fix the same test samples 84-88 scans and
observes zero torn reads; it was run 5x for flake. Two deterministic siblings
back it up: republishing changes the file's **inode** (a plain `writeFile`
reuses it — that is the in-place window in one assertion), and the run dir holds
only `verdict.json` afterwards, so the temp file is cleaned up.

**Why the temp file is in `runDir`.** A directory cannot span a mount, so a
rename between two entries of one directory is the atomic kind by construction —
that is the whole of the guarantee, and it is stated in the code comment
because CI cannot catch its violation: an `os.tmpdir()` temp file is one
`EXDEV` away from a copy on an artifacts root that lives on another mount, and
would still pass a same-machine test.

**The `missing` arm and the count-equivalence argument.** `missing` covers every
errno for which a `stat` of the same path also fails — ENOENT, ENOTDIR, ELOOP,
ENAMETOOLONG — which is exactly what the `existsSync` guard answered `false`
for, so no user-visible count moves. ENOTDIR is the one that reaches a real
user: the scan walks every entry under a task slug as a run dir, so a stray
*file* there is read as `<file>/verdict.json`; keying `missing` on ENOENT alone
would newly count every such file as a damaged artifact. EACCES and EISDIR
deliberately stay `unreadable` — something *is* at that path and this process
could not read it, which is the same answer as before for the reachable case (a
file whose parent is traversable). All four `missing` errnos are exercised by
tests, none is an unexercised set entry.

**Correction to the freshness audit's line pointers.** The audit warned that a
`missing` arm would rewrite two assertions at
`cli/test/unit/hosted/evalResultCache.test.ts:157,167` "asserting
`{status:"unreadable"}` for absent dirs". On `origin/main` those two lines are
not about absent dirs: `:157` asserts `{status: "stale-version", version: 1}`
for a dir holding a **v1** verdict.json, and `:167` asserts `unreadable` for a
dir holding a verdict.json that is present but unrecognizable. Both still hold
verbatim, and so does `:121` (`readVerdictArtifact` on an absent dir → `null`,
unchanged because the collapsing reader still collapses). **No existing
assertion moved or was deleted** — I checked every `readVerdictArtifactDetailed`
assertion site in the file (`:157, :167, :473, :482, :500, :511, :526, :632,
:645, :660`) and each writes a file first. The `missing` behaviour is pinned by
three new tests instead. The full CLI suite is green unchanged: 109 files, 1125
tests.

**A third `existsSync` went too.** `discoverRunSet`'s `if (!existsSync(target))`
early return was already dead weight: on a root that isn't there
`scanVerdictArtifactsDetailed`'s `readdir` throws and is caught, and the three
empty arrays produce the same nulls and zeros through `groupRunSets` /
`latestFailedRunSet` / `latestIncompleteRunSet` that the branch returned by
hand. Pinned by a test asserting a nonexistent target still reads as an empty
`kind: "root"`.

**Release.** `@pome-sh/cli` → **0.23.34** with a CHANGELOG entry. 0.23.31 and
0.23.32 were taken tonight by #403 (F-1417, now on `main`) and #406 (F-1441),
and 0.23.33 is reserved for F-1443; if the version check still goes red at
merge time the orchestrator resolves it. This branch was rebased onto #403 —
the only conflicts were the version line and the CHANGELOG insertion point, and
0.23.34 is unchanged by that. Note `cli/CHANGELOG.md`'s top entry was 0.23.27
before tonight, already behind `package.json`; the gap is not back-filled here.
`package-lock.json` is untouched (it is independently stale, and past cli
version bumps in this repo do not touch it).

**One incidental edit.** `lint:code-health` caps this module at 500 lines and
the new comments pushed it to 511, so some of the surrounding prose was
tightened rather than adding a `// file-size:` waiver. The on-disk artifact
bytes are unchanged — same `version: 2`, same fields, same trailing newline.
