### PR TITLE
twin-github: list_issues takes the array it advertises, and search stops answering false empties

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -10,6 +10,32 @@ write a version number here or in `package.json`. Released
 entries are insertions only: a correction is the next entry, naming the one it
 corrects.
 
+## Unreleased (patch)
+
+**The GitHub twin answers two calls it used to get wrong** (F-1614, F-791). Both
+were measured against real GitHub rather than reasoned about, and both had been
+answering plausibly for months.
+
+`list_issues` over MCP now accepts `labels` as the string ARRAY its own tool
+schema declares, and UNIONS them the way GitHub's MCP does (it runs on GraphQL,
+which ORs the set); it used to reject the array with 422 `invalid_type` while
+accepting a CSV string GitHub itself refuses. An empty array is no filter, and
+label names match case-insensitively. The REST door is unchanged: `?labels=a,b`
+still intersects, because GitHub's REST does.
+
+`search_issues` now tokenises the free text and requires every term to match a
+WHOLE token of the issue's title-and-body, so `coupon 500` finds an issue whose
+title carries both words — it used to match the whole query as one substring and
+answer nothing. `is:` is parsed: `is:open`/`is:closed` filter by state,
+`is:issue` is the identity, `is:pr` answers empty, and a value the surface cannot
+honour answers empty rather than becoming search text. Previously any query
+carrying `is:open`, GitHub's commonest issue qualifier, returned nothing.
+
+**Agents may see MORE results than before.** A multi-word query that silently
+returned nothing now returns matches, and a two-label MCP filter returns the
+union. A query relying on a PARTIAL word (`coup` for `coupon`) no longer matches,
+which is also GitHub's behaviour. The other four search surfaces are unchanged.
+
 ## 0.26.1 — 2026-08-21
 
 **The README no longer links a `RELEASING.md` that does not exist.** The release

--- a/packages/sandbox-domains/CHANGELOG.md
+++ b/packages/sandbox-domains/CHANGELOG.md
@@ -1,5 +1,31 @@
 # @pome-sh/sandbox-domains
 
+## Unreleased (patch)
+
+**The GitHub twin answers two calls it used to get wrong** (F-1614, F-791). Both
+were measured against real GitHub rather than reasoned about, and both had been
+answering plausibly for months.
+
+`list_issues` over MCP now accepts `labels` as the string ARRAY its own tool
+schema declares, and UNIONS them the way GitHub's MCP does (it runs on GraphQL,
+which ORs the set); it used to reject the array with 422 `invalid_type` while
+accepting a CSV string GitHub itself refuses. An empty array is no filter, and
+label names match case-insensitively. The REST door is unchanged: `?labels=a,b`
+still intersects, because GitHub's REST does.
+
+`search_issues` now tokenises the free text and requires every term to match a
+WHOLE token of the issue's title-and-body, so `coupon 500` finds an issue whose
+title carries both words — it used to match the whole query as one substring and
+answer nothing. `is:` is parsed: `is:open`/`is:closed` filter by state,
+`is:issue` is the identity, `is:pr` answers empty, and a value the surface cannot
+honour answers empty rather than becoming search text. Previously any query
+carrying `is:open`, GitHub's commonest issue qualifier, returned nothing.
+
+**Agents may see MORE results than before.** A multi-word query that silently
+returned nothing now returns matches, and a two-label MCP filter returns the
+union. A query relying on a PARTIAL word (`coup` for `coupon`) no longer matches,
+which is also GitHub's behaviour. The other four search surfaces are unchanged.
+
 ## 0.2.3 — 2026-08-20
 
 **The 501 unsupported body says "twin", not "twin clone"** (F-1547). The

--- a/packages/sdk/src/mcp-tool-fixture.ts
+++ b/packages/sdk/src/mcp-tool-fixture.ts
@@ -566,3 +566,71 @@ function issues(error: z.ZodError): string {
     .map((issue) => `${issue.path.join(".") || "<root>"}: ${issue.message}`)
     .join("; ");
 }
+
+// ── THE TYPE AXIS OF A CONFORMANCE COMPARISON (F-1614) ──────────────────────
+//
+// Each twin's `tool-schema-conformance.ts` compares its validators against the
+// vendor's `inputSchema` from the fixture above. Both of the two that exist
+// compared a key's PRESENCE and its requiredness, and neither compared the TYPE
+// of a key both sides declare — so twin-github advertised
+// `labels: {"type":"array","items":{"type":"string"}}`, validated it as
+// `z.string()`, and answered `tools/call` with 422 `invalid_type` to the exact
+// shape its own listing published. Both conformance reports were green
+// throughout: github's pinned residue carried nothing about `labels`, and
+// slack's asserts the empty list.
+//
+// The comparison lives here, once, rather than in each twin. Two copies of a
+// check drift, and a check that drifts is the failure this whole module exists
+// to end.
+
+/**
+ * A property's declared type as one comparable word, or `undefined` when it
+ * cannot be stated plainly.
+ *
+ * `integer` folds into `number`: zod emits `integer` for `.int()` and vendors
+ * spell the same argument `number`, so splitting them would report the
+ * projection rather than a disagreement an examinee can hit. Unions, `anyOf`,
+ * `$ref` and a missing `type` return `undefined` — silence, not a guess, for the
+ * same reason.
+ */
+export function describeSchemaType(spec: unknown): string | undefined {
+  if (!spec || typeof spec !== "object") return undefined;
+  const schema = spec as { type?: unknown; items?: unknown };
+  const name = (raw: unknown): string | undefined =>
+    typeof raw !== "string" ? undefined : raw === "integer" ? "number" : raw;
+  const type = name(schema.type);
+  if (!type) return undefined;
+  if (type !== "array") return type;
+  const items = schema.items && typeof schema.items === "object" ? (schema.items as { type?: unknown }) : undefined;
+  const element = name(items?.type);
+  return element ? `array<${element}>` : "array";
+}
+
+/**
+ * Every key both documents declare whose type they disagree about, phrased for
+ * a conformance residue.
+ *
+ * PURE and exported so each twin's argument-surface test can PLANT a pair and
+ * prove the comparison fires. Running it only over the real fixture cannot tell
+ * a working check from one that always returns `[]` — and `[]` is what both
+ * twins get today, which is the state a regression would also produce.
+ *
+ * @param vendor the vendor's name as the residue line should say it ("GitHub")
+ */
+export function typeDisagreements(
+  toolName: string,
+  vendor: string,
+  upstreamProperties: Record<string, unknown>,
+  projectedProperties: Record<string, unknown>,
+): string[] {
+  const problems: string[] = [];
+  for (const key of Object.keys(projectedProperties)) {
+    if (!(key in upstreamProperties)) continue;
+    const theirs = describeSchemaType(upstreamProperties[key]);
+    const ours = describeSchemaType(projectedProperties[key]);
+    if (theirs && ours && theirs !== ours) {
+      problems.push(`'${toolName}' validates '${key}' as ${ours}, and ${vendor} declares it as ${theirs}`);
+    }
+  }
+  return problems;
+}

--- a/packages/twin-github/FIDELITY.md
+++ b/packages/twin-github/FIDELITY.md
@@ -57,8 +57,8 @@ in the package README. Changing any of those is a breaking change for
 | `create_or_update_file` | SQLite files/commits | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | Requires `sha` for updates to preserve optimistic locking. |
 | `create_branch` | SQLite branches/files | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts`, `concurrency.test.ts` | Branch protection is not modeled. |
 | `push_files` | SQLite files/commits | hot | semantic | `mcp-contract.test.ts`, `domain.test.ts` | Multi-file pushes are one local commit; Git object APIs are simplified. |
-| `search_issues` | SQLite issues | hot | semantic | `mcp-contract.test.ts`, `performance.test.ts`, `fixture-endpoints.test.ts`, `search-query-qualifiers.test.ts` | Free text is substring based; `repo:`/`user:`/`org:`/`state:` are parsed, other qualifiers are not (divergence #1). No `state=open` default, deliberately (F-1427). |
-| `list_issues` | SQLite issues | hot | semantic | `mcp-contract.test.ts`, `performance.test.ts`, `fixture-endpoints.test.ts`, `list-state-default.test.ts` | Only state, labels, assignee, and pagination filters are supported. ⚠️ The two doors differ, as GitHub's do (F-1468): the MCP tool takes `state` as `["OPEN","CLOSED"]` and returns BOTH when it is absent, which is what GitHub's own listing declares and describes; the REST `GET /issues` takes `open`/`closed`/`all` and defaults to `open` (F-1427). |
+| `search_issues` | SQLite issues | hot | semantic | `mcp-contract.test.ts`, `performance.test.ts`, `fixture-endpoints.test.ts`, `search-query-qualifiers.test.ts`, `upstream-measured-semantics.test.ts` | Free text is TOKENISED, all-terms, whole-token (F-791); `repo:`/`user:`/`org:`/`state:`/`is:` are parsed, other qualifiers are not (divergence #1). No `state=open` default, deliberately (F-1427). |
+| `list_issues` | SQLite issues | hot | semantic | `mcp-contract.test.ts`, `performance.test.ts`, `fixture-endpoints.test.ts`, `list-state-default.test.ts`, `upstream-measured-semantics.test.ts` | Only state, labels, assignee, and pagination filters are supported. ⚠️ The two doors differ, as GitHub's do, on TWO arguments. `state` (F-1468): the MCP tool takes `["OPEN","CLOSED"]` and returns BOTH when it is absent, which is what GitHub's own listing declares and describes; the REST `GET /issues` takes `open`/`closed`/`all` and defaults to `open` (F-1427). `labels` (F-1614): the MCP tool takes a string ARRAY and UNIONS it (GitHub's MCP runs on GraphQL); REST takes a CSV and INTERSECTS it. See "The two doors take `labels` differently". |
 | `add_issue_comment` | SQLite issue comments | hot | semantic | `mcp-contract.test.ts`, `state-export.test.ts` | Comment edit/delete APIs are not implemented. |
 | `create_issue` | SQLite issues | hot | semantic | `mcp-contract.test.ts` | Issue templates and milestones are not modeled. |
 | `create_pull_request_review` | SQLite PR reviews | hot | semantic | `mcp-contract.test.ts`, `state-export.test.ts` | Inline review comments are not created by this tool. |
@@ -226,21 +226,63 @@ that entry which was never a gap — that these urls must stay GENERIC, because
 authentication fails before dispatch and there is no operation to name — was
 always 32's, and 32 now names the twin-only 401/403 surfaces explicitly.
 
-1. **Search query syntax is substring-based.** The free text left in `q` is
-   matched as one case-insensitive substring, scoped to the default branch —
-   not as GitHub's ranked, tokenised, boolean-aware index. Four SCOPE
-   qualifiers are lifted out of `q` and honoured on `/search/code`,
-   `/search/commits` and `/search/issues` (F-1389): `repo:owner/name`,
-   `user:login`, `org:login`, and `state:open|closed` on `/search/issues` only,
-   several of them OR-ing together the way GitHub's do. Everything else GitHub
-   has — `in:`, `language:`, `path:`, `is:`, `label:`, `author:`, the boolean
-   operators — is **not parsed**, and an unparsed qualifier stays in the
-   free-text term rather than being dropped, so it narrows the answer to nothing
-   instead of silently widening it past what GitHub would return. Three further
-   simplifications, each deliberate: `user:` and `org:` both resolve to the
-   repository's owner login with no account-type check; `search_repositories`
+1. **Search query syntax is simplified, and `/search/issues` is TOKENISED while
+   the other four are still substring-based.** `/search/issues` splits the free
+   text into tokens and requires every one of them to be a token of the issue's
+   title-plus-body — not GitHub's ranked, semantic index, but the same
+   all-terms, whole-token answer for an ordinary query. `/search/code`,
+   `/search/commits`, `/search/repositories` and `/search/users` still match the
+   whole remaining `q` as one case-insensitive substring.
+
+   Five SCOPE qualifiers are lifted out of `q` (F-1389, F-791):
+   `repo:owner/name`, `user:login`, `org:login` on all three scoped searches, and
+   `state:open|closed` plus `is:` on `/search/issues` only, several of them
+   OR-ing together the way GitHub's do. `is:open`/`is:closed` set the same filter
+   `state:` does, `is:issue` is the identity on this surface and `is:pr` answers
+   empty (this twin keeps pull requests out of the issues table), and an `is:`
+   value the surface cannot honour answers empty rather than becoming free text.
+   Everything else GitHub has — `in:`, `language:`, `path:`, `label:`, `author:`,
+   the boolean operators — is **not parsed**, and an unparsed qualifier stays in
+   the free-text term rather than being dropped, so it narrows the answer to
+   nothing instead of silently widening it past what GitHub would return. Three
+   further simplifications, each deliberate: `user:` and `org:` both resolve to
+   the repository's owner login with no account-type check; `search_repositories`
    and `search_users` parse no qualifiers at all and still match the whole `q`;
    and quoted qualifier values (`repo:"a/b"`) are not unquoted.
+
+   **⚠️ WHAT THIS ENTRY USED TO SAY, AND WHY IT WAS THE DEFECT (F-791).** It read
+   *"the free text left in `q` is matched as one case-insensitive substring"* and
+   listed `is:` among the unparsed, with `narrowing is the safe failure` as the
+   reason for both. Narrowing is the safe failure for a SIMULATOR. It is not for
+   a grading instrument, and these two turned it into the opposite of one:
+   `search_issues(q="coupon 500")` answered `total_count: 0` for an issue whose
+   title carries both words, and any query carrying `is:open` — GitHub's
+   commonest issue qualifier — answered nothing at all. An agent that searched
+   before filing was told the bug was untracked, filed a duplicate, and was
+   graded for not checking. Measured on a hosted run: five of one model's eight
+   failures were this, and every one of them would have passed against real
+   GitHub. A twin that says the agent is bad where production says it is fine is
+   the one property the instrument cannot have, and it fails as a plausible
+   number rather than as an error.
+
+   The replacement is measured rather than reasoned. Against `cli/cli`,
+   2026-08-21: `codespaces` 345 and `authentication` 607 answer 37 together, so
+   terms AND; `authenticati` answers 0 against `authentication`'s 607, so a term
+   matches a whole token and not a prefix; `is:open` and `state:open` answer the
+   same 5; `is:issue` 21 and `is:pr` 16 partition the unscoped 37; and
+   `is:bogusvalue` answers 0 rather than searching for the literal. The
+   whole-token half matters as much as the multi-word half and pulls the other
+   way — splitting the query and testing each term with a substring match, the
+   fix F-791 itself prescribed, would answer 607 for `authenticati` and score a
+   call GitHub refuses to serve. `test/upstream-measured-semantics.test.ts`
+   carries the table and the provenance of every row.
+
+   Still simplified, and still divergent: GitHub's index is ranked and — on the
+   MCP door — semantic (`search_issues` there is documented as *"natural-language
+   semantic matching … already scoped to `is:issue`"*), so a paraphrase that
+   shares no token with the issue finds it at GitHub and not here. That is a
+   narrowing this twin does not attempt to close; what it no longer does is
+   answer empty for a query whose every term is present.
 2. **PR diffs and patches are simplified placeholders.** `get_pull_request_diff`
    and `get_pull_request_files` return a unified-diff-shaped envelope whose
    `patch` bodies are placeholders, not byte-accurate GitHub patches.
@@ -838,6 +880,46 @@ All nine are now undeclared, which under the `ignore` ruling above means
 discarded rather than refused: a request still sending one gets the answer it
 would have got without it, the way real GitHub answers. None of the three
 surfaces 4xx's.
+
+### The two doors take `labels` differently, and both are right (F-1614)
+
+**This is fidelity, not an inconsistency. Do not "unify" it.** The same shape of
+fact as `content` below, and resolved the same way — but this one is a
+disagreement about MEANING as well as spelling, so it reaches one level further
+in:
+
+| door | takes | matches | measured 2026-08-21 |
+|---|---|---|---|
+| REST `GET /repos/:o/:r/issues?labels=a,b` | a CSV **string** | **all** of them | `gh api`, `cli/cli`: `auth,codespaces` → 0, against 18 and 21 alone |
+| MCP `list_issues {labels:["a","b"]}` | a string **array** | **any** of them | the deployed server at `api.githubcopilot.com/mcp/` → 39, an exact union |
+
+The MCP tool is not a wrapper over that REST route. `github/github-mcp-server`
+@ `c2bc7dc0` (the commit `config/mcp-capture-sources.json` pins) builds a
+**GraphQL** query in `pkg/github/issues.go` and hands `labels` to
+`issues(labels: [String!])`, which ORs the set — confirmed directly against
+GitHub's GraphQL API as well as end to end through the deployed MCP server. So
+an examinee filtering on two labels gets the union at GitHub and would have got
+the intersection from any twin that joined the array into the REST door's CSV.
+
+Three more measurements the same probe settled, all now matched:
+
+| sent to real GitHub's MCP | it answers |
+|---|---|
+| `labels: "auth"` — the REST CSV spelling | **refused**: `parameter labels could not be coerced to []string, is string` |
+| `labels: []` | no filter (the server guards its GraphQL argument with `len(labels) > 0`) |
+| `labels: ["AUTH"]`, `?labels=AUTH` | 18 — label names match **case-insensitively**, on both doors |
+
+The array→filter translation therefore lives at the MCP boundary
+(`normalizeIssueLabels` in `src/tools.ts`, beside `normalizeIssueState`) and the
+CSV split at the REST one, while the domain takes an explicit `LabelFilter`
+carrying `match: "all" | "any"` and never guesses from the argument's type.
+Case-insensitivity is the domain's, because both doors have it.
+
+⚠️ **The MCP door REFUSES the string on purpose.** Accepting both — the shape
+twin-slack's `jsonStringOrArray` uses, correctly, because Slack was measured to
+take both — would be a false PASS here: the twin would serve a call the vendor
+rejects. `test/upstream-measured-semantics.test.ts` and
+`test/mcp-argument-surface.test.ts` both fail if that comes back.
 
 ### The two doors take `content` differently, and both are right (F-1460)
 

--- a/packages/twin-github/src/domain/issues.ts
+++ b/packages/twin-github/src/domain/issues.ts
@@ -95,7 +95,43 @@ export function createIssue(domain: GitHubDomain, input: { owner: string; repo: 
 }
 
 
-export function listIssues(domain: GitHubDomain, input: { owner: string; repo: string; state?: "open" | "closed" | "all"; labels?: string; assignee?: string } & PageOptions) {
+/**
+ * How a label filter matches, because real GitHub's two doors DISAGREE and both
+ * are right (F-1614). This is the same shape of fact as F-1460's `content`, and
+ * it is resolved the same way: the disagreement lives at the boundary, and the
+ * domain is TOLD which semantics it was handed rather than sniffing the type.
+ *
+ * | door | argument | matches | measured 2026-08-21, `cli/cli` |
+ * |---|---|---|---|
+ * | REST `GET /issues?labels=a,b` | CSV | **all** of them | `auth,codespaces` → 0, against 18 and 21 alone |
+ * | MCP `list_issues {labels:["a","b"]}` | array | **any** of them | the same two → 39, an exact union |
+ *
+ * The MCP tool is not a wrapper over that REST route: `github/github-mcp-server`
+ * @ c2bc7dc0 `pkg/github/issues.go` builds a GraphQL query and hands `labels` to
+ * `issues(labels: [String!])`, which ORs the set. Confirmed end to end against
+ * the deployed server at `https://api.githubcopilot.com/mcp/`.
+ *
+ * Names match CASE-INSENSITIVELY on both doors (`?labels=AUTH` and
+ * `labels:["AUTH"]` each answered 18), so that part belongs here rather than at
+ * either boundary.
+ */
+export interface LabelFilter {
+  readonly names: readonly string[];
+  readonly match: "all" | "any";
+}
+
+/** A CSV from the REST door, an already-shaped filter from the MCP door, or nothing. */
+function labelFilter(labels: string | LabelFilter | undefined): LabelFilter | undefined {
+  if (labels === undefined) return undefined;
+  const raw = typeof labels === "string" ? { names: labels.split(","), match: "all" as const } : labels;
+  const names = raw.names.map((name) => name.trim().toLowerCase()).filter(Boolean);
+  // An EMPTY set is NO FILTER on both doors, not a match-nothing: REST answers
+  // the unfiltered list for `?labels=`, and the MCP server guards its GraphQL
+  // argument with `len(labels) > 0` so an empty array never reaches the query.
+  return names.length ? { names, match: raw.match } : undefined;
+}
+
+export function listIssues(domain: GitHubDomain, input: { owner: string; repo: string; state?: "open" | "closed" | "all"; labels?: string | LabelFilter; assignee?: string } & PageOptions) {
   const repo = domain.requireRepo(input.owner, input.repo);
   let rows = domain.listIssuesRows(repo.id);
   // Real GitHub defaults this route to `state=open` (F-1427). The filter used to
@@ -105,11 +141,13 @@ export function listIssues(domain: GitHubDomain, input: { owner: string; repo: s
   // constant-mismatch and `[].closed_at` type-changed against real GitHub.
   const state = input.state ?? "open";
   if (state !== "all") rows = rows.filter((issue) => issue.state === state);
-  if (input.labels) {
-    const wanted = input.labels.split(",").map((label) => label.trim()).filter(Boolean);
+  const wanted = labelFilter(input.labels);
+  if (wanted) {
     rows = rows.filter((issue) => {
-      const names = domain.listIssueLabels(repo.id, issue.number).map((label) => label.name);
-      return wanted.every((label) => names.includes(label));
+      const names = domain.listIssueLabels(repo.id, issue.number).map((label) => label.name.toLowerCase());
+      return wanted.match === "all"
+        ? wanted.names.every((label) => names.includes(label))
+        : wanted.names.some((label) => names.includes(label));
     });
   }
   if (input.assignee) rows = rows.filter((issue) => domain.listIssueAssignees(repo.id, issue.number).includes(input.assignee!));

--- a/packages/twin-github/src/domain/search.ts
+++ b/packages/twin-github/src/domain/search.ts
@@ -330,9 +330,11 @@ export function searchIssues(domain: GitHubDomain, input: { query?: string; q?: 
   // surfaces gained one because real GitHub defaults them; GitHub's SEARCH API
   // does not — a search returns what the query asks for, and `state:open` is a
   // query qualifier, not a default. Adding one to match the lists would be a new
-  // divergence in the other direction, and a worse one: this search is substring
-  // matching over the seeded world, so any query whose only match is closed would
-  // answer `[]` — an empty-array divergence in place of a value one.
+  // divergence in the other direction, and a worse one: this search matches
+  // tokens over the seeded world rather than ranking it, so any query whose only
+  // match is closed would answer `[]` — an empty-array divergence in place of a
+  // value one. (That clause read "substring matching" until F-791 tokenised the
+  // term; the argument it makes is unchanged by which of the two it is.)
   //
   // `state:` in `q` is GitHub's own spelling and wins over `input.state`, which
   // only an MCP caller can still set (F-1389 took `?state=` off the REST

--- a/packages/twin-github/src/domain/search.ts
+++ b/packages/twin-github/src/domain/search.ts
@@ -81,21 +81,67 @@ import type { FileChange, MutatingOptions, PageOptions, StateDeltaCallback } fro
  * correct one, and dropping the three parameters alone would have left that
  * standing.
  *
- * Four qualifiers are lifted out. Everything else GitHub has — `in:`,
- * `language:`, `path:`, `is:`, the boolean operators — stays in the free-text
+ * Five qualifiers are lifted out. Everything else GitHub has — `in:`,
+ * `language:`, `path:`, the boolean operators — stays in the free-text
  * term (FIDELITY.md divergence 1).
  */
-const QUALIFIER = /(^|\s)(repo|user|org|state):(\S+)/gi;
+const QUALIFIER = /(^|\s)(repo|user|org|state|is):(\S+)/gi;
 
 interface ParsedSearchQuery {
   /** What is left of `q` once the qualifiers are lifted out, lowercased. */
   readonly text: string;
+  /**
+   * The same remainder TOKENISED. `/search/issues` matches on this and every
+   * term has to be present; the code and commit searches still match `text` as
+   * one substring, which is divergence 1's remaining half.
+   */
+  readonly terms: readonly string[];
   /** `user:` / `org:` values — repository owner logins, lowercased. */
   readonly owners: readonly string[];
   /** `repo:` values — repository FULL names (`owner/name`), lowercased. */
   readonly fullNames: readonly string[];
-  /** `state:`, on the surfaces that have one. */
+  /** `state:` or `is:open|closed`, on the surfaces that have one. */
   readonly state?: "open" | "closed";
+  /** `is:issue` / `is:pr`, on the surfaces that have them. */
+  readonly type?: "issue" | "pr";
+  /**
+   * An `is:` value the surface cannot honour. GitHub reads the qualifier and
+   * answers NOTHING rather than searching for the text — measured 2026-08-21,
+   * `repo:cli/cli … is:bogusvalue` → `total_count: 0` where the same query
+   * without it answers 37. Modelled as a flag rather than as unmatched text so
+   * the answer does not depend on whether the literal happens to be indexed.
+   */
+  readonly unhonourable: boolean;
+}
+
+/**
+ * GitHub's issue index is TOKENISED, and a term matches a WHOLE token rather
+ * than a substring. Measured 2026-08-21 against `cli/cli`:
+ *
+ *   `authentication`  → 607      `authenticati` (a prefix of it) → 0
+ *   `codespaces` 345 ∧ `authentication` 607 → `codespaces authentication` 37
+ *
+ * So terms AND, and a partial word matches nothing. Both halves matter here and
+ * they pull in opposite directions: matching the whole query as one substring
+ * (the F-791 defect) answers EMPTY for a query whose terms are all present,
+ * while splitting the query and testing each term with `includes` — the fix the
+ * ticket prescribed — would answer 607 for `authenticati` and score a call
+ * GitHub refuses to serve. A false hit is the worse of the two for a grading
+ * instrument, so the match is token equality.
+ *
+ * `_` stays inside a token and `-` breaks one, which is GitHub's own split:
+ * `per_page` → 110 and `per page` → 226 are different queries there, while
+ * `pull-request` → 3222 and `pull request` → 3298 are the same one.
+ */
+function tokenise(text: string): string[] {
+  return text.toLowerCase().split(/[^a-z0-9_]+/).filter(Boolean);
+}
+
+/** Whether every term in `q` appears as a token of `document`. */
+function matchesTerms(terms: readonly string[], ...document: string[]): boolean {
+  if (terms.length === 0) return true;
+  const tokens = new Set(tokenise(document.join(" ")));
+  return terms.every((term) => tokens.has(term));
 }
 
 /**
@@ -112,10 +158,12 @@ interface ParsedSearchQuery {
  * Lifting `state:` out of a code search would filter by nothing and widen the
  * answer for the same reason.
  */
-function parseSearchQuery(raw: string, options: { state?: boolean } = {}): ParsedSearchQuery {
+function parseSearchQuery(raw: string, options: { state?: boolean; is?: boolean } = {}): ParsedSearchQuery {
   const owners: string[] = [];
   const fullNames: string[] = [];
   let state: "open" | "closed" | undefined;
+  let type: "issue" | "pr" | undefined;
+  let unhonourable = false;
   const text = raw.replace(QUALIFIER, (whole, lead: string, key: string, rawValue: string) => {
     const value = rawValue.toLowerCase();
     switch (key.toLowerCase()) {
@@ -138,11 +186,38 @@ function parseSearchQuery(raw: string, options: { state?: boolean } = {}): Parse
         if (!options.state || (value !== "open" && value !== "closed")) return whole;
         state = value;
         return lead;
+      case "is":
+        // GitHub's commonest issue qualifier, and the one whose absence hurt
+        // most: `is:open` left in the free text zeroed EVERY query carrying it
+        // (F-791). Measured 2026-08-21 on `cli/cli`: `is:open` and `state:open`
+        // returned the same 5, and `is:issue` 21 + `is:pr` 16 partitioned the
+        // unscoped 37 exactly.
+        //
+        // Gated on `options.is` for the same reason `state:` is: `is:archived`
+        // and `is:fork` are code-search qualifiers this twin does not model, and
+        // lifting them out there would widen the answer past GitHub's.
+        if (!options.is) return whole;
+        switch (value) {
+          case "open":
+          case "closed":
+            state = value;
+            return lead;
+          case "issue":
+          case "pr":
+            type = value;
+            return lead;
+          default:
+            // Not free text. GitHub reads the qualifier, cannot honour the
+            // value, and answers nothing — measured, `is:bogusvalue` → 0.
+            unhonourable = true;
+            return lead;
+        }
       default:
         return whole;
     }
   });
-  return { text: text.replace(/\s+/g, " ").trim().toLowerCase(), owners, fullNames, state };
+  const normalized = text.replace(/\s+/g, " ").trim().toLowerCase();
+  return { text: normalized, terms: tokenise(normalized), owners, fullNames, state, type, unhonourable };
 }
 
 /**
@@ -234,13 +309,20 @@ export function searchCommits(domain: GitHubDomain, input: { query?: string; q?:
 
 
 export function searchIssues(domain: GitHubDomain, input: { query?: string; q?: string; owner?: string; repo?: string; state?: "open" | "closed" | "all" } & PageOptions) {
-  const parsed = parseSearchQuery(input.query ?? input.q ?? "", { state: true });
+  const parsed = parseSearchQuery(input.query ?? input.q ?? "", { state: true, is: true });
   const rows = domain.db
     .prepare(
       "SELECT issues.*, repositories.owner, repositories.name, repositories.full_name, repositories.description, repositories.private, repositories.default_branch, repositories.fork, repositories.parent_full_name, repositories.entity_counter, repositories.created_at AS repo_created_at, repositories.updated_at AS repo_updated_at FROM issues INNER JOIN repositories ON issues.repo_id = repositories.id ORDER BY issues.updated_at DESC"
     )
     .all() as Array<IssueRow & { owner: string; name: string; full_name: string; description: string; private: 0 | 1; default_branch: string; fork: 0 | 1; parent_full_name: string | null; entity_counter: number; repo_created_at: string; repo_updated_at: string }>;
-  let filtered = rows.filter((issue) => !parsed.text || issue.title.toLowerCase().includes(parsed.text) || issue.body.toLowerCase().includes(parsed.text) || issue.full_name.toLowerCase().includes(parsed.text));
+  // The free text matches TOKENS of one document — title and body together, the
+  // way GitHub indexes an issue, which is why `in:title` / `in:body` exist there
+  // to narrow it. The repository's full name is deliberately NOT in that
+  // document: `repo:` is the qualifier that addresses it (and this twin parses
+  // it), and folding the name into an all-terms match would answer a query like
+  // `acme coupon` that GitHub answers with nothing — divergence 1's stated
+  // unsafe direction.
+  let filtered = rows.filter((issue) => matchesTerms(parsed.terms, issue.title, issue.body));
   filtered = filtered.filter((issue) => inScope(parsed, issue.owner, issue.full_name));
   if (input.owner) filtered = filtered.filter((issue) => issue.owner === input.owner);
   if (input.repo) filtered = filtered.filter((issue) => issue.name === input.repo);
@@ -258,6 +340,16 @@ export function searchIssues(domain: GitHubDomain, input: { query?: string; q?: 
   // qualifier is the half GitHub would have read.
   const state = parsed.state ?? (input.state === "all" ? undefined : input.state);
   if (state) filtered = filtered.filter((issue) => issue.state === state);
+  // `is:pr` asks for pull requests and this surface reads the `issues` table,
+  // which holds none — real GitHub models a PR as an issue and this twin keeps
+  // them apart. Answering EMPTY is the honest reply; answering with issues is
+  // the false PASS the MCP-lane registry files as GITHUB-MCP-010 (a search for
+  // PRs scored as if it had returned them). The missing `search_pull_requests`
+  // TOOL is the other half of that entry and is not closed here.
+  //
+  // `unhonourable` is the same shape for a different reason: GitHub reads an
+  // `is:` value it cannot serve and returns nothing.
+  if (parsed.type === "pr" || parsed.unhonourable) filtered = [];
   return {
     total_count: filtered.length,
     incomplete_results: false,

--- a/packages/twin-github/src/tool-schema-conformance.ts
+++ b/packages/twin-github/src/tool-schema-conformance.ts
@@ -28,6 +28,8 @@
 //     ignored today, which is survivable, but not silently;
 //   - a required-set disagreement in either direction — the twin refusing a
 //     call GitHub accepts, or accepting one GitHub refuses;
+//   - a TYPE disagreement on a key both sides declare — the twin validating a
+//     string where GitHub declares an array of them (F-1614);
 //   - a validator that rejects an unknown key where GitHub's schema declares no
 //     `additionalProperties`.
 //
@@ -51,6 +53,7 @@
 // is the same discipline as pome-cloud's `EXPECTED_OPT_OUTS` and for the same
 // reason: a count or an allowance would let the next one arrive unread.
 import { z } from "zod";
+import { typeDisagreements } from "@pome-sh/sdk/mcp-tool-fixture";
 import { githubToolFixture, toolArgumentSchemas } from "./tools.js";
 
 export function toolSchemaConformance(): string[] {
@@ -93,6 +96,26 @@ export function toolSchemaConformance(): string[] {
         problems.push(`'${tool.name}' does not model GitHub's parameter '${key}'`);
       }
     }
+
+    // ── AND THE TYPE OF THE KEYS BOTH SIDES HAVE (F-1614) ───────────────────
+    //
+    // The three checks above are about a key's PRESENCE and its requiredness,
+    // and for a year that was the whole comparison. It is not enough, and the
+    // gap is not theoretical: `list_issues.labels` was declared
+    // `{"type":"array","items":{"type":"string"}}` by GitHub and validated as
+    // `z.string()` here. Both sides had the key, neither side required it, so
+    // every check above passed and the pinned residue carried nothing about it
+    // — while `tools/call` answered 422 `invalid_type` to the exact shape the
+    // listing advertises. An examinee that read the schema and obeyed it was
+    // refused, and the guard whose job is that disagreement reported green.
+    //
+    // Only COMPARABLE types are reported. A zod schema projects unions, refines
+    // and coercions into shapes the vendor's hand-written JSON Schema has no
+    // counterpart for, and a residue line nobody can act on is the failure
+    // `EXPECTED_OPT_OUTS` and this list are both built to avoid.
+    // `describeSchemaType` returns undefined for anything it cannot state plainly, and an unstatable
+    // type is silence rather than a guess.
+    problems.push(...typeDisagreements(tool.name, "GitHub", upstream.properties ?? {}, projected.properties ?? {}));
 
     // ── REQUIRED-NESS IS PROBED, NOT PROJECTED ──────────────────────────────
     //

--- a/packages/twin-github/src/tools.ts
+++ b/packages/twin-github/src/tools.ts
@@ -100,6 +100,21 @@ function normalizeCommentId<T extends { comment_id?: number; commentId?: number 
 }
 
 /**
+ * The MCP door's `labels`, turned into the filter the domain takes (F-1614).
+ *
+ * This sits beside `normalizeIssueState` because it is the same kind of job —
+ * the MCP spelling of an argument translated once, at the boundary, rather than
+ * in each caller's head. It is NOT a join to the REST door's CSV: that door
+ * INTERSECTS and this one UNIONS, measured on both, so a join would answer
+ * empty for a two-label call GitHub answers with the union. `LabelFilter`'s
+ * comment carries the numbers.
+ */
+function normalizeIssueLabels<T extends { labels?: readonly string[] }>(input: T) {
+  const names = input.labels;
+  return { ...input, labels: names === undefined ? undefined : { names, match: "any" as const } };
+}
+
+/**
  * How each tool's arguments are validated, indexed by the name the fixture
  * declares. `githubToolInputSchema` is the projection that produced every
  * `inputSchema` in the fixture, and the contract suite runs it over each
@@ -195,7 +210,14 @@ export const toolArgumentSchemas = [
   },
   {
     name: "list_issues",
-    schema: z.object({ ...ownerRepo, state: z.enum(["OPEN", "CLOSED"]).optional(), labels: z.string().optional(), assignee: z.string().optional(), ...pageShape })
+    // `labels` is an ARRAY here and a CSV string on the REST door, and that is
+    // the vendor's own split rather than an inconsistency — see `LabelFilter` in
+    // `domain/issues.ts`. The string spelling is REFUSED on purpose: GitHub's MCP
+    // server answers `parameter labels could not be coerced to []string, is
+    // string` (`pkg/github/params.go`'s `OptionalStringArrayParam`, confirmed
+    // against the deployed server), so accepting it here would score a call the
+    // vendor rejects.
+    schema: z.object({ ...ownerRepo, state: z.enum(["OPEN", "CLOSED"]).optional(), labels: z.array(z.string()).optional(), assignee: z.string().optional(), ...pageShape })
   },
   {
     name: "add_issue_comment",
@@ -480,7 +502,7 @@ function dispatchTool(
     case "search_issues":
       return domain.searchIssues(parsed);
     case "list_issues":
-      return domain.listIssues(normalizeIssueState(parsed));
+      return domain.listIssues(normalizeIssueLabels(normalizeIssueState(parsed)));
     case "add_issue_comment":
       return domain.addIssueComment(normalizeIssueNumber(parsed), onDelta);
     case "create_issue":

--- a/packages/twin-github/test/list-state-default.test.ts
+++ b/packages/twin-github/test/list-state-default.test.ts
@@ -31,10 +31,13 @@
 // `GET /search/issues` is the deliberate exception and is asserted as one.
 // GitHub's search API has no `state=open` default — a search returns what the
 // query asks for — so `searchIssues` keeps filtering only on an explicit state.
-// That is not an oversight the next reader should "fix": the twin's search is
-// substring-based over the seeded world, so imposing an open default would
-// answer `[]` for any query whose only match is closed, turning a value
-// mismatch into an empty-array divergence in the other direction.
+// That is not an oversight the next reader should "fix": the twin's search
+// matches tokens over the seeded world rather than ranking it, so imposing an
+// open default would answer `[]` for any query whose only match is closed,
+// turning a value mismatch into an empty-array divergence in the other
+// direction. (This read "substring-based" until F-791 tokenised the term; the
+// argument does not depend on which of the two it is, and the state qualifier
+// itself now also answers to GitHub's `is:open` spelling.)
 //
 // Where that explicit state is SPELLED moved in F-1389: `state` is a `q`
 // qualifier (`q=idempotency state:closed`), not a query parameter. GitHub's

--- a/packages/twin-github/test/mcp-argument-surface.test.ts
+++ b/packages/twin-github/test/mcp-argument-surface.test.ts
@@ -50,8 +50,9 @@
 //     `fields`, `draft`, `reviewers`). Silently dropped rather than refused, so
 //     an examinee that passes it is graded on a call the twin did not make.
 import { describe, expect, it } from "vitest";
+import { typeDisagreements } from "@pome-sh/sdk/mcp-tool-fixture";
 import { toolSchemaConformance } from "../src/tool-schema-conformance.js";
-import { toolArgumentSchemas } from "../src/tools.js";
+import { githubToolFixture, toolArgumentSchemas } from "../src/tools.js";
 
 /** Every known disagreement between GitHub's declared arguments and this twin's
  * validators, sorted. Sorted so the diff of an addition is one line. */
@@ -186,6 +187,73 @@ describe("MCP argument surface vs GitHub's declared one (F-1468)", () => {
       // …and absent is still absent.
       expect(schema.safeParse({}).success, `${name} {}`).toBe(false);
     }
+  });
+
+  // ── THE TYPE AXIS (F-1614) ────────────────────────────────────────────────
+  //
+  // The residue above compares which arguments each side has and which it
+  // requires. Until F-1614 it compared nothing else, and that gap shipped a
+  // defect for as long as the pin existed: GitHub declared `list_issues.labels`
+  // as an array of strings, this twin validated it as one string, both
+  // documents had the key, neither required it, and `toolSchemaConformance()`
+  // reported nothing — while the twin answered 422 `invalid_type` to the exact
+  // shape its own listing advertises.
+  //
+  // These three cases are the guard on the guard. The real fixture now agrees
+  // everywhere, so a test that only read it would pass whether the comparison
+  // worked or not.
+  describe("a TYPE disagreement on a shared key is reported", () => {
+    it("catches the exact shape F-1614 was, replayed against a planted pair", () => {
+      expect(
+        typeDisagreements(
+          "list_issues",
+          "GitHub",
+          { labels: { type: "array", items: { type: "string" } } },
+          { labels: { type: "string" } },
+        ),
+      ).toEqual(["'list_issues' validates 'labels' as string, and GitHub declares it as array<string>"]);
+    });
+
+    it("says nothing when the two agree, including on the element type", () => {
+      const array = { type: "array", items: { type: "string" } };
+      expect(typeDisagreements("t", "GitHub", { labels: array }, { labels: array })).toEqual([]);
+      // An array of the WRONG element type is still a disagreement — this is the
+      // half a bare `type` comparison would miss.
+      expect(
+        typeDisagreements("t", "GitHub", { labels: array }, { labels: { type: "array", items: { type: "number" } } }),
+      ).toEqual(["'t' validates 'labels' as array<number>, and GitHub declares it as array<string>"]);
+    });
+
+    it("stays silent on shapes it cannot state, rather than guessing", () => {
+      // A key only one side has belongs to the presence checks above, not here.
+      expect(typeDisagreements("t", "GitHub", { a: { type: "string" } }, { b: { type: "number" } })).toEqual([]);
+      // `anyOf` / `$ref` / a missing `type` are projection artefacts with no
+      // vendor counterpart; reporting them would fill the residue with lines
+      // nobody can act on.
+      expect(typeDisagreements("t", "GitHub", { a: { anyOf: [] } }, { a: { type: "string" } })).toEqual([]);
+      expect(typeDisagreements("t", "GitHub", { a: { type: "string" } }, { a: {} })).toEqual([]);
+      // `integer` and `number` are the same argument spelled two ways.
+      expect(typeDisagreements("t", "GitHub", { a: { type: "number" } }, { a: { type: "integer" } })).toEqual([]);
+    });
+  });
+
+  // F-1614's own regression at the fixture level: the tool that carried the
+  // defect is asserted against GitHub's declaration directly, so a future edit
+  // that puts `labels` back on a string fails here as well as in
+  // `upstream-measured-semantics.test.ts`.
+  it("validates list_issues.labels as the array GitHub declares", () => {
+    const declared = githubToolFixture.tools.find((tool) => tool.name === "list_issues")!;
+    const labels = (declared.inputSchema as { properties: Record<string, { type?: string }> }).properties.labels;
+    expect(labels.type).toBe("array");
+
+    const schema = toolArgumentSchemas.find((tool) => tool.name === "list_issues")!.schema;
+    const call = { owner: "o", repo: "r" };
+    expect(schema.safeParse({ ...call, labels: ["bug"] }).success, "the advertised array").toBe(true);
+    expect(schema.safeParse({ ...call, labels: [] }).success, "an empty array").toBe(true);
+    // GitHub's MCP server refuses the CSV string with "parameter labels could
+    // not be coerced to []string, is string" — so accepting it here would be a
+    // false PASS, the class this file's header calls first in line.
+    expect(schema.safeParse({ ...call, labels: "bug" }).success, "the REST CSV spelling").toBe(false);
   });
 
   it("names no tool the twin does not serve", () => {

--- a/packages/twin-github/test/search-query-qualifiers.test.ts
+++ b/packages/twin-github/test/search-query-qualifiers.test.ts
@@ -265,11 +265,36 @@ describe("search `q` qualifiers (F-1389)", () => {
     });
 
     it("leaves the qualifiers GitHub has that this twin does not parse in the term", async () => {
-      // `in:`, `language:`, `path:`, `is:` and the boolean operators are named
-      // in FIDELITY.md divergence 1 as unparsed. They are unparsed the same way
+      // `in:`, `language:`, `path:` and the boolean operators are named in
+      // FIDELITY.md divergence 1 as unparsed. They are unparsed the same way
       // `bogus:` is — left in the term — rather than dropped.
-      expect(await issues("idempotency is:open")).toEqual([]);
+      //
+      // ⚠️ `is:` USED TO BE ON THAT LIST AND IS NOT ANY MORE (F-791). It was the
+      // costliest member of it: `is:open` is GitHub's commonest issue qualifier,
+      // so leaving it in the term zeroed every query that carried one, and an
+      // agent that wrote the request GitHub documents was told nothing existed.
+      // It is parsed now, and the case below pins the new behaviour.
       expect(await code("idempotency language:ts")).toEqual([]);
+    });
+
+    it("parses `is:` on `/search/issues`, where GitHub has it (F-791)", async () => {
+      // Measured against real GitHub 2026-08-21 on `cli/cli`: `is:open` and
+      // `state:open` answered the SAME 5 issues, and `is:issue` (21) + `is:pr`
+      // (16) partitioned the unscoped 37 exactly. So `is:open` is not a second
+      // filter with its own semantics — it is the spelling GitHub's own docs use
+      // for the one this surface already had.
+      expect(await issues("idempotency is:open")).toEqual(await issues("idempotency state:open"));
+      expect(await issues("idempotency repo:acme/api is:closed")).toEqual(["acme/api#2"]);
+      // `is:issue` is the identity here: this surface reads the issues table.
+      expect(await issues("idempotency is:issue")).toEqual(await issues("idempotency"));
+    });
+
+    it("is NOT a qualifier on `/search/code`, so `is:` stays free text there", async () => {
+      // Same rule `state:` follows two describes up, and the same reason:
+      // GitHub's code search has `is:archived` / `is:fork`, which this twin does
+      // not model, so lifting `is:` out of a code query would answer a BROADER
+      // set than GitHub rather than a narrower one.
+      expect(await code("idempotency is:archived")).toEqual([]);
     });
 
     it("leaves a `repo:` with no owner in the term — GitHub takes `owner/name`", async () => {

--- a/packages/twin-github/test/upstream-measured-semantics.test.ts
+++ b/packages/twin-github/test/upstream-measured-semantics.test.ts
@@ -1,0 +1,329 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// F-1614 + F-791 — the two `list_issues` / `search_issues` behaviours that were
+// MEASURED against real GitHub rather than reasoned about, and the twin pinned
+// to what came back.
+//
+// ── WHY THIS FILE EXISTS SEPARATELY FROM THE OTHER SEARCH SUITES ────────────
+//
+// `search-query-qualifiers.test.ts` pins how `q` is SCOPED; `list-state-default`
+// pins the state default. Neither could have caught either defect here, because
+// both defects are agreements between the twin and itself: the twin advertised
+// an array and validated a string, and it matched `q` as one substring. Nothing
+// in the repository held a statement about what the VENDOR does with the same
+// call, so there was nothing for either to disagree with.
+//
+// This file is that statement. Every expectation below is a measurement, its
+// provenance named on the case, and the twin is asserted against the vendor's
+// answer rather than against a prior reading of this twin's own code.
+//
+// ── HOW EACH ROW WAS MEASURED (2026-08-21) ──────────────────────────────────
+//
+// Four rungs were available and all four were used, weakest first:
+//
+//   1. the vendor's DECLARED schema — `fixtures/mcp-tools-list.raw.json`, which
+//      is GitHub's own `tools/list` capture (`config/mcp-capture-sources.json`
+//      pins `github/github-mcp-server` @ c2bc7dc0, `--toolsets=default`);
+//   2. the vendor's SOURCE at that pinned commit — `pkg/github/issues.go`'s
+//      `ListIssues` and `pkg/github/params.go`'s `OptionalStringArrayParam`;
+//   3. the vendor's live REST and GraphQL APIs, via `gh api` / `gh api graphql`
+//      against `cli/cli`;
+//   4. the vendor's DEPLOYED MCP server — `tools/call list_issues` against
+//      `https://api.githubcopilot.com/mcp/` with a GitHub token.
+//
+// Rung 4 had never been read before this ticket; `config/mcp-capture-sources.json`
+// asks for exactly that read under `unguardedDirection`.
+//
+//   call                                    real GitHub            rung
+//   ─────────────────────────────────────── ────────────────────── ────
+//   MCP list_issues labels:["auth"]          18 issues              3,4
+//   MCP list_issues labels:["auth","codesp"] 39 = 18+21 → ANY-of    3,4
+//   REST ?labels=auth,codespaces             0        → ALL-of      3
+//   MCP list_issues labels:"auth" (string)   REFUSED                2,4
+//   MCP list_issues labels:[]                no filter              2,4
+//   labels:["AUTH"] / ?labels=AUTH           18 → case-insensitive  3,4
+//   search q="codespaces"                    345                    3
+//   search q="authentication"                607                    3
+//   search q="codespaces authentication"     37       → ALL terms   3
+//   search q="authenticati" (prefix)         0        → whole token 3
+//   search q="… is:open"                     5  ≡ state:open        3
+//   search q="… is:issue" / "… is:pr"        21 / 16  → partition   3
+//   search q="… is:bogusvalue"               0                      3
+//
+// The two that decided the SHAPE of the fix, and would each have been got wrong
+// by reasoning from the ticket text:
+//
+//   * MULTI-LABEL IS A UNION, NOT AN INTERSECTION. GitHub's MCP `list_issues`
+//     runs on GraphQL (`issues(labels: [String!])`), and GraphQL ORs the set —
+//     18 + 21 = 39 on `cli/cli`. GitHub's REST `?labels=a,b` INTERSECTS the same
+//     two labels to 0. F-1614's prescribed fix was "join the array to CSV and
+//     call the REST-shaped domain", which would have answered 0 where GitHub
+//     answers 39 — the same false-empty class as F-791, introduced by the patch
+//     for F-1614.
+//
+//   * A TERM MATCHES A WHOLE TOKEN, NOT A SUBSTRING. `authentication` returns
+//     607 and `authenticati` returns 0. F-791's prescribed fix was "tokenise on
+//     whitespace and match all terms", which with a substring test per term
+//     would answer 607 for the prefix — trading a false EMPTY for a false HIT,
+//     and a false hit is the worse class for a grading instrument
+//     (`mcp-argument-surface.test.ts`'s own taxonomy).
+//
+// Counts on a live repository drift, so nothing below asserts 18 or 607. What is
+// asserted is the RELATION each count established — union vs intersection, whole
+// token vs prefix, `is:open` ≡ `state:open` — against a seeded world this repo
+// owns.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createGitHubCloneApp } from "../src/twin.js";
+import type { GitHubStateSeed } from "../src/types.js";
+import { TEST_AUTH_SECRET, TEST_SID, signTestToken, withAuth } from "./_authHelper.js";
+
+const previousSecret = process.env.TWIN_AUTH_SECRET;
+let token: string;
+beforeAll(async () => {
+  process.env.TWIN_AUTH_SECRET = TEST_AUTH_SECRET;
+  token = await signTestToken();
+});
+afterAll(() => {
+  if (previousSecret === undefined) delete process.env.TWIN_AUTH_SECRET;
+  else process.env.TWIN_AUTH_SECRET = previousSecret;
+});
+
+const base = `/s/${TEST_SID}`;
+
+/**
+ * A world shaped to make each measured relation observable, and to make the
+ * WRONG answer a different set rather than a different count.
+ *
+ * `bug` and `tracking` are carried by DIFFERENT issues with exactly one issue in
+ * common, so union (3), intersection (1) and either label alone (2, 2) are four
+ * distinct sets. A fix that ANDs where GitHub ORs cannot pass by coincidence.
+ *
+ * The coupon issue is F-791's own stated regression case, transplanted from the
+ * ticket: its title carries `coupon` and `500` as separate words, so a
+ * whole-string matcher finds nothing for `coupon 500` and a tokenised one finds
+ * it. `couponless` exists solely to be a token that a PREFIX match would reach
+ * and a whole-token match must not.
+ */
+const WORLD: GitHubStateSeed = {
+  users: [
+    { login: "acme", type: "Organization", name: "Acme" },
+    { login: "pome-agent", type: "User", name: "Pome Agent" },
+  ],
+  repositories: [
+    {
+      owner: "acme",
+      name: "orders-service",
+      description: "Order intake.",
+      default_branch: "main",
+      labels: [
+        { name: "bug", color: "d73a4a", description: "Something is not working" },
+        { name: "tracking", color: "0e8a16", description: "Umbrella issue" },
+      ],
+      issues: [
+        {
+          number: 8,
+          title: "POST /orders returns 500 when the coupon field is empty",
+          body: "An empty coupon should mean no discount rather than a lookup miss.",
+          state: "open",
+          labels: ["bug"],
+        },
+        {
+          number: 23,
+          title: "[tracking] Coupon-path regressions",
+          body: "Umbrella issue. Consolidates the coupon defects.",
+          state: "open",
+          labels: ["bug", "tracking"],
+        },
+        {
+          number: 31,
+          title: "Docs: describe the couponless checkout flow",
+          body: "The couponless path is undocumented.",
+          state: "open",
+          labels: ["tracking"],
+        },
+        {
+          number: 47,
+          title: "Flaky test: refunds idempotency",
+          body: "Fails about one run in twenty.",
+          state: "closed",
+          labels: ["bug"],
+        },
+      ],
+    },
+  ],
+};
+
+const app = createGitHubCloneApp({ seed: WORLD });
+
+/** `tools/call`, returning the twin's answer or the refusal it produced. */
+async function mcp(name: string, args: unknown): Promise<{ refused: boolean; body: any }> {
+  const response = await app.request(
+    `${base}/mcp`,
+    withAuth(token, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name, arguments: args } }),
+    }),
+  );
+  const envelope = (await response.json()) as any;
+  const text = envelope?.result?.content?.[0]?.text ?? JSON.stringify(envelope);
+  let body: unknown;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  return { refused: Boolean(envelope?.result?.isError || envelope?.error), body };
+}
+
+async function rest(path: string): Promise<{ status: number; body: any }> {
+  const response = await app.request(`${base}${path}`, withAuth(token, { method: "GET" }));
+  return { status: response.status, body: await response.json() };
+}
+
+/** Issue numbers, sorted — a SET, never a count (`list-state-default.test.ts`'s rule). */
+const numbers = (rows: unknown): number[] =>
+  (Array.isArray(rows) ? rows : []).map((row: any) => row.number).sort((a, b) => a - b);
+
+async function listIssues(args: Record<string, unknown>): Promise<number[] | "REFUSED"> {
+  const { refused, body } = await mcp("list_issues", { owner: "acme", repo: "orders-service", ...args });
+  return refused ? "REFUSED" : numbers(body);
+}
+
+async function searchIssues(query: string): Promise<number[]> {
+  const { refused, body } = await mcp("search_issues", { query });
+  expect(refused, `search_issues(${query}) was refused: ${JSON.stringify(body)}`).toBe(false);
+  return numbers(body?.items);
+}
+
+describe("F-1614 — the MCP door takes the array it advertises, and ORs it", () => {
+  // Rung 1 + 2: the fixture declares `{"type":"array","items":{"type":"string"}}`
+  // and `OptionalStringArrayParam` reads it as one. Rung 4: the deployed server
+  // answered 18 issues for `labels:["auth"]`.
+  it("accepts `labels: [\"bug\"]`, the shape its own inputSchema declares", async () => {
+    expect(await listIssues({ state: "OPEN", labels: ["bug"] })).toEqual([8, 23]);
+  });
+
+  // THE ROW THAT DECIDED THE FIX. Deployed MCP: 18 + 21 = 39, an exact union.
+  // REST on the same two labels: 0. Both measured 2026-08-21.
+  it("UNIONS multiple labels, the way GraphQL does — not the REST intersection", async () => {
+    const union = await listIssues({ state: "OPEN", labels: ["bug", "tracking"] });
+    expect(union).toEqual([8, 23, 31]);
+
+    // Stated as the relation the measurement established, so this fails loudly if
+    // someone "simplifies" the MCP door onto the REST CSV path later.
+    const bugOnly = await listIssues({ state: "OPEN", labels: ["bug"] });
+    const trackingOnly = await listIssues({ state: "OPEN", labels: ["tracking"] });
+    const intersection = (bugOnly as number[]).filter((n) => (trackingOnly as number[]).includes(n));
+    expect(union).toEqual([...new Set([...(bugOnly as number[]), ...(trackingOnly as number[])])].sort((a, b) => a - b));
+    expect(union).not.toEqual(intersection);
+  });
+
+  // Rung 2 + 4: `OptionalStringArrayParam`'s `default:` branch errors with
+  // "parameter labels could not be coerced to []string, is string", and the
+  // deployed server returned exactly that. The twin used to ACCEPT the string —
+  // a call the vendor refuses, which is the false-PASS class.
+  it("REFUSES a CSV string on the MCP door, because GitHub's MCP refuses it", async () => {
+    expect(await listIssues({ state: "OPEN", labels: "bug" })).toBe("REFUSED");
+  });
+
+  // Rung 2: `hasLabels := len(labels) > 0` omits the GraphQL argument entirely,
+  // so an empty array filters nothing. Rung 4 confirmed it. The twin used to 422.
+  it("treats an EMPTY array as no filter, not as a refusal and not as a match-nothing", async () => {
+    expect(await listIssues({ state: "OPEN", labels: [] })).toEqual([8, 23, 31]);
+  });
+
+  // Rung 3 + 4: `labels:["AUTH"]` and `?labels=AUTH` both answered 18, the same
+  // as `auth`. Both doors, so this belongs in the domain rather than at either
+  // boundary.
+  it("matches label names case-insensitively, on BOTH doors", async () => {
+    expect(await listIssues({ state: "OPEN", labels: ["BUG"] })).toEqual([8, 23]);
+    const { body } = await rest("/repos/acme/orders-service/issues?state=open&labels=BUG");
+    expect(numbers(body)).toEqual([8, 23]);
+  });
+
+  // The other half of F-1460's rule, applied here: the doors disagree and both
+  // are right, so the REST door must NOT drift onto the MCP door's semantics.
+  it("keeps the REST door on GitHub's CSV INTERSECTION", async () => {
+    const both = await rest("/repos/acme/orders-service/issues?state=open&labels=bug,tracking");
+    expect(numbers(both.body)).toEqual([23]);
+
+    // …and an empty CSV is no filter there too (measured: `?labels=` returned the
+    // unfiltered set).
+    const empty = await rest("/repos/acme/orders-service/issues?state=open&labels=");
+    expect(numbers(empty.body)).toEqual([8, 23, 31]);
+  });
+});
+
+describe("F-791 — free text is tokenised, and a term matches a whole token", () => {
+  // The ticket's own stated regression case, seeded and asserted.
+  it("finds the issue whose title carries every term, in any order", async () => {
+    expect(await searchIssues("coupon 500")).toEqual([8]);
+    expect(await searchIssues("500 coupon")).toEqual([8]);
+  });
+
+  it("matches ACROSS title and body, the way one indexed document does", async () => {
+    // `empty` is in #8's title, `discount` only in its body.
+    expect(await searchIssues("empty discount")).toEqual([8]);
+  });
+
+  it("ANDs the terms — a term that matches nothing empties the answer", async () => {
+    // #31 carries `couponless`, not `coupon`, so it is absent here for the same
+    // reason the prefix case below says it must be.
+    expect(await searchIssues("coupon")).toEqual([8, 23]);
+    expect(await searchIssues("coupon refunds")).toEqual([]);
+  });
+
+  // THE ROW THAT DECIDED THE FIX. `authentication` → 607, `authenticati` → 0.
+  // A per-term `.includes()` would answer #31 here and would be a false HIT.
+  it("does NOT match a prefix of a token — `coupon` must not reach `couponless`", async () => {
+    expect(await searchIssues("couponless")).toEqual([31]);
+    expect(await searchIssues("coupon")).not.toContain(31 as never);
+  });
+
+  it("is case-insensitive on both sides of the match", async () => {
+    expect(await searchIssues("COUPON 500")).toEqual([8]);
+  });
+});
+
+describe("F-791 — `is:` is GitHub's commonest issue qualifier and is parsed", () => {
+  // Measured: `is:open` → 5 and `state:open` → 5, the same set. The twin used to
+  // leave `is:open` in the free text, so ANY query carrying it answered [].
+  it("`is:open` filters to the open issues, exactly as `state:open` does", async () => {
+    expect(await searchIssues("refunds is:open")).toEqual([]);
+    expect(await searchIssues("coupon is:open")).toEqual([8, 23]);
+    expect(await searchIssues("coupon is:open")).toEqual(await searchIssues("coupon state:open"));
+  });
+
+  it("`is:closed` filters to the closed issues", async () => {
+    expect(await searchIssues("refunds is:closed")).toEqual([47]);
+    expect(await searchIssues("refunds is:closed")).toEqual(await searchIssues("refunds state:closed"));
+  });
+
+  // Measured: `is:issue` 21 and `is:pr` 16 partition the unscoped 37.
+  it("`is:issue` is the identity here, because this surface reads the issues table", async () => {
+    expect(await searchIssues("coupon is:issue")).toEqual(await searchIssues("coupon"));
+  });
+
+  // The twin's `searchIssues` reads the issues table and this world's pulls are
+  // not in it, so the honest answer is EMPTY rather than issues-dressed-as-PRs.
+  // That is GITHUB-MCP-010's false PASS closed in the safe direction; the missing
+  // `search_pull_requests` TOOL is a separate, still-registered gap.
+  it("`is:pr` answers empty rather than handing back issues", async () => {
+    expect(await searchIssues("coupon is:pr")).toEqual([]);
+  });
+
+  // Measured: `is:bogusvalue` → 0. GitHub recognises the qualifier and answers
+  // nothing for a value it cannot honour; it does not treat it as free text.
+  it("an `is:` value the surface cannot honour empties the answer, as GitHub's does", async () => {
+    expect(await searchIssues("coupon is:bogusvalue")).toEqual([]);
+  });
+
+  it("a qualifier this twin does not parse at all still narrows to nothing", async () => {
+    // Unchanged behaviour, re-pinned here because the `is:` case above could
+    // easily be generalised into dropping unknown qualifiers, which would WIDEN
+    // past GitHub — divergence 1's stated failure direction.
+    expect(await searchIssues("coupon bogus:x")).toEqual([]);
+  });
+});

--- a/packages/twin-slack/src/tool-schema-conformance.ts
+++ b/packages/twin-slack/src/tool-schema-conformance.ts
@@ -6,6 +6,7 @@
 // `tools.ts`: pome-cloud's fidelity-watch loads twin tool tables under bun,
 // which implements no `node:sqlite`, and the sdk root barrel reaches it.
 import { z } from "zod";
+import { typeDisagreements } from "@pome-sh/sdk/mcp-tool-fixture";
 import { slackToolFixture, toolSchemas } from "./tools.js";
 
 /**
@@ -65,6 +66,14 @@ export function toolSchemaConformance(): string[] {
         problems.push(`'${tool.name}' does not model Slack's parameter '${key}'`);
       }
     }
+
+    // The TYPE of the keys both sides declare (F-1614). twin-github shipped a
+    // 422 on the array its own listing advertised for a year because the two
+    // checks above see a key's PRESENCE and not its shape; this twin's
+    // conformance had the same blind spot and asserts `[]`, so the gap would
+    // have been indistinguishable from having none. `typeDisagreements` is
+    // shared rather than copied — one comparison, two vendors.
+    problems.push(...typeDisagreements(tool.name, "Slack", upstream.properties ?? {}, projected.properties ?? {}));
 
     const upstreamRequired = [...(upstream.required ?? [])].sort().join(",");
     const ourRequired = [...(projected.required ?? [])].sort().join(",");

--- a/packages/twin-slack/test/mcp-contract.test.ts
+++ b/packages/twin-slack/test/mcp-contract.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, expect, it } from "vitest";
 import { MUTATING_TOOL_NAMES, slackToolFixture, toolSchemas } from "../src/tools.js";
+import { describeSchemaType, typeDisagreements } from "@pome-sh/sdk/mcp-tool-fixture";
 import { toolSchemaConformance } from "../src/tool-schema-conformance.js";
 
 interface ExpectedTool {
@@ -134,6 +135,32 @@ describe("MCP tools contract", () => {
   // same keys, same required set, and no rejection of an unknown key.
   it("validates exactly the argument surface Slack declares", () => {
     expect(toolSchemaConformance()).toEqual([]);
+  });
+
+  // ⚠️ AND THAT `[]` NOW COVERS THE TYPE AXIS TOO (F-1614) — it did not before.
+  //
+  // twin-github advertised `list_issues.labels` as an array of strings,
+  // validated it as one string, and answered 422 `invalid_type` to the shape its
+  // own listing publishes. Its conformance stayed green the whole time, because
+  // the comparison looked at which arguments each side HAS and which it
+  // REQUIRES and never at their type. This twin's comparison had the same blind
+  // spot, and an empty residue is the one result that cannot tell the two apart.
+  //
+  // So the check is planted rather than assumed. `typeDisagreements` is shared
+  // (`@pome-sh/sdk/mcp-tool-fixture`) so both twins run one comparison.
+  it("would REPORT a type disagreement, so the empty residue above means something", () => {
+    expect(
+      typeDisagreements("slack_send_message", "Slack", { blocks: { type: "array" } }, { blocks: { type: "string" } }),
+    ).toEqual(["'slack_send_message' validates 'blocks' as string, and Slack declares it as array"]);
+  });
+
+  // The other half of "not a vacuum": at least one real key has a type BOTH
+  // documents state, so the comparison above ran over the fixture rather than
+  // skipping every key as unstatable.
+  it("compares a real key's type, not only planted ones", () => {
+    const declared = slackToolFixture.tools.find((tool) => tool.name === "slack_send_message")!;
+    const channel = (declared.inputSchema as { properties: Record<string, unknown> }).properties.channel_id;
+    expect(describeSchemaType(channel)).toBe("string");
   });
 
   it("the fixture serves camelCase inputSchema (MCP spec)", () => {


### PR DESCRIPTION
Closes F-1614. Closes F-791.

## Why

They are one PR because they were one failure. An agent that searched before
filing hit both in sequence, concluded the bug was untracked, filed a duplicate,
and was graded for not checking. Five of one model's eight hosted trials on
`examples/support-triage` were that exact chain, and **every one of them would
have passed against real GitHub**. Both defects fail as ordinary answers — a 422
the agent routes around, and an HTTP 200 with an empty array — so nothing
distinguishes them from "genuinely nothing matches."

## Neither fix is the one its ticket prescribed

Both prescriptions were measured, and both were wrong in the same direction:
they would have swapped one silent wrong answer for another.

**F-1614** said "join the array to CSV and call the REST-shaped domain."

| | real GitHub, `cli/cli`, 2026-08-21 |
|---|---|
| REST `?labels=auth,codespaces` | **0** — intersection |
| GraphQL `issues(labels:["auth","codespaces"])` | **39** = 18+21 — union |
| MCP `list_issues {labels:[…]}` (deployed server) | **39** |

GitHub's MCP `list_issues` is not a wrapper over that REST route. It builds a
GraphQL query (`github/github-mcp-server` @ `c2bc7dc0`, `pkg/github/issues.go`),
and GraphQL ORs the set — so the join would have answered empty for a two-label
call GitHub answers with the union. With one label the two are indistinguishable,
which is why the audit's `labels:["bug"]` case hid it.

**F-791** said "tokenise on whitespace and match all terms."

| | real GitHub |
|---|---|
| `codespaces` 345 ∧ `authentication` 607 | **37** — terms AND ✅ ticket right |
| `authentication` 607, `authenticati` | **0** — whole token, not a prefix |

A per-term `.includes()` would answer 607 for the prefix — trading a false EMPTY
for a false HIT, and a false hit is the worse class for a grading instrument
(this repo's own taxonomy, `mcp-argument-surface.test.ts`). Terms match token
equality.

## What changed

**`labels` (F-1614)** — the MCP door takes the string array its listing declares
and UNIONS it; an empty array is no filter; names match case-insensitively on
both doors. The REST door keeps GitHub's CSV intersection. The MCP door now
**refuses** the CSV string, because GitHub's does (`parameter labels could not be
coerced to []string, is string`) and accepting it would serve a call the vendor
rejects. This is F-1460's rule one level deeper: the disagreement lives at the
boundary, and the domain takes an explicit `LabelFilter` with `match: "all" |
"any"` rather than sniffing the argument's type.

**`search_issues` (F-791)** — free text is tokenised and every term must match a
whole token of the issue's title-and-body. `is:` is parsed on this surface only:
`is:open`/`is:closed` set the state filter (measured identical to `state:`),
`is:issue` is the identity, `is:pr` answers empty, and a value the surface cannot
honour answers empty rather than becoming search text.

**The guard that should have caught F-1614** — `toolSchemaConformance()` compared
which arguments each side declares and which it requires, and never their TYPE.
98 pinned residue entries, 9 on `list_issues`, not one about `labels`. twin-slack
had the identical blind spot and asserts `[]`, the one result that cannot tell a
working comparison from an absent one. `typeDisagreements` now lives in
`@pome-sh/sdk/mcp-tool-fixture` so both twins run one implementation, and both
suites **plant** F-1614's exact pair through it rather than trusting a green.

## How each row was measured

Four rungs, weakest first: the vendor's captured `tools/list`; its **source** at
the commit `config/mcp-capture-sources.json` already pins; its live REST and
GraphQL; and its **deployed MCP server** at `api.githubcopilot.com/mcp/`. That
last rung had never been read here — `mcp-capture-sources.json` asks for exactly
that read under `unguardedDirection`, and this closes it.

`test/upstream-measured-semantics.test.ts` carries the whole table with the
provenance of every row. It asserts the **relations** each measurement
established (union vs intersection, whole token vs prefix, `is:open` ≡
`state:open`) against a world this repo seeds, never the live counts, which drift.

## Reviewer notes

- **Corpus heat for the tightening** (whole-token is a narrowing): every caller
  measured — `performance.test.ts` (`needle`), `fixture-endpoints.test.ts` and
  `fidelity-parity.ts` (`500`), pome-cloud's L1 (`deploy`) and MCP read leg
  (`Seeded`) — uses a whole word. None moves.
- **pome-cloud's L1 lane is unaffected.** I regenerated
  `sandboxes/github/fixtures/sandbox-capture.json` against this branch: 36
  surfaces, all self-diffs green, every count identical, and the only leaves that
  moved are generated metadata (`sha`, `url`, timestamps) that `diff.ts` masks by
  design. Reverted, not committed here.
- **`FIDELITY.md` divergence 1 is rewritten**, because both halves of F-791 were
  written down there as deliberate, with "narrowing is the safe failure" as the
  reason. That is true for a simulator and false for a grading instrument, and
  the entry now says which it is and what is still divergent (GitHub's index is
  ranked, and semantic on the MCP door — a paraphrase sharing no token still
  finds an issue there and not here).
- **Deliberately out of scope**, each measured and worth its own ticket:
  `/search/code`, `/search/commits`, `/search/repositories` and `/search/users`
  are still whole-string substring; `list_issues.state` refuses `"all"` and
  lowercase `"open"` which the vendor accepts (reversing F-1468's deliberate
  tightening needs its own argument); and `twin-gmail`/`twin-linear`/`twin-stripe`
  have no conformance module at all.

## CI

Run locally on this branch: twin-github 675 ✅ · twin-slack 337 ✅ · cli 1170 ✅ ·
`test:contract` ✅ · typecheck, `gate:route-inputs`, `gate:mcp-fixture` (github,
slack), `gate:operation-docs`, `validate:mcp`, `lint:dead-code`,
`typecheck:examples`, `smoke:examples`, `probe:examples`, `probe:twins` all ✅ ·
release-note gate ✅ (`cli` and `sandbox-domains` bundle the twin sources, so both
carry an `## Unreleased (patch)` entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)