### PR TITLE
Point AGENTS.md at VOCABULARY.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,22 @@ Evaluation and scoring are hosted features — `pome run --local` records a trac
 only, no local scoring. The Pome platform (evaluation, simulation,
 observability) is at https://pome.sh. Apache-2.0.
 
+## Product vocabulary — read before writing anything a user reads
+
+Product nouns are defined in **[`VOCABULARY.md`](https://github.com/pome-sh/pome-cloud/blob/main/VOCABULARY.md)** in `pome-cloud`. Applies to this repo's README, `llms.txt`, per-package READMEs, and the CLI's human-readable output.
+
+| Word | Means |
+|---|---|
+| `sandbox` | the container a user starts — one id, one TTL, 1–3 twins, the billing unit |
+| `digital twin` | one stateful emulation of a real API. Full phrase on first use per page; `twin` is the short form after, and in every identifier (`pome twin start`, `packages/twin-github`) |
+| `pod` | the per-twin microVM. Internal only |
+
+**Banned in user-facing text:** `clone` (it already means a copy of the *customer's agent* in the hosted product — the opposite thing), `service`, `simulation` as a noun, `environment` for a twin, `mock`/`stub`/`fake`, `staging layer`, `self-healing`.
+
+**Never print a twin count without the depth number** — a bare "5 twins" invites a comparison we lose. Say "5 digital twins, 137 MCP tools, every route graded against live upstream daily".
+
+Identifiers do not move. `pome twin start`, `MOUNTED_TWINS`, `TWIN_*` env vars, `TwinHttpEvent`, and the `twins` key in the published `pome.json` schema all stay — `TwinHttpEvent` in particular is a v1.0-frozen discriminant stamped into every persisted trace.
+
 ## Docs
 
 Repo layout, full build/test workflow, conventions, and the contributor guide


### PR DESCRIPTION
Executive summary: This repo has no record of which product nouns are legal in user-facing text. `VOCABULARY.md` merged in `pome-cloud` and is the single source of truth across all three repos; this adds the pointer. Guidance only — no copy changes, one file.

## What

A "Product vocabulary" section in `AGENTS.md`, covering this repo's README, `llms.txt`, per-package READMEs, and the CLI's human-readable output.

| Word | Means |
|---|---|
| `sandbox` | the container a user starts — one id, one TTL, 1–3 twins, the billing unit |
| `digital twin` | one stateful emulation of a real API. Full phrase on first use per page; `twin` is the short form after, and in every identifier |
| `pod` | the per-twin microVM. Internal only |

## Why

The word that matters most here is **`clone`**. It is banned in user-facing text because the hosted product already uses it for the *opposite* thing — `intake_clone_scope` means a copy of the **customer's agent**, not of a vendor API. Marketing "clone" and product "clone" currently point in opposite directions.

Also banned: `service` (taken four ways, two of them opposites), `simulation` as a noun (in this market it means simulated *users*), `environment` for a twin (a billing-critical `pgEnum` in the cloud), `mock`/`stub`/`fake`, `staging layer`, `self-healing`.

## Notes for reviewer

**Identifiers do not move, and the section says so explicitly.** `pome twin start`, `MOUNTED_TWINS`, the `TWIN_*` env family, the `twins` key in the published `pome.json` schema, and `TwinHttpEvent` all stay. `TwinHttpEvent` especially — it is a v1.0-frozen discriminated-union tag already stamped into every persisted trace, and every runtime parse site *skips an unknown kind silently*, so a rename there fails upward: runs pass that should fail.

**No copy is changed.** The README (`# Pome Digital Twins`) and `llms.txt` sweep is one reviewed pass in M1 of the Linear project, not piecemeal edits.

## Tests / CI

Markdown only, no build surface, no package touched.

## Linear ticket

Milestone M0 of *Vocabulary and Messaging Rewrite: sandbox + twin*. Not linked to an issue, so nothing auto-closes.