### PR TITLE
docs: retire "simulation testing infrastructure" as the self-description

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Pome Digital Twins
 
-**Simulation testing infrastructure for AI agents.**
+**Testing infrastructure for AI agents.**
 Stateful, local digital twins of the APIs your agent calls — GitHub, Stripe, Slack, Gmail, and Linear.
 
 [![CI](https://github.com/pome-sh/pome-twins/actions/workflows/ci.yml/badge.svg)](https://github.com/pome-sh/pome-twins/actions/workflows/ci.yml)

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Pome Digital Twins
 
-> Simulation testing infrastructure for AI agents. Open-source, local, stateful digital twins of the APIs your agent calls — GitHub, Stripe, Slack, Gmail, and Linear — answering the same REST, GraphQL, and MCP calls as production, backed by real SQLite state. 137 MCP tools in total, all deterministic, resettable, and requiring no live infrastructure. The `pome` CLI runs your agent against a twin and captures the trace; evaluation is a hosted feature at pome.sh.
+> Testing infrastructure for AI agents. Open-source, local, stateful digital twins of the APIs your agent calls — GitHub, Stripe, Slack, Gmail, and Linear — answering the same REST, GraphQL, and MCP calls as production, backed by real SQLite state. 137 MCP tools in total, all deterministic, resettable, and requiring no live infrastructure. The `pome` CLI runs your agent against a twin and captures the trace; evaluation is a hosted feature at pome.sh.
 
 ## Docs
 
@@ -28,4 +28,4 @@
 
 - Run an agent task with no install: `npx @pome-sh/cli init && npx @pome-sh/cli run --local tasks/01-bug-happy-path.md`
 - Start a standalone twin: `npx @pome-sh/cli twin start github`
-- The hosted platform (evaluation, simulation, observability): https://pome.sh
+- The hosted platform (hosted twins, grading, observability): https://pome.sh


### PR DESCRIPTION
## What

The OSS repo was the last of the three surfaces still calling Pome "simulation testing infrastructure".

| Where | Was | Now |
|---|---|---|
| `README.md:7` | **Simulation** testing infrastructure for AI agents. | Testing infrastructure for AI agents. |
| `llms.txt:3` | same line | same |
| `llms.txt:31` | (evaluation, **simulation**, observability) | (hosted twins, grading, observability) |

## Why

M1 of [Vocabulary and Messaging Rewrite](https://linear.app/pome-sh/project/vocabulary-and-messaging-rewrite-sandbox-digital-twin-3fcbc4f6cdd7). pome.sh, app.pome.sh and docs.pome.sh all move to "testing infrastructure for AI agents" in the sibling PRs; someone comparing this README against the site should not meet a fourth phrasing of what Pome is. That mismatch is the whole defect the project exists to fix — the audit that opened it found **six** different self-descriptions shipping at once.

`simulation` is banned as a noun in [`VOCABULARY.md`](https://github.com/pome-sh/pome-cloud/blob/main/VOCABULARY.md): across this market it means simulated *users*, not simulated APIs (Maxim, LangWatch, Coval, Okareo), and it is our category word one level up — `terminology.mdx` defines a twin **as** "a deterministic simulation of a real SaaS API", so promoting the defining word to the defined word eats the definition.

The repo title stays `# Pome Digital Twins`. That one is now correct.

## Notes for reviewer

This repo came out of the audit **nearly clean** — 6 hits total, and 3 are deliberate and staying:

- `README.md:44` "No install, no clone" — that is `git clone`
- `packages/twin-stripe/README.md:14` `stripe-mock` — an upstream tool's actual name
- `packages/twin-stripe/README.md:234` "delay simulation" — a technique, not a noun for a twin

**Docs only, no package moves**, so no `## Unreleased` entry is owed. Confirmed rather than assumed:

```
$ node scripts/ci/check-release-note-required.mjs "$(git merge-base HEAD origin/main)"
Release inputs OK. 5 published package(s); 2 file(s) changed, 0 exempt from
publish relevance; 0 package(s) moved by this PR.
```

Sibling PRs: [pome-cloud#773](https://github.com/pome-sh/pome-cloud/pull/773) (brand assets), [pome-cloud#777](https://github.com/pome-sh/pome-cloud/pull/777) (docs/dashboard/MCP + the CI gate), [pome-landing-page#22](https://github.com/pome-sh/pome-landing-page/pull/22) (pome.sh + its own gate).