### PR TITLE
twin-github: a bare term reaches inside a compound again

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -10,6 +10,23 @@ write a version number here or in `package.json`. Released
 entries are insertions only: a correction is the next entry, naming the one it
 corrects.
 
+## Unreleased (patch)
+
+**`search_issues` reaches inside a compound word again** (F-791 follow-up). The
+tokeniser shipped in the previous release treated `apply_coupon` as a single
+token, so a search for `coupon` did not find a body that only says
+`apply_coupon`. Real GitHub indexes a compound BOTH whole and in parts — measured
+by negation on `cli/cli`: `per_page NOT page`, `per_page NOT per` and
+`pull-request NOT request` all answer 0 — so a bare term does reach inside one.
+
+A document now offers every compound plus the parts `_` and `-` join, while a
+query term keeps its compound intact, which is what keeps `per_page` (110)
+narrower than `per page` (226). A PREFIX still matches nothing: `coupon` does not
+reach `couponless`.
+
+**Agents may see slightly MORE results than the previous release**, on queries
+whose term appears only inside a snake_case or hyphenated identifier.
+
 ## 0.26.2 — 2026-08-21
 
 **The GitHub twin answers two calls it used to get wrong** (F-1614, F-791). Both

--- a/packages/sandbox-domains/CHANGELOG.md
+++ b/packages/sandbox-domains/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @pome-sh/sandbox-domains
 
+## Unreleased (patch)
+
+**`search_issues` reaches inside a compound word again** (F-791 follow-up). The
+tokeniser shipped in the previous release treated `apply_coupon` as a single
+token, so a search for `coupon` did not find a body that only says
+`apply_coupon`. Real GitHub indexes a compound BOTH whole and in parts — measured
+by negation on `cli/cli`: `per_page NOT page`, `per_page NOT per` and
+`pull-request NOT request` all answer 0 — so a bare term does reach inside one.
+
+A document now offers every compound plus the parts `_` and `-` join, while a
+query term keeps its compound intact, which is what keeps `per_page` (110)
+narrower than `per page` (226). A PREFIX still matches nothing: `coupon` does not
+reach `couponless`.
+
+**Agents may see slightly MORE results than the previous release**, on queries
+whose term appears only inside a snake_case or hyphenated identifier.
+
 ## 0.2.4 — 2026-08-21
 
 **The GitHub twin answers two calls it used to get wrong** (F-1614, F-791). Both

--- a/packages/twin-github/FIDELITY.md
+++ b/packages/twin-github/FIDELITY.md
@@ -277,6 +277,18 @@ always 32's, and 32 now names the twin-only 401/403 surfaces explicitly.
    call GitHub refuses to serve. `test/upstream-measured-semantics.test.ts`
    carries the table and the provenance of every row.
 
+   **A compound is indexed whole AND in parts, and the two sides of the match
+   therefore differ.** `per_page` → 110 against `per page` → 226 says a compound
+   is a token in its own right; it says nothing about containment, and reading
+   only that pair is how F-791's first fix concluded `_` holds a token together
+   and made a bare `coupon` miss a body saying `apply_coupon` — its own
+   false-empty class, one size smaller. The negation settles it:
+   `per_page NOT page` → 0, `per_page NOT per` → 0, `pull-request NOT request`
+   → 0. Every document carrying a compound also answers to its parts. So a
+   DOCUMENT offers each compound plus the parts `_` and `-` join, while a QUERY
+   term keeps its compound intact — which is what holds both measurements at
+   once, and is why those two functions must not be merged.
+
    Still simplified, and still divergent: GitHub's index is ranked and — on the
    MCP door — semantic (`search_issues` there is documented as *"natural-language
    semantic matching … already scoped to `is:issue`"*), so a paraphrase that

--- a/packages/twin-github/src/domain/search.ts
+++ b/packages/twin-github/src/domain/search.ts
@@ -129,18 +129,52 @@ interface ParsedSearchQuery {
  * GitHub refuses to serve. A false hit is the worse of the two for a grading
  * instrument, so the match is token equality.
  *
- * `_` stays inside a token and `-` breaks one, which is GitHub's own split:
- * `per_page` → 110 and `per page` → 226 are different queries there, while
- * `pull-request` → 3222 and `pull request` → 3298 are the same one.
+ * ── A COMPOUND IS INDEXED WHOLE *AND* IN PARTS, SO THE TWO SIDES DIFFER ─────
+ *
+ * `per_page` → 110 and `per page` → 226 are different queries, so a compound is
+ * a token in its own right and a query naming one asks for something narrower
+ * than its parts. It is tempting to conclude from that pair alone that `_` holds
+ * a token together — this file did conclude it, and it was wrong, because the
+ * pair says nothing about CONTAINMENT. The query that settles it is the negation:
+ *
+ *   `per_page NOT page`      → 0      every per_page document also has `page`
+ *   `per_page NOT per`       → 0
+ *   `pull-request NOT request` → 0    the same for the hyphen
+ *
+ * Zero on all three: the index emits the compound AND the parts `_` or `-` join.
+ * So a bare `coupon` DOES reach a body that only says `apply_coupon`, and the
+ * earlier reading made that a false EMPTY — F-791's own class, in a narrower
+ * form, introduced by F-791's own fix.
+ *
+ * Hence the asymmetry, which is not an accident and must not be "tidied" into one
+ * function: a DOCUMENT offers each compound plus its parts, and a QUERY term
+ * keeps its compound intact. Both measurements then hold at once — `coupon`
+ * reaches `apply_coupon` through the parts, and `per_page` stays narrower than
+ * `per page` because only a document that really carries the compound offers it.
+ * A prefix still matches nothing either way: `couponless` has no separator, so it
+ * offers only itself.
  */
-function tokenise(text: string): string[] {
-  return text.toLowerCase().split(/[^a-z0-9_]+/).filter(Boolean);
+
+/** What a QUERY asks for: `_` and `-` stay inside a term. */
+function queryTerms(text: string): string[] {
+  return text.toLowerCase().split(/[^a-z0-9_-]+/).filter(Boolean);
 }
 
-/** Whether every term in `q` appears as a token of `document`. */
+/** What a DOCUMENT offers: every compound, plus the parts `_` and `-` join. */
+function documentTokens(text: string): Set<string> {
+  const tokens = new Set<string>();
+  for (const compound of text.toLowerCase().split(/[^a-z0-9_-]+/)) {
+    if (!compound) continue;
+    tokens.add(compound);
+    for (const part of compound.split(/[_-]+/)) if (part) tokens.add(part);
+  }
+  return tokens;
+}
+
+/** Whether every term in `q` is a token the document offers. */
 function matchesTerms(terms: readonly string[], ...document: string[]): boolean {
   if (terms.length === 0) return true;
-  const tokens = new Set(tokenise(document.join(" ")));
+  const tokens = documentTokens(document.join(" "));
   return terms.every((term) => tokens.has(term));
 }
 
@@ -217,7 +251,7 @@ function parseSearchQuery(raw: string, options: { state?: boolean; is?: boolean 
     }
   });
   const normalized = text.replace(/\s+/g, " ").trim().toLowerCase();
-  return { text: normalized, terms: tokenise(normalized), owners, fullNames, state, type, unhonourable };
+  return { text: normalized, terms: queryTerms(normalized), owners, fullNames, state, type, unhonourable };
 }
 
 /**

--- a/packages/twin-github/test/upstream-measured-semantics.test.ts
+++ b/packages/twin-github/test/upstream-measured-semantics.test.ts
@@ -138,7 +138,11 @@ const WORLD: GitHubStateSeed = {
         {
           number: 31,
           title: "Docs: describe the couponless checkout flow",
-          body: "The couponless path is undocumented.",
+          // `apply_coupon` is the compound case and it is load-bearing: a bare
+          // `coupon` has to reach it, and `couponless` in the title has to stay
+          // out of reach. One issue carries both so a tokeniser cannot satisfy
+          // one by breaking the other.
+          body: "The couponless path is undocumented. See apply_coupon in src/orders.py.",
           state: "open",
           labels: ["tracking"],
         },
@@ -269,9 +273,9 @@ describe("F-791 — free text is tokenised, and a term matches a whole token", (
   });
 
   it("ANDs the terms — a term that matches nothing empties the answer", async () => {
-    // #31 carries `couponless`, not `coupon`, so it is absent here for the same
-    // reason the prefix case below says it must be.
-    expect(await searchIssues("coupon")).toEqual([8, 23]);
+    // #31 is here through `apply_coupon` in its body, not through `couponless`
+    // in its title — see the compound case below, which pins both directions.
+    expect(await searchIssues("coupon")).toEqual([8, 23, 31]);
     expect(await searchIssues("coupon refunds")).toEqual([]);
   });
 
@@ -279,7 +283,33 @@ describe("F-791 — free text is tokenised, and a term matches a whole token", (
   // A per-term `.includes()` would answer #31 here and would be a false HIT.
   it("does NOT match a prefix of a token — `coupon` must not reach `couponless`", async () => {
     expect(await searchIssues("couponless")).toEqual([31]);
-    expect(await searchIssues("coupon")).not.toContain(31 as never);
+  });
+
+  // Measured by NEGATION, which is the only query that settles containment:
+  // `per_page NOT page` → 0, `per_page NOT per` → 0, `pull-request NOT request`
+  // → 0 on `cli/cli`. Every document carrying the compound also answers to its
+  // parts, so the index emits both.
+  //
+  // ⚠️ This is the case F-791's own first fix got wrong. Reading only
+  // `per_page` 110 ≠ `per page` 226, it concluded `_` holds a token together —
+  // and a bare `coupon` then missed a body that says `apply_coupon`, which is
+  // F-791's false-empty class in a narrower form.
+  it("a bare term REACHES inside a snake_case or hyphenated compound", async () => {
+    // #31's body says `apply_coupon` and its title says `couponless`. The first
+    // must be reachable by `coupon`, the second must not — same issue, so this
+    // cannot be satisfied by loosening the match.
+    expect(await searchIssues("coupon")).toEqual([8, 23, 31]);
+    expect(await searchIssues("apply")).toEqual([31]);
+  });
+
+  it("…and a query naming the compound stays NARROWER than its parts", async () => {
+    // `per_page` 110 < `per page` 226 on `cli/cli`: only a document that really
+    // carries the compound offers it, so the query keeps `_` and `-` intact.
+    expect(await searchIssues("apply_coupon")).toEqual([31]);
+    // #8's title has `orders` and #31's body has `apply`, but no issue carries
+    // the compound `apply-orders`, so the narrower query answers nothing while
+    // the two loose terms would have matched.
+    expect(await searchIssues("apply-orders")).toEqual([]);
   });
 
   it("is case-insensitive on both sides of the match", async () => {
@@ -292,7 +322,7 @@ describe("F-791 — `is:` is GitHub's commonest issue qualifier and is parsed", 
   // leave `is:open` in the free text, so ANY query carrying it answered [].
   it("`is:open` filters to the open issues, exactly as `state:open` does", async () => {
     expect(await searchIssues("refunds is:open")).toEqual([]);
-    expect(await searchIssues("coupon is:open")).toEqual([8, 23]);
+    expect(await searchIssues("coupon is:open")).toEqual([8, 23, 31]);
     expect(await searchIssues("coupon is:open")).toEqual(await searchIssues("coupon state:open"));
   });
 


### PR DESCRIPTION
A defect in F-791's own fix (#455), found while verifying the promotion that
shipped it. Relates to F-791.

## What is wrong

The tokeniser kept `_` inside a token, so `apply_coupon` was one token and a
search for `coupon` did not find a body that only says `apply_coupon`. That is
**F-791's false-empty class, one size smaller, introduced by F-791**.

Measured on the promoted snapshot before this fix: `q=coupon` against the
support-triage seed answered 2 issues where the substring era answered 3. The
missing one was #31, whose only `coupon` is inside `apply_coupon`.

## Why the reasoning went wrong, precisely

`per_page` → 110 and `per page` → 226 on `cli/cli` proves a compound is a token
in its own right — **and says nothing about containment.** Reading only that
pair, #455 concluded `_` holds a token together.

The query that settles containment is the negation, and all three answer 0:

```
repo:cli/cli per_page NOT page          0
repo:cli/cli per_page NOT per           0
repo:cli/cli pull-request NOT request   0
```

Every document carrying a compound also answers to its parts. GitHub emits both.

## The fix is an asymmetry, on purpose

| side | rule |
|---|---|
| `documentTokens()` | every compound, **plus** the parts `_` and `-` join |
| `queryTerms()` | the compound kept **intact** |

That holds both measurements at once — `coupon` reaches `apply_coupon` through
the parts, and `per_page` stays narrower than `per page` because only a document
that really carries the compound offers it. A prefix still reaches nothing:
`couponless` has no separator, so it offers only itself.

⚠️ The two functions must not be merged back into one. The comment says so, and
the tests pin both directions on the **same issue** — #31 now carries
`apply_coupon` in its body and `couponless` in its title, so a tokeniser cannot
satisfy one direction by breaking the other.

## Verified

twin-github 677 ✅ · cli 1170 ✅ · `test:contract` ✅ · typecheck,
`gate:route-inputs`, `gate:mcp-fixture`, `validate:mcp`, `lint:dead-code`,
`smoke:examples` ✅ · release-note gate ✅.

FIDELITY.md divergence 1 gains the compound paragraph; its bullet **title** is
unchanged, so pome-cloud's `known-divergences` 1:1 lint is unaffected this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)