### PR TITLE
fix(examples): repin support-triage to the published adapter 0.3.6

### DIFF
--- a/examples/support-triage/package-lock.json
+++ b/examples/support-triage/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.215",
-        "@pome-sh/adapter-claude-sdk": "0.3.5"
+        "@pome-sh/adapter-claude-sdk": "0.3.6"
       },
       "devDependencies": {
         "@types/node": "^25.9.5",
@@ -890,9 +890,9 @@
       }
     },
     "node_modules/@pome-sh/adapter-claude-sdk": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@pome-sh/adapter-claude-sdk/-/adapter-claude-sdk-0.3.5.tgz",
-      "integrity": "sha512-E9b1UF/NU8inNgY9aMI8rPhe+0JOesskpSyd59W6/oqTPwkhtR5swMlUGqdQH94bz5YxcN+Qhz1ruMBkZoFb/g==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@pome-sh/adapter-claude-sdk/-/adapter-claude-sdk-0.3.6.tgz",
+      "integrity": "sha512-uXWXhqhMP/0UbDCfNqZub2ZI5I+bZgcjYv4iVBL9BHEmvANw6QpqsGSMEqGOkHwlHRWxnlSEYb85/yth1lxnBg==",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.221.0",

--- a/examples/support-triage/package.json
+++ b/examples/support-triage/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.215",
-    "@pome-sh/adapter-claude-sdk": "0.3.5"
+    "@pome-sh/adapter-claude-sdk": "0.3.6"
   },
   "devDependencies": {
     "@types/node": "^25.9.5",


### PR DESCRIPTION
`main` is red at `95240f9`.

The release-bump commit published `@pome-sh/adapter-claude-sdk 0.3.6` and moved the workspace version, but did not re-pin `examples/support-triage`, which still asked for `0.3.5`:

```
❌ published pin DRIFT in 1 example(s):
  examples/support-triage (dependencies.@pome-sh/adapter-claude-sdk): pins 0.3.5,
  but the workspace sibling is 0.3.6 and 0.3.6 is published. Re-pin to 0.3.6.
```

This is F-1483's registry-parity gate firing exactly as designed — the hero example must not resolve a stale published adapter. It blocks `main` and every branch cut from it.

Pin bumped to `0.3.6` and the example lockfile regenerated. `check-example-pins-published.mjs` now exits 0.

This is the **second** occurrence today; `0.3.4` required the same one-line follow-up this morning (#395). The pipeline gap — `allocate-version.yml` publishes an adapter without re-pinning the examples that consume it from the registry — is filed as F-1520 and is not fixed here, because `main` should not stay red while that is designed.