### PR TITLE
`pome sandbox` answers everywhere `pome session` does, from one command (F-1557)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -10,6 +10,28 @@ write a version number here or in `package.json` — see `RELEASING.md`. Release
 entries are insertions only: a correction is the next entry, naming the one it
 corrects.
 
+## Unreleased (minor)
+
+**`pome sandbox` is `pome session`** (F-1557). The `session` command now also
+answers to `sandbox`. `pome sandbox create`, `list` and `stop` — plus `stop`'s
+own `kill` alias — run the same code, take the same flags and print the same
+output as the `session` spelling; `pome --help` and `pome sandbox --help` both
+show it as `session|sandbox`.
+
+**Minor, not patch:** `sandbox` is a command spelling that did not exist before,
+so a script written against it will not run on an older CLI. Nothing existing
+moves. `session` is untouched, keeps working permanently, and is not deprecated
+— pick either.
+
+**Why both spellings.** `sandbox` is the product noun; `session` is what this
+CLI shipped with and what every existing script types. One Commander alias means
+there is no second command tree for the two to drift apart in — a subcommand or
+flag added to `session` is reachable under `sandbox` the moment it lands.
+
+Untouched: `pome twin start|reset|status` (the twin is the unit, already named
+correctly), and `@pome-sh/sandbox-domains`, which despite its name is the twin
+runtime rather than anything to do with sandboxes.
+
 ## 0.24.2 — 2026-08-20
 
 **The 501 unsupported body says "twin", not "twin clone"** (F-1547). Every cold

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -518,8 +518,13 @@ export function createProgram() {
       },
     );
 
+  // F-1557 — `sandbox` is the product noun (VOCABULARY.md); `session` is the
+  // spelling the CLI shipped with and every existing script types. Commander
+  // resolves both to this one command, so every subcommand, flag and line of
+  // output below is reachable under either without a second tree to drift.
   const session = program
     .command("session")
+    .alias("sandbox")
     .description(
       "Hosted sandbox sessions (same API as the dashboard Twins page — requires login)",
     );

--- a/cli/test/unit/session-sandbox-alias.test.ts
+++ b/cli/test/unit/session-sandbox-alias.test.ts
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// F-1557 — `pome sandbox` is an ALIAS of `pome session`, never a second
+// command tree. The docs leg of the session→sandbox copy pass rewrites
+// `apps/docs/docs/cli/session.mdx` to say `sandbox`, and a documented command
+// that does not answer is worse than the inconsistency it replaces — so the
+// alias is load-bearing for a page in another repo that nothing here can see.
+// These tests are what makes dropping it fail: the dispatch cases compare the
+// two spellings' runner arguments for deep equality (one implementation, not
+// two that agree today), and the help cases pin both listings.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Command } from "commander";
+
+const mocks = vi.hoisted(() => ({
+  runSessionCreate: vi.fn(async () => {}),
+  runSessionList: vi.fn(async () => {}),
+  runSessionStop: vi.fn(async () => {}),
+}));
+
+vi.mock("../../src/cli/session.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../src/cli/session.js")>();
+  return {
+    ...actual,
+    runSessionCreate: mocks.runSessionCreate,
+    runSessionList: mocks.runSessionList,
+    runSessionStop: mocks.runSessionStop,
+  };
+});
+
+import { createProgram } from "../../src/cli/main.js";
+
+/**
+ * An unknown command and `--help` both call `process.exit()`, which would take
+ * the vitest worker down instead of failing the assertion. `exitOverride()`
+ * only reaches the commands that existed when it was called, so walk the tree
+ * the program already built.
+ */
+function program(): Command {
+  const root = createProgram();
+  const walk = (cmd: Command) => {
+    cmd.exitOverride();
+    cmd.commands.forEach(walk);
+  };
+  walk(root);
+  return root;
+}
+
+function helpFor(...argv: string[]): string {
+  const chunks: string[] = [];
+  const root = program();
+  const walk = (cmd: Command) => {
+    cmd.configureOutput({
+      writeOut: (s) => void chunks.push(s),
+      writeErr: (s) => void chunks.push(s),
+    });
+    cmd.commands.forEach(walk);
+  };
+  walk(root);
+  try {
+    root.parse(["node", "pome", ...argv]);
+  } catch (err) {
+    // `--help` exits through exitOverride once the text is already written.
+    if ((err as { code?: string }).code !== "commander.helpDisplayed") throw err;
+  }
+  return chunks.join("");
+}
+
+type Runner = keyof typeof mocks;
+
+/** The arguments `spelling` handed the runner — proof of which code path ran. */
+async function dispatch(
+  spelling: string,
+  runner: Runner,
+  argv: string[],
+): Promise<unknown[]> {
+  mocks[runner].mockClear();
+  await program().parseAsync(["node", "pome", spelling, ...argv]);
+  expect(mocks[runner]).toHaveBeenCalledTimes(1);
+  return mocks[runner].mock.calls[0]!;
+}
+
+describe("`pome sandbox` aliases `pome session` (F-1557)", () => {
+  const originalExitCode = process.exitCode;
+
+  beforeEach(() => {
+    for (const mock of Object.values(mocks)) {
+      mock.mockClear();
+      mock.mockResolvedValue(undefined);
+    }
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = originalExitCode;
+  });
+
+  // Flags are carried on every case so a spelling that reached a *different*
+  // parser — its own command tree with drifted defaults — shows up as an
+  // argument diff rather than passing on the bare form.
+  const CASES: Array<{ name: string; runner: Runner; argv: string[] }> = [
+    {
+      name: "create",
+      runner: "runSessionCreate",
+      argv: [
+        "create",
+        "--twin",
+        "github",
+        "--twin",
+        "gmail",
+        "--format",
+        "json",
+        "--api-url",
+        "https://api.example.test",
+      ],
+    },
+    {
+      name: "list",
+      runner: "runSessionList",
+      argv: ["list", "--state", "all", "--limit", "5", "--format", "json"],
+    },
+    {
+      name: "stop",
+      runner: "runSessionStop",
+      argv: ["stop", "ses_a", "--discard"],
+    },
+    // The `stop` → `kill` alias nests under the outer one; both spellings of
+    // both levels have to compose.
+    {
+      name: "stop's own `kill` alias",
+      runner: "runSessionStop",
+      argv: ["kill", "ses_a", "--discard"],
+    },
+  ];
+
+  for (const { name, runner, argv } of CASES) {
+    it(`sandbox ${name} calls the same runner with the same arguments as session ${name}`, async () => {
+      const viaSandbox = await dispatch("sandbox", runner, argv);
+      const viaSession = await dispatch("session", runner, argv);
+
+      expect(viaSandbox).toEqual(viaSession);
+      expect(process.exitCode).toBeUndefined();
+    });
+  }
+
+  it("is one command object, not a second tree", () => {
+    const answering = program().commands.filter(
+      (cmd) =>
+        [cmd.name(), ...cmd.aliases()].includes("session") ||
+        [cmd.name(), ...cmd.aliases()].includes("sandbox"),
+    );
+
+    expect(answering).toHaveLength(1);
+    expect(answering[0]!.name()).toBe("session");
+    expect(answering[0]!.aliases()).toContain("sandbox");
+  });
+
+  it("`pome --help` lists the sandbox spelling", () => {
+    expect(helpFor("--help")).toContain("session|sandbox");
+  });
+
+  it("`pome sandbox --help` lists it, and is byte-identical to `pome session --help`", () => {
+    const viaSandbox = helpFor("sandbox", "--help");
+
+    expect(viaSandbox).toContain("session|sandbox");
+    expect(viaSandbox).toBe(helpFor("session", "--help"));
+    // Every subcommand is reachable under the alias, not just the ones the
+    // dispatch cases above happen to name.
+    for (const sub of ["create", "list", "stop"]) {
+      expect(viaSandbox).toContain(sub);
+    }
+  });
+});


### PR DESCRIPTION
Executive summary: `pome session` now also answers to `pome sandbox`, via one Commander `.alias()` — the same pattern `stop` already carries for `kill`. One line of implementation, one new test file that fails if the alias is dropped. `session` keeps working permanently and is not deprecated; nothing is renamed. The reviewable question is whether this is genuinely one command tree rather than two that agree today, which the tests are built to answer.

## What

`cli/src/cli/main.ts:521` — `.alias("sandbox")` on the `session` command.

That is the whole implementation. Commander resolves both spellings to the same `Command` object, so every subcommand, flag and line of output comes from the one implementation in `cli/src/cli/session.ts`:

| | |
|---|---|
| `pome sandbox create\|list\|stop` | same runner, same flags, same output |
| `pome sandbox kill <id>` | `stop`'s own alias composes under the outer one |
| `pome --help` | `session\|sandbox   Hosted sandbox sessions (…)` |
| `pome sandbox --help` | `Usage: pome session\|sandbox [options] [command]` |
| `pome docs sandbox` | already resolved — `cli-session` has carried the `sandbox` keyword all along |

## Why

`sandbox` is the product noun; `session` is what this CLI shipped with and what every existing script types.

The load-bearing consequence is a docs page, not a preference: the CLI page for this command says `session` 23 times and is being rewritten to say `sandbox`. It cannot be, unless the command answers to `sandbox` — documenting a command that does not exist is worse than the inconsistency it would replace. The docs leg blocks on this.

## Notes for reviewer

**The tests are written against the failure mode, not the happy path.** A duplicate command tree would pass a naive `pome sandbox create` smoke test on day one and drift on day two. So the four dispatch cases each invoke *both* spellings and compare **the arguments the runner actually received**, deep-equal:

```ts
const viaSandbox = await dispatch("sandbox", runner, argv);
const viaSession = await dispatch("session", runner, argv);
expect(viaSandbox).toEqual(viaSession);
```

Every case carries real flags (`--twin github --twin gmail --format json --api-url …`, `--state all --limit 5`, `--discard`) for that reason — a second parser with drifted defaults shows up as an argument diff instead of passing on the bare form. Three structural tests back it: exactly **one** command object answers to either spelling, `pome --help` contains `session|sandbox`, and `pome sandbox --help` is **byte-identical** to `pome session --help`.

All 7 fail if the alias is dropped. Confirmed by running them red first — `error: unknown command 'sandbox'`.

**Deliberately not in this PR.** `pome twin start|reset|status` (the twin is the unit, already named correctly); any file or identifier rename — `cli/src/cli/session.ts` stays; `@pome-sh/sandbox-domains`, which despite its name is the twin runtime and a grading pin, unrelated to sandboxes.

**The command description is untouched.** `stop` spells its alias out in prose (`"Stop a hosted session (aliased as \`kill\`)"`), but Commander already renders `session|sandbox` in both help outputs, so the alias is discoverable without it. Happy to add it if you'd rather it read like `stop`.

**Merging publishes `@pome-sh/cli`** — worth confirming nothing unrelated is mid-batch on `main` before pressing it.

## Tests / CI

- `npm test -w @pome-sh/cli` — **1172 passed**, 111 files. `npm run typecheck -w @pome-sh/cli` clean.
- `lint:code-health`, `lint:no-catch`, `gate:no-eval`, `lint:no-cloud-imports`, `lint:dead-code` all pass.
- **Exactly one package moves**, so the re-export chain owes nothing else. Confirmed rather than assumed:

```
$ node scripts/ci/check-release-note-required.mjs "$(git merge-base HEAD origin/main)"
Release inputs OK. 5 published package(s); 3 file(s) changed, 2 exempt from
publish relevance; 1 package(s) moved by this PR: @pome-sh/cli.
```

  `@pome-sh/checks` and `@pome-sh/sandbox-domains` are untouched — no twin behaviour moves and no grading vocabulary moves.
- `## Unreleased (minor)` in `cli/CHANGELOG.md`. **Minor, not patch:** `sandbox` is a spelling that did not exist before, so a script written against it will not run on an older CLI; nothing existing moves. No version number written by this PR — `allocate-version.yml` writes it at merge.
- Unmocked, end to end: `pome sandbox list` and `pome session list` both print `No sessions returned (state=running).`; `pome help sandbox` resolves. No fixture or golden snapshots the help text (`grep -rl "Hosted sandbox sessions"` returns the source file only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)