### PR TITLE
Remove internal ticket ids from cli/src

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -10,6 +10,14 @@ write a version number here or in `package.json`. Released
 entries are insertions only: a correction is the next entry, naming the one it
 corrects.
 
+## Unreleased (patch)
+
+**No consumer-visible change.** Internal tracker ids were removed from source
+comments and JSDoc across `src/`, and from the `--help` text of two flags that
+had been printing an id to users: `-n, --trials` and `--allow`. Both now open
+with what the flag does instead of a ticket number. No flag name, default, exit
+code, wire field or schema changed.
+
 ## 0.26.8 — 2026-08-23
 
 **No consumer-visible change.** Internal tracker ids were removed from the

--- a/cli/src/capture-server/egress.ts
+++ b/cli/src/capture-server/egress.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// FDRS-635 — deny-by-default egress floor for the capture-server.
+// Deny-by-default egress floor for the capture-server.
 //
 // "Prod-safety is a network control, not a rule" (north-star board block 06):
 // under `pome run` the CONNECT proxy refuses tunnels to any host outside the
@@ -13,7 +13,7 @@
 // through the paired valves — POME_AGENT_ENV_ALLOWLIST for the key,
 // POME_EGRESS_ALLOW for the host.
 //
-// Known boundary (by design, see FDRS-635): the floor only binds processes
+// Known boundary (by design): the floor only binds processes
 // that honor proxy env vars. Agents that bypass HTTPS_PROXY are caught by
 // `pome doctor`'s routing probe — the two layers are complementary.
 
@@ -100,7 +100,7 @@ export function parseAllowCsv(csv: string | undefined): string[] {
 // base-URL hosts + the POME_EGRESS_ALLOW valve + the twin URLs the runner is
 // about to inject (loopback in self-host; hosted twin domains future-proof).
 //
-// FDRS-643 — `extraHosts` is the demo-mode valve: `pome demo` adds the
+// `extraHosts` is the demo-mode valve: `pome demo` adds the
 // POME_API_BASE host so the bundled agent's anonymous-gateway calls
 // (POST /v1/demo/sessions/:id/llm) survive the deny-by-default floor. Same
 // pattern rules as everything else (exact host or `*.suffix`).

--- a/cli/src/capture-server/index.ts
+++ b/cli/src/capture-server/index.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-// FDRS-406 — HTTP CONNECT-tunnel proxy that emits one `LlmCallEvent` row per
-// tunnel into `events.jsonl`. Spawned by `pome run` (FDRS-399) as a child
+// HTTP CONNECT-tunnel proxy that emits one `LlmCallEvent` row per
+// tunnel into `events.jsonl`. Spawned by `pome run` as a child
 // process; agent traffic flows through it via `HTTPS_PROXY`.
 //
 // Mode: CONNECT-only (no TLS termination). The proxy never sees plaintext
@@ -22,7 +22,7 @@ import { isHostAllowed, type EgressRefusedRow } from "./egress.js";
 export interface CaptureServerOptions {
   port: number; // 0 = ephemeral
   eventsOut: string;
-  // FDRS-635 — deny-by-default egress floor. CONNECTs to hosts outside this
+  // Deny-by-default egress floor. CONNECTs to hosts outside this
   // allowlist (patterns: exact host, `*.suffix`, or bare `*`) are refused
   // with 403 before any upstream dial. Loopback is always allowed so twin
   // traffic can never be broken by a bad allowlist. Omitting the option means
@@ -46,7 +46,7 @@ export interface CaptureServerHandle {
 }
 
 // Mirror of `llmCallEventSchema` in `packages/wire/src/recorder-events.ts`
-// (locked by FDRS-398). The cli vendors shared-types at 0.3.0 which predates
+// (locked by the unified event schema). The cli vendors shared-types at 0.3.0 which predates
 // the unified discriminated-union schema, so the shape lives here as a
 // structural mirror. Bumping the vendored tarball is a separate ticket — the
 // on-disk JSON is what matters for downstream consumers, and that stays in
@@ -168,7 +168,7 @@ function handleConnect({
   }
   const { host, port } = target;
 
-  // FDRS-635 — the egress floor: refuse the tunnel BEFORE dialing upstream.
+  // The egress floor: refuse the tunnel BEFORE dialing upstream.
   // The refusal is recorded in the egress sidecar so `pome run` can name the
   // blocked host in its output.
   if (!isHostAllowed(host, allowHosts)) {

--- a/cli/src/capture-server/run.ts
+++ b/cli/src/capture-server/run.ts
@@ -9,7 +9,7 @@ import { runCaptureServer } from "./index.js";
 export interface RunCaptureServerCommandOptions {
   port: number;
   eventsOut: string;
-  // FDRS-635 — egress-floor allowlist patterns (already parsed from CSV) and
+  // Egress-floor allowlist patterns (already parsed from CSV) and
   // the sidecar path for refused-CONNECT rows.
   allowHosts?: readonly string[];
   egressOut?: string;

--- a/cli/src/cli/agent-identity.ts
+++ b/cli/src/cli/agent-identity.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Run-path agent identity (F-819). Resolves the `agt_` id + version to stamp on
+// Run-path agent identity. Resolves the `agt_` id + version to stamp on
 // a hosted session from the committed manifest + gitignored `.pome/link.json`.
 //
 // The cached id is trusted only when its `team_id` matches the caller's team: a
@@ -76,8 +76,8 @@ export async function resolveRunAgentIdentity(
     }
     // Silent re-resolution — a run never prompts for a near-miss. Send the
     // manifest's twins so a fork / first `pome run` that auto-creates the agent
-    // enables the declared services instead of the server's `github` default
-    // (F-926); the server merges additively, so this is safe when the agent
+    // enables the declared services instead of the server's `github` default;
+    // the server merges additively, so this is safe when the agent
     // already exists.
     const resolved = await postAgentResolver(
       creds,

--- a/cli/src/cli/agent-resolver.ts
+++ b/cli/src/cli/agent-resolver.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// The `POST /v1/agents` resolver round-trip (F-820), shared by `pome register`
+// The `POST /v1/agents` resolver round-trip, shared by `pome register`
 // (interactive near-miss) and the run paths (silent re-resolution of a
 // committed slug under the caller's team). Kept import-neutral — no register/
 // session dependency — so both sides can consume it without a cycle.
@@ -16,7 +16,7 @@ import type { ResolvedCredentials } from "./credentials.js";
 export interface InteractiveSeams {
   stdinIsTTY?: boolean;
   confirm?: (question: string) => Promise<boolean>;
-  /** Free-text prompt. Added by F-1074: picking a check from a numbered list and
+  /** Free-text prompt. Picking a check from a numbered list and
    *  filling its typed parameters needs an answer, not a yes/no. */
   ask?: (question: string) => Promise<string>;
 }
@@ -101,7 +101,7 @@ function mapHttpError(status: number, json: unknown): Error {
   return new HostedOrchError(err?.message ?? `POST /v1/agents → HTTP ${status}`);
 }
 
-/** Extract the near-miss suggested slug from a 409 conflict envelope. F-820
+/** Extract the near-miss suggested slug from a 409 conflict envelope. The resolver
  *  returns it under `error.details.suggestion`; we also tolerate `suggestions[]`
  *  and `slug` as forward-compatible fallbacks. */
 export function nearMissSuggestion(json: unknown): string | undefined {

--- a/cli/src/cli/checks-add.ts
+++ b/cli/src/cli/checks-add.ts
@@ -8,7 +8,7 @@
  * the cloud resolves them from a different one. Before writing, ask the cloud
  * for the vocabulary it GRADES against and compare digests.
  *   equal        → write, silently
- *   different    → REFUSE, and name what moved (`vocabulary-skew.ts`, F-1137 —
+ *   different    → REFUSE, and name what moved (`vocabulary-skew.ts` —
  *                  a check, a field of one, or the sdk that compiled it, but
  *                  never an empty list)
  *   unreachable  → write from the local pin with a named note on stderr
@@ -79,7 +79,7 @@ export async function handshake(
 
   if (localDigest(twin) === remote.digest) return { kind: "match" };
 
-  // F-1137 — the taxonomy lives in `vocabulary-skew.ts` and is NON-EMPTY by
+  // The taxonomy lives in `vocabulary-skew.ts` and is NON-EMPTY by
   // construction, so this refusal cannot name the disagreement and then list
   // nothing. Which is what it did whenever the skew was in `substrate` or in the
   // compiled pattern: the two fields `checksDigest` hashes that the old
@@ -291,7 +291,7 @@ export async function runChecksAddCommand(file: string, opts: ChecksAddOptions):
       : "  positive — this should FAIL on an untouched seed; the examinee has to make it true.",
   );
 
-  // F-1134 — audit the WHOLE block, not just the line just appended. A
+  // Audit the WHOLE block, not just the line just appended. A
   // hand-edited criterion binds nothing and leaves the score denominator in
   // silence, and this is the one moment a local-only author is looking at the
   // file. Audits `next`, so the sentence just written is included and has to come

--- a/cli/src/cli/checks-lint.ts
+++ b/cli/src/cli/checks-lint.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 /**
  * `pome checks lint <file...>` — do this task's `[code]` criteria bind to a check
- * their twin declares? (F-1134)
+ * their twin declares?
  *
  * `pome checks add` warns about the block it writes into, which covers an author
  * mid-edit. This covers the rest: a file already on disk, a whole directory of

--- a/cli/src/cli/checks.ts
+++ b/cli/src/cli/checks.ts
@@ -37,9 +37,9 @@ const REGISTRIES: Record<string, readonly DeclaredCheck[]> = {
 //
 // The distinction is still real: `pome checks <twin>` must answer "not migrated
 // yet" for a twin that exists, and "no such twin" for a typo. What is no longer
-// real is the hand-maintained literal. F-1126 removed slack from it, F-1127
-// stripe, F-1128 gmail, and F-1129 would have emptied it — four tickets each
-// editing one line of a list that `MOUNTED_TWINS` already knows.
+// real is the hand-maintained literal. Slack, stripe and gmail each came off it
+// one at a time, and the next migration would have emptied it — four changes
+// each editing one line of a list that `MOUNTED_TWINS` already knows.
 //
 // So it is a set difference instead. Today it is EMPTY, which is A3's whole
 // acceptance criterion. The day a sixth twin mounts, it repopulates itself and
@@ -60,12 +60,12 @@ export function twinsWithChecks(): string[] {
  *
  * Exported because the no-vocabulary PATH is a real behaviour with its own
  * tests, and those tests need a twin on this list to exercise it. Naming one
- * inline is what broke five of them when stripe left the list (F-1127) — a
+ * inline is what broke five of them when stripe left the list — a
  * literal there asserts the MEMBERSHIP of the set, where the test means to
- * assert the behaviour, which is the same defect F-1075 hit with a hard-coded
- * picker index.
+ * assert the behaviour, which is the same defect a hard-coded picker index
+ * once caused.
  *
- * A3 empties this list, and F-1129 answered the question that raised: the PATH
+ * A3 empties this list, and that raised a question with a clear answer: the PATH
  * stays, the LITERAL goes. It is now `MOUNTED_TWINS` minus the registry, so an
  * empty result is a fact about the world rather than a list nobody updated.
  */
@@ -225,7 +225,7 @@ export async function runChecksCommand(
     console.log(`    ${dim(`pome checks add <file> --check ${def.id} ${argFlagsFor(def)}`)}`);
     console.log("");
   }
-  // F-1126 — the digest, shown rather than only computed.
+  // The digest, shown rather than only computed.
   //
   // `checks add` already refuses to write a sentence when this disagrees with
   // the control plane's (`checks-add.ts`), and that refusal is correct but

--- a/cli/src/cli/credentials.ts
+++ b/cli/src/cli/credentials.ts
@@ -44,7 +44,7 @@ export interface ResolvedCredentials {
   apiKey: string;
   apiBaseUrl: string;
   /** The team the api key belongs to, when known (stored at login). Powers the
-   *  `.pome/link.json` team gate (F-819). Undefined for a bare `POME_API_KEY`
+   *  `.pome/link.json` team gate. Undefined for a bare `POME_API_KEY`
    *  env key, whose team is known only server-side. */
   teamId?: string;
 }

--- a/cli/src/cli/criterion-binding.ts
+++ b/cli/src/cli/criterion-binding.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 /**
- * F-1134 — does a `[code]` criterion bind to a check its twin declares?
+ * Does a `[code]` criterion bind to a check its twin declares?
  *
  * A criterion that binds nothing is not an error anywhere: the grader skips it
  * and the score is computed over the rest, so the denominator moves for a reason
@@ -11,15 +11,14 @@
  *
  * OFFLINE BY CONSTRUCTION. Nothing here consults the cloud. Binding is a
  * question about the sentence and the CLI's own pinned declaration, and any
- * answer that needed the network would inherit F-1132's skew problem in the one
+ * answer that needed the network would inherit the pin-skew problem in the one
  * mode where this gap lives. The digest handshake in `checks-add.ts` remains the
  * place where the two pins are compared — that is a question about WRITING a
  * sentence, and it is a different question from whether one already binds.
  *
  * Resolution comes from `./checks.js` and nowhere else. That module is already a
  * deliberate SECOND resolution point (pome-cloud's registry is the first); a
- * third would be a third thing that can silently resolve nothing, which is
- * F-989's lesson.
+ * third would be a third thing that can silently resolve nothing.
  */
 import { checkNearMissPattern, checkPattern, templateSlots } from "@pome-sh/sdk/checks";
 

--- a/cli/src/cli/default-task.ts
+++ b/cli/src/cli/default-task.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// FDRS-645 — "run yours": bare `pome run` (no path) defaults to the demo
+// "run yours": bare `pome run` (no path) defaults to the demo
 // task, closing the demo → run-yours seam (north-star moment 05: their
 // agent, k=5, the same task they just watched the demo agent attempt).
 //

--- a/cli/src/cli/docs-topics.ts
+++ b/cli/src/cli/docs-topics.ts
@@ -37,7 +37,7 @@ export const DOCS_TOPICS: DocsTopic[] = [
       "register",
       "pome.json",
       "connect",
-      // Migrated from the retired skills-setup topic (F-893): wiring your own
+      // Migrated from the retired skills-setup topic: wiring your own
       // agent is now the "bring your own agent" path. ("pome-setup" / "setup"
       // already resolve to getting-started via its "setup" keyword.)
       "wire",
@@ -49,8 +49,8 @@ export const DOCS_TOPICS: DocsTopic[] = [
     path: "/docs/how-pome-works",
     keywords: ["twins", "scenarios", "runs", "scoring", "artifacts", "loop"],
   },
-  // F-889 dropped the Gen-1 /setup and /test-with-pome skill pages from the
-  // docs nav; F-893 retired the CLI commands that pointed at them. The two
+  // The Gen-1 /setup and /test-with-pome skill pages were dropped from the docs
+  // nav, and the CLI commands that pointed at them are gone. The two
   // topic entries are gone, but their still-live keywords are MIGRATED onto the
   // surviving replacement topics so `pome docs <kw>` keeps routing:
   //   wire → existing-agent;  test-with-pome / pome-test → cli-run;
@@ -97,7 +97,7 @@ export const DOCS_TOPICS: DocsTopic[] = [
     id: "cli",
     title: "Command Line Interface",
     path: "/docs/cli",
-    // "eval" migrated from the retired skills-test topic (F-893): there is no
+    // "eval" migrated from the retired skills-test topic: there is no
     // dedicated `pome eval` docs page, and it is a distinct workflow from
     // `pome inspect`, so it routes to the CLI reference index that documents
     // every command rather than to a sibling command's page.
@@ -116,7 +116,7 @@ export const DOCS_TOPICS: DocsTopic[] = [
       "default",
       "demo task",
       "run yours",
-      // Migrated from the retired skills-test topic (F-893): running tasks is
+      // Migrated from the retired skills-test topic: running tasks is
       // how you test an agent with pome.
       "test-with-pome",
       "pome-test",
@@ -131,7 +131,7 @@ export const DOCS_TOPICS: DocsTopic[] = [
   {
     id: "cli-tasks",
     title: "pome tasks",
-    // F-912 — the M4 docs door renamed the docs.pome.sh page from
+    // The M4 docs door renamed the docs.pome.sh page from
     // /docs/cli/scenarios to /docs/cli/tasks (a redirect keeps the old URL
     // alive), so `path` now points at the new route. The "scenarios" keyword
     // stays so `pome docs scenarios` still resolves to this topic.

--- a/cli/src/cli/eval.ts
+++ b/cli/src/cli/eval.ts
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // `pome eval [run-dir]` — upload an EXISTING raw trace directory to Pome
-// cloud for authoritative evaluation and print the score (FDRS-656; the
+// cloud for authoritative evaluation and print the score (the
 // capture/eval split contract: CLI captures, cloud evaluates). No local
 // scoring happens anywhere in this command (ADR-013) — the printed verdict
 // is whatever POST /v1/sessions/:id/finalize returns.
 //
-// Server contract (FDRS-655, pome-cloud — must land + deploy first):
+// Server contract (pome-cloud — must land + deploy first):
 //   POST /v1/eval-sessions  { agent, task_name } → 201 { session_id, expires_at }
 // After that the EXISTING presigned upload-url routes and /finalize work
 // unchanged on the minted session.
@@ -174,7 +174,7 @@ function validateJsonl(name: string, raw: string): void {
 }
 
 /** Read + validate a raw trace directory. Every missing/corrupt artifact
- *  fails with an error that names the offending file (FDRS-656). */
+ *  fails with an error that names the offending file. */
 export async function readRunDirArtifacts(
   runDir: string,
 ): Promise<RunDirArtifacts> {
@@ -422,15 +422,15 @@ export async function runEval(options: RunEvalOptions): Promise<RunEvalResult> {
   // events.jsonl and the state blobs are written pre-redacted (and
   // pre-wrapped) by artifacts.ts, but `pome eval` also accepts hand-assembled
   // dirs — redaction is idempotent, so this is cheap insurance that mirrors
-  // what the hosted runner uploads (cloud's FDRS-398 schema gate rejects raw
+  // what the hosted runner uploads (cloud's schema gate rejects raw
   // legacy rows).
   //
-  // Only LEGACY rows (pre-FDRS-398 — no `kind` discriminator) get wrapped into
+  // Only LEGACY rows (no `kind` discriminator) get wrapped into
   // a TwinHttpEvent. Rows that already carry a `kind` (any union member —
   // LlmTurnEvent, ToolUseEvent, LlmCallEvent, …) are preserved as-is: routing
   // them through toTwinHttpEvent re-wraps every non-TwinHttpEvent kind,
   // clobbering `kind` to "TwinHttpEvent" and setting event_id to an absent
-  // `request_id` (the pre-F-766 corruption bug).
+  // `request_id` (an old corruption bug).
   const eventsJsonl =
     artifacts.eventsJsonl
       .split("\n")
@@ -493,7 +493,7 @@ export async function runEval(options: RunEvalOptions): Promise<RunEvalResult> {
       agentModel: "unknown",
       agentSdk: projectIdentity?.framework ?? null,
       // Eval sessions carry no client-side criteria — the cloud eval judge
-      // owns them (FDRS-655). Cloud's finalize schema defaults all scenario
+      // owns them. Cloud's finalize schema defaults all scenario
       // fields, so empty strings are accepted.
       criteria: [],
       taskName: taskName,
@@ -525,17 +525,17 @@ export async function runEval(options: RunEvalOptions): Promise<RunEvalResult> {
     finalized = await uploadAndFinalize(sessionId);
   }
 
-  // FDRS-657 — the cloud verdict is EPHEMERAL: printed to the terminal below,
+  // The cloud verdict is EPHEMERAL: printed to the terminal below,
   // never persisted next to the trace. Local artifacts stay trace-only (no
   // score.json), and the verdict lives in the cloud (see the dashboard URL).
   const score = scoreFromFinalizeResponse(finalized);
 
-  // Exit-code policy — the full FDRS-591/611 A5 guard: exit 0 ONLY when the run
+  // Exit-code policy — the full A5 guard: exit 0 ONLY when the run
   // was evaluated, every criterion was judged (can_pass), AND the score clears
   // the threshold. An INCOMPLETE verdict (any criterion not evaluated) exits 1.
   //
-  // F-925 retired the divergence that used to be documented here. `pome run`
-  // mapped the raw cloud score because "pre-FDRS-618 cloud builds don't emit
+  // The divergence that used to be documented here is retired. `pome run`
+  // mapped the raw cloud score because "older cloud builds don't emit
   // criteria_results" — but `scoreFromFinalizeResponse` already handles that
   // case (`hasCriteriaResults ? … : true`), so the guard degrades to score-only
   // for exactly those builds on its own. The divergence was protecting a case
@@ -654,11 +654,11 @@ export async function runEvalCommand(
     ) {
       // The upgrade hint promised at the client layer (createEvalSession):
       // a 404/405 means this control plane predates `POST /v1/eval-sessions`
-      // (FDRS-655) — the exact release-gate scenario where the endpoint is on
+      // — the exact release-gate scenario where the endpoint is on
       // main but not yet deployed to prod. Point the user at the cause instead
       // of a bare "Not Found".
       console.error(
-        "Tip: this control plane does not serve `POST /v1/eval-sessions` yet — the Pome cloud eval path (FDRS-655) is not deployed. Upgrade the control plane (or wait for the deploy). In the meantime, a hosted `pome run` still returns a cloud verdict.",
+        "Tip: this control plane does not serve `POST /v1/eval-sessions` yet — the Pome cloud eval path is not deployed. Upgrade the control plane (or wait for the deploy). In the meantime, a hosted `pome run` still returns a cloud verdict.",
       );
     }
     process.exitCode = code;

--- a/cli/src/cli/frameworks.ts
+++ b/cli/src/cli/frameworks.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Client-side did-you-mean for the manifest's open-enum `agent.framework`
-// (F-804 / F-819). An unknown framework is NEVER a validation error — the
+// Client-side did-you-mean for the manifest's open-enum `agent.framework`.
+// An unknown framework is NEVER a validation error — the
 // manifest schema keeps it a free string. We only surface a friendly warning
 // with the nearest known value so a typo like "langraph" is caught locally
 // before it reaches the dashboard badge.
@@ -22,7 +22,7 @@ export const KNOWN_FRAMEWORKS = [
 ] as const;
 
 /** A framework label the CLI itself recognizes. Anything a Pome surface WRITES
- *  into a manifest must be one of these (F-1393): the open enum tolerates an
+ *  into a manifest must be one of these: the open enum tolerates an
  *  author's own value, but a label the CLI mints and then warns about on the
  *  next command is the CLI disagreeing with itself. Authoring a value outside
  *  this union is a typecheck error, not a runtime surprise. */

--- a/cli/src/cli/init-sdk.ts
+++ b/cli/src/cli/init-sdk.ts
@@ -17,7 +17,7 @@ export type SupportedSdk = (typeof SUPPORTED_SDKS)[number];
 
 export interface ScaffoldResult {
   /** The `agent.framework` label `pome init --sdk` writes into the manifest.
-   *  Typed to `KnownFramework`, not `string` (F-1393): the `--sdk` FLAG name is
+   *  Typed to `KnownFramework`, not `string`: the `--sdk` FLAG name is
    *  a CLI selector (`claude`), not a framework label, and writing the flag
    *  name straight through produced a manifest that `pome register agent`'s own
    *  `warnUnknownFramework` then rejected as unknown on the very next command,

--- a/cli/src/cli/install.ts
+++ b/cli/src/cli/install.ts
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
-// F-893 — `pome install` (Gen-1 agent-driven wiring) is retired.
+// `pome install` (Gen-1 agent-driven wiring) is retired.
 //
 // It used to run a headless coding-agent session whose knowledge layer was the
 // `pome-setup` skill, staging the edits in a shadow copy and gating them behind
-// a terminal diff (FDRS-642/661). F-859 turned `pome-setup` into a redirect
+// a terminal diff. `pome-setup` then became a redirect
 // tombstone — so the wiring no longer actually ran, it just injected a pointer.
 // This command is now a thin redirect to the Gen-2 path; the shadow-diff engine
 // (`embedded-wiring.ts`) and the Agent SDK provisioning (`agent-sdk.ts`) were

--- a/cli/src/cli/link-cache.ts
+++ b/cli/src/cli/link-cache.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// `.pome/link.json` — the gitignored, machine-local resolver cache (F-819,
-// spec F-804). It maps the committed `agent.slug` to the `agt_` id the platform
+// `.pome/link.json` — the gitignored, machine-local resolver cache (see the
+// manifest format spec). It maps the committed `agent.slug` to the `agt_` id the platform
 // resolved for it, scoped to the team that resolved it. The cache is TRUSTED
 // only when its `team_id` matches the caller's team: a re-clone under the same
 // team short-circuits (Champion TTHW), a fork or team switch silently

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -94,7 +94,7 @@ const DEFAULT_AGENT_FILE = "examples/agents/scripted-triage-agent.ts";
 // with no error pointing at the real cause.
 const DEFAULT_AGENT_COMMAND = `node ${DEFAULT_AGENT_FILE}`;
 const MANIFEST_SCHEMA_URL = "https://pome.sh/schemas/v1/pome.json";
-// F-1411 — cap on how many unreadable verdict.json paths `fix-prompt`
+// Cap on how many unreadable verdict.json paths `fix-prompt`
 // discovery names individually, same "kept first N" convention as
 // `fix-prompt/prompt.ts`'s MAX_EVENTS trim.
 const MAX_UNREADABLE_PATHS_SHOWN = 5;
@@ -175,7 +175,7 @@ export function createProgram() {
         return;
       }
 
-      // F-904 — a directory that already has a package.json is the "bring your
+      // A directory that already has a package.json is the "bring your
       // own agent" case: scaffold only the manifest, never the starter library
       // (a 2026-07-24 cold walk dumped 28 untracked files into a real project).
       // --starter / --bare override the auto-decision in either direction.
@@ -233,12 +233,12 @@ export function createProgram() {
       }
 
       // Point the manifest at an existing task directory so bare `pome run`
-      // (F-865) resolves it. The starter path always creates tasks/; bare mode
+      // resolves it. The starter path always creates tasks/; bare mode
       // only claims it when the user already keeps their tasks there.
       const tasksDir =
         !bare || (await hasMarkdownTasks("tasks")) ? "tasks" : undefined;
 
-      // The manifest requires `agent.slug` (F-804). `pome init` runs before
+      // The manifest requires `agent.slug`. `pome init` runs before
       // `pome register`, so seed a portable slug derived from the directory
       // name; register later overwrites it with the server-canonical slug.
       const existing = await readManifest(process.cwd());
@@ -273,14 +273,14 @@ export function createProgram() {
 
   program
     .command("install")
-    // F-893 — the Gen-1 agent-driven wiring is retired; this is a redirect to
+    // The Gen-1 agent-driven wiring is retired; this is a redirect to
     // the Gen-2 path. allowUnknownOption + allowExcessArguments keep old
     // invocations (`pome install --interactive`, `--api-url …`) landing on the
     // redirect instead of erroring on a now-removed flag or stray operand.
     .allowUnknownOption()
     .allowExcessArguments()
     .description(
-      "Retired (F-893). Prints the Gen-2 wiring path: `claude mcp add … pome` + `npx skills add pome-sh/digital-twins --skill '*'`, then the pome-intake / REST-launch preflight.",
+      "Retired. Prints the Gen-2 wiring path: `claude mcp add … pome` + `npx skills add pome-sh/digital-twins --skill '*'`, then the pome-intake / REST-launch preflight.",
     )
     .action(async () => {
       const { runInstall } = await import("./install.js");
@@ -377,7 +377,7 @@ export function createProgram() {
       },
     );
 
-  // F-1074 — `pome checks` is a TOP-LEVEL group, not `pome tasks checks`:
+  // `pome checks` is a TOP-LEVEL group, not `pome tasks checks`:
   // `pome tasks` already takes `[twin]` positionally, so `tasks checks` would
   // parse "checks" as a twin id, and `pome task` one letter from `pome tasks`
   // is a trap.
@@ -418,7 +418,7 @@ export function createProgram() {
       });
     });
 
-  // F-1134 — the read-only half. `checks add` warns about the block it writes
+  // The read-only half. `checks add` warns about the block it writes
   // into, which covers an author mid-edit; this answers the same question about a
   // file already on disk, which is what a builder's own CI needs. Offline: it
   // reads this CLI's pinned declarations and never calls the cloud.
@@ -456,7 +456,7 @@ export function createProgram() {
       if (code !== 0) process.exitCode = code;
     });
 
-  // F-893 — `pome skills` / `pome skills install` retired. It only symlinked
+  // `pome skills` / `pome skills install` retired. It only symlinked
   // the two Gen-1 tombstone skills into ~/.claude/skills/; the Gen-2 coach set
   // installs via `npx skills add pome-sh/digital-twins`.
 
@@ -504,7 +504,7 @@ export function createProgram() {
       },
     );
 
-  // F-1557 — `sandbox` is the product noun (VOCABULARY.md); `session` is the
+  // `sandbox` is the product noun (VOCABULARY.md); `session` is the
   // spelling the CLI shipped with and every existing script types. Commander
   // resolves both to this one command, so every subcommand, flag and line of
   // output below is reachable under either without a second tree to drift.
@@ -624,7 +624,7 @@ export function createProgram() {
     )
     .option(
       "--discard",
-      "Confirm destroying a session whose run has not been graded (F-983)",
+      "Confirm destroying a session whose run has not been graded",
       false,
     )
     .action(
@@ -658,9 +658,9 @@ export function createProgram() {
     .option("--agent <command>", "Agent command to run")
     .option(
       "-n, --trials <count>",
-      "FDRS-636: run <count> isolated trials of the task as ONE trial group (integer 1-20; hosted only). " +
+      "Run <count> isolated trials of the task as ONE trial group (integer 1-20; hosted only). " +
         "Default is the task config's `runs` field (capped at 20). k>1 mints sessions with a shared group id up to your " +
-        "plan's concurrent-twin quota (FDRS-663: remaining trials reuse slots as earlier trials finish), runs trials at that " +
+        "plan's concurrent-twin quota (remaining trials reuse slots as earlier trials finish), runs trials at that " +
         "concurrency, prints the per-trial verdict table (numeric cloud-judge scores), and exits 0 iff at least one " +
         "trial completed and every completed trial passed (1: a completed trial failed; 2: nothing completed). " +
         "k=1 keeps today's single-run behavior exactly.",
@@ -682,7 +682,7 @@ export function createProgram() {
     )
     .option(
       "--no-capture",
-      "Self-host only: skip spawning the capture-server child and don't inject HTTP_PROXY/HTTPS_PROXY into the agent. Used by the CI overhead gate (FDRS-405) to baseline proxy-on-vs-off latency. No-op on hosted runs.",
+      "Self-host only: skip spawning the capture-server child and don't inject HTTP_PROXY/HTTPS_PROXY into the agent. Used by the CI overhead gate to baseline proxy-on-vs-off latency. No-op on hosted runs.",
     )
     .option(
       "--local",
@@ -715,7 +715,7 @@ export function createProgram() {
         // HostedUsageError, HostedOrchError) here and map via
         // `exitCodeFor` so the documented contract holds.
 
-        // FDRS-636 — validate -n before anything runs (documented exit 5 on
+        // Validate -n before anything runs (documented exit 5 on
         // a bad value, same as any other usage error).
         let trialsFlag: number | undefined;
         if (options.trials !== undefined) {
@@ -728,11 +728,11 @@ export function createProgram() {
           }
         }
 
-        // Read the manifest once — both bare-run task resolution (F-865) and
+        // Read the manifest once — both bare-run task resolution and
         // the agent command below consume it.
         const manifestRead = await readManifest(process.cwd()).catch(() => null);
 
-        // FDRS-645 / F-865 — bare `pome run` (no path) resolves its default:
+        // Bare `pome run` (no path) resolves its default:
         //   - a MIGRATED project (manifest with a `tasks` key) runs that whole
         //     declared directory, exactly like `pome run <that-dir>`: no demo
         //     drop, no "run yours" frame, each file at its own `runs`/-n;
@@ -777,7 +777,7 @@ export function createProgram() {
           return;
         }
 
-        // F-865 — make a manifest-driven bare run legible: name where the set
+        // Make a manifest-driven bare run legible: name where the set
         // came from, and never let an empty declared dir no-op silently.
         if (bareViaManifestTasks) {
           const manifestFile = basename(manifestRead!.path);
@@ -812,7 +812,7 @@ export function createProgram() {
 
         // Hosted is the default. Self-host runs against an in-process twin via
         // `--local` (documented) or POME_LOCAL=1 (an internal escape hatch).
-        // FDRS-657: self-host is CAPTURE-ONLY — it records the raw trace and
+        // Self-host is CAPTURE-ONLY — it records the raw trace and
         // never scores/judges/correlates. A verdict comes only from the cloud
         // (`pome eval <dir>`, or a hosted `pome run`). The --hosted flag is a
         // deprecated no-op kept for one release.
@@ -825,7 +825,7 @@ export function createProgram() {
           console.error("Note: --hosted is now the default; the flag is a deprecated no-op and will be removed in a future release.");
         }
 
-        // FDRS-636 — trial groups are a hosted feature: the verdicts come
+        // Trial groups are a hosted feature: the verdicts come
         // from cloud evaluation, and self-host runs are capture-only. Reject
         // the combination loudly instead of silently ignoring the flag.
         if (trialsFlag !== undefined && useLocal) {
@@ -836,15 +836,14 @@ export function createProgram() {
           return;
         }
 
-        // FDRS-641 — doctor preflight gate. A repo failing any applicable
+        // Doctor preflight gate. A repo failing any applicable
         // doctor check refuses to spawn the agent — BEFORE credentials are
         // resolved and before any twin/session is provisioned. Local runs get
         // the full engine (incl. local twin boot); hosted runs skip the local
         // twin (the cloud provisions the session twin) but still gate on
         // config, routing, and the egress floor. Deliberately no --force /
         // --skip-checks escape: "never a false success" — pome will not run
-        // trials against a live API. (Design: CLI moments 03; engine:
-        // FDRS-634.)
+        // trials against a live API. (Design: CLI moments 03.)
         {
           const { runDoctorChecks } = await import("../doctor/checks.js");
           const { renderDoctorReport } = await import("../doctor/render.js");
@@ -876,7 +875,7 @@ export function createProgram() {
           return;
         }
 
-        // FDRS-645 — the moment-05 frame, only for the bare-run default and
+        // The moment-05 frame, only for the bare-run default and
         // only once every gate that could refuse the run has passed.
         if (defaultTask) {
           for (const line of runYoursFrameLines()) console.error(line);
@@ -888,7 +887,7 @@ export function createProgram() {
             // documented exit codes. Anything else falls through to Commander
             // (treated like self-host).
             try {
-              // FDRS-636 — effective trial count: -n wins, else the task
+              // Effective trial count: -n wins, else the task
               // config's `runs` field (both capped at 20). k>1 takes the
               // trial-group path; k=1 stays EXACTLY the single-run path
               // below (no group is ever stamped for it).
@@ -901,7 +900,7 @@ export function createProgram() {
                 const { runTrialGroup } = await import(
                   "../runner/runTrialGroup.js"
                 );
-                // FDRS-644 — the literal re-run command the fix handoff
+                // The literal re-run command the fix handoff
                 // prints: bare default-task runs re-run as bare `pome run`;
                 // explicit paths re-run by (cwd-relative) path + -n.
                 const fileForRerun = relative(process.cwd(), file);
@@ -966,7 +965,7 @@ export function createProgram() {
               if (code > worstExit) worstExit = code;
             }
           } else {
-            // Self-host path (FDRS-657): CAPTURE-ONLY. Record the raw trace;
+            // Self-host path: CAPTURE-ONLY. Record the raw trace;
             // no score, no verdict, no judge. Let exceptions (file-not-found,
             // parse errors, agent failures) propagate to Commander's top-level
             // handler.
@@ -982,7 +981,7 @@ export function createProgram() {
             console.error(
               `  captured; run \`pome eval ${result.artifacts.runDir}\` for a cloud verdict.`,
             );
-            // FDRS-635 — name every host the egress floor refused, so a stray
+            // Name every host the egress floor refused, so a stray
             // production call is a visible event, never a silent passthrough.
             if (result.blockedEgress.length > 0) {
               const refusals = result.blockedEgress.reduce((n, b) => n + b.count, 0);
@@ -1045,7 +1044,7 @@ export function createProgram() {
     );
 
   // Hidden: the bundled demo agent `pome demo` spawns as its trial child
-  // through the real capture path (FDRS-643). Reads the POME_* env contract
+  // through the real capture path. Reads the POME_* env contract
   // injected by runTask plus POME_DEMO_* gateway coordinates.
   program
     .command("demo-agent", { hidden: true })
@@ -1105,7 +1104,7 @@ export function createProgram() {
       },
     );
 
-  // NOTE (FDRS-657): `matrix` / `matrix-html` / `eval-report` were removed.
+  // NOTE: `matrix` / `matrix-html` / `eval-report` were removed.
   // They were a pure LOCAL-scoring orchestrator — they shelled out to
   // `pome run` with POME_LOCAL=1 and aggregated the local score.json each
   // child wrote. With local evaluation gone (the OSS CLI is capture-only),
@@ -1124,7 +1123,7 @@ export function createProgram() {
 
       const eventsResult = await readEventsJsonl(runDir);
       if (eventsResult.kind === "legacy") {
-        // Exit code 2 is reserved by FDRS-403 for "legacy events.jsonl
+        // Exit code 2 is reserved for "legacy events.jsonl
         // detected" — distinct from a JSON parse error (which throws and
         // surfaces as exit code 1 via commander's default handling).
         console.error(LEGACY_EVENTS_MESSAGE);
@@ -1147,7 +1146,7 @@ export function createProgram() {
         for (const line of renderTraceHealth(health)) console.log(line);
         for (const line of renderEvents(eventsResult.events)) console.log(line);
       }
-      // FDRS-657 — `pome inspect` shows ONLY trace/audit content. There is no
+      // `pome inspect` shows ONLY trace/audit content. There is no
       // local verdict: score.json is never written (local artifacts are
       // trace-only). A verdict comes from the cloud — run `pome eval <dir>`
       // (or a hosted `pome run`) and read it on the terminal / dashboard.
@@ -1168,7 +1167,7 @@ export function createProgram() {
     )
     .action(async (target?: string, taskArg?: string) => {
       // Legacy 2-arg form: <events.jsonl> <task.md> — unchanged
-      // (CAPTURE-ONLY, FDRS-657: raw trace + declared criteria, no verdict).
+      // (CAPTURE-ONLY: raw trace + declared criteria, no verdict).
       if (target !== undefined && target.endsWith(".jsonl")) {
         if (!taskArg) {
           console.error(
@@ -1197,13 +1196,13 @@ export function createProgram() {
         return;
       }
 
-      // FDRS-644 — run-set mode. Reassemble the run set from persisted
+      // Run-set mode. Reassemble the run set from persisted
       // CLOUD verdicts (verdict.json, written by hosted `pome run`) + raw
       // traces, and emit ONE prompt with grouped failure signatures. Still
       // no network and no local judging — the verdicts were the cloud's.
       const root = target ?? "runs";
       const discovery = await discoverRunSet(resolve(root));
-      // F-1195 — a verdict.json this CLI can't read is a RECOGNIZABLE prior
+      // A verdict.json this CLI can't read is a RECOGNIZABLE prior
       // artifact version, not a foreign file, and the skip is named EVERY
       // time it happens — not only when nothing else was found. A runs/ that
       // holds one readable trial beside two stale ones would otherwise build
@@ -1215,7 +1214,7 @@ export function createProgram() {
           `${discovery.staleVersionCount} verdict.json file(s) under ${root} are not artifact version ${VERDICT_ARTIFACT_VERSION} (the only version this CLI reads) and were skipped — re-run \`pome run\` to record those trials again.`,
         );
       }
-      // F-1411 — a verdict.json that EXISTS but is truncated, hand-edited, or
+      // A verdict.json that EXISTS but is truncated, hand-edited, or
       // otherwise damaged is a different fact from a prior-version file (an
       // older CLI wrote that one correctly) and gets its own line, naming the
       // path(s) — a count alone would tell the user something was skipped but
@@ -1243,7 +1242,7 @@ export function createProgram() {
         return;
       }
       if (!discovery.set) {
-        // F-1404 — a root whose only non-passing run set is INCOMPLETE (the
+        // A root whose only non-passing run set is INCOMPLETE (the
         // grader never reached some criterion) is neither "all passed" nor a
         // failure to hand to a coding agent: routing it would assert an agent
         // defect nothing here established, and "all passed" would be false
@@ -1401,7 +1400,7 @@ export function createProgram() {
     )
     .option(
       "--allow <hosts>",
-      "FDRS-635: comma-separated egress allowlist patterns (exact host or *.suffix). The floor is deny-by-default: only these hosts + loopback are tunnelled; everything else gets 403.",
+      "Comma-separated egress allowlist patterns (exact host or *.suffix). The floor is deny-by-default: only these hosts + loopback are tunnelled; everything else gets 403.",
     )
     .option(
       "--egress-out <path>",
@@ -1505,7 +1504,7 @@ async function taskFiles(target: string) {
     .map((entry) => join(resolved, entry));
 }
 
-// F-904 — does the cwd already carry a task directory worth recording in the
+// Does the cwd already carry a task directory worth recording in the
 // manifest? A directory named `dir` counts only when it holds at least one
 // `.md` (an empty scaffold dir is not a task set).
 async function hasMarkdownTasks(dir: string): Promise<boolean> {

--- a/cli/src/cli/project-config.ts
+++ b/cli/src/cli/project-config.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// The pome MANIFEST loader (F-819, format spec F-804). Replaces the legacy
+// The pome MANIFEST loader. Replaces the legacy
 // `pome.config.json` handling — no back-compat, 0 users. The committed manifest
 // is `pome.json` (canonical) with `pome.yaml` / `pome.yml` as interchangeable
 // carriers of the same snake_case keys. One canonical zod schema
@@ -177,7 +177,7 @@ function slugErrorMessage(raw: Record<string, unknown>, path: string): string {
  *  normalized but NOT validated here — the server returns a friendly error for
  *  an unknown twin. Returns undefined when nothing survives so the cloud's
  *  default enablement still applies. Shared by the register command and the
- *  run-path identity resolver (F-926). */
+ *  run-path identity resolver. */
 export function normalizeManifestTwins(
   manifestTwins: readonly string[] | undefined,
 ): string[] | undefined {

--- a/cli/src/cli/register.ts
+++ b/cli/src/cli/register.ts
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // `pome register agent <name>` / `pome install` — the vercel-link seam. POSTs
-// the manifest identity to `POST /v1/agents` (the F-820 slug resolver: live
+// the manifest identity to `POST /v1/agents` (the slug resolver: live
 // slug → alias → near-miss 409 → auto-create under the caller's team), then
 // persists the server-canonical identity into `pome.json` and caches the
 // resolved `agt_` id in gitignored `.pome/link.json`.
 //
-// Wire shape (pome-cloud `docs/05-api-spec.md`, ADR-013, F-820):
+// Wire shape (pome-cloud `docs/05-api-spec.md`, ADR-013):
 //   POST /v1/agents  { name, slug?, description?, version?, framework?, twins?, confirm? }
 //     200 AgentResponse { id, slug, display_name, judge_model, framework?, … }
 //     401/403 auth | 404 route skew | 409 conflict (near-miss w/ details.suggestion)
@@ -73,7 +73,7 @@ export function normalizeRegisterTwins(raw: string | undefined): string[] | unde
 }
 
 /** Effective register twins = the manifest's declared `twins` (the default twin
- *  set for runs) unioned with any `--twins` flag additions (F-926). Before this,
+ *  set for runs) unioned with any `--twins` flag additions. Before this,
  *  the CLI sent only the flag, so a manifest like `twins: ["gmail"]` never
  *  reached `POST /v1/agents` and the server's `github` default won — the first
  *  `pome run` then errored with "Requested twins are not enabled".
@@ -116,7 +116,7 @@ function warnUnknownFramework(existingAgent: Record<string, unknown>): void {
   console.error(`Unknown agent.framework "${framework}".${hint} (Recorded as-is.)`);
 }
 
-/** F-861 — surface the slug rename when the resolver matched an old slug via an
+/** Surface the slug rename when the resolver matched an old slug via an
  *  alias (cloud emits `resolved_via: "alias"` + a `hint` since v0.4.18). By this
  *  point the manifest has already been rewritten to the new canonical slug, so
  *  attribution self-heals silently; this only makes the change visible. Shared
@@ -168,9 +168,9 @@ async function createAndPersistAgent(input: {
 
   // Write the manifest from the response — slug + display name are canonical;
   // description/version fall back to the manifest when the cloud returns
-  // nothing (older control plane). `framework` is NOT echoed back at all
-  // (F-1393): it is the author's declaration, never the cloud's — including
-  // when the cloud has nothing stored (F-1213: null, not a guessed default).
+  // nothing (older control plane). `framework` is NOT echoed back at all:
+  // it is the author's declaration, never the cloud's — including
+  // when the cloud has nothing stored (null, not a guessed default).
   // `nextAgent` already carries whatever the manifest declared (or omitted)
   // via the initial spread of `existingAgent` above; leave it untouched.
   const nextAgent: Record<string, unknown> = { ...existingAgent, slug: agent.slug };
@@ -217,7 +217,7 @@ export async function runRegisterAgent(opts: RegisterAgentOptions): Promise<void
   }
 
   // Send the manifest's declared twins (unioned with any --twins flag) so the
-  // cloud's enabled services match the manifest, not the server default (F-926).
+  // cloud's enabled services match the manifest, not the server default.
   const twins = mergeRegisterTwins(manifestRead.manifest.twins, opts.twins);
 
   const agent = await createAndPersistAgent({

--- a/cli/src/cli/session.ts
+++ b/cli/src/cli/session.ts
@@ -289,7 +289,7 @@ export async function runSessionList(opts: {
 export async function runSessionStop(opts: {
   apiBaseUrl: string;
   sessionId: string;
-  /** F-983: confirm destroying a session whose run has not been graded.
+  /** Confirm destroying a session whose run has not been graded.
    *  Off by default — a human-typed destructive command gets the refusal
    *  printed instead of silently discarding the evidence. */
   discard?: boolean;

--- a/cli/src/cli/tasks-catalog.ts
+++ b/cli/src/cli/tasks-catalog.ts
@@ -7,8 +7,8 @@
  * Stripe/Slack tasks remain opt-in via `pome tasks <twin> --copy`.
  *
  * `runnable: false` marks an entry the copy commands skip. NO ENTRY CARRIES IT
- * TODAY (F-1303 deleted `00-default-seed.md`, its only user), and the field is
- * kept rather than retired because F-1305 is what it is for: the twin-smoke
+ * TODAY (`00-default-seed.md`, its only user, was deleted), and the field is
+ * kept rather than retired because of what it is for: the twin-smoke
  * tasks — `10`, `13`, `23`, whose prompts say "the Stripe clone" and "exercise
  * all thirteen available Gmail tools" — are our self-tests, and they leave the
  * starter library the moment the zero-model prober can cover their routes.

--- a/cli/src/cli/vocabulary-skew.ts
+++ b/cli/src/cli/vocabulary-skew.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 /**
- * F-1137 — WHY do this CLI and the cloud disagree about a twin's vocabulary?
+ * WHY do this CLI and the cloud disagree about a twin's vocabulary?
  *
  * `checksDigest` hashes three fields per check: `id`, `substrate`, and the
  * COMPILED pattern (`packages/sdk/src/checks.ts`). The refusal in `checks-add.ts`
@@ -12,11 +12,11 @@
  *
  * The fix is a taxonomy with no silent branch: `explainSkew` returns a NON-EMPTY
  * list by construction, and the type says so. The class names are pome-cloud's
- * (`apps/control-plane/src/services/vocabulary-parity.ts`, F-1136) so the two
+ * (`apps/control-plane/src/services/vocabulary-parity.ts`) so the two
  * surfaces that explain the same disagreement stay greppable against each other.
  *
  * This side can say more than the cloud-side monitor can. `GET /v1/checks`
- * publishes the compiled `pattern` and the parameter patterns (F-1074 Phase 3),
+ * publishes the compiled `pattern` and the parameter patterns,
  * which the CLI's own `checks --json` does not — so a generator-only skew is
  * localisable to a check HERE, and only falls back to the unlocalised
  * `pattern_generation` class when the control plane published nothing to diff.

--- a/cli/src/contract/finalize-shapes.ts
+++ b/cli/src/contract/finalize-shapes.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // contract — /v1/sessions/:id/finalize response family (part of §4 PUBLIC
-// REST API). ADR-013 managed-judge synchronous result plus the F-700 async
+// REST API). ADR-013 managed-judge synchronous result plus the async
 // `Prefer: respond-async` accepted/status/union shapes. Re-exported through the
 // `cli/src/contract` barrel (index.ts).
 
@@ -19,7 +19,7 @@ import { criterionDefSchema, perTwinStateKeysSchema } from "./rest.js";
 //
 // Not `.strict()`: a tolerant reader that strips unknown additive keys, matching
 // the rest of the §4 request/response family. Field set mirrors the CLI body
-// exactly — `scenario_*` vocab (finalize does not take the W3 `task_*` aliases),
+// exactly — `scenario_*` vocab (finalize does not take the `task_*` aliases),
 // storage keys optional (cloud falls back to conventional paths when omitted).
 export const finalizeRequestSchema = z.object({
   stop_reason: z.string(),                       // "completed" | "timeout" | "preflight_failed" | …
@@ -62,7 +62,7 @@ export const finalizeResponseSchema = z.object({
 });
 export type FinalizeResponse = z.infer<typeof finalizeResponseSchema>;
 
-// F-700: `status_url` is a same-origin absolute URL *or* an absolute-path
+// `status_url` is a same-origin absolute URL *or* an absolute-path
 // relative URL (cloud returns `/v1/sessions/:id/evaluation`).
 export const finalizeStatusUrlSchema = z
   .string()
@@ -115,7 +115,7 @@ export type FinalizeRunningStatusResponse = z.infer<
   typeof finalizeRunningStatusResponseSchema
 >;
 
-// F-700 wire error on GET .../evaluation failed status.
+// Wire error on GET .../evaluation failed status.
 export const finalizeFailureErrorSchema = z.object({
   type: z.string().min(1),
   message: z.string().min(1),

--- a/cli/src/contract/identity.ts
+++ b/cli/src/contract/identity.ts
@@ -19,7 +19,7 @@ export const userSchema = z.object({
 });
 export type User = z.infer<typeof userSchema>;
 
-// FDRS-613: reconciled to pome-cloud /v1 wire truth — `hobby` and `team` were
+// Reconciled to pome-cloud /v1 wire truth — `hobby` and `team` were
 // added cloud-side for the launch pricing tiers; adopted here so a cloud-issued
 // MeResponse / UsageResponse (plan_tier) parses under the twins schema.
 export const planTierSchema = z.enum([

--- a/cli/src/contract/index.ts
+++ b/cli/src/contract/index.ts
@@ -5,7 +5,7 @@
  * Identity, sessions, task seeds, the completed-run row, the public REST
  * request/response family, the error envelope and the `pome.json` manifest. The
  * CLI is the only thing in this repo that speaks any of it: no twin does, which
- * is why F-942 moved these clusters out of the package all five twins depend on
+ * is why these clusters moved out of the package all five twins depend on
  * and into `cli/src/`. `pome-cloud` is the counterpart consumer, and CONTRACT.md
  * is the coordination point for a change here.
  *
@@ -13,13 +13,13 @@
  * `@pome-sh/wire`, which twins do depend on. `cli/src/types/shared.ts` re-exports
  * both so a CLI module names one import site.
  *
- * This file is a THIN BARREL (F-754): it re-exports only. The clusters live in
+ * This file is a THIN BARREL: it re-exports only. The clusters live in
  * topical leaf modules, each re-exported here with identical names, so the symbol
  * a consumer imports never depends on which leaf owns it.
  */
 
 export * from "./run.js";               // completed-run row
-export * from "./task-vocab.js";        // W3 task/criterion vocabulary + tolerant readers
+export * from "./task-vocab.js";        // task/criterion vocabulary + tolerant readers
 export * from "./identity.js";          // §1 IDENTITY
 export * from "./sessions.js";          // §2 SESSIONS
 export * from "./seed-state.js";        // §3 TASKS — provider seed-state schemas
@@ -28,4 +28,4 @@ export * from "./task.js";              // §3 TASKS — task config / task / pe
 export * from "./rest.js";              // §4 PUBLIC REST API (minus finalize family)
 export * from "./finalize-shapes.js";   // §4 PUBLIC REST API — /finalize response family
 export * from "./errors.js";            // §5 ERROR ENVELOPE
-export * from "./manifest.js";          // §6 MANIFEST — pome.json/pome.yaml + slug authority (F-818)
+export * from "./manifest.js";          // §6 MANIFEST — pome.json/pome.yaml + slug authority

--- a/cli/src/contract/manifest.ts
+++ b/cli/src/contract/manifest.ts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// contract §6 — the pome.json / pome.yaml MANIFEST (F-818, format spec
-// F-804). One canonical zod schema; JSON and YAML are interchangeable carriers
+// contract §6 — the pome.json / pome.yaml MANIFEST. One canonical zod schema; JSON and YAML are interchangeable carriers
 // of the same snake_case keys (both files present is a hard error at the CLI
 // loader, not here). The `agent` block is the stable cross-carrier identity
 // contract; top-level keys are CLI run-config and may evolve faster.
@@ -10,7 +9,7 @@
 // control-plane /v1/agents, dashboard, MCP). SLUG_RE is byte-identical to the
 // pome-cloud control-plane's regex; deriveAgentSlug is a behavior-identical
 // port of packages/db/src/agent-slug.ts (equivalence pinned in
-// test/manifest.test.ts). pome-cloud imports both from here as of F-820 —
+// test/manifest.test.ts). pome-cloud imports both from here —
 // local and server validation must never drift again.
 
 import { z } from "zod";
@@ -69,10 +68,10 @@ export const manifestSchema = z.object({
 });
 export type Manifest = z.infer<typeof manifestSchema>;
 // Writer-side shape: what an author may put in pome.json / pome.yaml before
-// the run-config defaults are injected (z.input trick, F-778).
+// the run-config defaults are injected (z.input trick).
 export type ManifestInput = z.input<typeof manifestSchema>;
 
-// The JSON Schema served at pome.sh/schemas/v1/pome.json (F-821) and resolved
+// The JSON Schema served at pome.sh/schemas/v1/pome.json and resolved
 // by editors via the manifest's `$schema` pointer. `io: "input"` emits the
 // AUTHOR-side shape — run-config keys with defaults stay optional instead of
 // being promoted to required by the parsed (output) view. Shared by the

--- a/cli/src/contract/rest.ts
+++ b/cli/src/contract/rest.ts
@@ -32,7 +32,7 @@ export type MeResponse = z.infer<typeof meResponseSchema>;
 
 // POST /v1/sessions
 //
-// W3 vocab (FDRS-653): `task_source` / `task_id` are canonical; the exported
+// Task vocab: `task_source` / `task_id` are canonical; the exported
 // schema wraps this object in the tolerant-reader preprocess so 0.3.0 CLIs
 // sending `scenario_source` / `scenario_id` keep working unchanged.
 const createSessionRequestObjectSchema = z
@@ -53,7 +53,7 @@ const createSessionRequestObjectSchema = z
     twins: z.array(z.string()).min(1).default(["github"]),
     task_source: z.string().optional(),        // base64-encoded UTF-8 markdown; 0.3.0 alias: scenario_source
     task_id: z.string().optional(),            // alternative: stored task; 0.3.0 alias: scenario_id
-    // FDRS-580 / ADR-015 (adopted from pome-cloud, FDRS-613): the seed override
+    // ADR-015 (adopted from pome-cloud): the seed override
     // is a PERMISSIVE, shape-blind boundary. The twin pod's own `parseSeed` is
     // the sole authority on the seed's domain shape; the cloud forwards it
     // verbatim. `z.record` keeps the one invariant that is the boundary's
@@ -66,14 +66,14 @@ const createSessionRequestObjectSchema = z
     // POST /v1/sessions. The dashboard generates one per Start-button click;
     // legacy clients work without it.
     idempotency_key: z.string().uuid().optional(),
-    // M3 / FDRS-636: client-minted trial-group identity — `pome run -n k`
+    // Client-minted trial-group identity — `pome run -n k`
     // (and `pome demo`) stamp one id per invocation, shared by all k trial
     // sessions. The cloud copies it onto sessions.group_id at mint and onto
     // runs.group_id at finalize; the demo/eval mints already accept the same
     // field. Format mirrors the cloud's GROUP_ID_RE. Legacy clients omit it.
     group_id: z.string().regex(/^[A-Za-z0-9_-]{6,64}$/).optional(),
-    // F-818 (spec F-804): per-run override of the manifest's agent.version —
-    // an opaque user-declared label stamped onto the session/run rows (F-820).
+    // Per the manifest format spec: per-run override of the manifest's agent.version —
+    // an opaque user-declared label stamped onto the session/run rows.
     // Absent = the agent's registered version. Additive; older clients omit it
     // and an older cloud strips it.
     agent_version: z.string().optional(),
@@ -83,7 +83,7 @@ const createSessionRequestObjectSchema = z
     { message: "Provide exactly one of task_source or task_id (scenario_source / scenario_id are accepted 0.3.0 aliases)" }
   );
 
-// Tolerant reader (FDRS-653): accepts both vocabularies, normalizes to task_*.
+// Tolerant reader: accepts both vocabularies, normalizes to task_*.
 export const createSessionRequestSchema = z.preprocess(
   normalizeTaskVocabKeys,
   createSessionRequestObjectSchema,
@@ -139,7 +139,7 @@ function normalizeCreateSessionResponse(value: unknown): unknown {
 // CLI release. `session_token` is the public token used in URLs — same value as
 // `session_id` in V1, but named separately so URL-shaped consumers stop reading
 // internal-id-shaped fields. Both `session_token` and `per_twin` reconciled
-// from pome-cloud /v1 wire truth (FDRS-613).
+// from pome-cloud /v1 wire truth.
 export const createSessionResponseSchema = z.preprocess(normalizeCreateSessionResponse, z.object({
   session_id: z.string(),
   session_token: z.string(),                   // = session_id in V1; public URL token
@@ -221,7 +221,7 @@ export const perTwinStateKeysSchema = z.record(
 );
 export type PerTwinStateKeys = z.infer<typeof perTwinStateKeysSchema>;
 
-// W3 vocab (FDRS-653): `task_name` / `task_hash` canonical; the exported
+// Task vocab: `task_name` / `task_hash` canonical; the exported
 // schema accepts 0.3.0 CLIs' `scenario_name` / `scenario_hash` and criterion
 // kinds D/P inside `criteria_results`, normalizing both.
 const submitResultRequestObjectSchema = z.object({
@@ -243,9 +243,9 @@ const submitResultRequestObjectSchema = z.object({
   lanes: z.array(laneSchema).default([]),
   steps: z.array(stepSchema).default([]),
   fix_prompt: z.string().nullable().default(null),
-  // FDRS-357 (adopted from pome-cloud, FDRS-613): storage key (NOT URL) returned
+  // Adopted from pome-cloud: storage key (NOT URL) returned
   // by POST /v1/sessions/:id/result-upload-url. Null on upload failure
-  // (best-effort), --no-upload opt-out, or pre-FDRS-357 CLI.
+  // (best-effort), --no-upload opt-out, or a CLI that predates the key.
   events_jsonl_url: z.string().nullable().default(null),
   // Trace blobs — safe to upload (HTTP between agent and twin, not LLM prompts):
   trace_jsonl_b64: z.string(),
@@ -256,7 +256,7 @@ const submitResultRequestObjectSchema = z.object({
   // locally for the [model] judge then discards it.
 });
 
-// Tolerant reader (FDRS-653): accepts both vocabularies, normalizes to task_*.
+// Tolerant reader: accepts both vocabularies, normalizes to task_*.
 export const submitResultRequestSchema = z.preprocess(
   normalizeTaskVocabKeys,
   submitResultRequestObjectSchema,
@@ -279,7 +279,7 @@ export type CreateEvalSessionResponse = z.infer<typeof createEvalSessionResponse
 export const criterionDefSchema = z.object({
   id: z.string().min(1),
   text: z.string().min(1),
-  // Tolerant reader (F-778): released CLIs still send the legacy "D"/"P"
+  // Tolerant reader: released CLIs still send the legacy "D"/"P"
   // spellings; parsed output is always the canonical "code"/"model". Single
   // source of truth for the rename is LEGACY_CRITERION_KIND_MAP.
   kind: z
@@ -291,7 +291,7 @@ export const criterionDefSchema = z.object({
   // attributes to. Absent = the session's primary twin (twins[0]). Additive —
   // single-twin tasks omit it and score against the sole twin as before.
   twin: z.string().min(1).optional(),
-  // F-1296 (pome-cloud) / F-1299 — forwards the markdown `always-scored`
+  // Forwards the markdown `always-scored`
   // keyword so the cloud's seed-exclusion rule
   // (docs/grading/seed-exclusion.md, pome-cloud) knows this [code] criterion
   // must be graded even when the seed already satisfies it. snake_case to
@@ -304,7 +304,7 @@ export const criterionDefSchema = z.object({
   always_scored: z.boolean().optional(),
 });
 export type CriterionDef = z.infer<typeof criterionDefSchema>;
-// Writer-side shape of the finalize wire during the F-778 compat window: a
+// Writer-side shape of the finalize wire during the criterion-kind compat window: a
 // producer may still send the legacy "D"/"P" spellings (released CLIs do);
 // readers always see the canonical CriterionDef after parse.
 export type CriterionDefInput = z.input<typeof criterionDefSchema>;
@@ -313,7 +313,7 @@ export type CriterionDefInput = z.input<typeof criterionDefSchema>;
 // canonical for the slug; the CLI persists whatever id/slug it returns.
 export const createAgentRequestSchema = z.object({
   name: z.string().min(1),
-  // Manifest identity (F-818, spec F-804): human-ish slug input — the server
+  // Manifest identity (per the format spec): human-ish slug input — the server
   // derives the canonical kebab slug with the same deriveAgentSlug exported
   // from `./manifest.js`, then validates it against SLUG_RE. Cap mirrors the
   // control-plane edge; shape is deliberately NOT enforced here.
@@ -322,7 +322,7 @@ export const createAgentRequestSchema = z.object({
   // User-declared version label from the manifest's agent.version — an opaque
   // string, never auto-bumped, never semver-interpreted.
   version: z.string().optional(),
-  // Open enum by design (F-804): unknown frameworks get a did-you-mean warning
+  // Open enum by design: unknown frameworks get a did-you-mean warning
   // server-side, never a validation error.
   framework: z.string().min(1).optional(),
   // Multi-twin (M3): the twins this agent is allowed to exercise. Absent = the
@@ -339,18 +339,18 @@ export const agentResponseSchema = z.object({
   slug: z.string(),
   display_name: z.string(),
   judge_model: z.string(),
-  // Manifest identity (F-818): registered agent.framework / agent.description /
-  // agent.version, nullable where the server has nothing stored (F-1213:
-  // unset, never a guessed default). Optional for the pre-F-820 cloud, which
+  // Manifest identity: registered agent.framework / agent.description /
+  // agent.version, nullable where the server has nothing stored (unset,
+  // never a guessed default). Optional for a cloud that predates the resolver, which
   // omits them.
   framework: z.string().nullable().optional(),
   description: z.string().nullable().optional(),
   version: z.string().nullable().optional(),
-  // F-818 resolver semantics: true when POST /v1/agents auto-registered a new
+  // Resolver semantics: true when POST /v1/agents auto-registered a new
   // agent for this slug, false when it resolved an existing one. Optional for
-  // the pre-F-820 cloud; absence means "unknown", not "resolved".
+  // a cloud that predates the resolver; absence means "unknown", not "resolved".
   created: z.boolean().optional(),
-  // F-861 slug-rename hint (cloud-emitted since v0.4.18): how the resolver
+  // Slug-rename hint (cloud-emitted since v0.4.18): how the resolver
   // matched this slug. Known values today are "slug" (live match), "alias" (an
   // old slug that was renamed; the returned `slug` is the new canonical), and
   // "created" (fresh auto-register) — the CLI surfaces a rename notice only on
@@ -397,7 +397,7 @@ export const stateUploadUrlResponseSchema = z.object({
 export type StateUploadUrlResponse = z.infer<typeof stateUploadUrlResponseSchema>;
 
 // GET /v1/usage — live concurrent-session quota snapshot.
-// FDRS-613: `sessions_remaining` tightened to `.int().min(0)` to match the
+// `sessions_remaining` tightened to `.int().min(0)` to match the
 // pome-cloud /v1 wire truth (cloud clamps remaining at 0 rather than exposing
 // negative overage on this live snapshot).
 export const usageResponseSchema = z.object({

--- a/cli/src/contract/run.ts
+++ b/cli/src/contract/run.ts
@@ -9,7 +9,7 @@
  *   - dashboard `/runs/:id` — renders lane-timeline + state-inspector + handoff card
  *
  * Lane/Step are flat parallel arrays on Run (not nested), aligning with the
- * `runs.lanes jsonb` + `runs.steps jsonb` two-column DB shape from FDRS-327.
+ * `runs.lanes jsonb` + `runs.steps jsonb` two-column DB shape.
  * Cross-reference: `Lane.step_id` → `Step.id`; `Lane.request_ids[]` →
  * `RecorderEvent.request_id`.
  */
@@ -25,7 +25,7 @@ export const judgeModelSchema = z.string().min(1);
 export type JudgeModel = z.infer<typeof judgeModelSchema>;
 
 // Which server-side correlator produced a run's lanes/steps. Reconciled from
-// pome-cloud /v1 (FDRS-613): OTEL M4/M6 clients distinguish heuristic legacy
+// pome-cloud /v1: OTEL M4/M6 clients distinguish heuristic legacy
 // timelines from exact span-context timelines.
 export const correlatorKindSchema = z.enum([
   "heuristic",
@@ -34,7 +34,7 @@ export const correlatorKindSchema = z.enum([
 ]);
 export type CorrelatorKind = z.infer<typeof correlatorKindSchema>;
 
-// Criterion kind — W3 vocab (FDRS-653): `code` = deterministic/code-checked
+// Criterion kind: `code` = deterministic/code-checked
 // predicate (formerly `D`), `model` = LLM-judged (formerly `P`). The canonical
 // enum is `code | model`; the INPUT schema below additionally accepts the
 // 0.3.0-era `D` / `P` spellings and normalizes them at parse time (tolerant
@@ -124,7 +124,7 @@ export const laneSchema = z.object({
 });
 export type Lane = z.infer<typeof laneSchema>;
 
-// Canonical Run row. W3 vocab (FDRS-653): `task_name` / `task_hash` /
+// Canonical Run row. Task vocab: `task_name` / `task_hash` /
 // `promoted_task_id` are the canonical wire keys (cloud DB: `tasks` table,
 // `runs.task_name`). The exported `runSchema` below wraps this object in the
 // tolerant-reader preprocess so 0.3.0-era rows carrying `scenario_name` /
@@ -137,7 +137,7 @@ const runObjectSchema = z.object({
   task_hash: z.string(),                       // sha256 of source markdown; 0.3.0 alias: scenario_hash
   satisfaction_score: z.number().int().min(0).max(100),  // CLI-computed (BYOK Flavor #1)
   criteria_results: z.array(criterionResultSchema),
-  trace_s3_key: z.string().nullable(),         // s3 key for events.jsonl (hosted only; F-689 deleted tool_calls.jsonl)
+  trace_s3_key: z.string().nullable(),         // s3 key for events.jsonl (hosted only)
   state_s3_key: z.string().nullable(),         // s3 key for state_final.json
   meta_s3_key: z.string().nullable(),
   duration_ms: z.number().int(),
@@ -145,7 +145,7 @@ const runObjectSchema = z.object({
   judge_model: judgeModelSchema,               // which model judged [model] criteria (free-form)
   judge_tokens_in: z.number().int().min(0).nullable(),
   judge_tokens_out: z.number().int().min(0).nullable(),
-  // ── FDRS-613: reconciled from pome-cloud /v1 wire truth (all additive with
+  // ── Reconciled from pome-cloud /v1 wire truth (all additive with
   // defaults so pre-existing Run constructors stay valid) ────────────────────
   // Sim deep-telemetry — per-run agent telemetry rollup, computed at finalize
   // from the agent's independently-correlated `gen_ai` span tree. Null = no
@@ -159,12 +159,12 @@ const runObjectSchema = z.object({
   agent_telemetry_span_count: z.number().int().min(0).nullable().default(null),
   // Which server-side correlator produced lanes/steps.
   correlator_kind: correlatorKindSchema.default("heuristic"),
-  // M0.2 (FDRS-509) — which surface this run belongs to. 'simulation' =
+  // M0.2 — which surface this run belongs to. 'simulation' =
   // CLI/staging scenario run (default for every legacy row); 'production' = an
   // ingested OTLP production trace (M2).
   environment: z.enum(["production", "simulation"]).default("simulation"),
-  // M0.5 (FDRS-512) — replay loop linkage (prod-run → task → replay-run).
-  // W3 vocab: canonical key; 0.3.0 alias: promoted_scenario_id.
+  // M0.5 — replay loop linkage (prod-run → task → replay-run).
+  // Canonical key; 0.3.0 alias: promoted_scenario_id.
   promoted_task_id: z.string().nullable().default(null),
   replay_run_id: z.string().nullable().default(null),
   // Storage key for the tar-and-upload state archive the replay engine seeds a
@@ -180,7 +180,7 @@ const runObjectSchema = z.object({
   // LLM endpoint failure, or legacy pre-M4-1 runs.
   fix_prompt: z.string().nullable().default(null),
   // Storage KEY (path) of the raw events.jsonl blob — NOT a URL (dashboard mints
-  // a signed GET URL on read). FDRS-613: relaxed from `.url()` to match the
+  // a signed GET URL on read). Relaxed from `.url()` to match the
   // pome-cloud shape, since persisted storage keys are not URLs. Null in
   // self-host mode, on upload failure, --no-upload opt-out, or legacy runs.
   events_jsonl_url: z.string().nullable().default(null),
@@ -188,7 +188,7 @@ const runObjectSchema = z.object({
   finished_at: z.string().datetime().nullable(),
 });
 
-// Tolerant reader (FDRS-653): accepts both the 0.3.0 `scenario_*` and the
+// Tolerant reader: accepts both the 0.3.0 `scenario_*` and the
 // canonical `task_*` keys and normalizes to the new vocabulary. When both are
 // present, the canonical key wins. The parsed output carries `task_*` only.
 export const runSchema = z.preprocess(normalizeTaskVocabKeys, runObjectSchema);

--- a/cli/src/contract/seed-state.ts
+++ b/cli/src/contract/seed-state.ts
@@ -12,7 +12,7 @@ import { z } from "zod";
 // Future twins (Linear, Slack) will add their own seed shapes; we union those
 // in here as the family grows.
 //
-// FDRS-653 (ported from pome-cloud): this schema used to model only the
+// Ported from pome-cloud: this schema used to model only the
 // issue-triage subset (repositories[].{issues,labels,collaborators}). Anywhere
 // it is used as a narrowing boundary, a field MISSING here is silently
 // zod-stripped before it reaches the twin pod's own parseSeed — which is
@@ -182,7 +182,7 @@ export const slackSeedStateSchema = z.object({
       })
     )
     .default([]),
-  // F-1509. Mirrors `seedSchema.files` in `@pome-sh/twin-slack`. `user` and
+  // Same shape as `seedSchema.files` in `@pome-sh/twin-slack`. `user` and
   // `channels` are seed HANDLES (a user/channel `name`) or ids.
   files: z
     .array(

--- a/cli/src/contract/sessions.ts
+++ b/cli/src/contract/sessions.ts
@@ -15,7 +15,7 @@ import { z } from "zod";
 // and reachable through the multi-twin runtime. Distinct from `KNOWN_TWIN_IDS`
 // (re-exported from `./recorder-events.ts`) which serves dashboard-rendering
 // pattern-matching for arbitrary `RecorderEvent.twin` values. Mirrored from
-// pome-cloud shared-types (FDRS-613).
+// pome-cloud shared-types.
 export const MOUNTED_TWINS = ["github", "stripe", "slack", "gmail", "linear"] as const;
 
 export const sessionStateSchema = z.enum([
@@ -31,7 +31,7 @@ export type SessionState = z.infer<typeof sessionStateSchema>;
 // Internal DB row shape — includes pod_id and api_key_id which are NOT exposed publicly.
 //
 // Multi-twin (M3): `twins[]` is the new authoritative field. `twin_type` is kept
-// populated as legacy = `twins[0]` for ≥1 OSS CLI release. FDRS-613: `twins`
+// populated as legacy = `twins[0]` for ≥1 OSS CLI release. `twins`
 // adopted from pome-cloud so a cloud-issued Session / SessionPublic parses here.
 export const sessionSchema = z.object({
   id: z.string(),                              // ses_<nanoid>

--- a/cli/src/contract/task-vocab.ts
+++ b/cli/src/contract/task-vocab.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 /**
- * task-vocab — the W3 "scenario → task" wire-vocabulary rename (FDRS-653).
+ * task-vocab — the "scenario → task" wire-vocabulary rename.
  *
- * W3 decision (binding, 2026-06): everything "scenario" becomes "task" on the
+ * The rename (binding, 2026-06): everything "scenario" becomes "task" on the
  * wire, and criterion kinds `D` / `P` become `code` / `model`. The cloud DB is
  * already renamed (`tasks` table, `runs.task_name`); this module gives the
  * shared trace format the same vocabulary WITHOUT breaking 0.3.0-era artifacts.
@@ -15,7 +15,7 @@
  *     vocabulary at parse time. Nothing a 0.3.0-era artifact contains becomes
  *     invalid: shipped CLIs vendor shared-types 0.3.0 and keep sending
  *     `scenario_*` keys and `D` / `P` criterion kinds for at least one more
- *     release train (the CLI vendored-tarball bump rides FDRS-654/657).
+ *     release train (the CLI vendored-tarball bump swaps the consumers).
  *   - When BOTH keys are present, the new key wins (a 0.5.0-aware writer is
  *     more authoritative about the canonical field than a mirrored legacy key).
  *
@@ -80,9 +80,9 @@ export function normalizeTaskVocabKeys(value: unknown): unknown {
 }
 
 /**
- * Legacy criterion kind → canonical criterion kind (W3: D→code, P→model).
+ * Legacy criterion kind → canonical criterion kind (D→code, P→model).
  *
- * SANCTIONED EXCEPTION (F-778). The full D/P→code/model migration removed the
+ * SANCTIONED EXCEPTION. The full D/P→code/model migration removed the
  * legacy spelling everywhere — including the markdown authoring marker, which
  * is now `[code]` / `[model]` — EXCEPT this read-only shim. It exists because:
  *   - 0.3.0-era persisted artifacts (run rows, `criteria_results` jsonb) carry

--- a/cli/src/contract/task.ts
+++ b/cli/src/contract/task.ts
@@ -13,16 +13,15 @@ import { seedStateSchema } from "./seed-state.js";
 // 3. TASKS (formerly "scenarios") — originally adopted verbatim from
 //    oslo/pome/src/scenario/scenarioSchema.ts
 //
-// W3 vocab (FDRS-653): "task" is the canonical name; the `scenario*` exports
-// below are deprecated aliases kept for the 0.3.0 window (FDRS-654 swaps the
-// consumers).
+// Task vocab: "task" is the canonical name; the `scenario*` exports
+// below are deprecated aliases kept for the 0.3.0 window.
 //
 // `criterionSchema` and `judgeModelSchema` were moved to `./run.ts` (2026-05-11
 // split) because CriterionResult depends on them; imported here from `./run.js`
 // and re-exported to consumers via the index.ts barrel.
 // ─────────────────────────────────────────────────────────────────────────────
 
-// F-1302 — which POPULATION a task belongs to, declared in its `## Config`
+// Which POPULATION a task belongs to, declared in its `## Config`
 // block. Three values, and the line between the first and the other two is what
 // the field exists for:
 //
@@ -51,7 +50,7 @@ export type TaskClass = z.infer<typeof taskClassSchema>;
 
 export const taskConfigSchema = z.object({
   twins: z.array(z.string()).default(["github"]),
-  class: taskClassSchema.optional(),                        // F-1302 — conformance vs the exam half
+  class: taskClassSchema.optional(),                        // conformance vs the exam half
   timeout: z.number().int().positive().default(60),         // seconds
   runs: z.number().int().positive().default(1),
   passThreshold: z.number().min(0).max(100).default(100),
@@ -59,13 +58,13 @@ export const taskConfigSchema = z.object({
 });
 export type TaskConfig = z.infer<typeof taskConfigSchema>;
 
-/** @deprecated FDRS-653 — use `taskConfigSchema`. Removed after the 0.3.0 window. */
+/** @deprecated Use `taskConfigSchema`. Removed after the 0.3.0 window. */
 export const scenarioConfigSchema = taskConfigSchema;
-/** @deprecated FDRS-653 — use `TaskConfig`. */
+/** @deprecated Use `TaskConfig`. */
 export type ScenarioConfig = TaskConfig;
 
 // The parsed task (formerly "scenario") markdown shape. Criterion kinds inside
-// `criteria` normalize D→code, P→model (tolerant reader, FDRS-653).
+// `criteria` normalize D→code, P→model (tolerant reader).
 export const taskSchema = z.object({
   slug: z.string().min(1),
   title: z.string().min(1),
@@ -78,14 +77,14 @@ export const taskSchema = z.object({
 });
 export type Task = z.infer<typeof taskSchema>;
 
-/** @deprecated FDRS-653 — use `taskSchema`. Removed after the 0.3.0 window. */
+/** @deprecated Use `taskSchema`. Removed after the 0.3.0 window. */
 export const scenarioSchema = taskSchema;
-/** @deprecated FDRS-653 — use `Task`. */
+/** @deprecated Use `Task`. */
 export type Scenario = Task;
 
 // Persisted Task row (dashboard upload path; cloud DB `tasks` table). Per
 // 04-data-model.md. Row ids keep the historical `scn_` prefix (persisted data;
-// renaming ids is a data migration, deliberately NOT part of FDRS-653).
+// renaming ids is a data migration, deliberately out of scope for the rename).
 export const persistedTaskSchema = z.object({
   id: z.string(),                              // scn_<nanoid>
   team_id: z.string(),
@@ -98,7 +97,7 @@ export const persistedTaskSchema = z.object({
 });
 export type PersistedTask = z.infer<typeof persistedTaskSchema>;
 
-/** @deprecated FDRS-653 — use `persistedTaskSchema`. Removed after the 0.3.0 window. */
+/** @deprecated Use `persistedTaskSchema`. Removed after the 0.3.0 window. */
 export const persistedScenarioSchema = persistedTaskSchema;
-/** @deprecated FDRS-653 — use `PersistedTask`. */
+/** @deprecated Use `PersistedTask`. */
 export type PersistedScenario = PersistedTask;

--- a/cli/src/demo/agent.ts
+++ b/cli/src/demo/agent.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// FDRS-643 — the bundled demo agent: a small tool-loop agent that drives the
+// The bundled demo agent: a small tool-loop agent that drives the
 // packaged first-run demo task against the LOCAL GitHub twin, with its model
-// calls served by pome's anonymous demo gateway (FDRS-637).
+// calls served by pome's anonymous demo gateway.
 //
 // It is spawned by `pome demo` as `pome demo-agent`, a child of the REAL
 // capture path (runTask): the runner injects the standard POME_* twin

--- a/cli/src/demo/capacity.ts
+++ b/cli/src/demo/capacity.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// FDRS-643 / FDRS-662 — honest at-capacity states for the anonymous demo.
+// Honest at-capacity states for the anonymous demo.
 //
 // The demo's cloud surface returns machine-readable 402/429 errors at three
 // choke points (mint, model-call gateway, finalize/judge). Each maps to an

--- a/cli/src/demo/gateway.ts
+++ b/cli/src/demo/gateway.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// FDRS-643 — client for the anonymous demo model-call gateway (FDRS-637):
+// Client for the anonymous demo model-call gateway:
 // POST {POME_API_BASE}/v1/demo/sessions/:id/llm, Authorization: Bearer
 // <demo_token>.
 //

--- a/cli/src/demo/ids.ts
+++ b/cli/src/demo/ids.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// FDRS-643 — trial-group identity for `pome demo`.
+// Trial-group identity for `pome demo`.
 //
 // One `grp_` + nanoid21 id per demo invocation, shared by all k=5 demo
 // sessions (mint body `group_id`), copied by the cloud onto

--- a/cli/src/demo/mint.ts
+++ b/cli/src/demo/mint.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// FDRS-643 — anonymous demo session minting.
+// Anonymous demo session minting.
 //
 // POST {POME_API_BASE}/v1/demo/sessions with
 //   { task_name: "first-run-demo", task_hash: "", group_id: "grp_…" }

--- a/cli/src/demo/proxyRequest.ts
+++ b/cli/src/demo/proxyRequest.ts
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
-// FDRS-643 — proxy-aware JSON POST for the bundled demo agent.
+// Proxy-aware JSON POST for the bundled demo agent.
 //
-// The demo agent is spawned through the real capture path (FDRS-399): the
+// The demo agent is spawned through the real capture path: the
 // runner injects HTTP(S)_PROXY pointing at the capture-server, whose CONNECT
 // tunnels become the LlmCallEvent rows in events.jsonl and whose
-// deny-by-default egress floor (FDRS-635) is the prod-safety control. Node's
+// deny-by-default egress floor is the prod-safety control. Node's
 // global fetch does NOT honor proxy env vars, so an agent that used bare
 // fetch for its gateway calls would silently bypass both — no trace row, no
 // floor. This helper restores the contract without adding a dependency:
@@ -185,7 +185,7 @@ function connectTunnel(
       if (headerEnd === -1) return;
       sock.off("data", onData);
       if (!/^HTTP\/1\.[01] 200/.test(buf)) {
-        // FDRS-635 — a refused CONNECT (egress floor) surfaces as its 403
+        // A refused CONNECT (egress floor) surfaces as its 403
         // status line, so the caller can say WHY the call failed.
         fail(new Error(`CONNECT ${targetHost}:${targetPort} refused: ${buf.split("\r\n")[0]}`));
         return;

--- a/cli/src/demo/render.ts
+++ b/cli/src/demo/render.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// FDRS-643 — pure terminal rendering for `pome demo`, matching the
+// Pure terminal rendering for `pome demo`, matching the
 // design-of-record (CLI moments.dc.html moment 01, task/code-model
 // vocabulary):
 //

--- a/cli/src/demo/runDemo.ts
+++ b/cli/src/demo/runDemo.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// FDRS-643 — `pome demo` orchestration: zero-auth cold start.
+// `pome demo` orchestration: zero-auth cold start.
 //
 // Flow per the 2026-07-05 [DECISION] set:
 //   1. Reassurance frame first.
@@ -11,10 +11,10 @@
 //      POST /finalize (explicit 60s timeout) — the terminal verdict comes
 //      from that cloud evaluation. The CLI never scores locally.
 //   4. Errored trials are excluded from the verdict fraction; at-capacity
-//      402/429s render as honest labeled states (FDRS-662), never stack
+//      402/429s render as honest labeled states, never stack
 //      traces, never fabricated completions. Any trial that errors after its
 //      session was minted best-effort ABANDONS that session with a machine
-//      error_code before the CLI exits (F-710 / F-664 decision 3), so the
+//      error_code before the CLI exits, so the
 //      share view flips the slot to errored immediately instead of waiting
 //      out the staleness window; a capacity abort also abandons the
 //      minted-but-never-run remainder.
@@ -173,7 +173,7 @@ export async function runDemo(options: RunDemoOptions): Promise<RunDemoResult> {
     const progress = { finalized: false };
 
     let verdict: TrialVerdict;
-    // F-710 — the machine error_code the abandon carries when this trial's
+    // The machine error_code the abandon carries when this trial's
     // error also aborts the whole demo (capacity); the never-run remainder
     // below reuses it so every orphaned slot names the same cause.
     let abortCode: string | null = null;
@@ -207,8 +207,8 @@ export async function runDemo(options: RunDemoOptions): Promise<RunDemoResult> {
           reason: shortReason(err instanceof Error ? err.message : String(err)),
         };
       }
-      // F-710 — flip the errored slot on the share view NOW instead of
-      // waiting out the staleness window (F-664 decision 3). Never after a
+      // Flip the errored slot on the share view NOW instead of
+      // waiting out the staleness window. Never after a
       // successful finalize: a judged run row must not race an abandon.
       if (!progress.finalized) {
         await abandonQuietly(client, session.session_id, abortCode ?? "trial_crashed");
@@ -219,7 +219,7 @@ export async function runDemo(options: RunDemoOptions): Promise<RunDemoResult> {
     out(trialLine(trialNumber, verdict));
 
     if (capacityAbort) {
-      // F-710 — the abort orphans every minted-but-never-run session; abandon
+      // The abort orphans every minted-but-never-run session; abandon
       // each with the same capacity code so the share view settles honestly
       // instead of showing "running" ghosts for the staleness window.
       for (let j = i + 1; j < trials; j += 1) {
@@ -264,7 +264,7 @@ interface RunOneTrialInput {
   captureServerCommand?: RunTaskOptions["captureServerCommand"];
   out: (line: string) => void;
   collectedFailures: string[];
-  /** F-710 — set once finalize succeeds, so the caller's error handling
+  /** Set once finalize succeeds, so the caller's error handling
    *  never abandons a session that already has a judged run row. */
   progress: { finalized: boolean };
 }
@@ -360,11 +360,11 @@ async function runOneTrial(input: RunOneTrialInput): Promise<TrialVerdict> {
   return { kind: "errored", reason: "cloud could not evaluate the trace" };
 }
 
-/** F-710 — best-effort session abandon on a trial error path: flips the
- *  share-view slot to errored with a machine error_code immediately (F-664
- *  decision 3). SILENT by contract — a network failure or non-200 must change
+/** Best-effort session abandon on a trial error path: flips the
+ *  share-view slot to errored with a machine error_code immediately.
+ *  SILENT by contract — a network failure or non-200 must change
  *  neither the CLI's exit code nor its terminal output; server-side staleness
- *  (F-664 decision 1) remains the fallback. */
+ *  remains the fallback. */
 async function abandonQuietly(
   client: DemoTrialClient,
   sessionId: string,

--- a/cli/src/demo/task.ts
+++ b/cli/src/demo/task.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// FDRS-643 — the packaged first-run demo task.
+// The packaged first-run demo task.
 //
 // `assets/demo/first-run-demo.md` (+ its hand-written seed sidecar) is the
 // CANONICAL demo task content. The cloud's server-owned judge definition

--- a/cli/src/doctor/checks.ts
+++ b/cli/src/doctor/checks.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// FDRS-634 — the doctor check engine: config → twin → routing → egress, in
+// The doctor check engine: config → twin → routing → egress, in
 // order, stopping at the first failure so the report carries exactly ONE
 // named cause and one concrete fix. "Never a false success": a wall of
 // maybes hides the next step; one cause names it.
 //
 // The engine is deliberately separate from the `pome doctor` command so
-// `pome run` can reuse it as a preflight gate (FDRS-641). Checks are written
+// `pome run` can reuse it as a preflight gate. Checks are written
 // against the generic twin surface (bootTwin / the sdk's `/_pome/health`
 // route contract) — twin internals are the architecture refactor's
 // construction zone and stay untouched.
@@ -41,7 +41,7 @@ export interface RunDoctorChecksOptions {
   // (floor wildcard) — NOT forwarded to any agent.
   env?: Record<string, string | undefined>;
   // "full" (default, `pome doctor` + local-run gate) boots the local twin.
-  // "hosted" (the hosted-run gate, FDRS-641) skips the local twin boot: a
+  // "hosted" (the hosted-run gate) skips the local twin boot: a
   // hosted run never touches it — the cloud provisions the session twin —
   // so booting a throwaway node:sqlite-backed twin here would gate the run
   // on machinery it never uses. Config/routing/egress still gate.
@@ -180,7 +180,7 @@ async function checkTwinReachable(_configDir: string): Promise<DoctorCheck> {
 
     // "boots locally", not "reachable": this check brings a throwaway twin up
     // on an ephemeral port and tears it down — it does NOT prove a twin is
-    // listening now. Overstating that (the F-906 cold walk read "reachable" as
+    // listening now. Overstating that (a cold walk read "reachable" as
     // "a twin is up") is exactly what this wording avoids.
     return {
       id: "twin",

--- a/cli/src/doctor/render.ts
+++ b/cli/src/doctor/render.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// FDRS-634 — terminal rendering for the doctor report, per
+// Terminal rendering for the doctor report, per
 // `CLI moments.dc.html` moment 03: one line per executed check, then (on
 // failure) exactly one cause/fix card and the two closing warning lines.
 // Plain text, no color deps — matches the rest of the CLI's output.
@@ -13,13 +13,13 @@ const CONTINUATION = " ".repeat(FIX_COLUMN.length);
 export interface RenderDoctorReportOptions {
   /** First line of the report. `pome doctor` and the run gate keep the
    *  moment-03 default; `pome install` passes moment 02's
-   *  "verifying the wiring …" (FDRS-642). */
+   *  "verifying the wiring …". */
   header?: string;
-  /** F-906 — when the report passes, append a caveat that a green check means
+  /** When the report passes, append a caveat that a green check means
    *  the wiring is right, not that the examinee runs cleanly. `pome doctor`
    *  never launches the agent; and a `pome run` preflight probe launches it
    *  with POME_PREFLIGHT=1, which most scaffolds honour by exiting before
-   *  their real work path — so a bug on that skipped path (as in F-900)
+   *  their real work path — so a bug on that skipped path
    *  surfaces only on a full trial run. Opt-in so only `pome doctor` shows it
    *  — the `run`/`install` consumers print the report as a gate, not as a
    *  self-diagnosis. */

--- a/cli/src/doctor/scan.ts
+++ b/cli/src/doctor/scan.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// FDRS-634 — static routing scan: the named-cause half of doctor's routing
+// Static routing scan: the named-cause half of doctor's routing
 // check.
 //
 // Finds hardcoded production API hosts (file:line) that would bypass the

--- a/cli/src/fix-prompt/index.ts
+++ b/cli/src/fix-prompt/index.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// `pome fix-prompt` — assemble a paste-into-IDE remediation prompt for a run
-// (FDRS-657). CAPTURE-ONLY: no LLM/judge call happens here. The former BYOK
+// `pome fix-prompt` — assemble a paste-into-IDE remediation prompt for a
+// run. CAPTURE-ONLY: no LLM/judge call happens here. The former BYOK
 // CLI-side judge call (`callJudge`) that generated the handoff was removed;
 // this now returns the fully-assembled prompt (system instructions + the
 // task's criteria + the captured trace) for the developer to paste into
@@ -29,7 +29,7 @@ export function buildFixPrompt(ctx: FixPromptContext): string {
 }
 
 /**
- * FDRS-644 — run-set mode: ONE prompt for a whole trial group, from the
+ * Run-set mode: ONE prompt for a whole trial group, from the
  * persisted cloud verdicts (grouped failure signatures) + raw traces.
  * Still PURE: no network, no LLM, no local judging — the verdicts were the
  * cloud's, cached at run time.

--- a/cli/src/fix-prompt/prompt.ts
+++ b/cli/src/fix-prompt/prompt.ts
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Assembles the paste-into-IDE fix prompt for a failed run (FDRS-657).
+// Assembles the paste-into-IDE fix prompt for a failed run.
 //
 // CAPTURE-ONLY: the OSS CLI does NOT call an LLM here. `pome fix-prompt`
 // assembles a self-contained prompt — system instructions + the task's
 // criteria + the raw captured trace — and prints it so the developer can paste
 // it into THEIR own coding assistant (Cursor / Claude Code). The former BYOK
 // local-judge call that generated the handoff CLI-side was removed under
-// FDRS-657 (no local LLM/judge anywhere in the OSS CLI). This module was also
+// No local LLM/judge anywhere in the OSS CLI. This module was also
 // relocated out of the deleted `src/evaluator/` tree.
 
 import { readFileSync } from "node:fs";
@@ -122,7 +122,7 @@ ${escapeTagContent(trace)}
 </agent-trace>`;
 }
 
-// ── FDRS-644: run-set mode ──────────────────────────────────────────────
+// ── Run-set mode ───────────────────────────────────────────────────────
 //
 // One prompt for a whole trial group, built from persisted CLOUD verdicts
 // (verdict.json — provenance-labeled /finalize payloads, still no local
@@ -157,7 +157,7 @@ function failedResults(verdict: VerdictArtifact): CriterionResult[] {
   return verdict.criteria_results.filter((r) => outcomeOf(r) === "failed");
 }
 
-/** F-1404 — a trial whose grading FINISHED: the only kind whose pass/fail
+/** A trial whose grading FINISHED: the only kind whose pass/fail
  *  this prompt may count. A trial's `state` is `"incomplete"` whenever the
  *  grader never reached some criterion (`scoreStatus`'s A5 guard), and such a
  *  trial is neither a pass nor a failure — it belongs in no numerator and no
@@ -199,7 +199,7 @@ function flattenLine(text: string, max = 300): string {
  *  outcome to actually be `passed` — skipped/errored are named as such,
  *  never counted as passes.
  *
- *  F-1392 — a criterion the seed already satisfied is `skipped` on the wire
+ *  A criterion the seed already satisfied is `skipped` on the wire
  *  and used to land in "not uniformly evaluated", which sends the reader's
  *  coding agent hunting for a grader gap that does not exist. It is its own
  *  class here, for the same reason it is its own count in `Score`: the grader
@@ -213,11 +213,11 @@ function renderGroupedSignatures(trials: TrialFixInput[]): string {
   >();
   // Criterion text → the set of outcome classes seen for it. "excluded" is a
   // class here and not in `outcomeOf` (the per-criterion marker stays `-`,
-  // F-1392's trap): this map exists to decide which NOTE a criterion belongs
+  // the trap): this map exists to decide which NOTE a criterion belongs
   // under, and "the seed already satisfied it" is a different note from "the
   // grader never reached it".
   const outcomesSeen = new Map<string, Set<string>>();
-  // F-1404 — per-criterion denominator: how many trials actually GRADED this
+  // Per-criterion denominator: how many trials actually GRADED this
   // criterion (reached a pass or a fail on it). The old denominator was
   // `trials.length`, which counted trials that never graded the criterion at
   // all — and once a set may hold an INCOMPLETE trial, a criterion can be
@@ -300,7 +300,7 @@ function renderGroupedSignatures(trials: TrialFixInput[]): string {
 /** The failing trial with the most failed criteria — the representative
  *  whose full trace anchors the prompt.
  *
- *  F-1404 — `state === "fail"`, not `!passed`: an INCOMPLETE trial is not a
+ *  `state === "fail"`, not `!passed`: an INCOMPLETE trial is not a
  *  failing one, and anchoring the prompt's one trace on it under the heading
  *  "the most-failing trial" asserted a failure the grading never reached. */
 export function representativeFailingTrial(
@@ -316,7 +316,7 @@ export function representativeFailingTrial(
 }
 
 export function buildGroupFixUserPrompt(ctx: GroupFixPromptContext): string {
-  // F-1404 — every fraction below is over GRADED trials only. An INCOMPLETE
+  // Every fraction below is over GRADED trials only. An INCOMPLETE
   // trial gets its own named section instead of being counted as a non-pass
   // in a denominator labelled "completed".
   const incomplete = ctx.trials.filter((t) => !isGraded(t));
@@ -393,7 +393,7 @@ ${escapeTagContent(trace)}
 ${escapeTagContent(redactSecrets(lines.join("\n")) as string)}`);
   }
 
-  // F-1404 — the gap, named, as the LAST thing the reading agent sees before
+  // The gap, named, as the LAST thing the reading agent sees before
   // it starts work. The prompt is allowed to be built over a set holding an
   // ungraded trial (a genuine failure alongside it, or a trial dir the user
   // pointed at directly); it is not allowed to let that trial read as

--- a/cli/src/hosted/client.ts
+++ b/cli/src/hosted/client.ts
@@ -86,7 +86,7 @@ export interface HostedClientConfig {
   finalizePollInitialDelayMs?: number;
   /** Maximum async-finalize polling delay. Defaults to 5s. */
   finalizePollMaxDelayMs?: number;
-  /** FDRS-643 — how the credential travels. "x-api-key" (default) is the
+  /** How the credential travels. "x-api-key" (default) is the
    *  team-key contract. "bearer" sends `Authorization: Bearer <apiKey>` for
    *  the session-token surface (upload-url/finalize accept a sid-scoped JWT
    *  via requireApiKeyOrSessionToken; `pome demo` authenticates each trial's
@@ -100,20 +100,20 @@ export interface CreateSessionInput {
   /** Omit for one-off sessions; reuse only when intentionally replaying a create after network uncertainty. */
   idempotencyKey?: string;
   /** Agents-as-first-class-entity (ADR-013). Resolved by callers from the
-   *  manifest slug via `.pome/link.json` / the `POST /v1/agents` resolver
-   *  (F-819). Server validates `agent.team_id === apiKey.team_id` and
+   *  manifest slug via `.pome/link.json` / the `POST /v1/agents` resolver.
+   *  Server validates `agent.team_id === apiKey.team_id` and
    *  `requested_twins ⊆ agent_enabled_services`. Optional during rollout;
    *  will become required once the dashboard / control-plane catch up. */
   agentId?: string;
-  /** F-818 (spec F-804): per-run agent version. The manifest's `agent.version`,
+  /** Per-run agent version. The manifest's `agent.version`,
    *  or the `--agent-version` override. Opaque, user-declared; stamped onto the
-   *  session/run rows (F-820). An older cloud strips it, so sending is safe. */
+   *  session/run rows. An older cloud strips it, so sending is safe. */
   agentVersion?: string;
   /** Pre-resolved seed JSON. When supplied, cloud uses it directly and skips
    *  extracting JSON from the scenario markdown — required for the post-2026-05-22
    *  prose `## Seed State` shape, where the markdown has no fenced JSON block. */
   seed?: unknown;
-  /** FDRS-636 — trial-group identity (`grp_` + nanoid21). `pome run -n k`
+  /** Trial-group identity (`grp_` + nanoid21). `pome run -n k`
    *  (k>1) stamps ONE shared id on every mint of the invocation; the cloud
    *  copies it onto `sessions.group_id` at mint and `runs.group_id` at
    *  finalize, and the reliability page reads the group by it.
@@ -124,7 +124,7 @@ export interface CreateSessionInput {
   groupId?: string;
 }
 
-/** FDRS-636 — POST /v1/sessions/:id/abandon response. `abandoned: false`
+/** POST /v1/sessions/:id/abandon response. `abandoned: false`
  *  means the session was already terminal and nothing was rewritten (the
  *  idempotent no-op branch); `state` echoes the row's current state. */
 export interface AbandonSessionResponse {
@@ -134,7 +134,7 @@ export interface AbandonSessionResponse {
   abandoned: boolean;
 }
 
-// FDRS-655/656 — `pome eval <run-dir>` capture/eval split. The cloud mints
+// `pome eval <run-dir>` capture/eval split. The cloud mints
 // a twin-less "eval session" scoped to an agent + task name; the existing
 // upload-url routes and /finalize then work unchanged on that session.
 export interface CreateEvalSessionInput {
@@ -162,21 +162,21 @@ export interface SubmitResultInput {
   judgeTokensIn: number | null;
   judgeTokensOut: number | null;
   // Free-form SDK / framework label persisted to runs.agent_sdk (pome-cloud
-  // ADR-013). CLI reads it from the manifest's `agent.framework` (F-819);
+  // ADR-013). CLI reads it from the manifest's `agent.framework`;
   // common values: "claude-agent-sdk", "openai-agents", "langgraph",
   // "custom". Omit / null when the user has not declared it — control-plane
   // accepts both shapes.
   agentSdk?: string | null;
-  // Correlator output (FDRS-326). Empty arrays when no adapter signals were
+  // Correlator output. Empty arrays when no adapter signals were
   // captured AND the heuristic correlator is unavailable.
   lanes: Lane[];
   steps: Step[];
-  // Wire field for a CLI-supplied fix prompt (FDRS-323). FDRS-657: the OSS CLI
+  // Wire field for a CLI-supplied fix prompt. The OSS CLI
   // is capture-only and never generates one CLI-side, so runners always submit
   // `null` here — the cloud owns the managed judge/fix-prompt handoff. Kept on
   // the finalize contract for compatibility.
   fixPrompt: string | null;
-  // FDRS-357: storage key returned by requestEventsUploadUrl, or null if the
+  // Storage key returned by requestEventsUploadUrl, or null if the
   // upload was skipped / failed. Cloud persists this into runs.events_jsonl_url.
   eventsJsonlUrl: string | null;
   traceJsonl: string;
@@ -233,7 +233,7 @@ export interface FinalizeInput {
   // Criterion *definitions* (not results). Cloud judges these against the
   // recorded trace/state and returns the authoritative score. Writer-side
   // input type (z.input, not z.infer): the CLI may send legacy "D"/"P" kinds
-  // during the F-778 compat window; cloud normalizes to "code"/"model" on
+  // during the criterion-kind compat window; cloud normalizes to "code"/"model" on
   // parse. z.input keeps this compiling against both the published 0.9.x
   // contract (D/P only) and the tolerant 0.10.0 reader.
   criteria: CriterionDefWire[];
@@ -273,9 +273,9 @@ export interface FinalizeOptions {
 
 export interface HostedClient {
   createSession(input: CreateSessionInput): Promise<CreateSessionResponse>;
-  /** FDRS-655/656 — POST /v1/eval-sessions. Mints a twin-less session for
+  /** POST /v1/eval-sessions. Mints a twin-less session for
    *  uploading + finalizing an EXISTING raw trace directory (`pome eval`).
-   *  Requires a control plane that ships the FDRS-655 route. */
+   *  Requires a control plane that ships the eval-sessions route. */
   createEvalSession(
     input: CreateEvalSessionInput,
   ): Promise<CreateEvalSessionResponse>;
@@ -298,7 +298,7 @@ export interface HostedClient {
     sessionId: string,
     input: SubmitResultInput,
   ): Promise<SubmitResultResponse>;
-  /** FDRS-636 — mark an errored trial's session failed NOW with a short
+  /** Mark an errored trial's session failed NOW with a short
    *  machine `error_code` (e.g. "agent_timeout"), instead of letting it sit
    *  open until the expiry sweeper reaps it. Contract: pome-cloud
    *  routes/abandon.ts — auth is the same surface as /finalize; an
@@ -327,7 +327,7 @@ export interface HostedClient {
    *  plane; callers must tolerate it silently). */
   requestMetaUploadUrl(sessionId: string): Promise<MetaUploadUrlResponse>;
   /** @param bestEffort default true — hosted runner swallows network errors on teardown
-   *  @param opts.discard F-983 — set true to confirm discarding an ungraded
+   *  @param opts.discard set true to confirm discarding an ungraded
    *  session after catching {@link HostedDiscardRefusedError}. Never implied
    *  by `bestEffort`: a refusal is a deliberate server decision, not
    *  transport noise. */
@@ -426,7 +426,7 @@ interface DiscardRefusal {
  *  token:
  *   - `none`     — an ordinary already-closed conflict, or an unparseable
  *                  body. Keeps the historic "409 means idempotent success".
- *   - `refusal`  — a well-formed F-983 refusal; replayable.
+ *   - `refusal`  — a well-formed discard refusal; replayable.
  *   - `unusable` — it CLAIMS to be a refusal but carries no usable
  *                  `discard_token`. The delete did not happen and cannot be
  *                  confirmed, so this must fail loudly; folding it into
@@ -436,7 +436,7 @@ type DiscardRefusalRead =
   | { kind: "refusal"; refusal: DiscardRefusal }
   | { kind: "unusable" };
 
-/** Read a 409 body as an F-983 discard refusal. Only ever called for status
+/** Read a 409 body as a discard refusal. Only ever called for status
  *  409 — a non-409 that happens to echo `details.reason` is a server error,
  *  not a refusal, and must keep its own status-based handling. */
 async function readDiscardRefusal(res: Response): Promise<DiscardRefusalRead> {
@@ -529,7 +529,7 @@ export function createHostedClient(config: HostedClientConfig): HostedClient {
         throw new HostedAuthError(msg, reqId);
       }
       if (res.status === 402 || res.status === 429) {
-        // FDRS-643 — carry the machine-readable envelope details (e.g.
+        // Carry the machine-readable envelope details (e.g.
         // `kind: "daily_judge_cap"`) so `pome demo` can render an honest
         // labeled at-capacity state instead of a generic quota message.
         throw new HostedQuotaError(msg, reqId, cloudDetails);
@@ -1171,7 +1171,7 @@ export function createHostedClient(config: HostedClientConfig): HostedClient {
 
     async deleteSession(sessionId, bestEffort = true, opts = {}) {
       // One DELETE attempt, including the read of a 409 body. `confirmDiscard`
-      // replays the token the control plane hands back with an F-983 refusal.
+      // replays the token the control plane hands back with a refusal.
       const attempt = async (
         confirmDiscard?: string,
       ): Promise<{ res: Response; read: DiscardRefusalRead } | null> => {
@@ -1186,7 +1186,7 @@ export function createHostedClient(config: HostedClientConfig): HostedClient {
             {
               method: "DELETE",
               // authHeaders, not a hardcoded x-api-key: demo teardown carries a
-              // bearer demo_token (FDRS-643 live-run finding — the hardcoded
+              // bearer demo_token (a live-run finding — the hardcoded
               // header made every demo DELETE an opaque 404, silently swallowed
               // by best-effort).
               headers: authHeaders,
@@ -1215,7 +1215,7 @@ export function createHostedClient(config: HostedClientConfig): HostedClient {
       if (!first) return; // bestEffort transport failure
       let res = first.res;
 
-      // F-983: a 409 carrying reason=ungraded_session is a REFUSAL, not the
+      // A 409 carrying reason=ungraded_session is a REFUSAL, not the
       // already-closed race. Never fold it into the idempotent-success branch
       // below — that swallow is exactly what made the CLI lie about stopping.
       // Scoped to 409: a 5xx that echoes the same `details` is a server
@@ -1255,7 +1255,7 @@ export function createHostedClient(config: HostedClientConfig): HostedClient {
 
       // Cloud spec (pome-cloud docs/05-api-spec.md): 204 on success. Accept
       // 200 too in case a future control-plane returns a body. A 409 that is
-      // NOT an F-983 refusal keeps best-effort teardown idempotent when a
+      // NOT a discard refusal keeps best-effort teardown idempotent when a
       // concurrent reaper already closed the row.
       if (res.status === 204 || res.status === 200 || res.status === 409) return;
       if (res.status === 404) {

--- a/cli/src/hosted/errors.ts
+++ b/cli/src/hosted/errors.ts
@@ -3,7 +3,7 @@
 //   0 — pass; 1 — below pass-threshold; 2 — twin/orch error;
 //   3 — auth (401/403); 4 — quota (402/429); 5 — usage error.
 //
-// Session A (Linear FDRS-423) audit confirmed cloud-side responses map
+// An audit confirmed cloud-side responses map
 // cleanly: 401 only from `lib/auth.ts` (CLI exit 3), 402/429 = quota (CLI
 // exit 4), 502 = downstream/gateway (CLI exit 2), 410/426 are not auth
 // errors (CLI exit 2). F0-5 covers the CLI-side mapping gaps the test
@@ -16,7 +16,7 @@
 //     `runTaskHosted.ts` mapped any non-zero agent exit to exit 3,
 //     stealing the auth slot.
 //
-// FDRS-636 — trial groups (`pome run -n k`, k>1) map the WHOLE GROUP to one
+// Trial groups (`pome run -n k`, k>1) map the WHOLE GROUP to one
 // exit code ([DECISION 2026-07-05]):
 //   0 — at least one trial completed AND every completed trial passed;
 //   1 — at least one completed trial failed its pass threshold;
@@ -34,7 +34,7 @@ export class HostedAuthError extends Error {
 
 export class HostedQuotaError extends Error {
   /** `details` mirrors the cloud error envelope's machine-readable details
-   *  (e.g. `{ kind: "daily_judge_cap" }`) so `pome demo` (FDRS-643/662) can
+   *  (e.g. `{ kind: "daily_judge_cap" }`) so `pome demo` can
    *  render honest labeled at-capacity states. Optional: older responses and
    *  the twin-pod 401 shape carry none. */
   constructor(
@@ -50,7 +50,7 @@ export class HostedQuotaError extends Error {
 export class HostedOrchError extends Error {
   /** `status` is the HTTP status that produced this error, when one exists
    *  (network/parse failures leave it undefined). `pome eval` uses it to
-   *  scope its reaped-session retry to 404/410 only (FDRS-656 review). */
+   *  scope its reaped-session retry to 404/410 only. */
   constructor(
     message: string,
     public readonly requestId?: string,
@@ -75,7 +75,7 @@ export class HostedUsageError extends Error {
   }
 }
 
-/** FDRS-636 — a group trial errored before a cloud verdict existed
+/** A group trial errored before a cloud verdict existed
  *  (preflight failure, agent timeout, agent crash). The session was
  *  abandoned (POST /v1/sessions/:id/abandon) with `errorCode`; the group
  *  runner renders the trial as an errored row EXCLUDED from the verdict
@@ -87,7 +87,7 @@ export class HostedTrialError extends Error {
   }
 }
 
-/** F-983 — `DELETE /v1/sessions/:id` refused to destroy a session whose run
+/** `DELETE /v1/sessions/:id` refused to destroy a session whose run
  *  has not been graded. Pome creates the `runs` row at finalize, so an open
  *  session holds an ungraded run and deleting it discards the evidence. The
  *  control plane issues `discardToken`; replaying it confirms the discard.

--- a/cli/src/hosted/evalResultCache.ts
+++ b/cli/src/hosted/evalResultCache.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// FDRS-644 — the per-trial CLOUD verdict artifact.
+// The per-trial CLOUD verdict artifact.
 //
 // Hosted `pome run` persists each finalized trial's cloud verdict payload
 // (what /finalize returned and the terminal rendered) as `verdict.json`
 // next to the trial's raw trace. This is a provenance-labeled CACHE of the
 // cloud judge's output — NOT a local score: the OSS CLI still has no
-// scoring engine (FDRS-657 / no-eval-in-oss), score.json is still never
+// scoring engine (no-eval-in-oss), score.json is still never
 // written, and deleting verdict.json loses nothing the dashboard doesn't
 // hold. `pome fix-prompt` reads these to hand grouped failure signatures
 // to the user's coding agent without a credentialed cloud round-trip —
@@ -16,7 +16,7 @@
 //   <artifacts-root>/<task-slug>/<session-id>/verdict.json
 // (runDir shape from recorder/artifacts.ts `writeRunArtifactsCore`).
 //
-// F-689/D16 — moved from `src/recorder/verdictArtifact.ts` to here (and
+// Moved from `src/recorder/verdictArtifact.ts` to here (and
 // renamed: the repo-wide no-eval gate denies any module NAMED verdict*, so
 // this file itself can't be called that anymore) and grouped under
 // `hosted/` since it caches a CLOUD response, not a recorder concern.
@@ -33,7 +33,7 @@ import {
   type RunSet,
 } from "./runSets.js";
 
-// F-1195 — bumped 1 → 2: the artifact gained `state` (the run's three-state
+// Bumped 1 → 2: the artifact gained `state` (the run's three-state
 // verdict, by name) and the `evaluated`/`not_evaluated`/`pre_satisfied`/
 // `total` counts `score` is computed over. Before this, a CI script reading
 // `score >= pass_threshold` on an incomplete run read `true`, because
@@ -69,7 +69,7 @@ export interface VerdictArtifact {
   cloud_dashboard_url: string;
   judge_model: string | null;
   /** Cloud-authoritative satisfaction score, 0-100 — the percentage over
-   *  `evaluated` ALONE, never over `total`. F-1195 shipped `evaluated`
+   *  `evaluated` ALONE, never over `total`. Version 2 shipped `evaluated`
    *  beside it for that reason: `score` on its own does not say how much of
    *  the task it covers, and `score >= pass_threshold` is not the gate on a
    *  run where `not_evaluated > 0` (`state` and `passed` are). When
@@ -77,7 +77,7 @@ export interface VerdictArtifact {
    *  "nothing was scored", not "nothing was correct". */
   score: number;
   pass_threshold: number;
-  /** F-1195 — the run's three-state verdict, BY NAME, taken from
+  /** The run's three-state verdict, BY NAME, taken from
    *  `RunTaskHostedResult.verdict` (itself `scoreStatus(score,
    *  passThreshold)`) rather than re-derived here. `passed` alone told a
    *  reader "not a pass" with no reason; `state` says which of the two
@@ -93,17 +93,17 @@ export interface VerdictArtifact {
    *      the task's threshold from. `pass_threshold` is in this artifact
    *      beside `state` precisely so a reader can see which bar was used.
    *
-   *  F-1399 closed the other one: a run whose criteria were ALL pre-satisfied
+   *  The other one is closed: a run whose criteria were ALL pre-satisfied
    *  used to read `incomplete` here (no denominator, so no verified pass —
    *  the A5 guard) against `fail` on the dashboard. pome-cloud's shared
    *  incomplete-run predicate now adds an `evaluated === 0` clause, so both
    *  surfaces say `incomplete`. The reasoning is in `evalResultView.ts`'s
    *  `scoreStatus` comment and stated only there: one place to correct when
    *  pome-cloud changes this again, rather than four that go false
-   *  independently (F-1413). */
+   *  independently. */
   state: ScoreStatus;
   passed: boolean;
-  /** F-1195 — `EvaluationCounts` from `evalResultView.ts`, so `score` is
+  /** `EvaluationCounts` from `evalResultView.ts`, so `score` is
    *  legible as "N of what" instead of a bare number beside a threshold. */
   evaluated: number;
   not_evaluated: number;
@@ -119,11 +119,11 @@ export interface TrialVerdict {
   verdict: VerdictArtifact;
 }
 
-/** F-1445 — publish by RENAME, never by writing the live path in place.
+/** Publish by RENAME, never by writing the live path in place.
  *  `writeFile` opens with `O_TRUNC` and the bytes land afterwards, so
  *  `verdict.json` was observably empty and then partial for the whole of a
  *  write, and a `pome fix-prompt` scanning the root while a `pome run`
- *  finalized in it read that prefix. Since F-1411 it REPORTED that read: path
+ *  finalized in it read that prefix. It then REPORTED that read: path
  *  named, counted in `unreadableCount`, described as "truncated, hand-edited,
  *  or not a verdict artifact" — a correct read of the bytes and a wrong
  *  account of the run, whose suggested fix (inspect it, delete it) is wrong
@@ -167,11 +167,11 @@ export async function writeVerdictArtifact(
  *  shape, or the FILE is rejected — discovery treats a half-recognizable
  *  verdict.json as foreign rather than crashing downstream on it.
  *
- *  F-1195 — this is RECOGNITION, not reading: the shape shared by every
+ *  This is RECOGNITION, not reading: the shape shared by every
  *  artifact version this repo has ever written, so a prior-version file can
  *  be told apart from a foreign/corrupt one and its skip NAMED rather than
  *  folded into "not a verdict file". Deliberately more generous than
- *  `isVerdictArtifact` below — including the pre-F-933 `scenario_path`
+ *  `isVerdictArtifact` below — including the legacy `scenario_path`
  *  spelling, which no reader accepts any more (see `isVerdictArtifact`) but
  *  which still identifies the file as one of ours worth naming. */
 function looksLikeVerdictArtifactBase(parsed: unknown): parsed is Record<string, unknown> {
@@ -201,13 +201,13 @@ function looksLikeVerdictArtifactBase(parsed: unknown): parsed is Record<string,
   });
 }
 
-/** F-1195 — the CURRENT version's shape: the base fields plus `version ===
+/** The CURRENT version's shape: the base fields plus `version ===
  *  VERDICT_ARTIFACT_VERSION`, the named `state`, and the four counts. A file
  *  that passes `looksLikeVerdictArtifactBase` but fails this is a prior
  *  version or a corrupt current one — `readVerdictArtifactDetailed` tells
  *  those two apart.
  *
- *  F-1195 also retired the pre-F-933 `scenario_path` tolerance the read path
+ *  Version 2 also retired the legacy `scenario_path` tolerance the read path
  *  used to carry: `task_path` is required here. Every file spelling it the
  *  old way was written by `@pome-sh/cli` <= 0.8.x at artifact version 1, so
  *  the version check refuses it before the spelling could matter — the
@@ -226,12 +226,12 @@ function isVerdictArtifact(parsed: unknown): parsed is VerdictArtifact {
   return true;
 }
 
-/** F-1195 — the detailed read: distinguishes "current-version artifact",
+/** The detailed read: distinguishes "current-version artifact",
  *  "recognizable, but written at a DIFFERENT artifact version" (a real trial
  *  this CLI can no longer read), and "not a verdict file at all"
  *  (foreign/corrupt/missing). Callers that only care about usable trials
  *  (`readVerdictArtifact`, `scanVerdictArtifacts`) collapse the last two
- *  together, same as before F-1195; discovery callers that need to NAME a
+ *  together, same as at version 1; discovery callers that need to NAME a
  *  version skip instead of silently reporting "no runs" use this directly.
  *
  *  `stale-version` is keyed on the version NUMBER differing, never on the
@@ -240,7 +240,7 @@ function isVerdictArtifact(parsed: unknown): parsed is VerdictArtifact {
  *  (`unreadable`), not a prior version. `version` is null when the file
  *  carries no numeric `version` at all.
  *
- *  F-1445 — `missing` is the fourth: no verdict.json at this path at all (no
+ *  `missing` is the fourth: no verdict.json at this path at all (no
  *  run finished here yet, or the caller pointed at an artifacts root rather
  *  than a trial dir). It used to collapse into `unreadable`, which is why both
  *  callers below re-`existsSync`'d the file they had just failed to read — a
@@ -252,7 +252,7 @@ export type VerdictReadResult =
   | { status: "unreadable" }
   | { status: "missing" };
 
-/** F-1445 — the errno set for "this path does not resolve to a file": exactly
+/** The errno set for "this path does not resolve to a file": exactly
  *  the set `existsSync` answered `false` for, since a `stat` fails the same
  *  way. ENOENT alone would move a user-visible count — the scan walks every
  *  entry under a task slug as a run dir, so a stray FILE there yields ENOTDIR
@@ -299,17 +299,17 @@ export async function readVerdictArtifact(
   return result.status === "ok" ? result.trial : null;
 }
 
-/** F-1195 — the detailed scan behind `scanVerdictArtifacts`: also collects
+/** The detailed scan behind `scanVerdictArtifacts`: also collects
  *  the dirs whose verdict.json was recognizable but a prior artifact version,
  *  so `discoverRunSet` can name that skip instead of it looking identical to
  *  "no run happened here".
  *
- *  F-1411 — likewise for `unreadableDirs`: a verdict.json that EXISTS but is
+ *  Likewise for `unreadableDirs`: a verdict.json that EXISTS but is
  *  truncated, hand-edited, or otherwise damaged. Kept out of `staleVersionDirs`
  *  on purpose — a prior-version file and a corrupt one are different facts
  *  (upgrade vs. damage) and want different fixes. A run dir with no
- *  verdict.json at all is neither (no run finished there yet): F-1445 put that
- *  distinction in the read's `missing` status, not a re-stat here.
+ *  verdict.json at all is neither (no run finished there yet), and that
+ *  distinction lives in the read's `missing` status, not a re-stat here.
  *
  *  `unreadableDirs` is SORTED, unlike the other two: it is the only one whose
  *  order reaches a user, via the path list `pome fix-prompt` prints and trims
@@ -374,7 +374,7 @@ export interface RunSetDiscovery {
    *  set is `incompleteSet` below rather than a failure to hand to an
    *  agent. */
   set: RunSet | null;
-  /** F-1404 — `kind: "root"` only, and only populated when `set` is null:
+  /** `kind: "root"` only, and only populated when `set` is null:
    *  the newest run set whose outcome is `"incomplete"`. Kept distinct from
    *  `set` so a caller can never conflate "route this to fix-prompt" with
    *  "something was never graded" — the routing decision and the message it
@@ -383,13 +383,13 @@ export interface RunSetDiscovery {
   /** Total finalized run sets seen — lets the caller distinguish "no runs
    *  at all" from "runs exist but none failed". */
   totalSets: number;
-  /** F-1195 — verdict.json files recognized as a PRIOR artifact version under
+  /** Verdict.json files recognized as a PRIOR artifact version under
    *  the scanned root (or, for `kind: "trial-dir"`, at the target itself).
    *  Named so a stale-version skip never renders identically to "no runs
    *  happened here" — a v1 file dropped silently is the exact shape this
    *  milestone exists to remove. */
   staleVersionCount: number;
-  /** F-1411 — verdict.json files that EXIST under the scanned root (or, for
+  /** Verdict.json files that EXIST under the scanned root (or, for
    *  `kind: "trial-dir"`, at the target itself) but could not be read: a
    *  truncated file, one hand-edited into an unexpected `state`, or valid
    *  JSON that isn't a verdict artifact at all. Never folded into
@@ -431,10 +431,10 @@ export async function discoverRunSet(target: string): Promise<RunSetDiscovery> {
       unreadablePaths: [],
     };
   }
-  // F-1411 — same reasoning as the stale-version branch above, for a target
+  // Same reasoning as the stale-version branch above, for a target
   // whose verdict.json exists but is damaged: name it as a trial-dir skip
   // rather than falling through to the "root" branch, which would scan
-  // `target` itself (two levels too shallow) and find nothing. F-1445 — what
+  // `target` itself (two levels too shallow) and find nothing. What
   // tells this apart from a target that IS an artifacts root (no verdict.json
   // of its own either, and must fall through) is the read's own `missing`
   // status, not a second `existsSync` of the path the read just failed on.
@@ -478,7 +478,7 @@ export async function discoverRunSet(target: string): Promise<RunSetDiscovery> {
   }
 
   // `missing` — no verdict.json at `target`, so it is an artifacts root (or
-  // nothing at all). F-1445 also dropped the `if (!existsSync(target))` early
+  // nothing at all). The `if (!existsSync(target))` early
   // return that sat here: on a root that isn't there `readdir` throws and is
   // caught, and the three empty arrays give the same nulls and zeros through
   // `groupRunSets` / `latestFailedRunSet` / `latestIncompleteRunSet`.

--- a/cli/src/hosted/evalResultView.ts
+++ b/cli/src/hosted/evalResultView.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Cloud-verdict DISPLAY model + pure label/render helpers (FDRS-656/657).
+// Cloud-verdict DISPLAY model + pure label/render helpers.
 //
 // The OSS CLI is CAPTURE-ONLY: it never computes a score, never runs a judge,
 // and never correlates locally. Every helper here operates on a score object
@@ -11,10 +11,10 @@
 // This is the relocation of the former `src/evaluator/score.ts` + the
 // verdict-rendering half of `src/cli/render.ts`. The local scoring engine
 // (`scoreResults`, the deterministic matchers, the BYOK LLM judge) was deleted
-// under FDRS-657; only the pure display model survives, moved out of the
+// under the no-eval-in-OSS rule; only the pure display model survives, moved out of the
 // `evaluator/` tree so the `no-eval-in-oss` gate can assert that tree is gone.
 //
-// F-689/D16 — moved AGAIN from `src/score/view.ts` to here. `score/` (a
+// Moved AGAIN from `src/score/view.ts` to here. `score/` (a
 // module-name stem the repo-wide gate now denies outright) has to cease to
 // exist, so this pure display model lives under `hosted/` with the rest of
 // the cloud-facing surface it renders.
@@ -22,14 +22,14 @@
 // Wire-side criterion, NOT the scenario-markdown one: cloud responses carry
 // the unified "code"/"model" vocabulary (legacy "D"/"P" tolerated) while
 // scenario files still parse [code]/[model] markers. This module renders CLOUD
-// verdicts, so it takes the wide wire shape (FDRS-643 live-run finding).
+// verdicts, so it takes the wide wire shape (a live-run finding).
 import { PRE_SATISFIED_REASON } from "@pome-sh/wire/run-completeness";
 import type { z } from "zod";
 import type { criterionSchema } from "../types/shared.js";
 
 type WireCriterion = z.infer<typeof criterionSchema>;
 
-// FDRS-591 + FDRS-611 — unified per-criterion outcome model as reported by the
+// Unified per-criterion outcome model as reported by the
 // cloud judge.
 //
 //   passed   — criterion evaluated and satisfied.
@@ -44,7 +44,7 @@ export type CriterionOutcome = "passed" | "failed" | "skipped" | "errored";
 
 export type CriterionResult = {
   criterion: WireCriterion;
-  // FDRS-591/611: explicit four-state outcome. ADDITIVE + OPTIONAL — when
+  // Explicit four-state outcome. ADDITIVE + OPTIONAL — when
   // absent (older cloud producers) it is derived from `passed`/`skipped` via
   // `outcomeOf`.
   outcome?: CriterionOutcome;
@@ -70,7 +70,7 @@ export type Score = {
   failed: number;
   skipped: number;
   errored: number;
-  // F-1392 — the SUBSET of `skipped` excluded because the seed already
+  // The SUBSET of `skipped` excluded because the seed already
   // satisfied it (`PRE_SATISFIED_REASON`/`isPreSatisfied` above). Not a
   // separate outcome — these criteria still count in `skipped` and still
   // render with the `-` marker (`outcomeOf` keeps mapping them to
@@ -100,7 +100,7 @@ export function outcomeOf(result: CriterionResult): CriterionOutcome {
   return result.passed ? "passed" : "failed";
 }
 
-// F-1296 (pome-cloud) stamps this reason on a criterion the seed already
+// pome-cloud stamps this reason on a criterion the seed already
 // satisfied — the control plane graded the FINAL state alone, found the
 // criterion true before the agent ran, and moved it out of the score
 // denominator so a task cannot earn credit for doing nothing (AutomationBench's
@@ -108,13 +108,13 @@ export function outcomeOf(result: CriterionResult): CriterionOutcome {
 // `criteria_results` wire shape (`apps/control-plane/src/services/evaluators/
 // deterministic/pre-satisfied.ts` on the pome-cloud side).
 //
-// F-1392 — the CLI is the fifth surface this string has to agree with
+// The CLI is the fifth surface this string has to agree with
 // (score-merge, run-report, run-status and drift-telemetry are the other
 // four, per pre-satisfied.ts's own doc comment). Re-exported ONCE from here so
 // every call site in this module reads one name and the string is never
 // repeated inline.
 //
-// F-1416 — IMPORTED rather than restated. The comment that used to sit here
+// IMPORTED rather than restated. The comment that used to sit here
 // said "restated here rather than imported: the CLI shares no code with the
 // control plane", and that stopped being true when the predicate this string
 // feeds moved into `@pome-sh/wire` — the package this repo publishes and
@@ -144,20 +144,20 @@ export type ScoreStatus = "pass" | "fail" | "incomplete";
 // required criterion was evaluated (can_pass), AND satisfaction cleared the
 // threshold. PURE — no computation of the score itself.
 //
-// F-932 renamed the third state from `unevaluated` to `incomplete` and CHANGED
+// The third state was renamed from `unevaluated` to `incomplete`, and that CHANGED
 // NOTHING ELSE HERE. The guard is the one place the CLI refuses to inflate a
 // partial run into a pass — the same refusal pome-cloud added server-side in
-// F-925 — so the rename must not become a loosening.
+// So the rename must not become a loosening.
 //
 // One rule, two repos: `can_pass` is false for any abstention EXCEPT a
 // criterion the seed already satisfied (`PRE_SATISFIED_REASON` above) —
 // `uploadAndFinalize.ts`'s `scoreFromFinalizeResponse` subtracts
 // `preSatisfied` out of the `skipped` tally before deciding `can_pass`, and
 // pome-cloud subtracts the same `preSatisfied` count out of `notEvaluated`
-// over the same `criteria_results`. Since F-1399 that subtraction lives in
+// over the same `criteria_results`. That subtraction lives in
 // `@pome-cloud/contract`'s `isIncompleteTally`, which the dashboard's
 // `isRunIncomplete` (apps/dashboard/src/lib/run-status.ts) and the markdown
-// report both CALL rather than each keeping a copy of. F-1392 — the CLI used
+// report both CALL rather than each keeping a copy of. The CLI used
 // to count every `skipped` result with no exemption, which called a run
 // INCOMPLETE that the dashboard called PASS. ANY OTHER skipped reason, and
 // every `errored`, still fails this guard — only the one named exemption is
@@ -167,18 +167,18 @@ export type ScoreStatus = "pass" | "fail" | "incomplete";
 // The all-pre-satisfied run — nothing passed, nothing failed, so no
 // denominator — is `incomplete` here: `evaluated` is false and the A5 guard
 // predates and outranks the exemption. Calling it `fail` locally would blame
-// the agent for a run in which nothing was ever at risk, which is the F-925
+// the agent for a run in which nothing was ever at risk, which is the
 // inversion pointed the other way. `runScoreLine` names this state explicitly
 // instead of printing "0 of N criteria not evaluated".
 //
-// F-1399 — the dashboard used to answer that same run `fail`, and this
+// The dashboard used to answer that same run `fail`, and this
 // paragraph used to say so at length. `isIncompleteTally`'s third clause
 // (`evaluated === 0`) closed it: both surfaces read it `incomplete` now, and
 // the last shape they still word differently is a task whose `passThreshold`
 // is not 100 (the dashboard's bar is a hard `satisfaction_score === 100` and
 // it has no field to learn the task's threshold from).
 //
-// F-1413 is what the correction cost, and is why the prose is here and not
+// Correcting that cost real work, and is why the prose is here and not
 // also somewhere else: pome-cloud shipped the fix and every copy of the old
 // claim in this repo went false while staying green.
 // `cross-surface-agreement.test.ts` pins the two PREDICATES row by row, which
@@ -195,7 +195,7 @@ export function taskPassed(score: Score, passThreshold: number): boolean {
   return scoreStatus(score, passThreshold) === "pass";
 }
 
-// FDRS-591/611 per-criterion marker: ✓ passed, ✗ failed, - skipped, ! errored.
+// Per-criterion marker: ✓ passed, ✗ failed, - skipped, ! errored.
 export function markerFor(outcome: CriterionOutcome): string {
   switch (outcome) {
     case "passed":
@@ -237,7 +237,7 @@ function criteriaWord(n: number): string {
   return n === 1 ? "criterion" : "criteria";
 }
 
-// F-1195 — the completeness arithmetic, factored out of `runScoreLine` so
+// The completeness arithmetic, factored out of `runScoreLine` so
 // `verdict.json` (runTaskHosted.ts) can carry the SAME counts the terminal
 // line already prints instead of a second, hand-rolled computation. Before
 // this existed, `verdict.json` wrote `score: 100, pass_threshold: 100,
@@ -284,9 +284,9 @@ export function runScoreLine(
     // Leads with the COUNT, which is the fact the reader needs and the same
     // fact the cloud's own header now states. The old copy said "cannot pass",
     // which is a verdict about the AGENT for a gap in the GRADER — the exact
-    // inversion F-925 exists to stop, one surface over.
+    // inversion this guard exists to stop, one surface over.
     //
-    // F-1392 — `preSatisfied` criteria are named APART from the abstentions
+    // `preSatisfied` criteria are named APART from the abstentions
     // instead of folded into "not evaluated", the way the dashboard's
     // `verdictLine` does (run-status.ts:174-206): a pre-satisfied criterion
     // reached a verdict (the grader wasn't gapped), it just tested nothing.

--- a/cli/src/hosted/runSets.ts
+++ b/cli/src/hosted/runSets.ts
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// F-1411 — split out of evalResultCache.ts to keep that module under the
+// Split out of evalResultCache.ts to keep that module under the
 // file-size tripwire: grouping trials into run sets and deriving their
 // outcome is a distinct concern from reading/writing/scanning the
 // verdict.json artifact itself, and depends on nothing but `TrialVerdict`.
 
 import type { TrialVerdict } from "./evalResultCache.js";
 
-// F-1404 — the three-way verdict a run SET can carry, named like
+// The three-way verdict a run SET can carry, named like
 // `ScoreStatus` (the per-trial word) because it is built from it: "fail" =
 // at least one trial genuinely failed (graded, unsatisfied) — the only
 // outcome that asserts an agent defect. "incomplete" = no trial failed, but
@@ -28,7 +28,7 @@ export interface RunSet {
   /** Trials sorted by finalized_at ascending. */
   trials: TrialVerdict[];
   latestFinalizedAt: string;
-  /** F-1404 — derived from the on-disk `state` (see `RunSetOutcome`), never
+  /** Derived from the on-disk `state` (see `RunSetOutcome`), never
    *  from `passed` alone: `passed` is false for BOTH a genuine failure and a
    *  trial the grader never finished, so it can't tell "agent defect" from
    *  "never graded" apart. The ONE computation both the routing decision
@@ -40,8 +40,8 @@ export interface RunSet {
 /** Group trials into run sets: trials sharing a group_id form one set; a
  *  null group_id is its own single-run set.
  *
- *  F-1404 — `outcome` reads the on-disk `state` (F-1195), not `!passed`
- *  (F-1392's finding: `!passed` is true for both a genuine failure and an
+ *  `outcome` reads the on-disk `state`, not `!passed`
+ *  (the finding was that `!passed` is true for both a genuine failure and an
  *  incomplete trial, so a set holding only incomplete trials used to trip
  *  the old `anyFailed` and get handed to `pome fix-prompt` as an agent
  *  defect). `evalResultCache.test.ts` pins all three outcomes against the
@@ -85,7 +85,7 @@ export function latestFailedRunSet(sets: RunSet[]): RunSet | null {
   return null;
 }
 
-/** F-1404 — the newest run set whose worst outcome is INCOMPLETE: no trial
+/** The newest run set whose worst outcome is INCOMPLETE: no trial
  *  failed, but at least one trial's grading never finished. Callers use this
  *  to name the gap distinctly from both "fix this" (a fail set exists) and
  *  "nothing to fix" (every set passed) — never silently folded into either. */

--- a/cli/src/hosted/trialEvents.ts
+++ b/cli/src/hosted/trialEvents.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// F-1411 — split out of evalResultCache.ts to keep that module under the
+// Split out of evalResultCache.ts to keep that module under the
 // file-size tripwire: this loads a trial's raw HTTP trace (events.jsonl),
 // which shares no shape or helper with the verdict.json artifact that file
 // reads/writes. Same behavior, just filed under its own concern.

--- a/cli/src/hosted/uploadAndFinalize.ts
+++ b/cli/src/hosted/uploadAndFinalize.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Shared presigned-upload + finalize-score orchestration for cloud sessions
-// (ADR-013). Extracted verbatim from runTaskHosted.ts (FDRS-656) so
+// (ADR-013). Extracted verbatim from runTaskHosted.ts so
 // `pome eval <run-dir>` reuses the exact same best-effort PUT semantics
 // without duplicating them. Behavior-preserving for the hosted run path:
 // warning text, the 30s PUT timeout, and the null-key fallbacks all match
@@ -112,7 +112,7 @@ async function putBlob(
  * `team-<>/session-<>/events.jsonl` path, so cloud's judge finds the trace
  * without an explicit override. State blobs and signals have no conventional
  * fallback today — without an explicit override the judge sees "{}" for
- * state files (FDRS-395) and skips the adapter-rich correlator (F0-4 / L7).
+ * state files and skips the adapter-rich correlator (F0-4 / L7).
  * meta.json (D18.1/D18.6) DOES have a conventional fallback: cloud finalize
  * auto-discovers it at `team-<>/session-<>/meta.json`, so its key is uploaded
  * to that path and never threaded onto /finalize (see uploadMeta below).
@@ -311,19 +311,19 @@ export async function uploadRunBlobs(
  * builds (pre-Session A) omit the field; default to an empty array — the
  * fix-prompt action still bails cleanly when results are missing.
  *
- * A1 CAVEAT (FDRS-618): `satisfaction` here is the CLOUD-authoritative
+ * A1 CAVEAT: `satisfaction` here is the CLOUD-authoritative
  * score (`finalized.score`) — the hosted judge does NOT yet implement the
- * FDRS-591/611 outcome semantics, so `evaluated`/`can_pass` are derived
+ * Four-state outcome semantics, so `evaluated`/`can_pass` are derived
  * locally only when /finalize returns per-criterion results. Older cloud
  * builds omit `criteria_results`; for those, preserve the cloud score as
  * renderable instead of inventing an empty local A5 verdict.
  *
- * F-1392 — `can_pass` exempts a `skipped` result stamped
+ * `can_pass` exempts a `skipped` result stamped
  * `PRE_SATISFIED_REASON` (`already_true_in_seed`): the seed already satisfied
  * that criterion, so it is not an abstention and a run holding one can still
  * pass. Every OTHER skipped reason, and every `errored`, still blocks
  * `can_pass` — this is the same exemption pome-cloud's `isRunIncomplete`
- * applies over the same `criteria_results` (F-1296), narrowed to nothing
+ * applies over the same `criteria_results`, narrowed to nothing
  * else.
  *
  * `errored` is a DISPLAY-MODEL state with no wire producer today: it is
@@ -348,7 +348,7 @@ export function scoreFromFinalizeResponse(finalized: FinalizeResponse): Score {
   const totalRequired = passed + failed;
   // The abstentions that actually block a pass: every skipped result MINUS
   // the ones the seed already satisfied, plus every errored result (never
-  // exempted — F-1392's "Traps": a pre-satisfied result is a wire-observed
+  // exempted — the trap here is that a pre-satisfied result is a wire-observed
   // fact for `skipped`, not for `errored`).
   const unresolvedAbstentions = skipped - preSatisfied + errored;
   return {
@@ -372,7 +372,7 @@ export function scoreFromFinalizeResponse(finalized: FinalizeResponse): Score {
 
 /** Redact a JSONL payload line-by-line before upload. Lines that fail to
  *  parse as JSON are redacted as raw strings. Moved verbatim from
- *  runTaskHosted.ts (FDRS-656). */
+ *  runTaskHosted.ts. */
 export function redactJsonl(body: string): string {
   const lines = body.split("\n");
   const redacted = lines

--- a/cli/src/recorder/artifacts.ts
+++ b/cli/src/recorder/artifacts.ts
@@ -8,9 +8,9 @@ import type { RecorderEvent } from "@pome-sh/wire";
 import { redactEvent, redactSecrets } from "./redaction.js";
 import { META_SPEC_VERSION, resolveTwinPackageVersions } from "./specMeta.js";
 
-// FDRS-399 / FDRS-398 — wrap a legacy RecorderEvent into the unified
+// Wrap a legacy RecorderEvent into the unified
 // events.jsonl shape. Delegates to twin-core `toTwinHttpEventRow` so durable
-// stream rows and finalize appends stay byte-identical (F-698).
+// stream rows and finalize appends stay byte-identical.
 export const toTwinHttpEvent = toTwinHttpEventRow;
 
 export type RunArtifacts = {
@@ -32,13 +32,13 @@ export type RunArtifactCoreInput = {
   stateFinal: unknown;
 };
 
-// FDRS-657 / F-689 — the OSS CLI is CAPTURE-ONLY: it writes raw trace + state
+// The OSS CLI is CAPTURE-ONLY: it writes raw trace + state
 // artifacts and NEVER a score.json. Local artifacts are trace/audit only; a
 // verdict comes only from the cloud and is printed ephemerally to the
 // terminal (hosted `pome run`, `pome eval`) — never persisted next to the
 // trace. There is no `writeScoreJson`/`readScore` anymore.
 //
-// F-689 remainder (D6) — a completed run dir contains EXACTLY these six
+// Per D6, a completed run dir contains EXACTLY these six
 // files: `meta.json`, `events.jsonl`, `state_initial.json`,
 // `state_final.json`, `stdout.txt`, `stderr.log`. The intermediate
 // correlation artifacts this CLI used to also write (`tool_calls.jsonl`,
@@ -68,12 +68,12 @@ export async function writeRunArtifactsCore(input: RunArtifactCoreInput): Promis
     spec_version: META_SPEC_VERSION,
     twin_versions: resolveTwinPackageVersions(input.scenario.config.twins),
   });
-  // events.jsonl is the unified discriminated-union view (FDRS-398). The
+  // events.jsonl is the unified discriminated-union view. The
   // in-process twin recorders still expose legacy RecorderEvent rows via
   // `events()`; wrap each into a TwinHttpEvent before serializing so
-  // `pome inspect` (FDRS-403) and dashboard ingest (FDRS-415) can parse them.
+  // `pome inspect` and dashboard ingest can parse them.
   //
-  // F-698: the durable recorder may already have appended TwinHttpEvent rows
+  // The durable recorder may already have appended TwinHttpEvent rows
   // during the run. Skip re-appending any event whose `event_id`/`request_id`
   // is already on disk so finalize does not duplicate crash-streamed rows.
   // APPEND (not truncate) so capture-server LlmCallEvent rows also survive.
@@ -93,14 +93,14 @@ export async function writeRunArtifactsCore(input: RunArtifactCoreInput): Promis
     await appendFile(eventsPath, eventsJsonl);
   } else if (!existsSync(eventsPath)) {
     // Preserve the six-file run-dir contract when nothing was streamed and
-    // the recorder emitted no events (F-689 / D6).
+    // the recorder emitted no events (D6).
     await writeFile(eventsPath, "");
   }
   await writeJson(join(runDir, "state_initial.json"), input.stateInitial);
   await writeJson(join(runDir, "state_final.json"), input.stateFinal);
   await writeFile(join(runDir, "stdout.txt"), redactText(input.stdout));
   await writeFile(join(runDir, "stderr.log"), redactText(input.stderr));
-  // F-933 — `task`, not `scenario`. latest.json is a purely local pointer:
+  // `task`, not `scenario`. latest.json is a purely local pointer:
   // every run overwrites it and its only readers are `pome eval` / `pome
   // inspect`, which dereference `run_dir`/`run_id`. Nothing on the wire and
   // nothing in the cloud parses it, so the rename needs no compat window.

--- a/cli/src/recorder/inspect.ts
+++ b/cli/src/recorder/inspect.ts
@@ -20,7 +20,7 @@ import {
  *   - `kind: "events"` — every row parsed cleanly against the discriminated
  *     union; the renderer walks `events` to print sections + trace health.
  *   - `kind: "legacy"` — at least one row is missing the `kind` discriminator
- *     (pre-FDRS-398 shape). `pome inspect` prints the legacy error and exits 2.
+ *     (legacy shape). `pome inspect` prints the legacy error and exits 2.
  *   - `kind: "missing"` — `events.jsonl` does not exist (run never produced
  *     trace blobs). Renderer prints a one-line note; no exit-2.
  */
@@ -60,7 +60,7 @@ export async function readEventsJsonl(runDir: string): Promise<ReadEventsResult>
 // ─────────────────────────────────────────────────────────────────────────────
 // Trace health
 //
-// Three layers, counted per FDRS-403 acceptance criteria:
+// Three layers:
 //   - proxy : LlmCallEvent           (HTTP_PROXY CONNECT capture-server)
 //   - twin  : TwinHttpEvent          (twin runtime HTTP traffic)
 //   - cas   : ToolUse/ToolResult/    (claude-agent-sdk adapter)
@@ -130,7 +130,7 @@ export function computeTraceHealth(input: TraceHealthInput): TraceHealthLayer[] 
 
   // CAS adapter layer — only active when the agent is wired through
   // `@pome-sh/claude-agent-sdk`. Heuristic: any of ToolUse/ToolResult/
-  // SubagentSpawn/Hook/LlmTurn indicates adapter is live. LlmTurnEvent (F-766)
+  // SubagentSpawn/Hook/LlmTurn indicates adapter is live. LlmTurnEvent
   // is adapter-emitted like its siblings, so it counts toward this layer.
   const casCount =
     counts.ToolUseEvent +

--- a/cli/src/recorder/recorder.ts
+++ b/cli/src/recorder/recorder.ts
@@ -9,9 +9,9 @@ import {
 
 /**
  * The CLI's event buffer. Structurally the engine's `RecorderStore` — the
- * ported twins (F-682) no longer export a per-twin Recorder type to borrow.
+ * ported twins no longer export a per-twin Recorder type to borrow.
  *
- * F-698: when `eventsPath` is set, uses the twin-core durable store so twin
+ * When `eventsPath` is set, uses the twin-core durable store so twin
  * HTTP events stream to `events.jsonl` during the run (crash-safe).
  */
 export type Recorder = RecorderStore;

--- a/cli/src/recorder/specMeta.ts
+++ b/cli/src/recorder/specMeta.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// meta.json contract constants (D18.1 / F-689 remainder). `spec_version` and
+// meta.json contract constants (D18.1). `spec_version` and
 // the twin package versions let cloud's ingest validate that a run's meta.json
 // matches a shape it knows how to parse, and let the dashboard attribute a
 // run's captured behavior to the exact twin build that produced it.

--- a/cli/src/runner/agentRunner.ts
+++ b/cli/src/runner/agentRunner.ts
@@ -100,7 +100,7 @@ const SAFE_PARENT_ENV = new Set([
 const DEFAULT_AGENT_ENV_ALLOWLIST = new Set([
   "AI_GATEWAY_API_KEY",
   "ANTHROPIC_API_KEY",
-  // FDRS-667 — Claude subscription auth (`claude setup-token`). Without
+  // Claude subscription auth (`claude setup-token`). Without
   // this the Claude Agent SDK inside the agent subprocess only sees an API
   // key, and subscription-only users fail auth under `pome run` while the
   // same agent works when launched by hand.

--- a/cli/src/runner/captureServerChild.ts
+++ b/cli/src/runner/captureServerChild.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// FDRS-399 — spawn `pome capture-server` as a child process for `pome run`.
+// Spawn `pome capture-server` as a child process for `pome run`.
 //
 // The runner needs an out-of-process CONNECT proxy so the agent subprocess
 // can be pointed at it via HTTPS_PROXY. Running capture-server in-process is
@@ -19,10 +19,10 @@ import { spawn, type ChildProcess } from "node:child_process";
 export interface SpawnCaptureServerChildOptions {
   // Absolute path to events.jsonl. Passed verbatim to `--events-out`.
   eventsOut: string;
-  // FDRS-635 — egress-floor allowlist patterns, passed as `--allow` (CSV).
+  // Egress-floor allowlist patterns, passed as `--allow` (CSV).
   // Omitted/empty means loopback-only: the floor is deny-by-default.
   allowHosts?: readonly string[];
-  // FDRS-635 — sidecar path for refused-CONNECT rows, passed as `--egress-out`.
+  // Sidecar path for refused-CONNECT rows, passed as `--egress-out`.
   egressOut?: string;
   // Override for tests. Defaults to process.execPath.
   execPath?: string;

--- a/cli/src/runner/groupRender.ts
+++ b/cli/src/runner/groupRender.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// FDRS-636 — pure terminal rendering for `pome run -n k` trial groups,
+// Pure terminal rendering for `pome run -n k` trial groups,
 // matching the design-of-record (CLI moments.dc.html moment 04,
 // task/code-model vocabulary):
 //
@@ -29,7 +29,7 @@ export type TrialRow =
       /** Cloud-authoritative satisfaction score, 0-100. */
       score: number;
       /**
-       * F-925 — three states, not a boolean. `incomplete` means the trial ran
+       * Three states, not a boolean. `incomplete` means the trial ran
        * and finalized but at least one criterion never produced a verdict, so
        * it is neither a pass nor the agent's failure. It was `passed: boolean`
        * fed from `exitCode === 0`, which counted a 100/100 run with 3 of 4
@@ -52,7 +52,7 @@ export function flagHintLine(agentCommandSource: string): string {
 }
 
 /** Printed once the upfront mints are done (the cloud provisions one
- *  isolated twin sandbox per session — ADR-012). FDRS-663: when the plan's
+ *  isolated twin sandbox per session — ADR-012). When the plan's
  *  concurrent-twin quota bounded the upfront mint below k, the bound is
  *  named honestly — k stays the design default, the wall-clock stretches. */
 export function provisioningLine(
@@ -79,7 +79,7 @@ export function trialRowLine(n: number, row: TrialRow): string {
   }
   // A dash for the ungradable trial: it ran, and it asserts nothing. Reusing
   // ✗ would make a grader gap look like the agent's failure at a glance, which
-  // is the whole reading F-925 removes.
+  // is the whole reading this removes.
   const mark =
     row.verdict === "pass" ? "✓" : row.verdict === "incomplete" ? "–" : "✗";
   const base = `trial ${n}  ${mark}  ${String(row.score).padEnd(9)}${row.seconds.toFixed(1)}s`;
@@ -102,7 +102,7 @@ export function groupSummaryLines(input: GroupSummaryInput): string[] {
   );
   const passed = completed.filter((r) => r.verdict === "pass").length;
   const incomplete = completed.filter((r) => r.verdict === "incomplete").length;
-  // F-925 — the fraction's denominator is the GRADED trials. A trial that
+  // The fraction's denominator is the GRADED trials. A trial that
   // finalized but could not be fully graded leaves both the numerator and the
   // denominator, so a 5-trial set with one of them reads "3 of 4", never the
   // "4 of 5" that counted it as a pass.
@@ -161,7 +161,7 @@ export function groupExitCode(rows: TrialRow[]): number {
     (r): r is Extract<TrialRow, { kind: "completed" }> => r.kind === "completed",
   );
   if (completed.length === 0) return 2;
-  // F-925 — an ungradable trial is not a pass, so a group holding one cannot
+  // An ungradable trial is not a pass, so a group holding one cannot
   // exit 0: green here would tell CI the set was verified when part of it was
   // never checked. It stays 1 rather than 2 even when EVERY trial was
   // incomplete — `2` means nothing completed, and these completed.
@@ -188,7 +188,7 @@ export function shortReason(reason: string): string {
   return flat.length > 72 ? `${flat.slice(0, 69)}…` : flat;
 }
 
-/** FDRS-644 — the fix & green handoff, printed under the group summary when
+/** The fix & green handoff, printed under the group summary when
  *  at least one COMPLETED trial failed (errored trials are sandbox noise —
  *  the answer there is re-run, not a code fix). Copy stays modest per the
  *  north-star honesty note ("don't sell a 5-trial bump as proof"): a

--- a/cli/src/runner/mergeAdapterSignals.ts
+++ b/cli/src/runner/mergeAdapterSignals.ts
@@ -3,15 +3,15 @@ import { readFile, writeFile } from "node:fs/promises";
 import { eventSchema, type Event } from "../types/shared.js";
 import { redactEvent } from "../recorder/redaction.js";
 
-// Post-run merge of the adapter signals JSONL into the canonical events.jsonl
-// (FDRS-411 + FDRS-412). This is a pure ts-sort/interleave step implemented
+// Post-run merge of the adapter signals JSONL into the canonical
+// events.jsonl. This is a pure ts-sort/interleave step implemented
 // inline so the OSS capture path has no dependency on any correlator package.
 //
 // Three sources write events.jsonl during a self-host run:
 //   1. The capture-server child appends `LlmCallEvent` rows as each CONNECT
-//      tunnel closes (FDRS-399) — capture-close order, not ts-order.
+//      tunnel closes — capture-close order, not ts-order.
 //   2. The trace writer then appends `TwinHttpEvent` rows from the in-process
-//      twin recorder (FDRS-415).
+//      twin recorder.
 //   3. This helper reads `signals.jsonl` (HookEvent / ToolUseEvent /
 //      ToolResultEvent / SubagentSpawnEvent / LlmTurnEvent rows written by the
 //      agent subprocess via `POME_ADAPTER_SIGNALS_PATH`), validates each line
@@ -26,7 +26,7 @@ import { redactEvent } from "../recorder/redaction.js";
 // events.jsonl rows that fail to parse are passed through unsorted at the
 // head of the file so a corrupted in-flight write is never silently dropped.
 /**
- * F-1200 — give every twin HTTP row the tool call that caused it.
+ * Give every twin HTTP row the tool call that caused it.
  *
  * The twin writes `parent_event_id: null` because it runs in its own process
  * and cannot know the agent-side `event_id`; the adapter knows the `event_id`
@@ -34,14 +34,14 @@ import { redactEvent } from "../recorder/redaction.js";
  * in hand, so the join belongs here — and it is a pure data operation over two
  * finished files, with no dependency on the order the two writers ran in.
  *
- * The join key is the SDK's `tool_use_id`, which since F-1200 is what the
+ * The join key is the SDK's `tool_use_id`, which is what the
  * adapter stamps on `x-pome-correlation-id`. The twin persists that header as
  * `correlation_id` ALWAYS and as `tool_call_id` only when it pins
  * `stampToolCallId` (github's frozen tape shape) — so `correlation_id` is the
  * key that works for every twin, with `tool_call_id` preferred when present
  * because it is unambiguously the header rather than the request-id fallback.
  *
- * A row keeps its null parent when the id names no tool call: a pre-F-1200
+ * A row keeps its null parent when the id names no tool call: an older
  * `tlc_…`, a `req_…` from the no-header fallback, or a direct REST call made
  * outside any tool handler. An unresolvable parent is the honest answer there —
  * inventing one would put twin calls under tools that did not make them.

--- a/cli/src/runner/runTask.ts
+++ b/cli/src/runner/runTask.ts
@@ -38,7 +38,7 @@ export type RunTaskOptions = {
   agentCommand: string;
   artifactsDir?: string;
   captureServerCommand?: CaptureServerCommand;
-  // FDRS-405 — skip spawning the capture-server child and do NOT inject
+  // Skip spawning the capture-server child and do NOT inject
   // HTTP_PROXY/HTTPS_PROXY into the agent env. Used by the overhead-gate
   // CI workflow to measure proxy-on-vs-off latency, and exposed as
   // `pome run --no-capture` for ad-hoc baselining.
@@ -46,13 +46,13 @@ export type RunTaskOptions = {
   // Fired once the capture-server child is up and listening, with its pid.
   // Tests use this to assert no orphan after the run.
   onCaptureServerSpawned?: (pid: number) => void;
-  // FDRS-643 — extra env injected into the agent child on top of the POME_*
+  // Extra env injected into the agent child on top of the POME_*
   // contract vars. `pome demo` uses this to hand the bundled agent its
   // anonymous-gateway coordinates (POME_DEMO_LLM_URL, POME_DEMO_TOKEN, …).
   // Spread after the built-ins (a caller may deliberately override them) but
   // BEFORE the proxy vars — the capture path is not overridable.
   extraAgentEnv?: Record<string, string>;
-  // FDRS-643 — extra egress-floor allowlist patterns for this run (demo mode
+  // Extra egress-floor allowlist patterns for this run (demo mode
   // adds the POME_API_BASE host so gateway CONNECTs aren't refused).
   egressExtraHosts?: readonly string[];
 };
@@ -63,11 +63,11 @@ export async function runTask(options: RunTaskOptions) {
   const artifactsDir = options.artifactsDir ?? "runs";
   const startedAt = new Date().toISOString();
 
-  // FDRS-657 — self-host is CAPTURE-ONLY: record the raw trace + state, never
+  // Self-host is CAPTURE-ONLY: record the raw trace + state, never
   // score/judge/correlate locally. A verdict comes only from the cloud.
   const writeRun = writeRunNoScore;
 
-  // FDRS-411: per-run signals file. Lives as a sibling of events.jsonl in the
+  // Per-run signals file. Lives as a sibling of events.jsonl in the
   // run's artifact directory so adapters that import `@pome-sh/adapter-claude-sdk`
   // and call `withPome()` can write M0 HookEvent / ToolUseEvent rows. The
   // runner merges these into events.jsonl post-run via
@@ -85,12 +85,12 @@ export async function runTask(options: RunTaskOptions) {
   // dies before any rows are written).
   await writeFile(eventsJsonlPath, "");
 
-  // FDRS-399: spawn the capture-server child BEFORE the twin and the agent.
+  // Spawn the capture-server child BEFORE the twin and the agent.
   // The agent inherits HTTP_PROXY/HTTPS_PROXY pointing at this child;
   // NO_PROXY keeps twin traffic out of the proxy so it isn't double-counted
-  // as LlmCallEvent. FDRS-405: `noCapture` skips spawn + env injection.
+  // as LlmCallEvent. `noCapture` skips spawn + env injection.
   //
-  // FDRS-635: the child enforces the deny-by-default egress floor. The
+  // The child enforces the deny-by-default egress floor. The
   // allowlist is LLM providers + custom base-URL hosts + POME_EGRESS_ALLOW;
   // the self-host twin lives on loopback, which the floor always allows.
   // Refused CONNECTs land in the egress sidecar, read back after the run so
@@ -199,7 +199,7 @@ export async function runTask(options: RunTaskOptions) {
 
   const proxyEnv: Record<string, string> = captureServer
     ? {
-        // FDRS-399 — agent's outbound traffic flows through the capture-server.
+        // Agent's outbound traffic flows through the capture-server.
         // Twin traffic is localhost, NO_PROXY excludes it so it stays a
         // TwinHttpEvent (recorded in-process) and isn't double-counted as a
         // proxy-captured LlmCallEvent.

--- a/cli/src/runner/runTaskCore.ts
+++ b/cli/src/runner/runTaskCore.ts
@@ -18,7 +18,7 @@ export interface WriteRunInput {
   stateFinal: unknown;
 }
 
-// Self-host (`pome run --local`) is CAPTURE-ONLY (FDRS-657): write the raw
+// Self-host (`pome run --local`) is CAPTURE-ONLY: write the raw
 // trace + state artifacts and DO NOT score, judge, or correlate. Local
 // evaluation was removed entirely from the OSS CLI — a verdict comes only from
 // the cloud (`pome eval <dir>`, or a hosted `pome run`). This produces an audit

--- a/cli/src/runner/runTaskHosted.ts
+++ b/cli/src/runner/runTaskHosted.ts
@@ -48,15 +48,15 @@ export interface RunTaskHostedOptions {
   client?: HostedClient;
   /** Informational; passed through to `runs.agent_model`. Defaults to "unknown". */
   agentModel?: string;
-  /** F-819 — `--agent-version` override. Wins over the manifest's
+  /** `--agent-version` override. Wins over the manifest's
    *  `agent.version` when stamping the session/run. */
   agentVersion?: string;
-  /** FDRS-636 — a session minted by the caller (trial groups mint all k
+  /** A session minted by the caller (trial groups mint all k
    *  upfront with one shared `group_id`). When set, the runner skips its own
    *  POST /v1/sessions and runs against this session; the `finally` teardown
    *  still DELETEs it (the trial owns its session either way). */
   premintedSession?: CreateSessionResponse;
-  /** FDRS-636 — group-trial failure semantics. When true, an agent failure
+  /** Group-trial failure semantics. When true, an agent failure
    *  (preflight failure / timeout / non-zero exit) or a machinery crash
    *  ABANDONS the session (POST /:id/abandon with a machine error_code,
    *  landing BEFORE the teardown DELETE so the code is recorded while the
@@ -65,7 +65,7 @@ export interface RunTaskHostedOptions {
    *  today's single-run behavior (finalize even on agent timeout) is
    *  unchanged. */
   abandonOnFailure?: boolean;
-  /** FDRS-644 — the trial group's shared id, recorded into the trial's
+  /** The trial group's shared id, recorded into the trial's
    *  verdict.json so `pome fix-prompt` can reassemble the run set from
    *  local artifacts. Absent on single runs (verdict.json gets null). */
   groupId?: string;
@@ -79,7 +79,7 @@ export interface RunTaskHostedResult {
   artifacts: RunArtifacts;
   score: Score;
   /**
-   * F-925 — the run's own three-state verdict, computed ONCE here and carried
+   * The run's own three-state verdict, computed ONCE here and carried
    * out so a caller never re-derives it. `exitCode` cannot express it: 1 means
    * both "failed" and "could not be graded", and a trial group needs to tell
    * them apart to keep the ungradable one out of its fraction.
@@ -87,7 +87,7 @@ export interface RunTaskHostedResult {
   verdict: ScoreStatus;
   exitCode: number;
   /** Wall time from run start to post-agent state capture — the same value
-   *  reported to /finalize as duration_ms. FDRS-636 renders it as the trial
+   *  reported to /finalize as duration_ms. Rendered as the trial
    *  row's duration. */
   durationMs: number;
 }
@@ -227,7 +227,7 @@ export async function runTaskHosted(
     options.client ??
     createHostedClient({ baseUrl: options.hosted.baseUrl, apiKey: options.hosted.apiKey });
 
-  // F-819 — resolve the agent id + version from the manifest (`agent.slug` →
+  // Resolve the agent id + version from the manifest (`agent.slug` →
   // `.pome/link.json` cache, team-gated, re-resolved by slug on miss) and the
   // `agent.framework` (the dashboard "SDK badge", formerly `agent.sdk`). The
   // `agent_version` stamps the session; `--agent-version` overrides it. All are
@@ -250,7 +250,7 @@ export async function runTaskHosted(
   // don't race the read in the empty case.
   await writeFile(signalsPath, "");
 
-  // 1. Spawn cloud session — fails fast on auth/quota/orch. FDRS-636 trial
+  // 1. Spawn cloud session — fails fast on auth/quota/orch. Trial
   // groups mint all k sessions upfront (one shared group_id) and pass each
   // one in as `premintedSession`; the single-run path mints its own here.
   // Forward the resolved seed (sidecar -> inline JSON -> twin defaults, in that
@@ -349,7 +349,7 @@ export async function runTaskHosted(
 
     let agentResult = preflight;
     if (preflight.exitCode === 0) {
-      // F-771 — the preflight probe appended its own signals (turns/steps/
+      // The preflight probe appended its own signals (turns/steps/
       // tool_calls) to the shared POME_ADAPTER_SIGNALS_PATH file. Those must
       // NOT reach the uploaded signals.jsonl / usage ledger. Truncate before
       // the real run so the blob counts real-run telemetry only. runAgentCommand
@@ -364,7 +364,7 @@ export async function runTaskHosted(
       });
     }
 
-    // FDRS-636 — group-trial failure semantics. An agent failure on a group
+    // Group-trial failure semantics. An agent failure on a group
     // trial ABANDONS the session with a machine error_code and throws,
     // instead of finalizing: verdicts come from cloud evaluation only, and a
     // crashed/timed-out trial must render as an errored row EXCLUDED from
@@ -382,7 +382,7 @@ export async function runTaskHosted(
       // scenario timeout. Only a real-run failure classifies as
       // agent_timeout / agent_exit_nonzero.
       //
-      // FDRS-667 — name the cause. The errored trial row renders the reason
+      // Name the cause. The errored trial row renders the reason
       // verbatim, so a bare "agent preflight failed" leaves the user with
       // zero forensics (the k=5 first-publish e2e died five times on the
       // same swallowed stderr). Append the agent's last stderr line to the
@@ -406,7 +406,7 @@ export async function runTaskHosted(
                 errorCode: "agent_exit_nonzero",
                 reason: `agent exited non-zero (exit ${agentResult.exitCode})${cause ? ` — ${cause}` : ""}`,
               };
-      // FDRS-667 — an abandoned trial never reaches the artifact write in
+      // An abandoned trial never reaches the artifact write in
       // step 5, so land the agent's output where a completed trial's would
       // go (runs/<slug>/<session>/): stdout.txt + stderr.log, redacted like
       // writeRunArtifactsCore's copies. Best effort — forensics must never
@@ -459,10 +459,10 @@ export async function runTaskHosted(
     // that signature here.
     const legacyEvents = events as unknown as LegacyGithubRecorderEvent[];
 
-    // 5. Write local artifacts — RAW TRACE + state. ADR-013 / FDRS-657:
+    // 5. Write local artifacts — RAW TRACE + state. Per ADR-013:
     //    the OSS CLI never scores locally (no score.json is ever written).
     //    Cloud is the authoritative judge; what /finalize returns is printed
-    //    to the terminal and — since FDRS-644 — also cached next to the
+    //    to the terminal and also cached next to the
     //    trace as a provenance-labeled verdict.json (step 11) so
     //    `pome fix-prompt` can read the cloud's verdict offline.
     const completedAt = new Date().toISOString();
@@ -504,7 +504,7 @@ export async function runTaskHosted(
       }
     }
 
-    // 6. FDRS-657 — NO local correlation. Correlation (like scoring/judging)
+    // 6. NO local correlation. Correlation (like scoring/judging)
     //    is a cloud responsibility; the OSS CLI only captures the raw trace.
     //    Cloud correlates the uploaded events/signals server-side. The events
     //    are uploaded exactly as captured (no local step_id back-fill).
@@ -514,13 +514,13 @@ export async function runTaskHosted(
     //    the conventional `team-<>/session-<>/events.jsonl` path, so cloud's
     //    judge finds the trace without an explicit override. State blobs
     //    and signals have no conventional fallback today — without an
-    //    explicit override the judge sees "{}" for state files (FDRS-395)
+    //    explicit override the judge sees "{}" for state files
     //    and skips the adapter-rich correlator (F0-4 / L7). All four
     //    uploads are best-effort: any failure leaves the corresponding
     //    blob missing, the judge still runs against whatever it does have,
     //    and the dashboard handles nulls gracefully.
     // Wrap legacy RecorderEvents (no `kind` discriminator) into the unified
-    // FDRS-398 shape before upload — cloud's schema gate rejects raw legacy
+    // canonical shape before upload — cloud's schema gate rejects raw legacy
     // rows. Matches the wrap that `writeRunArtifactsCore` applies for the
     // local events.jsonl file. Use `legacyEvents` (already cast) because
     // `toTwinHttpEvent`'s input is the legacy twin/github RecorderEvent type.
@@ -529,7 +529,7 @@ export async function runTaskHosted(
     const stateInitialJson = JSON.stringify(redactSecrets(stateInitial));
     const stateFinalJson = JSON.stringify(redactSecrets(stateFinal));
 
-    // Upload orchestration lives in ../hosted/uploadAndFinalize.ts (FDRS-656)
+    // Upload orchestration lives in ../hosted/uploadAndFinalize.ts
     // so `pome eval` shares the exact best-effort semantics. Signals are
     // read + redacted here (the tmp file is runner-owned); empty payloads
     // skip the upload inside uploadRunBlobs. Read + redaction stay inside a
@@ -590,13 +590,13 @@ export async function runTaskHosted(
     //    storage, calls the managed judge via AI Gateway, persists the run
     //    row, and returns the authoritative score the dashboard records.
     //    The CLI prints this score on the `score:` line.
-    // The finalize wire carries the canonical `code`/`model` kinds (F-778;
+    // The finalize wire carries the canonical `code`/`model` kinds (
     // needs shared-types >= 0.10.0 cloud-side, whose tolerant reader also
     // still accepts the legacy `D`/`P` spellings from older released CLIs).
     // Multi-twin (M3): carry the per-criterion twin attribution so the cloud
     // judge checks each criterion against its twin's state. Absent = the
     // primary twin (single-twin scenarios omit it entirely).
-    // F-1299: also carry the parsed `always-scored` flag — the cloud's
+    // Also carry the parsed `always-scored` flag — the cloud's
     // seed-exclusion escape hatch reads it off THIS request body
     // (criteria[].always_scored), not off re-parsed markdown, so a flag the
     // parser reads but this map drops would repeat the exact silent-loss
@@ -628,7 +628,7 @@ export async function runTaskHosted(
       // back. For events.jsonl the conventional `team-<>/session-<>/events.jsonl`
       // path matches what /result-upload-url signs, so omitting traceStorageKey
       // still resolves correctly. For state blobs there is no conventional
-      // fallback today (FDRS-395) — omitting them means cloud's judge sees
+      // fallback today — omitting them means cloud's judge sees
       // "{}", which we accept as best-effort degradation.
       traceStorageKey: eventsJsonlUrl ?? undefined,
       stateInitialStorageKey: stateKeys.initialKey ?? undefined,
@@ -641,11 +641,11 @@ export async function runTaskHosted(
     });
 
     // 9. Synthesize the cloud verdict for terminal display + the exit code.
-    //    FDRS-657: the CLI never computes a verdict — this is the CLOUD's,
+    //    The CLI never computes a verdict — this is the CLOUD's,
     //    reshaped. Synthesis (incl. the F0-3 / L5 criteria_results handling
-    //    and the A1/FDRS-618 caveat) lives in scoreFromFinalizeResponse —
-    //    shared with `pome eval` (FDRS-656). Step 11 caches it to
-    //    verdict.json (FDRS-644); score.json stays never-written.
+    //    and the A1 caveat) lives in scoreFromFinalizeResponse —
+    //    shared with `pome eval`. Step 11 caches it to
+    //    verdict.json; score.json stays never-written.
     const score: Score = scoreFromFinalizeResponse(finalized);
 
     // 10. Map cloud score → exit code. F18 / F0-5: the old policy
@@ -663,17 +663,17 @@ export async function runTaskHosted(
     //     Pre-finalize agent failures (auth, quota, twin spawn, exec
     //     errors) take other code paths via thrown HostedAuthError /
     //     HostedQuotaError / HostedOrchError and never reach this line.
-    //     F-925 — the score alone is not the verdict. A 100/100 run with a
+    //     The score alone is not the verdict. A 100/100 run with a
     //     criterion that never ran is `incomplete`, and exiting 0 on it is how
     //     "the fix passed" came to mean "the check never ran". `scoreStatus`
-    //     applies the A5 guard `pome eval` has always applied; the FDRS-618
+    //     applies the A5 guard `pome eval` has always applied; the older-cloud
     //     compat this used to preserve is already preserved inside
     //     `scoreFromFinalizeResponse`, which sets can_pass true when the
     //     response carries no criteria_results at all.
     const verdict = scoreStatus(score, scenario.config.passThreshold);
     const exitCode = verdict === "pass" ? 0 : 1;
 
-    // 11. FDRS-644 — cache the CLOUD verdict payload next to the raw trace
+    // 11. Cache the CLOUD verdict payload next to the raw trace
     //     (verdict.json, provenance-labeled `source: "cloud-finalize"`).
     //     Not a local score: evaluation stayed in the cloud; this records
     //     what /finalize returned so `pome fix-prompt` can hand grouped
@@ -681,11 +681,11 @@ export async function runTaskHosted(
     //     effort: a disk failure degrades to "fix-prompt won't see this
     //     trial", never fails a finalized run.
     try {
-      // F-1195 — `counts` is the SAME arithmetic `runScoreLine` prints beside
+      // `counts` is the SAME arithmetic `runScoreLine` prints beside
       // the terminal's verdict word, so the artifact's "N of total" can never
       // drift from what the terminal already said. `state` is the `verdict`
       // local computed above (`scoreStatus`), not a second derivation — the
-      // one place F-1392 shipped a bug was two call sites disagreeing on this
+      // one place a bug shipped was two call sites disagreeing on this
       // exact word.
       const counts = evaluationCounts(score);
       await writeVerdictArtifact(artifacts.runDir, {
@@ -730,7 +730,7 @@ export async function runTaskHosted(
       durationMs,
     };
   } catch (err) {
-    // FDRS-636 — a machinery crash on a group trial (twin state fetch,
+    // A machinery crash on a group trial (twin state fetch,
     // upload orchestration, finalize itself) also abandons the session so
     // the reliability page shows an errored slot with a cause instead of a
     // session stuck open until the sweeper. Must run BEFORE the `finally`
@@ -744,11 +744,11 @@ export async function runTaskHosted(
   } finally {
     // Best-effort teardown. TTL would reap anyway; explicit delete keeps
     // the dashboard sessions list tidy.
-    // F-983: this teardown deliberately discards. On the success path the
+    // This teardown deliberately discards. On the success path the
     // session is already `done` (finalize closed it) and the DELETE is a
     // no-op; on the failure path we accept losing an ungraded tape rather
     // than leaving open sessions to linger to TTL and pollute the
-    // reliability view. Flagged as known residue in the F-983 spec.
+    // reliability view. Known residue in the discard-refusal design.
     await client
       .deleteSession(session.session_id, true, { discard: true })
       .catch(() => undefined);
@@ -845,7 +845,7 @@ function mergeEventsByTimestamp(events: RecorderEvent[]): RecorderEvent[] {
     .map(({ event }) => event);
 }
 
-/** FDRS-667 — the last non-empty stderr line, flattened and bounded, as the
+/** The last non-empty stderr line, flattened and bounded, as the
  *  one named cause an errored trial row can render inline. Redacted with the
  *  same rules as the on-disk stderr.log copy. */
 function stderrTail(stderr: string): string | null {

--- a/cli/src/runner/runTrialGroup.ts
+++ b/cli/src/runner/runTrialGroup.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-// FDRS-636 — `pome run <task> -n k`: real trial groups end-to-end.
-// FDRS-663 — bounded/lazy minting + bounded trial parallelism.
+// `pome run <task> -n k`: real trial groups end-to-end.
+// Bounded/lazy minting + bounded trial parallelism.
 //
-// Flow per the 2026-07-05 [DECISION] set, revised by FDRS-663's 2026-07-06
+// Flow per the 2026-07-05 [DECISION] set, revised by the 2026-07-06
 // [DECISION] (option A — the free-tier `concurrentTwins: 3` mint gate was
 // killing the k=5 default at the 4th upfront mint):
 //   1. Mint sessions upfront (POST /v1/sessions), one shared
@@ -62,7 +62,7 @@ import type { CreateSessionResponse } from "../types/shared.js";
 /** Per-request transport timeout. Durable evaluation has a separate budget. */
 export const GROUP_FINALIZE_TIMEOUT_MS = 60_000;
 
-/** FDRS-663 — a lazy mint can quota-fail even though a trial just finished:
+/** A lazy mint can quota-fail even though a trial just finished:
  *  the finished trial's DELETE propagates asynchronously. Pause and retry a
  *  bounded number of times before declaring that trial errored. */
 export const LAZY_MINT_RETRY_MS = 2_000;
@@ -83,9 +83,9 @@ export interface RunTrialGroupOptions {
   dashboardBaseUrl: string;
   /** Informational; forwarded to every trial's `runs.agent_model`. */
   agentModel?: string;
-  /** F-819 — `--agent-version` override, forwarded to every trial's session. */
+  /** `--agent-version` override, forwarded to every trial's session. */
   agentVersion?: string;
-  /** FDRS-644 — the literal command the fix handoff tells the user to
+  /** The literal command the fix handoff tells the user to
    *  re-run after their coding agent applies a fix. The caller knows the
    *  invocation shape (bare `pome run` vs an explicit path + -n); default
    *  reconstructs it from taskPath + trials. */
@@ -95,7 +95,7 @@ export interface RunTrialGroupOptions {
   client?: HostedClient;
   runTaskHostedFn?: typeof runTaskHosted;
   groupId?: string;
-  /** FDRS-663 — lazy-mint retry pause; defaults to a real setTimeout. */
+  /** Lazy-mint retry pause; defaults to a real setTimeout. */
   sleepFn?: (ms: number) => Promise<void>;
 }
 
@@ -128,7 +128,7 @@ export async function runTrialGroup(
 
   const scenario = await parseTaskFile(options.taskPath);
   const taskSource = await readFile(options.taskPath, "utf8");
-  // Same agent resolution as the single-run path (F-819): the group's trials
+  // Same agent resolution as the single-run path: the group's trials
   // are recorded under the agent the manifest's `agent.slug` resolves to.
   const identity = await resolveRunAgentIdentity({
     startDir: dirname(options.taskPath),
@@ -158,7 +158,7 @@ export async function runTrialGroup(
       idempotencyKey: randomUUID(),
     });
 
-  // 1. Mint upfront, quota-bounded (FDRS-663). The group exists before the
+  // 1. Mint upfront, quota-bounded. The group exists before the
   // first agent spawns, and auth/orch failures surface HERE as one clean
   // error instead of half-way through a run. A quota push-back mid-mint is
   // NOT an error: it discovers the plan's concurrent-twin bound and the
@@ -178,7 +178,7 @@ export async function runTrialGroup(
     // sessions polluting the reliability view; then let the caller map the
     // error to the documented exit code.
     await Promise.all(
-      // F-983: these sessions were minted and never launched, so there is no
+      // These sessions were minted and never launched, so there is no
       // tape to lose — an explicit discard is honest here.
       sessions.map((s) =>
         client.deleteSession(s.session_id, true, { discard: true }).catch(
@@ -213,7 +213,7 @@ export async function runTrialGroup(
     }
   };
 
-  // 2. Trials at bounded concurrency (FDRS-663 resolves FDRS-636's deferred
+  // 2. Trials at bounded concurrency (resolves the earlier deferred
   // "bounded trial parallelism" thread: the bound IS the plan's quota).
   // Rows render in trial order — a finished trial's line waits for every
   // earlier trial's line.
@@ -239,7 +239,7 @@ export async function runTrialGroup(
         agentModel: options.agentModel,
         premintedSession: session,
         abandonOnFailure: true,
-        // FDRS-644 — stamped into the trial's verdict.json so fix-prompt
+        // Stamped into the trial's verdict.json so fix-prompt
         // can reassemble this run set from local artifacts.
         groupId,
       });
@@ -250,7 +250,7 @@ export async function runTrialGroup(
       row = {
         kind: "completed",
         score: result.score.satisfaction,
-        // F-925 — the trial's own verdict, carried out of the run rather than
+        // The trial's own verdict, carried out of the run rather than
         // re-derived here. It was `result.exitCode === 0`, which cannot express
         // the third state (1 means both "failed" and "could not be graded"), so
         // a 100/100 trial with 3 of 4 criteria skipped counted as a clean pass.
@@ -292,10 +292,10 @@ export async function runTrialGroup(
   );
 
   // 3. Summary + the framed handoff to the task's reliability page.
-  // FDRS-665 — the URL carries the agent by construction (Reliability IA v1
+  // The URL carries the agent by construction (Reliability IA v1
   // decision 1): a registered repo prints /agents/<slug>/tasks/<taskName>
   // with ?group for the run set (forward-compat — the page honors it in M1).
-  // Legacy fallbacks, both served by FDRS-668's cloud-side redirects:
+  // Legacy fallbacks, both served by cloud-side redirects:
   // agentId without a slug → /runs/task/<name>?agent=<id> (server-side
   // id→slug redirect); unregistered repo → the bare task URL, which
   // auto-selects when exactly one agent has runs for that task. Task name =
@@ -317,11 +317,11 @@ export async function runTrialGroup(
     out(line);
   }
 
-  // 4. FDRS-644 — the fix & green handoff, only when a COMPLETED trial
+  // 4. The fix & green handoff, only when a COMPLETED trial
   // failed. Errored trials are sandbox noise: the answer there is re-run,
   // not a code fix, so an errored-only group gets no handoff.
   //
-  // F-925 — `fail`, NOT "anything that isn't a pass". This was `!r.passed`,
+  // `fail`, NOT "anything that isn't a pass". This was `!r.passed`,
   // which now includes the incomplete trial, and pointing someone at
   // `pome fix-prompt` for a criterion that never ran tells them to fix an agent
   // that may be blameless. An abstention is a grader gap; the handoff is for

--- a/cli/src/runner/trialCount.ts
+++ b/cli/src/runner/trialCount.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// FDRS-636 — trial-count resolution for `pome run -n k`.
+// Trial-count resolution for `pome run -n k`.
 //
 // [DECISION 2026-07-05]: -n is an integer 1..20 on the hosted run path. The
 // DEFAULT is the scenario config's `runs` field (taskConfigSchema parses

--- a/cli/src/task/githubSeedCompat.ts
+++ b/cli/src/task/githubSeedCompat.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// `/seed`, not the package root (F-1306) — see `parseTask.ts`'s note.
+// `/seed`, not the package root — see `parseTask.ts`'s note.
 import { parseSeed, seedSchema } from "@pome-sh/twin-github/seed";
 
 // Bundled scenario sidecars and legacy compile output used singular `assignee`

--- a/cli/src/task/insertCriterion.ts
+++ b/cli/src/task/insertCriterion.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 /**
- * F-1074 — append one rendered criterion to a task file's `## Success Criteria`,
+ * Append one rendered criterion to a task file's `## Success Criteria`,
  * touching nothing else.
  *
  * It does NOT parse and re-serialize the markdown. Re-serializing is how the
@@ -20,12 +20,12 @@ const NEXT_HEADING_RE = /^##\s+/;
 // It reads a line; it does not VALIDATE one. A retired marker, or a tag naming
 // no declared twin, is still the parser's error to raise. That is also why the
 // `[code]` criteria this file compares against come from `readCodeCriteria`
-// rather than from this regex (F-1443): the twin a bare marker attributes to is
+// rather than from this regex: the twin a bare marker attributes to is
 // the parser's rule, and one rule in one place cannot disagree with itself.
 const CRITERION_RE =
   /^[-*]\s+\[(code|model)(?::([a-z][a-z0-9_-]*))?(\s+always-scored)?\]\s+(.+)$/;
 
-/** One criterion as the duplicate guard compares it — F-1443. NOT the rendered
+/** One criterion as the duplicate guard compares it. NOT the rendered
  *  line: the same check has several legal spellings (`- [code] X`,
  *  `- [code:github] X` and `- [code always-scored] X` all name it on a github
  *  task), and comparing the text an author sees instead of the check it
@@ -45,7 +45,7 @@ function identityKey(criterion: CriterionIdentity): string {
 }
 
 /** Read one line as a criterion, or `undefined` when it is not one. Group 3 (the
- *  F-1299 `always-scored` keyword) is deliberately not read: it says how an
+ *  the `always-scored` keyword) is deliberately not read: it says how an
  *  existing check is scored, not what it checks (see
  *  `taskCriterionSchema.alwaysScored`), so `- [code] X` and
  *  `- [code always-scored] X` are ONE check — appending the second gives the
@@ -88,7 +88,7 @@ export class MissingCriteriaSectionError extends Error {
 // a refusal rather than a warning.
 export class DuplicateCriterionError extends Error {
   constructor(path: string, line: string, existing = line) {
-    // F-1443 — echo the STORED spelling, and name the added one only when the
+    // Echo the STORED spelling, and name the added one only when the
     // two differ. They now can: the guard matches `- [code] X` against a stored
     // `- [code always-scored] X`, and an author sent to look for a line their
     // file does not contain has nothing to search for.
@@ -127,7 +127,7 @@ export function insertCriterion(source: string, line: string, path = "this task 
 
   // The `[code]` criteria the task already declares, keyed by identity and
   // valued by the spelling the file actually carries. `readCodeCriteria` is the
-  // parser's own reader (F-1134): it applies the `tag ?? twins[0]` rule, so a
+  // parser's own reader: it applies the `tag ?? twins[0]` rule, so a
   // bare `- [code] X` recognises a stored `- [code:github] X` on a github task,
   // and its reconstructed `marker` is built to be searchable in the file — which
   // is what the refusal now quotes.
@@ -173,7 +173,7 @@ export function insertCriterion(source: string, line: string, path = "this task 
     insertAt = lines[start + 1]?.trim() === "" ? start + 2 : start + 1;
   }
 
-  // F-1134 — a section whose only content is its blank line puts `insertAt` on
+  // A section whose only content is its blank line puts `insertAt` on
   // the NEXT heading, so the criterion would land against it with nothing
   // between. Cosmetic (it parses either way), but this is the very first write
   // into a freshly scaffolded task, which is the file an author reads hardest.

--- a/cli/src/task/parseTask.ts
+++ b/cli/src/task/parseTask.ts
@@ -5,7 +5,7 @@ import { readFile } from "node:fs/promises";
 import { basename, extname } from "node:path";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
-// The `/seed` SUBPATH, never the package root (F-1306). What this module wants
+// The `/seed` SUBPATH, never the package root. What this module wants
 // from a twin is its zod seed schema and its default world — pure data. The root
 // export additionally carries the domain, the SQLite schema, the Hono app and
 // (for linear) a GraphQL executor, and `main.ts` reaches this module on every
@@ -41,7 +41,7 @@ export async function parseTaskFile(path: string): Promise<Task> {
   return parseTask(markdown, slugFromPath(path), sidecarSeed, path);
 }
 
-/** The task's declared twins, read WITHOUT requiring criteria (F-1074).
+/** The task's declared twins, read WITHOUT requiring criteria.
  *  `taskSchema` demands at least one criterion, and `pome checks add` needs the
  *  twin list BEFORE it has written one. Reuses this module's own section
  *  splitter and config schema, so it is not a second parser. */
@@ -54,7 +54,7 @@ export function readConfigTwins(markdown: string): string[] {
 }
 
 /** Which heading holds the criteria. ONE definition, shared by `parseTask` and
- *  `readCodeCriteria` (F-1134): a reader that knew fewer spellings than the parser
+ *  `readCodeCriteria`: a reader that knew fewer spellings than the parser
  *  would find zero criteria in a task that has several, and zero criteria reads as
  *  a clean bill. Blessing a file whose criteria were never looked at is the exact
  *  failure the binding check exists to remove. */
@@ -73,7 +73,7 @@ export interface CodeCriterion {
 }
 
 /** The task's `[code]` criteria with each one's attributed twin, read WITHOUT the
- *  full task schema (F-1134). Same reason `readConfigTwins` exists, one step
+ *  full task schema. Same reason `readConfigTwins` exists, one step
  *  further along: `pome checks add` and `pome checks lint` audit files that are
  *  mid-edit, and `taskSchema` refuses one carrying no criteria or no resolvable
  *  seed. Reuses this module's own section splitter and criterion grammar, so it
@@ -101,7 +101,7 @@ export function readCodeCriteria(markdown: string): CodeCriterion[] {
     const match = rawLine.trim().match(CRITERION_LINE_RE);
     if (!match || match[1] !== "code") continue;
     const tag = match[2];
-    // F-1299: group 3 is the always-scored keyword, text moved to group 4.
+    // Group 3 is the always-scored keyword, text moved to group 4.
     // Reconstructing the marker WITH the keyword keeps the echoed line
     // findable by search, same reason the twin tag is reconstructed into it.
     const alwaysScored = match[3] !== undefined;
@@ -315,13 +315,13 @@ function splitSections(markdown: string) {
   return sections;
 }
 
-// Criterion marker grammar (F-778): `[code]` / `[model]` optionally carrying a
+// Criterion marker grammar: `[code]` / `[model]` optionally carrying a
 // twin tag, `[code:<twin>]` / `[model:<twin>]`, where <twin> is
 // `[a-z][a-z0-9_-]*`. The marker spells the canonical criterion kind directly.
 // The tag lands on `criterion.twin`; a bare marker leaves it undefined
 // (attributes to the session's primary twin, `twins[0]`).
 //
-// F-1296 (pome-cloud) / F-1299 added a third, optional part: the keyword
+// A third, optional part was added: the keyword
 // `always-scored`, after the kind and any tag — `- [code:slack always-scored]
 // No message was posted to …`. It marks a criterion graded even when the seed
 // already satisfies it (see `taskCriterionSchema.alwaysScored` in
@@ -332,15 +332,15 @@ function splitSections(markdown: string) {
 // (`apps/mcp/src/task/parseTask.ts`, pome-cloud): a task written with the
 // keyword used to parse hosted and silently lose the criterion here, because
 // the older CLI-side regex did not match the line and `parseCriteria` skipped
-// it as unrecognised prose — the exact defect F-1299 closes.
+// it as unrecognised prose — the exact defect this regex closes.
 const CRITERION_LINE_RE =
   /^[-*]\s+\[(code|model)(?::([a-z][a-z0-9_-]*))?(\s+always-scored)?\]\s+(.+)$/;
-// The retired pre-F-778 marker spelling, matched ONLY to fail loudly. Without
+// The retired legacy marker spelling, matched ONLY to fail loudly. Without
 // this guard a legacy `[D]`/`[P]` line would fall through the silent
 // skip-non-criterion path below and the scenario would "pass" with fewer
 // criteria than its author wrote.
 const LEGACY_CRITERION_LINE_RE = /^[-*]\s+\[([DP])(?::([a-z][a-z0-9_-]*))?\]\s+(.+)$/;
-// A line that REACHES for a criterion marker and misses (F-1444). The grammar
+// A line that REACHES for a criterion marker and misses. The grammar
 // above is exact and `parseCriteria` skips anything it does not match as prose,
 // so `- [code always-scored ] …`, `- [code:slack always-scored extra] …` and
 // `- [code alwaysscored] …` each loaded the task with one fewer criterion and no
@@ -365,7 +365,7 @@ const LEGACY_CRITERION_LINE_RE = /^[-*]\s+\[([DP])(?::([a-z][a-z0-9_-]*))?\]\s+(
 //
 // Must stay identical to the hosted parser's (`apps/mcp/src/task/parseTask.ts`,
 // pome-cloud), refusal message included. A guard in only one of the two repos
-// re-opens the cross-parser disagreement F-1299 closed with the sign flipped: a
+// re-opens the cross-parser disagreement, with the sign flipped: a
 // typo would parse hosted and throw here.
 const NEAR_MISS_CRITERION_LINE_RE = /^[-*]\s*\[\s*(code|model)\b[^\]]*\]/;
 
@@ -399,7 +399,7 @@ function parseCriteria(input: string, twins: string[]): Criterion[] {
     }
     const match = line.match(CRITERION_LINE_RE);
     if (!match) {
-      // F-1444: a near-miss is refused here rather than skipped. Reached only
+      // A near-miss is refused here rather than skipped. Reached only
       // after the grammar has said no, so an accepted line never lands here.
       if (NEAR_MISS_CRITERION_LINE_RE.test(line)) {
         throw new Error(nearMissCriterionMessage(line));
@@ -408,7 +408,7 @@ function parseCriteria(input: string, twins: string[]): Criterion[] {
     }
     const kind = match[1]!; // "code" | "model"
     const tag = match[2]; // twin tag or undefined
-    const alwaysScored = match[3] !== undefined; // F-1296/F-1299 `always-scored` keyword
+    const alwaysScored = match[3] !== undefined; // `always-scored` keyword
     const text = match[4]!.trim();
     // Reconstruct the human-facing marker for error messages.
     const marker = `[${kind}${tag ? `:${tag}` : ""}${alwaysScored ? " always-scored" : ""}]`;
@@ -477,7 +477,7 @@ function parseFencedYaml(input: string) {
   return parseYaml(stripFence(input));
 }
 
-// FDRS-365: scenario seed shape is FLAT per twin, disambiguated by config.twins.
+// Scenario seed shape is FLAT per twin, disambiguated by config.twins.
 // Stripe-only scenarios parse with the Stripe schema; everything else (default
 // `["github"]`, or explicit github) parses with the GitHub schema.
 function parseSeedStateForTask(input: unknown, config: TaskConfig): SeedState {

--- a/cli/src/task/seed-compiler-hosted.ts
+++ b/cli/src/task/seed-compiler-hosted.ts
@@ -16,7 +16,7 @@ import { z } from "zod";
 import { resolveCredentials } from "../cli/credentials.js";
 import { HostedAuthError, HostedOrchError, HostedQuotaError } from "../hosted/errors.js";
 import { parseGitHubSeedState } from "./githubSeedCompat.js";
-// `/seed`, not the package root (F-1306) — see `parseTask.ts`'s note.
+// `/seed`, not the package root — see `parseTask.ts`'s note.
 import { seedSchema as seedStateSchema } from "@pome-sh/twin-github/seed";
 import type { CompileResult } from "./seed-compiler.js";
 

--- a/cli/src/task/seed-compiler.ts
+++ b/cli/src/task/seed-compiler.ts
@@ -14,7 +14,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { zodOutputFormat } from "@anthropic-ai/sdk/helpers/zod";
 import { parseGitHubSeedState } from "./githubSeedCompat.js";
-// `/seed`, not the package root (F-1306) — see `parseTask.ts`'s note.
+// `/seed`, not the package root — see `parseTask.ts`'s note.
 import { seedSchema as seedStateSchema } from "@pome-sh/twin-github/seed";
 
 export const COMPILER_MODEL = "claude-opus-4-7";

--- a/cli/src/task/seed-verifier.ts
+++ b/cli/src/task/seed-verifier.ts
@@ -8,7 +8,7 @@
  *
  * Throws if the twin rejects the seed; otherwise returns silently.
  *
- * ASYNC because the twin import is DYNAMIC (F-1306). This is the one seed-side
+ * ASYNC because the twin import is DYNAMIC. This is the one seed-side
  * module that genuinely needs the github twin's domain and SQLite schema — every
  * other one wants only the zod schema and reads it from `@pome-sh/twin-github/seed`.
  * A top-level import here put 205 KB of domain into the CLI's startup path via

--- a/cli/src/task/taskSchema.ts
+++ b/cli/src/task/taskSchema.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// The `/seed` subpath, not the package root (F-1306): a schema is data, and the
+// The `/seed` subpath, not the package root: a schema is data, and the
 // roots carry each twin's domain + server. See `parseTask.ts`'s note.
 import { seedSchema as githubSeedStateSchema } from "@pome-sh/twin-github/seed";
 import { gmailSeedSchema as gmailSeedStateSchema } from "@pome-sh/twin-gmail/seed";
 import { linearSeedSchema as linearSeedStateSchema } from "@pome-sh/twin-linear/seed";
 // Criterion kinds are owned by the published contract. The markdown marker
-// grammar is `[code]`/`[model]` (F-778); `criterionSchema`'s tolerant input
+// grammar is `[code]`/`[model]`; `criterionSchema`'s tolerant input
 // (legacy `D`/`P` enum values) exists only for 0.3.0-era persisted artifacts,
 // never for scenario markdown. The former local criterion-kind fork is
 // retired here (M6 — one published contract).
@@ -14,7 +14,7 @@ import { z } from "zod";
 
 export { criterionSchema };
 
-// F-1296 (pome-cloud) / F-1299 (this repo) — the published contract's
+// The published contract's
 // criterion, plus the one thing this parser has to say about it that the
 // contract does not carry yet.
 //
@@ -37,7 +37,7 @@ export const taskCriterionSchema = criterionSchema.extend({
   alwaysScored: z.boolean().optional(),
 });
 
-// F-1302 — which population a task belongs to. See `taskClassSchema` in
+// Which population a task belongs to. See `taskClassSchema` in
 // ../contract/task.ts for what the three values mean and why the field is
 // optional here but mandatory for the tasks THIS repo ships.
 export const taskClassSchema = z.enum(["conformance", "restraint", "adversarial"]);
@@ -50,7 +50,7 @@ export const taskConfigSchema = z.object({
   passThreshold: z.number().min(0).max(100).default(100)
 });
 
-// FDRS-339: scenario-level failure injection. Mirrors the packaged
+// Scenario-level failure injection. Mirrors the packaged
 // twin-stripe `failureInjectionRuleSchema` without importing it into the
 // parser, so scenario validation stays decoupled from twin boot/runtime code.
 export const stripeFailureInjectionRuleSchema = z.object({
@@ -63,7 +63,7 @@ export const stripeFailureInjectionRuleSchema = z.object({
 });
 
 // `.strict()` at the top level: unknown keys (notably the legacy
-// `stripe: { seed: ... }` wrapper rejected by FDRS-365) fail parsing loudly
+// `stripe: { seed: ... }` wrapper) fail parsing loudly
 // instead of silently being stripped to an empty seed.
 export const stripeSeedStateSchema = z
   .object({
@@ -87,7 +87,7 @@ export const stripeSeedStateSchema = z
   })
   .strict();
 
-// FDRS-529: Slack seed shape (`{ team?, users: [...], channels: [...] }`).
+// Slack seed shape (`{ team?, users: [...], channels: [...] }`).
 // Kept LOCAL and permissive (arrays of records) for the same reason the Stripe
 // schema is — the scenario parser shouldn't take a structural dep on twin
 // internals; the vendored `cli/src/twin-slack` `parseSeed` does the strict,
@@ -100,7 +100,7 @@ export const slackSeedStateSchema = z
     team: z.record(z.string(), z.unknown()).optional(),
     users: z.array(z.record(z.string(), z.unknown())).default([]),
     channels: z.array(z.record(z.string(), z.unknown())).default([]),
-    // F-1509. Permissive like its siblings — the vendored `parseSeed` does the
+    // Permissive like its siblings — the vendored `parseSeed` does the
     // regex-level validation. It has to be listed at all because `.strict()`
     // REJECTS an unlisted key: without this line a slack seed declaring `files`
     // fails to parse rather than being stripped.
@@ -108,7 +108,7 @@ export const slackSeedStateSchema = z
   })
   .strict();
 
-// FDRS-365 [DECISION 2026-05-12]: scenario seeds are FLAT per twin.
+// [DECISION 2026-05-12]: scenario seeds are FLAT per twin.
 // GitHub scenarios use the GitHub seed shape (`{ repositories: [...] }`),
 // Stripe scenarios use the Stripe seed shape (`{ api_keys: [...], ... }`),
 // Slack scenarios use the Slack seed shape (`{ users, channels, ... }`).

--- a/cli/src/twin/registry.ts
+++ b/cli/src/twin/registry.ts
@@ -16,7 +16,7 @@
 //   2. `pome twin start github` only pays for github.
 //
 // THIS MODULE IS NOT THE WHOLE STORY, and for six releases it was the wrong
-// half of it (F-1306). Everything above was true here and false in aggregate:
+// half of it. Everything above was true here and false in aggregate:
 // `cli/src/task/{parseTask,taskSchema,githubSeedCompat,seed-compiler,
 // seed-compiler-hosted}.ts` top-level-imported twin-github/gmail/linear's
 // PACKAGE ROOTS to reach a zod seed schema, and a root export carries the domain
@@ -170,9 +170,9 @@ export const TWIN_REGISTRY: Record<TwinName, TwinEntry> = {
     version: stripeManifest.version,
     defaultSeed: async () => (await import("@pome-sh/twin-stripe")).defaultSeed(),
     async boot({ seedState, runId, recorder, twinBaseUrl }) {
-      // Engine-based twin (F-684): the factory owns middleware, MCP mount, and
+      // Engine-based twin: the factory owns middleware, MCP mount, and
       // the failure-injection store — seed rules ride in via `seed` and land in
-      // the same store the session middleware reads (FDRS-369), so e.g.
+      // the same store the session middleware reads, so e.g.
       // scenario 14's lost-response 402 actually fires. Recorder counters
       // (dropped) come from the engine handle, so the shared CLI recorder
       // suffices here too.

--- a/cli/src/twin/twinHarness.ts
+++ b/cli/src/twin/twinHarness.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Twin-agnostic in-process boot for the self-host runner (FDRS-528 / FDRS-529).
+// Twin-agnostic in-process boot for the self-host runner.
 //
 // `bootTwin` is a thin wrapper over `TWIN_REGISTRY`: given a twin name + the
 // scenario's (already twin-shaped) seed state, it stands up the matching
@@ -61,7 +61,7 @@ export async function bootTwin(opts: {
   runId: string;
   twinBaseUrl?: string;
   /**
-   * F-698: when set, twin HTTP events stream to this NDJSON path via the
+   * When set, twin HTTP events stream to this NDJSON path via the
    * twin-core durable recorder (same file capture-server appends to).
    */
   eventsPath?: string;

--- a/cli/src/twin/twinStart.ts
+++ b/cli/src/twin/twinStart.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// `pome twin start <twin>` (F-709) — the docker-free front door. Boots any
+// `pome twin start <twin>` — the docker-free front door. Boots any
 // of the three twins as a long-lived foreground server (Ctrl-C to stop) on
 // the same in-process boot path `pome run --local` uses (`bootTwin`), so
 // `npx @pome-sh/cli twin start github` serves the identical control plane
@@ -9,10 +9,10 @@
 // Auth: the twin's bearer middleware reads `TWIN_AUTH_SECRET` from the env
 // (engine contract). The CLI resolves the secret the same way an operator
 // would — an env-injected `TWIN_AUTH_SECRET` always wins, else the secret a
-// prior twin boot persisted at `.pome-data/<twin>/secret` (F-708 write side;
+// prior twin boot persisted at `.pome-data/<twin>/secret` (the twin writes it;
 // `POME_TWIN_DATA_DIR` overrides the directory) is reused, else a per-boot
 // ephemeral secret is generated. Loopback binds deliberately do NOT persist
-// a new secret file — that mirrors F-708's loopback carve-out, and the
+// a new secret file — that mirrors the twin's own loopback carve-out, and the
 // ready-to-use JWT is reprinted on every boot anyway.
 
 import { randomBytes } from "node:crypto";
@@ -35,7 +35,7 @@ export type StandaloneAuthSecret = {
 };
 
 /**
- * Read side of the F-708 secret contract. Resolution order:
+ * Read side of the boot-secret contract. Resolution order:
  *   1. env `TWIN_AUTH_SECRET` (always wins — same rule as the twin boots)
  *   2. the persisted `.pome-data/<twin>/secret` (`POME_TWIN_DATA_DIR`
  *      overrides the directory); blank file = absent, < 32 chars = loud
@@ -62,7 +62,7 @@ export function resolveStandaloneAuthSecret(
     return { secret: persisted, source: "persisted", path: secretPath };
   }
   if (persisted.length > 0) {
-    // Same rule as the engine's readSecretFile (F-708): a short secret is
+    // Same rule as the engine's readSecretFile: a short secret is
     // operator content we must not silently serve or regenerate over.
     throw new Error(
       `The persisted secret at ${secretPath} is shorter than 32 chars — fix or delete the file, or inject TWIN_AUTH_SECRET.`,

--- a/cli/test/unit/hosted/cross-surface-agreement.test.ts
+++ b/cli/test/unit/hosted/cross-surface-agreement.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-1392 / D3 — "no surface states more than it checked", applied to the two
+// D3 — "no surface states more than it checked", applied to the two
 // surfaces that answer ONE question: is this run a pass, a fail, or a run the
 // grader did not finish?
 //
@@ -9,20 +9,20 @@
 // run-status.ts`, pome-cloud). They share no code — the two repos publish no
 // module to each other, and the only thing that crosses is the
 // `criteria_results` wire shape plus one reason string. So "they agree" is a
-// claim someone has to check, and until this file existed nobody did: F-1392
-// was a run the CLI called INCOMPLETE and the dashboard called PASS, shipped
+// claim someone has to check, and until this file existed nobody did. The
+// defect was a run the CLI called INCOMPLETE and the dashboard called PASS, shipped
 // for as long as it took a human to notice the two screens disagreeing.
 //
 // `dashboardRunStatus` below WAS a transcription — a hand copy of pome-cloud's
 // three clauses, named clause by clause so a reviewer could diff it against the
-// original. F-1416 deleted the copy. It now CALLS the real predicate, which
+// original. That copy is deleted. It now CALLS the real predicate, which
 // both repositories install from `@pome-sh/wire/run-completeness`.
 //
-// WHY THAT MATTERS MORE THAN IT LOOKS. F-1399 moved the arithmetic out of
+// WHY THAT MATTERS MORE THAN IT LOOKS. The arithmetic moved out of
 // `run-status.ts` into a shared predicate inside pome-cloud, closing this exact
 // defect class one repo over — and the copy in THIS file went stale the moment
 // it did, and went stale GREEN: it kept passing while asserting something false
-// about the other repo. F-1413 was the second time that happened. Both times
+// about the other repo. That happened twice. Both times
 // nothing detected it; it was caught because one person happened to be holding
 // both sides. A transcription is a parallel copy with the longest possible
 // feedback loop, and it was sitting inside the very test written to prove
@@ -49,12 +49,12 @@
 // different animal: it is one line, it has no counts in it, and it cannot be
 // wrong by an off-by-one.
 //
-// There is no known divergence between the two surfaces today — F-1399 closed
-// the last one (below). A row CAN still carry a `divergence` marker if the two
+// There is no known divergence between the two surfaces today — the last one
+// is closed (below). A row CAN still carry a `divergence` marker if the two
 // surfaces disagree again: a known divergence with a test on it is a fact; the
-// same divergence with no test on it is the F-1392 defect again.
+// same divergence with no test on it is the original defect again.
 //
-// F-1195 — there is now a THIRD surface answering the same question: the
+// There is now a THIRD surface answering the same question: the
 // `state` field of the `verdict.json` a hosted run writes, which is what CI
 // reads instead of scraping stderr. It answers with the CLI's word by
 // construction (`runTaskHosted.ts` passes the one `verdict` local it already
@@ -105,7 +105,7 @@ function dashboardRunStatus(
   results: readonly CriterionResult[],
   satisfactionScore: number,
 ): DashboardStatus {
-  // F-925 — incomplete outranks the score, including a failing one. If `fail`
+  // Incomplete outranks the score, including a failing one. If `fail`
   // won that contest, the same instrument gap would produce a different run
   // state depending on how the agent performed.
   if (isIncompleteTally(tallyCriteriaResults(results))) return "incomplete";
@@ -186,7 +186,7 @@ const table: Row[] = [
     expected: "incomplete",
   },
   {
-    name: "F-925: an abstention outranks a failing score",
+    name: "an abstention outranks a failing score",
     results: [passing("a"), failing("b"), abstained("c")],
     satisfaction: 50,
     expected: "incomplete",
@@ -198,7 +198,7 @@ const table: Row[] = [
     expected: "incomplete",
   },
   {
-    // The F-1392 hero shape: support-triage-dedup scores 100 over three
+    // The hero shape: support-triage-dedup scores 100 over three
     // criteria with a fourth excluded as already true in the seed. This is the
     // row that used to read pass / incomplete.
     name: "seed-excluded criterion beside three passes",
@@ -219,7 +219,7 @@ const table: Row[] = [
     expected: "fail",
   },
   {
-    // F-1399 added `isIncompleteTally`'s third clause (`evaluated === 0`):
+    // `isIncompleteTally` gained a third clause (`evaluated === 0`):
     // an all-excluded run has an empty denominator, which used to fall
     // through to `satisfaction_score === 100 ? pass : fail` and land on
     // `fail` here. Both surfaces now agree it is `incomplete` — the CLI
@@ -237,7 +237,7 @@ const table: Row[] = [
  *  Not `table.find((r) => r.divergence)`: that predicate selected the row only
  *  while the row was MARKED as a divergence, so closing the divergence handed
  *  its caller `undefined` and the test kept passing on a `!`-asserted ghost
- *  (F-1413). Renaming a row must red with a readable message instead. */
+ *  Renaming a row must red with a readable message instead. */
 function rowNamed(name: string): Row {
   const row = table.find((r) => r.name === name);
   if (row === undefined) {
@@ -246,7 +246,7 @@ function rowNamed(name: string): Row {
   return row;
 }
 
-describe("CLI and dashboard answer `what state is this run in?` the same way (F-1392)", () => {
+describe("CLI and dashboard answer `what state is this run in?` the same way", () => {
   for (const row of table) {
     const label = row.divergence ? `${row.name} [known divergence]` : row.name;
     it(label, () => {
@@ -265,7 +265,7 @@ describe("CLI and dashboard answer `what state is this run in?` the same way (F-
   // ── isIncompleteTally's FIRST clause, which no row above reaches ─────────
   //
   // `total === 0 ⇒ never incomplete` is the one clause no row in the table
-  // exercises, since every row has criteria. Since F-1416 the clause itself is
+  // exercises, since every row has criteria. The clause itself is
   // pinned where it is implemented (`packages/wire/test/run-completeness.
   // test.ts` exhausts all three), so what these two cases are for is no longer
   // "cover the transcription" — it is the CROSS-SURFACE fact, which is the only
@@ -298,15 +298,15 @@ describe("CLI and dashboard answer `what state is this run in?` the same way (F-
     });
   });
 
-  // ── The third surface: verdict.json's `state` (F-1195) ───────────────────
+  // ── The third surface: verdict.json's `state` ───────────────────────────
   //
   // `runTaskHosted.ts` writes `state: verdict` — the same local that produced
   // the terminal's word — so agreement between the artifact and the terminal
   // is structural, and the e2e tests prove the wiring. The risk this block
   // covers is the OTHER one: that the artifact spells the answer in a
-  // vocabulary of its own, which would be the F-1392 defect reappearing in a
+  // vocabulary of its own, which would be the original defect reappearing in a
   // new file.
-  describe("verdict.json spells the state in the same three words (F-1195)", () => {
+  describe("verdict.json spells the state in the same three words", () => {
     async function roundtripState(state: string): Promise<string | undefined> {
       const dir = join(await mkdtemp(join(tmpdir(), "xsurface-")), "scn", "ses_1");
       await mkdir(dir, { recursive: true });
@@ -352,35 +352,35 @@ describe("CLI and dashboard answer `what state is this run in?` the same way (F-
       });
     }
 
-    it("records the same word as the dashboard now that F-1399 closed the divergence, and the closure is stated in the artifact's own doc", async () => {
+    it("records the same word as the dashboard now that the divergence is closed, and the closure is stated in the artifact's own doc", async () => {
       const row = rowNamed("every criterion seed-excluded — no denominator");
       const cliWord = cliRunStatus(row.results, row.satisfaction);
-      // The all-pre-satisfied run: F-1399 added `isIncompleteTally`'s
+      // The all-pre-satisfied run: `isIncompleteTally` gained an
       // `evaluated === 0` clause, so the dashboard now reads `incomplete`
       // here too — the CLI already did, via its own A5 guard. `passed` — the
-      // only bit CI can act on — agreed even before F-1399; now the word
+      // only bit CI can act on — agreed even before that; now the word
       // itself does too.
       expect(cliWord).toBe("incomplete");
       expect(dashboardRunStatus(row.results, row.satisfaction)).toBe("incomplete");
       expect(await roundtripState(cliWord)).toBe("incomplete");
 
       // The claim in this test's name is checked, not asserted: the field a
-      // CI reader meets first is `VerdictArtifact.state`, so the F-1399
-      // history has to be legible from there. Delete the mention and this
-      // goes red rather than the artifact quietly losing the only place that
-      // history was written down.
+      // CI reader meets first is `VerdictArtifact.state`, so the mechanism that
+      // closed the divergence has to be legible from there. Delete the
+      // explanation and this goes red rather than the artifact quietly losing
+      // the only place it was written down.
       const artifactSource = await readFile(
         new URL("../../../src/hosted/evalResultCache.ts", import.meta.url),
         "utf8",
       );
-      expect(artifactSource).toContain("F-1399");
+      expect(artifactSource).toContain("`evaluated === 0` clause");
     });
   });
 
   it("has no known divergences between the two surfaces", () => {
     // A guard on the guard: adding a `divergence` to a row is how this file
     // would be silenced, so the count is asserted rather than left to review.
-    // F-1399 closed the last one (the empty-denominator row above); the next
+    // The last one (the empty-denominator row above) is closed; the next
     // one has to be added deliberately, not slip in unnoticed.
     const diverging = table.filter((row) => row.divergence);
     expect(diverging.map((row) => row.name)).toEqual([]);
@@ -389,7 +389,7 @@ describe("CLI and dashboard answer `what state is this run in?` the same way (F-
 
 // ── What the table is still worth, now that the arithmetic is shared ────────
 //
-// A reasonable question after F-1416: if both surfaces call one predicate, is a
+// A reasonable question: if both surfaces call one predicate, is a
 // row-by-row agreement table anything but a tautology? No, and the rows above
 // say why. `dashboardRunStatus` and `cliRunStatus` reach their answers by
 // genuinely different routes — the dashboard runs the shared predicate over
@@ -403,6 +403,6 @@ describe("CLI and dashboard answer `what state is this run in?` the same way (F-
 //
 // So the table pins what it always pinned: that two independently-implemented
 // readers of one wire shape agree, row by row, and never split on the single
-// bit CI can act on. What F-1416 removed is the part that was never a test at
+// bit CI can act on. What was removed is the part that was never a test at
 // all — a copy of the other repo's counting, which could only ever agree with
 // itself.


### PR DESCRIPTION
## What

Second slice of the internal-reference cleanup: `cli/src` carried **447** tracker-id references across 77 files, in comments, JSDoc, and — in two places — in `--help` text a user reads.

```
-n, --trials <count>   FDRS-636: run <count> isolated trials of the task ...
--allow <hosts>        FDRS-635: comma-separated egress allowlist patterns ...
```

Both now open with what the flag does.

## How each occurrence was handled

- **The comment already explained the constraint** → the id was dropped, nothing else changed. This was most of them.
- **The id was the sentence's subject** (*"F-1399 moved the arithmetic out of run-status.ts"*) → rewritten to say what happened, so the comment stands on its own.
- **Pure history** → deleted. Git history already links each commit to its ticket.

Also removes the bare `W3` milestone marker from the contract modules, which was the label for the scenario→task wire rename. The prose now names the rename directly, which is what a reader needed anyway.

## Two changes outside `cli/src`, both forced by this one

**A test asserted the convention.** `cross-surface-agreement.test.ts` read `evalResultCache.ts` off disk and asserted its doc comment contains the literal string `"F-1399"` — a guard to stop the artifact quietly losing the only written record of why two surfaces agree. Good intent, wrong anchor. It now asserts the substantive phrase (`` `evaluated === 0` clause ``), which is the actual mechanism and still fails if someone deletes the explanation. The rest of that file's ids went with it, since it had to be edited anyway.

**A lint fired on a comment that never claimed to be a marker.** `seed-state.ts` said `// F-1509. Mirrors \`seedSchema.files\` in @pome-sh/twin-slack`. Dropping the prefix moved `Mirrors` to the start of the line — the exact declaration syntax `scripts/check-copy-markers.mjs` reserves for intentional cross-package copies. Reworded to "Same shape as", which is what it means, rather than allowlisting a marker that was never declared.

## Scope

Source only. `scripts/`, `contract/` and the test tree still carry the pattern and are follow-up work.

## Verification

- `tsc --noEmit` over `cli`
- Full vitest suite: **337 files, 3738 tests, all passing**
- Gates: `copy-markers`, `code-health`, `no-catch`, `parent-vocab`, `legacy-markers`, `route-inputs`, `import-meta-main`, `task-class`, `no-eval`, `no-native`, and the release-note gate
- No remaining id or bare `W3` in `cli/src`

The mechanical pass was checked for collateral damage: line-count deltas per file against base (to catch regex-joined lines), and a scan for comment lines left starting with punctuation. Six such artifacts were found and fixed.