### PR TITLE
Every release-CDN fetch in CI goes through one hardened path (F-1489)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,33 +63,27 @@ jobs:
           trap 'rm -rf "$tmp"' EXIT
           # This step puts the REQUIRED check (`typecheck-test`) behind a
           # third-party CDN fetch, so the backoff is load-bearing, not
-          # decoration. The GitHub release CDN was degraded throughout this
-          # PR's review and took out three separate pinned installs on its own
-          # runs: 31618873218 (gitleaks, 503), a twin-image syft install (503),
-          # and 31619759943 (this step, 503).
+          # decoration. The GitHub release CDN was degraded throughout F-1471's
+          # review and took out three separate pinned installs on its own runs:
+          # 31618873218 (gitleaks, 503), a twin-image syft install (503), and
+          # 31619759943 (this step, 503).
           #
-          # The retry is an explicit loop rather than curl's --retry flags,
-          # because those were measured doing two different things: locally
-          # `--retry-delay 0` backed off 1s/2s/4s as documented, while on the
-          # runner the same flags burned five attempts in 0.8s against a
-          # `curl: (56) Connection died` (run 31620014945) — a retry budget
-          # that looks handled and is not is worse than none. A loop with a
-          # literal `sleep` cannot be version-dependent.
+          # F-1489 moved the loop, the backoff and the sha256 check into
+          # scripts/ci/fetch-pinned-release.sh, which is now the ONE hardened
+          # fetch path for the whole workflow tree — this step and
+          # secret-scan.yml's gitleaks install were two hand-copied variants of
+          # it, and the syft install that started F-1489 had no copy at all.
+          # scripts/ci/assert-hardened-cdn-fetches.mjs (below, in the always-on
+          # block) reds on a third variant. The helper's header records why the
+          # retry is a literal loop rather than curl's --retry flags.
           #
           # Deliberately NOT cached, though that would make an outage a
-          # cold-cache-only problem: a cache hit skips the sha256 verification
-          # below, which is the whole reason for fetching a pinned binary
-          # instead of trusting a third-party Action.
-          url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${archive}"
-          for attempt in 1 2 3 4 5; do
-            if curl -sSfL --connect-timeout 10 --max-time 120 "$url" -o "$tmp/$archive"; then break; fi
-            if [ "$attempt" -eq 5 ]; then
-              echo "actionlint download failed after 5 attempts: $url" >&2
-              exit 1
-            fi
-            sleep "$(( attempt * 5 ))"
-          done
-          printf '%s  %s\n' "$ACTIONLINT_SHA256" "$tmp/$archive" | sha256sum -c -
+          # cold-cache-only problem: a cache hit skips the sha256 verification,
+          # which is the whole reason for fetching a pinned binary instead of
+          # trusting a third-party Action.
+          bash scripts/ci/fetch-pinned-release.sh actionlint \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${archive}" \
+            "$ACTIONLINT_SHA256" "$tmp/$archive"
           tar -xzf "$tmp/$archive" -C "$tmp" actionlint
           mkdir -p "$HOME/.local/bin"
           install "$tmp/actionlint" "$HOME/.local/bin/actionlint"
@@ -190,6 +184,23 @@ jobs:
       # alarm files under one key and looks itself up under another.
       - run: node scripts/ci/assert-schedule-alarm-coverage.mjs
       - run: node scripts/ci/assert-schedule-alarm-coverage.test.mjs
+      # F-1489 — every binary `.github/workflows/**` pulls off a release CDN
+      # goes through ONE hardened path, and a new one that does not reds here.
+      # Two shapes: a `run:` block fetching a non-loopback URL must call
+      # scripts/ci/fetch-pinned-release.sh (retry + backoff + an UNCONDITIONAL
+      # sha256 check + a fail-closed message naming the CDN), and a `uses:`
+      # action that installs a binary must appear as a repeated-attempt group,
+      # every copy carrying identical `uses:` and `with:` — the check that keeps
+      # twin-image.yml's three cosign installs on the same `cosign-release`.
+      # The SET of actions to judge is read out of the workflows, never typed
+      # here; the per-action verdict (does this action download an executable?
+      # unreadable from this repo) is a reviewed row in cdn-fetch-actions.json,
+      # and an action with no row reds. Same block as the derivations above and
+      # for the same reason: a `.github/workflows/**`-only diff is classified
+      # docs-only by the scope step, so a heavy-block gate would be skipped by
+      # exactly the PR that adds an unhardened fetch.
+      - run: node scripts/ci/assert-hardened-cdn-fetches.mjs
+      - run: node scripts/ci/assert-hardened-cdn-fetches.test.mjs
       # F-1226 — the plugin manifest is what makes the `skills` installer render
       # one select-all row instead of six unticked checkboxes. It has to live in
       # the always-on block: adding a skill touches only `skills/`, which the

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -31,20 +31,18 @@ jobs:
           # This exact fetch took a 503 from the release CDN on run 31618873218
           # and failed the scan for a reason unrelated to its subject — and now
           # that the scan has a failure alarm, a flaky download also files a
-          # bogus tracking issue, which teaches people to skim the label. An
-          # explicit loop rather than curl's --retry flags, for the reason
-          # measured in ci.yml's actionlint install: those flags backed off
-          # locally and burned five attempts in under a second on the runner.
-          url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${archive}"
-          for attempt in 1 2 3 4 5; do
-            if curl -sSfL --connect-timeout 10 --max-time 120 "$url" -o "$tmp/$archive"; then break; fi
-            if [ "$attempt" -eq 5 ]; then
-              echo "gitleaks download failed after 5 attempts: $url" >&2
-              exit 1
-            fi
-            sleep "$(( attempt * 5 ))"
-          done
-          printf '%s  %s\n' "$GITLEAKS_SHA256" "$tmp/$archive" | sha256sum -c -
+          # bogus tracking issue, which teaches people to skim the label.
+          #
+          # F-1489 replaced the loop that was inlined here with
+          # scripts/ci/fetch-pinned-release.sh: retry with backoff, an
+          # UNCONDITIONAL sha256 check, and an exhaustion message naming the CDN
+          # host rather than `exit code 1`. It is the same path ci.yml's
+          # actionlint install and twin-image.yml's syft/cosign steps now take,
+          # and scripts/ci/assert-hardened-cdn-fetches.mjs reds on any fetch in
+          # `.github/workflows/**` that goes around it.
+          bash scripts/ci/fetch-pinned-release.sh gitleaks \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${archive}" \
+            "$GITLEAKS_SHA256" "$tmp/$archive"
           tar -xzf "$tmp/$archive" -C "$tmp" gitleaks
           mkdir -p "$HOME/.local/bin"
           install "$tmp/gitleaks" "$HOME/.local/bin/gitleaks"

--- a/.github/workflows/twin-image.yml
+++ b/.github/workflows/twin-image.yml
@@ -185,13 +185,74 @@ jobs:
           exit-code: '1'
           ignore-unfixed: true
           trivyignores: .trivyignore
-      - name: Generate image SBOM
+      # F-1489 — anchore/sbom-action fetches the syft binary from the anchore
+      # release CDN (github.com/anchore/syft/releases) on every run, with no
+      # retry of its own. A 503 there killed this job twice on 2026-08-12
+      # (#390, #391) with `[error] received HTTP status=503 … unable to find
+      # tag=''`; on a PR that is noise, but on main the cosign sign/attest steps
+      # below DO run, so the same 503 fails an image publish.
+      #
+      # An action step cannot be wrapped in a shell retry loop, so the retry is
+      # the STEP, repeated. Attempts 1 and 2 are `continue-on-error`; each later
+      # attempt runs only `if:` the earlier ones actually FAILED (a skipped
+      # step's outcome is `skipped`, never `failure`, so the chain cannot
+      # self-trigger). The last attempt carries no escape hatch, so a genuinely
+      # unavailable CDN still refuses the publish exactly as it does today —
+      # this is persistence, not a policy change.
+      #
+      # Every copy MUST carry byte-identical `uses:` and `with:` — a retry that
+      # installs a different build, or writes a different output file, is not a
+      # retry. scripts/ci/assert-hardened-cdn-fetches.mjs enforces that, the
+      # attempt count, and the fatal last attempt.
+      - name: Generate image SBOM (attempt 1 of 3)
+        id: sbom_1
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        continue-on-error: true
+        with:
+          image: twin-${{ matrix.twin }}:scan
+          format: spdx-json
+          output-file: twin-${{ matrix.twin }}.spdx.json
+          upload-artifact: true
+      - name: Back off before SBOM attempt 2
+        if: ${{ steps.sbom_1.outcome == 'failure' }}
+        run: |
+          echo "::warning::SBOM attempt 1 failed. anchore/sbom-action fetches syft from github.com/anchore/syft/releases; retrying in 5s."
+          sleep 5
+      - name: Generate image SBOM (attempt 2 of 3)
+        id: sbom_2
+        if: ${{ steps.sbom_1.outcome == 'failure' }}
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        continue-on-error: true
+        with:
+          image: twin-${{ matrix.twin }}:scan
+          format: spdx-json
+          output-file: twin-${{ matrix.twin }}.spdx.json
+          upload-artifact: true
+      - name: Back off before SBOM attempt 3
+        if: ${{ steps.sbom_1.outcome == 'failure' && steps.sbom_2.outcome == 'failure' }}
+        run: |
+          echo "::warning::SBOM attempt 2 failed. github.com/anchore/syft/releases is degraded; last retry in 15s."
+          sleep 15
+      # Last attempt: no `continue-on-error`. Its failure fails the job.
+      - name: Generate image SBOM (attempt 3 of 3)
+        id: sbom_3
+        if: ${{ steps.sbom_1.outcome == 'failure' && steps.sbom_2.outcome == 'failure' }}
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: twin-${{ matrix.twin }}:scan
           format: spdx-json
           output-file: twin-${{ matrix.twin }}.spdx.json
           upload-artifact: true
+      # Fail closed, but say WHAT failed. The step above has already failed the
+      # job; this only replaces
+      # `##[error]The process '/usr/bin/sh' failed with exit code 1` with the
+      # name of the CDN that would not answer, so the run log says whether to
+      # re-run or to read the code.
+      - name: Name the CDN that failed the SBOM
+        if: ${{ failure() && steps.sbom_3.outcome == 'failure' }}
+        run: |
+          echo "::error::twin-${{ matrix.twin }}: could not generate the image SBOM after 3 attempts. anchore/sbom-action fetches the syft binary from the anchore release CDN (github.com/anchore/syft/releases), and that CDN is unavailable — this is not a failure of the twin, the build or the scan. Failing closed on purpose: an image with no SBOM is never signed, attested or pushed."
+          exit 1
       # cosign v2. The v3.0.6 bump (attempted RFC3161-timestamped signatures)
       # was reverted: it gave no benefit — the pome-cloud deploy gate hard-gates
       # only the image SIGNATURE, which verifies on un-timestamped v2 signatures
@@ -207,10 +268,52 @@ jobs:
       # bump of the action alone (as in #167) silently drifts the binary to v3
       # and reintroduces the failure above. Pinning the binary here decouples us
       # from the action version.
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      #
+      # F-1489 — repeated for the same reason as the SBOM group above: this
+      # installer's whole job is to pull the cosign binary off the sigstore
+      # release CDN, and it sits on the publish path one step before signing.
+      # ⚠️ ALL THREE COPIES MUST CARRY THE SAME `cosign-release: 'v2.6.4'`.
+      # A retry that installs a different cosign is not a retry, and v3 is the
+      # exact version the comment above explains was reverted.
+      # scripts/ci/assert-hardened-cdn-fetches.mjs reds if the three `with:`
+      # blocks ever disagree.
+      - name: Install cosign (attempt 1 of 3)
+        id: cosign_install_1
         if: ${{ github.event_name != 'pull_request' }}
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        continue-on-error: true
         with:
           cosign-release: 'v2.6.4'
+      - name: Back off before cosign install attempt 2
+        if: ${{ github.event_name != 'pull_request' && steps.cosign_install_1.outcome == 'failure' }}
+        run: |
+          echo "::warning::cosign install attempt 1 failed. sigstore/cosign-installer fetches cosign from github.com/sigstore/cosign/releases; retrying in 5s."
+          sleep 5
+      - name: Install cosign (attempt 2 of 3)
+        id: cosign_install_2
+        if: ${{ github.event_name != 'pull_request' && steps.cosign_install_1.outcome == 'failure' }}
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        continue-on-error: true
+        with:
+          cosign-release: 'v2.6.4'
+      - name: Back off before cosign install attempt 3
+        if: ${{ github.event_name != 'pull_request' && steps.cosign_install_1.outcome == 'failure' && steps.cosign_install_2.outcome == 'failure' }}
+        run: |
+          echo "::warning::cosign install attempt 2 failed. github.com/sigstore/cosign/releases is degraded; last retry in 15s."
+          sleep 15
+      # Last attempt: no `continue-on-error`. Its failure fails the job, which
+      # is the point — an unsigned image must never ship.
+      - name: Install cosign (attempt 3 of 3)
+        id: cosign_install_3
+        if: ${{ github.event_name != 'pull_request' && steps.cosign_install_1.outcome == 'failure' && steps.cosign_install_2.outcome == 'failure' }}
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: 'v2.6.4'
+      - name: Name the CDN that failed the cosign install
+        if: ${{ failure() && steps.cosign_install_3.outcome == 'failure' }}
+        run: |
+          echo "::error::twin-${{ matrix.twin }}: could not install cosign after 3 attempts. sigstore/cosign-installer fetches the pinned cosign v2.6.4 binary from the sigstore release CDN (github.com/sigstore/cosign/releases), and that CDN is unavailable — this is not a failure of the twin, the build or the scan. Failing closed on purpose: an image that cannot be signed and attested is not pushed."
+          exit 1
       # Push the EXACT image built + scanned above (already loaded into the local
       # daemon under every steps.meta.outputs.tags) — no second build, so the
       # published artifact is byte-identical to the one Trivy scanned. PR builds

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,37 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.23.38
+
+### Patch Changes
+
+- **One hardened path for every release-CDN fetch in CI** (F-1489). No change to
+  the published CLI's behaviour; this is release-pipeline hardening.
+  `anchore/sbom-action` fetched the `syft` binary from the anchore release CDN
+  with no retry, and a 503 there killed the `stripe` twin-image job twice on
+  2026-08-12 — noise on a PR, but on `main` the cosign sign/attest steps do run,
+  so the same 503 fails an image publish. The repo already had the fix in two
+  hand-copied variants (ci.yml's actionlint install, secret-scan.yml's gitleaks
+  install) and missing entirely from a third install.
+
+  All three now go through `scripts/ci/fetch-pinned-release.sh`: five attempts
+  with a literal backoff (not curl's `--retry` flags, which were measured
+  burning five attempts in 0.8s on a runner), an UNCONDITIONAL sha256 check, and
+  an exhaustion message naming the CDN host instead of `exit code 1`. The two
+  fetches that arrive through an ACTION rather than a `curl` — syft via
+  `anchore/sbom-action`, cosign via `sigstore/cosign-installer` — are repeated
+  steps instead: two `continue-on-error` attempts and a fatal third, so a
+  transient 5xx cannot stop a publish on the first try while a genuinely dead
+  CDN still refuses to ship an unsigned, unattested image.
+
+  `scripts/ci/assert-hardened-cdn-fetches.mjs` keeps that true as a property.
+  It derives the set of things to judge from `.github/workflows/**` rather than
+  a hand-kept list, so a sixth install reds the PR that adds it, and it refuses
+  to report a pass over an empty derivation. It also pins the hazard
+  twin-image.yml carries a paragraph defending: every copy of a repeated action
+  step must carry byte-identical `with:` inputs, so the three cosign installs
+  cannot drift off `cosign-release: 'v2.6.4'`.
+
 ## 0.23.37
 
 ### Patch Changes
@@ -41,6 +72,7 @@ packaging restructure: bump `version` here and in `package.json`, and merging to
   same guard and the same message, word for word, in the same change. A guard in
   only one of the two repos would re-open the disagreement F-1299 closed with
   the sign flipped: a typo would parse hosted and throw here.
+
 
 ## 0.23.34
 
@@ -109,7 +141,6 @@ packaging restructure: bump `version` here and in `package.json`, and merging to
   found live on a criterion whose polarity flips negative at count 0 — so the
   vacuous pass scored a point for an agent that did the forbidden thing. `labels`
   is now guarded for absence and truncation in both `labelIdsFor` consumers.
-
 
 ## 0.23.31
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.23.37",
+  "version": "0.23.38",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/scripts/ci/assert-hardened-cdn-fetches.mjs
+++ b/scripts/ci/assert-hardened-cdn-fetches.mjs
@@ -1,0 +1,595 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-1489 — every binary `.github/workflows/**` pulls off a release CDN must go
+// through one hardened path, and a new one that does not must red CI.
+//
+// WHY THIS EXISTS. `anchore/sbom-action` fetched syft with no retry; a CDN 503
+// killed the stripe twin-image job twice on 2026-08-12 (#390, #391), and on
+// `main` — where the cosign sign/attest steps do run — the same 503 fails an
+// image publish. The repo already knew the fix (ci.yml's actionlint loop,
+// F-1471) and had it in two hand-copied variants with a third install missing
+// it entirely. A list of "the installs we hardened" is the same shape as the
+// bug: it stays green while a sixth install lands unhardened. So this is a
+// PROPERTY check over the workflow tree.
+//
+// TWO SHAPES.
+//
+//   (a) A `run:` block that fetches a remote URL. Detected by scanning every
+//       `run:` script for a `curl` / `wget` / `aria2c` / `gh release download`
+//       invocation and resolving its target (literal URLs, plus one level of
+//       `VAR="https://…"` assignment in the same block). Anything that is not
+//       loopback — INCLUDING a target the resolver cannot work out, which is
+//       the fail-safe direction — must go through
+//       `scripts/ci/fetch-pinned-release.sh`, which is the only place the retry
+//       budget, the backoff and the unconditional sha256 check live.
+//
+//   (b) A `uses:` step for an action that installs a binary. Detected by
+//       collecting every non-local `uses:` in the tree and requiring each to
+//       have a row in scripts/ci/cdn-fetch-actions.json. Rows marked
+//       `repeat-attempts` must appear as a repeated-attempt group: an action
+//       step cannot be wrapped in a shell retry loop, so the retry is the step
+//       itself, repeated — at least three attempts, each carrying an `id:`, the
+//       earlier ones `continue-on-error: true`, every later one gated on
+//       `steps.<earlier-id>.outcome == 'failure'` (a SKIPPED step's outcome is
+//       `skipped`, never `failure`, so the chain cannot self-trigger), and the
+//       LAST attempt carrying no escape hatch at all. That last part is the
+//       fail-closed half: a genuinely unavailable CDN still refuses the
+//       publish. Every attempt must also carry a byte-identical `uses:` ref and
+//       `with:` block, which is what stops a repeated cosign install from
+//       drifting one copy off `cosign-release: 'v2.6.4'` — the pin twin-image.yml
+//       carries a paragraph of comment defending, because cosign v3
+//       `attest --type spdx` rejects the anchore SBOM predicate.
+//
+// WHAT THIS GATE CANNOT DERIVE, STATED PLAINLY. Whether a third-party action
+// downloads an executable is a fact about that action's implementation, not
+// about this repo — nothing in the string `anchore/sbom-action` says "fetches
+// syft from a release CDN", and `actions/checkout` looks identical from here.
+// So shape (b) is half-derived: the SET OF ACTIONS TO JUDGE comes from the
+// workflows (a new `uses:` is discovered the moment it lands, and reds until
+// someone classifies it), while the VERDICT PER ACTION is a reviewed row in
+// cdn-fetch-actions.json carrying its evidence. Rows are keyed on `owner/repo`,
+// so a sha bump keeps the classification and a major rewrite under the same
+// name would not be noticed. Two further known holes, recorded rather than
+// papered over: a fetch smuggled through a tool this scanner does not know
+// (a python one-liner, a Makefile) is invisible to shape (a); and two actions
+// are classified `step-is-the-check` — deliberately not retried, because
+// retrying a scanner turns "found a secret / found a CVE" into two swallowed
+// failures — each with a `residual` field naming what stays exposed.
+//
+// Usage: node scripts/ci/assert-hardened-cdn-fetches.mjs
+// Exits 1, naming every offender, on:
+//   - a `run:` block fetching a non-loopback URL outside the hardened helper
+//   - a `uses:` action with no row in cdn-fetch-actions.json
+//   - a row that is internally inconsistent (fetches from a CDN but claims
+//     `not-needed`, a `step-is-the-check` row with no `residual`, an empty `why`)
+//   - a `repeat-attempts` action used as a single step, or as a group whose
+//     last attempt is `continue-on-error`, whose attempts disagree on `uses:`
+//     or `with:`, or whose gating `if:` does not reference every earlier attempt
+//   - the structural step parse and the flat line scan disagreeing about which
+//     actions the tree uses (a parser regression makes the group check vacuous)
+//   - zero fetches, zero classified CDN actions, or zero hardened-helper call
+//     sites discovered (a vacuous green, not a true fact about the tree)
+
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { workflowLines } from "./list-scheduled-workflows.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/** The hardened path, relative to the repo root. */
+export const HELPER = "scripts/ci/fetch-pinned-release.sh";
+
+/**
+ * The F-1494 pattern is 2 escapable attempts + 1 fatal one. Fewer than three
+ * means a single transient 5xx can still reach the fatal attempt on its heels;
+ * the ticket's own failure was two 503s minutes apart on consecutive PRs.
+ */
+export const MIN_ATTEMPTS = 3;
+
+const FETCH_COMMANDS = /(?:^|[\s(`$])(?:curl|wget|aria2c|gh\s+release\s+download)(?=\s|$)/;
+
+const LOOPBACK = new Set(["localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"]);
+
+const VALID_HARDENING = new Set(["not-needed", "repeat-attempts", "step-is-the-check"]);
+
+export function loadTable(file = join(HERE, "cdn-fetch-actions.json")) {
+  return JSON.parse(readFileSync(file, "utf8"));
+}
+
+// ---------------------------------------------------------------------------
+// Structural read of a workflow file: jobs -> steps -> keys.
+//
+// Line-based and indentation-anchored, the same stance as
+// list-scheduled-workflows.mjs (whose comment-stripped lines this consumes):
+// a workflow's own prose contains the literal strings this looks for, and a
+// YAML parser is not a dependency this repo's always-on, pre-`npm ci` block can
+// take.
+// ---------------------------------------------------------------------------
+
+/** Jobs, each with its ordered list of raw step blocks. */
+export function parseJobs(lines) {
+  const jobs = [];
+  let inJobs = false;
+  let jobIndent = null;
+  let job = null;
+  let stepsIndent = null;
+  let itemIndent = null;
+  let step = null;
+
+  const flushStep = () => {
+    if (step && job) job.steps.push(step);
+    step = null;
+  };
+  const flushJob = () => {
+    flushStep();
+    if (job) jobs.push(job);
+    job = null;
+    stepsIndent = null;
+    itemIndent = null;
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() === "") continue;
+    const indent = /^\s*/.exec(line)[0].length;
+
+    if (indent === 0) {
+      flushJob();
+      inJobs = /^jobs:\s*$/.test(line);
+      jobIndent = null;
+      continue;
+    }
+    if (!inJobs) continue;
+    if (jobIndent === null) jobIndent = indent;
+
+    if (indent <= jobIndent) {
+      flushJob();
+      const m = /^\s+([A-Za-z0-9_.-]+):\s*$/.exec(line);
+      job = m ? { name: m[1], line: i + 1, steps: [] } : null;
+      continue;
+    }
+    if (!job) continue;
+
+    if (stepsIndent !== null && indent <= stepsIndent) {
+      flushStep();
+      stepsIndent = null;
+      itemIndent = null;
+    }
+    if (stepsIndent === null) {
+      if (/^\s*steps:\s*$/.test(line)) stepsIndent = indent;
+      continue;
+    }
+    if (/^\s*-\s/.test(line) && (itemIndent === null || indent === itemIndent)) {
+      flushStep();
+      itemIndent = indent;
+      step = { line: i + 1, lines: [line] };
+      continue;
+    }
+    if (step) step.lines.push(line);
+  }
+  flushJob();
+  return jobs;
+}
+
+/**
+ * A step's top-level keys as `name -> { value, lines }`, where `lines` holds
+ * the nested block (a `with:` mapping, a `run: |` script body).
+ */
+export function stepKeys(step) {
+  const norm = step.lines.map((l, i) => (i === 0 ? l.replace(/^(\s*)-(\s)/, "$1 $2") : l));
+  const base = /^\s*/.exec(norm[0])[0].length;
+  const keys = new Map();
+  let current = null;
+  for (const line of norm) {
+    const indent = /^\s*/.exec(line)[0].length;
+    if (indent <= base) {
+      const m = /^\s*([A-Za-z0-9_.-]+):\s*(.*)$/.exec(line);
+      current = m ? { value: m[2].trim(), lines: [] } : null;
+      if (m) keys.set(m[1], current);
+      continue;
+    }
+    if (current) current.lines.push(line);
+  }
+  return keys;
+}
+
+/** A key's full text, block scalar body included. */
+export function keyText(keys, name) {
+  const k = keys.get(name);
+  if (!k) return null;
+  const head = /^[|>][-+]?\d*$/.test(k.value) ? "" : k.value;
+  return [head, ...k.lines].join("\n");
+}
+
+/** A nested mapping (`with:`) as sorted, dedented, comparable lines. */
+export function blockLines(keys, name) {
+  const k = keys.get(name);
+  if (!k) return null;
+  return k.lines
+    .map((l) => l.trim())
+    .filter((l) => l !== "")
+    .sort();
+}
+
+// ---------------------------------------------------------------------------
+// Shape (a): remote fetches inside `run:` scripts.
+// ---------------------------------------------------------------------------
+
+export function hostOf(url) {
+  const m = /^[a-z][a-z0-9+.-]*:\/\/([^/?#\s"'`]+)/i.exec(url);
+  if (!m) return null;
+  let host = m[1].replace(/^[^@]*@/, "");
+  // The port is cut by POSITION, not by a `:\d+$` match: workflow scripts
+  // reach loopback through an expansion (`http://127.0.0.1:${port}/healthz`,
+  // `:${{ env.PORT }}`), and a digits-only strip leaves `127.0.0.1:${port}` as
+  // the "host" — which reads as a remote CDN and reds two smoke workflows that
+  // are doing nothing wrong.
+  if (host.startsWith("[")) {
+    const close = host.indexOf("]");
+    if (close !== -1) host = host.slice(0, close + 1);
+  } else {
+    const colon = host.indexOf(":");
+    if (colon !== -1) host = host.slice(0, colon);
+  }
+  return host;
+}
+
+export function isLoopback(url) {
+  const host = hostOf(url);
+  if (host === null) return false;
+  return LOOPBACK.has(host) || /^127(\.\d+){3}$/.test(host);
+}
+
+/**
+ * Every fetch invocation in one shell script, with the URL it targets when
+ * that can be worked out. An unresolvable target is reported as `null`, which
+ * every caller must treat as remote — the fail-safe direction.
+ */
+export function findFetchesInScript(script) {
+  // workflowLines() has already stripped YAML comments, which inside a `run: |`
+  // block are the same `#` a shell comment uses — so in production this second
+  // strip is a no-op. It is here so the rule holds for a script handed straight
+  // to this function: a commented-out fetch is not a fetch, and a gate that
+  // read one as a violation is a gate someone deletes.
+  const text = script
+    .split("\n")
+    .filter((l) => !/^\s*#/.test(l))
+    .join("\n");
+  const vars = new Map();
+  for (const m of text.matchAll(
+    /^\s*(?:local\s+|export\s+|declare\s+)?([A-Za-z_][A-Za-z0-9_]*)=(?:"([^"]*)"|'([^']*)'|(\S+))\s*$/gm,
+  )) {
+    vars.set(m[1], m[2] ?? m[3] ?? m[4] ?? "");
+  }
+  const findings = [];
+  for (const raw of text.split(/\n|;|&&|\|\||\|/)) {
+    const segment = raw.trim();
+    if (segment === "" || !FETCH_COMMANDS.test(segment)) continue;
+    findings.push({ segment, target: resolveTarget(segment, vars) });
+  }
+  return findings;
+}
+
+function resolveTarget(segment, vars) {
+  const literal = /[a-z][a-z0-9+.-]*:\/\/[^\s"'`)]+/i.exec(segment);
+  if (literal) return literal[0];
+  for (const m of segment.matchAll(/\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?/g)) {
+    const value = vars.get(m[1]);
+    if (value && /^[a-z][a-z0-9+.-]*:\/\//i.test(value)) return value;
+  }
+  return null;
+}
+
+/** `run:` blocks that fetch something remote without using the hardened path. */
+export function findUnhardenedRunFetches(root) {
+  const problems = [];
+  const hardened = [];
+  for (const [file, lines] of workflowLines(root)) {
+    for (const job of parseJobs(lines)) {
+      for (const step of job.steps) {
+        const keys = stepKeys(step);
+        const script = keyText(keys, "run");
+        if (script === null) continue;
+        if (script.includes(HELPER)) hardened.push(`${file}:${step.line} (${job.name})`);
+        for (const { segment, target } of findFetchesInScript(script)) {
+          if (target !== null && isLoopback(target)) continue;
+          if (script.includes(HELPER)) continue;
+          problems.push(
+            `${file}:${step.line} (job ${job.name}) fetches ${target ?? "an unresolvable target"} ` +
+              `outside ${HELPER}: ${segment}`,
+          );
+        }
+      }
+    }
+  }
+  return { problems, hardened: hardened.sort() };
+}
+
+// ---------------------------------------------------------------------------
+// Shape (b): `uses:` steps for binary-installing actions.
+// ---------------------------------------------------------------------------
+
+/** `owner/repo` for a `uses:` ref, or null for a local reusable workflow. */
+export function actionRepo(ref) {
+  if (!ref || ref.startsWith("./") || ref.startsWith(".\\")) return null;
+  if (ref.startsWith("docker://")) return ref;
+  const [path] = ref.split("@");
+  const parts = path.split("/");
+  if (parts.length < 2) return null;
+  return `${parts[0]}/${parts[1]}`;
+}
+
+/** Flat line scan: every non-local `uses:` in the tree. The SECOND read. */
+export function findActionRefsByLine(root) {
+  const refs = new Map();
+  for (const [file, lines] of workflowLines(root)) {
+    lines.forEach((line, i) => {
+      const m = /^\s*(?:-\s+)?uses:\s*["']?([^\s"'#]+)["']?\s*$/.exec(line);
+      if (!m) return;
+      const repo = actionRepo(m[1]);
+      if (repo === null) return;
+      if (!refs.has(repo)) refs.set(repo, []);
+      refs.get(repo).push(`${file}:${i + 1}`);
+    });
+  }
+  return refs;
+}
+
+/** Structural read: every non-local `uses:` reached through jobs -> steps. */
+export function findActionStepsByStructure(root) {
+  const steps = [];
+  for (const [file, lines] of workflowLines(root)) {
+    for (const job of parseJobs(lines)) {
+      job.steps.forEach((step, index) => {
+        const keys = stepKeys(step);
+        const uses = keys.get("uses")?.value;
+        const repo = actionRepo(uses);
+        if (repo === null) return;
+        steps.push({ file, job: job.name, index, line: step.line, ref: uses, repo, keys });
+      });
+    }
+  }
+  return steps;
+}
+
+/** Rows that contradict themselves, and actions with no row at all. */
+export function findTableDefects(table, refs) {
+  const problems = [];
+  const actions = table?.actions ?? {};
+  for (const [repo, sites] of [...refs].sort()) {
+    if (!Object.hasOwn(actions, repo)) {
+      problems.push(
+        `${repo} is used at ${sites.join(", ")} but has no row in scripts/ci/cdn-fetch-actions.json. ` +
+          "Read the action's own definition at the pinned ref and record whether it downloads an " +
+          "executable, with the evidence — this gate cannot read that from here.",
+      );
+    }
+  }
+  for (const [repo, row] of Object.entries(actions).sort()) {
+    if (typeof row.why !== "string" || row.why.trim() === "") {
+      problems.push(`${repo}: row has no \`why\` — an unexplained classification is not a reviewed one.`);
+    }
+    if (!VALID_HARDENING.has(row.hardening)) {
+      problems.push(
+        `${repo}: \`hardening: ${JSON.stringify(row.hardening)}\` is not one of ${[...VALID_HARDENING].join(", ")}.`,
+      );
+      continue;
+    }
+    if (row.fetchesFromCdn === true && row.hardening === "not-needed") {
+      problems.push(
+        `${repo}: claims it fetches from a CDN but also \`hardening: not-needed\`. Pick one — either it ` +
+          "pulls an executable and needs a repeated-attempt group, or it does not.",
+      );
+    }
+    if (row.fetchesFromCdn !== true && row.hardening !== "not-needed") {
+      problems.push(
+        `${repo}: \`hardening: ${row.hardening}\` on a row that says it fetches nothing. Hardening a step ` +
+          "that pulls nothing is decoration.",
+      );
+    }
+    if (row.hardening === "step-is-the-check" && (typeof row.residual !== "string" || row.residual.trim() === "")) {
+      problems.push(
+        `${repo}: \`step-is-the-check\` is a deliberate exemption, so it must carry a \`residual\` naming ` +
+          "what stays exposed and what would close it. An exemption with no residual reads as coverage.",
+      );
+    }
+  }
+  return problems;
+}
+
+/** One repeated-attempt group, checked against the F-1494 shape. */
+export function checkAttemptGroup(where, repo, attempts) {
+  const problems = [];
+  const at = (a) => `${where} step ${a.line}`;
+
+  if (attempts.length < MIN_ATTEMPTS) {
+    problems.push(
+      `${where}: ${repo} appears ${attempts.length} time(s); it downloads a binary from a release CDN, so it ` +
+        `needs a repeated-attempt group of at least ${MIN_ATTEMPTS} steps (${attempts.length === 1 ? "the single step at line " + attempts[0].line + " dies on the first 5xx" : "too few attempts to survive a degraded CDN"}).`,
+    );
+    return problems;
+  }
+
+  const ids = attempts.map((a) => a.keys.get("id")?.value ?? null);
+  ids.forEach((id, i) => {
+    if (!id) {
+      problems.push(
+        `${at(attempts[i])}: attempt ${i + 1} of the ${repo} group has no \`id:\`, so no later attempt can gate on it.`,
+      );
+    }
+  });
+
+  const refs = new Set(attempts.map((a) => a.ref));
+  if (refs.size > 1) {
+    problems.push(
+      `${where}: the ${repo} attempts disagree on \`uses:\` (${[...refs].join(" vs ")}) — a retry must install the same pinned build, not a different one.`,
+    );
+  }
+
+  const withBlocks = attempts.map((a) => (blockLines(a.keys, "with") ?? []).join("\n"));
+  const distinct = new Set(withBlocks);
+  if (distinct.size > 1) {
+    problems.push(
+      `${where}: the ${repo} attempts disagree on their \`with:\` inputs, so a retry would run with different ` +
+        "settings than the first try. (This is the check that keeps every repeated cosign install on the same " +
+        "`cosign-release`.)\n    " +
+        withBlocks.map((b, i) => `attempt ${i + 1} (line ${attempts[i].line}): ${b.replace(/\n/g, " | ") || "(none)"}`).join("\n    "),
+    );
+  }
+
+  attempts.forEach((a, i) => {
+    const cont = a.keys.get("continue-on-error")?.value;
+    const escapable = cont !== undefined && /true/.test(cont);
+    if (i < attempts.length - 1 && !escapable) {
+      problems.push(
+        `${at(a)}: attempt ${i + 1} of ${attempts.length} for ${repo} is not \`continue-on-error: true\`, so the ` +
+          "job dies on the first 5xx and the later attempts never run.",
+      );
+    }
+    if (i === attempts.length - 1 && escapable) {
+      problems.push(
+        `${at(a)}: the LAST ${repo} attempt is \`continue-on-error: true\`, so a genuinely unavailable CDN would ` +
+          "let an unsigned/unattested image through. The last attempt carries no escape hatch — that is the " +
+          "fail-closed half of the pattern.",
+      );
+    }
+  });
+
+  attempts.forEach((a, i) => {
+    if (i === 0) return;
+    const cond = keyText(a.keys, "if") ?? "";
+    for (let j = 0; j < i; j++) {
+      const id = ids[j];
+      if (!id) continue;
+      if (!new RegExp(`steps\\.${id}\\.outcome\\s*==\\s*'failure'`).test(cond)) {
+        problems.push(
+          `${at(a)}: attempt ${i + 1} for ${repo} does not gate on \`steps.${id}.outcome == 'failure'\`, so it ` +
+            "either runs when the earlier attempt succeeded (a duplicate install) or is unreachable. A skipped " +
+            "step's outcome is `skipped`, never `failure`, so the chain must name every earlier attempt.",
+        );
+      }
+    }
+  });
+
+  return problems;
+}
+
+export function findUnhardenedActionGroups(root, table) {
+  const problems = [];
+  const groups = [];
+  const byJob = new Map();
+  for (const step of findActionStepsByStructure(root)) {
+    const row = table?.actions?.[step.repo];
+    if (!row || row.hardening !== "repeat-attempts") continue;
+    const key = `${step.file}::${step.job}::${step.repo}`;
+    if (!byJob.has(key)) byJob.set(key, []);
+    byJob.get(key).push(step);
+  }
+  for (const [key, attempts] of [...byJob].sort()) {
+    const [file, job, repo] = key.split("::");
+    groups.push(`${file} (job ${job}) ${repo} x${attempts.length}`);
+    problems.push(...checkAttemptGroup(`${file} (job ${job})`, repo, attempts));
+  }
+  return { problems, groups };
+}
+
+/** The two reads of "which actions does this tree use" must agree. */
+export function findParseDisagreements(root) {
+  const byLine = new Set(findActionRefsByLine(root).keys());
+  const byStructure = new Set(findActionStepsByStructure(root).map((s) => s.repo));
+  const missed = [...byLine].filter((r) => !byStructure.has(r)).sort();
+  const extra = [...byStructure].filter((r) => !byLine.has(r)).sort();
+  return { missed, extra };
+}
+
+// ---------------------------------------------------------------------------
+
+// `table` is injectable so the regression suite can drive the whole assembly
+// over a scratch tree — the assertions are about the RULES, not about which
+// actions this repo happens to use today.
+export function main(root = resolve(HERE, "../.."), table = loadTable()) {
+  const failures = [];
+
+  if (!existsSync(join(root, HELPER))) {
+    throw new Error(`${HELPER} is missing — the one hardened fetch path this gate points every workflow at.`);
+  }
+
+  const { problems: runProblems, hardened } = findUnhardenedRunFetches(root);
+  failures.push(...runProblems);
+
+  const refs = findActionRefsByLine(root);
+  failures.push(...findTableDefects(table, refs));
+
+  const { missed, extra } = findParseDisagreements(root);
+  if (missed.length > 0 || extra.length > 0) {
+    failures.push(
+      "the flat `uses:` scan and the jobs->steps parse disagree about which actions this tree uses, so the " +
+        "repeated-attempt check is running on an incomplete step list:\n" +
+        `  seen only by the line scan  -> ${missed.join(", ") || "(none)"}\n` +
+        `  seen only by the step parse -> ${extra.join(", ") || "(none)"}\n` +
+        "Fix parseJobs() in this file, not the assertion — a step it cannot see is a step it cannot check.",
+    );
+  }
+
+  const { problems: groupProblems, groups } = findUnhardenedActionGroups(root, table);
+  failures.push(...groupProblems);
+
+  // Dead guards. Every one of these floors has been at a non-zero value since
+  // this gate landed, so a zero here is a parser that stopped matching, not a
+  // tree that stopped fetching. A gate that reports "all clear" over nothing
+  // is the failure mode this whole file exists to refuse.
+  if (refs.size === 0) {
+    throw new Error("found zero `uses:` actions in .github/workflows — a parser regression, not a true fact.");
+  }
+  const classifiedCdn = Object.entries(table.actions).filter(([repo, row]) => row.fetchesFromCdn === true && refs.has(repo));
+  if (classifiedCdn.length === 0) {
+    throw new Error(
+      "no action this tree uses is classified as fetching from a CDN, so the repeated-attempt half of this " +
+        "gate checked nothing. Refusing to report a vacuous green.",
+    );
+  }
+  if (groups.length === 0) {
+    throw new Error(
+      "no `repeat-attempts` action group was found in the tree, so the group shape check ran on nothing. " +
+        "Refusing to report a vacuous green.",
+    );
+  }
+  if (hardened.length === 0) {
+    throw new Error(
+      `no workflow calls ${HELPER}, so the hardened fetch path is dead code and shape (a) checked nothing. ` +
+        "Refusing to report a vacuous green.",
+    );
+  }
+
+  if (failures.length > 0) {
+    throw new Error(
+      `${failures.length} unhardened CDN fetch problem(s) in .github/workflows:\n  - ${failures.join("\n  - ")}\n\n` +
+        `Shape (a): route the fetch through ${HELPER} (pin + sha256, retry with backoff, fail closed by name).\n` +
+        "Shape (b): give the action a row in scripts/ci/cdn-fetch-actions.json, and if it downloads a binary, " +
+        "repeat the step (see this file's header for the exact shape).",
+    );
+  }
+
+  console.log(`hardened CDN fetches OK: ${refs.size} action(s) classified, ${classifiedCdn.length} of them CDN-fetching`);
+  for (const [repo, row] of classifiedCdn) console.log(`  - ${repo}: ${row.hardening}`);
+  console.log(`  ${groups.length} repeated-attempt group(s): ${groups.join(", ")}`);
+  console.log(`  ${hardened.length} hardened helper call site(s): ${hardened.join(", ")}`);
+  return { refs, groups, hardened };
+}
+
+// NOT `import.meta.main` (Node 24.2+; root `engines` allows >=24, so on
+// 24.0/24.1 it is `undefined` and this guard would be false, exiting 0 having
+// checked nothing). Same entry-guard idiom as list-scheduled-workflows.mjs.
+const SELF = realpathSync(fileURLToPath(import.meta.url));
+const ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";
+const invokedDirectly = ENTRY === SELF;
+
+if (!invokedDirectly && basename(ENTRY) === basename(SELF)) {
+  throw new Error(
+    `assert-hardened-cdn-fetches.mjs entry guard did not fire for ${ENTRY} (expected ${SELF}) — refusing to exit 0 having checked nothing`,
+  );
+}
+
+if (invokedDirectly) main();

--- a/scripts/ci/assert-hardened-cdn-fetches.test.mjs
+++ b/scripts/ci/assert-hardened-cdn-fetches.test.mjs
@@ -1,0 +1,451 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+//
+// Regression coverage for scripts/ci/fetch-pinned-release.sh and
+// scripts/ci/assert-hardened-cdn-fetches.mjs (F-1489).
+//
+// Two halves, and the second is the one that matters. A gate that has only
+// ever reported "all clear" on the tree it shipped with is a gate nobody has
+// seen fail — the F-1230 grep-based coverage check was defeated three separate
+// times by shapes its author was sure it caught. So every rule here is
+// exercised against a PLANTED violation in a scratch `.github/workflows` tree
+// and asserted to red, by name:
+//
+//   - a `run:` block curling a release CDN outside the hardened helper
+//   - a fetch whose target the resolver cannot work out (must red, not pass)
+//   - a `uses:` action with no row in the classification table
+//   - a table row that contradicts itself, or an exemption with no residual
+//   - a binary-installing action used as ONE step
+//   - a repeated group whose LAST attempt is `continue-on-error` (fail-open)
+//   - a repeated group whose attempts disagree on `with:` (the cosign-release
+//     hazard) or on `uses:`
+//   - a repeated group whose gating `if:` skips an earlier attempt
+//   - the whole gate, end to end, over a scratch tree
+//   - the vacuous-green dead guards
+//
+// The helper half drives the real shell script against a local server that
+// 503s on demand: retry-then-succeed, exhaustion failing closed with the CDN
+// HOST in the message, and a good download with a wrong sha256 still refused.
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { createServer } from "node:http";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  HELPER,
+  MIN_ATTEMPTS,
+  findFetchesInScript,
+  findParseDisagreements,
+  findTableDefects,
+  findUnhardenedActionGroups,
+  findUnhardenedRunFetches,
+  findActionRefsByLine,
+  hostOf,
+  isLoopback,
+  loadTable,
+  main,
+} from "./assert-hardened-cdn-fetches.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const HELPER_PATH = join(HERE, "fetch-pinned-release.sh");
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg);
+}
+
+function assertNames(problems, needle, msg) {
+  assert(
+    problems.some((p) => p.includes(needle)),
+    `${msg}\n  expected a problem naming ${JSON.stringify(needle)}, got:\n    ${problems.join("\n    ") || "(none)"}`,
+  );
+}
+
+function withScratchRoot(files, fn) {
+  const root = mkdtempSync(join(tmpdir(), "hardened-cdn-fetches-"));
+  const dir = join(root, ".github", "workflows");
+  mkdirSync(dir, { recursive: true });
+  mkdirSync(join(root, "scripts", "ci"), { recursive: true });
+  // main() refuses to run without the hardened path it points every workflow
+  // at, so the scratch tree carries a stand-in.
+  writeFileSync(join(root, HELPER), "#!/usr/bin/env bash\nexit 0\n");
+  for (const [name, content] of Object.entries(files)) writeFileSync(join(dir, name), content);
+  try {
+    return fn(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+const wf = (steps) => `name: planted
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+${steps}
+`;
+
+/** A step group in the shape the gate demands, so fixtures can perturb ONE thing. */
+function goodGroup({ ref = "vendor/installer@aaaa", withBlock = "          pin: 'v1'", last = {} } = {}) {
+  const attempt = (n, id, cond, escapable, block) =>
+    `      - name: install ${n}
+        id: ${id}
+${cond ? `        if: \${{ ${cond} }}\n` : ""}        uses: ${ref}
+${escapable ? "        continue-on-error: true\n" : ""}        with:
+${block}`;
+  return [
+    attempt(1, "inst_1", null, true, withBlock),
+    attempt(2, "inst_2", "steps.inst_1.outcome == 'failure'", true, withBlock),
+    attempt(
+      3,
+      "inst_3",
+      last.cond ?? "steps.inst_1.outcome == 'failure' && steps.inst_2.outcome == 'failure'",
+      last.escapable ?? false,
+      last.withBlock ?? withBlock,
+    ),
+  ].join("\n");
+}
+
+const TABLE = {
+  actions: {
+    "vendor/installer": {
+      fetchesFromCdn: true,
+      hardening: "repeat-attempts",
+      why: "fixture: pulls a binary",
+    },
+    "vendor/inert": { fetchesFromCdn: false, hardening: "not-needed", why: "fixture: pulls nothing" },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Shape (a): remote fetches in `run:` blocks.
+// ---------------------------------------------------------------------------
+
+// PLANTED FAILURE — a raw curl at a release CDN. This is the shape the two
+// hand-copied install loops had before F-1489, and the shape a third copy
+// would have.
+withScratchRoot(
+  {
+    "planted.yml": wf(`      - name: Install thing
+        run: |
+          set -euo pipefail
+          curl -sSfL https://evil-cdn.example.com/thing/releases/download/v1/thing.tar.gz -o /tmp/thing.tar.gz`),
+  },
+  (root) => {
+    const { problems } = findUnhardenedRunFetches(root);
+    assertNames(problems, "evil-cdn.example.com", "a raw curl at a release CDN must red");
+    assertNames(problems, "planted.yml", "the offending file must be named");
+  },
+);
+
+// PLANTED FAILURE — the same fetch behind a variable the resolver cannot see
+// (set from `env:` rather than in the block). An unresolvable target must be
+// treated as REMOTE; the alternative is a gate that is silenced by an
+// indirection.
+withScratchRoot(
+  {
+    "planted.yml": wf(`      - name: Install thing
+        env:
+          TOOL_URL: https://evil-cdn.example.com/thing.tar.gz
+        run: |
+          curl -sSfL "$TOOL_URL" -o /tmp/thing.tar.gz`),
+  },
+  (root) => {
+    const { problems } = findUnhardenedRunFetches(root);
+    assertNames(problems, "unresolvable target", "a fetch the resolver cannot follow must red, not pass");
+  },
+);
+
+// The same fetch routed through the hardened helper is clean.
+withScratchRoot(
+  {
+    "ok.yml": wf(`      - name: Install thing
+        run: |
+          bash ${HELPER} thing "https://cdn.example.com/thing.tar.gz" "$SHA" /tmp/thing.tar.gz`),
+  },
+  (root) => {
+    const { problems, hardened } = findUnhardenedRunFetches(root);
+    assert(problems.length === 0, `the hardened path must not red: ${problems.join("; ")}`);
+    assert(hardened.length === 1, "the helper call site must be counted for the dead guard");
+  },
+);
+
+// A loopback health poll is not a CDN fetch and must not red — including the
+// `:${port}` form, which a digits-only port strip reads as a remote host.
+withScratchRoot(
+  {
+    "smoke.yml": wf(`      - name: Wait for healthz
+        run: |
+          curl -fsS http://127.0.0.1:3333/healthz >/dev/null 2>&1
+          curl -fsS "http://127.0.0.1:\${port}/healthz" >/dev/null 2>&1
+          curl -fsS "http://localhost:\${{ env.PORT }}/healthz" >/dev/null 2>&1`),
+  },
+  (root) => {
+    const { problems } = findUnhardenedRunFetches(root);
+    assert(problems.length === 0, `loopback polls must not red: ${problems.join("; ")}`);
+  },
+);
+
+assert(isLoopback("http://127.0.0.1:${port}/x"), "an expansion in the port must not hide loopback");
+assert(isLoopback("http://[::1]:8080/x"), "bracketed IPv6 loopback");
+assert(!isLoopback("https://github.com/o/r/releases/download/v1/x.tar.gz"), "a release CDN is not loopback");
+assert(hostOf("https://user@github.com:443/x") === "github.com", "userinfo and port are stripped");
+assert(findFetchesInScript("echo curling is fine\n# curl https://x.example/y\n").length === 0, "prose is not a fetch");
+assert(findFetchesInScript("wget https://x.example/y").length === 1, "wget counts");
+assert(findFetchesInScript("gh release download v1 -R o/r").length === 1, "gh release download counts");
+
+// ---------------------------------------------------------------------------
+// Shape (b): the classification table.
+// ---------------------------------------------------------------------------
+
+// PLANTED FAILURE — a brand new binary-installing action lands and nobody
+// classifies it. This is the "a new one that does not reds CI" property.
+withScratchRoot(
+  {
+    "planted.yml": wf(`      - uses: brandnew/tool-installer@0123456789abcdef0123456789abcdef01234567 # v1.2.3`),
+  },
+  (root) => {
+    const problems = findTableDefects(TABLE, findActionRefsByLine(root));
+    assertNames(problems, "brandnew/tool-installer", "an unclassified action must red");
+    assertNames(problems, "cdn-fetch-actions.json", "the message must say where to classify it");
+  },
+);
+
+// Rows that contradict themselves, and an exemption with no residual.
+{
+  const problems = findTableDefects(
+    {
+      actions: {
+        "a/lies": { fetchesFromCdn: true, hardening: "not-needed", why: "x" },
+        "b/decorates": { fetchesFromCdn: false, hardening: "repeat-attempts", why: "x" },
+        "c/silent": { fetchesFromCdn: true, hardening: "step-is-the-check", why: "x" },
+        "d/unexplained": { fetchesFromCdn: false, hardening: "not-needed", why: "  " },
+        "e/nonsense": { fetchesFromCdn: true, hardening: "sprinkle-hope", why: "x" },
+      },
+    },
+    new Map(),
+  );
+  assertNames(problems, "a/lies", "fetches-from-CDN + not-needed must red");
+  assertNames(problems, "b/decorates", "hardening on a row that fetches nothing must red");
+  assertNames(problems, "residual", "step-is-the-check with no residual must red");
+  assertNames(problems, "d/unexplained", "an empty `why` must red");
+  assertNames(problems, "e/nonsense", "an unknown hardening value must red");
+}
+
+// The shipped table must itself be internally consistent — the gate's own
+// input is not exempt from the gate's own rules.
+assert(findTableDefects(loadTable(), new Map()).length === 0, "scripts/ci/cdn-fetch-actions.json is inconsistent");
+
+// ---------------------------------------------------------------------------
+// Shape (b): the repeated-attempt group.
+// ---------------------------------------------------------------------------
+
+assert(MIN_ATTEMPTS === 3, "the F-1494 pattern is 2 escapable attempts + 1 fatal one");
+
+// PLANTED FAILURE — the exact state twin-image.yml's syft step was in.
+withScratchRoot(
+  { "planted.yml": wf(`      - uses: vendor/installer@aaaa\n        with:\n          pin: 'v1'`) },
+  (root) => {
+    const { problems } = findUnhardenedActionGroups(root, TABLE);
+    assertNames(problems, "appears 1 time(s)", "a single-step binary install must red");
+    assertNames(problems, "dies on the first 5xx", "the message must say why one step is not enough");
+  },
+);
+
+// PLANTED FAILURE — three attempts, but the last one can be escaped. That is
+// fail-OPEN: a permanently dead CDN would let an unsigned image through.
+withScratchRoot({ "planted.yml": wf(goodGroup({ last: { escapable: true } })) }, (root) => {
+  const { problems } = findUnhardenedActionGroups(root, TABLE);
+  assertNames(problems, "LAST vendor/installer attempt is `continue-on-error: true`", "a fail-open group must red");
+});
+
+// PLANTED FAILURE — the cosign-release hazard: one copy drifts off the pin.
+withScratchRoot(
+  { "planted.yml": wf(goodGroup({ last: { withBlock: "          pin: 'v3'" } })) },
+  (root) => {
+    const { problems } = findUnhardenedActionGroups(root, TABLE);
+    assertNames(problems, "disagree on their `with:` inputs", "attempts with different inputs must red");
+    assertNames(problems, "cosign-release", "the message must name the hazard it exists for");
+  },
+);
+
+// PLANTED FAILURE — one attempt pinned to a different build of the action.
+withScratchRoot(
+  {
+    "planted.yml": wf(
+      goodGroup().replace("      - name: install 3\n        id: inst_3", "      - name: install 3\n        id: inst_3").replace(
+        /uses: vendor\/installer@aaaa\n(?![\s\S]*uses: vendor)/,
+        "uses: vendor/installer@bbbb\n",
+      ),
+    ),
+  },
+  (root) => {
+    const { problems } = findUnhardenedActionGroups(root, TABLE);
+    assertNames(problems, "disagree on `uses:`", "attempts on different pins must red");
+  },
+);
+
+// PLANTED FAILURE — attempt 3 gates only on attempt 2. Attempt 2 is SKIPPED
+// when attempt 1 succeeded, and a skipped step's outcome is `skipped`, never
+// `failure` — so this chain looks right and never fires.
+withScratchRoot(
+  { "planted.yml": wf(goodGroup({ last: { cond: "steps.inst_2.outcome == 'failure'" } })) },
+  (root) => {
+    const { problems } = findUnhardenedActionGroups(root, TABLE);
+    assertNames(problems, "steps.inst_1.outcome == 'failure'", "a chain skipping an earlier attempt must red");
+  },
+);
+
+// The shape the gate demands is clean, and an unclassified-but-inert action
+// alongside it does not manufacture a group.
+withScratchRoot({ "ok.yml": wf(`${goodGroup()}\n      - uses: vendor/inert@cccc`) }, (root) => {
+  const { problems, groups } = findUnhardenedActionGroups(root, TABLE);
+  assert(problems.length === 0, `the correct shape must not red: ${problems.join("; ")}`);
+  assert(groups.length === 1, `expected exactly one group, got ${groups.join(", ")}`);
+  const { missed, extra } = findParseDisagreements(root);
+  assert(missed.length === 0 && extra.length === 0, `the two reads disagree: ${missed} / ${extra}`);
+});
+
+// ---------------------------------------------------------------------------
+// The whole gate, end to end.
+// ---------------------------------------------------------------------------
+
+function mainThrows(files, table, needle, msg) {
+  withScratchRoot(files, (root) => {
+    let err = null;
+    try {
+      main(root, table);
+    } catch (e) {
+      err = e;
+    }
+    assert(err !== null, `${msg} — main() returned instead of throwing`);
+    assert(err.message.includes(needle), `${msg}\n  expected ${JSON.stringify(needle)} in:\n${err.message}`);
+  });
+}
+
+// A tree that is otherwise correct, plus one planted raw curl.
+mainThrows(
+  {
+    "ok.yml": wf(
+      `${goodGroup()}\n      - name: Install thing\n        run: |\n          bash ${HELPER} thing "https://cdn.example.com/t.tgz" "$SHA" /tmp/t.tgz`,
+    ),
+    "planted.yml": wf(`      - name: Install other\n        run: |\n          curl -sSfL https://evil-cdn.example.com/o.tgz -o /tmp/o.tgz`),
+  },
+  TABLE,
+  "evil-cdn.example.com",
+  "the assembled gate must red on a planted raw fetch",
+);
+
+// Dead guards: a tree with a correct group but nothing using the hardened
+// helper means shape (a) checked nothing, and must refuse to report green.
+mainThrows({ "ok.yml": wf(goodGroup()) }, TABLE, "Refusing to report a vacuous green", "no helper call site must red");
+
+// A tree whose actions are all inert means the repeated-attempt half checked
+// nothing.
+mainThrows(
+  {
+    "ok.yml": wf(
+      `      - uses: vendor/inert@cccc\n      - name: Install thing\n        run: |\n          bash ${HELPER} thing "https://cdn.example.com/t.tgz" "$SHA" /tmp/t.tgz`,
+    ),
+  },
+  TABLE,
+  "vacuous green",
+  "no CDN-fetching action must red",
+);
+
+// ---------------------------------------------------------------------------
+// scripts/ci/fetch-pinned-release.sh itself.
+// ---------------------------------------------------------------------------
+
+const BODY = "pretend binary\n";
+const GOOD_SHA = createHash("sha256").update(BODY).digest("hex");
+
+// Deliberately `spawn` + await, NOT spawnSync: the 503 server below lives in
+// THIS process, and spawnSync blocks the event loop, so curl would connect,
+// wait for a response node cannot deliver until the child exits, and deadlock
+// until --max-time. That is a two-minute hang per case with no useful output.
+function runHelper(url, sha, { attempts = 3 } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "fetch-pinned-release-"));
+  const dest = join(dir, "artifact");
+  const child = spawn("bash", [HELPER_PATH, "fixture-tool", url, sha, dest], {
+    env: {
+      ...process.env,
+      FETCH_PINNED_RELEASE_ATTEMPTS: String(attempts),
+      FETCH_PINNED_RELEASE_SLEEP_UNIT: "0",
+    },
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (d) => (stdout += d));
+  child.stderr.on("data", (d) => (stderr += d));
+  return new Promise((resolvePromise) => {
+    child.on("close", (status) => {
+      let content = null;
+      try {
+        content = readFileSync(dest, "utf8");
+      } catch {
+        /* the fetch never landed; that is the assertion's business, not ours */
+      }
+      rmSync(dir, { recursive: true, force: true });
+      resolvePromise({ status, stdout, stderr, content });
+    });
+  });
+}
+
+const failuresLeft = { "/flaky": 2 };
+const server = createServer((req, res) => {
+  const path = req.url ?? "/";
+  if (path === "/always503") {
+    res.writeHead(503).end("degraded");
+    return;
+  }
+  if (path === "/flaky" && failuresLeft["/flaky"] > 0) {
+    failuresLeft["/flaky"] -= 1;
+    res.writeHead(503).end("degraded");
+    return;
+  }
+  res.writeHead(200, { "content-type": "application/octet-stream" }).end(BODY);
+});
+
+await new Promise((r) => server.listen(0, "127.0.0.1", r));
+const base = `http://127.0.0.1:${server.address().port}`;
+
+try {
+  // A transient 5xx cannot fail the fetch on the first attempt — F-1489's
+  // first done-when, measured rather than asserted in a comment.
+  const flaky = await runHelper(`${base}/flaky`, GOOD_SHA);
+  assert(flaky.status === 0, `two 503s then a 200 must succeed, got ${flaky.status}\n${flaky.stderr}`);
+  assert(flaky.content === BODY, "the retried fetch must land the real bytes");
+  assert(
+    `${flaky.stdout}`.includes("only on attempt 3"),
+    `a flaky-but-passing run must SAY so, got: ${flaky.stdout}`,
+  );
+
+  // A genuinely unavailable CDN fails closed, naming what could not be
+  // fetched and from where — not `exit code 1`.
+  const dead = await runHelper(`${base}/always503`, GOOD_SHA, { attempts: 2 });
+  assert(dead.status !== 0, "a permanently 503ing CDN must fail closed");
+  assert(dead.stderr.includes("::error::"), "the failure must be an annotated error");
+  assert(dead.stderr.includes("fixture-tool"), "the message must name the tool");
+  assert(dead.stderr.includes("127.0.0.1"), "the message must name the CDN host that would not answer");
+  assert(dead.stderr.includes("after 2 attempts"), "the message must say how many attempts were spent");
+  assert(dead.stderr.includes("Failing closed"), "the message must say the refusal is deliberate");
+
+  // The verification is unconditional: a perfectly successful download with
+  // the wrong hash is still refused. A hash checked with `|| true` would pass
+  // this one.
+  const wrong = await runHelper(`${base}/ok`, "0".repeat(64));
+  assert(wrong.status !== 0, "a sha256 mismatch must fail the fetch");
+  assert(wrong.stderr.includes("sha256 mismatch"), `expected a named mismatch, got: ${wrong.stderr}`);
+  assert(wrong.stderr.includes(GOOD_SHA), "the mismatch message must show what was actually fetched");
+
+  const ok = await runHelper(`${base}/ok`, GOOD_SHA);
+  assert(ok.status === 0, `a good fetch must pass: ${ok.stderr}`);
+  assert(ok.stdout.includes("verified sha256"), "a passing fetch must say it verified");
+} finally {
+  server.close();
+}
+
+console.log("assert-hardened-cdn-fetches.test.mjs: all assertions passed");

--- a/scripts/ci/assert-hardened-cdn-fetches.test.mjs
+++ b/scripts/ci/assert-hardened-cdn-fetches.test.mjs
@@ -275,7 +275,10 @@ withScratchRoot(
 withScratchRoot(
   {
     "planted.yml": wf(
-      goodGroup().replace("      - name: install 3\n        id: inst_3", "      - name: install 3\n        id: inst_3").replace(
+      // Only the LAST attempt's pin is moved: the negative lookahead makes the
+      // regex bind to the final `uses:` in the group, so the group disagrees
+      // with itself rather than being uniformly on a different pin.
+      goodGroup().replace(
         /uses: vendor\/installer@aaaa\n(?![\s\S]*uses: vendor)/,
         "uses: vendor/installer@bbbb\n",
       ),

--- a/scripts/ci/cdn-fetch-actions.json
+++ b/scripts/ci/cdn-fetch-actions.json
@@ -1,0 +1,112 @@
+{
+  "_readme": [
+    "F-1489 — the classification half of scripts/ci/assert-hardened-cdn-fetches.mjs.",
+    "",
+    "WHAT IS DERIVED, AND WHAT IS NOT. The gate derives the SET OF ACTIONS TO JUDGE",
+    "from `.github/workflows/**` — never from this file — so a new `uses:` step is",
+    "discovered the moment it lands. What cannot be derived from this repo is",
+    "whether a given third-party action downloads an executable over the network:",
+    "that fact lives in the action's own implementation, on someone else's default",
+    "branch. `actions/checkout` does not; `sigstore/cosign-installer` exists to.",
+    "Guessing from the action's NAME is exactly the heuristic that silently misses",
+    "(nothing in the string `anchore/sbom-action` says 'fetches syft from a release",
+    "CDN'). So the residual is made explicit instead: every action the workflows",
+    "reference must have a row here, the gate reds on any that does not, and each",
+    "row records the evidence the verdict was read from.",
+    "",
+    "Rows are keyed on `owner/repo`, NOT on the pinned sha. A routine sha bump",
+    "keeps the classification; a MAJOR rewrite of an action under the same name",
+    "could in principle invalidate a row, and nothing here would notice. That is",
+    "the one thing this file cannot see, stated rather than hidden. `evidence`",
+    "names the ref each verdict was read at so a re-audit is a diff, not a re-read.",
+    "",
+    "FIELDS",
+    "  fetchesFromCdn  Does running this action pull an executable over the network",
+    "                  from outside this repo (release CDN, container registry)?",
+    "  hardening       not-needed      | fetchesFromCdn must be false.",
+    "                  repeat-attempts | every occurrence must be a repeated-attempt",
+    "                                    group (see the gate's header for the shape).",
+    "                  step-is-the-check | deliberately NOT retried; requires",
+    "                                    `residual`.",
+    "  why             Required, non-empty. What was read, and what it said.",
+    "  residual        Required iff hardening is `step-is-the-check`. What is still",
+    "                  exposed, and what would close it."
+  ],
+  "_classifiedOn": "2026-08-13",
+  "actions": {
+    "actions/checkout": {
+      "fetchesFromCdn": false,
+      "hardening": "not-needed",
+      "why": "A JavaScript action that talks to the GitHub API and git for the repository being built. It installs no tool. A failure here is a GitHub outage, which no amount of retrying inside GitHub Actions routes around.",
+      "evidence": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 (v7.0.1), action.yml `runs: using: node24`."
+    },
+    "actions/setup-node": {
+      "fetchesFromCdn": false,
+      "hardening": "not-needed",
+      "why": "Resolves `node-version: 24` from the runner's own tool cache, where GitHub-hosted ubuntu images already ship it; a cache miss falls back to actions/node-versions via @actions/tool-cache, whose downloader retries internally. Neither is a third-party release CDN, and no binary here is pinned by sha in this repo, so the hardened-fetch path has nothing to verify.",
+      "evidence": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 (v7.0.0) and @a0853c24544627f65ddf259abe73b1d18a591444 (v6.4.0); every call site in this repo passes `node-version: 24`."
+    },
+    "actions/upload-artifact": {
+      "fetchesFromCdn": false,
+      "hardening": "not-needed",
+      "why": "Uploads to the GitHub Actions artifact service. Installs nothing.",
+      "evidence": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a (v7.0.1)."
+    },
+    "actions/dependency-review-action": {
+      "fetchesFromCdn": false,
+      "hardening": "not-needed",
+      "why": "Calls GitHub's dependency-review API for the PR. Installs nothing.",
+      "evidence": "actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 (v5.0.0)."
+    },
+    "docker/login-action": {
+      "fetchesFromCdn": false,
+      "hardening": "not-needed",
+      "why": "Writes a registry credential into the local docker config. Installs nothing.",
+      "evidence": "docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 (v4.4.0)."
+    },
+    "docker/metadata-action": {
+      "fetchesFromCdn": false,
+      "hardening": "not-needed",
+      "why": "Computes tag and label strings from the event payload. Pure JS, no network fetch of any executable.",
+      "evidence": "docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 (v6.2.0)."
+    },
+    "docker/setup-buildx-action": {
+      "fetchesFromCdn": false,
+      "hardening": "not-needed",
+      "why": "Its src/main.ts downloads buildx from GitHub Releases only when `Util.isValidRef(version)` (build from source), or when `!(await toolkit.buildx.isAvailable()) || version` — i.e. when a `version:` input is set, or when the runner has no buildx. This repo's single call site sets no `version:`, and GitHub-hosted ubuntu runners ship buildx, so that branch is not taken. NOTE THE CONDITION: adding a `version:` input to that step turns this row false without touching this file, and nothing here would notice.",
+      "evidence": "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c (v4.2.0), src/main.ts lines 46-70."
+    },
+    "docker/build-push-action": {
+      "fetchesFromCdn": false,
+      "hardening": "not-needed",
+      "why": "Drives the buildx binary that setup-buildx-action already put in place. Pulls base images from the registries the Dockerfile names, which is the build itself, not a tool install.",
+      "evidence": "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a (v7.3.0)."
+    },
+    "anchore/sbom-action": {
+      "fetchesFromCdn": true,
+      "hardening": "repeat-attempts",
+      "why": "Downloads the syft binary from the anchore release CDN (github.com/anchore/syft/releases) on every run, with no retry of its own. THIS IS F-1489's SUBJECT: a 503 there killed the stripe twin-image job twice on 2026-08-12 (PRs #390, #391) with `[error] received HTTP status=503 ... [error] unable to find tag=''`. On a PR that is noise; on main the cosign sign/attest steps below it do run, so the same 503 fails an image publish. Retrying the whole step is sound here because the step has no verdict of its own — SBOM generation either produces the file or fails for an infrastructure reason.",
+      "evidence": "anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 (v0.24.0), action.yml `syft-version` input; observed run output quoted in F-1489."
+    },
+    "sigstore/cosign-installer": {
+      "fetchesFromCdn": true,
+      "hardening": "repeat-attempts",
+      "why": "Its entire purpose is to download the pinned cosign binary from the sigstore release CDN, so it is the same exposure as syft one step later on the same publish path. Retrying is free: the step installs a tool and asserts nothing. The `cosign-release` input is load-bearing and MUST stay `v2.6.4` in every copy (see twin-image.yml's comment: cosign v3 `attest --type spdx` rejects the anchore SBOM predicate) — which is why the gate requires every attempt in a repeated group to carry byte-identical `with:` inputs.",
+      "evidence": "sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 (v4.1.2)."
+    },
+    "aquasecurity/trivy-action": {
+      "fetchesFromCdn": true,
+      "hardening": "step-is-the-check",
+      "why": "Composite action whose first step is `aquasecurity/setup-trivy`, which downloads the Trivy binary from its release CDN — so the exposure is real. It is deliberately NOT wrapped in a repeated-attempt group, because in this repo the step runs with `exit-code: '1'` on HIGH/CRITICAL: its failure means EITHER the install broke OR Trivy found a fixable vulnerability. A repeated-attempt group retries the whole step, so attempts 1 and 2 would swallow a real CVE finding under `continue-on-error`, and the `::warning::` would report a flaky download on a run that actually found a vulnerability. Turning a finding into a retry is a worse property than the one F-1489 fixes.",
+      "residual": "A trivy install that 5xxes still reds twin-image, and on main still stops a publish, with no retry. Closing it means splitting the install from the scan — `skip-setup-trivy: true` on the trivy-action step plus an explicit `aquasecurity/setup-trivy` step in a repeated-attempt group — which adds a third-party pin and rewires the scanner on the publish path. Out of scope for F-1489, which is about the SBOM/sign leg; file it against twin-image.yml when the trivy CDN actually costs a run.",
+      "evidence": "aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 (v0.36.0), action.yaml lines 120-133."
+    },
+    "trufflesecurity/trufflehog": {
+      "fetchesFromCdn": true,
+      "hardening": "step-is-the-check",
+      "why": "Named in F-1489's sweep list, and swept: at the pinned ref it is a composite action that `docker run`s ghcr.io/trufflesecurity/trufflehog (and apt-get installs jq if missing). That is a container-registry pull, not a release-CDN binary fetch, so the sha256-pinned-fetch path has nothing to pin. It is also, like trivy, a step that IS the check — its failure normally means a verified secret was found, and retrying it twice under `continue-on-error` would swallow exactly that.",
+      "residual": "A GHCR outage still reds secret-scan (a required context) with no retry. The fix, if it ever costs a run, is a `docker pull` of the pinned image in a repeated-attempt group BEFORE the scan step, leaving the scan itself un-retried — not wrapping the scan.",
+      "evidence": "trufflesecurity/trufflehog@27b0417c16317ca9a472a9a8092acce143b49c55 (v3.95.9), action.yml `runs: using: composite`, `image` input defaulting to ghcr.io/trufflesecurity/trufflehog."
+    }
+  }
+}

--- a/scripts/ci/fetch-pinned-release.sh
+++ b/scripts/ci/fetch-pinned-release.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# F-1489 — the ONE hardened path every release-CDN fetch in
+# `.github/workflows/**` goes through. Before this file there were two
+# hand-copied variants of the same loop (ci.yml's actionlint install and
+# secret-scan.yml's gitleaks install), each with its own retry budget, its own
+# message and its own chance of getting the verification wrong; the same
+# degradation that produced them also killed a twin-image syft install, which
+# had no retry at all.
+#
+# Usage: fetch-pinned-release.sh <tool> <url> <sha256> <dest>
+#
+# Properties, all three load-bearing:
+#
+#   1. RETRY WITH BACKOFF. Five attempts, sleeping 5s/10s/15s/20s between them.
+#      An explicit loop rather than curl's `--retry` flags, because those were
+#      measured doing two different things: locally `--retry-delay 0` backed
+#      off 1s/2s/4s as documented, while on the runner the same flags burned
+#      five attempts in 0.8s against a `curl: (56) Connection died`
+#      (run 31620014945). A retry budget that looks handled and is not is worse
+#      than none, and a loop with a literal `sleep` cannot be version-dependent.
+#      (F-1471 got this wrong twice before landing it.)
+#
+#   2. UNCONDITIONAL VERIFICATION. The sha256 comparison is not `|| true`, not
+#      `if [ -n "$sha" ]`, and not skippable by a cache hit — a hash checked
+#      conditionally is decoration. Fetching a pinned, checksummed binary
+#      instead of trusting a third-party Action is the whole reason these steps
+#      exist, so the check is the last thing this script does and its failure is
+#      the script's failure. Comparison is spelled out rather than piped into
+#      `sha256sum -c -` so the mismatch message can name both hashes, and so it
+#      works on a developer's macOS (`shasum -a 256`) as well as the runner.
+#
+#   3. FAIL CLOSED, BY NAME. A genuinely unavailable CDN must stop the job —
+#      on the publish path in twin-image.yml that means an unsigned, unattested
+#      image never ships. But it must not stop it as
+#      `##[error]The process '/usr/bin/sh' failed with exit code 1`, which says
+#      nothing about whether to retry or to read the code. Exhaustion prints an
+#      `::error::` naming the tool, the host that would not answer, and the URL.
+#
+# Env knobs exist ONLY for scripts/ci/assert-hardened-cdn-fetches.test.mjs,
+# which drives this script against a local server that 503s on demand; nothing
+# in `.github/workflows/**` sets them, and the defaults are the production
+# values asserted by that test.
+set -euo pipefail
+
+tool="${1:?usage: fetch-pinned-release.sh <tool> <url> <sha256> <dest>}"
+url="${2:?usage: fetch-pinned-release.sh <tool> <url> <sha256> <dest>}"
+sha256="${3:?usage: fetch-pinned-release.sh <tool> <url> <sha256> <dest>}"
+dest="${4:?usage: fetch-pinned-release.sh <tool> <url> <sha256> <dest>}"
+
+attempts="${FETCH_PINNED_RELEASE_ATTEMPTS:-5}"
+sleep_unit="${FETCH_PINNED_RELEASE_SLEEP_UNIT:-5}"
+
+# `https://github.com/rhysd/actionlint/releases/...` -> `github.com`. Used in
+# every message so the run log names the CDN, not just the exit code.
+host="${url#*://}"
+host="${host%%/*}"
+
+fetched=false
+attempt=1
+while [ "$attempt" -le "$attempts" ]; do
+  if curl -sSfL --connect-timeout 10 --max-time 120 "$url" -o "$dest"; then
+    fetched=true
+    if [ "$attempt" -gt 1 ]; then
+      # A flaky-but-passing run has to say so, or the degradation is invisible
+      # until the day it is total.
+      echo "::warning::${tool}: fetched from ${host} only on attempt ${attempt}/${attempts} — that release CDN is degraded right now (${url})"
+    fi
+    break
+  fi
+  if [ "$attempt" -lt "$attempts" ]; then
+    delay=$((attempt * sleep_unit))
+    echo "::warning::${tool}: fetch attempt ${attempt}/${attempts} from ${host} failed; retrying in ${delay}s (${url})" >&2
+    sleep "${delay}"
+  fi
+  attempt=$((attempt + 1))
+done
+
+if [ "${fetched}" != "true" ]; then
+  echo "::error::${tool}: could not be fetched from ${host} after ${attempts} attempts — ${url}. The release CDN (${host}) is unavailable; this is not a failure of the code under test. Failing closed on purpose: nothing unverified is installed, so nothing unsigned or unattested can ship." >&2
+  exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+  actual="$(sha256sum "${dest}" | cut -d' ' -f1)"
+else
+  actual="$(shasum -a 256 "${dest}" | cut -d' ' -f1)"
+fi
+
+if [ "${actual}" != "${sha256}" ]; then
+  echo "::error::${tool}: sha256 mismatch on the artifact fetched from ${host} — expected ${sha256}, got ${actual} (${url}). Refusing to install an unverified binary." >&2
+  exit 1
+fi
+
+echo "${tool}: fetched from ${host} and verified sha256 ${sha256}"


### PR DESCRIPTION
## What broke

`anchore/sbom-action` fetches the `syft` binary from `github.com/anchore/syft/releases` with no retry. A 503 there killed the `stripe` twin-image job twice on 2026-08-12, on #390 and #391, while the build and Trivy steps passed:

```
[error] received HTTP status=503 for url='https://github.com/anchore/syft/releases/v1.42.3'
[error] unable to find tag=''
##[error]The process '/usr/bin/sh' failed with exit code 1
```

On a PR that is noise — twin-image is not a required context. On `main` the cosign sign/attest steps do run, so the same 503 fails an image publish.

The repo already knew the fix and had it three different ways: a retry loop inlined in `ci.yml`'s actionlint install (F-1471, after `curl --retry-delay` was got wrong twice), a hand-copied variant of the same loop in `secret-scan.yml`'s gitleaks install, and nothing at all on the syft install that started this.

## What this does

**One hardened path for a `curl`.** `scripts/ci/fetch-pinned-release.sh` — five attempts with a literal backoff, an **unconditional** sha256 comparison, and an exhaustion message naming the CDN host. `ci.yml` and `secret-scan.yml` now call it instead of carrying their own copy. The comparison is spelled out rather than piped into `sha256sum -c -` so a mismatch can print both hashes.

**Repeated steps for a fetch that arrives through an action.** syft comes in via `anchore/sbom-action` and cosign via `sigstore/cosign-installer`; neither can be wrapped in a shell loop, so the retry is the step, repeated — F-1494's pattern. Attempts 1 and 2 are `continue-on-error`, each later attempt is gated on the earlier ones' `outcome == 'failure'` (a skipped step's outcome is `skipped`, never `failure`, so the chain cannot self-trigger), and the last attempt carries no escape hatch. Replacing `sbom-action` with a raw pinned syft fetch was rejected deliberately: it would change the SBOM predicate bytes cosign v2 attests, which is the thing this file already carries a paragraph defending.

**Bullet 3 — fail closed, by name.** A genuinely unavailable CDN still stops the publish; that is the right answer and it is unchanged. What changes is what the run log says. Each group is followed by an `if: failure() && steps.<last>.outcome == 'failure'` step that emits an `::error::` naming the CDN, the tool, and the fact that the refusal is deliberate, instead of `##[error]The process '/usr/bin/sh' failed with exit code 1`.

## The gate, and what it cannot derive

`scripts/ci/assert-hardened-cdn-fetches.mjs` makes this a property rather than a list of the installs hardened today. It reads `.github/workflows/**` for both shapes:

- **(a)** a `run:` block invoking `curl` / `wget` / `aria2c` / `gh release download` at a non-loopback target must call the helper. It resolves literal URLs and one level of `VAR="https://…"`; **a target it cannot resolve counts as remote**, so an indirection cannot silence it. Loopback health polls (including the `:${port}` form) do not red.
- **(b)** every non-local `uses:` must have a row in `scripts/ci/cdn-fetch-actions.json`. Rows marked `repeat-attempts` must appear as a group of ≥3 attempts, all with `id:`, earlier ones `continue-on-error: true`, the last one not, each gated on every earlier attempt, and **all copies carrying byte-identical `uses:` and `with:`** — which is the check that stops the three cosign installs drifting off `cosign-release: 'v2.6.4'`.

**The honest limit, stated in the script header, in the JSON's `_readme`, and here.** Whether a third-party action downloads an executable is a fact about that action's implementation, not about this repo — nothing in the string `anchore/sbom-action` says "fetches syft from a release CDN", and `actions/checkout` looks identical from here. So shape (b) is half-derived: **the set of actions to judge comes from the workflows** (a new `uses:` reds until someone classifies it, which is the "a new one that does not reds CI" bullet), while **the verdict per action is a reviewed row** carrying the evidence it was read from. Three further residuals, recorded rather than papered over:

1. Rows are keyed on `owner/repo`, so a sha bump keeps the classification and a major rewrite under the same name would not be noticed. Keying per-sha would red on every dependabot bump.
2. Shape (a) knows four fetch commands. A fetch smuggled through a python one-liner or a Makefile is invisible to it.
3. `aquasecurity/trivy-action` and `trufflesecurity/trufflehog` are classified `step-is-the-check` and deliberately **not** wrapped. Both fetch over the network, but both steps *are* the check: a repeated-attempt group would let attempts 1 and 2 swallow "found a fixable CVE" / "found a verified secret" under `continue-on-error`, and report it as a flaky download. Turning a finding into a retry is worse than the problem being fixed. The gate requires each such row to carry a `residual` naming what stays exposed and what would close it, so the exemption cannot read as coverage.

## Proving the gate can fail

`scripts/ci/assert-hardened-cdn-fetches.test.mjs` (wired in `ci.yml`'s always-on block, next to the other derivation gates) plants a violation for every rule in a scratch `.github/workflows` tree and asserts the gate reds naming it: a raw curl at a release CDN, a fetch behind an unresolvable variable, an unclassified action, five kinds of self-contradicting table row, a binary install used as ONE step, a group whose last attempt is `continue-on-error` (fail-open), a group whose `with:` blocks disagree, a group on two different pins, a chain whose `if:` skips an earlier attempt — plus the assembled `main()` end to end and the three vacuous-green dead guards.

The helper half drives the real shell script against a local server that 503s on demand: two 503s then a 200 succeeds and says it retried; a permanent 503 exits non-zero with the host in the message; and a *successful* download with the wrong sha256 is still refused, which is the assertion a `|| true` would fail.

Mutation-tested against this tree as well — flipping one cosign copy to `v3.0.6`, making the last SBOM attempt escapable, and reverting the actionlint install to a raw curl each red the gate; restoring them turns it green.

## Notes for review

- `cosign-release: 'v2.6.4'` is identical in all three copies and now enforced. The comment explaining why v3.0.6 was reverted is untouched.
- Nothing about *what* is signed, scanned or attested changes. `docker/build-push-action`, Trivy's inputs and `sign-image-digests.sh` are untouched; the SBOM step's `with:` block is byte-identical to the one it replaces.
- `@pome-sh/cli` 0.23.35, changelog entry included. `package-lock.json` and `cli/tasks/` untouched.
- Local: gate green, its suite green, `actionlint` clean, `shellcheck` clean on the new script, `knip` clean, and the schedule-alarm / repo-policy / version-bump gates still pass.