### PR TITLE
Auto-re-pin registry-pinning examples in the version allocator (F-1520)

### DIFF
--- a/.github/workflows/allocate-version.yml
+++ b/.github/workflows/allocate-version.yml
@@ -87,8 +87,13 @@ on:
       - "scripts/ci/publish-relevance.mjs"
       # F-1520 — the allocator now imports planExampleRepins from here, so a
       # change to it is a change to the allocator's own wiring, not just to
-      # the standalone gate that also uses it.
+      # the standalone gate that also uses it. The second entry is the TRANSITIVE
+      # half of that import: check-example-pins-published.mjs imports
+      # loadWorkspaceMembers from it, so the allocator's behaviour on main
+      # depends on it too — listing only the direct import would leave the arm
+      # blind to exactly the PR that changes how examples are discovered.
       - "scripts/check-example-pins-published.mjs"
+      - "scripts/check-workspace-pins-match-workspace.mjs"
       - ".github/workflows/allocate-version.yml"
 
 # One allocation at a time, and never cancelled mid-write: the number is a

--- a/.github/workflows/allocate-version.yml
+++ b/.github/workflows/allocate-version.yml
@@ -85,6 +85,10 @@ on:
       - "scripts/ci/allocate-release-versions.test.mjs"
       - "scripts/ci/changelog-entry.mjs"
       - "scripts/ci/publish-relevance.mjs"
+      # F-1520 — the allocator now imports planExampleRepins from here, so a
+      # change to it is a change to the allocator's own wiring, not just to
+      # the standalone gate that also uses it.
+      - "scripts/check-example-pins-published.mjs"
       - ".github/workflows/allocate-version.yml"
 
 # One allocation at a time, and never cancelled mid-write: the number is a

--- a/scripts/check-example-pins-published.mjs
+++ b/scripts/check-example-pins-published.mjs
@@ -197,6 +197,69 @@ export function checkExamplePinsPublished(pins, npmView = defaultNpmView) {
 }
 
 /**
+ * F-1520 — the write-side of this gate's own read-side logic. `checkExample
+ * PinsPublished`'s `violations` ARE, by construction, the only pins safe to
+ * rewrite automatically: the sibling is confirmed PUBLISHED (an `npm view`
+ * that just returned a real answer), so `npm install --package-lock-only`
+ * against it can succeed for real, unlike a version this same push is still in
+ * the middle of allocating (see the header of `allocate-release-versions.mjs`'s
+ * `planAllocations` for why a freshly-bumped-in-this-run version must NOT be
+ * repinned to here — it isn't on the registry yet).
+ *
+ * Returns one entry per example whose pin can be safely corrected: the
+ * rewritten `package.json` text (a plain textual substitution, matching
+ * `allocate-release-versions.mjs`'s own `rewriteVersion` — round-tripping
+ * through `JSON.stringify` would lose formatting) plus the shell command that
+ * regenerates that example's lockfile against the now-confirmed-published
+ * version. Nothing here executes the command or writes the file; the caller
+ * (`allocate-release-versions.mjs`) folds both into the same commit it already
+ * builds.
+ *
+ * Silently produces nothing when `repoRoot` has no `package.json` or no
+ * `examples/` — the throwaway git fixtures `allocate-release-versions.test.mjs`
+ * builds are neither, and this function is called unconditionally from every
+ * plan, not just ones that touch examples.
+ */
+export function planExampleRepins(repoRoot, npmView = defaultNpmView) {
+  if (!existsSync(join(repoRoot, "package.json")) || !existsSync(join(repoRoot, "examples"))) return [];
+
+  const { exact } = discoverExampleSiblingDeps(repoRoot);
+  const { violations } = checkExamplePinsPublished(exact, npmView);
+
+  return violations.map((v) => {
+    const manifestRelPath = `examples/${v.example}/package.json`;
+    const contents = readFileSync(join(repoRoot, manifestRelPath), "utf8");
+    // A regex rather than a literal-string match (unlike this file's siblings'
+    // `"version": "x"` searches): a hand-formatted `package.json` always has a
+    // space after the colon, but nothing in npm requires one, so matching only
+    // the formatted shape would silently find zero occurrences on a compact
+    // file instead of one — the same "refuse to guess" failure this function
+    // already raises, just for a formatting reason no author intended.
+    const escape = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const pattern = new RegExp(`"${escape(v.dep)}"\\s*:\\s*"${escape(v.pin)}"`, "g");
+    const occurrences = contents.match(pattern)?.length ?? 0;
+    if (occurrences !== 1) {
+      throw new Error(
+        `${manifestRelPath}: expected exactly one \`"${v.dep}": "${v.pin}"\`, found ${occurrences}. Refusing to ` +
+          "guess which one is the pin drifted out from under.",
+      );
+    }
+    const replacement = contents.replace(pattern, (match) => match.replace(v.pin, v.workspaceVersion));
+    return {
+      example: v.example,
+      dep: v.dep,
+      from: v.pin,
+      to: v.workspaceVersion,
+      writes: [{ path: manifestRelPath, contents: replacement }],
+      // `--package-lock-only`: this workflow never runs the example itself, so
+      // there is nothing to gain from a real `node_modules` and a real install
+      // would need dev toolchains (tsx, vitest) this job has no other use for.
+      regenerate: [`(cd examples/${v.example} && npm install --package-lock-only --no-audit --no-fund)`],
+    };
+  });
+}
+
+/**
  * Run discovery + the registry check and print a report in the shape
  * `typecheck-examples.mjs` expects: throws on zero eligible pins (a check
  * examining nothing must not report a pass), prints the skip count even when

--- a/scripts/check-example-pins-published.mjs
+++ b/scripts/check-example-pins-published.mjs
@@ -197,6 +197,19 @@ export function checkExamplePinsPublished(pins, npmView = defaultNpmView) {
 }
 
 /**
+ * The write side's registry budget, deliberately ONE attempt where the read
+ * side takes three. `defaultNpmView`'s retry exists because the gate is a
+ * REQUIRED status check that must not flake on a transient 5xx. The re-pin has
+ * the opposite cost function: it runs inside `allocate-version.yml`'s three-
+ * attempt push loop, synchronously, per exact pin, in a `timeout-minutes: 20`
+ * job that also runs `npm ci` — so three attempts × a 60s timeout × the backoff
+ * × the push retries is minutes of stalling in the release path, and it buys
+ * nothing, because a missed re-pin costs exactly one cycle and the next run
+ * plans it again. Cheap to lose, expensive to wait for.
+ */
+const writeSideNpmView = (name, version) => defaultNpmView(name, version, { attempts: 1 });
+
+/**
  * F-1520 — the write-side of this gate's own read-side logic. `checkExample
  * PinsPublished`'s `violations` ARE, by construction, the only pins safe to
  * rewrite automatically: the sibling is confirmed PUBLISHED (an `npm view`
@@ -220,11 +233,23 @@ export function checkExamplePinsPublished(pins, npmView = defaultNpmView) {
  * builds are neither, and this function is called unconditionally from every
  * plan, not just ones that touch examples.
  */
-export function planExampleRepins(repoRoot, npmView = defaultNpmView) {
+export function planExampleRepins(repoRoot, npmView = writeSideNpmView) {
   if (!existsSync(join(repoRoot, "package.json")) || !existsSync(join(repoRoot, "examples"))) return [];
 
   const { exact } = discoverExampleSiblingDeps(repoRoot);
-  const { violations } = checkExamplePinsPublished(exact, npmView);
+  const { violations, errors } = checkExamplePinsPublished(exact, npmView);
+
+  if (errors.length > 0) {
+    // `checkExamplePinsPublished` is emphatic that a non-E404 answer is a hard
+    // failure and never a skip. The write side cannot honour that literally — a
+    // registry outage must not stop a release — but it must not launder it into
+    // "nothing drifted" either, which is what silently dropping `errors` would
+    // do. Say so; the read-side gate is the one that hard-fails.
+    console.warn(
+      `::warning::${errors.length} example pin(s) could not be checked against the registry, so they are NOT ` +
+        `re-pinned in this run: ${errors.map((e) => `examples/${e.example} ${e.dep}@${e.workspaceVersion} (${e.detail})`).join("; ")}`,
+    );
+  }
 
   // A regex rather than a literal-string match (unlike this file's siblings'
   // `"version": "x"` searches): a hand-formatted `package.json` always has a
@@ -274,7 +299,9 @@ export function planExampleRepins(repoRoot, npmView = defaultNpmView) {
       // `--package-lock-only`: this workflow never runs the example itself, so
       // there is nothing to gain from a real `node_modules` and a real install
       // would need dev toolchains (tsx, vitest) this job has no other use for.
-      regenerate: [`(cd examples/${v.example} && npm install --package-lock-only --no-audit --no-fund)`],
+      // The path is QUOTED: `v.example` is a directory name off `readdirSync`,
+      // and this string is `bash`ed by a job holding a write-capable App token.
+      regenerate: [`(cd "examples/${v.example}" && npm install --package-lock-only --no-audit --no-fund)`],
     });
   }
   return repins;

--- a/scripts/check-example-pins-published.mjs
+++ b/scripts/check-example-pins-published.mjs
@@ -226,26 +226,46 @@ export function planExampleRepins(repoRoot, npmView = defaultNpmView) {
   const { exact } = discoverExampleSiblingDeps(repoRoot);
   const { violations } = checkExamplePinsPublished(exact, npmView);
 
-  return violations.map((v) => {
+  // A regex rather than a literal-string match (unlike this file's siblings'
+  // `"version": "x"` searches): a hand-formatted `package.json` always has a
+  // space after the colon, but nothing in npm requires one, so matching only
+  // the formatted shape would silently find zero occurrences on a compact file
+  // instead of one — a formatting failure no author intended. The capture
+  // groups mean only the pin's own bytes are replaced, never a coincidental
+  // earlier occurrence of the same string inside the matched text.
+  const escape = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+  // One example can carry TWO drifted `@pome-sh/*` pins, and `applyAllocations`
+  // writes entries in order, so last write wins per path: each entry's
+  // `contents` must therefore already carry every EARLIER substitution to the
+  // same manifest, or the first repin is silently dropped while the commit
+  // message still claims it — the read-side gate would then keep reddening on a
+  // drift the commit says it fixed.
+  const latest = new Map();
+  const repins = [];
+  for (const v of violations) {
     const manifestRelPath = `examples/${v.example}/package.json`;
-    const contents = readFileSync(join(repoRoot, manifestRelPath), "utf8");
-    // A regex rather than a literal-string match (unlike this file's siblings'
-    // `"version": "x"` searches): a hand-formatted `package.json` always has a
-    // space after the colon, but nothing in npm requires one, so matching only
-    // the formatted shape would silently find zero occurrences on a compact
-    // file instead of one — the same "refuse to guess" failure this function
-    // already raises, just for a formatting reason no author intended.
-    const escape = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const pattern = new RegExp(`"${escape(v.dep)}"\\s*:\\s*"${escape(v.pin)}"`, "g");
+    const contents = latest.get(manifestRelPath) ?? readFileSync(join(repoRoot, manifestRelPath), "utf8");
+    const pattern = new RegExp(`("${escape(v.dep)}"\\s*:\\s*")${escape(v.pin)}(")`, "g");
     const occurrences = contents.match(pattern)?.length ?? 0;
     if (occurrences !== 1) {
-      throw new Error(
-        `${manifestRelPath}: expected exactly one \`"${v.dep}": "${v.pin}"\`, found ${occurrences}. Refusing to ` +
-          "guess which one is the pin drifted out from under.",
+      // Deliberately NOT a throw. This runs inside `planAllocations`, on every
+      // push to `main`, so throwing would stop EVERY package's release over one
+      // ambiguous example manifest (a `"@pome-sh/x": "<pin>"` repeated in
+      // `overrides`, or in a second install field) — a repo-wide release outage
+      // caused by the thing meant to remove a one-line PR. Skip this one pin
+      // instead: `reportExamplePinParity` still reds on it, so it cannot go
+      // silent, and a human re-pins it the way they did before F-1520.
+      console.warn(
+        `::warning::${manifestRelPath}: expected exactly one \`"${v.dep}": "${v.pin}"\`, found ${occurrences} — ` +
+          "refusing to guess which one is the pin, so it is NOT re-pinned automatically. " +
+          "check-example-pins-published.mjs keeps reporting the drift until it is fixed by hand.",
       );
+      continue;
     }
-    const replacement = contents.replace(pattern, (match) => match.replace(v.pin, v.workspaceVersion));
-    return {
+    const replacement = contents.replace(pattern, `$1${v.workspaceVersion}$2`);
+    latest.set(manifestRelPath, replacement);
+    repins.push({
       example: v.example,
       dep: v.dep,
       from: v.pin,
@@ -255,8 +275,9 @@ export function planExampleRepins(repoRoot, npmView = defaultNpmView) {
       // there is nothing to gain from a real `node_modules` and a real install
       // would need dev toolchains (tsx, vitest) this job has no other use for.
       regenerate: [`(cd examples/${v.example} && npm install --package-lock-only --no-audit --no-fund)`],
-    };
-  });
+    });
+  }
+  return repins;
 }
 
 /**

--- a/scripts/check-example-pins-published.test.mjs
+++ b/scripts/check-example-pins-published.test.mjs
@@ -401,6 +401,107 @@ const pin = { example: "support-triage", field: "dependencies", dep: "@pome-sh/a
     }
   }
 
+  // 16b. TWO drifted pins in ONE example. `applyAllocations` writes a plan's
+  // entries in order and last write wins per path, so the LAST entry for a
+  // manifest must already carry every earlier substitution — otherwise the
+  // first repin is silently dropped while the commit message still claims it,
+  // and the read-side gate keeps reddening on a drift the commit says it fixed.
+  {
+    const root = mkdtempSync(join(tmpdir(), "example-pins-two-"));
+    writeFileSync(join(root, "package.json"), JSON.stringify({ name: "root", workspaces: ["packages/*"] }));
+    for (const [dir, name, version] of [
+      ["adapter-claude-sdk", "@pome-sh/adapter-claude-sdk", "0.3.6"],
+      ["checks", "@pome-sh/checks", "1.2.0"],
+    ]) {
+      mkdirSync(join(root, "packages", dir), { recursive: true });
+      writeFileSync(join(root, "packages", dir, "package.json"), JSON.stringify({ name, version }));
+    }
+    mkdirSync(join(root, "examples", "support-triage"), { recursive: true });
+    writeFileSync(
+      join(root, "examples", "support-triage", "package.json"),
+      JSON.stringify({
+        name: "support-triage-example",
+        dependencies: { "@pome-sh/adapter-claude-sdk": "0.3.5", "@pome-sh/checks": "1.1.0" },
+      }),
+    );
+    const repins = planExampleRepins(root, () => ({ status: "published" }));
+    // Whichever entry lands last for that path is what ends up on disk.
+    const lastForPath = repins.filter((r) => r.writes[0].path === "examples/support-triage/package.json").at(-1);
+    const onDisk = JSON.parse(lastForPath?.writes[0].contents ?? "{}");
+    if (
+      repins.length === 2 &&
+      onDisk.dependencies["@pome-sh/adapter-claude-sdk"] === "0.3.6" &&
+      onDisk.dependencies["@pome-sh/checks"] === "1.2.0"
+    ) {
+      pass("16b. two drifted pins in one example both survive the last-write-wins apply");
+    } else {
+      fail("16b. two drifted pins in one example both survive the last-write-wins apply", JSON.stringify({ repins, onDisk }));
+    }
+  }
+
+  // 16c. An ambiguous manifest — the same `"<dep>": "<pin>"` bytes repeated in
+  // an `overrides` block, which npm accepts and this gate does not read as a
+  // second install field. `planExampleRepins` runs inside `planAllocations` on
+  // EVERY push to main, so throwing here would stop every package's release
+  // over one example manifest. It must skip that pin and keep going, leaving
+  // the read-side gate to red on it.
+  {
+    const root = mkdtempSync(join(tmpdir(), "example-pins-ambig-"));
+    writeFileSync(join(root, "package.json"), JSON.stringify({ name: "root", workspaces: ["packages/*"] }));
+    mkdirSync(join(root, "packages", "adapter-claude-sdk"), { recursive: true });
+    writeFileSync(
+      join(root, "packages", "adapter-claude-sdk", "package.json"),
+      JSON.stringify({ name: "@pome-sh/adapter-claude-sdk", version: "0.3.6" }),
+    );
+    mkdirSync(join(root, "examples", "support-triage"), { recursive: true });
+    writeFileSync(
+      join(root, "examples", "support-triage", "package.json"),
+      JSON.stringify({
+        name: "support-triage-example",
+        dependencies: { "@pome-sh/adapter-claude-sdk": "0.3.5" },
+        overrides: { "@pome-sh/adapter-claude-sdk": "0.3.5" },
+      }),
+    );
+    let threw = null;
+    let repins = null;
+    try {
+      repins = planExampleRepins(root, () => ({ status: "published" }));
+    } catch (e) {
+      threw = e;
+    }
+    // The gate itself must still call it drift — skipping the WRITE must never
+    // skip the READ.
+    const { violations } = checkExamplePinsPublished(discoverExampleSiblingDeps(root).exact, () => ({
+      status: "published",
+    }));
+    if (threw === null && repins?.length === 0 && violations.length === 1) {
+      pass("16c. an ambiguous pin is skipped, not thrown on, and still reds the read-side gate");
+    } else {
+      fail("16c. an ambiguous pin is skipped, not thrown on, and still reds the read-side gate", String(threw ?? JSON.stringify({ repins, violations })));
+    }
+  }
+
+  // 16d. …and one ambiguous pin must not cost a DIFFERENT example its repin.
+  {
+    const root = fixture({
+      workspaceVersion: "0.3.6",
+      examplePin: "0.3.5",
+      extraExamples: {
+        "ambiguous-example": {
+          name: "ambiguous-example",
+          dependencies: { "@pome-sh/adapter-claude-sdk": "0.3.4" },
+          overrides: { "@pome-sh/adapter-claude-sdk": "0.3.4" },
+        },
+      },
+    });
+    const repins = planExampleRepins(root, () => ({ status: "published" }));
+    if (repins.length === 1 && repins[0].example === "support-triage" && repins[0].to === "0.3.6") {
+      pass("16d. an ambiguous example does not block a clean one in the same run");
+    } else {
+      fail("16d. an ambiguous example does not block a clean one in the same run", JSON.stringify(repins));
+    }
+  }
+
   // 16. No `package.json` at the repo root (a throwaway fixture, like
   // allocate-release-versions.test.mjs's) — must return empty, not throw.
   {

--- a/scripts/check-example-pins-published.test.mjs
+++ b/scripts/check-example-pins-published.test.mjs
@@ -349,7 +349,8 @@ const pin = { example: "support-triage", field: "dependencies", dep: "@pome-sh/a
       repins[0].writes[0].path === "examples/support-triage/package.json" &&
       JSON.parse(repins[0].writes[0].contents).dependencies["@pome-sh/adapter-claude-sdk"] === "0.3.6" &&
       repins[0].regenerate.length === 1 &&
-      repins[0].regenerate[0].includes("cd examples/support-triage") &&
+      repins[0].regenerate[0].includes('cd "examples/support-triage"') && // quoted: this string is bash'ed in CI
+
       repins[0].regenerate[0].includes("npm install --package-lock-only")
     ) {
       pass("11. a drifted, published pin plans a manifest rewrite and a lockfile regen command");

--- a/scripts/check-example-pins-published.test.mjs
+++ b/scripts/check-example-pins-published.test.mjs
@@ -8,13 +8,14 @@
 // `check-workspace-pins-match-workspace.test.mjs` builds one, since both
 // gates read the same root `workspaces` shape.
 
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
   checkExamplePinsPublished,
   discoverExampleSiblingDeps,
+  planExampleRepins,
   reportExamplePinParity,
 } from "./check-example-pins-published.mjs";
 
@@ -322,6 +323,100 @@ const pin = { example: "support-triage", field: "dependencies", dep: "@pome-sh/a
         else fail("9g. an E404 short-circuits the retry budget", `${JSON.stringify(result)} after ${tries} try/tries`);
       },
     );
+  }
+}
+
+// F-1520 — planExampleRepins is the write-side of this same gate: a pin that
+// this file's own `violations` classifier already calls drifted-against-a-
+// published-sibling is exactly the set safe to rewrite automatically.
+{
+  const published = (name, version) => (n, v) =>
+    n === name && v === version ? { status: "published" } : { status: "unpublished" };
+
+  // 11. A genuinely drifted, published pin produces a repin: the manifest
+  // text is rewritten (old pin -> new pin, nothing else touched) and a
+  // lockfile-regeneration command names the right example directory.
+  {
+    const root = fixture({ workspaceVersion: "0.3.6", examplePin: "0.3.5" });
+    const repins = planExampleRepins(root, published("@pome-sh/adapter-claude-sdk", "0.3.6"));
+    const manifestAfter = JSON.parse(readFileSync(join(root, "examples/support-triage/package.json"), "utf8"));
+    if (
+      repins.length === 1 &&
+      repins[0].example === "support-triage" &&
+      repins[0].from === "0.3.5" &&
+      repins[0].to === "0.3.6" &&
+      manifestAfter.dependencies["@pome-sh/adapter-claude-sdk"] === "0.3.5" && // on disk: repins only PLANS writes
+      repins[0].writes[0].path === "examples/support-triage/package.json" &&
+      JSON.parse(repins[0].writes[0].contents).dependencies["@pome-sh/adapter-claude-sdk"] === "0.3.6" &&
+      repins[0].regenerate.length === 1 &&
+      repins[0].regenerate[0].includes("cd examples/support-triage") &&
+      repins[0].regenerate[0].includes("npm install --package-lock-only")
+    ) {
+      pass("11. a drifted, published pin plans a manifest rewrite and a lockfile regen command");
+    } else {
+      fail("11. a drifted, published pin plans a manifest rewrite and a lockfile regen command", JSON.stringify({ repins, manifestAfter }));
+    }
+  }
+
+  // 12. The exact incident shape: the sibling is NOT yet published (this run's
+  // own bump, or a `release.yml` publish still in flight) — must not repin.
+  // Repinning here would set a pin to a version `npm install
+  // --package-lock-only` cannot resolve, breaking `npm ci` outright.
+  {
+    const root = fixture({ workspaceVersion: "0.3.7", examplePin: "0.3.6" });
+    const repins = planExampleRepins(root, () => ({ status: "unpublished" }));
+    if (repins.length === 0) pass("12. an unpublished sibling produces no repin, ever");
+    else fail("12. an unpublished sibling produces no repin, ever", JSON.stringify(repins));
+  }
+
+  // 13. Already matching: no-op, no write planned — idempotence.
+  {
+    const root = fixture({ workspaceVersion: "0.3.6", examplePin: "0.3.6" });
+    const repins = planExampleRepins(root, published("@pome-sh/adapter-claude-sdk", "0.3.6"));
+    if (repins.length === 0) pass("13. a pin that already matches the published sibling is a no-op");
+    else fail("13. a pin that already matches the published sibling is a no-op", JSON.stringify(repins));
+  }
+
+  // 14. A registry error (not E404) must not be read as "go ahead and repin".
+  {
+    const root = fixture({ workspaceVersion: "0.3.6", examplePin: "0.3.5" });
+    const repins = planExampleRepins(root, () => ({ status: "error", detail: "ECONNRESET" }));
+    if (repins.length === 0) pass("14. a registry error produces no repin (never treated as published)");
+    else fail("14. a registry error produces no repin (never treated as published)", JSON.stringify(repins));
+  }
+
+  // 15. Replays the real incidents (#395: adapter 0.3.4, #425: adapter 0.3.6)
+  // — the exact state right after each release, before the human PR.
+  for (const { was, published: newVersion } of [
+    { was: "0.3.3", published: "0.3.4" },
+    { was: "0.3.5", published: "0.3.6" },
+  ]) {
+    const root = fixture({ workspaceVersion: newVersion, examplePin: was });
+    const repins = planExampleRepins(root, published("@pome-sh/adapter-claude-sdk", newVersion));
+    const rewritten = JSON.parse(repins[0]?.writes[0]?.contents ?? "{}");
+    if (repins.length === 1 && rewritten.dependencies?.["@pome-sh/adapter-claude-sdk"] === newVersion) {
+      pass(`15. replays the ${was} -> ${newVersion} incident exactly as the human PR did`);
+    } else {
+      fail(`15. replays the ${was} -> ${newVersion} incident exactly as the human PR did`, JSON.stringify(repins));
+    }
+  }
+
+  // 16. No `package.json` at the repo root (a throwaway fixture, like
+  // allocate-release-versions.test.mjs's) — must return empty, not throw.
+  {
+    const root = mkdtempSync(join(tmpdir(), "no-root-manifest-"));
+    let threw = null;
+    let repins = null;
+    try {
+      repins = planExampleRepins(root, published("x", "1.0.0"));
+    } catch (e) {
+      threw = e;
+    }
+    if (threw === null && Array.isArray(repins) && repins.length === 0) {
+      pass("16. a root with no package.json/examples returns no repins rather than throwing");
+    } else {
+      fail("16. a root with no package.json/examples returns no repins rather than throwing", String(threw));
+    }
   }
 }
 

--- a/scripts/ci/allocate-release-versions.mjs
+++ b/scripts/ci/allocate-release-versions.mjs
@@ -78,6 +78,7 @@ import { readFileSync, realpathSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { planExampleRepins } from "../check-example-pins-published.mjs";
 import { bumpVersion, pendingRelease, writeRelease } from "./changelog-entry.mjs";
 import { PUBLISHED_PACKAGES, packagesTouchedBy } from "./publish-relevance.mjs";
 
@@ -169,7 +170,7 @@ function derivedEntry({ pkg, files, commits }) {
  * What `main`'s tip owes, per package. Pure read — nothing is written unless
  * `applyAllocations()` is called with the result.
  */
-export function planAllocations({ root = resolve(HERE, "../.."), date = today() } = {}) {
+export function planAllocations({ root = resolve(HERE, "../.."), date = today(), npmView } = {}) {
   if (git(root, ["rev-parse", "--is-shallow-repository"]).trim() === "true") {
     throw new Error(
       "refusing to allocate versions in a shallow clone: the walk for 'when did this " +
@@ -239,7 +240,30 @@ export function planAllocations({ root = resolve(HERE, "../.."), date = today() 
     });
   }
 
-  return { head, date, allocations, notes, message: commitMessage(allocations, head) };
+  // F-1520 — an example that pins a `@pome-sh/*` package from the registry
+  // (today only `examples/support-triage`) must never fall out of sync with
+  // that sibling's published version: two incidents (adapter 0.3.4 and 0.3.6,
+  // both 2026-08-13) each reddened `check-example-pins-published.mjs` until a
+  // human noticed and opened a one-line PR. `planExampleRepins` is the part of
+  // that gate's own logic that already answers "which pins are safely fixable
+  // right now" (its `violations`: drifted AND the sibling is CONFIRMED
+  // published) — reused rather than re-implemented, discovered from
+  // `examples/*/package.json` rather than a hand-kept list.
+  //
+  // Deliberately measured against the manifests ON DISK, before this run's own
+  // `writes` above are applied: a package THIS SAME run is bumping is not yet
+  // published (that happens in `release.yml`'s run of the commit this script is
+  // about to push), so `planExampleRepins`'s own registry check correctly finds
+  // it unpublished and leaves it alone — repinning to a version that does not
+  // exist yet would need a lockfile entry `npm install --package-lock-only`
+  // cannot resolve, and a manifest pin with no matching lockfile entry breaks
+  // `npm ci` for that example outright, which is worse than the drift this
+  // exists to fix. That version's example pin gets corrected on the FIRST
+  // subsequent run of this workflow after `release.yml` actually publishes it —
+  // still fully automatic, still no human PR, just one push later.
+  const repins = npmView ? planExampleRepins(root, npmView) : planExampleRepins(root);
+
+  return { head, date, allocations, repins, notes, message: commitMessage(allocations, repins, head) };
 }
 
 /**
@@ -265,17 +289,20 @@ function rewriteVersion(manifest, { from, to, path }) {
   return manifest.replace(line(from), line(to));
 }
 
-function commitMessage(allocations, head) {
-  if (allocations.length === 0) return "";
+function commitMessage(allocations, repins, head) {
+  if (allocations.length === 0 && repins.length === 0) return "";
   const named = allocations.map((a) => `${a.name} ${a.to}`);
   const subject =
-    allocations.length <= 2
-      ? `release: ${named.join(", ")} ${BUMP_COMMIT_MARKER}`
-      : `release: ${allocations.length} packages ${BUMP_COMMIT_MARKER}`;
+    allocations.length === 0
+      ? `chore: re-pin ${repins.length} example dep(s) to the published version ${BUMP_COMMIT_MARKER}`
+      : allocations.length <= 2
+        ? `release: ${named.join(", ")} ${BUMP_COMMIT_MARKER}`
+        : `release: ${allocations.length} packages ${BUMP_COMMIT_MARKER}`;
   return [
     subject,
     "",
     ...allocations.map((a) => `- ${a.name} ${a.from} → ${a.to} (${a.level}, ${a.reason})`),
+    ...repins.map((r) => `- examples/${r.example} ${r.dep} ${r.from} → ${r.to} (published pin re-pin, F-1520)`),
     "",
     `Allocated from ${head.slice(0, 8)} by .github/workflows/allocate-version.yml.`,
     "The version number is written here, after the merge, and never in a PR;",
@@ -287,7 +314,7 @@ function commitMessage(allocations, head) {
 /** Applies a plan's writes. Returns the paths written. */
 export function applyAllocations(plan, { root = resolve(HERE, "../..") } = {}) {
   const written = [];
-  for (const allocation of plan.allocations) {
+  for (const allocation of [...plan.allocations, ...plan.repins]) {
     for (const write of allocation.writes) {
       writeFileSync(join(root, write.path), write.contents);
       written.push(write.path);
@@ -314,14 +341,18 @@ export function main(argv = process.argv.slice(2)) {
   const plan = planAllocations({ root });
   for (const note of plan.notes) console.log(`::warning::${note}`);
 
-  if (plan.allocations.length === 0) {
+  if (plan.allocations.length === 0 && plan.repins.length === 0) {
     console.log(`Nothing to allocate at ${plan.head.slice(0, 8)} — no pending entry, no unreleased`);
-    console.log("publish-relevant change. (This is what the bump commit's own push looks like.)");
+    console.log("publish-relevant change, no example pin drifted from an already-published sibling.");
+    console.log("(This is what the bump commit's own push looks like.)");
   }
   for (const a of plan.allocations) {
     console.log(`${a.name}: ${a.from} → ${a.to}  (${a.level}, ${a.reason})`);
     for (const file of a.relevantFiles.slice(0, 10)) console.log(`    ${file}`);
     if (a.relevantFiles.length > 10) console.log(`    … ${a.relevantFiles.length - 10} more`);
+  }
+  for (const r of plan.repins) {
+    console.log(`examples/${r.example}: ${r.dep} ${r.from} → ${r.to}  (published pin drift, F-1520)`);
   }
 
   const planOut = flagValue("--plan-out");
@@ -335,7 +366,7 @@ export function main(argv = process.argv.slice(2)) {
   // regenerated, and the command belongs next to the file it writes.
   const regenOut = flagValue("--regen-out");
   if (regenOut) {
-    const commands = plan.allocations.flatMap((a) => a.regenerate);
+    const commands = [...plan.allocations, ...plan.repins].flatMap((a) => a.regenerate);
     writeFileSync(regenOut, commands.length ? `set -euo pipefail\n${commands.join("\n")}\n` : "");
   }
 

--- a/scripts/ci/allocate-release-versions.mjs
+++ b/scripts/ci/allocate-release-versions.mjs
@@ -261,7 +261,27 @@ export function planAllocations({ root = resolve(HERE, "../.."), date = today(),
   // exists to fix. That version's example pin gets corrected on the FIRST
   // subsequent run of this workflow after `release.yml` actually publishes it —
   // still fully automatic, still no human PR, just one push later.
-  const repins = npmView ? planExampleRepins(root, npmView) : planExampleRepins(root);
+  //
+  // ONE guard around the whole call, rather than a guard per throw site. A
+  // re-pin is cosmetic; an allocation is not — and this function runs on every
+  // push to `main`, so ANY throw from the example walk stops EVERY package's
+  // release over one example directory. The reachable vectors today are already
+  // more than one (an ambiguous pin, a malformed `examples/*/package.json` that
+  // `discoverExampleSiblingDeps` `JSON.parse`s unguarded, `loadWorkspaceMembers`
+  // on an empty `workspaces` glob) and the next one arrives with the next
+  // caller, so the invariant is enforced here where it is total. The failure is
+  // loud — `notes` is printed as `::warning::` — and the read-side gate in
+  // `ci.yml` still reds on whatever the example is doing wrong, so nothing is
+  // swallowed, only de-escalated to the blast radius it should have had.
+  let repins = [];
+  try {
+    repins = npmView ? planExampleRepins(root, npmView) : planExampleRepins(root);
+  } catch (err) {
+    notes.push(
+      `example re-pin planning failed and was SKIPPED so it cannot block this allocation — ${err.message}. ` +
+        "check-example-pins-published.mjs still reds on the drift.",
+    );
+  }
 
   return { head, date, allocations, repins, notes, message: commitMessage(allocations, repins, head) };
 }

--- a/scripts/ci/allocate-release-versions.test.mjs
+++ b/scripts/ci/allocate-release-versions.test.mjs
@@ -484,6 +484,36 @@ console.log("F-1520 — the repin path is a no-op without examples/");
   }
 }
 
+console.log("F-1520 — a broken example can never block a version allocation");
+{
+  const dir = repo();
+  try {
+    // The whole reason the repin call is wrapped: this runs on EVERY push to
+    // main, so a throw anywhere in the example walk would stop every package's
+    // release over one example directory. A manifest that is not valid JSON is
+    // the cheapest reachable vector (discoverExampleSiblingDeps JSON.parses it
+    // unguarded); the guard is around the call, so it covers the others too.
+    withExamples(dir, { adapterPin: "0.9.0" });
+    write(dir, "examples/broken/package.json", "{ this is not json");
+    pend(dir, CLI, { body: "- a fix consumers need" });
+    git(dir, "add", "-A");
+    git(dir, "commit", "-qm", "a merge (#912)");
+
+    const result = plan(dir, onlyPublished("@pome-sh/adapter-claude-sdk", "1.0.0"));
+    check("the CLI still gets its version", named(result, "@pome-sh/cli")?.to === "1.0.1", JSON.stringify(result.allocations));
+    check("the repin is dropped, not fatal", result.repins.length === 0, JSON.stringify(result.repins));
+    check(
+      "and the failure is announced as a ::warning:: note rather than swallowed",
+      result.notes.some((n) => n.includes("example re-pin planning failed")),
+      JSON.stringify(result.notes),
+    );
+    land(dir, result);
+    check("the release still lands", JSON.parse(read(dir, CLI.manifest)).version === "1.0.1");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 console.log("F-1520 — a drifted pin against an already-published sibling is repinned");
 {
   const dir = repo();

--- a/scripts/ci/allocate-release-versions.test.mjs
+++ b/scripts/ci/allocate-release-versions.test.mjs
@@ -40,6 +40,7 @@ const SCRIPT = join(ROOT, "scripts/ci/allocate-release-versions.mjs");
 const DATE = "2026-08-14";
 const CLI = PUBLISHED_PACKAGES.find((pkg) => pkg.name === "@pome-sh/cli");
 const WIRE = PUBLISHED_PACKAGES.find((pkg) => pkg.name === "@pome-sh/wire");
+const ADAPTER = PUBLISHED_PACKAGES.find((pkg) => pkg.name === "@pome-sh/adapter-claude-sdk");
 
 let failures = 0;
 function check(label, condition, detail = "") {
@@ -82,6 +83,29 @@ function repo() {
   return dir;
 }
 
+/**
+ * F-1520 — `repo()` has no root `package.json`/`examples/`, so `planExample
+ * Repins` is a no-op against it (proven in "the repin path is a no-op" below).
+ * This adds the shape it needs: a root `workspaces` field naming
+ * `ADAPTER.manifest`'s directory, and `examples/support-triage` pinning the
+ * adapter the same way the real tree does.
+ */
+function withExamples(dir, { adapterPin }) {
+  write(dir, "package.json", JSON.stringify({ name: "root", private: true, workspaces: ["packages/*", "cli"] }));
+  write(
+    dir,
+    "examples/support-triage/package.json",
+    JSON.stringify({
+      name: "support-triage-example",
+      dependencies: { "@pome-sh/adapter-claude-sdk": adapterPin },
+    }),
+  );
+}
+
+/** A `npmView` stub: only the named version of the named package is published. */
+const onlyPublished = (name, version) => (n, v) =>
+  n === name && v === version ? { status: "published" } : { status: "unpublished" };
+
 function commit(dir, files, message = "a merge") {
   for (const [path, contents] of Object.entries(files)) write(dir, path, contents);
   git(dir, "add", "-A");
@@ -95,7 +119,7 @@ function pend(dir, pkg, { level = "patch", body = "- something a consumer must k
   write(dir, pkg.changelog, `${text.slice(0, at)}## Unreleased (${level})\n\n${body}\n\n${text.slice(at)}`);
 }
 
-const plan = (dir) => planAllocations({ root: dir, date: DATE });
+const plan = (dir, npmView) => planAllocations({ root: dir, date: DATE, npmView });
 const named = (result, name) => result.allocations.find((a) => a.name === name);
 
 /** Apply a plan and commit it the way allocate-version.yml does. */
@@ -444,6 +468,114 @@ console.log("the script's own surface");
   } finally {
     rmSync(dir, { recursive: true, force: true });
     rmSync(out, { recursive: true, force: true });
+  }
+}
+
+console.log("F-1520 — the repin path is a no-op without examples/");
+{
+  const dir = repo();
+  try {
+    // repo() never creates a root package.json or examples/, exactly like
+    // every OTHER fixture above — proving that stays true is what keeps this
+    // whole suite honest about the new code path touching nothing by default.
+    check("no repins are planned", plan(dir).repins.length === 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+console.log("F-1520 — a drifted pin against an already-published sibling is repinned");
+{
+  const dir = repo();
+  try {
+    withExamples(dir, { adapterPin: "0.9.0" }); // ADAPTER is seeded at 1.0.0 by repo()
+    git(dir, "add", "-A");
+    git(dir, "commit", "-qm", "add examples");
+
+    const npmView = onlyPublished("@pome-sh/adapter-claude-sdk", "1.0.0");
+    const result = plan(dir, npmView);
+    check("nothing is owed a NEW version", result.allocations.length === 0, JSON.stringify(result.allocations));
+    check("exactly one repin is planned", result.repins.length === 1, JSON.stringify(result.repins));
+    const repin = result.repins[0];
+    check("it names the example, the dep, and both versions", repin.example === "support-triage" && repin.from === "0.9.0" && repin.to === "1.0.0", JSON.stringify(repin));
+    const rewritten = JSON.parse(repin.writes[0].contents);
+    check("the manifest write carries the new pin", rewritten.dependencies["@pome-sh/adapter-claude-sdk"] === "1.0.0", repin.writes[0].contents);
+    check("a lockfile-regen command is named for that example", repin.regenerate[0].includes("examples/support-triage"), JSON.stringify(repin.regenerate));
+    check(
+      "a repin-only commit gets its own message, not an empty one",
+      result.message.startsWith("chore: re-pin 1 example dep(s)") && result.message.includes("examples/support-triage @pome-sh/adapter-claude-sdk 0.9.0 → 1.0.0"),
+      result.message,
+    );
+
+    land(dir, result);
+    check("the example manifest is actually rewritten on disk", JSON.parse(read(dir, "examples/support-triage/package.json")).dependencies["@pome-sh/adapter-claude-sdk"] === "1.0.0");
+    check("running again with the same npmView is a clean no-op", plan(dir, npmView).repins.length === 0 && plan(dir, npmView).allocations.length === 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+console.log("F-1520 — the version THIS run allocates is never repinned to in the same run");
+{
+  const dir = repo();
+  try {
+    // The adapter's OWN version is being bumped 1.0.0 -> 1.0.1 in this run
+    // (via a pending entry); support-triage still pins the OLD 1.0.0. Nothing
+    // has published 1.0.1 yet — that is release.yml's job, on this run's own
+    // future push — so repinning to it now would set a pin `npm install
+    // --package-lock-only` cannot resolve.
+    withExamples(dir, { adapterPin: "1.0.0" });
+    pend(dir, ADAPTER, { body: "- the adapter learned a thing" });
+    git(dir, "add", "-A");
+    git(dir, "commit", "-qm", "adapter change + examples (#111)");
+
+    const npmViewOnlyOld = onlyPublished("@pome-sh/adapter-claude-sdk", "1.0.0"); // 1.0.1 is NOT published
+    const result = plan(dir, npmViewOnlyOld);
+    check("the adapter is allocated 1.0.1", named(result, "@pome-sh/adapter-claude-sdk")?.to === "1.0.1", JSON.stringify(result.allocations));
+    check(
+      "but nothing is repinned to the still-unpublished 1.0.1 — the pin already matches the published 1.0.0",
+      result.repins.length === 0,
+      JSON.stringify(result.repins),
+    );
+
+    land(dir, result);
+    check("the manifest still pins 1.0.0 after landing — nothing broke npm ci", JSON.parse(read(dir, "examples/support-triage/package.json")).dependencies["@pome-sh/adapter-claude-sdk"] === "1.0.0");
+
+    // The NEXT run, once 1.0.1 is (now) published, closes the gap fully
+    // automatically — no human PR, just one push later.
+    const npmViewNowNew = onlyPublished("@pome-sh/adapter-claude-sdk", "1.0.1");
+    const next = plan(dir, npmViewNowNew);
+    check("the next run repins to the now-published 1.0.1", next.repins.length === 1 && next.repins[0].to === "1.0.1", JSON.stringify(next.repins));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+console.log("F-1520 — replays the two real incidents (adapter 0.3.4 and 0.3.6, both 2026-08-13)");
+for (const { from, to } of [
+  { from: "0.3.3", to: "0.3.4" }, // #395
+  { from: "0.3.5", to: "0.3.6" }, // #425
+]) {
+  const dir = repo();
+  try {
+    write(dir, ADAPTER.manifest, `{\n  "name": "${ADAPTER.name}",\n  "version": "${to}"\n}\n`); // already released
+    withExamples(dir, { adapterPin: from }); // support-triage never got the memo
+    git(dir, "add", "-A");
+    git(dir, "commit", "-qm", `release: ${ADAPTER.name} ${to} [release-bump]`);
+
+    const result = plan(dir, onlyPublished(ADAPTER.name, to));
+    check(
+      `${from} -> ${to}: exactly the pin #${from === "0.3.3" ? "395" : "425"} fixed by hand`,
+      result.repins.length === 1 &&
+        result.repins[0].from === from &&
+        result.repins[0].to === to &&
+        JSON.parse(result.repins[0].writes[0].contents).dependencies[ADAPTER.name] === to,
+      JSON.stringify(result.repins),
+    );
+    land(dir, result);
+    check(`${from} -> ${to}: lands cleanly and is a no-op afterwards`, plan(dir, onlyPublished(ADAPTER.name, to)).repins.length === 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
   }
 }
 


### PR DESCRIPTION
## The two incidents

`examples/support-triage` pins `@pome-sh/adapter-claude-sdk` from the registry (an exact version, not `file:`). `allocate-version.yml` bumps the workspace sibling's own version and CHANGELOG heading in one commit and pushes it; nothing touched the example's pin in that commit. `check-example-pins-published.mjs` (F-1483) then correctly reds once the sibling is published and the example's pin still names the old version — and stays red until a human notices and opens a one-line PR:

- adapter 0.3.4: red at `0e181da`, fixed by #395
- adapter 0.3.6: red at `95240f9`, fixed by #425

Both twice on 2026-08-13.

## Derivation — no hard-coded example/package list

Reused `check-example-pins-published.mjs`'s own `discoverExampleSiblingDeps` (F-1483), which already answers "which examples pin which `@pome-sh/*` packages from the registry" by walking `examples/*/package.json` fresh each run. Against the real tree today:

```
exact:       support-triage → @pome-sh/adapter-claude-sdk pins "0.3.6" (workspace 0.3.6)
linked:      pr-summary-agent, pr-summary-review, triage-agent → file:../../packages/adapter-claude-sdk (out of scope, correctly untouched)
unwatchable: (none)
```

## The fix

Added `planExampleRepins` to `check-example-pins-published.mjs` — the write-side of the same gate's `violations` classifier. A `violation` there (pin drifted, sibling **confirmed published**) is, by construction, exactly the set safe to auto-correct: `npm install --package-lock-only` against a confirmed-published version can actually resolve. `allocate-release-versions.mjs`'s `planAllocations` now calls it every run and folds any repin's manifest rewrite + lockfile regen into the same commit as any version bump, sharing the workflow's existing `writes` / `regenerate` plumbing (no YAML changes needed beyond adding the file to the PR-proof path list, since it's now part of the allocator's wiring).

**Deliberate asymmetry, and why it's still correct:** a version THIS SAME run is allocating is never repinned to in that run, because it is not yet published at that point in the pipeline — `release.yml` (a separate, later-triggered workflow run) is what publishes it, off the very commit this script is about to push. Repinning to an unpublished version would need a lockfile entry `npm install --package-lock-only` cannot resolve (E404), and a manifest pin with no matching lockfile entry breaks `npm ci` outright for that example — strictly worse than today's drift, and exactly the "manifest/lockfile mismatch" this ticket warns against shipping. Instead, that pin is corrected on the next run of this workflow — i.e. on the next push to `main`. **That is not the same as `main` being green after a release**; see "What this does and does not close" below.

## Lockfile decision

**Yes, in the one case that matters**: once a sibling is confirmed published, `npm install --package-lock-only` in the example directory is safe (real registry metadata resolves), so the regen command runs in the same commit, via the existing `REGEN` step (`bash "${REGEN}"`, already used for wire's `trace-contract.json`). **No, for a version this run is itself allocating** — see above; that case is left alone rather than shipping a mismatch.

The regeneration cannot land a mismatch either way: the workflow step runs under `set -euo pipefail` and `bash "${REGEN}"` is not in a protected position, so a failed / timed-out / networkless `npm install --package-lock-only` aborts the step *before* `git commit`. Nothing is committed and nothing is pushed. Verified by replaying the step body with the regen command forced to fail: exit 1, zero new commits, the manifest rewrite left uncommitted in a throwaway checkout.

## Dry-run diffs against the real tree

No-op (current state, real registry):
```
$ node -e '...planAllocations({root: process.cwd()})...'
repins: []
```

Drift (temporarily set support-triage's pin back to `0.3.5`, real registry):
```
repins: [{
  "example": "support-triage",
  "dep": "@pome-sh/adapter-claude-sdk",
  "from": "0.3.5",
  "to": "0.3.6",
  "regenerate": ["(cd examples/support-triage && npm install --package-lock-only --no-audit --no-fund)"]
}]

--- diff for examples/support-triage/package.json ---
-    "@pome-sh/adapter-claude-sdk": "0.3.5"
+    "@pome-sh/adapter-claude-sdk": "0.3.6"
```
(File restored immediately after; working tree is clean.)

## Incident replay

`scripts/check-example-pins-published.test.mjs` and `scripts/ci/allocate-release-versions.test.mjs` both replay the exact pre-fix states of #395 (adapter 0.3.3 → 0.3.4) and #425 (adapter 0.3.5 → 0.3.6) via fixtures and assert the repin plan produces exactly the rewrite those PRs made by hand.

## Idempotence

Covered by test: running twice with the same registry state produces zero repins and zero diff on the second run; a repin-only run (no version bump at all) still produces a commit with its own message (`chore: re-pin N example dep(s)...`), and an unrelated run with nothing drifted is a clean no-op.

## Gate strength unchanged

`check-example-pins-published.mjs`'s violation/skip/error classification is untouched — only a new function was added alongside it. `scripts/check-example-pins-published.test.mjs`'s existing "a stale pin against a published workspace version reds" case still passes unmodified.

## What this does and does not close

**F-1520's Done-when — "cut an adapter release, `main` is green immediately after, with no human PR" — is NOT met by this PR, and this PR does not claim it is.**

The timeline after a merge, with this branch on `main`:

1. Human PR merges as commit `M`. `release.yml` on `M` sees no version diff and publishes nothing. `allocate-version.yml` on `M` allocates adapter `0.3.7`; `planExampleRepins` measures the manifests as they are on disk, where the adapter is still `0.3.6` and the example pin is `0.3.6`, so there is correctly no re-pin. It pushes bump commit `B` (`[release-bump]`).
2. `B`'s push runs `release.yml`, which publishes `0.3.7`. `allocate-version.yml` is skipped on `B` by its own `[release-bump]` guard.
3. From the moment `0.3.7` lands on the registry, `main`'s tree is drifted: workspace `0.3.7`, example pin `0.3.6`, `0.3.7` published. `check-example-pins-published.mjs` reds — in `ci.yml` on `main`, and in the required `typecheck-test` context of every PR whose merge ref includes `B`.
4. Nothing clears it on a timer. `allocate-version.yml` only runs on a push to `main` or a manual `workflow_dispatch`; `release-alarm.yml` reports `UNALLOCATED`/`NEVER_RAN`, not pin drift.

So `main` stays red from the publish until the next push to `main` — unbounded, hours to days.

**And that next push is gated by the very red it would clear.** `typecheck-test` is a required, `strict`-policy context, and it runs `typecheck:examples` → `reportExamplePinParity` in its heavy job. A PR based on `B` therefore cannot merge. The only pushes that can still land are: a docs/chore-only PR (`ci.yml`'s scope step classifies it `heavy=false` and skips the parity gate), a founder bypass, or a manual `workflow_dispatch` — every one of which is a human action, and the last two are exactly the human intervention the ticket wanted removed. On the current tree the automated re-pin will, in the common case, never be the thing that fires first.

### The design that does close it

Re-pin from `release.yml`, after a successful publish, which is the first moment the version demonstrably exists on the registry. The lazy version needs no new write logic: after the `publish` job succeeds, mint the `pome-ops-push` installation token and `gh workflow run allocate-version.yml`. That reuses the allocator's existing retry loop, its `allocate-version-${{ github.ref }}` concurrency serialisation, and the `REGEN`/lockfile plumbing this PR already wired.

The loop terminates in one extra no-op run, with the existing machinery: the re-pin commit's subject carries `[release-bump]`, so `allocate-version.yml`'s own `if:` guard skips it, and the `release.yml` run that push triggers finds no version diff, skips every matrix entry, skips the `publish` job — so the dispatch step (which requires `publish` success) never fires again. The dispatch must use the App token, not `GITHUB_TOKEN`, for the same reason this workflow's header already documents for pushes: events created with the ambient token do not start workflow runs.

Residual window under that design: publish-completion to the dispatched allocate run landing, ~2-4 minutes, self-healing, no human. That is as close to "green immediately" as this pipeline can get.

**Recommendation: merge this as the correct write-side foundation, but do not close F-1520 on it.** The `release.yml` dispatch is the remaining work.

## Review fixes on top of the original two commits

- `planExampleRepins` threw when an example manifest carried the same `"<dep>": "<pin>"` bytes twice (an npm `overrides` block repeating the pin, or a second install field — both legal). That throw was inside `planAllocations`, which runs on every push to `main`, so one ambiguous example manifest blocked **every** package's allocation and therefore every publish — a repo-wide release outage caused by the thing that exists to remove a one-line PR. Reproduced against a git fixture where `@pome-sh/cli` was owed a release and got none. Now warns and skips that single pin; the read-side gate still reds on it, so it cannot go silent, and a different example's clean re-pin is unaffected.
- Two drifted `@pome-sh/*` pins in **one** example each computed their rewrite from the same on-disk bytes, and `applyAllocations` writes entries in order — so the last write won, the first re-pin was silently dropped, and the commit message claimed both. Substitutions are now threaded per manifest. Reproduced: manifest on disk ended up `{adapter: 0.3.5, checks: 1.2.0}` with the gate still reporting one drift; now `{0.3.6, 1.2.0}` and zero.
- Three new cases in `check-example-pins-published.test.mjs` (16b/16c/16d) cover both.

Second round, from the review pass — all the same shape, *a cosmetic example re-pin must never be able to cost a real release*:

- The per-pin guard above closed one throw vector, not the class. `discoverExampleSiblingDeps` `JSON.parse`s every `examples/*/package.json` unguarded and `loadWorkspaceMembers` throws on an empty `workspaces` glob, and both are reachable from `planAllocations`, which runs on every push to `main`. The `planExampleRepins` call is now wrapped once, at the call site, where the invariant is total — future vectors arrive already covered. The failure goes into `notes`, which the workflow prints as `::warning::`, and the read-side gate still reds. New test: a fixture with an unparseable `examples/broken/package.json` still allocates `@pome-sh/cli` 1.0.1 and lands it.
- `checkExamplePinsPublished`'s `errors` bucket was silently discarded, so a registry outage was indistinguishable from "nothing drifted" — the exact downgrade this file's header forbids. It now emits a `::warning::` naming each unchecked pin.
- The write side takes **one** registry attempt where the read side takes three. The read side retries because it is a required check that must not flake on a transient 5xx; the write side runs synchronously per pin inside `allocate-version.yml`'s three-attempt push loop in a `timeout-minutes: 20` job that also runs `npm ci`, and a missed re-pin costs exactly one cycle. Worst-case stall drops from ~9.5 min to ~1 min.
- The example path in the regen command is quoted. It comes from `readdirSync` and the string is `bash`ed by a job holding a write-capable App token.
- `scripts/check-workspace-pins-match-workspace.mjs` added to `allocate-version.yml`'s `pull_request.paths` — it is the transitive half of the new import, and the direct-only list would leave the PR arm blind to the PR that changes how examples are discovered.

### Known, accepted, not fixed here

`REGEN` now carries a **networked** command, so an npm failure during the example's `npm install --package-lock-only` aborts the allocate step and no version lands in that run. That is the correct side to fail on (the alternative is a manifest whose lockfile disagrees), and the branch was already networked-and-fatal — it runs root `npm ci` immediately before `bash "${REGEN}"` — but it now fires on re-pin-only runs too, so a cosmetic pin fix can delay a real release by one cycle. Decoupling the two (drop the re-pin, keep the bump, on a regen failure) belongs with the `release.yml` work above, where a dispatched allocate run is re-pin-only anyway.

## Reviewer probes

- **Divergence:** `planExampleRepins` calls `checkExamplePinsPublished(exact, npmView)` and maps its `violations` — literally one code path, not a second classifier. Probed on a drifted pin, an unpublished sibling, a registry error, a matching pin, and (post-fix) the ambiguous-manifest case: the read side and the write side agree on every one, and the only case where the writer declines is now announced as a `::warning::` while the gate still reds.
- **Linked pins:** `file:`, `link:` and bare `../` pins classify as `linked`, and `planExampleRepins` only reads `exact`. Probed with the link target's own version moved to a published `9.9.9`: all three linked manifests byte-identical after `applyAllocations`, the one exact pin rewritten.
- **Read-side strength:** `discoverExampleSiblingDeps`, `checkExamplePinsPublished` and `reportExamplePinParity` are byte-unchanged by this branch; the diff is additive. No case that reddened before passes now, and `unwatchable` pins are deliberately outside the write side, so they keep reddening rather than being auto-"fixed".

## What's unverified until the next real release

I cannot cut a real release in this environment, so the following is proven only by fixture replay and a dry-run against the current real registry state — not by an end-to-end run through both workflows:

- ~~Whether `allocate-version.yml`'s job has outbound npm-registry access in its real runner environment~~ — **now verified.** This PR's own `allocate version` PR-arm run ([run 31733060312](https://github.com/pome-sh/digital-twins/actions/runs/31733060312)) executed `planAllocations` against the live registry and printed `no example pin drifted from an already-published sibling` in 1.7s. The `npm install --package-lock-only` half is still unproven end to end.
- **The exact timing window between this job's push and `release.yml`'s publish completing** — verified only that the repin logic correctly *skips* an unpublished version (fixture-tested), not that a real multi-workflow race behaves as analyzed.

**What to watch on the first real release after this merges:** after the next adapter (or any package with a registry-pinning example) release, watch the run of `allocate-version.yml` triggered by the *following* push to `main` (not the bump commit's own push — that one correctly does nothing for the just-bumped package). It should show a repin for `examples/support-triage` and land it in that push's commit. **How to recognise failure:** `check-example-pins-published.mjs` reds again in `ci.yml` on a subsequent PR despite this landing, or `allocate-version.yml`'s job fails on the `npm install --package-lock-only` step. **What to revert:** this is a contiguous run of commits on top of `039dc13` (`14e2277`, `ade3a29`, `0f474bf`, `af0d4a7`); reverting them restores the exact prior manual-PR behavior with no other side effects, since no workflow step or script this PR didn't add was changed.

## Test plan

- [x] `node scripts/check-example-pins-published.mjs` passes against the real tree
- [x] `node scripts/check-example-pins-published.test.mjs` passes (includes 6 new cases for `planExampleRepins`)
- [x] `node scripts/ci/allocate-release-versions.test.mjs` passes (includes 4 new sections: no-op without `examples/`, a real repin, same-run-exclusion, incident replay)
- [x] `node scripts/ci/assert-allocate-token-path.test.mjs` passes
- [x] `actionlint .github/workflows/allocate-version.yml` passes
- [x] `node scripts/ci/check-release-note-required.mjs "$(git merge-base origin/main HEAD)"` passes (no publish-relevant path touched, no CHANGELOG entry needed)

