### PR TITLE
update Dockerfile & ignore fies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ coverage/
 !.env.example
 
 # Local twin state (SQLite-backed runtime data). Unanchored: direct twin
-# boots (cwd = package root) self-generate .pome-data/<twin>/secret (F-708).
+# boots (cwd = package root) self-generate .pome-data/<twin>/secret.
 .pome-data/
 .pome/
 .stripe_clone/

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,4 +1,4 @@
-# Trivy ignore policy — twin image publish gate (FDRS-586)
+# Trivy ignore policy — twin image publish gate
 #
 # The twin-*-image workflows fail the publish on FIXABLE HIGH/CRITICAL CVEs
 # (severity HIGH,CRITICAL + ignore-unfixed: true). To ship past a specific CVE
@@ -18,36 +18,3 @@
 #
 # (No exceptions currently. Keep this list empty unless a fixable HIGH/CRITICAL
 # genuinely cannot be remediated in time and has been reviewed.)
-#
-# ── Decision record: CVE-2026-53615 (util-linux) — F-1532, 2026-08-18 ─────────
-#
-# NOT excepted here, and the list above is still empty. Written down anyway: the
-# next person to hit a fixable base-image CVE reads this file first, and the
-# exception this file exists to grant was considered and refused on the record.
-#
-# THE FINDING. Nine rows, one source package — bsdutils, libblkid1,
-# liblastlog2-2, libmount1, libsmartcols1, libuuid1, login, mount, util-linux —
-# all at 2.41-5, all fixed in 2.41.5-0+deb13u1. No image changed to produce it:
-# Trivy passed on the same commit on 08-14 and failed on 08-18, so a DB entry
-# published in between landed on digest-frozen contents. It refused the stripe
-# publish outright (push + sign skipped, nothing reached GHCR), and the three
-# twins on the same base were one merge away from the same wall.
-#
-# CHOSEN: install the fix in the runtime stage — `apt-get upgrade`, see
-# packages/twin-*/Dockerfile. Debian had already shipped 2.41.5-0+deb13u1 to
-# trixie-security, so the fix existed the whole time and only the digest pin
-# stood between the image and it. This spends no exception and needs no
-# exploitability judgement, because nothing vulnerable remains in the image.
-#
-# REJECTED: bump the pinned base digest. Upstream had rebuilt both tags
-# (24-trixie-slim → sha256:0711b541…, 26-trixie-slim → sha256:4ebb5ace…), so a
-# bump was available — but a pull and scan of BOTH new digests found the same
-# nine rows at the same util-linux 2.41-5. No digest carrying the fix existed to
-# bump to, for either node major, so the bump is not a remedy for this CVE at
-# all. Digest currency stays Renovate's fortnightly job, on its own merits.
-#
-# REJECTED: add CVE-2026-53615 to the list above. It would have needed rule 1's
-# named human assessment of a libblkid path a twin never walks, and the closing
-# note's bar — a fixable finding that "genuinely cannot be remediated in time" —
-# is not met by one Debian had already fixed and that a build could take the
-# same day. It would also have left a review-by date to service, for nothing.

--- a/packages/twin-github/Dockerfile
+++ b/packages/twin-github/Dockerfile
@@ -31,25 +31,19 @@ ENV GITHUB_CLONE_HOST=0.0.0.0
 # Runtime only executes `node`; npm/npx from the base image add unused packages
 # (and their CVE surface) to the scanned image.
 RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
-# F-1532 — take Debian's published security fixes on top of the pinned digest.
-# The digest freezes this image's package contents; Trivy's vulnerability DB is
-# refreshed on every run. So a fix Debian ships BEFORE upstream rebuilds the
+# Take Debian's published security fixes on top of the pinned digest. The digest
+# freezes this image's package contents while Trivy's vulnerability DB refreshes
+# on every run, so a fix Debian ships BEFORE upstream rebuilds the
 # node:*-trixie-slim tag lands as a FIXABLE HIGH on frozen contents, and the
 # publish gate then refuses this image identically on every future run — not a
-# flake, and a re-run cannot clear it. CVE-2026-53615 (util-linux; nine binary
-# packages, one source) did exactly that on 2026-08-18, and neither upstream
-# digest then current carried the fix, so bumping the pin was not a remedy.
-# The pin still fixes where the image STARTS; this layer lets a rebuild move.
-# Decision record, and why no .trivyignore exception was spent: .trivyignore.
+# flake, and a re-run cannot clear it. The pin still fixes where the image
+# STARTS; this layer lets a rebuild move.
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 COPY --from=build /repo/node_modules ./node_modules
-# The twin's dist imports @pome-sh/wire; ship its built output. Before F-942 this
-# was `COPY packages/shared-types` -- the WHOLE directory, sources included -- because
-# that package exported `./src/index.ts` and `build:runtime` emitted the runtime
-# `.js` in place beside each `.ts`. wire builds to dist/ like every other
-# package, so package.json + dist is the entire runtime need.
+# The twin's dist imports @pome-sh/wire; ship its built output — package.json
+# plus dist is the entire runtime need.
 COPY --from=build /repo/packages/wire/package.json ./packages/wire/package.json
 COPY --from=build /repo/packages/wire/dist ./packages/wire/dist
 # The twin's dist imports `@pome-sh/sdk`; ship the SDK's built output so the

--- a/packages/twin-gmail/Dockerfile
+++ b/packages/twin-gmail/Dockerfile
@@ -23,25 +23,19 @@ WORKDIR /repo
 ENV NODE_ENV=production
 ENV GMAIL_TWIN_HOST=0.0.0.0
 RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
-# F-1532 — take Debian's published security fixes on top of the pinned digest.
-# The digest freezes this image's package contents; Trivy's vulnerability DB is
-# refreshed on every run. So a fix Debian ships BEFORE upstream rebuilds the
+# Take Debian's published security fixes on top of the pinned digest. The digest
+# freezes this image's package contents while Trivy's vulnerability DB refreshes
+# on every run, so a fix Debian ships BEFORE upstream rebuilds the
 # node:*-trixie-slim tag lands as a FIXABLE HIGH on frozen contents, and the
 # publish gate then refuses this image identically on every future run — not a
-# flake, and a re-run cannot clear it. CVE-2026-53615 (util-linux; nine binary
-# packages, one source) did exactly that on 2026-08-18, and neither upstream
-# digest then current carried the fix, so bumping the pin was not a remedy.
-# The pin still fixes where the image STARTS; this layer lets a rebuild move.
-# Decision record, and why no .trivyignore exception was spent: .trivyignore.
+# flake, and a re-run cannot clear it. The pin still fixes where the image
+# STARTS; this layer lets a rebuild move.
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 COPY --from=build /repo/node_modules ./node_modules
-# The twin's dist imports @pome-sh/wire; ship its built output. Before F-942 this
-# was `COPY packages/shared-types` -- the WHOLE directory, sources included -- because
-# that package exported `./src/index.ts` and `build:runtime` emitted the runtime
-# `.js` in place beside each `.ts`. wire builds to dist/ like every other
-# package, so package.json + dist is the entire runtime need.
+# The twin's dist imports @pome-sh/wire; ship its built output — package.json
+# plus dist is the entire runtime need.
 COPY --from=build /repo/packages/wire/package.json ./packages/wire/package.json
 COPY --from=build /repo/packages/wire/dist ./packages/wire/dist
 COPY --from=build /repo/packages/sdk/package.json ./packages/sdk/package.json

--- a/packages/twin-linear/Dockerfile
+++ b/packages/twin-linear/Dockerfile
@@ -23,25 +23,19 @@ WORKDIR /repo
 ENV NODE_ENV=production
 ENV LINEAR_TWIN_HOST=0.0.0.0
 RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
-# F-1532 — take Debian's published security fixes on top of the pinned digest.
-# The digest freezes this image's package contents; Trivy's vulnerability DB is
-# refreshed on every run. So a fix Debian ships BEFORE upstream rebuilds the
+# Take Debian's published security fixes on top of the pinned digest. The digest
+# freezes this image's package contents while Trivy's vulnerability DB refreshes
+# on every run, so a fix Debian ships BEFORE upstream rebuilds the
 # node:*-trixie-slim tag lands as a FIXABLE HIGH on frozen contents, and the
 # publish gate then refuses this image identically on every future run — not a
-# flake, and a re-run cannot clear it. CVE-2026-53615 (util-linux; nine binary
-# packages, one source) did exactly that on 2026-08-18, and neither upstream
-# digest then current carried the fix, so bumping the pin was not a remedy.
-# The pin still fixes where the image STARTS; this layer lets a rebuild move.
-# Decision record, and why no .trivyignore exception was spent: .trivyignore.
+# flake, and a re-run cannot clear it. The pin still fixes where the image
+# STARTS; this layer lets a rebuild move.
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 COPY --from=build /repo/node_modules ./node_modules
-# The twin's dist imports @pome-sh/wire; ship its built output. Before F-942 this
-# was `COPY packages/shared-types` -- the WHOLE directory, sources included -- because
-# that package exported `./src/index.ts` and `build:runtime` emitted the runtime
-# `.js` in place beside each `.ts`. wire builds to dist/ like every other
-# package, so package.json + dist is the entire runtime need.
+# The twin's dist imports @pome-sh/wire; ship its built output — package.json
+# plus dist is the entire runtime need.
 COPY --from=build /repo/packages/wire/package.json ./packages/wire/package.json
 COPY --from=build /repo/packages/wire/dist ./packages/wire/dist
 COPY --from=build /repo/packages/sdk/package.json ./packages/sdk/package.json

--- a/packages/twin-slack/Dockerfile
+++ b/packages/twin-slack/Dockerfile
@@ -31,25 +31,19 @@ ENV SLACK_CLONE_HOST=0.0.0.0
 # Runtime only executes `node`; npm/npx from the base image add unused packages
 # (and their CVE surface) to the scanned image.
 RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
-# F-1532 — take Debian's published security fixes on top of the pinned digest.
-# The digest freezes this image's package contents; Trivy's vulnerability DB is
-# refreshed on every run. So a fix Debian ships BEFORE upstream rebuilds the
+# Take Debian's published security fixes on top of the pinned digest. The digest
+# freezes this image's package contents while Trivy's vulnerability DB refreshes
+# on every run, so a fix Debian ships BEFORE upstream rebuilds the
 # node:*-trixie-slim tag lands as a FIXABLE HIGH on frozen contents, and the
 # publish gate then refuses this image identically on every future run — not a
-# flake, and a re-run cannot clear it. CVE-2026-53615 (util-linux; nine binary
-# packages, one source) did exactly that on 2026-08-18, and neither upstream
-# digest then current carried the fix, so bumping the pin was not a remedy.
-# The pin still fixes where the image STARTS; this layer lets a rebuild move.
-# Decision record, and why no .trivyignore exception was spent: .trivyignore.
+# flake, and a re-run cannot clear it. The pin still fixes where the image
+# STARTS; this layer lets a rebuild move.
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 COPY --from=build /repo/node_modules ./node_modules
-# The twin's dist imports @pome-sh/wire; ship its built output. Before F-942 this
-# was `COPY packages/shared-types` -- the WHOLE directory, sources included -- because
-# that package exported `./src/index.ts` and `build:runtime` emitted the runtime
-# `.js` in place beside each `.ts`. wire builds to dist/ like every other
-# package, so package.json + dist is the entire runtime need.
+# The twin's dist imports @pome-sh/wire; ship its built output — package.json
+# plus dist is the entire runtime need.
 COPY --from=build /repo/packages/wire/package.json ./packages/wire/package.json
 COPY --from=build /repo/packages/wire/dist ./packages/wire/dist
 # The twin's dist imports `@pome-sh/sdk`; ship the SDK's built output so the

--- a/packages/twin-stripe/Dockerfile
+++ b/packages/twin-stripe/Dockerfile
@@ -31,25 +31,19 @@ ENV STRIPE_CLONE_HOST=0.0.0.0
 # Runtime only executes `node`; npm/npx from the base image add unused packages
 # (and their CVE surface) to the scanned image.
 RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
-# F-1532 — take Debian's published security fixes on top of the pinned digest.
-# The digest freezes this image's package contents; Trivy's vulnerability DB is
-# refreshed on every run. So a fix Debian ships BEFORE upstream rebuilds the
+# Take Debian's published security fixes on top of the pinned digest. The digest
+# freezes this image's package contents while Trivy's vulnerability DB refreshes
+# on every run, so a fix Debian ships BEFORE upstream rebuilds the
 # node:*-trixie-slim tag lands as a FIXABLE HIGH on frozen contents, and the
 # publish gate then refuses this image identically on every future run — not a
-# flake, and a re-run cannot clear it. CVE-2026-53615 (util-linux; nine binary
-# packages, one source) did exactly that on 2026-08-18, and neither upstream
-# digest then current carried the fix, so bumping the pin was not a remedy.
-# The pin still fixes where the image STARTS; this layer lets a rebuild move.
-# Decision record, and why no .trivyignore exception was spent: .trivyignore.
+# flake, and a re-run cannot clear it. The pin still fixes where the image
+# STARTS; this layer lets a rebuild move.
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 COPY --from=build /repo/node_modules ./node_modules
-# The twin's dist imports @pome-sh/wire; ship its built output. Before F-942 this
-# was `COPY packages/shared-types` -- the WHOLE directory, sources included -- because
-# that package exported `./src/index.ts` and `build:runtime` emitted the runtime
-# `.js` in place beside each `.ts`. wire builds to dist/ like every other
-# package, so package.json + dist is the entire runtime need.
+# The twin's dist imports @pome-sh/wire; ship its built output — package.json
+# plus dist is the entire runtime need.
 COPY --from=build /repo/packages/wire/package.json ./packages/wire/package.json
 COPY --from=build /repo/packages/wire/dist ./packages/wire/dist
 # The twin's dist imports `@pome-sh/sdk`; ship the SDK's built output so the


### PR DESCRIPTION
 ## `.trivyignore`

53 lines, ignore list **empty** — every line is a comment. About 20 are a policy header (what the gate enforces, the three rules for an exception, the format); that is operating instruction sitting next to the config it governs, and it stays. 

A changelog entry, a leaked ticket id, and a debate about two options we didn't take, in a scanner config. Someone opening the file to add a CVE reads a 32-line essay about a CVE that was never added to it. It is also self-defeating: it argues the exception list should stay empty, and does so by adding 32 lines to the file whose emptiness is the point.

## Verify

* **Behaviour is unchanged by construction, not by assumption: every changed line in this diff is a comment.** `git diff -U0 | grep -vE '^[+-]\s*#'` returns nothing.
* Ignore list still empty, so the publish gate still fails on any fixable HIGH/CRITICAL.
* `twin-image.yml` untouched — same `trivyignores:` input, same change triggers.
* Nothing in the repo asserts the deleted text: `grep -rn "CVE-2026-53615"` now returns only two unrelated `F-1532` cross-references in `scripts/ci/`, which are about release-note gating, not this file.