### PR TITLE
twin-github's three release surfaces carry `immutable`, the last leaf real GitHub sends that they did not (F-1533)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -10,6 +10,17 @@ write a version number here or in `package.json` — see `RELEASING.md`. Release
 entries are insertions only: a correction is the next entry, naming the one it
 corrects.
 
+## Unreleased (patch)
+
+**twin-github's three release surfaces carry `immutable`** (F-1533).
+`GET /repos/:o/:r/releases`, `GET /repos/:o/:r/releases/latest` and
+`GET /repos/:o/:r/releases/tags/:tag` now emit `immutable: false`, the last
+top-level leaf real GitHub sends on those routes that the twin did not. `false`
+is the true value rather than a placeholder: the twin models no
+immutable-release feature and has no route that could enable one, so every
+release in every reachable state is mutable. Nothing a consumer must act on —
+the key is added, none is removed or renamed.
+
 ## 0.24.0 — 2026-08-18
 
 **A Slack seed can plant files** (F-1509). `slackSeedStateSchema` gains a `files`

--- a/packages/sandbox-domains/CHANGELOG.md
+++ b/packages/sandbox-domains/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @pome-sh/sandbox-domains
 
+## Unreleased (patch)
+
+**`GitHubDomain`'s three release surfaces carry `immutable`** (F-1533).
+`listReleases`, `getLatestRelease` and `getReleaseByTag` now emit
+`immutable: false`, the last top-level leaf real GitHub sends on those routes
+that the twin did not. `false` is the true value rather than a placeholder: the
+twin models no immutable-release feature and has no route that could enable one,
+so every release in every reachable state is mutable. Nothing a consumer must
+act on — the key is added, none is removed or renamed.
+
 ## 0.2.1 — 2026-08-18
 
 **`SlackDomain.seed` writes files, and `slackSeedSchema` accepts them** (F-1509).

--- a/packages/twin-github/src/serializers.ts
+++ b/packages/twin-github/src/serializers.ts
@@ -610,7 +610,24 @@ export function releaseJson(release: ReleaseRow, repo: RepoRow) {
     upload_url: `https://uploads.github.com/repos/${repo.full_name}/releases/${release.id}/assets{?name,label}`,
     tarball_url: `https://api.github.com/repos/${repo.full_name}/tarball/${release.tag_name}`,
     zipball_url: `https://api.github.com/repos/${repo.full_name}/zipball/${release.tag_name}`,
-    assets: []
+    assets: [],
+    // F-1533 — the last leaf real GitHub sends on all three release surfaces
+    // that this twin did not. Same shape of fix as `updated_at` above (F-1459),
+    // and the same reason it went unnoticed: `satisfies DeepPartial<Release>`
+    // encodes "faithful SUBSET", so it cannot see an omission.
+    //
+    // `false` is the TRUE value here, not a placeholder. This twin models no
+    // immutable-release feature and has no route that could enable one — no
+    // `PUT /repos/:o/:r/immutable-releases`, nothing on the seed — so every
+    // release in every reachable twin state IS mutable. That is what separates
+    // this from the nine sibling fields F-1504 registered rather than fixed:
+    // stating `false` invents no model.
+    //
+    // Not a column. A stored value would be a second source of truth for a
+    // feature that does not exist, and the first route to enable immutability
+    // is the change that owes one — the inverse of `updated_at`, which IS a
+    // column precisely because a future update route must be able to move it.
+    immutable: false
   } satisfies DeepPartial<Release>;
 }
 

--- a/packages/twin-github/test/seed-entities.test.ts
+++ b/packages/twin-github/test/seed-entities.test.ts
@@ -376,6 +376,60 @@ describe("F-1421 — the release surfaces that had no seedable state", () => {
     expect(body.map((tag: { name: string }) => tag.name)).toEqual([WORLD_A.tagName]);
   });
 
+  // F-1533 — the three release surfaces serve one object, so a leaf missing
+  // from ONE of them is the whole defect. Asserted per surface rather than on
+  // `releaseJson` directly, because a serializer-level test passes while a
+  // route serves something else, and it is the ROUTE that the declared lane
+  // measures (`topLevelKeys(body[0])` of the committed capture).
+  //
+  // Neither existing guard catches an omission here, which is why this test is
+  // written by hand:
+  //   - `satisfies DeepPartial<Release>` permits omitting any field. That is
+  //     the point of the anchor — it encodes "faithful SUBSET" — so it fires on
+  //     a wrong name or a wrong type and never on a missing one.
+  //   - `AssertNoUncovered` in upstream-coverage.types.ts is one-directional:
+  //     it reds on an upstream field that is neither emitted nor listed in
+  //     `Release_Allow`, and `immutable` was listed. (So was `updated_at`, long
+  //     after F-1459 emitted it — a dead allowance the assertion cannot see.)
+  //
+  // The whole reason this is one test over three surfaces: F-1459 fixed the
+  // same serializer for `updated_at` and left no test behind, so the next leaf
+  // to go missing had nothing to fail against.
+  const RELEASE_SURFACES: Array<{ id: string; path: string; element: (body: any) => any }> = [
+    { id: "GET /releases", path: "/repos/acme/api/releases", element: (body) => body[0] },
+    { id: "GET /releases/latest", path: "/repos/acme/api/releases/latest", element: (body) => body },
+    {
+      id: "GET /releases/tags/:tag",
+      path: `/repos/acme/api/releases/tags/${WORLD_A.tagName}`,
+      element: (body) => body
+    }
+  ];
+
+  it.each(RELEASE_SURFACES)("serves `immutable` on $id", async ({ path, element }) => {
+    const { status, body } = await get(appFor(WORLD_A), path);
+    expect(status).toBe(200);
+    const release = element(body);
+    expect(release).toMatchObject({ tag_name: WORLD_A.tagName });
+    // Two assertions, because the defect is the KEY and the value is `false`.
+    // `toHaveProperty` first so an omission reports as a missing leaf, which is
+    // what it is; on its own, `toBe(false)` against an absent key reads as a
+    // value bug and sends the next reader to the wrong place.
+    expect(release).toHaveProperty("immutable");
+    // `false` is the true value, not a placeholder: this twin models no
+    // immutable-release feature and has no route that could enable one, so
+    // every release in every reachable state IS mutable.
+    expect(release.immutable).toBe(false);
+  });
+
+  // The leaf F-1459 added, retro-covered by the same property. It had no test
+  // either, and it is one `git revert` away from being the next silent
+  // omission on exactly these three surfaces.
+  it.each(RELEASE_SURFACES)("serves `updated_at` on $id", async ({ path, element }) => {
+    const release = element((await get(appFor(WORLD_A), path)).body);
+    expect(release).toHaveProperty("updated_at");
+    expect(typeof release.updated_at).toBe("string");
+  });
+
   it("mints the tag for a release whose tag the seed did not declare", async () => {
     const untagged = world(WORLD_A);
     untagged.repositories[0]!.tags = [];

--- a/packages/twin-github/test/upstream-coverage.types.ts
+++ b/packages/twin-github/test/upstream-coverage.types.ts
@@ -169,8 +169,15 @@ const _cov_milestoneJson: AssertNoUncovered<Milestone, ReturnType<typeof milesto
 type Tag_Allow = never;
 const _cov_tagJson: AssertNoUncovered<Tag, ReturnType<typeof tagJson>, Tag_Allow> = true;
 
+// F-1533 dropped `immutable` (now emitted) and, with it, `updated_at` — which
+// F-1459 emitted and left listed here. A stale entry is invisible to the
+// assertion below: `AssertNoUncovered` is one-directional, reddening on an
+// upstream field that is neither emitted nor allowed, never on an allowance
+// with nothing behind it. So the header's claim that a green typecheck makes
+// every `_Allow` union "provably exact" holds in one direction only; keeping
+// these two would have read as two deliberate omissions that were not.
 type Release_Allow =
-  | "updated_at" | "reactions" | "body_html" | "body_text" | "immutable"
+  | "reactions" | "body_html" | "body_text"
   | "mentions_count" | "discussion_url";
 const _cov_releaseJson: AssertNoUncovered<Release, ReturnType<typeof releaseJson>, Release_Allow> = true;
 


### PR DESCRIPTION
## What

`releaseJson` emits `immutable: false`, so `GET /repos/:o/:r/releases`, `GET /repos/:o/:r/releases/latest` and `GET /repos/:o/:r/releases/tags/:tag` all carry the key — the last top-level leaf real GitHub sends on those routes that the twin did not. A test asserts it on each of the three.

**This is the twin half only.** The pome-cloud half is a separate PR and must do all three of its parts or none — see *What comes next*.

## Why `false` is the true value, not a placeholder

The twin models no immutable-release feature and has no route that could enable one, so every release in every reachable twin state *is* mutable. That is what separates this from the nine sibling fields F-1504 registered rather than fixed: stating `false` invents no model.

It is deliberately **not a column**. A stored value would be a second source of truth for a feature that does not exist; the first route to enable immutability is the change that owes one. That is the inverse of `updated_at`, which *is* a column precisely because a future update route must be able to move it.

## Reviewer notes

**Neither existing guard can see an omission here, and F-1459 proved it.** That ticket made the same fix to the same serializer for `updated_at` and left no test behind, so the next leaf to go missing had nothing to fail against:

| guard | why it stayed green |
|---|---|
| `satisfies DeepPartial<Release>` | encodes "faithful **subset**" by design — fires on a wrong name or type, never on a missing one |
| `AssertNoUncovered` | one-directional: reds on an upstream field neither emitted nor listed in `Release_Allow`. `immutable` was listed. |

So the test is written by hand, and asserted **per route** rather than on `releaseJson` — a serializer-level test passes while a route serves something else, and the route is what the declared lane measures (`topLevelKeys(body[0])` of the committed capture).

**Two judgement calls worth confirming:**

1. **The same property retro-covers `updated_at`.** It had no test either and is one `git revert` away from being the next silent omission on exactly these three surfaces. Three extra assertions, no new machinery.
2. **`Release_Allow` loses `updated_at` too, not just `immutable`.** It has been dead cover since F-1459 emitted it — invisible because the assertion cannot see an allowance with nothing behind it. Keeping it would read as a deliberate omission that is not one. This also means the file header's claim that a green typecheck makes every `_Allow` union "provably exact" holds in one direction only; I noted that inline rather than fixing the guard, which is out of scope here.

**Release notes land in two changelogs**, not one: `serializers.ts` is publish-relevant to both `@pome-sh/cli` and `@pome-sh/sandbox-domains`. I let the PR gate tell me that rather than reading it off. `(patch)` — the key is added, none removed or renamed, and `CONTRACT.md` enumerates no release route.

## Verification

- The three new assertions were **red before the fix** (one failure per surface, `to have property "immutable"`), green after.
- Mutation-checked both directions: reverting `immutable: false` reds 3; reverting `updated_at` reds 3.
- Full local sweep green — 3,735 tests across all workspaces, `npm run typecheck`, the 115-test `contract/` suite, both tarball manifest gates, and the always-on lint/derivation gates.
- The release-note gate was **red naming both packages** before the changelog entries, green after.

## What comes next (not in this PR)

One pome-cloud PR doing all three or none, because both sides of the coupling are red:

- advance `.github/twins-ref` (today at `769d10f`) to this commit's merge SHA, re-resolved from a freshly fetched `main` at write time;
- re-run the sandbox captures — **all five**, in one commit, since a pin move invalidates every committed `sandbox-capture.json` (F-1466) and the assertions read HEAD (F-1508);
- delete the `GH-DECL-008` `open-defect` entry from `known-divergences/github.declared.yaml`.

Delete the allowance without the pin and `shape_drift` goes 0 → 3; move the pin without the delete and `unusedShapeAllowances` fails the gate on dead cover. Verified after merge by `gh workflow run declared-diff.yml --ref main` — the committed store holds pre-fix numbers until the next morning's run, so reading it straight after a merge gives a stale count that looks like a verdict. Expect twin-github `shape_drift` to **stay 0**: the three release routes move out of `allowedShapeDrift` into `matched`.

Closes F-1533

🤖 Generated with [Claude Code](https://claude.com/claude-code)