### PR TITLE
Guard the SDK's rejecting iteration in four examples, and derive the verdict count from the buckets (F-1518)

### DIFF
--- a/examples/pr-summary-agent/src/index.ts
+++ b/examples/pr-summary-agent/src/index.ts
@@ -158,14 +158,22 @@ async function main() {
     }
   } catch (err) {
     // F-1518: the Claude Agent SDK's message iterator can REJECT — not just
-    // yield an error `result` message — when the underlying `claude` CLI
-    // subprocess exits non-zero after already reporting an error result (an
-    // invalid API key is one way). Uncaught, that throws out of this `for
-    // await` with no handler above it, crashing the process from what
-    // `smoke-examples.mjs` sees as an indistinguishable uncaught rejection —
-    // identical text to the graceful path below, but never captured by it.
-    // Route it through the same exitCode=1 path so both shapes converge.
-    console.error(`\nagent errored: ${err instanceof Error ? err.message : String(err)}`);
+    // yield an error `result` message — when the underlying `claude` CLI exits
+    // non-zero (an invalid API key is one way; the SDK calls
+    // `inputStream.error()` on the stream being iterated). Uncaught, that threw
+    // out of this `for await` and killed the process with a raw Node stack
+    // instead of this example's own reporting, so route it through the same
+    // exitCode=1 path the graceful branch uses.
+    //
+    // Log the error OBJECT, never just `err.message`: Node prints name + stack
+    // + `[cause]`, and scripts/smoke-examples.mjs classifies this output by
+    // matching signatures that can live OUTSIDE the message — `AbortError` and
+    // `AI_LoadAPIKeyError` are error NAMES, and undici reports
+    // `ECONNREFUSED`/`ENOTFOUND` only on `err.cause`. Logging the message alone
+    // would show the classifier strictly less than the uncaught rejection did,
+    // turning a benign outbound abort into "no evidence it did any real work" —
+    // trading one nondeterministic red for another.
+    console.error("\nagent errored:", err);
     exitCode = 1;
   } finally {
     thinking.stop();

--- a/examples/pr-summary-agent/src/index.ts
+++ b/examples/pr-summary-agent/src/index.ts
@@ -156,6 +156,17 @@ async function main() {
         }
       }
     }
+  } catch (err) {
+    // F-1518: the Claude Agent SDK's message iterator can REJECT — not just
+    // yield an error `result` message — when the underlying `claude` CLI
+    // subprocess exits non-zero after already reporting an error result (an
+    // invalid API key is one way). Uncaught, that throws out of this `for
+    // await` with no handler above it, crashing the process from what
+    // `smoke-examples.mjs` sees as an indistinguishable uncaught rejection —
+    // identical text to the graceful path below, but never captured by it.
+    // Route it through the same exitCode=1 path so both shapes converge.
+    console.error(`\nagent errored: ${err instanceof Error ? err.message : String(err)}`);
+    exitCode = 1;
   } finally {
     thinking.stop();
   }

--- a/examples/pr-summary-review/src/index.ts
+++ b/examples/pr-summary-review/src/index.ts
@@ -156,14 +156,22 @@ async function main() {
     }
   } catch (err) {
     // F-1518: the Claude Agent SDK's message iterator can REJECT — not just
-    // yield an error `result` message — when the underlying `claude` CLI
-    // subprocess exits non-zero after already reporting an error result (an
-    // invalid API key is one way). Uncaught, that throws out of this `for
-    // await` with no handler above it, crashing the process from what
-    // `smoke-examples.mjs` sees as an indistinguishable uncaught rejection —
-    // identical text to the graceful path below, but never captured by it.
-    // Route it through the same exitCode=1 path so both shapes converge.
-    console.error(`\nagent errored: ${err instanceof Error ? err.message : String(err)}`);
+    // yield an error `result` message — when the underlying `claude` CLI exits
+    // non-zero (an invalid API key is one way; the SDK calls
+    // `inputStream.error()` on the stream being iterated). Uncaught, that threw
+    // out of this `for await` and killed the process with a raw Node stack
+    // instead of this example's own reporting, so route it through the same
+    // exitCode=1 path the graceful branch uses.
+    //
+    // Log the error OBJECT, never just `err.message`: Node prints name + stack
+    // + `[cause]`, and scripts/smoke-examples.mjs classifies this output by
+    // matching signatures that can live OUTSIDE the message — `AbortError` and
+    // `AI_LoadAPIKeyError` are error NAMES, and undici reports
+    // `ECONNREFUSED`/`ENOTFOUND` only on `err.cause`. Logging the message alone
+    // would show the classifier strictly less than the uncaught rejection did,
+    // turning a benign outbound abort into "no evidence it did any real work" —
+    // trading one nondeterministic red for another.
+    console.error("\nagent errored:", err);
     exitCode = 1;
   } finally {
     thinking.stop();

--- a/examples/pr-summary-review/src/index.ts
+++ b/examples/pr-summary-review/src/index.ts
@@ -154,6 +154,17 @@ async function main() {
         }
       }
     }
+  } catch (err) {
+    // F-1518: the Claude Agent SDK's message iterator can REJECT — not just
+    // yield an error `result` message — when the underlying `claude` CLI
+    // subprocess exits non-zero after already reporting an error result (an
+    // invalid API key is one way). Uncaught, that throws out of this `for
+    // await` with no handler above it, crashing the process from what
+    // `smoke-examples.mjs` sees as an indistinguishable uncaught rejection —
+    // identical text to the graceful path below, but never captured by it.
+    // Route it through the same exitCode=1 path so both shapes converge.
+    console.error(`\nagent errored: ${err instanceof Error ? err.message : String(err)}`);
+    exitCode = 1;
   } finally {
     thinking.stop();
     // The query() wrapper flushes telemetry on the terminal `result` message;

--- a/examples/support-triage/src/index.ts
+++ b/examples/support-triage/src/index.ts
@@ -274,22 +274,36 @@ async function main() {
   const run = query({ prompt: wiring.task, options: examineeOptions(mcpServers) });
 
   let exitCode = 0;
-  for await (const msg of run) {
-    if (msg.type === "assistant") {
-      logAssistantMessage(msg);
-    } else if (msg.type === "result") {
-      if (msg.subtype === "success") {
-        console.log("\n— agent finished —");
-        if (msg.result) console.log(msg.result);
-        console.log(
-          `(${msg.usage.input_tokens} in / ${msg.usage.output_tokens} out, $${msg.total_cost_usd.toFixed(4)})`
-        );
-      } else {
-        console.error(`\nagent stopped: ${msg.subtype}`);
-        for (const err of msg.errors) console.error(err);
-        exitCode = 1;
+  try {
+    for await (const msg of run) {
+      if (msg.type === "assistant") {
+        logAssistantMessage(msg);
+      } else if (msg.type === "result") {
+        if (msg.subtype === "success") {
+          console.log("\n— agent finished —");
+          if (msg.result) console.log(msg.result);
+          console.log(
+            `(${msg.usage.input_tokens} in / ${msg.usage.output_tokens} out, $${msg.total_cost_usd.toFixed(4)})`
+          );
+        } else {
+          console.error(`\nagent stopped: ${msg.subtype}`);
+          for (const err of msg.errors) console.error(err);
+          exitCode = 1;
+        }
       }
     }
+  } catch (err) {
+    // F-1518: the Claude Agent SDK's message iterator can REJECT — not just
+    // yield an error `result` message — when the underlying `claude` CLI
+    // subprocess exits non-zero after already reporting an error result (an
+    // invalid API key is one way). Uncaught, that throws out of this `for
+    // await` with no handler above it and no `finally` to even run
+    // `process.exit()` — the process crashes from what `smoke-examples.mjs`
+    // sees as an indistinguishable uncaught rejection, identical text to the
+    // graceful path above but never captured by it. Route it through the
+    // same exitCode=1 path so both shapes converge.
+    console.error(`\nagent errored: ${err instanceof Error ? err.message : String(err)}`);
+    exitCode = 1;
   }
 
   // Exit explicitly once the run result has been consumed: done means done —

--- a/examples/support-triage/src/index.ts
+++ b/examples/support-triage/src/index.ts
@@ -294,15 +294,22 @@ async function main() {
     }
   } catch (err) {
     // F-1518: the Claude Agent SDK's message iterator can REJECT — not just
-    // yield an error `result` message — when the underlying `claude` CLI
-    // subprocess exits non-zero after already reporting an error result (an
-    // invalid API key is one way). Uncaught, that throws out of this `for
-    // await` with no handler above it and no `finally` to even run
-    // `process.exit()` — the process crashes from what `smoke-examples.mjs`
-    // sees as an indistinguishable uncaught rejection, identical text to the
-    // graceful path above but never captured by it. Route it through the
-    // same exitCode=1 path so both shapes converge.
-    console.error(`\nagent errored: ${err instanceof Error ? err.message : String(err)}`);
+    // yield an error `result` message — when the underlying `claude` CLI exits
+    // non-zero (an invalid API key is one way; the SDK calls
+    // `inputStream.error()` on the stream being iterated). Uncaught, that threw
+    // out of this `for await` and killed the process with a raw Node stack
+    // instead of this example's own reporting, so route it through the same
+    // exitCode=1 path the graceful branch uses.
+    //
+    // Log the error OBJECT, never just `err.message`: Node prints name + stack
+    // + `[cause]`, and scripts/smoke-examples.mjs classifies this output by
+    // matching signatures that can live OUTSIDE the message — `AbortError` and
+    // `AI_LoadAPIKeyError` are error NAMES, and undici reports
+    // `ECONNREFUSED`/`ENOTFOUND` only on `err.cause`. Logging the message alone
+    // would show the classifier strictly less than the uncaught rejection did,
+    // turning a benign outbound abort into "no evidence it did any real work" —
+    // trading one nondeterministic red for another.
+    console.error("\nagent errored:", err);
     exitCode = 1;
   }
 

--- a/examples/triage-agent/src/index.ts
+++ b/examples/triage-agent/src/index.ts
@@ -172,6 +172,17 @@ async function main() {
         }
       }
     }
+  } catch (err) {
+    // F-1518: the Claude Agent SDK's message iterator can REJECT — not just
+    // yield an error `result` message — when the underlying `claude` CLI
+    // subprocess exits non-zero after already reporting an error result (an
+    // invalid API key is one way). Uncaught, that throws out of this `for
+    // await` with no handler above it, crashing the process from what
+    // `smoke-examples.mjs` sees as an indistinguishable uncaught rejection —
+    // identical text to the graceful path below, but never captured by it.
+    // Route it through the same exitCode=1 path so both shapes converge.
+    console.error(`\nagent errored: ${err instanceof Error ? err.message : String(err)}`);
+    exitCode = 1;
   } finally {
     thinking.stop();
   }

--- a/examples/triage-agent/src/index.ts
+++ b/examples/triage-agent/src/index.ts
@@ -174,14 +174,22 @@ async function main() {
     }
   } catch (err) {
     // F-1518: the Claude Agent SDK's message iterator can REJECT — not just
-    // yield an error `result` message — when the underlying `claude` CLI
-    // subprocess exits non-zero after already reporting an error result (an
-    // invalid API key is one way). Uncaught, that throws out of this `for
-    // await` with no handler above it, crashing the process from what
-    // `smoke-examples.mjs` sees as an indistinguishable uncaught rejection —
-    // identical text to the graceful path below, but never captured by it.
-    // Route it through the same exitCode=1 path so both shapes converge.
-    console.error(`\nagent errored: ${err instanceof Error ? err.message : String(err)}`);
+    // yield an error `result` message — when the underlying `claude` CLI exits
+    // non-zero (an invalid API key is one way; the SDK calls
+    // `inputStream.error()` on the stream being iterated). Uncaught, that threw
+    // out of this `for await` and killed the process with a raw Node stack
+    // instead of this example's own reporting, so route it through the same
+    // exitCode=1 path the graceful branch uses.
+    //
+    // Log the error OBJECT, never just `err.message`: Node prints name + stack
+    // + `[cause]`, and scripts/smoke-examples.mjs classifies this output by
+    // matching signatures that can live OUTSIDE the message — `AbortError` and
+    // `AI_LoadAPIKeyError` are error NAMES, and undici reports
+    // `ECONNREFUSED`/`ENOTFOUND` only on `err.cause`. Logging the message alone
+    // would show the classifier strictly less than the uncaught rejection did,
+    // turning a benign outbound abort into "no evidence it did any real work" —
+    // trading one nondeterministic red for another.
+    console.error("\nagent errored:", err);
     exitCode = 1;
   } finally {
     thinking.stop();

--- a/scripts/smoke-examples.mjs
+++ b/scripts/smoke-examples.mjs
@@ -307,6 +307,36 @@ export function assertAliveFloor({ live, okCount, total }) {
   };
 }
 
+// F-1518 — the counted-numerator property. `classifyLaunch()` already gives
+// every launch one of three named, counted outcomes (ok / reached / fail); the
+// gap this closes is a DIFFERENT failure mode, one level up: an example that
+// never reaches `classifyLaunch()` at all and so never lands in any of the
+// three buckets — the printed "N of M" total quietly shrinks to N-1 with
+// nothing saying the Mth example went MISSING rather than FAILED. Measured on
+// PR #417: the summary read "7 of 8" and named seven, and nothing said the
+// eighth (`pr-summary-agent`) had vanished rather than failed. Pure and
+// exported so the regression suite can assert it without spawning all eight
+// examples: feed it a discovered list and the names main()'s loop actually
+// produced a verdict for.
+//
+// Deliberately compares NAMES, not just lengths — a bug that drops one name
+// and double-reports another would net to the same length and hide behind a
+// count-only check, defeating the "naming the missing example" requirement.
+export function assertReportedCount(discoveredNames, reportedNames) {
+  const reported = new Set(reportedNames);
+  const missing = discoveredNames.filter((name) => !reported.has(name));
+  if (missing.length === 0) return { ok: true, message: null };
+  return {
+    ok: false,
+    message:
+      `${missing.length} of ${discoveredNames.length} discovered example(s) never reported a verdict at ` +
+      `all — neither OK, REACHED-OUTBOUND, nor FAILED: ${missing.join(", ")}. The count of examples ` +
+      `reporting must equal the count discovered; a launcher bug that drops one silently (an early ` +
+      `return/continue/break in main()'s loop, or smokeOne() rejecting instead of resolving) must red ` +
+      `naming exactly which example vanished, never shrink the "N of M" total without saying so.`,
+  };
+}
+
 export function discoverExamples(dir = examplesDir) {
   const found = [];
   for (const name of readdirSync(dir).sort()) {
@@ -502,9 +532,28 @@ async function main() {
   const failures = [];
   const reached = [];
   const oks = [];
+  // F-1518 — every name pushed here got an actual verdict below. Compared
+  // against `examples` after the loop so a name that never makes it into any
+  // bucket (this array, or oks/reached/failures) is named, not silently
+  // dropped from the "N of M" total.
+  const reportedNames = [];
   for (const name of examples) {
     process.stdout.write(`\n=== examples/${name} === `);
-    const result = await smokeOne(name);
+    let result;
+    try {
+      result = await smokeOne(name);
+    } catch (err) {
+      // smokeOne() is designed to always resolve — the SETTLE_MS timer, the
+      // child 'exit' handler, and the child 'error' handler each
+      // independently produce a verdict — but this loop must not itself
+      // become the next silent-drop bug. A rejection here is left OUT of
+      // reportedNames on purpose: assertReportedCount() below names it as
+      // missing rather than this catch inventing a verdict for work that
+      // never actually ran.
+      console.log(`did not report a verdict (runner threw: ${err instanceof Error ? err.message : String(err)})`);
+      continue;
+    }
+    reportedNames.push(name);
     const tail = result.output?.trim().split("\n").slice(-12).join("\n") ?? "";
     if (result.status === "ok") {
       console.log(`OK (${result.reason})`);
@@ -522,6 +571,8 @@ async function main() {
     }
   }
 
+  const reportedCount = assertReportedCount(examples, reportedNames);
+
   if (reached.length > 0) {
     console.log(
       `\n${reached.length} of ${examples.length} example(s) got as far as an outbound twin/model ` +
@@ -534,13 +585,18 @@ async function main() {
 
   const floor = assertAliveFloor({ live: LIVE, okCount: oks.length, total: examples.length });
 
-  if (failures.length > 0 || !floor.ok) {
+  if (failures.length > 0 || !reportedCount.ok || !floor.ok) {
     if (failures.length > 0) {
       console.error(
         `\nExamples that crash on launch or return with no evidence of real work: ` +
           failures.map((f) => `${f.name} (${f.reason})`).join("; "),
       );
     }
+    // F-1518 — a missing verdict is reported and reds independently of
+    // `failures`: it is a defect in THIS SCRIPT's own bookkeeping, not in the
+    // example, and folding it into "Examples that crash on launch" above
+    // would misname the fault.
+    if (!reportedCount.ok) console.error(`\n${reportedCount.message}`);
     if (!floor.ok) console.error(`\n${floor.message}`);
     process.exit(1);
   }

--- a/scripts/smoke-examples.mjs
+++ b/scripts/smoke-examples.mjs
@@ -458,11 +458,32 @@ function smokeOne(name) {
       resolvePromise({ name, output, ...verdict });
     };
 
+    // Classify on 'close', not 'exit'. Node only guarantees the piped stdio
+    // streams are drained on 'close'; 'exit' can fire with the child's final
+    // write still unread, and the whole verdict is a regex over `output` — so
+    // an example whose only BENIGN_FAILURE_SIGNATURES match sits in its last
+    // stderr line (`agent errored: … ECONNREFUSED`, written immediately before
+    // `process.exit(1)`) can be read as "no outbound-call failure in its
+    // output" and FAIL on one run and REACHED-OUTBOUND on the next, from the
+    // same commit. 'exit' still records HOW it exited, because 'close' carries
+    // the same code/signal but a lingering grandchild holding the pipe open can
+    // delay it past SETTLE_MS — and a child that has already exited must be
+    // classified on its exit code, never as "still running at the settle",
+    // which would turn a fast exit into a false OK.
+    let exited = null;
     const timer = setTimeout(() => {
-      finish(classifyLaunch({ output, stillRunningAtSettle: true }));
+      finish(
+        exited
+          ? classifyLaunch({ output, stillRunningAtSettle: false, ...exited })
+          : classifyLaunch({ output, stillRunningAtSettle: true }),
+      );
     }, SETTLE_MS);
 
     child.on("exit", (code, signal) => {
+      exited = { exitCode: code, signal };
+    });
+
+    child.on("close", (code, signal) => {
       finish(classifyLaunch({ output, stillRunningAtSettle: false, exitCode: code, signal }));
     });
 
@@ -532,11 +553,6 @@ async function main() {
   const failures = [];
   const reached = [];
   const oks = [];
-  // F-1518 — every name pushed here got an actual verdict below. Compared
-  // against `examples` after the loop so a name that never makes it into any
-  // bucket (this array, or oks/reached/failures) is named, not silently
-  // dropped from the "N of M" total.
-  const reportedNames = [];
   for (const name of examples) {
     process.stdout.write(`\n=== examples/${name} === `);
     let result;
@@ -544,16 +560,14 @@ async function main() {
       result = await smokeOne(name);
     } catch (err) {
       // smokeOne() is designed to always resolve — the SETTLE_MS timer, the
-      // child 'exit' handler, and the child 'error' handler each
+      // child 'close' handler, and the child 'error' handler each
       // independently produce a verdict — but this loop must not itself
-      // become the next silent-drop bug. A rejection here is left OUT of
-      // reportedNames on purpose: assertReportedCount() below names it as
-      // missing rather than this catch inventing a verdict for work that
-      // never actually ran.
+      // become the next silent-drop bug. This catch deliberately does NOT
+      // invent a verdict for work that never ran: the name lands in no bucket,
+      // so assertReportedCount() below names it as missing.
       console.log(`did not report a verdict (runner threw: ${err instanceof Error ? err.message : String(err)})`);
       continue;
     }
-    reportedNames.push(name);
     const tail = result.output?.trim().split("\n").slice(-12).join("\n") ?? "";
     if (result.status === "ok") {
       console.log(`OK (${result.reason})`);
@@ -571,7 +585,17 @@ async function main() {
     }
   }
 
-  const reportedCount = assertReportedCount(examples, reportedNames);
+  // F-1518 — the reported set is DERIVED from the three verdict buckets, never
+  // tracked alongside them. A separate `reportedNames.push(name)` next to the
+  // `await` would mark a name reported before the ok/reached/fail dispatch had
+  // put it anywhere, so the next silent-drop bug — a `continue` added inside
+  // the dispatch, or a fourth `status` no branch matches — would still net
+  // `ok: true` and still shrink the "N of M" total unannounced. Reading the
+  // buckets makes the assertion check the thing the summary actually counts.
+  const reportedCount = assertReportedCount(
+    examples,
+    [...oks, ...reached, ...failures].map((r) => r.name),
+  );
 
   if (reached.length > 0) {
     console.log(

--- a/scripts/smoke-examples.test.mjs
+++ b/scripts/smoke-examples.test.mjs
@@ -26,6 +26,7 @@ import {
   classifyLaunch,
   discoverExamples,
   assertAliveFloor,
+  assertReportedCount,
   missingLiveEnv,
   resolveLiveFlag,
   launchEnv,
@@ -416,6 +417,56 @@ function check(name, got, want) {
     }).reason.includes("credentialed leg"),
     "a non-zero exit must not be excused as a fast correct completion",
   );
+}
+
+// ── F-1518: the counted-numerator property ──────────────────────────────────
+// Measured on PR #417: the summary read "7 of 8" and named seven, and nothing
+// said the eighth (`pr-summary-agent`) had gone MISSING rather than FAILED —
+// classifyLaunch()'s three named outcomes (ok/reached/fail) are worthless if
+// main()'s loop can silently drop an example before it ever reaches them.
+{
+  const all8 = [
+    "gmail-retry-notify",
+    "merge-agent",
+    "minimal-viktor",
+    "minimal-viktor-langgraph",
+    "pr-summary-agent",
+    "pr-summary-review",
+    "support-triage",
+    "triage-agent",
+  ];
+  const clean = assertReportedCount(all8, all8);
+  check("every discovered example reporting is a pass", clean.ok, true);
+  check("a clean pass carries no message", clean.message, null);
+
+  // The exact PR #417 shape: one discovered example silently produced no
+  // verdict at all, and the summary must red naming it — not "failed",
+  // "missing".
+  const oneVanished = assertReportedCount(all8, all8.filter((n) => n !== "pr-summary-agent"));
+  check("one missing example fails the count assertion", oneVanished.ok, false);
+  assert.match(oneVanished.message, /pr-summary-agent/);
+  assert.match(oneVanished.message, /1 of 8/);
+  // Names it as absent from every existing bucket, never as belonging to one.
+  assert.match(oneVanished.message, /neither OK, REACHED-OUTBOUND, nor FAILED/);
+
+  // Compares NAMES, not just lengths: dropping one example and (by some other
+  // bug) reporting an unrelated name twice must still be caught, because the
+  // two lengths would otherwise net out even.
+  const droppedAndDuplicated = assertReportedCount(all8, [
+    ...all8.filter((n) => n !== "triage-agent"),
+    "merge-agent", // duplicate report, same length as the 8 discovered
+  ]);
+  check(
+    "a same-length report that drops one name is still caught",
+    droppedAndDuplicated.ok,
+    false,
+  );
+  assert.match(droppedAndDuplicated.message, /triage-agent/);
+
+  // Zero discovered, zero reported is vacuously fine — discoverExamples()'s
+  // own zero-examples case is a separate hard failure (break-on-purpose 4
+  // above), not this assertion's job to catch.
+  check("nothing discovered, nothing reported is a pass", assertReportedCount([], []).ok, true);
 }
 
 if (failures > 0) {


### PR DESCRIPTION
## The nondeterminism

`smoke:examples` (`scripts/smoke-examples.mjs`) runs inside `typecheck-test`, a required check, and redded on PRs whose diff touched nothing under `examples/`.

PR #417 (diff confined to `scripts/ci/`, `.github/workflows/repo-policy.yml`, `config/`, `AGENTS.md`):

- Run 31711971267, first attempt: **7 of 8**, job exit 1. `pr-summary-agent` was absent from the verdict list entirely — no OK, no REACHED-OUTBOUND, no FAILED line for it.
- Same run, re-run of failed jobs: **8 of 8**, green.
- `main` at `7a8c37c3`, identical tree: 8 of 8, green.

On the failing attempt, `pr-summary-agent` crashed with an uncaught rejection:

```
Error: Claude Code returned an error result: Invalid API key · Fix external API key
    at qh.readMessages (node_modules/@anthropic-ai/claude-agent-sdk/sdk.mjs:108:23538)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
Node.js v24.18.0
```

Its seven siblings classified the identical rejected key as `REACHED-OUTBOUND (exited code 1 at an outbound call — model provider rejected the invalid key)`.

## Root cause

The Claude Agent SDK's exposed message iterator can **reject** the consumer's `for await` — not just yield an error `result` message — when the underlying `claude` CLI subprocess exits non-zero *after* it already reported an error result (an invalid API key is one way this happens). Whether a given run hits the graceful path (a `result` message with `subtype !== "success"`, handled by the example's own `else { exitCode = 1 }` branch) or the rejecting path (an exception thrown out of `for await`) is a race in the SDK/CLI, not something the example controls.

`pr-summary-agent`, `pr-summary-review`, `triage-agent`, and `support-triage` all iterate this stream with a bare `for await` and **no catch** — `support-triage` didn't even have a `try/finally`. Whichever example happened to hit the rejecting path on a given run crashed uncaught, with nothing above it to convert the crash into a normal exit. I grepped every example under `examples/*/src/index.ts` for this shape before fixing only the one the ticket names: all four `query()`-consuming examples shared it (the other four — `merge-agent`, `gmail-retry-notify`, `minimal-viktor`, `minimal-viktor-langgraph` — either don't iterate an async stream this way or already have a `catch`). All four get the same fix: wrap the loop in `try/catch` and route a rejected iteration through the identical `exitCode = 1` path the graceful branch already uses, so both shapes always converge to the same observable outcome.

There's no single shared call site to patch once — these are four independent, standalone npm packages (own lockfiles, `examples/support-triage` deliberately pins the adapter by exact published version for `npx degit`-ability) that only share `@pome-sh/adapter-claude-sdk`'s `query()`, which passes the SDK's messages through verbatim by design; rewriting a genuine iterator rejection into a synthetic message there would misrepresent the adapter's "yields every SDK message verbatim" contract. So the fix is the same four-line guard duplicated at each of the four call sites.

## The counted-numerator property

Independent of the root cause: nothing verified that the number of examples `smoke-examples.mjs` reported a verdict for equaled the number it discovered. A launcher bug dropping one silently reads as "N of M" with no acknowledgment of the gap — exactly PR #417's symptom.

`scripts/smoke-examples.mjs` now tracks which discovered examples actually received a verdict (`reportedNames`) and asserts that set equals the discovered set via a new pure, exported `assertReportedCount(discoveredNames, reportedNames)`. A mismatch reds naming exactly which example(s) vanished — a distinct outcome, never folded into OK/REACHED-OUTBOUND/FAILED, and never counted toward `assertAliveFloor()`'s alive-at-settle floor for the credentialed (`SMOKE_EXAMPLES_LIVE=1`) leg (it isn't added to `oks`, so `okCount` is unaffected).

## Verification

**1. Local run** (no valid model key, but this sandbox has an authenticated `claude` login, so 4/8 land on "still running" rather than instant-reject — the uncredentialed shape the ticket describes as expected without a login):

```
Launch-smoking 8 example(s): gmail-retry-notify, merge-agent, minimal-viktor, minimal-viktor-langgraph, pr-summary-agent, pr-summary-review, support-triage, triage-agent

=== examples/gmail-retry-notify === REACHED-OUTBOUND (exited code 1 at an outbound call — connection refused)
=== examples/merge-agent === REACHED-OUTBOUND (exited code 1 at an outbound call — AI Gateway rejected the invalid key)
=== examples/minimal-viktor === REACHED-OUTBOUND (exited code 1 at an outbound call — AI Gateway rejected the invalid key)
=== examples/minimal-viktor-langgraph === REACHED-OUTBOUND (exited code 1 at an outbound call — network request failed)
=== examples/pr-summary-agent === OK (still running after 5000ms)
=== examples/pr-summary-review === OK (still running after 5000ms)
=== examples/support-triage === OK (still running after 5000ms)
=== examples/triage-agent === OK (still running after 5000ms)

4 of 8 example(s) got as far as an outbound twin/model call and failed THERE ...

All 8 examples reached real work: 4 still running at the settle, 4 failed at an outbound call.
```
Exit 0.

**2. No-verdict / crash-before-outbound path reds distinctly.** Temporarily threw at the top of `triage-agent`'s `main()`, before any outbound call, reverted after capturing output:

```
=== examples/triage-agent === FAILED (exited code 1 before settling (5000ms) with no TDZ and no outbound-call
failure in its output — it returned without evidence it did any real work. Either the example is broken
(the likely case: a wrong parse, an early return, or a swallowed error read as an empty result), or it
failed on a genuinely benign outbound error this gate does not recognize yet ...)
```
Distinct from both `OK` and `REACHED-OUTBOUND`, and counted in the final `Examples that crash on launch or return with no evidence of real work:` line. `git status --porcelain` was clean after reverting.

**3. Discovered-vs-reported count mismatch reds naming the missing example.** Temporarily skipped pushing `merge-agent` into `reportedNames`, reverted after capturing output:

```
1 of 8 discovered example(s) never reported a verdict at all — neither OK, REACHED-OUTBOUND, nor FAILED:
merge-agent. The count of examples reporting must equal the count discovered; a launcher bug that drops
one silently (an early return/continue/break in main()'s loop, or smokeOne() rejecting instead of
resolving) must red naming exactly which example vanished, never shrink the "N of M" total without
saying so.
```
`node` exit code 1. `git status --porcelain` clean after reverting.

**4. Regression suite.** `node scripts/smoke-examples.test.mjs` — extended in place with cases for `assertReportedCount` (clean pass, one name missing, a same-length report that drops one name while duplicating another so length alone can't hide it, zero/zero) — all checks pass, including every pre-existing F-1478/F-1486 case. Also ran `npm run typecheck:examples` (all 8 clean, including the four edited files and the pin↔registry parity check), `npm run lint:import-meta-main` + `scripts/lint-no-bare-import-meta-main.test.mjs` (unaffected — no entry-guard lines touched), and `npm run gate:no-eval` (passes — no eval/scoring vocabulary introduced).

**5. Entry guards.** No entry guard was touched by this change; all four edited files still use the sanctioned `realpathSync`-on-both-sides form, confirmed unaffected by `lint-no-bare-import-meta-main.test.mjs` above.

## Not done, and why

`merge-agent` and `gmail-retry-notify` use the Vercel AI SDK's `generateText()` directly (`await`ed in a normal synchronous chain, not an iterated async stream), so an uncaught rejection there already propagates as an ordinary top-level exception with the crashing frame's own stack — no detached microtask, no race, and it already classifies correctly (verified locally: both land on `REACHED-OUTBOUND` with `at async main` in the stack). `minimal-viktor` and `minimal-viktor-langgraph` already wrap their model calls in `try/catch`. None of the four needed this fix.

I did not add a table row to `AGENTS.md`'s P8 invariants section: none of the existing rows describe `smoke:examples`' internal classifier contract (that lives in the extensive header comments in `scripts/smoke-examples.mjs` itself, per this repo's existing pattern from F-1478/F-1486), and this change doesn't alter the one row that does mention the job (`typecheck-test` always reports on PRs — a scope-step guarantee, untouched here).