### PR TITLE
The twin runtime takes Debian's security fixes, so a pinned base cannot freeze a fixable CVE (F-1532)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -18,3 +18,36 @@
 #
 # (No exceptions currently. Keep this list empty unless a fixable HIGH/CRITICAL
 # genuinely cannot be remediated in time and has been reviewed.)
+#
+# ── Decision record: CVE-2026-53615 (util-linux) — F-1532, 2026-08-18 ─────────
+#
+# NOT excepted here, and the list above is still empty. Written down anyway: the
+# next person to hit a fixable base-image CVE reads this file first, and the
+# exception this file exists to grant was considered and refused on the record.
+#
+# THE FINDING. Nine rows, one source package — bsdutils, libblkid1,
+# liblastlog2-2, libmount1, libsmartcols1, libuuid1, login, mount, util-linux —
+# all at 2.41-5, all fixed in 2.41.5-0+deb13u1. No image changed to produce it:
+# Trivy passed on the same commit on 08-14 and failed on 08-18, so a DB entry
+# published in between landed on digest-frozen contents. It refused the stripe
+# publish outright (push + sign skipped, nothing reached GHCR), and the three
+# twins on the same base were one merge away from the same wall.
+#
+# CHOSEN: install the fix in the runtime stage — `apt-get upgrade`, see
+# packages/twin-*/Dockerfile. Debian had already shipped 2.41.5-0+deb13u1 to
+# trixie-security, so the fix existed the whole time and only the digest pin
+# stood between the image and it. This spends no exception and needs no
+# exploitability judgement, because nothing vulnerable remains in the image.
+#
+# REJECTED: bump the pinned base digest. Upstream had rebuilt both tags
+# (24-trixie-slim → sha256:0711b541…, 26-trixie-slim → sha256:4ebb5ace…), so a
+# bump was available — but a pull and scan of BOTH new digests found the same
+# nine rows at the same util-linux 2.41-5. No digest carrying the fix existed to
+# bump to, for either node major, so the bump is not a remedy for this CVE at
+# all. Digest currency stays Renovate's fortnightly job, on its own merits.
+#
+# REJECTED: add CVE-2026-53615 to the list above. It would have needed rule 1's
+# named human assessment of a libblkid path a twin never walks, and the closing
+# note's bar — a fixable finding that "genuinely cannot be remediated in time" —
+# is not met by one Debian had already fixed and that a build could take the
+# same day. It would also have left a review-by date to service, for nothing.

--- a/packages/twin-github/Dockerfile
+++ b/packages/twin-github/Dockerfile
@@ -31,6 +31,19 @@ ENV GITHUB_CLONE_HOST=0.0.0.0
 # Runtime only executes `node`; npm/npx from the base image add unused packages
 # (and their CVE surface) to the scanned image.
 RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
+# F-1532 — take Debian's published security fixes on top of the pinned digest.
+# The digest freezes this image's package contents; Trivy's vulnerability DB is
+# refreshed on every run. So a fix Debian ships BEFORE upstream rebuilds the
+# node:*-trixie-slim tag lands as a FIXABLE HIGH on frozen contents, and the
+# publish gate then refuses this image identically on every future run — not a
+# flake, and a re-run cannot clear it. CVE-2026-53615 (util-linux; nine binary
+# packages, one source) did exactly that on 2026-08-18, and neither upstream
+# digest then current carried the fix, so bumping the pin was not a remedy.
+# The pin still fixes where the image STARTS; this layer lets a rebuild move.
+# Decision record, and why no .trivyignore exception was spent: .trivyignore.
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
 COPY --from=build /repo/node_modules ./node_modules
 # The twin's dist imports @pome-sh/wire; ship its built output. Before F-942 this
 # was `COPY packages/shared-types` -- the WHOLE directory, sources included -- because

--- a/packages/twin-gmail/Dockerfile
+++ b/packages/twin-gmail/Dockerfile
@@ -23,6 +23,19 @@ WORKDIR /repo
 ENV NODE_ENV=production
 ENV GMAIL_TWIN_HOST=0.0.0.0
 RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
+# F-1532 — take Debian's published security fixes on top of the pinned digest.
+# The digest freezes this image's package contents; Trivy's vulnerability DB is
+# refreshed on every run. So a fix Debian ships BEFORE upstream rebuilds the
+# node:*-trixie-slim tag lands as a FIXABLE HIGH on frozen contents, and the
+# publish gate then refuses this image identically on every future run — not a
+# flake, and a re-run cannot clear it. CVE-2026-53615 (util-linux; nine binary
+# packages, one source) did exactly that on 2026-08-18, and neither upstream
+# digest then current carried the fix, so bumping the pin was not a remedy.
+# The pin still fixes where the image STARTS; this layer lets a rebuild move.
+# Decision record, and why no .trivyignore exception was spent: .trivyignore.
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
 COPY --from=build /repo/node_modules ./node_modules
 # The twin's dist imports @pome-sh/wire; ship its built output. Before F-942 this
 # was `COPY packages/shared-types` -- the WHOLE directory, sources included -- because

--- a/packages/twin-linear/Dockerfile
+++ b/packages/twin-linear/Dockerfile
@@ -23,6 +23,19 @@ WORKDIR /repo
 ENV NODE_ENV=production
 ENV LINEAR_TWIN_HOST=0.0.0.0
 RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
+# F-1532 — take Debian's published security fixes on top of the pinned digest.
+# The digest freezes this image's package contents; Trivy's vulnerability DB is
+# refreshed on every run. So a fix Debian ships BEFORE upstream rebuilds the
+# node:*-trixie-slim tag lands as a FIXABLE HIGH on frozen contents, and the
+# publish gate then refuses this image identically on every future run — not a
+# flake, and a re-run cannot clear it. CVE-2026-53615 (util-linux; nine binary
+# packages, one source) did exactly that on 2026-08-18, and neither upstream
+# digest then current carried the fix, so bumping the pin was not a remedy.
+# The pin still fixes where the image STARTS; this layer lets a rebuild move.
+# Decision record, and why no .trivyignore exception was spent: .trivyignore.
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
 COPY --from=build /repo/node_modules ./node_modules
 # The twin's dist imports @pome-sh/wire; ship its built output. Before F-942 this
 # was `COPY packages/shared-types` -- the WHOLE directory, sources included -- because

--- a/packages/twin-slack/Dockerfile
+++ b/packages/twin-slack/Dockerfile
@@ -31,6 +31,19 @@ ENV SLACK_CLONE_HOST=0.0.0.0
 # Runtime only executes `node`; npm/npx from the base image add unused packages
 # (and their CVE surface) to the scanned image.
 RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
+# F-1532 — take Debian's published security fixes on top of the pinned digest.
+# The digest freezes this image's package contents; Trivy's vulnerability DB is
+# refreshed on every run. So a fix Debian ships BEFORE upstream rebuilds the
+# node:*-trixie-slim tag lands as a FIXABLE HIGH on frozen contents, and the
+# publish gate then refuses this image identically on every future run — not a
+# flake, and a re-run cannot clear it. CVE-2026-53615 (util-linux; nine binary
+# packages, one source) did exactly that on 2026-08-18, and neither upstream
+# digest then current carried the fix, so bumping the pin was not a remedy.
+# The pin still fixes where the image STARTS; this layer lets a rebuild move.
+# Decision record, and why no .trivyignore exception was spent: .trivyignore.
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
 COPY --from=build /repo/node_modules ./node_modules
 # The twin's dist imports @pome-sh/wire; ship its built output. Before F-942 this
 # was `COPY packages/shared-types` -- the WHOLE directory, sources included -- because

--- a/packages/twin-stripe/Dockerfile
+++ b/packages/twin-stripe/Dockerfile
@@ -31,6 +31,19 @@ ENV STRIPE_CLONE_HOST=0.0.0.0
 # Runtime only executes `node`; npm/npx from the base image add unused packages
 # (and their CVE surface) to the scanned image.
 RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
+# F-1532 — take Debian's published security fixes on top of the pinned digest.
+# The digest freezes this image's package contents; Trivy's vulnerability DB is
+# refreshed on every run. So a fix Debian ships BEFORE upstream rebuilds the
+# node:*-trixie-slim tag lands as a FIXABLE HIGH on frozen contents, and the
+# publish gate then refuses this image identically on every future run — not a
+# flake, and a re-run cannot clear it. CVE-2026-53615 (util-linux; nine binary
+# packages, one source) did exactly that on 2026-08-18, and neither upstream
+# digest then current carried the fix, so bumping the pin was not a remedy.
+# The pin still fixes where the image STARTS; this layer lets a rebuild move.
+# Decision record, and why no .trivyignore exception was spent: .trivyignore.
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
 COPY --from=build /repo/node_modules ./node_modules
 # The twin's dist imports @pome-sh/wire; ship its built output. Before F-942 this
 # was `COPY packages/shared-types` -- the WHOLE directory, sources included -- because

--- a/scripts/ci/check-release-note-required.test.mjs
+++ b/scripts/ci/check-release-note-required.test.mjs
@@ -26,6 +26,10 @@
  *           over: a twin's top-level `.md`.
  *   F-1354  Same prefix again: a twin's own top-level `scripts/`, found on the
  *           PR whose whole job was wiring such a script into CI.
+ *   F-1532  Same prefix, one file over: a twin's own `Dockerfile`. A GHCR image
+ *           is not an npm artifact, so patching a base image was demanding both
+ *           a cli and a sandbox-domains release. Found on the PR that had to
+ *           edit all five to clear a fixable base-image CVE.
  *
  * Each carve-out is paired with an anchoring case (`src/examples/`,
  * `src/scripts/`, `cli/scripts/`, a doc riding along with a src change) because
@@ -252,6 +256,46 @@ console.log("check-release-note-required.mjs — publish relevance (inherited)")
   });
   check(
     "a script change RIDING ALONG with a src change still demands an entry",
+    r.status === 1 && r.out.includes("@pome-sh/cli"),
+    r.out,
+  );
+}
+
+{
+  // F-1532: a twin's Dockerfile builds its GHCR image, which no tarball carries.
+  // The real case was all five at once, to clear a fixable base-image CVE.
+  const r = run({
+    changes: {
+      "packages/twin-github/Dockerfile": "FROM node:24-trixie-slim\n",
+      "packages/twin-gmail/Dockerfile": "FROM node:26-trixie-slim\n",
+      "packages/twin-linear/Dockerfile": "FROM node:26-trixie-slim\n",
+      "packages/twin-slack/Dockerfile": "FROM node:24-trixie-slim\n",
+      "packages/twin-stripe/Dockerfile": "FROM node:24-trixie-slim\n",
+    },
+  });
+  check("a change confined to the twins' Dockerfiles needs no entry", r.status === 0, r.out);
+}
+
+{
+  // Anchoring check, exact filename under the twin root: `src/` is where tsup
+  // actually reaches, so a Dockerfile sitting there is not exempt.
+  const r = run({ changes: { "packages/twin-stripe/src/Dockerfile": "FROM scratch\n" } });
+  check(
+    "a Dockerfile under a twin's src/ with no entry still fails",
+    r.status === 1 && r.out.includes("@pome-sh/cli"),
+    r.out,
+  );
+}
+
+{
+  const r = run({
+    changes: {
+      "packages/twin-stripe/Dockerfile": "FROM node:24-trixie-slim\n",
+      "packages/twin-stripe/src/index.ts": "export const a = 1;\n",
+    },
+  });
+  check(
+    "a Dockerfile change RIDING ALONG with a src change still demands an entry",
     r.status === 1 && r.out.includes("@pome-sh/cli"),
     r.out,
   );

--- a/scripts/ci/publish-relevance.mjs
+++ b/scripts/ci/publish-relevance.mjs
@@ -138,6 +138,38 @@ function isTwinScriptPath(file) {
 }
 
 /**
+ * A twin's own `Dockerfile` is the recipe for its GHCR image, and that image is
+ * not an npm artifact: `release.yml` publishes tarballs, `twin-image.yml`
+ * publishes images, and no version number spans the two. It ships in no tarball
+ * for the same load-bearing reason as the three carve-outs above — every twin is
+ * `private: true` — and here the weaker reason happens to hold as well: no
+ * twin's `files` array names a Dockerfile, unlike the `dist/examples/` and
+ * `dist/scripts/` cases.
+ *
+ * The CLI's and `@pome-sh/sandbox-domains`' tarballs are the other artifacts
+ * that could carry these bytes, and do not: tsup inlines twin source reached
+ * from each twin's package `exports`, which resolve into `src/` only, and a
+ * Dockerfile is imported by nothing.
+ *
+ * Fourth instance of the F-1455 over-match, one file over from `examples/`,
+ * top-level `.md` and `scripts/`: `packages/twin-` is a plain prefix, so
+ * patching a base image demanded BOTH a `@pome-sh/cli` and a
+ * `@pome-sh/sandbox-domains` release — two republishes that would each be
+ * byte-identical. Found on F-1532, where a fixable base-image CVE had frozen the
+ * twin image publish deterministically and the remedy could only be applied in
+ * these five files. RELEASING.md's "if your change doesn't warrant a release it
+ * shouldn't be touching a publish-relevant path" has no answer here either: a
+ * twin's Dockerfile has nowhere else to live.
+ *
+ * The filename is matched EXACTLY and anchored directly under the twin root, so
+ * a Dockerfile somewhere a bundler could plausibly reach —
+ * `packages/twin-stripe/src/Dockerfile` — is NOT exempt.
+ */
+function isTwinDockerfilePath(file) {
+  return /^packages\/twin-[^/]+\/Dockerfile$/.test(file);
+}
+
+/**
  * F-1511 — a `CHANGELOG.md` is exempt, and this one is NOT the F-1455 shape:
  * these bytes really do ship (`packages/checks/package.json` and
  * `packages/twin-linear/package.json` name `CHANGELOG.md` in `files`, and npm
@@ -179,6 +211,7 @@ export function isPublishIrrelevantPath(file) {
   if (isTwinExamplePath(file)) return "a twin's top-level examples/ (every twin is `private: true`)";
   if (isTwinTopLevelDocPath(file)) return "a twin's top-level docs (every twin is `private: true`)";
   if (isTwinScriptPath(file)) return "a twin's top-level scripts/ (dev tooling, in no tarball)";
+  if (isTwinDockerfilePath(file)) return "a twin's Dockerfile (a GHCR image recipe, in no tarball)";
   if (isChangelogPath(file)) return "a CHANGELOG.md (the entry, not the artifact — see publish-relevance.mjs)";
   return null;
 }


### PR DESCRIPTION
## What this fixes

`CVE-2026-53615` (integer overflow in `libblkid/src/partitions/dos.c`) was
failing `twin-image.yml`'s Trivy gate deterministically, refusing the `stripe`
publish outright. No image had changed: the runtime base is digest-pinned while
Trivy's DB is downloaded fresh every run, so a Debian fix published after the
last upstream base rebuild lands as a FIXABLE HIGH on frozen contents. `Total: 9
(HIGH: 9)` — nine binary packages from one source (`util-linux`).

The runtime stage now takes Debian's published security updates, so the finding
is **fixed in the image** rather than excepted. `.trivyignore` still carries zero
rules: this PR passes the gate on the fix, not on a waiver.

## The two remedies on the table were both measured, and both refused

Recorded in full in `.trivyignore`, because that file is the audit trail.

**Bump the pinned base digest — not a remedy at all.** Upstream had rebuilt both
tags, so a bump was available. But a pull + scan of *both* new digests found the
same nine rows at the same `util-linux 2.41-5`:

| image | debian | util-linux | CVE-2026-53615 |
|---|---|---|---|
| `node:24-trixie-slim@9022946f…` (pinned) | 13.5 | 2.41-5 | 9 rows |
| `node:24-trixie-slim@0711b541…` (upstream) | 13.6 | 2.41-5 | **9 rows** |
| `node:26-trixie-slim@715e55e4…` (pinned) | 13.6 | 2.41-5 | **9 rows** |
| `node:26-trixie-slim@4ebb5ace…` (upstream) | 13.6 | 2.41-5 | **9 rows** |

No digest carrying the fix existed, for either node major. Digest currency stays
Renovate's fortnightly job, on its own merits — the pins **are** stale (node
24.17→24.19, debian 13.5→13.6), that is just a separate change from this one.

**Add the CVE to `.trivyignore` — refused.** It would have spent this repo's
first-ever exception, plus rule 1's named human exploitability assessment of a
libblkid path a twin never walks, on a CVE Debian had **already fixed** and that
a build could take the same day. The closing note's bar — a fixable finding that
"genuinely cannot be remediated in time" — is not met.

**What this does instead.** Debian had shipped `2.41.5-0+deb13u1` to
`trixie-security` the whole time; only the pin stood between the image and it.
The pin still fixes where the image *starts*; the new layer lets a rebuild move,
which a pin alone can never do. Blanket `apt-get upgrade` over a targeted
`--only-upgrade util-linux` because the measured cost is nearly nothing (11 vs 9
packages on the stale node:24 base — the extras are `base-files` and `liblzma5`,
themselves point-release/security updates; 9 vs 9 on node:26) and it stops the
*next* base-lag CVE from freezing the publish the same way.

## Scope was five twins, not three

The open question about `node:26-trixie-slim` is settled by measurement, not
inference: it carries the **identical** nine-row finding. `gmail` and `linear`
were one merge away from the same wall; only `stripe` showed it because `stripe`
was the only image missing.

## Second commit: a twin's Dockerfile is not an npm artifact

The five-Dockerfile change above tripped `check-release-note-required.mjs`,
which demanded a release note from **both** `@pome-sh/cli` and
`@pome-sh/sandbox-domains` — two republishes that would each have been
byte-identical.

That is the fourth instance of the over-match `publish-relevance.mjs` already
documents three times (`F-1455` twin `examples/`, twin top-level `.md`, `F-1354`
twin `scripts/`): `packages/twin-` is a plain string prefix. A Dockerfile ships
in no tarball — every twin is `private: true` (the load-bearing reason), no
twin's `files` names a Dockerfile, and tsup reaches twin source only through each
twin's `exports`, which resolve into `src/`. Carve-out added in the same shape,
matched exactly and anchored at the twin root.

## Verification

Built all five images locally for `linux/amd64` as CI does, then ran the gate's
exact flags (`--severity HIGH,CRITICAL --ignore-unfixed --exit-code 1
--ignorefile .trivyignore`):

```
util-linux   github/gmail/linear/slack/stripe → 2.41.5-0+deb13u1
trivy        all five: exit=0, fixable HIGH/CRITICAL findings=0
/healthz     all five: OK, build provenance intact
```

Plus `check-release-note-required.test.mjs` (with three new paired cases:
Dockerfile-only exempt, `src/Dockerfile` NOT exempt, Dockerfile riding along with
a `src/` change still owes an entry), `allocate-release-versions.test.mjs`, and
`lint:code-health`.

## Reviewer notes

- **`.trivyignore` gains 33 lines and zero rules.** Worth a read — it is where
  the rejected options live, and it is what the next person hitting a fixable
  base CVE will find.
- **The gate's own verdict is the one that matters.** A PR run of
  `twin-image.yml` builds and scans but never pushes, so this PR proves the
  Trivy gate for all five twins; `stripe-<sha>` only reaches GHCR on the merge
  run.
- Additive only: `+175 / -0`.
- Deliberately untouched: the pinned digests, and the separate smell that five
  twins carry two node majors and two base digests.

Refs F-1532. Unblocks the `twin-snapshot-verify` stripe leg.
