### PR TITLE
The 501 body says "twin", not "twin clone"

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -10,6 +10,27 @@ write a version number here or in `package.json` — see `RELEASING.md`. Release
 entries are insertions only: a correction is the next entry, naming the one it
 corrects.
 
+## Unreleased (patch)
+
+**The 501 unsupported body says "twin", not "twin clone"** (F-1547). Every cold
+route on the GitHub and Stripe twins answered
+`"This endpoint is not supported by this GitHub twin clone."`; it now reads
+`"… by this GitHub twin."` (and the Stripe equivalent). Four GitHub MCP
+refusals — `issue_read`, `pull_request_read`, and two `pull_request_review_write`
+paths — carry the same wording change.
+
+`clone` already means a copy of the *customer's agent* elsewhere in the product
+(`intake_clone_scope`), so using it for the twin named the opposite thing.
+
+`CONTRACT.md`'s frozen surface for this case is the **501 status** and
+`_twin.fidelity: "unsupported"`, and both are untouched — hence `(patch)`. The
+strings `CONTRACT.md` does freeze verbatim are the auth ones (`"Bad
+credentials"`, `"Requires authentication"`), which mirror real GitHub; this one
+mirrors nothing upstream and is ours to word.
+
+Act on it only if you **string-match the message**. Match on the status code or
+on `_twin.fidelity` instead — those are the contract, and they did not move.
+
 ## 0.24.1 — 2026-08-19
 
 **twin-github's three release surfaces carry `immutable`** (F-1533).

--- a/packages/sandbox-domains/CHANGELOG.md
+++ b/packages/sandbox-domains/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @pome-sh/sandbox-domains
 
+## Unreleased (patch)
+
+**The 501 unsupported body says "twin", not "twin clone"** (F-1547). The
+GitHub and Stripe twins' cold-route refusal now reads `"This endpoint is not
+supported by this GitHub twin."` instead of `"… this GitHub twin clone."`, and
+the four GitHub MCP method refusals reachable through `executeTool` carry the
+same wording.
+
+`clone` already means a copy of the *customer's agent* elsewhere in the product
+(`intake_clone_scope`), so using it for the twin named the opposite thing.
+
+No exported symbol, signature or type changes — this is a message **value**
+behind an unchanged public surface, hence `(patch)`. Act on it only if you
+string-match that message; match the 501 status or `_twin.fidelity:
+"unsupported"` instead.
+
 ## 0.2.2 — 2026-08-19
 
 **`GitHubDomain`'s three release surfaces carry `immutable`** (F-1533).

--- a/packages/twin-github/FIDELITY.md
+++ b/packages/twin-github/FIDELITY.md
@@ -93,7 +93,7 @@ unsupported routes return a loud 501 envelope:
 
 ```json
 {
-  "message": "This endpoint is not supported by this GitHub twin clone.",
+  "message": "This endpoint is not supported by this GitHub twin.",
   "_twin": {
     "fidelity": "unsupported",
     "supported_surfaces": [

--- a/packages/twin-github/src/tools.ts
+++ b/packages/twin-github/src/tools.ts
@@ -468,7 +468,7 @@ function dispatchTool(
           // `get_sub_issues` and `get_parent` are GitHub methods this twin does
           // not model. Loud, not silent: an examinee must not read an empty
           // answer as "this issue has no parent".
-          throw new TwinError(`issue_read method '${parsed.method}' is not supported by this GitHub twin clone.`, 501);
+          throw new TwinError(`issue_read method '${parsed.method}' is not supported by this GitHub twin.`, 501);
       }
     case "issue_write":
       switch (parsed.method) {
@@ -521,7 +521,7 @@ function dispatchTool(
         }
         default:
           throw new TwinError(
-            `pull_request_read method '${parsed.method}' is not supported by this GitHub twin clone.`,
+            `pull_request_read method '${parsed.method}' is not supported by this GitHub twin.`,
             501
           );
       }
@@ -529,7 +529,7 @@ function dispatchTool(
     case "pull_request_review_write":
       if (parsed.method !== "create") {
         throw new TwinError(
-          `pull_request_review_write method '${parsed.method}' is not supported by this GitHub twin clone.`,
+          `pull_request_review_write method '${parsed.method}' is not supported by this GitHub twin.`,
           501
         );
       }
@@ -538,7 +538,7 @@ function dispatchTool(
       // caller did not ask to submit.
       if (parsed.event === undefined) {
         throw new TwinError(
-          "pull_request_review_write method 'create' without an `event` opens a pending review, which this GitHub twin clone does not model.",
+          "pull_request_review_write method 'create' without an `event` opens a pending review, which this GitHub twin does not model.",
           501
         );
       }

--- a/packages/twin-github/src/unsupported-envelope.ts
+++ b/packages/twin-github/src/unsupported-envelope.ts
@@ -12,7 +12,7 @@
 export const unsupportedEnvelope = {
   status: 501,
   body: {
-    message: "This endpoint is not supported by this GitHub twin clone.",
+    message: "This endpoint is not supported by this GitHub twin.",
     _twin: {
       fidelity: "unsupported" as const,
       supported_surfaces: [

--- a/packages/twin-github/test/mcp-error-semantics.test.ts
+++ b/packages/twin-github/test/mcp-error-semantics.test.ts
@@ -34,7 +34,7 @@ describe("GitHub-shaped error semantics", () => {
       _twin: { fidelity: string };
     };
     expect(body).toMatchObject({
-      message: "This endpoint is not supported by this GitHub twin clone.",
+      message: "This endpoint is not supported by this GitHub twin.",
       _twin: { fidelity: "unsupported" }
     });
     expect(body.fidelity).toBeUndefined();

--- a/packages/twin-stripe/FIDELITY.md
+++ b/packages/twin-stripe/FIDELITY.md
@@ -112,7 +112,7 @@ etc.) is the unlisted cold tail and returns:
   "error": {
     "type": "invalid_request_error",
     "code": "endpoint_not_supported",
-    "message": "This endpoint is not supported by this Stripe twin clone.",
+    "message": "This endpoint is not supported by this Stripe twin.",
     "fidelity": "unsupported",
     "supported_surfaces": [
       "Stripe-shaped REST under /v1/* (see FIDELITY.md)",

--- a/packages/twin-stripe/src/errors.ts
+++ b/packages/twin-stripe/src/errors.ts
@@ -150,7 +150,7 @@ export function unsupported() {
   return stripeError(
     "invalid_request_error",
     "endpoint_not_supported",
-    "This endpoint is not supported by this Stripe twin clone.",
+    "This endpoint is not supported by this Stripe twin.",
     {
       statusCode: 501,
       fidelity: "unsupported",


### PR DESCRIPTION
## What

Every cold route on the GitHub and Stripe twins answered:

```json
{ "message": "This endpoint is not supported by this GitHub twin clone.",
  "_twin": { "fidelity": "unsupported" } }
```

`clone` already means a copy of the **customer's agent** elsewhere in the product — `intake_clone_scope` is a live MCP tool where "clone scope" is a copy of the thing under test. Using it for the twin named the opposite thing, in a body a developer reads while debugging an unsupported route. It was the last banned word in a shipped response, and `VOCABULARY.md` bans it for exactly this collision.

## Nine occurrences, six files — one more than the ticket found

| File | |
|---|---|
| `packages/twin-github/src/unsupported-envelope.ts` | the envelope |
| `packages/twin-github/src/tools.ts` | **4** MCP refusals |
| `packages/twin-stripe/src/errors.ts` | the Stripe envelope |
| `packages/twin-github/FIDELITY.md` · `packages/twin-stripe/FIDELITY.md` | both documented |
| `packages/twin-github/test/mcp-error-semantics.test.ts` | asserted |

The ticket listed three in `tools.ts`. There are four — `pull_request_review_write`'s pending-review refusal at `:541` reads *"which this GitHub twin clone does not model"* and was missed.

**"this GitHub twin" converges rather than inventing a third phrasing** — `twin-gmail` has said `"is not supported by the Gmail twin"` all along.

## Patch, not minor — and the contract test is the evidence

`CONTRACT.md:45` freezes the **501 status** and `_twin.fidelity: "unsupported"` for this case. Neither moves.

The message strings `CONTRACT.md` *does* freeze verbatim are the auth ones — `"Bad credentials"`, `"Requires authentication"`, `"Forbidden"` — and those are frozen because they mirror real GitHub word for word. This one mirrors nothing upstream; it is ours to word.

`npm run test:contract` passes **115/115**, including the case that would catch it: *"unknown session route → 501 unsupported envelope; unknown root route frozen"*.

## Release notes: two packages, both `(patch)`

`scripts/ci/check-release-note-required.mjs` names `@pome-sh/cli` and `@pome-sh/sandbox-domains`. Both bundle these strings because `twin-github`'s **root barrel** exports from `./tools.js` (`src/index.ts:13`).

`@pome-sh/checks` is correctly **not** on that list — it reaches the twin through `./checks` + `./seed`, deliberately keeping the engine out of a declarations package.

Both entries say the one thing a consumer must know: act on this only if you **string-match the message**; match the status code or `_twin.fidelity` instead, because those are the contract and they did not move.

## Notes for reviewer

**Zero goldens.** `grep -rl "twin clone"` returns exactly the six files above — no JSON fixtures, no `sandbox-capture.json`, no upstream golden. The 90-day capture clock is not involved.

**This does not red pome-cloud, contrary to the ticket.** The ticket says `tools/fidelity-watch/lint-twin-namespace.test.ts:43` "asserts the exact string". It does not — line 43 is a hand-written **legacy-shape** fixture, and its assertions are about `fidelity` and `supported_surfaces` being bare at top level, not about the message text. Nothing in pome-cloud asserts this wording. That line should stay as-is: it documents what the historical bug looked like, and `tools/` is outside the vocabulary gate's scan set anyway.

The genuine cross-repo ordering still holds for the **pin bump** — this and its release land first, then pome-cloud moves its `@pome-sh/*` pins.

**Verified:** twin-github 652 tests · twin-stripe 330 tests · typecheck clean on both · contract 115/115.