### PR TITLE
Divergence 19 names both commit-count surfaces, and the count it was measured at

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,30 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.23.46
+
+### Patch Changes
+
+- **Divergence 19 names the two commit-count surfaces it was actually measured on,
+  and the number it was measured at.** The bullet listed `/commits`,
+  `/commits/:ref` and `/compare/:basehead`, but `GET /repos/:o/:r/pulls/:n/commits`
+  reports the same seeded-history count difference and was missing — so the prose
+  described less than the registry entry it binds to, which is how a registry
+  starts understating what it covers.
+
+  Measured against the real `pome-sh/twin-fixtures-sandbox` on 2026-08-13, after
+  the sandbox was seeded with the `renamed_from` move: **twin 1 vs upstream 4** on
+  `compare.commits` and on `/pulls/:n/commits`. The bullet now carries that number
+  and the reason it is four rather than the two or three a reader derives from
+  "one twin commit vs a PUT plus a DELETE" — the real repo also carries the
+  branch-convergence merge that gives the move a source to consume (F-1510).
+  Without that sentence the next reader re-derives three, finds four, and
+  concludes the golden went stale.
+
+  Behaviour-free: `FIDELITY.md` only. The twin serialises its own seeded commits
+  faithfully either way; what changed is that the accepted set is now written down
+  where it is read.
+
 ## 0.23.43
 
 ### Patch Changes

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,7 +4,7 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
-## 0.23.46
+## 0.23.44
 
 ### Patch Changes
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.23.46",
+  "version": "0.23.44",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.23.43",
+  "version": "0.23.46",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/packages/twin-github/FIDELITY.md
+++ b/packages/twin-github/FIDELITY.md
@@ -397,8 +397,16 @@ on each bullet's bold title and never on its number, so gaps cost it nothing.
     The commits-collection length, per-commit `parents` count (seeded commits are roots,
     0 vs 1), and per-commit `files` changed-set count differ because the seeded sandbox's
     git history is not a byte-for-byte mirror of the real repo's commit DAG. On the
-    `GET /repos/:o/:r/commits`, `.../commits/:ref`, `.../compare/:basehead` read surfaces
-    these length differences are accepted (INFO), not drift.
+    `GET /repos/:o/:r/commits`, `.../commits/:ref`, `.../compare/:basehead`,
+    `.../pulls/:n/commits` read surfaces these length differences are accepted (INFO),
+    not drift. Measured against the real sandbox on 2026-08-13: **twin 1 vs upstream 4**
+    on the compare surface's `commits` leaf and on `/pulls/:n/commits`. Four, not the
+    two-commit figure a reader derives from "the twin spends one commit where the
+    Contents API spends a PUT plus a DELETE": the real repo also carries the
+    branch-convergence merge that gives a `renamed_from` move a source to consume
+    (F-1510), and the seeder issues that merge rather than rewriting history through the
+    Git Data API, so the golden and the seeder agree on one commit shape. A count of two
+    or three here means the seeder changed, not that the golden went stale.
 20. **`/labels` and `/collaborators` list counts reflect the seeded sandbox content.**
     The `/labels` (2 vs 10) and `/collaborators` (3 vs 2) collection counts reflect the
     seeded sandbox's smaller label set and different collaborator set, not a serializer


### PR DESCRIPTION
## What

`packages/twin-github/FIDELITY.md` divergence 19 listed `/commits`, `/commits/:ref` and `/compare/:basehead`. `GET /repos/:o/:r/pulls/:n/commits` reports the same seeded-history count difference and was missing, so the prose described **less** than the pome-cloud registry entry it binds to.

## Measured

`fidelity-watch` run 31708055467, against an upstream golden captured from the real `pome-sh/twin-fixtures-sandbox` after it was seeded with the `renamed_from` move:

| surface | path | upstream | twin |
| -- | -- | -- | -- |
| `GET /repos/:o/:r/compare/:basehead` | `commits` | 4 | 1 |
| `GET /repos/:o/:r/pulls/:n/commits` | *(array root)* | 4 | 1 |

## Why the bullet now states "four"

`seed-real-repo.ts` predicted **three** at its own code site and refused to register it, correctly, because the number was a forecast. The forecast assumed the move costs upstream one PUT plus one DELETE against the twin's single commit.

The fourth commit is the **branch-convergence merge**. The `feature` branch had never inherited the default branch's newer commits, so a `renamed_from` move had no source to consume and the rename never materialised upstream at all (F-1510). Repairing it took `POST /repos/:o/:r/merges`, and the seeder fix issues that same call rather than rewriting history through the Git Data API — deliberately, so the seeder and the captured golden agree on one commit shape.

So four is the steady state, and the bullet says so. Without that sentence the next reader re-derives three, measures four, and concludes the golden went stale.

## Lint safety

`md_bullet_title` is **byte-identical**. The bidirectional 1:1 lint matches on it verbatim, so this bullet stays bound to `GH-DIV-020`. Verified against pome-cloud's current registry:

```
known-divergences lint OK — 30 entries 1:1
```

## The other half

The matching pome-cloud widening — add `GET /repos/:o/:r/pulls/:n/commits` to `surface`, add `commits` to `accepted_fields`, replace the stale "twin 1 vs real 2" in `reason` — lands with the pin move, in one commit with the five sandbox re-captures. The lint runs both directions, so neither side can land alone: widening the yaml first orphans nothing but leaves the entry claiming a surface the pinned bullet does not mention, and moving the pin first is fine only because this bullet's title did not change.

⚠️ Explicitly NOT in this PR: `files[].status` and `files[].previous_filename` on `/compare/:basehead` are the **opposite** ruling — a twin fix, tracked separately. Two dispositions on one surface: widen the counts, fix the file rows.

## Scope

`FIDELITY.md` plus the version bump. No behaviour change: the twin serialises its own seeded commits faithfully either way. What changed is that the accepted set is written down where it is read.