### PR TITLE
The pull request file list serves the path a renamed file moved from (grading-vocabulary change)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,40 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.23.42
+
+### Patch Changes
+
+- **`GET /repos/:o/:r/pulls/:n/files` now serves `previous_filename` on a
+  renamed file, and the twin's branch diff detects the rename that makes it
+  reachable.** The CLI bundles the twins, so this is the bundled twin-github
+  half of the same change published as `@pome-sh/checks@0.1.8`.
+
+  GitHub's `diff-entry` carries `previous_filename` and sends it exactly when
+  `status: "renamed"`. `PullRequestFileRow` had declared `"renamed"` since it was
+  written and nothing could produce it: `calculatePullFiles` diffs the two
+  branches' file tables path by path, so a moved file read as one `removed` entry
+  plus one `added` entry with the whole file counted as a rewrite. An examinee
+  that renamed a file and read its own pull request's diff back saw a shape real
+  GitHub does not serve — and, because nothing in GitHub's REST API is a
+  "rename", that is how every agent moves a file.
+
+  The diff now pairs a path that left the base with a path that arrived on the
+  head when the two hold the same blob, and reports one `renamed` entry carrying
+  the pre-rename path and zero additions, zero deletions. Exact moves only, which
+  is git's `--find-renames` at 100% similarity: a move that also edits the file
+  still reports as an add plus a remove, because picking a similarity threshold
+  GitHub's declared schema does not expose would be inventing vendor behaviour
+  rather than reproducing it. The commit and compare surfaces are unchanged —
+  they read `file_versions`, whose status column has no `renamed` member.
+
+  The seed gained `repositories[].files[].renamed_from`, the only way it can take
+  a path AWAY from a branch: a seeded branch is created from the default branch
+  and inherits every path, and a plain entry can add or overwrite but never
+  remove, so before this the field was unreachable from any seed rather than
+  merely unemitted. `content` is refused alongside `renamed_from` and carried
+  over from the source instead, which makes a seeded move exact by construction.
+
 ## 0.23.41
 
 ### Patch Changes

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.23.41",
+  "version": "0.23.42",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/packages/checks/CHANGELOG.md
+++ b/packages/checks/CHANGELOG.md
@@ -1,5 +1,32 @@
 # @pome-sh/checks
 
+## 0.1.8
+
+**Grading-vocabulary change: twin-github's seed gained
+`repositories[].files[].renamed_from`.** No check declaration moves, no criterion
+moves and `checksDigest` is unaffected — this package's other half is the seed
+schemas, and this is one of them.
+
+`renamed_from` names the path a file was MOVED from on `branch`, and it is the
+only way a seed can take a path away from a branch. A seeded branch is created
+from the default branch and inherits every path, and a plain `files[]` entry can
+add or overwrite but never remove — so `status: "renamed"`, which
+`PullRequestFileRow` has always declared, was reachable from no seed at all, and
+`GET /pulls/:n/files` could not be made to serve GitHub's `previous_filename` by
+any world. Registering that as an allowance would have been accepting a gap in
+the twin's core file model.
+
+`content` is refused alongside `renamed_from` and read from the source path
+instead. That is not ergonomics: the branch diff detects a move by pairing
+identical blobs, so a seed naming both a source and different content would be
+asking for a rename the diff would report as an add plus a remove — the same
+unreachability one level up. A seed that sets `renamed_from` with no `branch`, or
+whose source is not a file on the branch, or whose source is its own destination,
+is refused with a message naming the field.
+
+Every seed valid before this is valid now: `content` became optional in the
+object and required by refine wherever `renamed_from` is absent.
+
 ## 0.1.7
 
 A section a check's verdict reads is now measured HERE, where the worlds are

--- a/packages/checks/package.json
+++ b/packages/checks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/checks",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Pome's grading vocabulary — the check declarations, seed schemas and default seeds of all five digital twins, plus the check DSL they are written in. Declarations only: no twin server, no database, no routes, no tools.",
   "private": false,
   "type": "module",

--- a/packages/twin-github/src/db.ts
+++ b/packages/twin-github/src/db.ts
@@ -232,6 +232,12 @@ CREATE TABLE IF NOT EXISTS pull_request_files (
   raw_url TEXT NOT NULL DEFAULT '',
   contents_url TEXT NOT NULL DEFAULT '',
   patch TEXT NOT NULL DEFAULT '',
+  -- F-1500 — the pre-rename path, NULL on every status but 'renamed'. Nullable
+  -- rather than DEFAULT '': the serializer reads presence off the status, and
+  -- an empty string here would be indistinguishable from a rename whose source
+  -- path the diff failed to resolve. (No backticks in this literal: it is a
+  -- template string, and one would close it.)
+  previous_filename TEXT,
   PRIMARY KEY (repo_id, pull_number, filename),
   FOREIGN KEY (repo_id, pull_number) REFERENCES pull_requests(repo_id, number) ON DELETE CASCADE
 );
@@ -332,6 +338,10 @@ export function migrate(db: GitHubCloneDatabase) {
   // database migrates without a rewrite; `hydrateDerivedColumns` backfills it
   // from `created_at` for rows written before the column existed.
   ensureColumn(db, "releases", "updated_at", "TEXT NOT NULL DEFAULT ''");
+  // F-1500 — nullable, so a database written before renames were detected
+  // migrates with its existing rows reading `previous_filename: null`, which is
+  // exactly what a non-renamed file should carry.
+  ensureColumn(db, "pull_request_files", "previous_filename", "TEXT");
   ensureIssueNumberCascade(db);
   ensureCommentsAllowPullRequests(db);
   hydrateDerivedColumns(db);

--- a/packages/twin-github/src/domain/github-domain.ts
+++ b/packages/twin-github/src/domain/github-domain.ts
@@ -23,7 +23,7 @@ import type {
 } from "../types.js";
 import type { PullRequestStack } from "../upstream-types.js";
 import { conflict, notFound, validationFailed } from "../errors.js";
-import { fileSha, linesChanged, makeSha, nowIso, paginate, stableNumericId, treeSha } from "../util.js";
+import { detectRenames, fileSha, linesChanged, makeSha, nowIso, paginate, stableNumericId, treeSha } from "../util.js";
 import { defaultSeedState, parseSeed } from "../seed.js";
 import {
   authenticatedUserJson,
@@ -135,12 +135,26 @@ export class GitHubDomain {
         }
         this.createBranchInternal(repo, repo.default_branch, null);
         const files = repoSeed.files?.filter((file) => (file.branch ?? repo.default_branch) === repo.default_branch) ?? [];
-        this.commitFiles(repo, repo.default_branch, "Initial seed commit", files, "pome-agent");
+        // F-1500 — the default branch IS the initial commit, so there is no
+        // earlier tree for a path to have moved out of. Refusing here rather than
+        // letting `commitFiles` fail on a delete of an absent path is what makes
+        // the message name the seed field the author got wrong.
+        const rootRename = files.find((file) => file.renamed_from !== undefined);
+        if (rootRename) {
+          // `conflict`, not `validationFailed`, matching the duplicate-tag refusal
+          // below: a seed fault is read by whoever authored the seed, and
+          // `validationFailed` buries its detail in an `errors[].value` shaped for
+          // an API caller.
+          conflict(
+            `Seed sets renamed_from on ${rootRename.path} with no branch: the default branch is the initial commit, so there is no earlier tree to move out of`
+          );
+        }
+        this.commitFiles(repo, repo.default_branch, "Initial seed commit", files as FileChange[], "pome-agent");
         const nonDefaultBranches = new Set((repoSeed.files ?? []).map((file) => file.branch ?? repo.default_branch).filter((branch) => branch !== repo.default_branch));
         for (const branch of nonDefaultBranches) {
           this.createBranch({ owner: repo.owner, repo: repo.name, branch, from_branch: repo.default_branch });
           const branchFiles = repoSeed.files?.filter((file) => (file.branch ?? repo.default_branch) === branch) ?? [];
-          this.commitFiles(repo, branch, `Seed ${branch}`, branchFiles, "pome-agent");
+          this.commitFiles(repo, branch, `Seed ${branch}`, this.seedFileChanges(repo, branch, branchFiles), "pome-agent");
         }
         for (const issue of repoSeed.issues ?? []) {
           const legacyAssignee = (issue as { assignee?: string | null }).assignee;
@@ -283,6 +297,41 @@ export class GitHubDomain {
       before: { repositories: before },
       after: { repositories: this.summarizeRepositories() }
     });
+  }
+
+  /**
+   * F-1500 — expand a branch's seeded file entries into the commit that produces
+   * them, turning each `renamed_from` into what a move actually is: the source
+   * path deleted and its content written at the new path, in ONE commit.
+   *
+   * The source content is read off the branch rather than taken from the seed, so
+   * a seeded move is an exact one by construction — the two blobs cannot drift
+   * apart, which is the condition `calculatePullFiles` pairs on. (`seedSchema`
+   * refuses a `renamed_from` entry that also names `content` for the same
+   * reason.) The branch was created from the default branch a line earlier, so
+   * the source path is the copy it inherited.
+   */
+  seedFileChanges(
+    repo: RepoRow,
+    branch: string,
+    entries: Array<{ path: string; content?: string; renamed_from?: string }>
+  ): FileChange[] {
+    const changes: FileChange[] = [];
+    for (const entry of entries) {
+      if (entry.renamed_from === undefined) {
+        changes.push({ path: entry.path, content: entry.content ?? "" });
+        continue;
+      }
+      const source = this.getFile(repo.id, branch, normalizePath(entry.renamed_from));
+      if (!source) {
+        conflict(
+          `Seed sets renamed_from to ${entry.renamed_from} on branch ${branch}, which holds no such file: a move's source must exist on the branch it moves on`
+        );
+      }
+      changes.push({ path: entry.renamed_from, content: "", delete: true });
+      changes.push({ path: entry.path, content: source!.content });
+    }
+    return changes;
   }
 
   /**
@@ -835,7 +884,14 @@ export class GitHubDomain {
         blob_url: `https://github.com/${repo.full_name}/blob/${commit.sha}/${version.path}`,
         raw_url: `https://raw.githubusercontent.com/${repo.full_name}/${commit.sha}/${version.path}`,
         contents_url: `https://api.github.com/repos/${repo.full_name}/contents/${version.path}?ref=${commit.sha}`,
-        patch: `@@ ${version.path} @@`
+        patch: `@@ ${version.path} @@`,
+        // F-1500 detects moves on the PULL REQUEST's branch diff only. The
+        // commit and compare surfaces read `file_versions`, whose `status`
+        // column has no `renamed` member, so they report a move the way they
+        // always have — an add and a remove — and carry no pre-rename path.
+        // Widening them is a shape change on two more routes and belongs with
+        // whatever measures those routes, not here.
+        previous_filename: null
       };
     });
   }
@@ -864,7 +920,9 @@ export class GitHubDomain {
         blob_url: `https://github.com/${repo.full_name}/blob/${head.sha}/${path}`,
         raw_url: `https://raw.githubusercontent.com/${repo.full_name}/${head.sha}/${path}`,
         contents_url: `https://api.github.com/repos/${repo.full_name}/contents/${path}?ref=${head.sha}`,
-        patch: `@@ ${path} @@`
+        patch: `@@ ${path} @@`,
+        // See `computeCommitFiles` — the compare surface is outside F-1500.
+        previous_filename: null
       });
     }
     return rows;
@@ -1032,24 +1090,42 @@ export class GitHubDomain {
     const baseFiles = new Map((this.db.prepare("SELECT * FROM files WHERE repo_id = ? AND branch = ?").all(baseRepo.id, baseRef) as FileRow[]).map((file) => [file.path, file]));
     const headFiles = new Map((this.db.prepare("SELECT * FROM files WHERE repo_id = ? AND branch = ?").all(headRepo.id, headRef) as FileRow[]).map((file) => [file.path, file]));
     const paths = [...new Set([...baseFiles.keys(), ...headFiles.keys()])].sort();
+    // F-1500 — which base-only path each head-only path MOVED from, keyed by the
+    // head path. Resolved before the row loop so the removed side can be skipped
+    // in the same pass that emits the renamed row.
+    const renames = detectRenames(
+      paths.filter((path) => baseFiles.has(path) && !headFiles.has(path)).map((path) => ({ path, sha: baseFiles.get(path)!.sha })),
+      paths.filter((path) => headFiles.has(path) && !baseFiles.has(path)).map((path) => ({ path, sha: headFiles.get(path)!.sha }))
+    );
+    const movedFrom = new Set(renames.values());
     const rows: PullRequestFileRow[] = [];
     for (const path of paths) {
       const base = baseFiles.get(path);
       const head = headFiles.get(path);
       if (base?.sha === head?.sha) continue;
+      // The source side of a move is not a deletion of its own — GitHub reports
+      // one `renamed` entry, not a removal plus an addition. Emitting both would
+      // have the response count the move twice.
+      if (movedFrom.has(path)) continue;
+      const previousFilename = renames.get(path) ?? null;
       const diff = linesChanged(base?.content, head?.content ?? "");
       rows.push({
         repo_id: baseRepo.id,
         pull_number: 0,
         filename: path,
-        status: base && head ? "modified" : head ? "added" : "removed",
-        additions: diff.additions,
-        deletions: head ? diff.deletions : base?.content.split("\n").length ?? 0,
-        changes: diff.additions + diff.deletions,
+        status: previousFilename ? "renamed" : base && head ? "modified" : head ? "added" : "removed",
+        // A detected move is an EXACT one (identical blobs), so it touches no
+        // lines — which is what GitHub reports for it. `linesChanged` would call
+        // the whole file an addition, because from its path-by-path view the
+        // destination is a file that did not exist.
+        additions: previousFilename ? 0 : diff.additions,
+        deletions: previousFilename ? 0 : head ? diff.deletions : base?.content.split("\n").length ?? 0,
+        changes: previousFilename ? 0 : diff.additions + diff.deletions,
         blob_url: `https://github.com/${headRepo.full_name}/blob/${headRef}/${path}`,
         raw_url: `https://raw.githubusercontent.com/${headRepo.full_name}/${headRef}/${path}`,
         contents_url: `https://api.github.com/repos/${headRepo.full_name}/contents/${path}`,
-        patch: `@@ ${path} @@`
+        patch: `@@ ${path} @@`,
+        previous_filename: previousFilename
       });
     }
     return rows;
@@ -1059,7 +1135,7 @@ export class GitHubDomain {
   replacePullFiles(repoId: number, pullNumber: number, files: PullRequestFileRow[]) {
     this.db.prepare("DELETE FROM pull_request_files WHERE repo_id = ? AND pull_number = ?").run(repoId, pullNumber);
     for (const file of files) {
-      this.db.prepare("INSERT INTO pull_request_files (repo_id, pull_number, filename, status, additions, deletions, changes, blob_url, raw_url, contents_url, patch) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(
+      this.db.prepare("INSERT INTO pull_request_files (repo_id, pull_number, filename, status, additions, deletions, changes, blob_url, raw_url, contents_url, patch, previous_filename) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(
         repoId,
         pullNumber,
         file.filename,
@@ -1070,7 +1146,8 @@ export class GitHubDomain {
         file.blob_url,
         file.raw_url,
         file.contents_url,
-        file.patch
+        file.patch,
+        file.previous_filename
       );
     }
   }

--- a/packages/twin-github/src/seed.ts
+++ b/packages/twin-github/src/seed.ts
@@ -29,7 +29,58 @@ export const seedSchema = z.object({
           })
         )
         .default([]),
-      files: z.array(z.object({ path: z.string().min(1), content: z.string(), branch: z.string().optional() })).default([]),
+      // F-1500 — `renamed_from` is how a seed expresses a MOVE, and with it the
+      // `status: "renamed"` the row type has always declared and no world could
+      // reach. A seeded branch is created from the default branch and inherits
+      // every path, and a plain `files[]` entry can only add or overwrite, so
+      // before this there was no way to make a path ABSENT from the head branch
+      // — and `previous_filename` was therefore unreachable from any seed, not
+      // merely unemitted.
+      //
+      // `content` is refused alongside `renamed_from` rather than merged with
+      // it: the diff detects a move by pairing identical blobs (see
+      // `calculatePullFiles`), so a seed naming a source AND different content
+      // would be asking for a rename the diff would report as an add plus a
+      // remove. Refusing it keeps "the seed asked for a rename" and "the twin
+      // serves a rename" the same statement. The content comes from the source
+      // path, which the domain resolves on the branch the move happens on.
+      files: z
+        .array(
+          z
+            .object({
+              path: z.string().min(1),
+              content: z.string().optional(),
+              branch: z.string().optional(),
+              renamed_from: z.string().min(1).optional()
+            })
+            .superRefine((file, ctx) => {
+              if (file.renamed_from === undefined) {
+                if (file.content === undefined) {
+                  ctx.addIssue({
+                    code: "custom",
+                    path: ["content"],
+                    message: "content is required on a file entry that declares no renamed_from"
+                  });
+                }
+                return;
+              }
+              if (file.content !== undefined) {
+                ctx.addIssue({
+                  code: "custom",
+                  path: ["content"],
+                  message: `renamed_from carries the source file's content, so content must be omitted (${file.path})`
+                });
+              }
+              if (file.renamed_from === file.path) {
+                ctx.addIssue({
+                  code: "custom",
+                  path: ["renamed_from"],
+                  message: `renamed_from must name a different path than the file it moves to (${file.path})`
+                });
+              }
+            })
+        )
+        .default([]),
       // F-1421 — milestones, tags and releases are repository-level entities the
       // twin already SERVES (`GET /milestones`, `/tags`, `/releases`,
       // `/releases/latest`, `/releases/tags/:tag`) and the seed could not

--- a/packages/twin-github/src/serializers.ts
+++ b/packages/twin-github/src/serializers.ts
@@ -474,7 +474,15 @@ export function pullRequestFileJson(file: PullRequestFileRow) {
     blob_url: file.blob_url,
     raw_url: file.raw_url,
     contents_url: file.contents_url,
-    patch: file.patch
+    patch: file.patch,
+    // F-1500 — GitHub sends `previous_filename` exactly when `status` is
+    // `"renamed"` and omits the KEY otherwise, so this is a conditional spread
+    // rather than a `null`: emitting `previous_filename: null` on an added file
+    // would trade a missing-field divergence for a type-changed one and have
+    // every file claim to know where it came from. `status` is what gates it,
+    // not the column being set, so a row that somehow carried a source path on
+    // another status cannot leak it onto the wire.
+    ...(file.status === "renamed" && file.previous_filename ? { previous_filename: file.previous_filename } : {})
   } satisfies DeepPartial<DiffEntry>;
 }
 

--- a/packages/twin-github/src/types.ts
+++ b/packages/twin-github/src/types.ts
@@ -31,7 +31,20 @@ export type SeedRepository = {
   default_branch?: string;
   collaborators?: string[];
   labels?: Array<{ name: string; color?: string; description?: string }>;
-  files?: Array<{ path: string; content: string; branch?: string }>;
+  // F-1500 — `renamed_from` names the path this file was MOVED from on
+  // `branch`, and is the only way a seed can take a path away from a branch: a
+  // seeded branch is created from the default branch and inherits every path,
+  // and a plain entry can add or overwrite but never remove. `content` is
+  // omitted on a rename and carried over from the source, which is what keeps a
+  // seeded move an EXACT one — the only kind the diff can detect.
+  //
+  // Exactly one of `content` / `renamed_from` is required, and that is enforced
+  // by `seedSchema`'s refine rather than by a union here: `parseSeed`'s OUTPUT is
+  // one object shape with both keys optional, so a union would refuse the very
+  // value `ParsedGitHubStateSeed` hands back. Every path into `seed()` runs
+  // `parseSeed` first, so the rule is checked whichever door a seed arrives
+  // through.
+  files?: Array<{ path: string; content?: string; branch?: string; renamed_from?: string }>;
   // F-1421 — the five entities the twin serves but the seed used to strip.
   milestones?: Array<{
     number?: number;
@@ -216,6 +229,13 @@ export type PullRequestFileRow = {
   raw_url: string;
   contents_url: string;
   patch: string;
+  // F-1500 — the path this file was moved FROM, non-null exactly when `status`
+  // is `"renamed"`. GitHub's `diff-entry` carries `previous_filename` on that
+  // status and omits the key on every other, which is why this is nullable
+  // rather than defaulted to the file's own name: the serializer decides
+  // presence from `status`, and a placeholder here would make an added file
+  // claim to have moved.
+  previous_filename: string | null;
 };
 
 export type CommitStatusRow = {

--- a/packages/twin-github/src/util.ts
+++ b/packages/twin-github/src/util.ts
@@ -50,6 +50,43 @@ export function paginate<T>(items: T[], page = 1, perPage = 30) {
   return items.slice(start, start + safePerPage);
 }
 
+/**
+ * F-1500 — pair the paths a diff dropped with the paths it gained, so a moved
+ * file reads as one `renamed` entry carrying `previous_filename` instead of a
+ * removal plus an addition. Returns head path -> the base path it moved from.
+ *
+ * Blob identity is the whole mechanism, and it is git's: nothing in GitHub's
+ * REST API is a "rename", so an agent moves a file by writing the new path and
+ * deleting the old one, and the diff has no recorded intent to read. Two paths
+ * holding the SAME content, one only on the base and one only on the head, are
+ * a move. That is exact-rename detection — git's `--find-renames` at 100%
+ * similarity — and nothing weaker: a move that also edits the file is reported
+ * as an add plus a remove, because guessing at a similarity threshold GitHub's
+ * declared schema does not expose would be the twin inventing vendor behaviour
+ * rather than reproducing it.
+ *
+ * `sorted` and pairing in path order make the answer deterministic when several
+ * dropped paths share one content: the same two trees always produce the same
+ * pairing, so a seeded world and a replayed capture agree.
+ */
+export function detectRenames(
+  removed: Array<{ path: string; sha: string }>,
+  added: Array<{ path: string; sha: string }>
+): Map<string, string> {
+  const byContent = new Map<string, string[]>();
+  for (const file of [...removed].sort((a, b) => a.path.localeCompare(b.path))) {
+    const paths = byContent.get(file.sha);
+    if (paths) paths.push(file.path);
+    else byContent.set(file.sha, [file.path]);
+  }
+  const renames = new Map<string, string>();
+  for (const file of [...added].sort((a, b) => a.path.localeCompare(b.path))) {
+    const source = byContent.get(file.sha)?.shift();
+    if (source !== undefined) renames.set(file.path, source);
+  }
+  return renames;
+}
+
 export function linesChanged(before: string | undefined, after: string) {
   if (before === undefined) {
     return { additions: after.split("\n").filter(Boolean).length || 1, deletions: 0 };

--- a/packages/twin-github/test/pull-request-renamed-files.test.ts
+++ b/packages/twin-github/test/pull-request-renamed-files.test.ts
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// `GET /repos/:o/:r/pulls/:n/files` and the pre-rename path.
+//
+// GitHub's `diff-entry` schema carries `previous_filename`, and GitHub sends it
+// exactly when `status: "renamed"`. The twin declared `"renamed"` in
+// `PullRequestFileRow["status"]` and could not produce it: `calculatePullFiles`
+// diffs the two branches' file tables path by path, so a file that moved read as
+// one `removed` entry plus one `added` entry, and `previous_filename` was
+// registered as a deliberate omission in `upstream-coverage.types.ts`. An
+// examinee that renamed a file and read its own PR's diff back therefore saw a
+// shape real GitHub does not serve — a false pass on a routine operation.
+//
+// Two things had to be true for the field to be worth anything, and each has its
+// own tooth below:
+//
+//   1. It is REACHABLE. A serializer that can emit a field no state can produce
+//      is not a fix. The seed could not express a rename at all — a seeded
+//      branch is created FROM the default branch and inherits every path, and a
+//      `files[]` entry can only add or overwrite, never remove — so
+//      `files[].renamed_from` is what carries the intent. The test drives the
+//      field through the SEED, not through a hand-built `PullRequestFileRow`:
+//      a row built in the test proves the serializer and says nothing about
+//      whether any world can reach it.
+//
+//   2. It is CONDITIONAL. GitHub sends `previous_filename` on renames and omits
+//      the key otherwise, so a serializer that emitted it always would be a new
+//      divergence pointing the other way. The counter-tooth reads the added and
+//      modified entries of the same response and asserts the key is absent.
+//
+// The value assertions run against two worlds that differ only in the path the
+// file was renamed FROM. Asserting `previous_filename` is merely present would
+// pass against a twin answering a constant; asserting each world's own value,
+// and that they differ, is what makes the field load-bearing.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { GitHubDomain } from "../src/domain/index.js";
+import { openGitHubCloneDatabase } from "../src/db.js";
+import { parseSeed } from "../src/seed.js";
+import { createGitHubCloneApp } from "../src/twin.js";
+import type { GitHubStateSeed } from "../src/types.js";
+import { TEST_AUTH_SECRET, TEST_SID, signTestToken, withAuth } from "./_authHelper.js";
+
+const previousSecret = process.env.TWIN_AUTH_SECRET;
+let token: string;
+
+beforeAll(async () => {
+  process.env.TWIN_AUTH_SECRET = TEST_AUTH_SECRET;
+  token = await signTestToken();
+});
+afterAll(() => {
+  if (previousSecret === undefined) delete process.env.TWIN_AUTH_SECRET;
+  else process.env.TWIN_AUTH_SECRET = previousSecret;
+});
+
+const base = `/s/${TEST_SID}`;
+const MOVED = "export function handle() {\n  return 'ok';\n}\n";
+
+/**
+ * One world, parameterised by the path the moved file came FROM. Both worlds
+ * rename to the same destination, so the only thing that can distinguish their
+ * `/pulls/1/files` responses is `previous_filename` itself.
+ *
+ * The head branch also carries a plain addition and a plain modification, so the
+ * counter-tooth can read a non-renamed entry out of the SAME response rather
+ * than out of a second world where something else might differ.
+ */
+function world(previousPath: string): GitHubStateSeed {
+  return {
+    users: [
+      { login: "acme", type: "Organization", name: "Acme" },
+      { login: "pome-agent", type: "User", name: "Pome Agent" }
+    ],
+    repositories: [
+      {
+        owner: "acme",
+        name: "api",
+        default_branch: "main",
+        collaborators: ["pome-agent"],
+        files: [
+          { path: "README.md", content: "# Acme API\n" },
+          { path: previousPath, content: MOVED },
+          // Modified on the head branch below.
+          { path: "src/index.ts", content: "export const ok = true;\n" },
+          // The rename: same content, new path, and `previousPath` is gone from
+          // the head branch as a result.
+          { path: "src/handler.ts", branch: "move-handler", renamed_from: previousPath },
+          { path: "src/index.ts", content: "export const ok = false;\n", branch: "move-handler" },
+          { path: "docs/handler.md", content: "# handler\n", branch: "move-handler" }
+        ],
+        pull_requests: [
+          {
+            title: "Move the handler",
+            body: "Renames the handler module.",
+            head: "move-handler",
+            base: "main",
+            author: "pome-agent"
+          }
+        ]
+      }
+    ]
+  };
+}
+
+const WORLD_A = "src/legacy-handler.ts";
+const WORLD_B = "src/old/entrypoint.ts";
+
+async function filesOf(previousPath: string) {
+  const app = createGitHubCloneApp({ seed: world(previousPath) });
+  const response = await app.request(`${base}/repos/acme/api/pulls/1/files`, withAuth(token));
+  const text = await response.text();
+  return {
+    status: response.status,
+    // The parsed WIRE body, not a domain return value: whether a key reaches the
+    // examinee is a fact about the JSON, and `JSON.stringify` drops an
+    // `undefined`-valued key that an in-process object would still report.
+    body: (text ? JSON.parse(text) : null) as Array<Record<string, unknown>> | null
+  };
+}
+
+function entry(body: Array<Record<string, unknown>> | null, filename: string) {
+  return (body ?? []).find((file) => file.filename === filename);
+}
+
+describe("previous_filename — the pre-rename path is served and seedable", () => {
+  it("serves the renamed file with the path THIS seed moved it from", async () => {
+    const a = await filesOf(WORLD_A);
+    const b = await filesOf(WORLD_B);
+
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(200);
+
+    const movedA = entry(a.body, "src/handler.ts");
+    const movedB = entry(b.body, "src/handler.ts");
+    expect(movedA?.status).toBe("renamed");
+    expect(movedB?.status).toBe("renamed");
+
+    // The value, per world — not merely "the key is there".
+    expect(movedA?.previous_filename).toBe(WORLD_A);
+    expect(movedB?.previous_filename).toBe(WORLD_B);
+    expect(movedA?.previous_filename).not.toBe(movedB?.previous_filename);
+  });
+
+  it("collapses the move into one entry — the old path is not also served as removed", async () => {
+    const { body } = await filesOf(WORLD_A);
+    const paths = (body ?? []).map((file) => file.filename);
+
+    // Real GitHub reports a move as ONE renamed entry. Emitting
+    // `previous_filename` on a renamed row while ALSO serving the old path as a
+    // separate `removed` row would leave the response counting the move twice.
+    expect(paths).not.toContain(WORLD_A);
+    expect(paths.filter((path) => path === "src/handler.ts")).toHaveLength(1);
+  });
+
+  it("reports an exact move as zero additions and zero deletions", async () => {
+    const { body } = await filesOf(WORLD_A);
+    const moved = entry(body, "src/handler.ts");
+
+    // A move with no content change touches no lines. Carrying the old file's
+    // line count as deletions — which is what the `removed` arm of the path-by-
+    // path diff did — would tell an examinee the file was rewritten.
+    expect(moved).toMatchObject({ additions: 0, deletions: 0, changes: 0 });
+  });
+
+  it("omits the key entirely on files that were not renamed", async () => {
+    const { body } = await filesOf(WORLD_A);
+
+    const added = entry(body, "docs/handler.md");
+    const modified = entry(body, "src/index.ts");
+    expect(added?.status).toBe("added");
+    expect(modified?.status).toBe("modified");
+
+    // GitHub sends `previous_filename` exactly on renames. Emitting it
+    // unconditionally — as `null`, or as the file's own name — would be a fresh
+    // divergence in the opposite direction to the one this fixes.
+    expect(added).not.toHaveProperty("previous_filename");
+    expect(modified).not.toHaveProperty("previous_filename");
+  });
+
+  it("serves the moved file's contents at the new path and nothing at the old one", async () => {
+    const app = createGitHubCloneApp({ seed: world(WORLD_A) });
+    const at = async (path: string) => {
+      const response = await app.request(
+        `${base}/repos/acme/api/contents/${path}?ref=move-handler`,
+        withAuth(token)
+      );
+      return response.status;
+    };
+
+    // The rename is a real state change on the branch, not a label attached to
+    // the diff: the pre-rename path has to be GONE from the head branch, or the
+    // twin is serving a diff that contradicts its own file tree.
+    expect(await at("src/handler.ts")).toBe(200);
+    expect(await at(WORLD_A)).toBe(404);
+    // Still on the base branch, which is what makes it a diff at all.
+    const onMain = await app.request(`${base}/repos/acme/api/contents/${WORLD_A}`, withAuth(token));
+    expect(onMain.status).toBe(200);
+  });
+});
+
+/** The world an examinee moves a file in, and its domain handle. */
+function writeWorld(sourcePath: string) {
+  const domain = new GitHubDomain(openGitHubCloneDatabase(":memory:"));
+  domain.seed({
+    users: [{ login: "acme", type: "Organization" }],
+    repositories: [
+      {
+        owner: "acme",
+        name: "api",
+        default_branch: "main",
+        collaborators: ["pome-agent"],
+        files: [
+          { path: "README.md", content: "# Acme API\n" },
+          { path: sourcePath, content: MOVED }
+        ]
+      }
+    ]
+  });
+  return domain;
+}
+
+/** `DELETE /contents/*` requires the blob sha, the way GitHub does. */
+function shaOf(domain: GitHubDomain, path: string, ref: string) {
+  return (domain.getFileContents({ owner: "acme", repo: "api", path, ref }) as { sha: string }).sha;
+}
+
+describe("previous_filename — an examinee's own rename, through the write path", () => {
+  /**
+   * The scenario the omission actually cost: nothing in GitHub's REST API is a
+   * "rename", so an agent moves a file by writing the new path and deleting the
+   * old one. GitHub's diff detects the move from the blob; the twin has to do
+   * the same, because the write path carries no rename intent to record.
+   */
+  it("detects a delete-plus-create as a rename in the pull request it opens", async () => {
+    const domain = writeWorld("src/legacy.ts");
+
+    domain.createBranch({ owner: "acme", repo: "api", branch: "agent-move", from_branch: "main" });
+    domain.createOrUpdateFile({
+      owner: "acme",
+      repo: "api",
+      path: "src/current.ts",
+      message: "Add the new module",
+      content: MOVED,
+      branch: "agent-move"
+    });
+    domain.deleteFile({
+      owner: "acme",
+      repo: "api",
+      path: "src/legacy.ts",
+      message: "Drop the old module",
+      sha: shaOf(domain, "src/legacy.ts", "agent-move"),
+      branch: "agent-move"
+    });
+    domain.createPullRequest({ owner: "acme", repo: "api", title: "Move it", head: "agent-move", base: "main" });
+
+    const files = domain.getPullRequestFiles({ owner: "acme", repo: "api", pull_number: 1 }) as Array<
+      Record<string, unknown>
+    >;
+    const moved = files.find((file) => file.filename === "src/current.ts");
+    expect(moved?.status).toBe("renamed");
+    expect(moved?.previous_filename).toBe("src/legacy.ts");
+    expect(files.map((file) => file.filename)).not.toContain("src/legacy.ts");
+  });
+
+  it("leaves an unpaired delete as removed", async () => {
+    const domain = writeWorld("src/gone.ts");
+
+    domain.createBranch({ owner: "acme", repo: "api", branch: "agent-delete", from_branch: "main" });
+    domain.deleteFile({
+      owner: "acme",
+      repo: "api",
+      path: "src/gone.ts",
+      message: "Drop it",
+      sha: shaOf(domain, "src/gone.ts", "agent-delete"),
+      branch: "agent-delete"
+    });
+    domain.createPullRequest({ owner: "acme", repo: "api", title: "Delete it", head: "agent-delete", base: "main" });
+
+    const files = domain.getPullRequestFiles({ owner: "acme", repo: "api", pull_number: 1 }) as Array<
+      Record<string, unknown>
+    >;
+    const gone = files.find((file) => file.filename === "src/gone.ts");
+    // A deletion with nothing to pair against must stay a deletion. Pairing it
+    // with any addition would invent a move the agent never made.
+    expect(gone?.status).toBe("removed");
+    expect(gone).not.toHaveProperty("previous_filename");
+  });
+});
+
+describe("previous_filename — what the seed refuses", () => {
+  const seedWith = (file: Record<string, unknown>) => () =>
+    parseSeed({
+      repositories: [
+        {
+          owner: "acme",
+          name: "api",
+          files: [{ path: "src/old.ts", content: MOVED }, file]
+        }
+      ]
+    });
+
+  // Both refusals name `renamed_from` in the message on purpose: matching any
+  // error at all would let these pass on the pre-fix "content is required"
+  // type error, which is not the rule under test.
+  it("refuses a rename whose source is the destination", () => {
+    expect(seedWith({ path: "src/old.ts", branch: "move", renamed_from: "src/old.ts" })).toThrow(/renamed_from/);
+  });
+
+  it("refuses a rename that also declares content", () => {
+    // The twin detects EXACT moves — a paired blob. Letting a seed name both a
+    // source and a different content would let it ask for a rename the diff
+    // could not report, which is the same unreachability this fixes.
+    expect(seedWith({ path: "src/new.ts", branch: "move", renamed_from: "src/old.ts", content: "different\n" })).toThrow(
+      /renamed_from/
+    );
+  });
+
+  it("refuses a file entry with neither content nor a rename source", () => {
+    expect(seedWith({ path: "src/new.ts", branch: "move" })).toThrow();
+  });
+
+  it("refuses a rename on the default branch, where there is nothing to move from", () => {
+    const app = () => createGitHubCloneApp({ seed: world(WORLD_A) });
+    // The valid world stands; the same rename with no `branch` does not.
+    expect(app).not.toThrow();
+    expect(() =>
+      createGitHubCloneApp({
+        seed: {
+          repositories: [
+            {
+              owner: "acme",
+              name: "api",
+              files: [
+                { path: "src/old.ts", content: MOVED },
+                { path: "src/new.ts", renamed_from: "src/old.ts" }
+              ]
+            }
+          ]
+        }
+      })
+    ).toThrow(/renamed_from/);
+  });
+
+  it("refuses a rename whose source is not a file on the branch", () => {
+    expect(() =>
+      createGitHubCloneApp({
+        seed: {
+          repositories: [
+            {
+              owner: "acme",
+              name: "api",
+              files: [
+                { path: "README.md", content: "# Acme API\n" },
+                { path: "src/new.ts", branch: "move", renamed_from: "src/never-existed.ts" }
+              ]
+            }
+          ]
+        }
+      })
+    ).toThrow(/renamed_from/);
+  });
+});

--- a/packages/twin-github/test/upstream-coverage.types.ts
+++ b/packages/twin-github/test/upstream-coverage.types.ts
@@ -145,7 +145,13 @@ type PullRequestList_Allow =
   | "deletions" | "changed_files";
 const _cov_pullRequestListJson: AssertNoUncovered<PullRequestSimple, ReturnType<typeof pullRequestListJson>, PullRequestList_Allow> = true;
 
-type PullRequestFile_Allow = "previous_filename";
+// F-1500 — `previous_filename` used to sit here. It is served now: the branch
+// diff detects an exact move and `pullRequestFileJson` emits the pre-rename path
+// on `status: "renamed"`, which is the only status GitHub sends it on. Leaving
+// the allowance behind would put the twin on record as still choosing to omit a
+// field it emits — and would stop this guard from failing if the emit were ever
+// dropped again.
+type PullRequestFile_Allow = never;
 const _cov_pullRequestFileJson: AssertNoUncovered<DiffEntry, ReturnType<typeof pullRequestFileJson>, PullRequestFile_Allow> = true;
 
 type Review_Allow = "_links" | "body_html" | "body_text" | "author_association";


### PR DESCRIPTION
## What

`GET /repos/:o/:r/pulls/:n/files` now serves `previous_filename` on a renamed
file, and the branch diff detects the rename that makes the field reachable.
The seed gained `repositories[].files[].renamed_from`, and the deliberate
omission of `previous_filename` in `test/upstream-coverage.types.ts` is gone.

## Why

GitHub's `diff-entry` carries `previous_filename` and sends it exactly when
`status: "renamed"`. `PullRequestFileRow` had declared `"renamed"` since it was
written and nothing could produce it: `calculatePullFiles` diffs the two
branches' file tables path by path, so a moved file read as one `removed` entry
plus one `added` entry with the whole file counted as a rewrite. An examinee
that renamed a file and read its own pull request's diff back saw a shape real
GitHub does not serve — and since nothing in GitHub's REST API is a "rename",
delete-plus-create is how every agent moves a file. That is a false pass on a
routine operation, which is why this is a fix rather than a registered
allowance.

## Notes for reviewer

**Mechanism.** `detectRenames` (in `util.ts`) pairs a path that left the base
with a path that arrived on the head when the two hold the same blob, and
`calculatePullFiles` emits one `renamed` row carrying the pre-rename path with
zero additions / deletions / changes. Blob identity is deliberate and it is
git's own: the write path carries no rename intent to record, so detection is
the only mechanism that can see an agent's move. Exact moves only —
`--find-renames` at 100% similarity. A move that also edits the file still
reports as an add plus a remove, because picking a similarity threshold
GitHub's declared schema does not expose would be inventing vendor behaviour
rather than reproducing it. Pairing is in sorted-path order so identical-content
ambiguity resolves the same way every time.

**Reachability is the load-bearing half.** A serializer that can emit a field no
world can produce is not a fix. A seeded branch is created FROM the default
branch and inherits every path, and a plain `files[]` entry can add or overwrite
but never remove — so before this, `previous_filename` was unreachable from any
seed rather than merely unemitted. `renamed_from` is the only way a seed can
take a path AWAY from a branch; the seeder expands it into what a move actually
is (source deleted, its content written at the new path, one commit), and the
content is read off the branch rather than from the seed, which makes a seeded
move exact by construction. Every test drives the field through the seed or the
write path — none hand-builds a `PullRequestFileRow`, which would prove the
serializer and say nothing about reachability.

**The two teeth, and what each catches** (both perturbed during authoring, each
confirmed red, then restored):

- *"serves the renamed file with the path THIS seed moved it from"* — two worlds
  renaming to the same destination from different sources, so the only thing
  that can distinguish the responses is `previous_filename` itself. Asserting
  mere presence would pass against a twin answering a constant. Deleting the
  emit makes this red, plus the write-path test.
- *"omits the key entirely on files that were not renamed"* — reads the added
  and modified entries of the SAME response and asserts the key is absent from
  the parsed wire body. GitHub sends the field exactly on renames, so emitting
  it always would be a fresh divergence pointing the other way. Emitting
  `previous_filename: file.previous_filename ?? file.filename` makes this red,
  plus "leaves an unpaired delete as removed".

`PullRequestFile_Allow` went from `"previous_filename"` to `never`, and that
guard is live rather than vacuous: with the emit removed, `tsc` fails with
`{ __UNCOVERED_UPSTREAM_FIELDS__: "previous_filename" }`. Verified.

**Deliberately out of scope.** The commit and compare surfaces
(`computeCommitFiles`, `computeCompareFiles`) still report a move as an add plus
a remove and carry `previous_filename: null`. They read `file_versions`, whose
status column has no `renamed` member, and widening them is a shape change on
two more captured routes. Also unchanged: the synthetic `patch` is still emitted
on a rename, where real GitHub omits it for a pure move — a pre-existing
property of `patch: "@@ path @@"` on every file, not something this introduces.

## Versions

- **`@pome-sh/cli` 0.23.41 → 0.23.42** (bundles the twins).
- **`@pome-sh/checks` 0.1.7 → 0.1.8 — this IS a grading-vocabulary change.**
  `packages/twin-github/src/seed.ts` is one of the declaration files that
  package's tarball inlines, so the seed vocabulary a task author writes against
  moved. No check declaration moves, no criterion moves, `checksDigest` is
  untouched. Every seed valid before is valid now: `content` became optional in
  the object and required by refine wherever `renamed_from` is absent.
- `@pome-sh/wire` and `@pome-sh/adapter-claude-sdk` untouched, so no cascade and
  no example pin moves. `scripts/ci/check-version-bump-required.mjs` run locally
  against `origin/main`: OK, and confirmed it genuinely evaluated both packages
  (`packages/twin-github/src/seed.ts` matches the checks `pathPatterns`).

## Review required

Yes — twin fidelity contract, and a grading-vocabulary change (`@pome-sh/checks`
seed schema).

## Verified locally

`packages/twin-github` 614 tests + typecheck green; full workspace `npm test`
and `npm run typecheck` green after `npm run build`; `contract/run.mjs`,
`knip`, `lint-code-health`, `check-copy-markers`,
`check-first-party-twin-registration`, `check-checks-tarball --manifest-only`,
`lint-route-input-declarations`, `check-twin-leaf-portability`,
`check-twin-chunk-laziness`, `no-catch-and-continue`,
`check-example-pins-published`, `check-workspace-pins-match-workspace`,
`capture-mcp-tools-list --check --offline`, `check-bundled-runtime-deps`,
`typecheck-examples` all OK. `npm ci` left `package-lock.json` untouched.
