### PR TITLE
The commit comparison detects a rename, the way the pull request file list does

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,51 @@ Entries are hand-written from 0.9.0 on. Changesets was retired with the
 packaging restructure: bump `version` here and in `package.json`, and merging to
 `main` publishes (see `.github/workflows/release.yml`).
 
+## 0.23.45
+
+### Patch Changes
+
+- **`GET /repos/:o/:r/compare/:basehead` detects a rename, the way
+  `GET /repos/:o/:r/pulls/:n/files` already did.** A live capture from the real
+  `pome-sh/twin-fixtures-sandbox` read `files[].status` as `["added","renamed"]`
+  upstream against `["added","removed"]` from the twin, and `previous_filename`
+  as present upstream and field-removed from the twin — two CRITICALs on one
+  surface. Real GitHub runs rename detection on both diff surfaces; the twin ran
+  it on one.
+
+  The cause was not a missing rule but a second copy of the question. Both
+  surfaces derive `diff-entry` rows from a pair of file trees, and each had its
+  own path-by-path loop: F-1500 taught the pull request's loop to pair a path
+  that left the base with a path that arrived on the head holding the same blob,
+  and the comparison's loop went on expanding one move into an `added` plus a
+  `removed` carrying no pre-rename path at all. The pull surface then measured
+  green while the comparison measured red, on the same repository, over the same
+  two commits.
+
+  So this is one derivation, not a second correct copy. `diffFileRows` is now the
+  only place the rule lives; `calculatePullFiles` and `computeCompareFiles` differ
+  in where their two trees come from (two branch file tables against two commit
+  snapshots) and in how their urls name the head — a branch ref for a pull
+  request, the head commit sha for a comparison, because `basehead` can be two
+  shas with no branch in it anywhere. The rename semantics F-1500 established are
+  unchanged and now apply to both: exact moves only (git's `--find-renames` at
+  100% similarity), one `renamed` row rather than a removal plus an addition,
+  zero additions and zero deletions, and `previous_filename` emitted on that
+  status and no other.
+
+  What deliberately did NOT move: the comparison's commit walk. `ahead_by`,
+  `behind_by`, `total_commits` and the `commits` array read exactly as before —
+  that count is a separately tracked divergence about the seeded sandbox's git
+  history, and pairing files is a fact about trees. The single-commit surface
+  `GET /repos/:o/:r/commits/:ref` also still reports a move as an add plus a
+  remove: it reads one commit's `file_versions` rows, so there is no pair of
+  trees there to detect a move between.
+
+  The property under test is that the two surfaces AGREE over the same base and
+  head — asserted as a comparison between them rather than as two expected
+  literals, because two literals is exactly the shape that let them drift apart
+  while both looked covered.
+
 ## 0.23.43
 
 ### Patch Changes

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pome-sh/cli",
-  "version": "0.23.43",
+  "version": "0.23.45",
   "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
   "keywords": [
     "ai",

--- a/packages/twin-github/src/domain/github-domain.ts
+++ b/packages/twin-github/src/domain/github-domain.ts
@@ -23,7 +23,8 @@ import type {
 } from "../types.js";
 import type { PullRequestStack } from "../upstream-types.js";
 import { conflict, notFound, validationFailed } from "../errors.js";
-import { detectRenames, fileSha, linesChanged, makeSha, nowIso, paginate, stableNumericId, treeSha } from "../util.js";
+import type { DiffTree } from "../util.js";
+import { diffFileRows, fileSha, linesChanged, makeSha, nowIso, paginate, stableNumericId, treeSha } from "../util.js";
 import { defaultSeedState, parseSeed } from "../seed.js";
 import {
   authenticatedUserJson,
@@ -885,12 +886,15 @@ export class GitHubDomain {
         raw_url: `https://raw.githubusercontent.com/${repo.full_name}/${commit.sha}/${version.path}`,
         contents_url: `https://api.github.com/repos/${repo.full_name}/contents/${version.path}?ref=${commit.sha}`,
         patch: `@@ ${version.path} @@`,
-        // F-1500 detects moves on the PULL REQUEST's branch diff only. The
-        // commit and compare surfaces read `file_versions`, whose `status`
-        // column has no `renamed` member, so they report a move the way they
-        // always have — an add and a remove — and carry no pre-rename path.
-        // Widening them is a shape change on two more routes and belongs with
-        // whatever measures those routes, not here.
+        // F-1513 moved the COMPARE surface onto the shared `diffFileRows`; this
+        // one is still outside it, and for a reason that is not scope. A single
+        // commit's change set is read straight out of `file_versions`, whose
+        // `status` column has no `renamed` member, so there is no pair of trees
+        // here to detect a move BETWEEN — the row loop below sees one version
+        // row at a time. Pairing them would mean re-deriving the commit's parent
+        // tree, which is a different derivation from the one this fixes, on a
+        // route no capture has measured a move on. It reports an add and a
+        // remove and carries no pre-rename path.
         previous_filename: null
       };
     });
@@ -898,34 +902,22 @@ export class GitHubDomain {
 
 
   computeCompareFiles(repo: RepoRow, base: CommitRow, head: CommitRow): PullRequestFileRow[] {
-    // Build path → latest version snapshot at each commit by walking ancestry
-    // and folding file_versions. Used by /compare.
-    const baseSnapshot = this.snapshotAtCommit(repo.id, base.sha);
-    const headSnapshot = this.snapshotAtCommit(repo.id, head.sha);
-    const paths = [...new Set([...baseSnapshot.keys(), ...headSnapshot.keys()])].sort();
-    const rows: PullRequestFileRow[] = [];
-    for (const path of paths) {
-      const baseFile = baseSnapshot.get(path);
-      const headFile = headSnapshot.get(path);
-      if (baseFile?.sha === headFile?.sha) continue;
-      const diff = linesChanged(baseFile?.content, headFile?.content ?? "");
-      rows.push({
-        repo_id: repo.id,
-        pull_number: 0,
-        filename: path,
-        status: baseFile && headFile ? "modified" : headFile ? "added" : "removed",
-        additions: diff.additions,
-        deletions: headFile ? diff.deletions : (baseFile?.content.split("\n").length ?? 0),
-        changes: diff.additions + diff.deletions,
+    // F-1513 — the trees this surface diffs are built by walking ancestry and
+    // folding `file_versions`, where the pull surface reads two branch file
+    // tables; past that the two answer the same question and now do it with the
+    // same code, so a move reads as one `renamed` entry here too. The urls are
+    // the difference that stays: a comparison names the head COMMIT, because
+    // `basehead` can be two shas with no branch anywhere in it.
+    return diffFileRows(
+      repo.id,
+      this.snapshotAtCommit(repo.id, base.sha),
+      this.snapshotAtCommit(repo.id, head.sha),
+      (path) => ({
         blob_url: `https://github.com/${repo.full_name}/blob/${head.sha}/${path}`,
         raw_url: `https://raw.githubusercontent.com/${repo.full_name}/${head.sha}/${path}`,
-        contents_url: `https://api.github.com/repos/${repo.full_name}/contents/${path}?ref=${head.sha}`,
-        patch: `@@ ${path} @@`,
-        // See `computeCommitFiles` — the compare surface is outside F-1500.
-        previous_filename: null
-      });
-    }
-    return rows;
+        contents_url: `https://api.github.com/repos/${repo.full_name}/contents/${path}?ref=${head.sha}`
+      })
+    );
   }
 
 
@@ -1086,49 +1078,28 @@ export class GitHubDomain {
   }
 
 
+  /** The tree a branch holds right now, in the shape `diffFileRows` diffs. */
+  branchTree(repoId: number, branch: string): DiffTree {
+    const files = this.db.prepare("SELECT path, content, sha FROM files WHERE repo_id = ? AND branch = ?").all(repoId, branch) as Array<{ path: string; content: string; sha: string }>;
+    return new Map(files.map((file) => [file.path, { content: file.content, sha: file.sha }]));
+  }
+
+
   calculatePullFiles(baseRepo: RepoRow, baseRef: string, headRepo: RepoRow, headRef: string): PullRequestFileRow[] {
-    const baseFiles = new Map((this.db.prepare("SELECT * FROM files WHERE repo_id = ? AND branch = ?").all(baseRepo.id, baseRef) as FileRow[]).map((file) => [file.path, file]));
-    const headFiles = new Map((this.db.prepare("SELECT * FROM files WHERE repo_id = ? AND branch = ?").all(headRepo.id, headRef) as FileRow[]).map((file) => [file.path, file]));
-    const paths = [...new Set([...baseFiles.keys(), ...headFiles.keys()])].sort();
-    // F-1500 — which base-only path each head-only path MOVED from, keyed by the
-    // head path. Resolved before the row loop so the removed side can be skipped
-    // in the same pass that emits the renamed row.
-    const renames = detectRenames(
-      paths.filter((path) => baseFiles.has(path) && !headFiles.has(path)).map((path) => ({ path, sha: baseFiles.get(path)!.sha })),
-      paths.filter((path) => headFiles.has(path) && !baseFiles.has(path)).map((path) => ({ path, sha: headFiles.get(path)!.sha }))
-    );
-    const movedFrom = new Set(renames.values());
-    const rows: PullRequestFileRow[] = [];
-    for (const path of paths) {
-      const base = baseFiles.get(path);
-      const head = headFiles.get(path);
-      if (base?.sha === head?.sha) continue;
-      // The source side of a move is not a deletion of its own — GitHub reports
-      // one `renamed` entry, not a removal plus an addition. Emitting both would
-      // have the response count the move twice.
-      if (movedFrom.has(path)) continue;
-      const previousFilename = renames.get(path) ?? null;
-      const diff = linesChanged(base?.content, head?.content ?? "");
-      rows.push({
-        repo_id: baseRepo.id,
-        pull_number: 0,
-        filename: path,
-        status: previousFilename ? "renamed" : base && head ? "modified" : head ? "added" : "removed",
-        // A detected move is an EXACT one (identical blobs), so it touches no
-        // lines — which is what GitHub reports for it. `linesChanged` would call
-        // the whole file an addition, because from its path-by-path view the
-        // destination is a file that did not exist.
-        additions: previousFilename ? 0 : diff.additions,
-        deletions: previousFilename ? 0 : head ? diff.deletions : base?.content.split("\n").length ?? 0,
-        changes: previousFilename ? 0 : diff.additions + diff.deletions,
+    // F-1513 — the rows themselves are `diffFileRows`, shared with
+    // `computeCompareFiles`. What is local to a pull request is the pair of
+    // trees (two BRANCHES, one of which can live in a fork) and the urls, which
+    // name the head branch ref because that is what the PR is opened against.
+    return diffFileRows(
+      baseRepo.id,
+      this.branchTree(baseRepo.id, baseRef),
+      this.branchTree(headRepo.id, headRef),
+      (path) => ({
         blob_url: `https://github.com/${headRepo.full_name}/blob/${headRef}/${path}`,
         raw_url: `https://raw.githubusercontent.com/${headRepo.full_name}/${headRef}/${path}`,
-        contents_url: `https://api.github.com/repos/${headRepo.full_name}/contents/${path}`,
-        patch: `@@ ${path} @@`,
-        previous_filename: previousFilename
-      });
-    }
-    return rows;
+        contents_url: `https://api.github.com/repos/${headRepo.full_name}/contents/${path}`
+      })
+    );
   }
 
 

--- a/packages/twin-github/src/util.ts
+++ b/packages/twin-github/src/util.ts
@@ -4,6 +4,7 @@
 // encoding, pagination, diff-stat counting. Request-id stamping moved to
 // the engine's recorder with the port.
 import { createHash, randomUUID } from "node:crypto";
+import type { PullRequestFileRow } from "./types.js";
 
 export function nowIso() {
   return new Date().toISOString();
@@ -85,6 +86,72 @@ export function detectRenames(
     if (source !== undefined) renames.set(file.path, source);
   }
   return renames;
+}
+
+/** One side of a file diff: the tree, keyed by path. */
+export type DiffTree = Map<string, { content: string; sha: string }>;
+
+/**
+ * F-1513 — the ONE derivation of GitHub's `diff-entry` rows from a pair of file
+ * trees, serving both `GET /repos/:o/:r/pulls/:n/files` and
+ * `GET /repos/:o/:r/compare/:basehead`.
+ *
+ * The two surfaces ask the same question of two different pairs of trees — the
+ * pull's two branch file tables, the compare's two commit snapshots — and until
+ * this they answered it with two independent path-by-path loops. F-1500 taught
+ * the pull loop to pair a move; the compare loop kept expanding one into an
+ * `added` plus a `removed` carrying no `previous_filename` at all, and a live
+ * capture against the real sandbox read `["added","renamed"]` upstream against
+ * `["added","removed"]` from the twin on a repo where the pull surface was
+ * already green. Two implementations of one rule is HOW they drifted, so the
+ * fix is one implementation rather than a second correct copy: the callers now
+ * differ only in where the trees come from and how the urls are built (a branch
+ * ref for the pull, the head commit sha for the compare).
+ */
+export function diffFileRows(
+  repoId: number,
+  base: DiffTree,
+  head: DiffTree,
+  urls: (path: string) => { blob_url: string; raw_url: string; contents_url: string }
+): PullRequestFileRow[] {
+  const paths = [...new Set([...base.keys(), ...head.keys()])].sort();
+  // F-1500 — which base-only path each head-only path MOVED from, keyed by the
+  // head path. Resolved before the row loop so the removed side can be skipped
+  // in the same pass that emits the renamed row.
+  const renames = detectRenames(
+    paths.filter((path) => base.has(path) && !head.has(path)).map((path) => ({ path, sha: base.get(path)!.sha })),
+    paths.filter((path) => head.has(path) && !base.has(path)).map((path) => ({ path, sha: head.get(path)!.sha }))
+  );
+  const movedFrom = new Set(renames.values());
+  const rows: PullRequestFileRow[] = [];
+  for (const path of paths) {
+    const before = base.get(path);
+    const after = head.get(path);
+    if (before?.sha === after?.sha) continue;
+    // The source side of a move is not a deletion of its own — GitHub reports
+    // one `renamed` entry, not a removal plus an addition. Emitting both would
+    // have the response count the move twice.
+    if (movedFrom.has(path)) continue;
+    const previousFilename = renames.get(path) ?? null;
+    const diff = linesChanged(before?.content, after?.content ?? "");
+    rows.push({
+      repo_id: repoId,
+      pull_number: 0,
+      filename: path,
+      status: previousFilename ? "renamed" : before && after ? "modified" : after ? "added" : "removed",
+      // A detected move is an EXACT one (identical blobs), so it touches no
+      // lines — which is what GitHub reports for it. `linesChanged` would call
+      // the whole file an addition, because from its path-by-path view the
+      // destination is a file that did not exist.
+      additions: previousFilename ? 0 : diff.additions,
+      deletions: previousFilename ? 0 : after ? diff.deletions : before?.content.split("\n").length ?? 0,
+      changes: previousFilename ? 0 : diff.additions + diff.deletions,
+      ...urls(path),
+      patch: `@@ ${path} @@`,
+      previous_filename: previousFilename
+    });
+  }
+  return rows;
 }
 
 export function linesChanged(before: string | undefined, after: string) {

--- a/packages/twin-github/test/compare-renamed-files.test.ts
+++ b/packages/twin-github/test/compare-renamed-files.test.ts
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// `GET /repos/:o/:r/compare/:basehead` and the path a renamed file moved from.
+//
+// F-1500 taught `GET /repos/:o/:r/pulls/:n/files` to pair an exact move into one
+// `renamed` entry carrying `previous_filename`, and a live capture against the
+// real `pome-sh/twin-fixtures-sandbox` then read that half green. The compare
+// surface answers the SAME question — the file-level diff of a base tree against
+// a head tree — out of what was, until F-1513, its own independent path-by-path
+// loop. It expanded a move into an `added` plus a `removed` and carried no
+// pre-rename path at all, which is what the capture measured as two CRITICALs on
+// one surface:
+//
+//   files[].status             upstream ["added","renamed"]  twin ["added","removed"]
+//   files[].previous_filename  upstream present              twin field-removed
+//
+// Real GitHub runs rename detection on both surfaces. Two implementations of one
+// rule is how these two drifted apart, so the teeth below are not "compare emits
+// a rename" twice over — the load-bearing one asserts the two surfaces AGREE
+// over the same base and head, which is the property whose absence produced the
+// ticket and which cannot silently come apart again the way two independent
+// expected-value literals can.
+//
+// NOT under test here, deliberately: the `commits` count on this surface. That
+// leaf reads 4 upstream against 1 from the twin because the seeded sandbox's git
+// history is not a mirror of the real repo's commit DAG (GH-DIV-020), it is
+// registered separately, and pairing files must not move it — which is itself
+// asserted below rather than assumed.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createGitHubCloneApp } from "../src/twin.js";
+import type { GitHubStateSeed } from "../src/types.js";
+import { TEST_AUTH_SECRET, TEST_SID, signTestToken, withAuth } from "./_authHelper.js";
+
+const previousSecret = process.env.TWIN_AUTH_SECRET;
+let token: string;
+
+beforeAll(async () => {
+  process.env.TWIN_AUTH_SECRET = TEST_AUTH_SECRET;
+  token = await signTestToken();
+});
+afterAll(() => {
+  if (previousSecret === undefined) delete process.env.TWIN_AUTH_SECRET;
+  else process.env.TWIN_AUTH_SECRET = previousSecret;
+});
+
+const base = `/s/${TEST_SID}`;
+const MOVED = "export function handle() {\n  return 'ok';\n}\n";
+const DESTINATION = "src/handler.ts";
+const HEAD_BRANCH = "move-handler";
+
+/**
+ * One world, parameterised by the path the moved file came FROM, and carrying a
+ * pull request over the very same base and head so the two surfaces can be asked
+ * the identical question.
+ *
+ * The head branch also gains a plain addition and a plain modification, so the
+ * counter-teeth can read a non-renamed entry out of the SAME response rather
+ * than out of a second world where something else might differ.
+ */
+function world(previousPath: string): GitHubStateSeed {
+  return {
+    users: [
+      { login: "acme", type: "Organization", name: "Acme" },
+      { login: "pome-agent", type: "User", name: "Pome Agent" }
+    ],
+    repositories: [
+      {
+        owner: "acme",
+        name: "api",
+        default_branch: "main",
+        collaborators: ["pome-agent"],
+        files: [
+          { path: "README.md", content: "# Acme API\n" },
+          { path: previousPath, content: MOVED },
+          // Modified on the head branch below.
+          { path: "src/index.ts", content: "export const ok = true;\n" },
+          // The move: same content, new path, and `previousPath` therefore
+          // leaves the head branch.
+          { path: DESTINATION, branch: HEAD_BRANCH, renamed_from: previousPath },
+          { path: "src/index.ts", content: "export const ok = false;\n", branch: HEAD_BRANCH },
+          { path: "docs/handler.md", content: "# handler\n", branch: HEAD_BRANCH }
+        ],
+        pull_requests: [
+          {
+            title: "Move the handler",
+            body: "Renames the handler module.",
+            head: HEAD_BRANCH,
+            base: "main",
+            author: "pome-agent"
+          }
+        ]
+      }
+    ]
+  };
+}
+
+const WORLD_A = "src/legacy-handler.ts";
+const WORLD_B = "src/old/entrypoint.ts";
+
+type Row = Record<string, unknown>;
+
+/**
+ * The parsed WIRE body on both surfaces, not a domain return value: whether a
+ * key reaches the examinee is a fact about the JSON, and `JSON.stringify` drops
+ * an `undefined`-valued key that an in-process object would still report.
+ */
+function twin(previousPath: string) {
+  const app = createGitHubCloneApp({ seed: world(previousPath) });
+  const get = async (path: string) => {
+    const response = await app.request(`${base}${path}`, withAuth(token));
+    const text = await response.text();
+    return { status: response.status, body: text ? JSON.parse(text) : null };
+  };
+  return {
+    compare: () => get(`/repos/acme/api/compare/main...${HEAD_BRANCH}`),
+    pullFiles: () => get("/repos/acme/api/pulls/1/files"),
+    headSha: async () => ((await get(`/repos/acme/api/commits/${HEAD_BRANCH}`)).body as { sha: string }).sha
+  };
+}
+
+function entry(files: Row[], filename: string) {
+  return files.find((file) => file.filename === filename);
+}
+
+describe("compare — the pre-rename path is served on the comparison too", () => {
+  it("serves the moved file as ONE renamed row naming the path THIS seed moved it from", async () => {
+    const a = (await twin(WORLD_A).compare()).body as { files: Row[] };
+    const b = (await twin(WORLD_B).compare()).body as { files: Row[] };
+
+    const movedA = entry(a.files, DESTINATION);
+    const movedB = entry(b.files, DESTINATION);
+    expect(movedA?.status).toBe("renamed");
+    expect(movedB?.status).toBe("renamed");
+
+    // The value, per world — not merely "the key is there". Two worlds that
+    // differ ONLY in the source path is what makes a twin answering a constant
+    // fail here.
+    expect(movedA?.previous_filename).toBe(WORLD_A);
+    expect(movedB?.previous_filename).toBe(WORLD_B);
+    expect(movedA?.previous_filename).not.toBe(movedB?.previous_filename);
+
+    // One row, not two: the old path must not ALSO be served as a `removed`
+    // entry, which is what the surface did before and what has the comparison
+    // count the move twice.
+    const paths = a.files.map((file) => file.filename);
+    expect(paths).not.toContain(WORLD_A);
+    expect(paths.filter((path) => path === DESTINATION)).toHaveLength(1);
+  });
+
+  it("serves the WHOLE renamed row, not just a status and a new key", async () => {
+    const world = twin(WORLD_A);
+    const headSha = await world.headSha();
+    const { files } = (await world.compare()).body as { files: Row[] };
+
+    // `toEqual`, not `toMatchObject`: a fix that adds `previous_filename` while
+    // dropping a sibling leaf — or that grows one GitHub does not send — has to
+    // fail here. Every value is a literal except the fabricated blob `sha`,
+    // which the test refuses to re-derive: reimplementing the twin's own hash to
+    // assert it would be a second copy of the rule, which is the mistake this
+    // ticket exists to undo.
+    expect(entry(files, DESTINATION)).toEqual({
+      sha: expect.stringMatching(/^file_\d+$/),
+      filename: DESTINATION,
+      status: "renamed",
+      // An exact move touches no lines. Reporting the old file's line count as
+      // deletions would tell an examinee the file was rewritten.
+      additions: 0,
+      deletions: 0,
+      changes: 0,
+      blob_url: `https://github.com/acme/api/blob/${headSha}/${DESTINATION}`,
+      raw_url: `https://raw.githubusercontent.com/acme/api/${headSha}/${DESTINATION}`,
+      contents_url: `https://api.github.com/repos/acme/api/contents/${DESTINATION}?ref=${headSha}`,
+      patch: `@@ ${DESTINATION} @@`,
+      previous_filename: WORLD_A
+    });
+  });
+
+  it("omits the key entirely on files that were not renamed", async () => {
+    const { files } = (await twin(WORLD_A).compare()).body as { files: Row[] };
+
+    const added = entry(files, "docs/handler.md");
+    const modified = entry(files, "src/index.ts");
+    expect(added?.status).toBe("added");
+    expect(modified?.status).toBe("modified");
+
+    // GitHub sends `previous_filename` exactly on renames. Emitting it
+    // unconditionally — as `null`, or as the file's own name — would trade the
+    // measured field-removed divergence for a type-changed one.
+    expect(added).not.toHaveProperty("previous_filename");
+    expect(modified).not.toHaveProperty("previous_filename");
+  });
+});
+
+describe("compare — the two diff surfaces answer the same question", () => {
+  // The three leaves that legitimately differ between the surfaces: a pull
+  // request's urls name its head BRANCH REF, a comparison's name the head
+  // COMMIT, because `basehead` can be two shas with no branch in it anywhere.
+  const REF_DEPENDENT = new Set(["blob_url", "raw_url", "contents_url"]);
+  const shape = (files: Row[]) =>
+    files.map((file) => Object.fromEntries(Object.entries(file).filter(([key]) => !REF_DEPENDENT.has(key))));
+
+  it("reports the same rename set over the same base and head", async () => {
+    const world = twin(WORLD_A);
+    const compare = (await world.compare()).body as { files: Row[] };
+    const pull = (await world.pullFiles()).body as Row[];
+
+    const renamesIn = (files: Row[]) =>
+      files
+        .filter((file) => file.status === "renamed")
+        .map((file) => ({ filename: file.filename, previous_filename: file.previous_filename }));
+
+    // Two empty sets agree vacuously, and that is exactly the state a neutered
+    // pairing leaves BOTH surfaces in — so the equality below is only worth
+    // something with this line above it.
+    const detected = renamesIn(compare.files);
+    expect(detected.length).toBeGreaterThan(0);
+    expect(detected).toEqual([{ filename: DESTINATION, previous_filename: WORLD_A }]);
+    expect(detected).toEqual(renamesIn(pull));
+  });
+
+  it("reports the same rows, in the same order, with the same counts", async () => {
+    const world = twin(WORLD_A);
+    const compare = (await world.compare()).body as { files: Row[] };
+    const pull = (await world.pullFiles()).body as Row[];
+
+    // The stronger form of the property: not just the renames, the whole diff.
+    // A surface that gains a row, loses one, reorders them, or disagrees on a
+    // status or a line count fails here — compared against the OTHER SURFACE'S
+    // answer rather than against a literal, because a literal copied into both
+    // tests is precisely how the two implementations drifted while both looked
+    // asserted.
+    expect(shape(compare.files)).toEqual(shape(pull));
+    expect(compare.files.length).toBe(pull.length);
+  });
+});
+
+describe("compare — pairing files leaves the commit walk alone", () => {
+  it("does not move ahead_by, behind_by, total_commits or the commits array", async () => {
+    const compare = (await twin(WORLD_A).compare()).body as {
+      status: string;
+      ahead_by: number;
+      behind_by: number;
+      total_commits: number;
+      commits: Row[];
+    };
+
+    // The commit-count leaf on this surface is a separately tracked divergence
+    // (the seeded history is not a mirror of the real repo's DAG). Detecting a
+    // rename is a fact about TREES; it must not touch the ancestry walk in
+    // either direction, or this fix would silently move a number someone else
+    // is measuring.
+    expect(compare.status).toBe("ahead");
+    expect(compare.ahead_by).toBe(1);
+    expect(compare.behind_by).toBe(0);
+    expect(compare.total_commits).toBe(1);
+    expect(compare.commits).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## What was measured

`fidelity-watch` run 31706719920, live twin-github against an upstream golden freshly captured from the real `pome-sh/twin-fixtures-sandbox`:

| surface | path | upstream (real GitHub) | twin |
| -- | -- | -- | -- |
| `GET /repos/:o/:r/compare/:basehead` | `files[].status` | `["added","renamed"]` | `["added","removed"]` |
| `GET /repos/:o/:r/compare/:basehead` | `files[].previous_filename` | present | field-removed |

Both CRITICAL, and both on a repository where the sibling surface `GET /repos/:o/:r/pulls/:n/files` had just measured green — F-1500 fixed that one.

## Why it was red

Not a missing rule. A second copy of the question.

Both surfaces derive GitHub's `diff-entry` rows from a pair of file trees, and each had its own path-by-path loop. F-1500 taught the pull request's loop to pair a path that left the base with a path that arrived on the head holding the same blob. The comparison's loop went on expanding one move into an `added` plus a `removed` carrying no pre-rename path at all. Real GitHub runs rename detection on both.

## The fix

One derivation, not a second correct copy. `diffFileRows` (`packages/twin-github/src/util.ts`) is now the only place the rule lives, and the two callers differ only in what they always differed in:

- **where the trees come from** — two branch file tables for a pull request, two commit snapshots for a comparison;
- **how the urls name the head** — a branch ref for a pull request, the head commit sha for a comparison, because `basehead` can be two shas with no branch in it anywhere.

F-1500's semantics are unchanged and now reach both surfaces: exact moves only (git's `--find-renames` at 100% similarity), one `renamed` row rather than a removal plus an addition, zero additions and zero deletions, and `previous_filename` emitted on that status and no other.

## What deliberately does NOT move

- **The comparison's commit walk.** `ahead_by`, `behind_by`, `total_commits` and the `commits` array read exactly as before. That count is a separately tracked divergence about the seeded sandbox's git history not mirroring the real repo's commit DAG; pairing files is a fact about trees. Asserted in the suite rather than assumed.
- **`GET /repos/:o/:r/commits/:ref`.** Still reports a move as an add plus a remove. It reads one commit's `file_versions` rows, so there is no pair of trees there to detect a move between — a different derivation from this one, on a route no capture has measured a move on.

## Teeth

`packages/twin-github/test/compare-renamed-files.test.ts`, six assertions. The load-bearing one is that the two surfaces **AGREE** over the same base and head — written as a comparison between the two responses rather than as two expected literals, because two literals is the shape that let these drift apart while both looked covered. It carries an explicit non-vacuity guard, since two empty rename sets agree perfectly.

Both neuters were run and restored:

- Reverting `computeCompareFiles` to its own independent loop: **4 of 6 red**, and all 12 F-1500 pull-surface tests stayed green — which is what proves the cross-surface assertion is a real comparison and not a copied literal.
- Killing the pairing inside the shared `diffFileRows`: **3 of 6 red**, including the non-vacuity guard, plus 4 of F-1500's. The whole-diff equality stayed green under this one — both surfaces agreeing on being wrong is exactly the case the guard exists for.

Restored: 18/18 green across both files.

## FIDELITY.md

**No change needed**, checked rather than assumed. Nothing in `packages/twin-github/FIDELITY.md` claims this behaviour as accepted — zero hits for `renamed` / `previous_filename` / `diff-entry`, and none of the four bullets that touch this surface (2, 3, 9, 19) covers add-and-remove-instead-of-rename or the missing pre-rename path. The one registry entry that ever did, pome-cloud's declared-lane `GH-DECL-007`, was deleted by F-1500 and named the pull surface only. No bullet title moves, so nothing on the pome-cloud yaml side needs to move with it.

## Verification

`npm run lint:dead-code`, `npm run build`, `npm run typecheck`, `npm run gate:route-inputs`, the nine dependency-free gates, `npm run test:coverage -w @pome-sh/twin-github` (620 passed / 48 files), the four other per-twin github gates plus `validate:mcp` and `REVIEW_TARGET=local review:harness`, the six sibling package suites (1537 passed), `npm test -w @pome-sh/cli` (1147 passed), `npm run test:contract`, `npm run probe:twins` (128 probes). All green.

`cli/CHANGELOG.md` diff against `origin/main` is 45 insertions / 0 deletions; the top heading matches `cli/package.json` at `0.23.45`.