### PR TITLE
A Slack seed can plant files, so files.list measures more than a count

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -10,6 +10,34 @@ write a version number here or in `package.json` — see `RELEASING.md`. Release
 entries are insertions only: a correction is the next entry, naming the one it
 corrects.
 
+## Unreleased (minor)
+
+**A Slack seed can plant files** (F-1509). `slackSeedStateSchema` gains a `files`
+key — `{id?, name, title?, filetype?, user?, channels?, content?}` — and
+`SlackDomain.seed` writes the rows, so `files.list` / `files.info` /
+`slack_read_file` have something to read before the agent uploads anything.
+`user` and `channels` take seed handles or ids, exactly as `channels[].members`
+does; `mimetype`, `size` and the `title` default are derived the way
+`files.upload` derives them, so a seeded file and an uploaded one are
+indistinguishable in a response.
+
+**Minor, not patch:** it is new seed vocabulary. Every existing seed still
+parses byte-identically — `files` defaults to `[]` and the twin's `files` table
+is untouched when it is empty — but a task file can now declare something this
+CLI could not express before, and a task that declares it will not parse on an
+older CLI.
+
+**Why it existed as a hole.** `files` had exactly one writer, `filesUpload`, a
+MUTATION. So every read-only capture against a freshly seeded world answered on
+an empty table, and pome-cloud's fidelity watchdog measured
+`GET /files.list upstream=1 twin=0` — the twin serving no files where real Slack
+served one. Worse than the count: the diff engine compares NO array elements when
+either side is empty, so the empty array was masking every field-level comparison
+on the surface. Seeding one file is what makes the file object's 41 upstream
+leaves comparable at all; the 15 the twin does not serve are registered as
+twin-slack divergence #24, and the canvas-is-a-file modelling difference the same
+capture surfaced is #25.
+
 ## 0.23.50 — 2026-08-14
 
 **`` `add_issue_comment` was called `` binds offline** (F-1521).

--- a/cli/src/contract/seed-state.ts
+++ b/cli/src/contract/seed-state.ts
@@ -182,6 +182,21 @@ export const slackSeedStateSchema = z.object({
       })
     )
     .default([]),
+  // F-1509. Mirrors `seedSchema.files` in `@pome-sh/twin-slack`. `user` and
+  // `channels` are seed HANDLES (a user/channel `name`) or ids.
+  files: z
+    .array(
+      z.object({
+        id: z.string().regex(/^F[A-Z0-9_]+$/).optional(),
+        name: z.string().min(1),
+        title: z.string().optional(),
+        filetype: z.string().min(1).default("text"),
+        user: z.string().optional(),
+        channels: z.array(z.string()).default([]),
+        content: z.string().optional(),
+      })
+    )
+    .default([]),
   emoji: z
     .array(
       z.object({

--- a/cli/src/task/taskSchema.ts
+++ b/cli/src/task/taskSchema.ts
@@ -99,7 +99,12 @@ export const slackSeedStateSchema = z
   .object({
     team: z.record(z.string(), z.unknown()).optional(),
     users: z.array(z.record(z.string(), z.unknown())).default([]),
-    channels: z.array(z.record(z.string(), z.unknown())).default([])
+    channels: z.array(z.record(z.string(), z.unknown())).default([]),
+    // F-1509. Permissive like its siblings — the vendored `parseSeed` does the
+    // regex-level validation. It has to be listed at all because `.strict()`
+    // REJECTS an unlisted key: without this line a slack seed declaring `files`
+    // fails to parse rather than being stripped.
+    files: z.array(z.record(z.string(), z.unknown())).default([])
   })
   .strict();
 

--- a/cli/test/contract/schemas-slack.test.ts
+++ b/cli/test/contract/schemas-slack.test.ts
@@ -40,6 +40,50 @@ describe("slackSeedStateSchema", () => {
     });
     expect(parsed.success).toBe(false);
   });
+
+  // F-1509 — the seed vocabulary the hosted contract has to speak for a scenario
+  // to declare a file. The twin's own `seedSchema` is the strict authority; this
+  // schema has to accept the same shape or the cloud strips the key on the way in.
+  it("accepts a files key with handles for user and channels", () => {
+    const parsed = slackSeedStateSchema.safeParse({
+      channels: [{ name: "general" }],
+      files: [
+        {
+          id: "F_RUNBOOK",
+          name: "runbook.md",
+          title: "Incident runbook",
+          filetype: "markdown",
+          user: "alice",
+          channels: ["general"],
+          content: "# Runbook\n",
+        },
+      ],
+    });
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && parsed.data.files[0]!.filetype).toBe("markdown");
+  });
+
+  it("defaults files to an empty array, so every pre-F-1509 seed is unchanged", () => {
+    const parsed = slackSeedStateSchema.safeParse({ channels: [{ name: "general" }] });
+    expect(parsed.success && parsed.data.files).toEqual([]);
+  });
+
+  it("defaults a file's filetype and channels rather than leaving them absent", () => {
+    const parsed = slackSeedStateSchema.safeParse({ files: [{ name: "notes.txt" }] });
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && parsed.data.files[0]!.filetype).toBe("text");
+    expect(parsed.success && parsed.data.files[0]!.channels).toEqual([]);
+  });
+
+  it("rejects a file id that is not Slack-file-shaped", () => {
+    const parsed = slackSeedStateSchema.safeParse({ files: [{ id: "C_NOPE", name: "x.txt" }] });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects a file with no name", () => {
+    const parsed = slackSeedStateSchema.safeParse({ files: [{ title: "no name" }] });
+    expect(parsed.success).toBe(false);
+  });
 });
 
 describe("providerScopedSeedStateSchema", () => {

--- a/cli/test/unit/parseTask.test.ts
+++ b/cli/test/unit/parseTask.test.ts
@@ -450,6 +450,27 @@ ${seed ? `\n## Seed State\n\`\`\`json\n${seed}\n\`\`\`\n` : ""}${MULTI_CONFIG}`;
     expect("channels" in envelope.slack).toBe(true);
   });
 
+  // F-1509. The slack arm is the union's only `.strict()` one, so an unlisted key
+  // is REJECTED rather than stripped — `files` had to be added to the arm, not
+  // just to the twin. Without that line this parse throws.
+  it("carries a slack seed's files key through the envelope", () => {
+    const scenario = parseTask(
+      multiTask(
+        "- [code:github] x\n- [code:slack] y",
+        JSON.stringify({
+          github: { repositories: [{ owner: "acme", name: "api" }] },
+          slack: {
+            channels: [{ name: "general" }],
+            files: [{ id: "F_RUNBOOK", name: "runbook.md", channels: ["general"] }],
+          },
+        }),
+      ),
+    );
+    const envelope = scenario.seedState as SeedEnvelope;
+    const files = (envelope.slack as { files?: Array<{ name?: unknown }> }).files;
+    expect(files?.map((f) => f.name)).toEqual(["runbook.md"]);
+  });
+
   it("fills a twin's default seed when its envelope key is missing", () => {
     const scenario = parseTask(
       multiTask(

--- a/packages/checks/CHANGELOG.md
+++ b/packages/checks/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @pome-sh/checks
 
+## Unreleased (patch)
+
+**`slackSeedSchema` accepts a `files` key** (F-1509). This package re-exports
+twin-slack's seed schema (`slackSeedSchema` / `parseSlackSeed` /
+`defaultSlackSeed`), and that schema gained
+`files: [{id?, name, title?, filetype?, user?, channels?, content?}]` so a Slack
+world can be seeded with files rather than only acquiring them through a
+`files.upload` mutation.
+
+**No check changed.** `SLACK_CHECKS` is the same tuple, every compiled pattern is
+byte-identical, and `checksDigest` does not move — so a cloud pin does NOT have to
+catch up for this release, unlike 0.3.0 above. The seed schema is a separate export
+from the check vocabulary and only the former widened.
+
+**Patch, not minor.** `files` defaults to `[]`, so every seed that parsed before
+parses to the same value, and no consumer must act. It is a widening of an INPUT
+schema, which is the direction that cannot break a caller.
+
 ## 0.3.0 — 2026-08-14
 
 **`` `add_issue_comment` was called `` binds, and the github tape slot widens

--- a/packages/sandbox-domains/CHANGELOG.md
+++ b/packages/sandbox-domains/CHANGELOG.md
@@ -1,5 +1,31 @@
 # @pome-sh/sandbox-domains
 
+## Unreleased (patch)
+
+**`SlackDomain.seed` writes files, and `slackSeedSchema` accepts them** (F-1509).
+The seed gained
+`files: [{id?, name, title?, filetype?, user?, channels?, content?}]`, so
+`filesList` / `filesInfo` / `slack_read_file` read a populated table on a freshly
+seeded world. Until now `filesUpload` — a mutation — was the `files` table's only
+writer, so every read-only run against a fresh seed answered on an empty table.
+
+`user` and `channels` take seed HANDLES (a user/channel `name`) or ids, the same
+currency `channels[].members` already accepts. `mimetype` is derived from
+`filetype`, `size` from the byte length of `content`, and `title` defaults to
+`name` — the same derivations `filesUpload` applies, so a seeded file and an
+uploaded one are indistinguishable in a response. A `channels` entry naming no
+seeded channel is dropped rather than stored, so `files.list?channel=…` can never
+filter against an id no channel has.
+
+**No check vocabulary moved**, so this release does NOT need to be pinned in
+lockstep with `@pome-sh/checks` the way 0.2.0 below did — `checks-package-drift`
+compares the binding surface, and the binding surface is unchanged. Both packages
+carry an entry only because both re-export the seed schema.
+
+**Patch, not minor.** `files` defaults to `[]`: every existing seed parses to the
+same value and the `files` table is untouched when the key is empty. Widening an
+input schema cannot break a caller.
+
 ## 0.2.0 — 2026-08-14
 
 **`GITHUB_CHECKS`' tape slot widens from two action names to three** (F-1521), so

--- a/packages/twin-slack/FIDELITY.md
+++ b/packages/twin-slack/FIDELITY.md
@@ -108,7 +108,7 @@ so the MCP divergence lane reads a decision rather than an omission.
 | `users.profile.set` | warm | semantic | `domain.test.ts`, `app-routes.test.ts` | Warm-ruled (no vendor MCP write): see the tier-mismatch ledger. |
 | `pins.add` / `remove` / `list` | warm | semantic | `domain.test.ts`, `app-routes.test.ts` | `already_pinned` / `no_pin` codes; SQL constraint-mapped on race. Warm-ruled: see the tier-mismatch ledger. |
 | `search.messages` | hot | semantic | `domain.test.ts`, `performance.test.ts` | Substring (LIKE-based) match; query syntax is intentionally smaller than real Slack search. |
-| `files.upload` / `info` / `list` / `delete` | warm | shape | `domain.test.ts`, `app-routes.test.ts` | Metadata-only; no binary storage. URL fields point to deterministic `pome-twin-files.slack.com` hosts. Shape is at the warm target (SL5). |
+| `files.upload` / `info` / `list` / `delete` | warm | shape | `domain.test.ts`, `app-routes.test.ts`, `seed-files.test.ts` | Metadata-only; no binary storage. URL fields point to deterministic `pome-twin-files.slack.com` hosts. Since F-1509 the seed's `files` key can plant rows, so these read on a populated table without a prior upload; the file object's leaf set is divergence #24. Shape is at the warm target (SL5). |
 | `bookmarks.add` / `remove` / `list` | warm | semantic | `domain.test.ts`, `app-routes.test.ts` | `link` type accepted; other bookmark types are unsupported per real Slack 2024 changelog. Warm-ruled: see the tier-mismatch ledger. |
 | `team.info` | warm | semantic | `app-routes.test.ts` | Returns workspace metadata; enterprise fields are NULL for non-Enterprise twins. Warm-ruled context read: see the tier-mismatch ledger. |
 | `canvases.create` / `canvases.edit` / `canvases.delete` | warm | shape | `domain-wave3.test.ts`, `app-routes.test.ts` | Wave 3 (SL3). Markdown title/content persistence; section_id-relative edits are coarse whole-document ops (shape at warm target). Since F-1330 `edit` applies every operation in `changes`, in order, against one snapshot — it used to apply the first and answer ok for the rest. Reading a canvas is MCP-only (`slack_read_canvas`); real Slack reads one over `files.info`, which this twin backs from a separate table. |
@@ -206,8 +206,8 @@ out. The number is built from source, never hand-typed
   the MCP-envelope check rolls out next), 20 mutating REST methods (no write
   round-trip yet — including the `chat.postMessage` / `reactions.add` that back the
   3 verified MCP write tools, since the REST contract is verified separately), and
-  `files.info` (needs a minted file id; see the L1 read exception). A surface is
-  counted only once it has its own evidence — never credited by proxy.
+  `files.info` (not yet an L1 capture row; see the L1 read exception). A surface
+  is counted only once it has its own evidence — never credited by proxy.
 
 ## Known divergences from real Slack
 
@@ -357,6 +357,51 @@ _Shape-anchoring divergences (compile-time anchor to `@slack/web-api`):_
     strictly harder to detect than an honest absent key. The no-blocks case is
     asserted from pome-cloud by `sandboxes/slack/rest-writes.ts`, which until
     this entry only ever asserted the block text it SENT. F-1496.
+
+24. **File objects omit thumbnail, collaborative-edit, per-file-ACL and
+    Slack-AI metadata.** `serializeFile` emits 27 leaves; the file real Slack
+    returns on `files.list` carries 41, and the 15 it has that the twin does not
+    split cleanly in two. ELEVEN are leaves `@slack/web-api` types and this
+    package's own compile-time anchor already declares deliberate omissions —
+    they are in `File_Allow` (`test/upstream-coverage.types.ts`), which is the
+    twin saying "known, not emitted": the per-file permission level `access`,
+    the collaborative-edit trio `editors` / `edit_timestamp` /
+    `update_notification`, the server-side `updated` mtime, the unread hint
+    `show_badge`, the sharing-policy pair `teams_shared_with` /
+    `is_restricted_sharing_enabled`, and the canvas-document leaves
+    `quip_thread_id` / `title_blocks` / `url_static_preview`. FOUR are leaves the
+    SDK does not type at all, so the anchor never saw them and only live capture
+    could: `canvas_creator_id`, `canvas_readtime`, `is_ai_suggested` and
+    `is_modified_by_ai` — the same SDK-lags-Slack situation divergence #16
+    describes, one object over. The twin's `files` table is metadata-only (no
+    binary storage, no thumbnails, no ACL model, no edit history), so all 15 are
+    absent rather than wrong, and NONE is fabricated: `access: "write"` or an
+    `updated` copied off `created` would be a plausible-but-wrong value an agent
+    trusts, which is strictly harder to detect than an honest absent key (the
+    same reasoning as #23). On an L1 READ surface an upstream-only leaf the twin
+    omits is INFO, not drift. Measured 2026-08-13 against
+    `pome-twin-sandbox`; unmeasurable before that, because the twin served
+    `files: []` and the diff engine compares NO elements when either array side
+    is empty. F-1509.
+
+25. **A canvas is a FILE to real Slack and a separate entity here, so
+    `files.list` does not enumerate canvases.** Real Slack stores a canvas in the
+    file table: the only file in `pome-twin-sandbox` on 2026-08-13 was one, and
+    it came back from `files.list` as an ordinary file row with
+    `filetype: "quip"`, `mode: "quip"`, `pretty_type: "Canvas"` and
+    `mimetype: "application/vnd.slack-docs"`. This twin keeps canvases in their
+    own `canvases` table (`domain/canvases.ts`) — which is why reading one is
+    `slack_read_canvas` rather than `files.info`, as the Wave-3 row in the
+    capability table above already says — and `filesList` selects from `files`
+    only. So `canvases.create` followed by `files.list` shows nothing, where real
+    Slack shows the new canvas. NOT imitated here, and the reason is blast radius
+    rather than difficulty: projecting a canvas row into a file row is
+    mechanical, but it changes what `files.list` / `files.info` / `slack_read_file`
+    return for every already-saved task whose criteria count or address files,
+    and a criterion that silently starts seeing one more entity is the failure
+    mode a twin change must not ship as a side effect. Registered as the fact it
+    is; imitating it is its own decision, with its own re-verification of the
+    task corpus. F-1509.
 
 ## Shape anchoring (compile-time, `@slack/web-api@7.16.0`)
 

--- a/packages/twin-slack/README.md
+++ b/packages/twin-slack/README.md
@@ -56,6 +56,35 @@ The default seed creates:
 - Workspace `T_POME` ("Pome Twin Workspace", domain `pome-twin`)
 - Users `pome-agent` (`U_PRIMARY`, admin), `alice` (`U_ALICE`), `bob` (`U_BOB`)
 - Channels `#general` (`C_GENERAL`, all three members, 2 seeded messages) and `#random` (`C_RANDOM`, no members)
+- No files. `files` is a seed key (below) and the default seed declares none.
+
+A seed may also plant files, so `files.list` / `files.info` /
+`slack_read_file` have something to read before the agent uploads anything
+(F-1509 — until that key existed `files.upload` was the table's only writer):
+
+```json
+{
+  "files": [
+    {
+      "id": "F_RUNBOOK",
+      "name": "runbook.md",
+      "title": "Incident runbook",
+      "filetype": "markdown",
+      "user": "alice",
+      "channels": ["general"],
+      "content": "# Runbook\n1. Page the on-call.\n"
+    }
+  ]
+}
+```
+
+`user` and `channels` take seed HANDLES (a user/channel `name`) or ids, the same
+as `channels[].members`. `mimetype` comes from `filetype`, `size` from the byte
+length of `content` and `title` defaults to `name` — the same derivations
+`files.upload` applies, so a seeded file and an uploaded one are
+indistinguishable in a response. A `channels` entry naming no seeded channel is
+dropped rather than stored, so `files.list?channel=…` can never filter against
+an id no channel has.
 
 ## APIs
 

--- a/packages/twin-slack/src/domain/slack-domain.ts
+++ b/packages/twin-slack/src/domain/slack-domain.ts
@@ -43,6 +43,7 @@ import type {
   WorkspaceRow,
 } from "../types.js";
 import { cursorDecode, cursorEncode, nowIso, nowUnix, padTsCounter, tsBaseSeconds } from "../util.js";
+import { filetypeMimetype } from "./helpers.js";
 import * as bookmarks from "./bookmarks.js";
 import * as chat from "./chat.js";
 import * as conversations from "./conversations.js";
@@ -131,9 +132,15 @@ export class SlackDomain {
       }
 
       // Channels + members + messages.
+      // `channelIdByHandle` is what lets `files[].channels` name a channel the
+      // way `channels[].members` names a user — by seed handle, never by a
+      // minted id (F-1509).
+      const channelIdByHandle = new Map<string, string>();
       const seedChannels = state.channels ?? [];
       for (const ch of seedChannels) {
         const channelId = ch.id ?? this.allocId(teamId, ch.is_private ? "G" : "C");
+        channelIdByHandle.set(ch.name, channelId);
+        channelIdByHandle.set(channelId, channelId);
         const creator = this.resolveSeedUserId(ch.creator, userIdByHandle) ?? DEFAULT_BOT_USER;
         this.db
           .prepare(
@@ -195,6 +202,41 @@ export class SlackDomain {
               .run(channelId, ts, r.name, reactorId, now);
           }
         }
+      }
+
+      // Files (F-1509). Written with the SAME derivations `filesUpload` uses —
+      // `mimetype` from `filetype`, `size` from the byte length of `content`,
+      // `title` defaulting to `name` — so a seeded file and an uploaded one are
+      // indistinguishable to `serializeFile`. A `channels` handle that names no
+      // seeded channel is DROPPED rather than stored raw: storing it would make
+      // `files.list?channel=…` filter against an id no channel has, which reads
+      // as "the file is in no channel" from every angle except the stored row.
+      for (const f of state.files ?? []) {
+        const fileId = f.id ?? this.allocId(teamId, "F");
+        const uploader = this.resolveSeedUserId(f.user, userIdByHandle) ?? DEFAULT_BOT_USER;
+        const channelIds = (f.channels ?? [])
+          .map((ref) => channelIdByHandle.get(ref))
+          .filter((id): id is string => id !== undefined);
+        const filetype = f.filetype ?? "text";
+        const content = f.content ?? null;
+        this.db
+          .prepare(
+            `INSERT INTO files (id, team_id, user_id, name, title, mimetype, filetype, size, url_private, channels_json, deleted, content, created_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, '', ?, 0, ?, ?)`
+          )
+          .run(
+            fileId,
+            teamId,
+            uploader,
+            f.name,
+            f.title ?? f.name,
+            filetypeMimetype(filetype),
+            filetype,
+            content === null ? 0 : Buffer.byteLength(content, "utf8"),
+            JSON.stringify(channelIds),
+            content,
+            now
+          );
       }
 
       const seedEmoji = state.emoji ?? [];

--- a/packages/twin-slack/src/seed.ts
+++ b/packages/twin-slack/src/seed.ts
@@ -53,6 +53,22 @@ export const seedSchema = z.object({
       })
     )
     .default([]),
+  // F-1509. Files present in the world before the agent runs. `user` and
+  // `channels` are seed HANDLES (a user/channel `name`) or ids — the same
+  // currency `channels[].members` and `channels[].messages[].user` already use.
+  files: z
+    .array(
+      z.object({
+        id: z.string().regex(/^F[A-Z0-9_]+$/).optional(),
+        name: z.string().min(1),
+        title: z.string().optional(),
+        filetype: z.string().min(1).default("text"),
+        user: z.string().optional(),
+        channels: z.array(z.string()).default([]),
+        content: z.string().optional(),
+      })
+    )
+    .default([]),
   emoji: z
     .array(
       z.object({

--- a/packages/twin-slack/src/types.ts
+++ b/packages/twin-slack/src/types.ts
@@ -58,10 +58,41 @@ export type SeedEmoji = {
   alias?: string;
 };
 
+/**
+ * A file present in the world before the agent touches it (F-1509).
+ *
+ * Until this existed the `files` table had exactly ONE writer — `filesUpload`,
+ * a mutation — so every read of `files.list` / `files.info` against a freshly
+ * seeded world answered on an empty table. That is not a serializer gap and it
+ * was not a deliberate ruling; it is simply a hole in the seed vocabulary, and
+ * it made `files.list` a surface no read-only comparison could measure.
+ *
+ * `user` and `channels` carry SEED HANDLES (a user `name` / channel `name`), the
+ * same currency `SeedMessage.user` and `SeedChannel.members` use, so a seed never
+ * has to know a minted id. Both also accept an explicit id.
+ */
+export type SeedFile = {
+  /** Explicit stable id (`F…`). Minted from the workspace counter when absent. */
+  id?: string;
+  /** Filename, e.g. `runbook.md`. */
+  name: string;
+  /** Display title. Defaults to `name`, matching `files.upload`. */
+  title?: string;
+  /** Slack filetype (`text`, `markdown`, `javascript`, …). Drives `mimetype`. */
+  filetype?: string;
+  /** Uploader — a seed user handle or id. Defaults to the seed's agent user. */
+  user?: string;
+  /** Channels the file is shared into — seed channel handles or ids. */
+  channels?: string[];
+  /** File body. `size` is derived from it, as `files.upload` derives it. */
+  content?: string;
+};
+
 export type SlackStateSeed = {
   team?: SeedTeam;
   users?: SeedUser[];
   channels?: SeedChannel[];
+  files?: SeedFile[];
   emoji?: SeedEmoji[];
 };
 

--- a/packages/twin-slack/test/seed-files.test.ts
+++ b/packages/twin-slack/test/seed-files.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Seeded files (F-1509).
+ *
+ * WHAT WAS WRONG, stated as the thing these tests refuse. `files` had exactly
+ * one writer — `filesUpload`, a mutation — so `files.list` and `files.info`
+ * against a freshly seeded world always answered on an empty table. The
+ * fidelity watchdog measured that as `GET /files.list upstream=1 twin=0` and,
+ * because the diff engine compares NO elements when either array side is empty,
+ * the empty twin array masked every field-level comparison on the surface: one
+ * count finding, and not one thing more.
+ *
+ * So the load-bearing assertion here is not "a row exists" — it is that a
+ * SEEDED file reaches `files.list` and `files.info` with the SAME derivations an
+ * UPLOADED file gets. A seed that planted rows `serializeFile` renders
+ * differently would trade the empty-array blind spot for a subtler one.
+ */
+import { describe, expect, it } from "vitest";
+import { openSlackTwinDatabase } from "../src/db.js";
+import { SlackDomain } from "../src/domain/index.js";
+import { defaultSeedState, parseSeed } from "../src/seed.js";
+import type { SeedFile, SlackStateSeed } from "../src/types.js";
+
+function withFiles(files: SlackStateSeed["files"]): SlackDomain {
+  const db = openSlackTwinDatabase(":memory:");
+  const domain = new SlackDomain(db);
+  domain.seed({ ...defaultSeedState(), files });
+  return domain;
+}
+
+const RUNBOOK_CONTENT = "# Runbook\n1. Page the on-call.\n";
+
+const RUNBOOK: SeedFile = {
+  id: "F_RUNBOOK",
+  name: "runbook.md",
+  title: "Incident runbook",
+  filetype: "markdown",
+  user: "alice",
+  channels: ["general"],
+  content: RUNBOOK_CONTENT,
+};
+
+describe("seeded files — files.list", () => {
+  it("serves a seeded file, so the surface is no longer an empty array", () => {
+    const listed = withFiles([{ ...RUNBOOK }]).filesList({}) as {
+      files: Array<{ id: string }>;
+      paging: { total: number; pages: number };
+    };
+    expect(listed.files.map((f) => f.id)).toEqual(["F_RUNBOOK"]);
+    // `paging` is derived from the table, so it moves with the seed rather than
+    // reporting the zeros an empty world produced.
+    expect(listed.paging.total).toBe(1);
+    expect(listed.paging.pages).toBe(1);
+  });
+
+  it("still serves an empty array when the seed declares no files", () => {
+    const domain = new SlackDomain(openSlackTwinDatabase(":memory:"));
+    domain.seed(defaultSeedState());
+    const listed = domain.filesList({}) as { files: unknown[]; paging: { total: number } };
+    expect(listed.files).toEqual([]);
+    expect(listed.paging.total).toBe(0);
+  });
+
+  it("derives mimetype, size and title exactly as files.upload does", () => {
+    const seeded = withFiles([{ ...RUNBOOK }]).filesList({}) as {
+      files: Array<{ mimetype: string; size: number; title: string; filetype: string }>;
+    };
+    const uploadDomain = withFiles([]);
+    const uploaded = uploadDomain.filesUpload(
+      { channels: "C_GENERAL", filename: RUNBOOK.name, filetype: RUNBOOK.filetype, content: RUNBOOK.content },
+      { login: "alice" },
+    ) as { file: { mimetype: string; size: number; title: string; filetype: string } };
+
+    expect(seeded.files[0]!.mimetype).toBe(uploaded.file.mimetype);
+    expect(seeded.files[0]!.mimetype).toBe("text/markdown");
+    expect(seeded.files[0]!.size).toBe(uploaded.file.size);
+    expect(seeded.files[0]!.size).toBe(Buffer.byteLength(RUNBOOK_CONTENT, "utf8"));
+    expect(seeded.files[0]!.filetype).toBe("markdown");
+    // `title` was given here; `files.upload` defaults it to the filename, and so
+    // does the seed — asserted separately below.
+    expect(seeded.files[0]!.title).toBe("Incident runbook");
+    expect(uploaded.file.title).toBe(RUNBOOK.name);
+  });
+
+  it("defaults title to name and size to 0 with no content, like files.upload", () => {
+    const listed = withFiles([{ name: "empty.txt" }]).filesList({}) as {
+      files: Array<{ title: string; size: number; mimetype: string; user: string }>;
+    };
+    expect(listed.files[0]!.title).toBe("empty.txt");
+    expect(listed.files[0]!.size).toBe(0);
+    expect(listed.files[0]!.mimetype).toBe("text/plain");
+    // No `user` handle → the seed's agent user, not a dangling id.
+    expect(listed.files[0]!.user).toBe("U_PRIMARY");
+  });
+});
+
+describe("seeded files — handle resolution", () => {
+  it("resolves a user handle to the seeded user id", () => {
+    const listed = withFiles([{ ...RUNBOOK }]).filesList({}) as { files: Array<{ user: string }> };
+    expect(listed.files[0]!.user).toBe("U_ALICE");
+  });
+
+  it("resolves a channel handle to the minted channel id", () => {
+    const listed = withFiles([{ ...RUNBOOK }]).filesList({}) as { files: Array<{ channels: string[] }> };
+    expect(listed.files[0]!.channels).toEqual(["C_GENERAL"]);
+  });
+
+  it("accepts an explicit channel id as well as a handle", () => {
+    const listed = withFiles([{ ...RUNBOOK, channels: ["C_RANDOM"] }]).filesList({}) as {
+      files: Array<{ channels: string[] }>;
+    };
+    expect(listed.files[0]!.channels).toEqual(["C_RANDOM"]);
+  });
+
+  it("drops a channel handle that names no seeded channel rather than storing it raw", () => {
+    // Storing the raw ref would make `files.list?channel=…` filter against an id
+    // no channel has: the row would claim a channel that cannot be addressed.
+    const domain = withFiles([{ ...RUNBOOK, channels: ["general", "nope"] }]);
+    const listed = domain.filesList({}) as { files: Array<{ channels: string[] }> };
+    expect(listed.files[0]!.channels).toEqual(["C_GENERAL"]);
+  });
+
+  it("filters files.list by the seeded channel the file is shared into", () => {
+    const domain = withFiles([
+      { ...RUNBOOK },
+      { id: "F_MEMO", name: "memo.txt", channels: ["random"] },
+    ]);
+    const general = domain.filesList({ channel: "C_GENERAL" }) as { files: Array<{ id: string }> };
+    const random = domain.filesList({ channel: "C_RANDOM" }) as { files: Array<{ id: string }> };
+    expect(general.files.map((f) => f.id)).toEqual(["F_RUNBOOK"]);
+    expect(random.files.map((f) => f.id)).toEqual(["F_MEMO"]);
+  });
+});
+
+describe("seeded files — files.info", () => {
+  it("addresses a seeded file by its stable seed id", () => {
+    // This is what made `GET /files.info` a documented capture EXCEPTION: with
+    // no seedable file there was no stable id to address.
+    const info = withFiles([{ ...RUNBOOK }]).filesInfo({ file: "F_RUNBOOK" }) as {
+      file: { id: string; name: string };
+    };
+    expect(info.file.id).toBe("F_RUNBOOK");
+    expect(info.file.name).toBe("runbook.md");
+  });
+
+  it("mints an F-prefixed id when the seed does not pin one", () => {
+    const listed = withFiles([{ name: "minted.txt" }]).filesList({}) as { files: Array<{ id: string }> };
+    expect(listed.files[0]!.id).toMatch(/^F/);
+  });
+});
+
+describe("seeded files — schema", () => {
+  it("defaults files to an empty array so every existing seed still parses", () => {
+    expect(parseSeed({}).files).toEqual([]);
+  });
+
+  it("rejects an id that is not Slack-file-shaped", () => {
+    expect(() => parseSeed({ files: [{ id: "C_NOPE", name: "x.txt" }] })).toThrow();
+  });
+
+  it("rejects a file with no name", () => {
+    expect(() => parseSeed({ files: [{ title: "no name" }] })).toThrow();
+  });
+
+  it("reseeding wipes previously seeded files rather than accumulating them", () => {
+    const domain = withFiles([{ ...RUNBOOK }]);
+    domain.seed({ ...defaultSeedState(), files: [{ id: "F_OTHER", name: "other.txt" }] });
+    const listed = domain.filesList({}) as { files: Array<{ id: string }> };
+    expect(listed.files.map((f) => f.id)).toEqual(["F_OTHER"]);
+  });
+});
+
+describe("seeded files — state export", () => {
+  it("reports seeded files in the exported state", () => {
+    const state = withFiles([{ ...RUNBOOK }]).exportState() as { files: Array<{ id: string }> };
+    expect(state.files.map((f) => f.id)).toEqual(["F_RUNBOOK"]);
+  });
+});


### PR DESCRIPTION
## What

A Slack seed can declare `files`, so `files.list` / `files.info` / `slack_read_file`
have something to read before the agent uploads anything.

`files` had exactly one writer — `filesUpload`, a **mutation**. So every read-only
capture against a freshly seeded world answered on an empty table, and pome-cloud's
fidelity watchdog measured `GET /files.list upstream=1 twin=0` once real Slack's
sandbox workspace began returning a file on 2026-08-13.

**The count was the smaller half.** `diffArray` returns before any element work when
*either* array side is empty, so that one count finding was the most the surface could
ever produce — all 41 leaves of real Slack's file object went uncompared behind it. The
empty array was not just a mismatch, it was a mask. Seeding one file is what makes the
object comparable at all, so **expect the finding count to go up**, not down. That is
the point.

Diagnosed for F-1509 (a fidelity-seam ticket in pome-cloud). This half is the twin
capability; pome-cloud's half declares a file in `FIDELITY_SLACK_SEED` and registers
what the newly-possible comparison found.

## The seed shape

```json
{ "files": [{ "id": "F_RUNBOOK", "name": "runbook.md", "title": "Incident runbook",
              "filetype": "markdown", "user": "alice", "channels": ["general"],
              "content": "# Runbook\n" }] }
```

`user` and `channels` take seed **handles** or ids — the same currency
`channels[].members` and `channels[].messages[].user` already use, so a seed never has
to know a minted id.

## Reviewer notes

**The derivations are deliberately `filesUpload`'s, not new ones.** `mimetype` from
`filetype`, `size` from the byte length of `content`, `title` defaulting to `name`. A
seed that planted rows `serializeFile` rendered differently would trade the
empty-array blind spot for a subtler one, so `test/seed-files.test.ts` asserts a
seeded file and an uploaded one field-for-field rather than asserting constants.

**A `channels` handle naming no seeded channel is dropped, not stored raw.** Storing
it would make `files.list?channel=…` filter against an id no channel has: the row
would claim a channel that cannot be addressed from any direction except the stored
JSON.

**`cli/src/task/taskSchema.ts` is not optional.** Its slack arm is the union's only
`.strict()` one, so an unlisted key there is *rejected*, not stripped — without that
line a task seed declaring `files` fails to parse. `parseTask.test.ts` covers it.

**Two new FIDELITY.md divergences, and they are what the comparison found**, not
anticipation:

- **#24** — the 15 upstream leaves the file object omits. Eleven are already in
  `File_Allow` (`test/upstream-coverage.types.ts`), i.e. this package's compile-time
  anchor already declared them deliberate omissions; four (`canvas_creator_id`,
  `canvas_readtime`, `is_ai_suggested`, `is_modified_by_ai`) are not typed by
  `@slack/web-api` at all, so only live capture could see them. None is fabricated —
  `access: "write"` for every caller, or an `updated` copied off `created`, is a
  plausible-but-wrong value an agent trusts, which is harder to detect than an honest
  absent key (#23's reasoning).
- **#25** — a canvas is a **file** to real Slack and a separate table here, so
  `files.list` does not enumerate canvases. The only file the sandbox holds *is* a
  canvas, which is why those four leaves are in the payload at all. Not imitated, and
  the reason is blast radius: projecting a canvas row into a file row is mechanical,
  but it changes what `files.list` / `files.info` / `slack_read_file` return for every
  saved task whose criteria count or address files.

Their structured halves land in pome-cloud's `known-divergences/slack.yaml`; the 1:1
lint passes at 25 entries.

**This change is inert until pome-cloud's half merges.** `files` defaults to `[]`,
nothing in this repo declares one, and the `files` table is untouched when the key is
empty. Merging this alone moves no fidelity reading.

## Verification

| Check | Result |
|---|---|
| `packages/twin-slack` vitest | 335 pass (35 files), incl. 16 new in `seed-files.test.ts` |
| Same 16 against `main`'s `src/` | **15 fail** — the tests bind |
| `cli` vitest | 1164 pass, 1 skipped |
| 6 new CLI tests against `main`'s `cli/src/` | **6 fail** — they bind |
| `npm run test:contract` | 110 pass, 5 skipped, 0 fail |
| `tsc --noEmit` (twin-slack, cli) | clean |
| `lint:code-health`, `lint:no-catch`, `lint:twin-leaves`, `lint:copy-markers`, `lint:import-meta-main` | pass |
| `known-divergences` 1:1 lint | OK, 25 entries |

`route-inputs.json` is untouched — no route input declaration changed.

`cli/CHANGELOG.md` carries an `## Unreleased (minor)` entry and no version number
(F-1511: the allocator writes the number after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
