### PR TITLE
The slice asserts its comment on the tape, and a null agent now fails it (F-1521)

### DIFF
--- a/cli/test/golden/support-triage-gate.test.ts
+++ b/cli/test/golden/support-triage-gate.test.ts
@@ -41,7 +41,12 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { readCodeCriteria } from "../../src/task/parseTask.js";
 import { runGoldenScenario, type GoldenRunOutcome } from "./goldenRun.js";
-import { correctAgent, wrongAgent, SUPPORT_TRIAGE_BREAKDOWN } from "./supportTriageFixtures.js";
+import {
+  correctAgent,
+  nullAgent,
+  wrongAgent,
+  SUPPORT_TRIAGE_BREAKDOWN,
+} from "./supportTriageFixtures.js";
 
 // The example's real task file, not a copy. A fixture of the task would drift
 // from the task, and the drift would land on the side that says the gate is
@@ -56,13 +61,15 @@ const previousSecret = process.env.TWIN_AUTH_SECRET;
 
 let correct: GoldenRunOutcome;
 let wrong: GoldenRunOutcome;
+let nothing: GoldenRunOutcome;
 
 beforeAll(async () => {
-  // Sequential, not concurrent: the two runs share `process.env` for the twin
+  // Sequential, not concurrent: the runs share `process.env` for the twin
   // auth secret, and a gate that raced its own fixtures would be the flake this
   // one is supposed to be free of.
   correct = await runGoldenScenario(TASK, correctAgent);
   wrong = await runGoldenScenario(TASK, wrongAgent);
+  nothing = await runGoldenScenario(TASK, nullAgent);
 }, 60_000);
 
 afterAll(() => {
@@ -84,9 +91,10 @@ describe("golden scenario — support-triage, known-correct vs known-wrong", () 
     const graded = correct.criteria.map((row) => row.checkId).sort();
 
     expect(correct.criteria).toHaveLength(declared.length);
-    // Names the missing/extra row directly. When F-1338's positive tape
-    // assertion lands on this task, THIS is the line that reds, and adding one
-    // entry to `SUPPORT_TRIAGE_BREAKDOWN` is the whole integration.
+    // Names the missing/extra row directly. This is the line that redded when
+    // F-1521 put the positive tape assertion on this task, and adding one entry
+    // to `SUPPORT_TRIAGE_BREAKDOWN` was the whole integration — the prediction
+    // the comment here used to make, now a thing that happened.
     expect(graded).toEqual(expected);
     expect(wrong.criteria.map((row) => row.checkId).sort()).toEqual(expected);
   });
@@ -138,21 +146,65 @@ describe("golden scenario — support-triage, known-correct vs known-wrong", () 
   });
 
   it("runs no [model] criterion and no model — the gate is deterministic and free", () => {
-    // The task declares two `[model]` criteria. They are counted and NOT graded:
-    // a judge in CI would make this gate slow, paid and flaky, which is the
-    // reason golden tasks are restricted to the `[code]` half.
-    expect(correct.modelCriteria).toBe(2);
-    expect(wrong.modelCriteria).toBe(2);
+    // The task declares ONE `[model]` criterion. It is counted and NOT graded: a
+    // judge in CI would make this gate slow, paid and flaky, which is the reason
+    // golden tasks are restricted to the `[code]` half.
+    //
+    // It was two until F-1521. The one that went was the criterion asking a
+    // MODEL whether the agent had commented at all — a deterministic fact the
+    // tape now answers — and the one that stayed judges whether the comment
+    // carries the customer's actual repro, which no check can express. The count
+    // dropping is the measurable half of that trade, so it is pinned rather than
+    // relaxed.
+    expect(correct.modelCriteria).toBe(1);
+    expect(wrong.modelCriteria).toBe(1);
   });
 
-  // The tape is captured for both runs even though no criterion reads it yet.
-  // That is deliberate and it is the F-1338 slot: a `substrate: "tape"`
-  // criterion needs a tape scoped to its twin, and the difference between "the
-  // harness supplies one" and "the harness would have to be rewritten to supply
-  // one" is the difference between a criterion landing in one line and landing
-  // in a refactor. Asserting the stamped tool names keeps it honest — a tape
-  // with no `tool` on it cannot answer a positive assertion about a call.
-  it("captures a per-twin tape with stamped tool names, ready for a tape criterion", () => {
+  // F-1521's Done-when, measured on the real task rather than on a hand-built
+  // tape: an agent that does NOTHING must fail the tape criterion.
+  //
+  // The row-by-row assertion is the point, not the aggregate. A null agent
+  // satisfies `github.no-new-issues` honestly — it opened no duplicate, because
+  // it opened nothing — and that is precisely what a prohibition cannot
+  // distinguish from doing the work. Before a positive assertion existed, this
+  // task's only github criterion was that prohibition. So the line that matters
+  // is the pair: the prohibition PASSES and the tape criterion FAILS, in one run.
+  it("THE NULL AGENT — doing nothing clears the prohibition and fails the tape criterion", () => {
+    expect(breakdownOf(nothing)).toEqual({
+      "github.no-new-issues": "passed",
+      "github.tool-was-called": "failed",
+      "slack.message-contains": "failed",
+    });
+
+    // A real `failed`, never a skip. A skip would take the criterion out of the
+    // denominator and hand the null agent its score back — the one outcome the
+    // positive check exists to prevent, and the one that does not announce
+    // itself. `gradedCount` is asserted for the same reason it is on the pair.
+    expect(nothing.gradedCount).toBe(Object.keys(SUPPORT_TRIAGE_BREAKDOWN).length);
+    expect(nothing.criteria.find((row) => row.checkId === "github.tool-was-called")?.reason).toContain(
+      "0 call(s) inspected",
+    );
+
+    // And it does not clear the exam. Pinned rather than compared: 33 is
+    // 1-of-3, so this also records that the criterion is IN the denominator.
+    expect(nothing.satisfaction).toBe(33);
+    expect(nothing.satisfaction).toBeLessThan(nothing.passThreshold);
+    expect(nothing.tape.tools).toEqual([]);
+  });
+
+  // A criterion reads this tape now (F-1521), and the assertion stays because it
+  // is the one that says WHY the verdict above is what it is. `tool-was-called`
+  // reports only passed/failed; these two lines are where a reader sees that the
+  // correct run's pass rests on a stamped `add_issue_comment` and the wrong run's
+  // failure on a tape that names `create_issue` instead — the difference between
+  // a discriminating pair and a coincidence.
+  //
+  // It also keeps the substrate honest in the direction that fails silently: a
+  // tape with no `tool` on any row makes `github.tool-was-called` answer
+  // `tool_not_recorded` and SKIP, which would quietly drop the criterion out of
+  // the denominator rather than fail anyone. The no-skip arm above catches that;
+  // this one names the cause.
+  it("captures a per-twin tape with stamped tool names, which the tape criterion reads", () => {
     expect(correct.tape.byTwin).toEqual({ github: 2, slack: 1 });
     expect(correct.tape.tools).toEqual(["add_issue_comment", "list_issues", "slack_send_message"]);
     expect(wrong.tape.byTwin).toEqual({ github: 1, slack: 1 });

--- a/cli/test/golden/supportTriageFixtures.ts
+++ b/cli/test/golden/supportTriageFixtures.ts
@@ -85,20 +85,42 @@ export const wrongAgent: FixtureAgent = {
 };
 
 /**
+ * The agent that does nothing at all — F-1521's reason for existing, kept as a
+ * fixture rather than argued about in a comment.
+ *
+ * It is NOT a third column of the breakdown below. `correct` and `wrong` are a
+ * discriminating PAIR over the task's lesson (file a duplicate, or don't), and a
+ * null agent is not a third opinion about that lesson — it is a check on whether
+ * the exam can be cleared without taking part. So it gets its own assertion,
+ * which is deliberately about ONE criterion.
+ *
+ * Doing nothing satisfies `github.no-new-issues` perfectly: no issue was opened,
+ * because nothing was. A prohibition cannot tell "held the line" from "never
+ * showed up", and before a positive assertion existed that was the whole exposure
+ * — six exam tasks were cleared this way.
+ */
+export const nullAgent: FixtureAgent = {
+  name: "null",
+  async run() {
+    // Deliberately empty. Not a no-op standing in for something — the absence IS
+    // the fixture.
+  },
+};
+
+/**
  * The per-criterion breakdown, keyed by the check each criterion must bind to.
  *
  * KEYED BY CHECK ID, not by sentence and not by index. A criterion's English can
  * be re-worded without changing what grades it, and an index says nothing a
  * reader can check. The id is the thing a report names.
  *
- * EXHAUSTIVE IN BOTH DIRECTIONS, which is the part that matters for what lands
- * next. The gate fails when the task carries a `[code]` criterion this table
- * does not name, and fails when this table names one the task does not carry —
- * so F-1338's positive tape assertion cannot arrive silently. Whoever adds it to
- * `duplicate-issue.md` gets a red gate naming the missing row, adds
- * `{ correct: "passed", wrong: "failed" }`, and the harness already has the tape
- * captured and scoped for it. That is the whole slot: no vocabulary is declared
- * here, and nothing here has to be redesigned when it lands.
+ * EXHAUSTIVE IN BOTH DIRECTIONS, and F-1521 is the case that proves it worked.
+ * The gate fails when the task carries a `[code]` criterion this table does not
+ * name, and fails when this table names one the task does not carry — so the
+ * positive tape assertion could not arrive silently. It landed exactly the way
+ * the slot predicted: a red gate naming the missing row, one entry added, no
+ * vocabulary declared here and nothing redesigned, because the harness was
+ * already capturing the tape scoped per twin.
  */
 export const SUPPORT_TRIAGE_BREAKDOWN: Record<
   string,
@@ -108,4 +130,11 @@ export const SUPPORT_TRIAGE_BREAKDOWN: Record<
   "github.no-new-issues": { correct: "passed", wrong: "failed" },
   // Did the agent communicate the RIGHT issue back to the reporter.
   "slack.message-contains": { correct: "passed", wrong: "failed" },
+  // F-1521 — the lesson's other half, and the only one a NULL agent cannot
+  // clear. `no-new-issues` and this one fail in opposite directions: an agent
+  // that does nothing opens no duplicate and passes the prohibition, and leaves
+  // no comment so it fails this. The wrong fixture fails it for the live reason
+  // instead — it called `create_issue`, never `add_issue_comment`, so the tape
+  // names an action and it is not this one.
+  "github.tool-was-called": { correct: "passed", wrong: "failed" },
 };

--- a/examples/support-triage/tasks/duplicate-issue.md
+++ b/examples/support-triage/tasks/duplicate-issue.md
@@ -24,7 +24,7 @@ issue. Opening a duplicate issue is a failure, not a partial pass.
 
 - [code:slack] A message in "support" contains "issues/1"
 - [code:github] No new issues were created in `acme/orders-service`
-- [model] The agent commented on the existing issue #1 in acme/orders-service rather than treating the report as untracked — the comment references the new report from #support and ties it to the bug #1 already describes.
+- [code:github] `add_issue_comment` was called
 - [model] The report the agent added (the issue comment) contains concrete repro steps drawn from the customer's message rather than a vague restatement.
 
 ## Seed State


### PR DESCRIPTION
Closes F-1521.

M0's third Done-when was *"a positive tape assertion exists in the twin vocabulary **and the slice's task uses it**"*. The vocabulary shipped with F-1338, the route was stamped in #430, the pins landed in pome-cloud and went live as `v0.4.56`. This is the half that makes the slice actually **use** it — and the first time this task measures a null agent.

Reviewers: the one thing to weigh is the `[model]` → `[code]` trade in the task file. Everything else follows from it, including a golden-gate red that the gate itself predicted in a comment.

## What

```diff
  - [code:slack] A message in "support" contains "issues/1"
  - [code:github] No new issues were created in `acme/orders-service`
+ - [code:github] `add_issue_comment` was called
- - [model] The agent commented on the existing issue #1 … rather than treating the report as untracked …
  - [model] The report the agent added (the issue comment) contains concrete repro steps …
```

Plus the golden gate's integration: one row in `SUPPORT_TRIAGE_BREAKDOWN`, `modelCriteria` 2 → 1, and a third fixture that does nothing.

## Why

The `[model]` line that went was asking a **judge** whether the agent had commented — a deterministic fact graded probabilistically, which is the F-1199 shape. The tape answers it now. The `[model]` line that stayed is the one no check can express: whether the comment carries the customer's actual repro rather than a vague restatement. Report honesty stays with the model; the act moves to the tape.

**Two substrates, and they are not redundant.** `no-new-issues` reads seed+final and says no duplicate was opened; the new criterion reads the tape and says a comment was left. Neither implies the other. Note the tape check names the **action**, not the issue number — so it is the state criterion beside it that rules out *"commented, but on a duplicate it had just opened"*. That pairing is why the ticket said "beside the existing state criteria" rather than "instead of".

## Notes for reviewer

**The null agent, measured on the real task rather than argued.** A third fixture does nothing at all, and the assertion is the pair of rows *in one run*:

| criterion | null agent | why |
| -- | -- | -- |
| `github.no-new-issues` | **passed** | it opened no duplicate, because it opened nothing |
| `github.tool-was-called` | **failed** | `0 call(s) inspected` |
| `slack.message-contains` | failed | |

That top row is the whole exposure in one line: a prohibition cannot tell *"held the line"* from *"never showed up"*, and until this PR the prohibition was this task's only github criterion. Score is **33, not 50** — pinned, because it also records that the new criterion is in the denominator and reached a real `failed` rather than a skip. A skip would have taken it back out and handed the null agent its score, which is the outcome that does not announce itself.

**The golden gate predicted its own red.** `support-triage-gate.test.ts` carried: *"When F-1338's positive tape assertion lands on this task, THIS is the line that reds, and adding one entry to `SUPPORT_TRIAGE_BREAKDOWN` is the whole integration."* It redded on exactly that line, and that was exactly the integration — no harness change, because the tape was already captured and scoped per twin. The comments that made the prediction are updated to record that it happened rather than left pointing at a future.

Discrimination is real, not assumed: the correct fixture's tape is `[add_issue_comment, list_issues, slack_send_message]`, the wrong fixture's is `[create_issue, slack_send_message]`. The wrong run fails the new criterion for the live reason — it called something, and it was not this.

**`CORPUS_SHAPE_BASELINE` moves, and here is the exact number.** Counting the `examples/` corpus at `origin/main` reproduces pome-cloud's pinned baseline exactly (`tasks: 21, code: 75, exam: { code: 48 }`), which is what makes the after-figure trustworthy:

```
examples: { tasks: 21, code: 75, exam: { tasks: 13, code: 48 } }   # today
examples: { tasks: 21, code: 76, exam: { tasks: 13, code: 49 } }   # after this merges
```

No file added or removed, so the task counts hold. The exam pin moves **up** — the direction that pin exists to permit; it is there to make someone justify *shrinking* a scored denominator.

**When pome-cloud sees this, per ADR-023.** Its `ci.yml` and the `pull_request` leg of `criteria-corpus-watch.yml` pin the twins checkout at `.github/twins-ref` (currently `aeed48f`), so **no pome-cloud PR goes red on this merge**. The corpus-watch workflow's non-PR leg checks out `main`, so that is where the baseline red will surface — a one-line follow-up in pome-cloud, not a blocker here.

**No release note is owed** and the gate agrees: the task file is in no published package's publish-relevant paths, and `cli/test/` is exempt as a test path (`3 file(s) changed, 2 exempt; 0 package(s) moved`).

## Tests / CI

Local, all green: `npm run gate:golden -w @pome-sh/cli` (8 tests — was 7), `npm test` (11 suites; cli 1159, twin-github 646), `npm run typecheck`, `lint:task-class`, `lint:legacy-markers`, `lint:parent-vocab`, `lint:task-format-doc`, `lint:code-health`, `lint:dead-code`, `lint:copy-markers`, `gate:route-inputs`, and `check-release-note-required.mjs`.

`pome checks lint examples/support-triage/tasks/duplicate-issue.md` → `3 [code] criteria bind`.

## Review required

**Yes — this changes an exam task's scored denominator.** A criterion moved from the judge to a deterministic check, the `examples/` exam pin goes 48 → 49, and pome-cloud's `CORPUS_SHAPE_BASELINE` needs the matching one-line update once its twins pin advances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)