### PR TITLE
The run-completeness predicate ships in @pome-sh/wire, so both repos import one copy

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,60 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.23.39
+
+### Patch Changes
+
+- **The CLI stops restating the seed-exclusion reason string, and its
+  cross-surface agreement test stops transcribing pome-cloud's completeness
+  predicate** (F-1416). No user-visible behaviour changes: every word the CLI
+  prints, and every field of `verdict.json`, is byte-identical.
+
+  `cli/test/unit/hosted/cross-surface-agreement.test.ts` exists to catch one
+  defect — the CLI and the pome-cloud dashboard stating different things about
+  the same run (F-1392 shipped exactly that, until a human noticed two screens
+  disagreeing). To do it, the file carried a hand-written copy of pome-cloud's
+  `isIncompleteTally` as an oracle. That copy went stale twice, and both times
+  it went stale GREEN: it kept passing while asserting something false about
+  the other repo. A parallel copy across a repo boundary is the same defect the
+  test was written to catch, with the longest possible feedback loop, sitting
+  inside the test itself.
+
+  The predicate now lives in `@pome-sh/wire@0.2.3`'s new
+  `run-completeness` subpath — the package this repo publishes and pome-cloud
+  consumes — so both sides import one implementation. `evalResultView.ts`
+  re-exports `PRE_SATISFIED_REASON` from there instead of declaring its own
+  copy of `"already_true_in_seed"`, and the test calls the real function. A
+  change to the predicate is now a type error or a red test on whichever side
+  has not moved; it can no longer be a silent pass on both.
+
+- **One hardened path for every release-CDN fetch in CI** (F-1489). No change to
+  the published CLI's behaviour; this is release-pipeline hardening.
+  `anchore/sbom-action` fetched the `syft` binary from the anchore release CDN
+  with no retry, and a 503 there killed the `stripe` twin-image job twice on
+  2026-08-12 — noise on a PR, but on `main` the cosign sign/attest steps do run,
+  so the same 503 fails an image publish. The repo already had the fix in two
+  hand-copied variants (ci.yml's actionlint install, secret-scan.yml's gitleaks
+  install) and missing entirely from a third install.
+
+  All three now go through `scripts/ci/fetch-pinned-release.sh`: five attempts
+  with a literal backoff (not curl's `--retry` flags, which were measured
+  burning five attempts in 0.8s on a runner), an UNCONDITIONAL sha256 check, and
+  an exhaustion message naming the CDN host instead of `exit code 1`. The two
+  fetches that arrive through an ACTION rather than a `curl` — syft via
+  `anchore/sbom-action`, cosign via `sigstore/cosign-installer` — are repeated
+  steps instead: two `continue-on-error` attempts and a fatal third, so a
+  transient 5xx cannot stop a publish on the first try while a genuinely dead
+  CDN still refuses to ship an unsigned, unattested image.
+
+  `scripts/ci/assert-hardened-cdn-fetches.mjs` keeps that true as a property.
+  It derives the set of things to judge from `.github/workflows/**` rather than
+  a hand-kept list, so a sixth install reds the PR that adds it, and it refuses
+  to report a pass over an empty derivation. It also pins the hazard
+  twin-image.yml carries a paragraph defending: every copy of a repeated action
+  step must carry byte-identical `with:` inputs, so the three cosign installs
+  cannot drift off `cosign-release: 'v2.6.4'`.
+
 ## 0.23.38
 
 ### Patch Changes
@@ -34,6 +88,7 @@ packaging restructure: bump `version` here and in `package.json`, and merging to
   twin-image.yml carries a paragraph defending: every copy of a repeated action
   step must carry byte-identical `with:` inputs, so the three cosign installs
   cannot drift off `cosign-release: 'v2.6.4'`.
+
 
 ## 0.23.37
 
@@ -101,6 +156,7 @@ packaging restructure: bump `version` here and in `package.json`, and merging to
   fails too (ENOENT, ENOTDIR, ELOOP, ENAMETOOLONG), so a stray file under a
   task slug is still silently skipped rather than counted as damage, while
   EACCES/EISDIR stay `unreadable` exactly as before.
+
 
 ## 0.23.33
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.23.38",
+  "version": "0.23.39",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/cli/src/hosted/evalResultView.ts
+++ b/cli/src/hosted/evalResultView.ts
@@ -23,6 +23,7 @@
 // the unified "code"/"model" vocabulary (legacy "D"/"P" tolerated) while
 // scenario files still parse [code]/[model] markers. This module renders CLOUD
 // verdicts, so it takes the wide wire shape (FDRS-643 live-run finding).
+import { PRE_SATISFIED_REASON } from "@pome-sh/wire/run-completeness";
 import type { z } from "zod";
 import type { criterionSchema } from "../types/shared.js";
 
@@ -103,16 +104,25 @@ export function outcomeOf(result: CriterionResult): CriterionOutcome {
 // satisfied — the control plane graded the FINAL state alone, found the
 // criterion true before the agent ran, and moved it out of the score
 // denominator so a task cannot earn credit for doing nothing (AutomationBench's
-// "no reward for doing nothing" rule). Restated here rather than imported: the
-// CLI shares no code with the control plane, and this travels as a string on
-// the `criteria_results` wire shape (`apps/control-plane/src/services/
-// evaluators/deterministic/pre-satisfied.ts` on the pome-cloud side).
+// "no reward for doing nothing" rule). It travels as a string on the
+// `criteria_results` wire shape (`apps/control-plane/src/services/evaluators/
+// deterministic/pre-satisfied.ts` on the pome-cloud side).
 //
 // F-1392 — the CLI is the fifth surface this string has to agree with
 // (score-merge, run-report, run-status and drift-telemetry are the other
-// four, per pre-satisfied.ts's own doc comment). Defined ONCE and read from
-// here at every call site so the string is never repeated inline.
-export const PRE_SATISFIED_REASON = "already_true_in_seed";
+// four, per pre-satisfied.ts's own doc comment). Re-exported ONCE from here so
+// every call site in this module reads one name and the string is never
+// repeated inline.
+//
+// F-1416 — IMPORTED rather than restated. The comment that used to sit here
+// said "restated here rather than imported: the CLI shares no code with the
+// control plane", and that stopped being true when the predicate this string
+// feeds moved into `@pome-sh/wire` — the package this repo publishes and
+// pome-cloud consumes. A literal restated on both sides of a repo boundary is
+// the D3 parallel copy with the longest possible feedback loop; a rename now
+// breaks the build on whichever side has not moved, instead of quietly making
+// one of them count every seed exclusion as an abstention.
+export { PRE_SATISFIED_REASON };
 
 /**
  * Was this criterion excluded for having already been true in the seed?

--- a/cli/test/unit/hosted/cross-surface-agreement.test.ts
+++ b/cli/test/unit/hosted/cross-surface-agreement.test.ts
@@ -13,20 +13,41 @@
 // was a run the CLI called INCOMPLETE and the dashboard called PASS, shipped
 // for as long as it took a human to notice the two screens disagreeing.
 //
-// `dashboardRunStatus` below is a TRANSCRIPTION, named clause by clause so a
-// reviewer can diff it against the original, and deliberately NOT a
-// generalization of it. It is the oracle, not an implementation: nothing in
-// `src/` imports it. When pome-cloud changes its predicate, this table is what
-// goes red.
+// `dashboardRunStatus` below WAS a transcription — a hand copy of pome-cloud's
+// three clauses, named clause by clause so a reviewer could diff it against the
+// original. F-1416 deleted the copy. It now CALLS the real predicate, which
+// both repositories install from `@pome-sh/wire/run-completeness`.
 //
-// F-1399 moved the arithmetic out of `run-status.ts` and into
-// `@pome-cloud/contract`'s `isIncompleteTally` (`packages/contract/src/
-// run-completeness.ts`), the shared predicate the dashboard and the control
-// plane's markdown report both now call instead of keeping their own copies —
-// closing the exact defect class this file exists to catch, one repo over.
-// This transcription still cannot import that package (ADR-002: no cloud
-// imports in OSS), so it stays a transcription; see the note at the bottom of
-// this file on what a real fix would take.
+// WHY THAT MATTERS MORE THAN IT LOOKS. F-1399 moved the arithmetic out of
+// `run-status.ts` into a shared predicate inside pome-cloud, closing this exact
+// defect class one repo over — and the copy in THIS file went stale the moment
+// it did, and went stale GREEN: it kept passing while asserting something false
+// about the other repo. F-1413 was the second time that happened. Both times
+// nothing detected it; it was caught because one person happened to be holding
+// both sides. A transcription is a parallel copy with the longest possible
+// feedback loop, and it was sitting inside the very test written to prove
+// parallel copies are gone.
+//
+// The fix was a cross-repo move, not a one-file patch: `isIncompleteTally`,
+// `tallyCriteriaResults` and `PRE_SATISFIED_REASON` now live in
+// `packages/wire/src/run-completeness.ts` here, published as
+// `@pome-sh/wire/run-completeness` and imported by pome-cloud's dashboard,
+// control plane and markdown report instead of by a private cloud package.
+// There is one implementation left across both repos. Changing it can no longer
+// leave this file asserting the old behaviour — the two things that could
+// happen are a type error and a red test, and no third thing.
+//
+// WHAT IS STILL WRITTEN OUT BY HAND HERE, stated so nobody has to guess: the
+// two-line COMPOSITION in `dashboardRunStatus` — incomplete outranks the score,
+// and the pass bar is a hard 100. That is `deriveRunStatus`
+// (`apps/dashboard/src/lib/run-status.ts`), and it stays cloud-side on purpose:
+// its `RunStatus` includes `in_progress`, a state derived from a `runs` row's
+// `finished_at`, and wire has no business knowing what a runs row is. What
+// moved is the ARITHMETIC — the counting, the exemption, the empty denominator
+// — which is the part that drifted twice and the part that drifts SILENTLY,
+// because a miscounting copy still returns a boolean. An ordering change is a
+// different animal: it is one line, it has no counts in it, and it cannot be
+// wrong by an off-by-one.
 //
 // There is no known divergence between the two surfaces today — F-1399 closed
 // the last one (below). A row CAN still carry a `divergence` marker if the two
@@ -44,6 +65,7 @@
 import { mkdir, mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { isIncompleteTally, tallyCriteriaResults } from "@pome-sh/wire/run-completeness";
 import { describe, expect, it } from "vitest";
 import type { CriterionResult } from "../../../src/contract/index.js";
 import {
@@ -55,31 +77,25 @@ import {
 import { PRE_SATISFIED_REASON, scoreStatus } from "../../../src/hosted/evalResultView.js";
 import { scoreFromFinalizeResponse } from "../../../src/hosted/uploadAndFinalize.js";
 
-// ── The oracle: pome-cloud's answer, transcribed ────────────────────────────
+// ── The oracle: pome-cloud's answer, CALLED rather than copied ──────────────
 //
-// @pome-cloud/contract's packages/contract/src/run-completeness.ts:
-//   isIncompleteTally (107-109) — three clauses, in order:
-//     1. `total === 0` ⇒ false, never incomplete (no criteria recorded is a
-//        different fact from "recorded and none could be evaluated").
-//     2. `notEvaluated - preSatisfied > 0` ⇒ incomplete (F-925, narrowed by
-//        F-1296's seed-exclusion exemption).
-//     3. `evaluated === 0` ⇒ incomplete (F-1399). Fires for exactly the shape
-//        clause 2 does not already catch: every criterion excluded as already
-//        true in the seed. That run has an empty denominator and used to fall
-//        through to `satisfaction_score === 100 ? pass : fail` and land on
-//        `fail` — a verdict about the agent for a run nothing was ever at
-//        risk in.
+// This is `deriveRunStatus` (`apps/dashboard/src/lib/run-status.ts`), minus the
+// `in_progress` arm that only a live `runs` row can be in. Every line of
+// counting inside it is now an import:
 //
-// apps/dashboard/src/lib/run-status.ts:
-//   deriveCriteriaCounts (73-93)   — skipped ⇒ notEvaluated, +preSatisfied
-//                                    when the reason matches; else evaluated
-//                                    (+passed)
-//   isRunIncomplete      (110-114) — isIncompleteTally(deriveCriteriaCounts(results))
-//   deriveRunStatus      (127-133) — incomplete first, then
-//                                    satisfaction_score === 100 ? pass : fail
+//   isRunIncomplete(results)
+//     = isIncompleteTally(deriveCriteriaCounts(results))     ← dashboard
+//     = isIncompleteTally(tallyCriteriaResults(results))     ← here
+//
+// The two are the same call. `deriveCriteriaCounts` is `{ passed, ...
+// tallyCriteriaResults(results) }` — it adds the score's numerator, which the
+// predicate does not read, and pome-cloud's own `run-status.test.ts` asserts
+// that equality directly. So this function makes the same two decisions the
+// dashboard makes, out of the same package, and the only thing left written
+// down twice is their ORDER.
 //
 // The satisfaction score the dashboard reads is the run row's, which the
-// control plane computes in `score-merge.ts:314-315` as
+// control plane computes in `score-merge.ts` as
 // `evaluated === 0 ? 0 : round(passed / evaluated * 100)` — the same number
 // /finalize returns to the CLI, so one `satisfaction` input drives both sides
 // of every row below.
@@ -89,16 +105,10 @@ function dashboardRunStatus(
   results: readonly CriterionResult[],
   satisfactionScore: number,
 ): DashboardStatus {
-  let notEvaluated = 0;
-  let preSatisfied = 0;
-  for (const r of results) {
-    if (!r.skipped) continue;
-    notEvaluated += 1;
-    if (r.reason === PRE_SATISFIED_REASON) preSatisfied += 1;
-  }
-  const total = results.length;
-  const evaluated = total - notEvaluated;
-  if (total > 0 && (notEvaluated - preSatisfied > 0 || evaluated === 0)) return "incomplete";
+  // F-925 — incomplete outranks the score, including a failing one. If `fail`
+  // won that contest, the same instrument gap would produce a different run
+  // state depending on how the agent performed.
+  if (isIncompleteTally(tallyCriteriaResults(results))) return "incomplete";
   return satisfactionScore === 100 ? "pass" : "fail";
 }
 
@@ -254,11 +264,13 @@ describe("CLI and dashboard answer `what state is this run in?` the same way (F-
 
   // ── isIncompleteTally's FIRST clause, which no row above reaches ─────────
   //
-  // `total === 0 ⇒ never incomplete` is transcribed above as the `total > 0 &&`
-  // conjunct, and every row in the table has criteria, so nothing exercises
-  // it: delete that conjunct and the whole table stays green. A transcribed
-  // clause with no assertion on it is this file's own defect one level down,
-  // so it gets assertions here.
+  // `total === 0 ⇒ never incomplete` is the one clause no row in the table
+  // exercises, since every row has criteria. Since F-1416 the clause itself is
+  // pinned where it is implemented (`packages/wire/test/run-completeness.
+  // test.ts` exhausts all three), so what these two cases are for is no longer
+  // "cover the transcription" — it is the CROSS-SURFACE fact, which is the only
+  // thing this file has ever been about: on the empty-results shape the two
+  // surfaces answer DIFFERENTLY, and that is correct rather than a divergence.
   //
   // It is NOT a table row because the table's third assertion — the two
   // surfaces never split on `passed` — is false for this input at
@@ -375,49 +387,22 @@ describe("CLI and dashboard answer `what state is this run in?` the same way (F-
   });
 });
 
-// ── F-1413: why this stays a transcription, and what would stop it drifting
-// again ───────────────────────────────────────────────────────────────────
+// ── What the table is still worth, now that the arithmetic is shared ────────
 //
-// F-1413 is the second time this table has gone stale-green: pome-cloud
-// changed the predicate under it and nothing here noticed until a human read
-// both repos side by side. That is the parallel-copy defect this repo is
-// otherwise trying to close (D3) — one level up, across a repo boundary
-// instead of within one file.
+// A reasonable question after F-1416: if both surfaces call one predicate, is a
+// row-by-row agreement table anything but a tautology? No, and the rows above
+// say why. `dashboardRunStatus` and `cliRunStatus` reach their answers by
+// genuinely different routes — the dashboard runs the shared predicate over
+// `criteria_results` and then a hard-100 bar, while the CLI goes through
+// `scoreFromFinalizeResponse` (which builds its own `Score`, including its own
+// `preSatisfied` subtraction and the A5 `can_pass` guard) and then
+// `scoreStatus`. Nothing forces those two routes to land on the same word; the
+// shared predicate only forces them to count the same way. The empty-results
+// case a few blocks up is the standing proof — same input, two different
+// answers, both correct.
 //
-// This repo cannot import `@pome-cloud/contract` to fix that at the root.
-// Two independent reasons, not one:
-//   1. Policy — `scripts/lint-no-cloud-imports.sh` denies every `pome-cloud/*`
-//      import (bare or scoped) anywhere under `packages/`, `cli/src/`,
-//      `cli/scripts/`, `scripts/`; this file lives under `cli/test/`, which
-//      the gate does not cover, but the module it would need to import does
-//      not reach here regardless of the gate — see (2).
-//   2. Reachability — `@pome-cloud/contract` is a `private` workspace member
-//      of pome-cloud, published to no registry. `@pome-sh/wire` is the one
-//      package this repo publishes FOR pome-cloud to consume (GitHub
-//      Packages, F-949); nothing runs the other direction today.
-//
-// A REAL fix exists but is a cross-repo migration, not a one-file patch:
-// extract `isIncompleteTally` + `PRE_SATISFIED_REASON` out of pome-cloud's
-// private `packages/contract` and into the already-published `@pome-sh/wire`
-// (or a new sibling package built the same way), with the dashboard, the
-// control plane, and the markdown report importing it from there instead of
-// owning the source — the same collapse F-1399 just did for `run-status.ts`
-// and `run-report.ts`, one repo boundary further out. That needs a pome-cloud
-// PR to consume the published package, a `@pome-sh/wire` version bump here,
-// and this file's `dashboardRunStatus`/`cliRunStatus` comparison rewritten
-// against ONE real predicate instead of an oracle transcription — at which
-// point a table like this one still has value (agreement is still worth
-// pinning row by row) but the copy of the ARITHMETIC disappears, and with it
-// the only thing that can go stale.
-//
-// Short of that, there is no self-detecting middle ground available from
-// inside this repo's CI: a job that diffs this transcription against
-// pome-cloud's source would need read access to a private repo, which is
-// exactly the credential the public repo's "zero embedded cloud config"
-// guardrail (AGENTS.md, Public Repo Guardrails) exists to keep out of here.
-// A pinned commit SHA plus a maintainer-run (non-CI) diff script is possible
-// and would be strictly better than today — it turns "silently stale" into
-// "stale unless someone runs the check" — but it is still not automatic, and
-// building it is out of scope for this ticket. Filing the `@pome-sh/wire`
-// extraction as its own ticket is the concrete next step if this drift is
-// worth spending more than a comment on.
+// So the table pins what it always pinned: that two independently-implemented
+// readers of one wire shape agree, row by row, and never split on the single
+// bit CI can act on. What F-1416 removed is the part that was never a test at
+// all — a copy of the other repo's counting, which could only ever agree with
+// itself.

--- a/packages/adapter-claude-sdk/CHANGELOG.md
+++ b/packages/adapter-claude-sdk/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pome-sh/adapter-claude-sdk — CHANGELOG
 
+## 0.3.5
+
+Republished for `@pome-sh/wire` 0.2.3. No source change in this package: it
+depends on `wire` as a workspace `*`, so a wire release changes the bytes this
+package ships and `check-version-bump-required.mjs` requires the bump. The new
+`@pome-sh/wire/run-completeness` subpath is additive and this adapter does not
+consume it.
+
 ## 0.3.4 — 2026-08-12
 
 No user-visible change. Version-only bump: F-1488 fixed

--- a/packages/adapter-claude-sdk/package.json
+++ b/packages/adapter-claude-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/adapter-claude-sdk",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Pome adapter for Anthropic's Claude Agent SDK \u2014 wraps query() and tools so agent traces land in the Pome trace format.",
   "private": false,
   "type": "module",

--- a/packages/wire/CHANGELOG.md
+++ b/packages/wire/CHANGELOG.md
@@ -4,6 +4,51 @@ SPDX-License-Identifier: Apache-2.0
 
 # @pome-sh/wire — CHANGELOG
 
+## 0.2.3 — 2026-08-13
+
+**New subpath: `@pome-sh/wire/run-completeness`.** Additive — no existing export,
+schema, type or behaviour changed, and the root barrel's snapshot is
+byte-identical.
+
+Three symbols and two structural interfaces: `isIncompleteTally`,
+`tallyCriteriaResults`, `PRE_SATISFIED_REASON`, `CriteriaTallyLike`,
+`CriterionResultLike`. Together they answer one question — does this finished
+run have a verdict to state, or did its grader fail to produce one? — over the
+`skipped` and `reason` fields of a `criteria_results` row.
+
+They moved here from pome-cloud's private `packages/contract` (F-1416). Four
+surfaces in two repositories ask that question about the same run: pome-cloud's
+dashboard badge and markdown report header, and this repo's CLI terminal verdict
+and `verdict.json` `state`. F-1399 had already collapsed the two pome-cloud
+copies into one predicate, and they have not drifted since. Across the repo
+boundary the defect survived: `cli/test/unit/hosted/cross-surface-agreement.
+test.ts` held a hand-written transcription of the predicate so it could assert
+the CLI and the dashboard never split on "did this pass", and it went stale the
+moment F-1399 changed the original — stale GREEN, passing while asserting
+something false about the other repo. Neither repo could fix that alone:
+`@pome-cloud/contract` is private and unpublished, `lint-no-cloud-imports.sh`
+denies the import by design, and no CI check here could diff a transcription
+against a private source. wire is the one package that already crosses this
+boundary, so the predicate lives here now and both sides import it.
+
+**Subpath-only, deliberately off the root barrel.** The barrel's F-942 doc says
+nothing on it knows about sessions, tasks, runs or the cloud REST surface, and
+the five twins / the sdk / the adapter — every root-barrel consumer — have no
+run to ask about. `test/export-surface.test.ts` fails if any of these symbols
+appears on the barrel. The barrel's doc was narrowed to name this one exception
+and why it is not a loosening: the predicate reads two fields of a wire row and
+returns a boolean, names no session / task / run id / REST route / column,
+imports nothing, and takes structural inputs so no cloud type crosses with it.
+
+`trace-contract.json` gains the `runCompleteness` entry in its `exports` map,
+for the same reason `correlation` is in there and `otel/fixtures` is not: it is
+a surface a consumer codes against, not a test artifact.
+
+Consumers must move together — pome-cloud's eight `@pome-sh/wire` pins go
+`0.2.1 → 0.2.3` in one change, and its dashboard, control plane and markdown
+report import from `@pome-sh/wire/run-completeness` instead of from
+`@pome-cloud/contract`, whose copy is deleted.
+
 ## 0.2.2 — 2026-08-12
 
 No schema, type, export or behaviour change. F-1488 fixed

--- a/packages/wire/package.json
+++ b/packages/wire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/wire",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Pome's wire format — Zod schemas for recorder events, the OpenTelemetry extension surface, secret redaction, and framework-agnostic trace correlation. Shared by every twin, the sdk, the adapter and the CLI.",
   "private": false,
   "type": "module",
@@ -30,6 +30,10 @@
     "./correlation": {
       "types": "./dist/correlation/index.d.ts",
       "default": "./dist/correlation/index.js"
+    },
+    "./run-completeness": {
+      "types": "./dist/run-completeness.d.ts",
+      "default": "./dist/run-completeness.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/wire/scripts/emit-trace-contract.mjs
+++ b/packages/wire/scripts/emit-trace-contract.mjs
@@ -240,6 +240,13 @@ export function buildContract({ pkg, eventKinds, fixtures }) {
       // `x-pome-correlation-id` protocol whose recorder side these event
       // schemas describe.
       correlation: "@pome-sh/wire/correlation",
+      // F-1416. Present for the same reason `correlation` is: it is a surface a
+      // consumer codes against, not a test artifact. pome-cloud's dashboard and
+      // control plane import it to answer "does this finished run have a
+      // verdict to state?" over the `criteria_results` rows these schemas put
+      // on the wire, and the CLI imports it so its cross-surface agreement test
+      // compares against the real predicate instead of a transcription of it.
+      runCompleteness: "@pome-sh/wire/run-completeness",
     },
     canonicalSchemas: [...CANONICAL_SCHEMAS],
     // Union declaration order, not sorted: the contract mirrors the schema.

--- a/packages/wire/src/index.ts
+++ b/packages/wire/src/index.ts
@@ -6,16 +6,35 @@
  * and the CLI reads (`recorder-events.ts`), the OpenTelemetry-native extension
  * of that union (`otel/`), and the secret redactor applied on the way to disk
  * (`redaction.ts`). Every twin, the sdk, the adapter and the CLI depend on this
- * package; NOTHING here knows about sessions, tasks, runs or the cloud REST
- * surface — those live in `cli/src/contract/` (F-942).
+ * package; NOTHING ON THIS BARREL knows about sessions, tasks, runs or the
+ * cloud REST surface — those live in `cli/src/contract/` (F-942).
  *
- * Two SUBPATH-ONLY surfaces are deliberately absent from this barrel, because
- * only some consumers should pay to load them: `@pome-sh/wire/otel/fixtures`
- * (the golden-fixture corpus, a test/dev artifact) and
- * `@pome-sh/wire/correlation` (F-950 — the agent-side AsyncLocalStorage +
- * fetch-patching plumbing that stamps `x-pome-correlation-id`; importing it
- * constructs an AsyncLocalStorage, and no twin is the agent side of that
- * protocol). `test/export-surface.test.ts` pins both halves of that call.
+ * F-1416 NARROWED THAT CLAIM ONCE, and this is the whole of the narrowing: the
+ * package now also ships `@pome-sh/wire/run-completeness`, four symbols that
+ * read two fields of a `criteria_results` row (`skipped`, `reason`) and return
+ * whether a finished run has a verdict to state. That is the one predicate
+ * pome-cloud's dashboard and control plane and this repo's CLI all have to
+ * agree on, and until F-1416 the CLI's agreement test kept a hand-written copy
+ * of it that went stale green. It is run-ADJACENT, so the sentence above would
+ * be false if it said "this package"; it is not run vocabulary, because it
+ * names no session, task, run id, REST route or column, imports nothing, and
+ * takes structural inputs so no cloud type crosses with it. Keeping it OFF this
+ * barrel is what keeps the sentence above enforceable rather than merely
+ * written down — see below.
+ *
+ * Three SUBPATH-ONLY surfaces are deliberately absent from this barrel.
+ * `@pome-sh/wire/otel/fixtures` (the golden-fixture corpus, a test/dev
+ * artifact) and `@pome-sh/wire/correlation` (F-950 — the agent-side
+ * AsyncLocalStorage + fetch-patching plumbing that stamps
+ * `x-pome-correlation-id`) are absent because only some consumers should pay to
+ * LOAD them: importing correlation constructs an AsyncLocalStorage, and no twin
+ * is the agent side of that protocol. `@pome-sh/wire/run-completeness` (F-1416)
+ * is absent for a different reason — SCOPE, not cost. The five twins, the sdk
+ * and the adapter import this barrel and not one of them has a run to ask
+ * about, so a symbol they cannot use has no business in their namespace, and an
+ * opt-in subpath is what makes the F-942 boundary above a thing CI can check.
+ * `test/export-surface.test.ts` pins all three: each subpath's own surface, and
+ * its absence from the snapshot below.
  *
  * This file is a THIN BARREL: it re-exports only.
  */

--- a/packages/wire/src/run-completeness.ts
+++ b/packages/wire/src/run-completeness.ts
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * When a finished run has a verdict to state, and when it has none.
+ *
+ * WHY THIS IS IN WIRE AND NOT IN EITHER REPO'S OWN TREE. Four surfaces answer
+ * this question about the same run, and they do not all live in the same
+ * repository. In pome-cloud: the dashboard's badge (`run-status.ts`'s
+ * `isRunIncomplete`, over the wire `criteria_results`) and the markdown
+ * report's header word (`run-report.ts`, over `criteria_breakdown`). In
+ * digital-twins: the CLI's terminal verdict and the `state` field of the
+ * `verdict.json` a hosted run writes for CI to read.
+ *
+ * F-1399 collapsed the first two into one predicate inside pome-cloud's private
+ * `packages/contract`, and they have not drifted since — they cannot, because
+ * there is nothing left to drift from. Across the repo boundary the same defect
+ * survived it: `cli/test/unit/hosted/cross-surface-agreement.test.ts` held a
+ * hand-written TRANSCRIPTION of the predicate so it could assert the CLI and
+ * the dashboard never split on "did this pass". A transcription is a parallel
+ * copy with a longer feedback loop, and it went stale GREEN — passing while
+ * asserting something false about the other repo — the moment F-1399 changed
+ * the original. Nothing detected that; it was caught because one person
+ * happened to be holding both sides.
+ *
+ * Neither repo could fix it alone. `@pome-cloud/contract` is a private,
+ * unpublished workspace package, so digital-twins cannot depend on it;
+ * `scripts/lint-no-cloud-imports.sh` denies the import by design (ADR-002); and
+ * no CI check in digital-twins could diff the transcription against a private
+ * source without a credential the public repo's guardrails exist to keep out.
+ * So the predicate moved to the one package that ALREADY crosses this boundary
+ * (F-1416): wire is published from digital-twins and consumed by pome-cloud,
+ * so both sides can import the same function and a change to it is a type error
+ * or a red test on both sides rather than a silent pass on one.
+ *
+ * WHY IT IS WIRE'S TO CARRY, and why that does not loosen F-942. Everything
+ * below reads exactly two fields of a `criteria_results` row — `skipped` and
+ * `reason` — and returns a boolean. That row is a WIRE shape: it is what
+ * /finalize puts on the wire and what both repos parse back. `reason` in
+ * particular carries `PRE_SATISFIED_REASON` as a VALUE, so the string is
+ * already wire vocabulary in the same sense a semconv attribute key is. Nothing
+ * here names a session, a task, a run id, a REST route or a database column,
+ * and nothing here imports anything. The input types are structural on purpose
+ * (see `CriteriaTallyLike`), so no cloud class crosses the boundary with the
+ * predicate — only the arithmetic does.
+ *
+ * SUBPATH-ONLY (`@pome-sh/wire/run-completeness`), deliberately off the root
+ * barrel — the call `correlation/` and `otel/fixtures` already make, for a
+ * different reason. Theirs is load cost; this one is scope: the barrel is what
+ * every twin, the sdk and the adapter import, none of them has a run to ask
+ * about, and the barrel's F-942 doc is the thing that keeps control-plane
+ * vocabulary from creeping into them. `test/export-surface.test.ts` fails if any
+ * symbol below appears on the root barrel.
+ */
+
+/**
+ * The reason stamped on a criterion excluded for having already been true in
+ * the seed.
+ *
+ * Owned here because it is the input to the predicate below on every side, so a
+ * drift in the string is a silent drift in the predicate: a reader on a stale
+ * spelling would count every exclusion as an abstention and stamp `Incomplete`
+ * on every correctly-scored dedup run. pome-cloud's control plane
+ * (`evaluators/deterministic/pre-satisfied.ts`) is what STAMPS it and
+ * re-exports this constant; the CLI's `hosted/evalResultView.ts` re-exports it
+ * for its own call sites. Nothing anywhere re-declares it.
+ */
+export const PRE_SATISFIED_REASON = "already_true_in_seed";
+
+/**
+ * The shape every surface reduces its criteria to before asking the question.
+ *
+ * `preSatisfied` is a SUBSET of `notEvaluated`, not a fourth bucket — a consumer
+ * that adds `evaluated + notEvaluated` and expects `total` keeps working, and
+ * one that ignores `preSatisfied` gets the pre-F-1296 arithmetic rather than a
+ * wrong one. Structural rather than a shared class so the dashboard's
+ * `CriteriaCounts` (which also carries `passed`) and the control plane's
+ * `CriteriaTally` (which also carries `failed`) both satisfy it as they are —
+ * and, since F-1416, so that this module can be published to a consumer whose
+ * classes wire has never heard of. A nominal type here would have dragged one
+ * repo's vocabulary into the other; a structural one drags nothing.
+ */
+export interface CriteriaTallyLike {
+  /** Criteria the grader reached a verdict on: the score's denominator. */
+  evaluated: number;
+  /** Criteria that left the denominator, for any reason. */
+  notEvaluated: number;
+  /** The subset of `notEvaluated` the seed already satisfied. */
+  preSatisfied: number;
+  /** Every criterion the run recorded. */
+  total: number;
+}
+
+/**
+ * Has this finished run's grader failed to produce a verdict it can be scored
+ * on?
+ *
+ * `true` means the run is neither a pass nor a failure: the honest word is
+ * `incomplete` / `INCOMPLETE`, and no pass-rate denominator may contain it.
+ *
+ * THREE CLAUSES, EACH LOAD-BEARING:
+ *
+ * 1. `total === 0` → `false`, never incomplete. A production run carries no
+ *    criteria at all until online eval scores it, and a replay run records none
+ *    by construction (pome-cloud's `replay-run.ts` writes `criteriaResults: []`
+ *    and encodes "the bug came back" as the score itself). Calling those
+ *    incomplete would relabel every one of them. "No criteria were recorded" is
+ *    a different fact from "criteria were recorded and none could be
+ *    evaluated", and only the second is a finding — the same reading
+ *    `score-merge.ts`'s `isFullyUnevaluated` settled on for `all_skipped`.
+ *
+ * 2. `notEvaluated - preSatisfied > 0` → incomplete (F-925, narrowed by
+ *    F-1296). ANY criterion the grader could not reach makes the run neither
+ *    green nor red, because a score of 100 over a shrunken denominator is what
+ *    "the check never ran" looks like. Subtracting `preSatisfied` is the F-1296
+ *    exemption: a criterion excluded for having already been true in the seed
+ *    is not an abstention — the grader DID reach a verdict, and the verdict is
+ *    that the criterion tested nothing. Counting it would stamp the word on
+ *    every correctly-scored dedup and injection run, which is how a reader
+ *    learns to stop reading it.
+ *
+ * 3. `evaluated === 0` → incomplete (F-1399). Given clauses 1 and 2 this fires
+ *    for exactly ONE shape that clause 2 does not already catch: every
+ *    criterion excluded as already true in the seed. (If `total > 0` and
+ *    `evaluated === 0` then `notEvaluated === total`, so clause 2 is false only
+ *    when `preSatisfied === total`.) That run scores 0 — not because anything
+ *    failed, but because `score-merge.ts` returns 0 rather than dividing by an
+ *    empty denominator — and without this clause it fell through to
+ *    `satisfaction_score === 100 ? pass : fail` and landed on `fail`: a verdict
+ *    about the AGENT for a run in which the agent could not have done anything
+ *    wrong. It is written as its own clause rather than folded into clause 2
+ *    because it is a different fact (there is no denominator) from clause 2's
+ *    (something was not reached), and because folding it in would require
+ *    `preSatisfied` to stop being an exemption.
+ *
+ * WHAT THIS DELIBERATELY DOES NOT DO is distinguish the two ways an empty
+ * denominator arises — "nothing was at risk" (all pre-satisfied) from "not
+ * evaluable" (the grader could not run). Both are `incomplete`, because neither
+ * is a pass or a failure. WHICH one it was is a separate question, answered in
+ * the same words on both surfaces by the dashboard's `verdictLine` and the
+ * report's `scoreBasis`, and both key that off `notEvaluated - preSatisfied`
+ * rather than off this boolean.
+ */
+export function isIncompleteTally(tally: CriteriaTallyLike): boolean {
+  if (tally.total === 0) return false;
+  return tally.notEvaluated - tally.preSatisfied > 0 || tally.evaluated === 0;
+}
+
+/**
+ * One `criteria_results` row, reduced to the two facts the tally needs.
+ *
+ * Structural rather than either repo's full `CriterionResult` so a caller
+ * reading the column back off a DB row satisfies it without importing a
+ * criterion union — and so it is obvious that nothing else on the row can
+ * change the answer. `passed` in particular cannot: a criterion that was
+ * evaluated counts toward the denominator whichever way it went.
+ */
+export interface CriterionResultLike {
+  /** Did this criterion leave the score denominator? */
+  skipped: boolean;
+  /** Why it left. `PRE_SATISFIED_REASON` is the one reason that is not a gap. */
+  reason?: string;
+}
+
+/**
+ * `criteria_results` → the counts `isIncompleteTally` reads.
+ *
+ * WHY THIS IS HERE AND NOT BESIDE ITS CALLERS. F-1399 merged the PREDICATE and
+ * left the reduction written by hand on the dashboard, which was fine while the
+ * dashboard was the only surface counting this column. F-1414 added two more:
+ * the MCP's `first_failure_viewed` and the control plane's prior-failure probe
+ * both have a runs row in hand and must decide the same question about it. Three
+ * hand-written copies of `if (skipped) { notEvaluated++; if (reason === …) }` is
+ * the shape this file's header says will drift — and it drifts SILENTLY here,
+ * because a copy that miscounts still returns a boolean and still looks like an
+ * answer. So the reduction moved next to the predicate that consumes it, and
+ * F-1416 carried the pair across the repo boundary together for the same
+ * reason: separating them would have left one repo owning half the arithmetic.
+ *
+ * `criteria_results` and not `criteria_breakdown`: the two agree on this split
+ * by construction (`score-merge.ts` builds both from one `criteria.map`), and
+ * only `criteria_results` is populated on every row, including the pre-M7 ones
+ * whose breakdown column is empty. A surface that already has a breakdown in
+ * hand (the markdown report) keeps using `tallyBreakdown`, which produces the
+ * same counts plus the `failed` split the report prints.
+ *
+ * NOTE THE EMPTY ARRAY IS `total: 0`, which `isIncompleteTally` reads as "not
+ * incomplete" — see clause 1 there. That is what keeps a replay run (which
+ * records no criteria and encodes its verdict as the score) and a pre-M7 row
+ * readable as the pass or failure they are.
+ */
+export function tallyCriteriaResults(
+  results: readonly CriterionResultLike[],
+): CriteriaTallyLike {
+  let evaluated = 0;
+  let notEvaluated = 0;
+  let preSatisfied = 0;
+  for (const result of results) {
+    if (result.skipped) {
+      notEvaluated += 1;
+      if (result.reason === PRE_SATISFIED_REASON) preSatisfied += 1;
+      continue;
+    }
+    evaluated += 1;
+  }
+  return { evaluated, notEvaluated, preSatisfied, total: results.length };
+}

--- a/packages/wire/test/export-surface.test.ts
+++ b/packages/wire/test/export-surface.test.ts
@@ -221,3 +221,42 @@ describe("@pome-sh/wire/correlation subpath surface (F-950)", () => {
     expect(CORRELATION_HEADER).toBe("x-pome-correlation-id");
   });
 });
+
+// F-1416. `run-completeness/` is the THIRD subpath-only surface, and the one
+// whose absence from the root barrel is load-bearing rather than economical:
+// the barrel's own doc says nothing on it knows about runs, the five twins /
+// the sdk / the adapter all import the barrel and none of them has a run to ask
+// about, and this block is what turns that sentence into a check. The four
+// symbols below are also the ONE copy of a predicate two repositories call, so
+// a rename here is a breaking change for pome-cloud's dashboard and control
+// plane — which is exactly the coupling F-1416 wanted, replacing a transcribed
+// copy that could go stale green with an import that cannot.
+describe("@pome-sh/wire/run-completeness subpath surface (F-1416)", () => {
+  const EXPECTED_RUN_COMPLETENESS_EXPORTS = [
+    "PRE_SATISFIED_REASON",
+    "isIncompleteTally",
+    "tallyCriteriaResults",
+  ] as const;
+
+  it("exports exactly the run-completeness surface", async () => {
+    const runCompleteness = await import("../src/run-completeness.js");
+    expect(Object.keys(runCompleteness).sort()).toEqual([...EXPECTED_RUN_COMPLETENESS_EXPORTS]);
+  });
+
+  it("stays off the root barrel — the F-942 claim, checked", async () => {
+    for (const name of EXPECTED_RUN_COMPLETENESS_EXPORTS) {
+      expect(Object.keys(api)).not.toContain(name);
+    }
+  });
+
+  it("pins the reason string every surface keys the exemption off", async () => {
+    // Both sides of one wire value. pome-cloud's control plane STAMPS this
+    // literal on an excluded criterion (`evaluators/deterministic/
+    // pre-satisfied.ts`); the dashboard, the markdown report and this repo's
+    // CLI all read it back off `criteria_results.reason`. A rename on one side
+    // without the other counts every exclusion as an abstention and stamps
+    // `Incomplete` on every correctly-scored dedup run.
+    const { PRE_SATISFIED_REASON } = await import("../src/run-completeness.js");
+    expect(PRE_SATISFIED_REASON).toBe("already_true_in_seed");
+  });
+});

--- a/packages/wire/test/run-completeness.test.ts
+++ b/packages/wire/test/run-completeness.test.ts
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-1399 — the truth table for the one predicate that decides whether a
+// finished run has a verdict to state.
+//
+// F-1416 MOVED THIS FILE HERE, from pome-cloud's private `packages/contract`,
+// along with the predicate it tests. Four surfaces in two repositories ask this
+// question about the same run — pome-cloud's dashboard badge (`run-status.ts`)
+// and markdown report header (`run-report.ts`), and this repo's CLI terminal
+// verdict and `verdict.json` `state`. Each pome-cloud surface used to carry a
+// hand-written copy of the clauses, edited in lockstep twice (F-1296 added the
+// seed-exclusion exemption to both, F-1399 the empty-denominator clause) before
+// F-1399 merged them; the CLI's agreement test then carried a THIRD copy, as a
+// transcription, and that one went stale green. The table belongs wherever the
+// shared answer lives, because a test on one side can only ever pin what one
+// side believes — and since F-1416 the shared answer is here, in the one
+// package both repositories install.
+//
+// Each row is a real run shape, and the comment on it is the shape's name in
+// the product, not a restatement of the arithmetic.
+
+import { describe, expect, it } from "vitest";
+import {
+  isIncompleteTally,
+  PRE_SATISFIED_REASON,
+  tallyCriteriaResults,
+} from "../src/run-completeness.js";
+
+/** Build a tally the way both surfaces do: `preSatisfied` ⊆ `notEvaluated`. */
+function tally(opts: { evaluated: number; unreached?: number; preSatisfied?: number }) {
+  const unreached = opts.unreached ?? 0;
+  const preSatisfied = opts.preSatisfied ?? 0;
+  const notEvaluated = unreached + preSatisfied;
+  return {
+    evaluated: opts.evaluated,
+    notEvaluated,
+    preSatisfied,
+    total: opts.evaluated + notEvaluated,
+  };
+}
+
+describe("isIncompleteTally", () => {
+  const cases: Array<{ name: string; tally: ReturnType<typeof tally>; incomplete: boolean }> = [
+    {
+      // A replay run, or a production run whose criteria online eval has not
+      // scored yet. `replay-run.ts` writes an empty `criteriaResults` and
+      // encodes "the bug came back" in the score itself, so calling this
+      // incomplete would take the verdict away from every replay.
+      name: "no criteria recorded at all",
+      tally: tally({ evaluated: 0 }),
+      incomplete: false,
+    },
+    {
+      name: "every criterion evaluated, all passed",
+      tally: tally({ evaluated: 3 }),
+      incomplete: false,
+    },
+    {
+      name: "every criterion evaluated, some failed",
+      tally: tally({ evaluated: 3 }),
+      incomplete: false,
+    },
+    {
+      // F-925: a score of 100 over a shrunken denominator is what "the check
+      // never ran" looks like, so ANY unreached criterion takes the verdict.
+      name: "one criterion the grader could not reach beside three it could",
+      tally: tally({ evaluated: 3, unreached: 1 }),
+      incomplete: true,
+    },
+    {
+      // F-1296: an exclusion is a verdict, not a gap. A dedup task scoring 3/3
+      // with a fourth criterion the seed already satisfied is a clean pass.
+      name: "one criterion excluded as already true in the seed beside three evaluated",
+      tally: tally({ evaluated: 3, preSatisfied: 1 }),
+      incomplete: false,
+    },
+    {
+      name: "an exclusion AND a gap beside evaluated criteria — the gap still wins",
+      tally: tally({ evaluated: 3, unreached: 1, preSatisfied: 1 }),
+      incomplete: true,
+    },
+    {
+      // F-1399, the hero shape. Score 0, and not one thing the agent could
+      // have got wrong. This is the row the third clause exists for.
+      name: "EVERY criterion excluded as already true in the seed",
+      tally: tally({ evaluated: 0, preSatisfied: 2 }),
+      incomplete: true,
+    },
+    {
+      name: "a single criterion, excluded — the smallest all-excluded run",
+      tally: tally({ evaluated: 0, preSatisfied: 1 }),
+      incomplete: true,
+    },
+    {
+      // Already incomplete before F-1399 and still incomplete after: the new
+      // clause must not be the only thing holding these up.
+      name: "EVERY criterion unreached — nothing could be evaluated",
+      tally: tally({ evaluated: 0, unreached: 4 }),
+      incomplete: true,
+    },
+    {
+      name: "every criterion gone, some excluded and some unreached",
+      tally: tally({ evaluated: 0, unreached: 1, preSatisfied: 1 }),
+      incomplete: true,
+    },
+  ];
+
+  for (const c of cases) {
+    it(`${c.incomplete ? "has no verdict" : "has a verdict"}: ${c.name}`, () => {
+      expect(isIncompleteTally(c.tally)).toBe(c.incomplete);
+    });
+  }
+
+  // THE CLAIM THAT MAKES THE FIX SAFE. `evaluated === 0` reads much broader
+  // than "every criterion was excluded", and a reviewer is right to ask what
+  // else it swept up. The answer is nothing, and it is arithmetic rather than
+  // luck: with `total > 0` and `evaluated === 0` we have
+  // `notEvaluated === total`, so the older `notEvaluated - preSatisfied > 0`
+  // clause is false only when `preSatisfied === total`. Exhausted here over
+  // every tally up to a realistic width, so a later edit to any clause that
+  // widens the third one's reach fails this rather than shipping a run
+  // relabelled by accident.
+  it("changes the answer for exactly one shape: every criterion excluded", () => {
+    const beforeF1399 = (t: ReturnType<typeof tally>) =>
+      t.total > 0 && t.notEvaluated - t.preSatisfied > 0;
+    const moved: string[] = [];
+    for (let evaluated = 0; evaluated <= 4; evaluated++) {
+      for (let unreached = 0; unreached <= 4; unreached++) {
+        for (let preSatisfied = 0; preSatisfied <= 4; preSatisfied++) {
+          const t = tally({ evaluated, unreached, preSatisfied });
+          if (isIncompleteTally(t) !== beforeF1399(t)) {
+            moved.push(`${evaluated}/${unreached}/${preSatisfied}`);
+          }
+        }
+      }
+    }
+    // evaluated=0, unreached=0, preSatisfied=1..4 — and nothing else.
+    expect(moved).toEqual(["0/0/1", "0/0/2", "0/0/3", "0/0/4"]);
+  });
+});
+
+// F-1414 — the reduction that feeds the table above, now that three surfaces in
+// three apps count the same column: the dashboard's badge, the MCP's
+// `first_failure_viewed`, and the control plane's prior-failure probe. Only the
+// `skipped` flag and the reason move the counts; everything else on a criterion
+// row is the caller's business.
+describe("tallyCriteriaResults", () => {
+  const scored = (passed: boolean) => ({ skipped: false, passed, reason: "judged" });
+  const excludedBySeed = () => ({ skipped: true, passed: false, reason: PRE_SATISFIED_REASON });
+  const unreached = () => ({ skipped: true, passed: false, reason: "judge_unavailable" });
+
+  it("counts an evaluated criterion into the denominator whichever way it went", () => {
+    // The failing one is the point: `passed` is the SCORE's business, and a
+    // reduction that let it move `evaluated` would make a red run read as a
+    // shrunken denominator.
+    expect(tallyCriteriaResults([scored(true), scored(false)])).toEqual({
+      evaluated: 2,
+      notEvaluated: 0,
+      preSatisfied: 0,
+      total: 2,
+    });
+  });
+
+  it("counts a seed exclusion as BOTH notEvaluated and preSatisfied", () => {
+    // `preSatisfied` is a subset, not a fourth bucket — `evaluated +
+    // notEvaluated` still equals `total`, which is what lets the predicate
+    // subtract one from the other.
+    const tally = tallyCriteriaResults([scored(true), excludedBySeed()]);
+    expect(tally).toEqual({ evaluated: 1, notEvaluated: 1, preSatisfied: 1, total: 2 });
+    expect(tally.evaluated + tally.notEvaluated).toBe(tally.total);
+    expect(isIncompleteTally(tally)).toBe(false);
+  });
+
+  it("counts a criterion the grader could not reach as notEvaluated only", () => {
+    const tally = tallyCriteriaResults([scored(true), unreached()]);
+    expect(tally).toEqual({ evaluated: 1, notEvaluated: 1, preSatisfied: 0, total: 2 });
+    expect(isIncompleteTally(tally)).toBe(true);
+  });
+
+  it("reduces the all-excluded run to the empty denominator the predicate refuses", () => {
+    // The F-1399 hero shape as a criteria array rather than a hand-built tally:
+    // this is the run that scores 0 with nothing at risk, and the run every
+    // funnel used to read as an agent failure.
+    const tally = tallyCriteriaResults([excludedBySeed(), excludedBySeed()]);
+    expect(tally).toEqual({ evaluated: 0, notEvaluated: 2, preSatisfied: 2, total: 2 });
+    expect(isIncompleteTally(tally)).toBe(true);
+  });
+
+  it("reduces no criteria at all to total 0 — which is NOT incomplete", () => {
+    const tally = tallyCriteriaResults([]);
+    expect(tally).toEqual({ evaluated: 0, notEvaluated: 0, preSatisfied: 0, total: 0 });
+    expect(isIncompleteTally(tally)).toBe(false);
+  });
+
+  it("treats an unrecognised skip reason as a gap, not an exclusion", () => {
+    // The fail-safe direction for a reason this package has never heard of
+    // (a future evaluator's, or a stale spelling of the seed exclusion):
+    // counting it as `preSatisfied` would exempt it from clause 2 and hand a
+    // verdict to a run nothing was evaluated in.
+    const tally = tallyCriteriaResults([
+      { skipped: true, reason: `${PRE_SATISFIED_REASON}_v2` },
+      { skipped: true },
+    ]);
+    expect(tally.preSatisfied).toBe(0);
+    expect(isIncompleteTally(tally)).toBe(true);
+  });
+});
+
+describe("PRE_SATISFIED_REASON", () => {
+  // The literal is on the wire in `runs.criteria_results`, so it is a
+  // compatibility surface, not an internal name. pome-cloud's control plane
+  // stamps it (`evaluators/deterministic/pre-satisfied.ts`, which re-exports
+  // this), pome-cloud's dashboard counts it, and this repo's CLI reads it back
+  // (`cli/src/hosted/evalResultView.ts`, which also re-exports it rather than
+  // restating it — F-1416). A rename that reached only some of them would make
+  // every dedup run read as incomplete on those surfaces alone.
+  it("is the exact string the control plane stamps and every reader counts", () => {
+    expect(PRE_SATISFIED_REASON).toBe("already_true_in_seed");
+  });
+});

--- a/packages/wire/trace-contract.json
+++ b/packages/wire/trace-contract.json
@@ -1,6 +1,6 @@
 {
   "package": "@pome-sh/wire",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "zod": {
     "range": "^4.1.13",
     "major": 4
@@ -10,7 +10,8 @@
     "recorderEvents": "@pome-sh/wire/recorder-events",
     "otel": "@pome-sh/wire/otel",
     "redaction": "@pome-sh/wire/redaction",
-    "correlation": "@pome-sh/wire/correlation"
+    "correlation": "@pome-sh/wire/correlation",
+    "runCompleteness": "@pome-sh/wire/run-completeness"
   },
   "canonicalSchemas": [
     "recorderEventSchema",


### PR DESCRIPTION
## What

`isIncompleteTally`, `tallyCriteriaResults` and `PRE_SATISFIED_REASON` move into
`@pome-sh/wire` as a new subpath, `@pome-sh/wire/run-completeness`. The CLI's
`evalResultView.ts` re-exports the reason string from there instead of
restating the literal, and `cli/test/unit/hosted/cross-surface-agreement.test.ts`
calls the real predicate instead of a hand-written transcription of it — the
transcription, and the long comment explaining why one was unavoidable, are
deleted.

wire `0.2.2 → 0.2.3` (additive). cli `0.23.33 → 0.23.38`.
`trace-contract.json` regenerated.

## Why

`cross-surface-agreement.test.ts` exists to catch one defect: the CLI and the
pome-cloud dashboard stating different things about the same run. F-1392 shipped
exactly that, and it stayed shipped until a human noticed two screens
disagreeing. To do its job the file carried a hand copy of pome-cloud's
completeness predicate as an oracle.

**That copy went stale twice, and both times it went stale GREEN** — passing
while asserting something false about the other repo. A parallel copy across a
repo boundary, with the longest possible feedback loop, sitting inside the very
test written to prove parallel copies are gone.

Neither repo could fix it alone. `@pome-cloud/contract` is a private,
unpublished workspace package; `scripts/lint-no-cloud-imports.sh` denies the
import by design (ADR-002); and no CI job here could diff the transcription
against a private source without exactly the credential this repo's guardrails
exist to keep out. So the predicate moved to the one package that already
crosses this boundary.

Paired with **pome-sh/pome-cloud#721**, which consumes it. **Land this one
first** — it is what publishes wire 0.2.3, and pome-cloud cannot pin a version
that does not exist. The ticket's own Sequencing section has this backwards.

## Notes for reviewer

**The barrel-doc decision, which the ticket asked to be made deliberately.**
wire's barrel carries an F-942 line saying nothing in it knows about sessions,
tasks, runs or the cloud REST surface. A run-completeness predicate makes that
claim false as written, so both halves of the available fix are applied rather
than one:

* **Subpath, not barrel.** `@pome-sh/wire/run-completeness` is off the root
  barrel, the same call `correlation/` and `otel/fixtures` already make — but
  for a different reason, and the doc now says which. Theirs is load cost
  (importing `correlation` constructs an AsyncLocalStorage). This one is scope:
  the five twins, the sdk and the adapter import the barrel and not one of them
  has a run to ask about. Keeping it off the barrel is what makes the F-942
  boundary a thing CI checks rather than a sentence — `export-surface.test.ts`
  now fails if any of the three symbols appears on the root snapshot.
* **And the doc line is amended anyway**, narrowly, because the old claim was
  about the PACKAGE and not just the file. It now names the one exception and
  why it is not a loosening: everything in the new module reads two fields of a
  `criteria_results` row (`skipped`, `reason`) and returns a boolean. It names
  no session, task, run id, REST route or column, it imports nothing, and its
  inputs are structural interfaces — so no cloud type crosses the boundary with
  it. Deleting the sentence instead would have removed the constraint, not just
  the claim.

**No cloud vocabulary came with it.** This was the stated stop-and-ask
condition. It did not fire: `CriteriaTallyLike` is four numbers and
`CriterionResultLike` is `{ skipped, reason? }`. Both were already structural in
pome-cloud (so the dashboard's `CriteriaCounts` and the control plane's
`CriteriaTally` could each satisfy them as-is), which is precisely what made the
module portable without dragging a class across.

**Verified by mutation, not by inspection.** Dropping the `evaluated === 0`
clause from the wire predicate turns `cross-surface-agreement.test.ts` red (2
failures, naming the all-pre-satisfied row). Restoring it returns 21/21. That is
the ticket's "done when" — the drift is a red test, not a silent pass —
demonstrated rather than asserted.

**What is still written by hand in that test, stated so nobody has to find it.**
The two-line composition in `dashboardRunStatus`: incomplete outranks the score,
and the pass bar is a hard 100. That is `deriveRunStatus`, and it stays
cloud-side on purpose — its `RunStatus` includes `in_progress`, a state derived
from a `runs` row's `finished_at`, and wire has no business knowing what a runs
row is. What moved is the arithmetic: the counting, the exemption, the empty
denominator. That is the part that drifted twice, and the part that drifts
silently, because a miscounting copy still returns a boolean. The file says this
in its header rather than implying the residue is zero.

**Why the table is still worth having** once both sides share a predicate (it is
not a tautology): the two surfaces reach their answers by genuinely different
routes — the dashboard runs the shared predicate then a hard-100 bar, the CLI
goes through `scoreFromFinalizeResponse`'s own `Score` construction, its own
`preSatisfied` subtraction and the A5 `can_pass` guard, then `scoreStatus`. The
empty-results case is the standing proof: same input, two different answers,
both correct.

### Gates run locally

| gate | result |
| --- | --- |
| `@pome-sh/wire` tests | 15 files / 282 pass |
| `@pome-sh/cli` tests | 109 files / 1123 pass |
| root `npm run typecheck` | clean |
| `check:trace-contract` | clean after regen |
| `gate:wire-tarball` | pass — 14 declared paths ship, new subpath included |
| `gate:wire-manifest` | pass |
| `lint:no-cloud-imports` | pass |
| `lint:dead-code` (knip) | clean |

`package-lock.json` and `cli/tasks/` are untouched.

## Review required

Yes — public OSS API. This adds a published export subpath to `@pome-sh/wire`
and changes which package owns a predicate two repositories depend on. Additive:
no existing export, schema, type or behaviour changed, and the root barrel's
export snapshot is byte-identical.
