### PR TITLE
A criterion line that reaches for always-scored and misses is refused, not dropped as prose

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,44 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.23.37
+
+### Patch Changes
+
+- **A line that reaches for the `always-scored` keyword and misses is now
+  refused, not dropped as prose** (F-1444). F-1299 closed the disagreement
+  between this parser and the hosted one on the keyword itself — both accept it.
+  Neither noticed a line that tried to use it and mistyped it. `parseCriteria`
+  skips every line `CRITERION_LINE_RE` does not match, so `- [code
+  always-scored ] X` (a stray space before the bracket), `- [code:slack
+  always-scored extra] X` (an extra word inside the marker) and `- [code
+  alwaysscored] X` (the keyword misspelled) each loaded the task with ONE FEWER
+  criterion and no error at all. The task then ran, scored out of a smaller
+  denominator, and read as a clean bill — the same silent-drop failure
+  `LEGACY_CRITERION_LINE_RE` already refuses for the retired marker spellings.
+
+  A separate `NEAR_MISS_CRITERION_LINE_RE` now catches those lines and throws,
+  quoting the line so the author can find it by searching the file and naming
+  the grammar it failed. `CRITERION_LINE_RE` itself is untouched and stays
+  byte-identical to the hosted parser's: it is the registered authority
+  pome-cloud's `scripts/check-criterion-grammar.ts` compares across five copies,
+  and the accepted language has not moved.
+
+  Deliberately narrow, because the over-correction is worse than the defect. It
+  fires only on a bullet the grammar itself knows (`-`/`*`) whose bracket names
+  `code` or `model` AS A WORD, so ordinary markdown stays prose: `- [ ] todo`,
+  `- [x] done`, `- [note] …`, `- [checks] …`, `- [codex] …`, `- [modeling] …`
+  and any line without a bullet are all untouched. It is also checked only after
+  the grammar has already refused the line, so no accepted form can reach it.
+  The tolerant reader behind `pome checks add` / `pome checks lint` still skips a
+  near-miss rather than throwing — turning a warning surface into a crash on a
+  file that is mid-edit is how that surface stops being used.
+
+  The hosted parser (`apps/mcp/src/task/parseTask.ts`, pome-cloud) takes the
+  same guard and the same message, word for word, in the same change. A guard in
+  only one of the two repos would re-open the disagreement F-1299 closed with
+  the sign flipped: a typo would parse hosted and throw here.
+
 ## 0.23.34
 
 ### Patch Changes

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.23.34",
+  "version": "0.23.37",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/cli/src/task/parseTask.ts
+++ b/cli/src/task/parseTask.ts
@@ -1,3 +1,4 @@
+// file-size: the criterion marker grammar and the two guards that refuse a line reaching for it (retired markers, near-misses) belong with the parser that applies them — and pome-cloud's scripts/check-criterion-grammar.ts reads CRITERION_LINE_RE as its registered authority by THIS path and binding, so splitting the grammar out would move the authority the cross-repo gate is pinned to.
 // SPDX-License-Identifier: Apache-2.0
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
@@ -339,6 +340,47 @@ const CRITERION_LINE_RE =
 // skip-non-criterion path below and the scenario would "pass" with fewer
 // criteria than its author wrote.
 const LEGACY_CRITERION_LINE_RE = /^[-*]\s+\[([DP])(?::([a-z][a-z0-9_-]*))?\]\s+(.+)$/;
+// A line that REACHES for a criterion marker and misses (F-1444). The grammar
+// above is exact and `parseCriteria` skips anything it does not match as prose,
+// so `- [code always-scored ] …`, `- [code:slack always-scored extra] …` and
+// `- [code alwaysscored] …` each loaded the task with one fewer criterion and no
+// error at all. That is the same failure LEGACY_CRITERION_LINE_RE exists to
+// prevent for the retired markers: a line visibly trying to be a criterion is
+// worth an error, not a shrug.
+//
+// DELIBERATELY NARROW. It fires only on a bullet the grammar itself knows
+// (`-`/`*`) whose bracket names `code` or `model` AS A WORD, so ordinary
+// markdown stays prose: `- [ ] todo`, `- [x] done`, `- [note] …`, `- [checks] …`,
+// `- [codex] …` and `- [modeling] …` are all untouched, and so is any line with
+// no bullet. A greedier rule would turn plain markdown into a parse error — a
+// louder failure than the silent drop it replaces, and a far more disruptive one.
+//
+// Checked ONLY once CRITERION_LINE_RE has already refused the line, so by
+// construction it can never refuse a line the grammar accepts.
+//
+// NOT REGISTERED in pome-cloud's `scripts/check-criterion-grammar.ts`, and must
+// not be: that gate compares the accepted LANGUAGE of CRITERION_LINE_RE across
+// its five copies, and the accepted language is unchanged here. This sits beside
+// the grammar exactly the way LEGACY_CRITERION_LINE_RE already does.
+//
+// Must stay identical to the hosted parser's (`apps/mcp/src/task/parseTask.ts`,
+// pome-cloud), refusal message included. A guard in only one of the two repos
+// re-opens the cross-parser disagreement F-1299 closed with the sign flipped: a
+// typo would parse hosted and throw here.
+const NEAR_MISS_CRITERION_LINE_RE = /^[-*]\s*\[\s*(code|model)\b[^\]]*\]/;
+
+/** The one wording for a near-miss refusal, shared with the hosted parser word
+ *  for word. It quotes the line so an author can find it by searching the file,
+ *  and names the grammar it failed by reading CRITERION_LINE_RE itself — so the
+ *  message cannot drift from the rule it is reporting. */
+function nearMissCriterionMessage(line: string): string {
+  return (
+    `Criterion line "${line}" reaches for a [code]/[model] marker but does not match the ` +
+    `criterion grammar ${CRITERION_LINE_RE.source} — fix the marker (e.g. "[code]", ` +
+    `"[code:slack]", "[code:slack always-scored]"); a line this close to a criterion is ` +
+    `refused rather than silently dropped as prose.`
+  );
+}
 
 function parseCriteria(input: string, twins: string[]): Criterion[] {
   const multiTwin = twins.length > 1;
@@ -356,7 +398,14 @@ function parseCriteria(input: string, twins: string[]): Criterion[] {
       );
     }
     const match = line.match(CRITERION_LINE_RE);
-    if (!match) continue;
+    if (!match) {
+      // F-1444: a near-miss is refused here rather than skipped. Reached only
+      // after the grammar has said no, so an accepted line never lands here.
+      if (NEAR_MISS_CRITERION_LINE_RE.test(line)) {
+        throw new Error(nearMissCriterionMessage(line));
+      }
+      continue;
+    }
     const kind = match[1]!; // "code" | "model"
     const tag = match[2]; // twin tag or undefined
     const alwaysScored = match[3] !== undefined; // F-1296/F-1299 `always-scored` keyword

--- a/cli/test/unit/parseTask.test.ts
+++ b/cli/test/unit/parseTask.test.ts
@@ -692,6 +692,153 @@ twins: ["github", "slack"]
   });
 });
 
+// F-1444 — a line that reaches for the criterion grammar and MISSES.
+//
+// F-1299 made both parsers accept `always-scored`; neither noticed a line that
+// tried to use it and mistyped it. `parseCriteria` skips every line the marker
+// regex refuses, so each of the three lines below loaded the task with one fewer
+// criterion and no error — the task ran, scored out of a smaller denominator,
+// and read as a clean bill. Same failure class the retired-marker guard already
+// covers for [D]/[P], which is why the fix has the same shape: a SEPARATE regex
+// beside CRITERION_LINE_RE, which is untouched (it is the registered authority
+// pome-cloud's scripts/check-criterion-grammar.ts compares across five copies).
+//
+// The over-correction is the thing to watch. A near-miss rule that fires on
+// "bullet, then bracket" turns ordinary markdown — task lists, prose asides —
+// into a parse error, which is louder than the silent drop but far more
+// disruptive. The prose cases below are as load-bearing as the throwing ones.
+describe("near-miss criterion lines are refused, not dropped as prose (F-1444)", () => {
+  const single = (criteria: string) => `# Markers
+
+## Prompt
+Do the thing.
+
+## Success Criteria
+${criteria}
+
+## Config
+\`\`\`yaml
+twins: ["slack"]
+\`\`\`
+`;
+  // A valid criterion rides alongside, so a test that fails fails because the
+  // near-miss was tolerated — not because `taskSchema` refused an empty list.
+  const withKeeper = (line: string) => single(`${line}\n- [code] The keeper criterion`);
+  const KEEPER = { type: "code", text: "The keeper criterion" };
+
+  const NEAR_MISSES: ReadonlyArray<[string, string]> = [
+    ["- [code always-scored ] X", "a stray space before the closing bracket"],
+    ["- [code:slack always-scored extra] X", "an extra word inside the marker"],
+    ["- [code alwaysscored] X", "the keyword misspelled"],
+  ];
+
+  for (const [line, why] of NEAR_MISSES) {
+    it(`refuses \`${line}\` — ${why}`, () => {
+      expect(() => parseTask(withKeeper(line))).toThrow(
+        /reaches for a \[code\]\/\[model\] marker but does not match the criterion grammar/,
+      );
+    });
+
+    it(`quotes \`${line}\` back and names the grammar it failed`, () => {
+      // The whole point of the error is that the author can find the line. A
+      // message that only said "a criterion is malformed" would leave them
+      // diffing a criteria section by eye.
+      expect(() => parseTask(withKeeper(line))).toThrow(
+        new RegExp(line.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+      );
+      expect(() => parseTask(withKeeper(line))).toThrow(/always-scored/);
+    });
+  }
+
+  // The message is pinned WHOLE, because it is shared with the hosted parser
+  // (`apps/mcp/src/task/parseTask.ts`, pome-cloud) word for word. Wording that
+  // drifts is the cross-parser disagreement F-1299 closed, in a new costume:
+  // the same typo would be described two different ways depending on where the
+  // task was parsed.
+  it("refuses with the exact wording the hosted parser uses", () => {
+    expect(() => parseTask(withKeeper("- [code alwaysscored] X"))).toThrow(
+      'Criterion line "- [code alwaysscored] X" reaches for a [code]/[model] marker but does ' +
+        "not match the criterion grammar " +
+        "^[-*]\\s+\\[(code|model)(?::([a-z][a-z0-9_-]*))?(\\s+always-scored)?\\]\\s+(.+)$" +
+        ' — fix the marker (e.g. "[code]", "[code:slack]", "[code:slack always-scored]"); a ' +
+        "line this close to a criterion is refused rather than silently dropped as prose.",
+    );
+  });
+
+  it("refuses a near-miss [model] marker the same way", () => {
+    expect(() => parseTask(withKeeper("- [model alwaysscored] X"))).toThrow(
+      /reaches for a \[code\]\/\[model\] marker/,
+    );
+  });
+
+  // ── The over-correction guard ──────────────────────────────────────────────
+  //
+  // Each of these opens `- [` inside the criteria section and must stay prose.
+  const STILL_PROSE: ReadonlyArray<[string, string]> = [
+    ["- [note] X", "names neither kind — the Done-when case"],
+    ["- [ ] an unchecked markdown task", "a markdown task list item"],
+    ["- [x] a checked markdown task", "a checked markdown task list item"],
+    ["- [checks] X", "an unknown marker"],
+    ["- [codex] X", "`code` must not match a longer word"],
+    ["- [modeling] the data", "`model` must not match a longer word"],
+    ["- just prose, not a criterion", "a bullet with no bracket at all"],
+    ["Prose mentioning [code] with no bullet", "no bullet"],
+  ];
+
+  for (const [line, why] of STILL_PROSE) {
+    it(`still treats \`${line}\` as prose — ${why}`, () => {
+      const task = parseTask(withKeeper(line));
+      expect(task.criteria).toEqual([KEEPER]);
+    });
+  }
+
+  // The guard runs only after CRITERION_LINE_RE has refused the line, so no
+  // accepted form can reach it. Measured rather than argued: every spelling the
+  // grammar accepts still parses to a criterion.
+  it("refuses nothing the criterion grammar accepts", () => {
+    const accepted = [
+      "- [code] x",
+      "* [code] x",
+      "- [code:slack] x",
+      "- [code always-scored] x",
+      "- [code:slack always-scored] x",
+      "- [code  always-scored] x",
+      "- [code:slack]  x",
+      "- [model] x",
+      "- [model:slack] x",
+      '- [code:slack] No message containing "[code]" appears in any public channel',
+    ];
+    for (const line of accepted) {
+      expect(() => parseTask(single(line)), line).not.toThrow();
+      expect(parseTask(single(line)).criteria, line).toHaveLength(1);
+    }
+  });
+
+  // `readCodeCriteria` is the TOLERANT reader `pome checks add` / `checks lint`
+  // use on a file that is mid-edit. It warns, it does not gate, and turning it
+  // into a crash is how a warning surface stops being used — the same reason it
+  // skips a retired [D] marker instead of throwing.
+  it("leaves the tolerant reader tolerant — a near-miss is skipped there, not thrown", () => {
+    const file = `# Audit
+
+## Success Criteria
+
+- [code alwaysscored] X
+- [code] Issue #1 exists in \`acme/api\`
+
+## Config
+
+\`\`\`yaml
+twins: [github]
+\`\`\`
+`;
+    expect(() => readCodeCriteria(file)).not.toThrow();
+    expect(readCodeCriteria(file)).toEqual([
+      { marker: "[code]", twin: "github", text: "Issue #1 exists in `acme/api`" },
+    ]);
+  });
+});
+
 // F-1134 — the tolerant reader `pome checks add` and `pome checks lint` use to
 // audit a file they did not necessarily finish writing. Separate from
 // `parseTask` on purpose: an in-progress task file may carry zero criteria and


### PR DESCRIPTION
## What

`parseCriteria` skips any line `CRITERION_LINE_RE` does not match, treating it as prose. So a line that reaches for the `always-scored` keyword and misses loaded the task with **one fewer criterion and no error**:

| line | before | after |
| -- | -- | -- |
| `- [code always-scored ] X` | silently skipped | throws |
| `- [code:slack always-scored extra] X` | silently skipped | throws |
| `- [code alwaysscored] X` | silently skipped | throws |

A separate `NEAR_MISS_CRITERION_LINE_RE` now refuses those lines, quoting the line so the author can find it by searching the file and naming the grammar it failed. `cli` 0.23.37.

## Why

F-1299 closed the disagreement between this parser and the hosted one on the `always-scored` keyword — both accept it. Neither noticed a line that tried to use it and mistyped it. The task then ran, scored out of a smaller denominator, and read as a clean bill. That is the exact failure `LEGACY_CRITERION_LINE_RE` already exists to prevent for the retired `[D]`/`[P]` spellings: a line visibly trying to be a criterion is worth an error, not a shrug.

## Lands together with pome-sh/pome-cloud#720

**This is one half of a seam pair and must not merge alone.** The other half is **https://github.com/pome-sh/pome-cloud/pull/720**, which takes the same guard and the same message into `apps/mcp/src/task/parseTask.ts`. A guard in only one repo re-opens the cross-parser disagreement F-1299 closed, with the sign flipped: a typo would parse hosted and throw here.

The two refusal messages are identical **at runtime**, not just by inspection — both parsers were run over the three lines and the outputs `diff`ed clean:

```
Criterion line "- [code alwaysscored] X" reaches for a [code]/[model] marker but does not
match the criterion grammar ^[-*]\s+\[(code|model)(?::([a-z][a-z0-9_-]*))?(\s+always-scored)?\]\s+(.+)$
— fix the marker (e.g. "[code]", "[code:slack]", "[code:slack always-scored]"); a line this
close to a criterion is refused rather than silently dropped as prose.
```

The message interpolates `CRITERION_LINE_RE.source` rather than restating the grammar, so it cannot drift from the rule it reports.

## Notes for reviewer

**`CRITERION_LINE_RE` is untouched — byte-identical to before, and to the hosted mirror's.** It is the registered authority pome-cloud's `scripts/check-criterion-grammar.ts` compares across five copies, and that table already pins `- [code:slack always-scored extra] x` as `grammar:refuse`. The near-miss detection is therefore a *separate, unregistered* regex, sitting beside the grammar exactly the way `LEGACY_CRITERION_LINE_RE` already does. The gate was run against this branch and against the current pin (`6f38ef65`) — passes both, so the pome-cloud half is green standalone too.

**The over-correction guard is the part worth reading.** A near-miss rule that fires on "bullet, then bracket" turns ordinary markdown into a parse error — louder than the silent drop, and far more disruptive. This one fires only on a bullet the grammar itself knows (`-`/`*`) whose bracket names `code` or `model` **as a word**, so all of these stay prose: `- [ ] todo`, `- [x] done`, `- [note] X`, `- [checks] X`, `- [codex] X`, `- [modeling] the data`, and any line without a bullet. It is also checked *only after* `CRITERION_LINE_RE` has already refused the line, so by construction no accepted form can reach it — measured by a test that re-parses every accepted spelling.

**Blast radius, measured not assumed.** Every `.md`/`.ts`/`.json`/`.yml` file in both repos (2,855 files, 330 grammar-accepted criterion lines) was scanned for a line the new regex refuses that the grammar also refuses: **zero hits**. No existing task, fixture, doc or test changes behaviour. A task *persisted* with a near-miss line would now fail to parse rather than lose a criterion silently — which is the point of the ticket, and there is nothing to normalize the way `[D]`/`[P]` has a shim, because a typo is not a retired spelling.

**`readCodeCriteria` stays tolerant.** It is the warn-only reader behind `pome checks add` / `pome checks lint`, used on files that are mid-edit; it skips a near-miss rather than throwing, the same way it already skips a retired `[D]` marker. Pinned by a test.

**The `// file-size:` header on `parseTask.ts` is new.** The added comment pushed the file past the 500-LOC tripwire. Splitting the grammar out is the wrong fix here: `check-criterion-grammar.ts` reads `CRITERION_LINE_RE` by *this path and binding*, so a split would move the authority the cross-repo gate is pinned to. Header reason says exactly that.

**TDD.** The three cases were written first as assertions on the *current* behaviour — "loads one fewer criterion, no error" — and watched to pass in both repos before any fix existed.

Verified locally: `cli` 1147 tests / 109 files pass (re-run on the rebased head), `typecheck` clean, and `lint:legacy-markers`, `lint:copy-markers`, `lint:task-format-doc`, `lint:no-catch`, `lint:code-health` all green. `npm ci` left `package-lock.json` untouched; `cli/tasks/` untouched.

