### PR TITLE
Remove internal ticket ids from scripts/ and contract/

### DIFF
--- a/contract/cli-start.test.mjs
+++ b/contract/cli-start.test.mjs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// CLI front-door contract suite (F-709). Runs the same frozen FDRS-711
+// CLI front-door contract suite. Runs the same frozen
 // assertions against twins started via `pome twin start <twin>` — the
 // docker-free quickstart path — instead of the packaged boot entries. The
 // CLI boots the twins in-process (cli/src/twin/twinHarness.ts) from its
@@ -11,11 +11,11 @@
 // `npm run build`) — NOT chained by the root `test:contract` script
 // (contract/run.mjs only builds its own five packages: wire, sdk, twin-*).
 // ci.yml's heavy job runs this file as its own step, after the earlier
-// root-wide `npm run build` already built cli/ (F-1353). Run locally with
+// root-wide `npm run build` already built cli/. Run locally with
 // `node --test contract/cli-start.test.mjs`.
 //
 // bootGuardCase is deliberately absent: `pome twin start` binds loopback
-// only, so the F-708 non-loopback self-generation guard lives with the
+// only, so the non-loopback self-generation guard lives with the
 // packaged entries (contract.test.mjs). The CLI's read side of the secret
 // contract (env wins → persisted `.pome-data/<twin>/secret` → ephemeral)
 // is covered by the CLI's own unit + e2e suites.

--- a/contract/contract.test.mjs
+++ b/contract/contract.test.mjs
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Black-box twin runtime-contract suite (FDRS-711). Spawns each BUILT twin
+// Black-box twin runtime-contract suite. Spawns each BUILT twin
 // exactly the way pome-cloud does (`node dist/src/server.js`, cwd = package
 // root, TWIN_AUTH_SECRET/PORT injected) and asserts the control-plane surface
 // documented in /CONTRACT.md from outside the process.
 //
 // These assertions FREEZE observed wire behavior — including per-twin
-// divergences that are themselves under review (see FDRS-712). Changing any
+// divergences that are themselves under review. Changing any
 // asserted status or shape is a contract change: update CONTRACT.md in the
 // same PR and coordinate the pome-cloud consumer PR per the contract doc.
-// The suite body lives in ./suite.mjs (FDRS-681) so the identical assertions
+// The suite body lives in ./suite.mjs so the identical assertions
 // also run against the sdk-booted proof entry (./sdk-boot.test.mjs).
 //
 // Prerequisite: `npm run build -w @pome-sh/wire`,

--- a/contract/gmail-fault.test.mjs
+++ b/contract/gmail-fault.test.mjs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-917 black-box case: a Gmail seed with a named `rate-limited` fault throttles
+// Black-box case: a Gmail seed with a named `rate-limited` fault throttles
 // `messages.send` by call count over the real wire. Proves the contract that
 // pome-cloud relies on — the deployed dist, not a library import.
 

--- a/contract/helpers.mjs
+++ b/contract/helpers.mjs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Zero-dependency helpers for the black-box twin contract suite (FDRS-711).
+// Zero-dependency helpers for the black-box twin contract suite.
 // Plain node:child_process + node:crypto + global fetch, so the same suite
 // can run against any built twin artifact — the workspace dist today, a
-// cloud-built snapshot tomorrow (FDRS-714) — without installing this repo's
+// cloud-built snapshot tomorrow — without installing this repo's
 // dependencies. The wire format is the contract, not a library.
 
 import { spawn } from "node:child_process";
@@ -25,7 +25,7 @@ const ALL_TWINS = [
   { name: "linear", pkg: "packages/twin-linear", dbEnv: "LINEAR_TWIN_DB", hostEnv: "LINEAR_TWIN_HOST" },
 ];
 
-// FDRS-714: the suite can target an external built twin — e.g. a cloud-built
+// The suite can target an external built twin — e.g. a cloud-built
 // Vercel Sandbox — instead of this repo's workspace dists. CONTRACT_TWIN_ONLY
 // narrows the run to one twin; CONTRACT_TWIN_PKG_ROOT (absolute path) replaces
 // the repo-relative package root as the spawn cwd, and only makes sense
@@ -67,8 +67,8 @@ export async function freePort() {
 }
 
 // A twin descriptor may carry an `entry` (repo-root-relative) to boot an
-// alternate server entry — used by the sdk-boot proof suite (FDRS-681) and
-// the CLI front-door suite (F-709), which also appends `args` (e.g.
+// alternate server entry — used by the sdk-boot proof suite and
+// the CLI front-door suite, which also appends `args` (e.g.
 // `twin start github`). Default is the contract's own `dist/src/server.js`.
 function entryArgs(twin) {
   if (twin.entry && TWIN_PKG_ROOT_OVERRIDE) {
@@ -80,8 +80,8 @@ function entryArgs(twin) {
 }
 
 // Package root the twin is spawned from: the repo-relative workspace dist by
-// default, or CONTRACT_TWIN_PKG_ROOT when the suite targets an external built
-// twin (FDRS-714).
+// default, or CONTRACT_TWIN_PKG_ROOT when the suite targets an external
+// built twin.
 function twinCwd(twin) {
   return TWIN_PKG_ROOT_OVERRIDE ?? path.join(REPO_ROOT, twin.pkg);
 }

--- a/contract/run.mjs
+++ b/contract/run.mjs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Orchestrator for the twin runtime-contract suite (FDRS-711): build the wire
+// Orchestrator for the twin runtime-contract suite: build the wire
 // contract + the five twins, then run the black-box suite with plain `node`.
 
 import { spawnSync } from "node:child_process";
@@ -40,7 +40,7 @@ function run(cmd, args) {
 // `>=24`, so on 24.0/24.1 it is `undefined`, this guard is false, and
 // `npm run test:contract` exits 0 having built nothing and asserted nothing —
 // the exact "a check that never ran reads like one that passed" failure
-// F-1353 exists to remove, promoted from one file to the whole suite. The
+// this runner exists to remove, promoted from one file to the whole suite. The
 // argv/import.meta.url comparison the repo's other entry guards use, pinned
 // for the same reason in scripts/capture-mcp-tools-list.test.mjs — but
 // realpath'd on BOTH sides: node resolves symlinks before deriving
@@ -64,7 +64,7 @@ if (invokedDirectly) {
   // the twins with plain `node`, so wire's dist/ must exist before anything boots.
   let status = run("npm", ["run", "build", "-w", "@pome-sh/wire"]);
   // The sdk build must precede the twin builds: twin-slack is a thin
-  // @pome-sh/sdk plugin since F-683 and compiles against the sdk dist.
+  // @pome-sh/sdk plugin and compiles against the sdk dist.
   if (status === 0) status = run("npm", ["run", "build", "-w", "@pome-sh/sdk"]);
   if (status === 0) status = run("npm", ["run", "build", "-w", "@pome-sh/twin-github"]);
   if (status === 0) status = run("npm", ["run", "build", "-w", "@pome-sh/twin-slack"]);

--- a/contract/run.test.mjs
+++ b/contract/run.test.mjs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Regression for F-1353: contract/run.mjs must discover every *.test.mjs file
+// Regression: contract/run.mjs must discover every *.test.mjs file
 // under contract/ instead of hand-listing them. The three fixture-directory
 // cases pin the discovery mechanism itself; the last case proves it against
 // the real contract/ directory by recomputing the expectation from an
@@ -70,7 +70,7 @@ test("real contract/ directory matches an independent readdir scan, minus the do
 // (discovered by run.mjs) ∪ (invoked by a named ci.yml step) provably TOTAL
 // over contract/*.test.mjs, so a second cli-dependent contract test cannot be
 // excluded from the runner without a workflow step that runs it — the drift
-// F-1353 found, where two lists each assumed the other covered the file. The
+// we found, where two lists each assumed the other covered the file. The
 // second reds if the runner's `node --test` argv goes back to literal paths,
 // which the discoverTestFiles() cases above would stay green through: they
 // test the helper, not what the pipeline actually invokes.
@@ -80,7 +80,7 @@ const REPO_ROOT = path.resolve(CONTRACT_DIR, "..");
 
 test("every contract/*.test.mjs file is run by the runner or by a named ci.yml step", () => {
   // Only lines where the COMMAND starts with `node --test` count: a comment
-  // naming the file is not a step that runs it (ci.yml's own F-1353 note names
+  // naming the file is not a step that runs it (ci.yml's own note names
   // cli-start.test.mjs in prose), and neither is a `name:` or an `echo`. Then
   // whole-token matching, not a RegExp built from a filename — a path is not a
   // pattern, and `foo.test.mjs` as a regex also matches `fooXtest.mjs`.

--- a/contract/sdk-boot.test.mjs
+++ b/contract/sdk-boot.test.mjs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// sdk-boot suite (F-681 → F-683). Before the port this ran the frozen
-// FDRS-711 slack assertions against a proof entry (contract/proof/
+// sdk-boot suite. Before the port this ran the frozen
+// slack assertions against a proof entry (contract/proof/
 // slack-sdk-server.mjs) that assembled the twin on the @pome-sh/sdk engine.
-// Since F-683 the slack package's OWN entry (`node dist/src/server.js`, cwd
+// The slack package's OWN entry (`node dist/src/server.js`, cwd
 // = package root — the frozen boot contract) boots through defineTwin(), so
 // the proof entry is superseded and deleted: this suite now spawns the real
 // package and keeps the same 11 frozen assertions running against the

--- a/contract/suite.mjs
+++ b/contract/suite.mjs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Reusable body of the black-box twin runtime-contract suite (FDRS-711).
-// Extracted verbatim from contract.test.mjs (FDRS-681) so the same frozen
+// Reusable body of the black-box twin runtime-contract suite.
+// Extracted verbatim from contract.test.mjs so the same frozen
 // assertions can run against any built twin artifact AND the sdk-booted
 // proof entry (contract/sdk-boot.test.mjs). Changing any asserted status or
 // shape here is a contract change: update CONTRACT.md in the same PR and
@@ -26,10 +26,10 @@ export const PER_TWIN = {
     sessionHealthz: { status: 200 },
     // github validates seeds: a garbage body is a 422 GitHub validation error.
     adminSeedGarbage: { status: 422, check: (b) => b.message === "Validation Failed" },
-    // F-1497 CONTRACT CHANGE: `noAuth` sends NO Authorization header, and real
+    // CONTRACT CHANGE: `noAuth` sends NO Authorization header, and real
     // GitHub answers that with `Requires authentication` — `Bad credentials`
     // is what it answers a bad token. Measured live 2026-08-13 on `GET /user`,
-    // both ways. The twin collapsed the two until F-1497; CONTRACT.md's auth
+    // both ways. The twin used to collapse the two; CONTRACT.md's auth
     // table moved with this line. No pome-cloud consumer reads either string
     // (searched: zero hits for "Bad credentials" in that repo).
     noAuth: {
@@ -51,7 +51,7 @@ export const PER_TWIN = {
     expired: { status: 401, check: (b) => b.message === "Bad credentials" },
     rawToken: { status: 401 },
     mcpCallUnknown: { status: 422, check: (b) => b.message === "Validation Failed" },
-    // Body-parsing corners (F-683 review pins, probed 2026-07-08): github is
+    // Body-parsing corners (review pins, probed 2026-07-08): github is
     // strict JSON everywhere — form-encoded and malformed bodies answer the
     // GitHub wire error; {name}/{params} aliases are not accepted.
     aliasTool: "list_repos",
@@ -77,7 +77,7 @@ export const PER_TWIN = {
     expired: { status: 401, check: (b) => b.error === "token_expired" },
     rawToken: { status: 401 },
     mcpCallUnknown: { status: 404, check: (b) => b.error === "unknown_tool" },
-    // Body-parsing corners (F-683 review pins; probed 2026-07-08 against the
+    // Body-parsing corners (review pins; probed 2026-07-08 against the
     // pre-port 3cd86eb build): slack parses form-or-JSON tolerantly on every
     // surface (official Slack SDKs default to form-urlencoded; malformed JSON
     // collapses to {}), accepts the {name}/{params} alias keys, a body naming
@@ -111,10 +111,11 @@ export const PER_TWIN = {
     // stripe is the only twin answering a sid mismatch with 403 (not 401).
     wrongSid: { status: 403, check: (b) => b.error?.code === "forbidden" },
     expired: { status: 401, check: (b) => b.error?.code === "unauthorized" },
-    // stripe accepts a prefix-less bearer (raw JWT) today — FDRS-712 row 4.
+    // stripe accepts a prefix-less bearer (raw JWT) today — the raw-bearer row
+    // of CONTRACT.md's per-twin frozen differences.
     rawToken: { status: 200 },
     mcpCallUnknown: { status: 400, check: (b) => b.error?.code === "tool_unknown" },
-    // Body-parsing corners (F-683 review pins, probed on the pre-port twin):
+    // Body-parsing corners (review pins, probed on the pre-port twin):
     // stripe reads form-or-JSON (malformed JSON collapses to {}), rejects the
     // alias keys with its parameter_invalid envelope, and dispatches
     // form-encoded legacy /mcp/call bodies.
@@ -260,7 +261,7 @@ function checkBody(expectation, body, label) {
 }
 
 /**
- * F-1497 — what each vendor actually puts on an auth-refusal envelope, and the
+ * What each vendor actually puts on an auth-refusal envelope, and the
  * 403 body the twin's admin gate must answer with.
  *
  * ── HOW THIS WAS OBTAINED ─────────────────────────────────────────────────
@@ -275,11 +276,11 @@ function checkBody(expectation, body, label) {
  * ⚠️ ONE of the five sends `documentation_url`. GitHub. The other four send no
  * such key anywhere in the body, which is why `docsUrl: null` below is an
  * assertion and not a "not measured" — it says the twin must not invent one.
- * Before F-1497 all five COULD, because the 401/403 defaults in `@pome-sh/sdk`
+ * All five used to, because the 401/403 defaults in `@pome-sh/sdk`
  * carried `documentation_url: ""`, and gmail + linear were reaching that
  * default on their admin 403.
  *
- * The `docsUrl` github does send is the GENERIC one on every 401 (8/8, F-1490)
+ * The `docsUrl` github does send is the GENERIC one on every 401 (8/8)
  * — authentication fails before dispatch, so there is no operation to name, and
  * the twin's admin route is twin-only for the same reason.
  */
@@ -337,7 +338,7 @@ function collectDocumentationUrls(value, found = []) {
 }
 
 /**
- * The cross-twin half of F-1497: a twin may carry its OWN vendor's
+ * The cross-twin half of the auth contract: a twin may carry its OWN vendor's
  * `documentation_url` and no other twin's, and a twin whose vendor sends none
  * must send none — not `""`, not a nested one, not GitHub's.
  *
@@ -486,7 +487,7 @@ export function contractSuite(twin, exp, label = twin.name) {
       });
       assert.equal(raw.status, exp.rawToken.status, "raw (prefix-less) bearer behavior is frozen per twin");
 
-      // F-1497 — the same four refusals, read for ONE leaf across all five
+      // The same four refusals, read for ONE leaf across all five
       // twins: `documentation_url` is GitHub's key and only GitHub's vendor
       // sends it. This ran green while every twin was emitting
       // `documentation_url: ""` from the shared SDK default, which is exactly
@@ -605,7 +606,7 @@ export function adminGateCase(twin, label = twin.name) {
       const wrong = await req(t.base, "/admin/reset", { method: "POST", headers: { "X-Admin-Token": "nope" } });
       assert.equal(wrong.status, 403);
 
-      // F-1497 — the BODY, not just the status. This gate lives in
+      // The BODY, not just the status. This gate lives in
       // `@pome-sh/sdk` and is shared by all five twins, so its default could
       // never be vendor-shaped: it answered github's
       // `{message:"Forbidden", documentation_url:""}` on every twin that had
@@ -631,7 +632,7 @@ export function adminGateCase(twin, label = twin.name) {
 }
 
 /**
- * F-708 boot-secret contract: a non-loopback bind with no env-injected
+ * Boot-secret contract: a non-loopback bind with no env-injected
  * TWIN_AUTH_SECRET self-generates a 32-byte hex secret, persists it at the
  * compose-era location (POME_TWIN_DATA_DIR overrides `.pome-data/<twin>`),
  * prints it once to stdout, and reuses it on reboot. An env-injected secret

--- a/packages/checks/CHANGELOG.md
+++ b/packages/checks/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pome-sh/checks
 
+## Unreleased (patch)
+
+**No consumer-visible change.** Internal tracker ids were removed from comments
+in the shared declaration bundler (`scripts/bundle-declarations.mjs`) and the CI
+gates around it. Comment text only: the bundle's inputs, outputs and export
+surface are unchanged. Listed only because that script sits on a path the next
+release carries.
+
 ## 0.3.3 — 2026-08-22
 
 **No consumer-visible change.** The repo's top-level `examples/` directory is now

--- a/packages/sandbox-domains/CHANGELOG.md
+++ b/packages/sandbox-domains/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pome-sh/sandbox-domains
 
+## Unreleased (patch)
+
+**No consumer-visible change.** Internal tracker ids were removed from comments
+in the shared declaration bundler (`scripts/bundle-declarations.mjs`) and the CI
+gates around it. Comment text only: the bundle's inputs, outputs and export
+surface are unchanged. Listed only because that script sits on a path the next
+release carries.
+
 ## 0.2.9 — 2026-08-23
 
 **No consumer-visible change.** Internal tracker ids were removed from the

--- a/scripts/bundle-declarations.mjs
+++ b/scripts/bundle-declarations.mjs
@@ -15,10 +15,10 @@
 //
 // It lived at `packages/checks/scripts/` while `@pome-sh/checks` was the only
 // bundling package with re-export-only sources. `@pome-sh/sandbox-domains`
-// (F-1526) is the second, and the algorithm below is entirely
+// is the second, and the algorithm below is entirely
 // package-agnostic — it reads the caller's `dist/` and resolves specifiers
 // through the OWNING package's `exports` map. Copying ~300 lines into a second
-// package would be the F-1135 shape `scripts/ci/publish-relevance.mjs` argues
+// package would be the hand-maintained shape `scripts/ci/publish-relevance.mjs` argues
 // against in its own header: one copy goes stale while both still look like
 // they are doing the job, and here the stale one ships broken `.d.ts` to a
 // cross-repo consumer. Both packages' entries in `publish-relevance.mjs` name

--- a/scripts/capture-mcp-tools-list.mjs
+++ b/scripts/capture-mcp-tools-list.mjs
@@ -1,21 +1,21 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-1326 — the capture producer for upstream MCP `tools/list`.
+// The capture producer for upstream MCP `tools/list`.
 //
 // C1's note on the parent ticket: "what is missing is a producer, not an
 // engine." This is the producer. It freezes, per twin, the tool listing the
-// VENDOR serves, so F-1325's lane has something real to compare a twin
+// VENDOR serves, so the divergence lane has something real to compare a twin
 // against. It is deliberately NOT on a cron: goldens are refreshed on purpose
-// and reviewed as a diff, and the staleness alarm over them is F-1328.
+// and reviewed as a diff. There is no staleness alarm over them yet.
 //
 // Three things are load-bearing:
 //
 // 1. THE SOURCE TABLE IS DATA. Every twin, its substrate, and the exact
 //    configuration that substrate was read under live in
 //    `config/mcp-capture-sources.json`. Nothing in this file names a twin.
-//    Adding one is a data edit — the F-1117 shape — because the alternative,
-//    a switch over twin ids, is the rot F-989 and F-1130 produced twice: a
+//    Adding one is a data edit, because the alternative — a switch over twin
+//    ids — is the rot that produced the same bug twice: a
 //    hand-kept list that stops covering its subject while the gate reading it
 //    stays green.
 //
@@ -23,7 +23,7 @@
 //    surfaces are not uniform. The remote GitHub server serves a DIFFERENT set
 //    at /mcp/ (44 tools, the `default` toolset) than at /mcp/x/all (85). An
 //    adapter that read the union would report 41 coverage gaps for tools no
-//    examinee of ours can call, and F-1179 is explicit that a lane reporting
+//    examinee of ours can call, and a lane reporting
 //    divergence that is not real is worse than one honestly reporting
 //    not-compared. So the toolset the capture assumed is declared, pinned, and
 //    copied verbatim into meta.json — and a source with no declared
@@ -42,7 +42,7 @@
 //                      golden or a hand-typed sha.
 //   --offline          the same re-derivation, WRITTEN. See below.
 //
-// ── WHY --offline HAS A WRITE MODE (F-1394) ────────────────────────────────
+// ── WHY --offline HAS A WRITE MODE ─────────────────────────────────────────
 //
 // `configuration` is prose about a capture, and it is copied verbatim into
 // meta.json and canonical.json — so a sentence added to the source table moves
@@ -59,7 +59,7 @@
 // the mode can restate what a capture meant and can never restate what it
 // FOUND. And `captureDate` is carried from the committed meta.json, exactly as
 // `--check` carries it, so a re-derivation cannot make an old reading look like
-// a fresh one. F-1328's staleness alarm is downstream of that date; a mode that
+// a fresh one. A staleness alarm is downstream of that date; a mode that
 // stamped today would reset the alarm without contacting anybody.
 import { execFileSync, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
@@ -102,7 +102,8 @@ export function sha256(text) {
 
 // ── adapters ────────────────────────────────────────────────────────────────
 // `live-wire-oauth` is the SAME reader as `live-wire-unauth` plus a bearer, so
-// F-1329 adds a token to the source table, not an adapter to this file. The
+// An OAuth-gated substrate adds a token to the source table, not an adapter to
+// this file. The
 // test asserts the two entries hold the identical function reference, because
 // "same code path" is only true for as long as nobody forks it.
 
@@ -114,9 +115,9 @@ async function readLiveWire(source) {
     if (!envName) {
       throw new Error(`${source.twin}: substrate ${SUBSTRATE_OAUTH} requires \`authTokenEnv\` on the source table`);
     }
-    // BLANK AND ABSENT ARE DIFFERENT FACTS, AND SO IS WHITESPACE (F-1184).
+    // BLANK AND ABSENT ARE DIFFERENT FACTS, AND SO IS WHITESPACE.
     //
-    // F-1184's lesson is that a value blanked in the secret store must not reach
+    // A value blanked in the secret store must not reach
     // a runner as an empty string and READ AS "no credential configured" — the
     // operator who blanked it and the operator who never set it need different
     // instructions. The previous guard was `if (!token)` with the message "is
@@ -326,9 +327,10 @@ const SUBSTRATES = {
  * validator of the same field can be checked against it.
  *
  * `packages/sdk/src/mcp-tool-fixture.ts` validates `substrate` on the
- * PER-TWIN tool-table fixtures (F-1325). Two validators of one field name, in
+ * PER-TWIN tool-table fixtures. Two validators of one field name, in
  * two languages, in two trees, with no import between them is how a vocabulary
- * forks without anyone noticing — and F-1327 has to read both trees. The SDK's
+ * forks without anyone noticing — and the divergence lane has to read both
+ * trees. The SDK's
  * enum is required to be a superset of this list; its
  * `substrate-vocabulary.test.ts` imports this array and asserts it.
  */
@@ -355,9 +357,10 @@ export function adapterFor(substrate) {
  * criterion 9 refuses a twin for serving a tool the golden does not declare, and
  * its own reasoning turns on this field: it is sound against `exact`, and against
  * `subset-of-remote` only because github's golden ENUMERATES its delta from the
- * remote with written evidence. F-1394 is what an undeclared class costs.
- * linear's golden was captured under a read-only grant, said nothing about
- * completeness, and the gate reported six write tools that mcp.linear.app really
+ * remote with written evidence. An undeclared class has already cost us one
+ * false report: linear's golden was captured under a read-only grant, said
+ * nothing about completeness, and the gate reported six write tools that
+ * mcp.linear.app really
  * serves — `save_issue`, `save_comment`, `delete_comment`, `create_issue_label`,
  * `save_project`, `save_document` — as tools twin-linear had invented. Fabricated
  * findings are the one thing that lane must never produce.
@@ -399,7 +402,7 @@ export function loadSources({ repoRoot = REPO_ROOT, sourcesPath, table } = {}) {
           `${twin}: a capturable source must declare \`configuration.completeness\` as one of ` +
             `${COMPLETENESS_CLASSES.join(", ")} (got ${JSON.stringify(config.completeness)}). ` +
             `A consumer that reports a tool as twin-only is asserting the vendor does not serve it, ` +
-            `which this golden can only support if it says what it covers — see F-1394.`
+            `which this golden can only support if it says what it covers.`
         );
       }
       for (const field of ["endpoint", "method", "protocol", "protocolVersion"]) {
@@ -508,8 +511,8 @@ export function deriveGolden({ source, rawText, captureDate }) {
  *
  * `configuration` and `authTokenEnv` are written here for the same reason they
  * are written into a captured meta.json. A deferred twin's declared
- * configuration is the thing F-1329's capture will ASSUME — it is the whole
- * content of "F-1329 adds a token, not an adapter" — so leaving it out of the
+ * configuration is the thing a credentialed capture will ASSUME — it is the whole
+ * content of "a token, not an adapter" — so leaving it out of the
  * recorded artefact would let someone change what that capture reads while
  * this gate stayed green.
  */
@@ -527,7 +530,7 @@ export function deriveStatus({ source }) {
     ...(source.evidence ? { evidence: source.evidence } : {}),
     ...(source.revisitWhen ? { revisitWhen: source.revisitWhen } : {}),
     consumerContract:
-      "F-1325's lane must report this twin as not-compared. It must never report it as zero coverage.",
+      "The divergence lane must report this twin as not-compared. It must never report it as zero coverage.",
   });
 }
 
@@ -606,7 +609,7 @@ export async function runCapture(options = {}) {
       // they were fetched. Every other field is derived from the raw response
       // and so cannot be forged this way; captureDate is the one that can.
       //
-      // This matters to F-1328. A staleness alarm that reads meta.captureDate
+      // This matters to a staleness alarm that reads meta.captureDate
       // is reading the one field in the golden that this gate cannot check.
       // It should date a golden from git history (the commit that last touched
       // <twin>.raw.json) and treat the JSON field as a label, not evidence.
@@ -650,7 +653,7 @@ export async function runCapture(options = {}) {
       // a twin became capturable. So the first credentialed capture of slack,
       // linear or stripe would commit a real golden and the lane would go on
       // publishing "401 missing_token", with no red anywhere. That is the whole
-      // F-1329 errand landing and reading as if it had not.
+      // credentialed capture landing and reading as if it had not.
       if (existsSync(paths.status)) {
         problems.push(
           `${twin}: both a golden and ${twin}.status.json exist. Every consumer resolves the status file ` +
@@ -726,7 +729,7 @@ function parseArgv(argv) {
 // Realpath'd on both sides — node resolves symlinks before deriving
 // `import.meta.url`, so a bare `pathToFileURL(resolve(...))` of argv[1]
 // misses through a symlinked checkout (a worktree, or macOS's symlinked
-// `/tmp`) in the same silent shape (F-1488), and a guard miss while invoked
+// `/tmp`) in the same silent shape, and a guard miss while invoked
 // as this file throws rather than exits 0.
 const SELF = realpathSync(fileURLToPath(import.meta.url));
 const ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";

--- a/scripts/capture-mcp-tools-list.test.mjs
+++ b/scripts/capture-mcp-tools-list.test.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Regression coverage for scripts/capture-mcp-tools-list.mjs (F-1326).
+// Regression coverage for scripts/capture-mcp-tools-list.mjs.
 //
 // No network, no `go`, no clone: every case here drives the producer through
 // its injected `readSubstrate` seam, or through `--offline`, which re-derives
@@ -9,7 +9,7 @@
 // fixture of the upstream response — a second copy of the same bytes under
 // scripts/fixtures/ would be one more thing to drift.
 //
-// The block that matters most is "the guard fires" (F-1170): a --check that
+// The block that matters most is "the guard fires": a --check that
 // has never been watched go red is not a guard. Each of the four ways a
 // golden can be wrong — edited raw, edited canonical, edited meta provenance,
 // hand-typed sha — gets its own red here.
@@ -76,11 +76,12 @@ function sandbox() {
 /**
  * A sandbox whose source table carries one SYNTHETIC uncaptured twin.
  *
- * F-1329 captured the last three deferred twins, so `sources.twins` now has no
+ * The last three deferred twins are captured, so `sources.twins` now has no
  * `capture: false` row at all. The guards below cover the not-captured path —
  * the recorded-reason gate and the declared-configuration round-trip — and if
  * they simply iterated the real table they would now iterate NOTHING and report
- * the same green as a satisfied guard. That is this repo's F-1170 rule, and the
+ * the same green as a satisfied guard. That is this repo's vacuous-green rule,
+ * and the
  * fix is a fixture rather than a weakened assertion: the behaviour is still
  * reachable the moment a sixth twin is added deferred, so it stays tested.
  */
@@ -97,9 +98,9 @@ function sandboxWithDeferredTwin() {
     method: "tools/list",
     protocol: "JSON-RPC 2.0 over HTTP",
     protocolVersion: "2025-06-18",
-    authTokenEnv: "F1329_DEFERRED_PROBE_TOKEN",
+    authTokenEnv: "DEFERRED_PROBE_TOKEN",
     reason: "OAuth-gated, and nobody has minted a grant for this fixture.",
-    deferredTo: "F-1329",
+    deferredTo: "a follow-up capture errand",
     configuration: { auth: "bearer", requestHeaders: { "content-type": "application/json" } },
   };
   const { twin: _omit, ...declared } = source;
@@ -111,7 +112,7 @@ function sandboxWithDeferredTwin() {
 }
 
 // ── the declared source table ───────────────────────────────────────────────
-// F-1117's shape: adding a twin is a data edit, never a new `case:`. The gate
+// Adding a twin is a data edit, never a new `case:`. The gate
 // on that is that nothing in the producer enumerates twin ids.
 {
   const sources = loadSources({ repoRoot: ROOT });
@@ -135,7 +136,7 @@ function sandboxWithDeferredTwin() {
   // some other broken shape would still pass an absence check). The absence
   // of a bare `import.meta.main` ANYWHERE under scripts/**/contract/** —
   // including in this file — is asserted repo-wide by
-  // scripts/lint-no-bare-import-meta-main.mjs (F-1481), which subsumes what
+  // scripts/lint-no-bare-import-meta-main.mjs, which subsumes what
   // used to be a second, narrower copy of that same assertion here: two
   // checks asserting one property in different places is the shape D5 warns
   // about, and the repo-wide one covers strictly more (every file, not just
@@ -143,7 +144,7 @@ function sandboxWithDeferredTwin() {
   //
   // Two independent, ORDER-INDEPENDENT assertions, one per side. The single
   // regex these replace was `/process\.argv\[1\][\s\S]{0,120}import\.meta\.url/`,
-  // which encodes source ORDER rather than the guard: F-1488 rewrote this guard
+  // which encodes source ORDER rather than the guard: this guard was rewritten
   // into the sanctioned realpath-both-sides form, which declares the
   // `import.meta.url` const first, and the old regex failed on a guard that had
   // just been made strictly STRONGER.
@@ -222,10 +223,10 @@ function sandboxWithDeferredTwin() {
   );
 }
 
-// ── F-1329 adds a token, not an adapter ─────────────────────────────────────
+// ── A credential adds a token, not an adapter ───────────────────────────────
 // live-wire-oauth and live-wire-unauth must resolve to the SAME reader. If they
-// ever diverge, "F-1329 adds a token" stops being true and nobody finds out
-// until F-1329.
+// ever diverge, "a token, not an adapter" stops being true and nobody finds out
+// until the next credentialed capture.
 {
   assert(
     adapterFor("live-wire-oauth").read === adapterFor("live-wire-unauth").read,
@@ -237,10 +238,10 @@ function sandboxWithDeferredTwin() {
         twin: "acme",
         endpoint: "https://example.invalid/mcp",
         substrate: "live-wire-oauth",
-        authTokenEnv: "F1326_TOKEN_THAT_IS_NOT_SET",
+        authTokenEnv: "TOKEN_THAT_IS_NOT_SET",
         configuration: { auth: "bearer" },
       }),
-    "F1326_TOKEN_THAT_IS_NOT_SET",
+    "TOKEN_THAT_IS_NOT_SET",
     "the oauth reader refuses to fall back to an unauthenticated request"
   );
 }
@@ -325,7 +326,7 @@ function sandboxWithDeferredTwin() {
   assert(code === 0, "`--check --offline` is green against the committed goldens");
 }
 
-// ── the guard fires (F-1170) ────────────────────────────────────────────────
+// ── the guard fires ─────────────────────────────────────────────────────────
 // Four independent edits, four reds, and nothing written back.
 {
   const sources = loadSources({ repoRoot: ROOT });
@@ -402,7 +403,7 @@ function sandboxWithDeferredTwin() {
     rmSync(dir, { recursive: true, force: true });
   }
 
-  // 7. the DEFERRED twins' declared configuration is the thing F-1329's
+  // 7. the DEFERRED twins' declared configuration is the thing a credentialed
   //    capture will assume, so it has to be recorded and gated exactly like a
   //    captured twin's. Without this, someone could change which header
   //    Slack's future capture sends, or which env var holds its token, and
@@ -510,7 +511,7 @@ function sandboxWithDeferredTwin() {
   rmSync(dir, { recursive: true, force: true });
 }
 
-// ── --offline WRITES the re-derivation, and cannot forge a capture (F-1394) ──
+// ── --offline WRITES the re-derivation, and cannot forge a capture ───────────
 //
 // The mode exists because `configuration` is prose about a capture that is
 // copied into two derived files, and three of the five sources sit behind
@@ -579,7 +580,7 @@ function sandboxWithDeferredTwin() {
 }
 {
   // An undated golden cannot be re-derived either: `today` belongs to a run
-  // that read a substrate, and stamping it here would reset F-1328's staleness
+  // that read a substrate, and stamping it here would reset any staleness
   // clock without anybody having contacted the vendor.
   const dir = sandbox();
   const sources = loadSources({ repoRoot: dir });
@@ -598,7 +599,7 @@ function sandboxWithDeferredTwin() {
   rmSync(dir, { recursive: true, force: true });
 }
 
-// ── every capturable source states what its capture COVERS (F-1394) ─────────
+// ── every capturable source states what its capture COVERS ──────────────────
 //
 // The field is required at load, beside `configuration` itself. linear's golden
 // was captured under a read-only grant, declared no completeness class, and
@@ -666,8 +667,8 @@ function sandboxWithDeferredTwin() {
   }
 }
 
-// ── a deferred oauth row is CAPTURE-READY, not merely declared (F-1329) ──────
-// The whole content of "F-1329 adds a token, not an adapter" is that the errand
+// ── a deferred oauth row is CAPTURE-READY, not merely declared ───────────────
+// The whole content of "a token, not an adapter" is that the errand
 // is one env var away. It was not: slack and linear declared no
 // `protocolVersion`, which `loadSources` requires on every capturable source, so
 // flipping `capture` threw `must declare protocolVersion` before opening a
@@ -679,7 +680,7 @@ function sandboxWithDeferredTwin() {
 // mid-errand.
 {
   const table = JSON.parse(readFileSync(join(ROOT, "config/mcp-capture-sources.json"), "utf8"));
-  // Every oauth row, captured or deferred. F-1329 captured all three, so keying
+  // Every oauth row, captured or deferred. All three are captured, so keying
   // this on `!row.capture` would now select NOTHING and report the same green as
   // a satisfied guard — the shape the flip-throws bug hid behind in the first
   // place. The durable invariant is the one that made the flip safe: an oauth
@@ -710,7 +711,7 @@ function sandboxWithDeferredTwin() {
     try {
       loadSources({ table: flipped });
     } catch (err) {
-      assert(false, `${twin}: flipping \`capture\` must not throw — F-1329 is a token, not a schema edit (${err.message})`);
+      assert(false, `${twin}: flipping \`capture\` must not throw — a credential is a token, not a schema edit (${err.message})`);
     }
   }
 }
@@ -718,7 +719,7 @@ function sandboxWithDeferredTwin() {
 // ── the recorded refusal is RETIRED by the capture that supersedes it ────────
 // pome-cloud's `loadUpstreamMcpGolden` resolves `<twin>.status.json` FIRST and
 // never looks at the raw/meta beside it. Nothing used to delete that file, so
-// F-1329's first credentialed capture would have committed a real golden while
+// The first credentialed capture would have committed a real golden while
 // the lane went on publishing "401 missing_token" — the errand landing and
 // reading as though it had not, with nothing red anywhere.
 {
@@ -765,15 +766,15 @@ function sandboxWithDeferredTwin() {
   }
 }
 
-// ── SET-BUT-BLANK is not UNSET (F-1184) ─────────────────────────────────────
-// F-1184: a value blanked in the secret store must not reach a runner and read
+// ── SET-BUT-BLANK is not UNSET ──────────────────────────────────────────────
+// A value blanked in the secret store must not reach a runner and read
 // as "no credential configured" — the operator who blanked it and the operator
 // who never set it need different instructions. `if (!token)` said "is not set"
 // for both, and let whitespace through entirely: `Bearer    ` went on the wire
 // and came back as the VENDOR's 401, which reads as a bad token and sends
 // whoever just minted one back through the OAuth flow.
 {
-  const ENV = "F1329_BLANK_PROBE";
+  const ENV = "BLANK_PROBE";
   const source = {
     twin: "acme",
     endpoint: "https://example.invalid/mcp",
@@ -794,7 +795,7 @@ function sandboxWithDeferredTwin() {
   delete process.env[ENV];
 }
 
-// ── the Streamable HTTP transport may frame the answer as SSE (F-1329) ──────
+// ── the Streamable HTTP transport may frame the answer as SSE ───────────────
 // MCP lets a server answer a POST with either a JSON body or an SSE stream, and
 // both are correct. Measured 2026-08-09: gmail, slack and stripe answer
 // application/json; LINEAR answers SSE. Before this, `JSON.parse` on the wire

--- a/scripts/check-bundled-runtime-deps.mjs
+++ b/scripts/check-bundled-runtime-deps.mjs
@@ -98,7 +98,7 @@ if (leakedInternal.length > 0) {
   console.error(
     "They are not installable by an end user: the sdk and the twins are `private: true`\n" +
       "and on no registry at all, and `@pome-sh/wire` is published only to GitHub Packages,\n" +
-      "which answers 401 without a GitHub token (F-949). All of them are inlined by the\n" +
+      "which answers 401 without a GitHub token. All of them are inlined by the\n" +
       "bundler instead — remove the dependency, do not publish it.",
   );
   process.exit(1);

--- a/scripts/check-copy-markers.mjs
+++ b/scripts/check-copy-markers.mjs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-679/M6 copy-marker gate. Cross-package file copies are not allowed in OSS
+// Copy-marker gate (M6). Cross-package file copies are not allowed in OSS
 // packages; shared code should move through published packages instead.
 import { readFile } from "node:fs/promises";
 import { readdir } from "node:fs/promises";

--- a/scripts/check-example-pins-published.mjs
+++ b/scripts/check-example-pins-published.mjs
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-1483 — `agent-examples/*` pins a PUBLISHED `@pome-sh/*` version on purpose
+// `agent-examples/*` pins a PUBLISHED `@pome-sh/*` version on purpose
 // (`agent-examples/support-triage` documents why in `gate-examples.mjs`'s
 // header: it is `npx degit`-fetchable as a standalone subtree, so a `file:`
 // link out of its own directory would break its `npm install`). Nothing
 // watched that pin drift out from under the sibling workspace version twice
 // (#308 off 0.2.5, then off 0.3.1 — the second time dragging the retired
 // `@pome-sh/shared-types` back into the example's install graph as a runtime
-// dependency, F-942 instantiated in the one example that exists to demonstrate
+// dependency — two schema identities in one process, in the one example that
+// exists to demonstrate
 // a correctly-joined trace).
 //
 // `check-workspace-pins-match-workspace.mjs` cannot own this: it runs OFFLINE
@@ -134,7 +135,7 @@ export function discoverExampleSiblingDeps(repoRoot) {
  * conservative side, and the same side a 401 or a 5xx lands on.
  *
  * `--prefer-online` forces npm's staleness check instead of accepting a cached
- * packument, and it is load-bearing on the write side (F-1520): both the workflow
+ * packument, and it is load-bearing on the write side: both the workflow
  * that calls this and the one that publishes restore npm's HTTP cache via
  * `setup-node`'s `cache: npm`, keyed on the root lockfile — which a release
  * commit changes, so the run immediately BEFORE a publish takes the miss and
@@ -222,7 +223,7 @@ export function checkExamplePinsPublished(pins, npmView = defaultNpmView) {
 const writeSideNpmView = (name, version) => defaultNpmView(name, version, { attempts: 1 });
 
 /**
- * F-1520 — the write-side of this gate's own read-side logic. `checkExample
+ * The write-side of this gate's own read-side logic. `checkExample
  * PinsPublished`'s `violations` ARE, by construction, the only pins safe to
  * rewrite automatically: the sibling is confirmed PUBLISHED (an `npm view`
  * that just returned a real answer), so `npm install --package-lock-only`
@@ -292,7 +293,7 @@ export function planExampleRepins(repoRoot, npmView = writeSideNpmView) {
       // `overrides`, or in a second install field) — a repo-wide release outage
       // caused by the thing meant to remove a one-line PR. Skip this one pin
       // instead: `reportExamplePinParity` still reds on it, so it cannot go
-      // silent, and a human re-pins it the way they did before F-1520.
+      // silent, and a human re-pins it the way they did before the repin path existed.
       console.warn(
         `::warning::${manifestRelPath}: expected exactly one \`"${v.dep}": "${v.pin}"\`, found ${occurrences} — ` +
           "refusing to guess which one is the pin, so it is NOT re-pinned automatically. " +

--- a/scripts/check-example-pins-published.test.mjs
+++ b/scripts/check-example-pins-published.test.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Regression suite for `check-example-pins-published.mjs` (F-1483). Pure
+// Regression suite for `check-example-pins-published.mjs`. Pure
 // functions, no network and no `npm ci` needed: `checkExamplePinsPublished`
 // takes an injected `npmView`, and `discoverExampleSiblingDeps` runs against
 // a throwaway fixture tree built the same way
@@ -326,7 +326,7 @@ const pin = { example: "support-triage", field: "dependencies", dep: "@pome-sh/a
   }
 }
 
-// F-1520 — planExampleRepins is the write-side of this same gate: a pin that
+// PlanExampleRepins is the write-side of this same gate: a pin that
 // this file's own `violations` classifier already calls drifted-against-a-
 // published-sibling is exactly the set safe to rewrite automatically.
 {

--- a/scripts/check-example-sdk-isolation.mjs
+++ b/scripts/check-example-sdk-isolation.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-1295: a bundled Claude-Agent-SDK example whose `query()` options omit
+// A bundled Claude-Agent-SDK example whose `query()` options omit
 // `tools` or `settingSources` is not isolated, however carefully its comments
 // say it is.
 //
@@ -10,7 +10,7 @@
 //   options.tools           the BUILT-IN base set (Bash, Read, Grep, WebFetch,
 //                           …). `[]` replaces the set, so it is complete by
 //                           construction. Closed for the hero example by
-//                           F-1292.
+//                           the denial-enumeration finding.
 //   options.settingSources  FILESYSTEM settings — user (~/.claude/settings.json),
 //                           project (.claude/settings.json) and local
 //                           (.claude/settings.local.json), INCLUDING the
@@ -19,7 +19,7 @@
 //                           (matches CLI defaults). Pass [] to disable
 //                           filesystem settings (SDK isolation mode)."
 //
-// Measured 2026-08-05 (F-1295): a hosted `claude-haiku-4-5` trial of
+// Measured 2026-08-05: a hosted `claude-haiku-4-5` trial of
 // support-triage-dedup, launched from a developer shell with `options.tools: []`
 // ALREADY SET, called `mcp__plugin_slack_slack__slack_search_channels`,
 // `…__slack_search_public` and `…__slack_list_channel_members` — it searched the
@@ -36,7 +36,7 @@
 // lines above the options object it was deleted from, which is the single most
 // likely way this regresses.
 //
-// [DECISION] F-1295 — central AND per-example, and the central half is NOT here.
+// [DECISION] central AND per-example, and the central half is NOT here.
 // Per-example options are what this gate enforces, and they are load-bearing on
 // their own: `agent-examples/support-triage` is `npx degit`-fetchable as a standalone
 // subtree, so the options a reader copies out must carry the isolation with
@@ -44,12 +44,12 @@
 // — the one in-process chokepoint EVERY bundled example already routes through,
 // and the only one that holds for all three launchers (`pome run`, the coach's
 // `run_task` local-subprocess spawn, and a plain `npm start`). Deliberately not
-// the `pome run` path itself: the measured F-1295 trial was launched from a
+// the `pome run` path itself: the measured trial was launched from a
 // developer shell by the coach, so a CLI-side clamp would not have caught the
 // very incident this ticket is about, and the obvious mechanism there
 // (`CLAUDE_CONFIG_DIR` at an empty dir, which the SDK does honor) also holds
 // `.credentials.json` — it would break subscription auth under `pome run`, the
-// thing FDRS-667 fixed. The adapter change is a behavior change to a PUBLISHED
+// thing an earlier fix addressed. The adapter change is a behavior change to a PUBLISHED
 // package's documented drop-in contract, so it is its own ticket with its own
 // version bump; this gate is what keeps the class closed until then, and stays
 // useful after, because the adapter cannot fix an example someone copies out.
@@ -445,7 +445,7 @@ const REASONS = {
 };
 
 // Realpath'd on both sides, and throws rather than exits 0 on a guard miss
-// (F-1481 / F-1488) — a gate whose own entry guard silently falls false is the
+// — a gate whose own entry guard silently falls false is the
 // failure it exists to catch.
 const SELF = realpathSync(fileURLToPath(import.meta.url));
 const ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";
@@ -485,7 +485,7 @@ if (invokedDirectly) {
     console.error(
       "\n`options.tools` and `options.settingSources` close DIFFERENT doors. `tools: []` replaces the built-in " +
         "base set (Bash, Read, WebFetch, …); `settingSources: []` disables filesystem settings — user, project " +
-        "and local — INCLUDING the developer's Claude Code plugin MCP servers. Measured 2026-08-05 (F-1295): a " +
+        "and local — INCLUDING the developer's Claude Code plugin MCP servers. Measured 2026-08-05: a " +
         "trial with `tools: []` already set searched the developer's real Slack workspace, made zero twin calls, " +
         "and would have scored as a triage failure. Set BOTH on every `query()` in a bundled example.",
     );

--- a/scripts/check-example-sdk-isolation.test.mjs
+++ b/scripts/check-example-sdk-isolation.test.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Regression coverage for scripts/check-example-sdk-isolation.mjs (F-1295).
+// Regression coverage for scripts/check-example-sdk-isolation.mjs.
 //
 // The gate's own failure mode is the one it exists to prevent: a checker that
 // silently classifies nothing prints the same "no findings" as a repo that is
@@ -50,7 +50,7 @@ const OPEN_DOORS = {
     source: `${IMPORT_LINE}\nawait query({ prompt: "go", options: { maxTurns: 5 } });`,
     missing: ["settingSources", "tools"],
   },
-  "tools set, settingSources omitted — the F-1295 incident itself": {
+  "tools set, settingSources omitted — the incident itself": {
     source: `${IMPORT_LINE}\nawait query({ prompt: "go", options: { tools: [] } });`,
     missing: ["settingSources"],
   },
@@ -222,7 +222,7 @@ for (const [label, source] of Object.entries(NOT_SUBJECTS)) {
   assert(scan.silentExamples.length === 0, `every bundled SDK example calls query() (got ${JSON.stringify(scan.silentExamples)})`);
   assert(
     JSON.stringify(REQUIRED_OPTIONS) === JSON.stringify(["tools", "settingSources"]),
-    "the gate requires exactly the two doors F-1295 is about",
+    "the gate requires exactly the two doors this gate is about",
   );
 }
 

--- a/scripts/check-first-party-twin-registration.mjs
+++ b/scripts/check-first-party-twin-registration.mjs
@@ -52,7 +52,7 @@ compare(
   "cli/src/twin/registry.ts TWIN_NAME_LIST",
   quotedArray("cli/src/twin/registry.ts", "TWIN_NAME_LIST"),
 );
-// F-1308 — `@pome-sh/checks` carries every twin's grading vocabulary to
+// `@pome-sh/checks` carries every twin's grading vocabulary to
 // pome-cloud, and its barrel names the five twins explicitly (five `export`
 // blocks and a keyed `TWIN_CHECKS` record; there is no way to derive them, since
 // each twin's array has a different element type). A sixth twin missing here
@@ -63,7 +63,7 @@ compare(
   "packages/checks/src/index.ts CHECKS_TWIN_NAMES",
   quotedArray("packages/checks/src/index.ts", "CHECKS_TWIN_NAMES"),
 );
-// F-1526 — `@pome-sh/sandbox-domains` carries the other half to the same
+// `@pome-sh/sandbox-domains` carries the other half to the same
 // consumer: the in-process domain runtime `lib/twin-state.ts` boots. Same seam,
 // same failure shape as the line above and one step worse — a sixth twin missing
 // here compiles, and its criteria do not merely fail to bind, they bind against

--- a/scripts/check-packages-scripts-wired.mjs
+++ b/scripts/check-packages-scripts-wired.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-1472 — closes the class F-1354 found one instance of: a `packages/*` npm
+// Closes a class we found one instance of: a `packages/*` npm
 // script that names itself a check (`validate:mcp`) declared in a
 // package.json and invoked by NOTHING. It went red for weeks with no
 // verdict, and no verdict reads exactly like a pass.
@@ -19,9 +19,9 @@
 //
 // Anything else fails this gate by name.
 //
-// This gate started life (F-1472) as an allowlist of check-NAME prefixes
+// This gate started life as an allowlist of check-NAME prefixes
 // (`validate:*`, `check:*`, `lint:*`, `gate:*`, `test:*`, `assert:*`) — the
-// vocabulary F-1472 specified. That vocabulary could not see
+// vocabulary originally specified. That vocabulary could not see
 // `verify:cloud-token`, a real check that had also never run, and the audit
 // found it by hand instead. A prefix list of what counts as a check is itself
 // a hand-maintained list, which is the exact shape D5 names as the bug: it
@@ -50,7 +50,7 @@
 //
 // Usage: node scripts/check-packages-scripts-wired.mjs
 //
-// F-1476 — `cli/` extension. F-1472 scoped this gate to `packages/*`; `cli/`
+// The `cli/` extension. This gate was first scoped to `packages/*`; `cli/`
 // is a root workspace member too (AGENTS.md) and had the identical shape:
 // `gate:no-eval`, `gate:no-native`, `gate:recorder-overhead` and `test:e2e`
 // declared, only `check:manifest-schema` reached. Same total partition, same
@@ -59,7 +59,7 @@
 //
 // `cli/` also has raw executable files under `cli/scripts/*` that are not
 // declared as ANY npm script. The motivating instance was
-// `cli/scripts/make-unwired-fixture.mjs` (deleted by F-1476, so do not go
+// `cli/scripts/make-unwired-fixture.mjs` (since deleted, so do not go
 // looking for it): broken on `main` — a stale exact-text replacement threw
 // before it did anything — reached by nothing, and invisible to a denominator
 // built only from npm SCRIPT NAMES. So `cli/`'s denominator is the union of
@@ -83,7 +83,7 @@
 // scripts/overhead-gate.ts` — is a real, running check that this gate reds
 // anyway, by name, saying "no workflow reaches it". Verified by hand against
 // that exact shape. Three of `agent-trace-overhead-gate.yml`'s steps were
-// written that way and F-1476 converted all three to `npm run <name> -w
+// written that way and all three were converted to `npm run <name> -w
 // @pome-sh/cli` rather than teach the gate a second wiring shape, because one
 // detection mechanism is the whole reason the marker path can be trusted.
 // The cost is real and is accepted deliberately: the NEXT person who adds a
@@ -121,7 +121,7 @@ const ROOT = process.cwd();
  * far less load-bearing list than the check-name PREFIX vocabulary it replaced
  * — nine exact names that already exist in every package, versus an open set of
  * every prefix someone might invent for a new check — but it is not zero. The
- * set is shared by `packages/*` and `cli/` (F-1476 widened the denominator to
+ * set is shared by `packages/*` and `cli/` (the denominator was widened to
  * both), so adding `pome` for `cli/`'s sake also exempts that exact name in a
  * `packages/*` member; same accepted residual, one more name.
  */
@@ -207,7 +207,7 @@ export function findCheckScripts(root) {
 }
 
 /**
- * F-1476 — the same enumeration as `findCheckScripts`, for `cli/`'s own
+ * The same enumeration as `findCheckScripts`, for `cli/`'s own
  * `package.json` instead of every `packages/*` member. `cli/` is a single
  * root workspace member (AGENTS.md), not a directory of them, so this reads
  * one file rather than looping a directory. Returns `[]` if `cli/package.json`
@@ -274,7 +274,7 @@ export function isWired(entry, corpus) {
   // `(?![\w:.-])`, never `\b`: `-` and `:` are non-word characters, so `\b`
   // after `gate:mcp` matches inside `gate:mcp-fixture`. A package declaring
   // both would have had the longer script's real CI line certify the shorter
-  // one as wired while nothing ran it — the F-1354 shape, produced by the gate
+  // one as wired while nothing ran it — the original shape, produced by the gate
   // meant to catch it. Same guard on the package name, so `@pome-sh/twin-slack`
   // is not wired by a line naming `@pome-sh/twin-slack-legacy`.
   const nameEnd = "(?![\\w:.-])";
@@ -386,13 +386,13 @@ export function invokedFile(entry, root) {
   // Whole-token, never a substring. Unanchored, `[\w./-]+\.(?:ts|mjs|js|sh)`
   // matches `tsconfig.js` INSIDE the literal `tsconfig.json`, so
   // `tsx --tsconfig tsconfig.json scripts/x.ts` resolved to a config file
-  // instead of the script. Under F-1472 that only cost a missed exemption
-  // marker; under F-1476 it also keeps the real script out of
+  // instead of the script. Under the narrow scope that only cost a missed
+  // exemption marker; under the widened one it also keeps the real script out of
   // `invokedByScript`, so the file reds as an orphan with a diagnosis
   // pointing at the wrong file entirely.
   const fileMatch = entry.command.match(/(?:^|\s)([\w./-]+\.(?:ts|mts|cts|tsx|mjs|cjs|js|sh))(?=\s|$)/);
   if (!fileMatch) return null;
-  // F-1476 — `cli/` is a single workspace member at `cli/`, not one of many
+  // `cli/` is a single workspace member at `cli/`, not one of many
   // under `packages/<name>`, so it resolves against a different base.
   const pkgRoot = entry.pkgKind === "cli" ? resolve(root, "cli") : resolve(root, "packages", entry.pkgDir);
   const scriptPath = resolve(pkgRoot, fileMatch[1]);
@@ -403,7 +403,7 @@ export function invokedFile(entry, root) {
 /**
  * Reads the `pome:unwired-ok(<name>): <reason>` marker straight out of a
  * file's own bytes, shared by both the script-command path
- * (`findExemptionReason`, below) and the raw-file path (F-1476's
+ * (`findExemptionReason`, below) and the raw-file path (the
  * `cli/scripts/**` entries, which have no command to derive a file from —
  * the file IS the entry).
  */
@@ -475,7 +475,7 @@ function resolveRelativeImport(fromFile, specifier) {
 }
 
 /**
- * F-1476 — every file under `cli/scripts/**` that is neither the invoked
+ * Every file under `cli/scripts/**` that is neither the invoked
  * file of a declared `cli/package.json` script (any of them, including
  * LIFECYCLE ones — `prepublishOnly` reaching `assert-publishable.mjs` counts
  * as reached) nor imported by a sibling file in the same tree. What is left
@@ -539,7 +539,7 @@ export function findCliOrphanFileEntries(root) {
 }
 
 export function run(root) {
-  // F-1476 — cli/'s own non-lifecycle scripts join packages/*'s in ONE array,
+  // Cli/'s own non-lifecycle scripts join packages/*'s in ONE array,
   // so the derived write/--check coverage below (same `pkgDir`, same command
   // shape) applies to cli/'s `emit:manifest-schema`/`check:manifest-schema`
   // pair with no new code — it is the identical shape three packages/* pairs
@@ -627,7 +627,7 @@ export function run(root) {
     failures.push(entry);
   }
 
-  // F-1476 — cli/scripts/** files nothing declares as a script at all
+  // Cli/scripts/** files nothing declares as a script at all
   // (the deleted make-unwired-fixture.mjs's shape). No script name exists for these, so
   // the only way to clear one is the marker, read straight from the file.
   for (const entry of fileEntries) {

--- a/scripts/check-packages-scripts-wired.test.mjs
+++ b/scripts/check-packages-scripts-wired.test.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Regression suite for `check-packages-scripts-wired.mjs` (F-1472).
+// Regression suite for `check-packages-scripts-wired.mjs`.
 //
-// The motivating bug (F-1354) was a `packages/*` script named like a check
+// The motivating bug was a `packages/*` script named like a check
 // that sat unreachable for weeks with no verdict. The thing most worth
 // proving here is that this gate CAN go red on that exact shape — a fresh
 // `check:foo` with no caller — and that it can also go GREEN correctly: on a
@@ -216,7 +216,7 @@ check(
 // Case 13 (break-on-purpose): a longer script's real CI line must not certify
 // a shorter prefix-named one. `\b` after `gate:mcp` matches inside
 // `gate:mcp-fixture` because `-` is a non-word character, so the gate meant to
-// catch F-1354's shape would have produced it.
+// catch the original shape would have produced it.
 check(
   "a prefix-named sibling is not wired by the longer script's line",
   {
@@ -354,7 +354,7 @@ for (const [label, line] of [
   );
 }
 
-// Cases 25+ (F-1476): the cli/ extension. cli/ is a single workspace member
+// Cases 25+: the cli/ extension. cli/ is a single workspace member
 // at `cli/`, not a directory of many under `packages/*`, so it needs its own
 // coverage — same mechanisms, different base path.
 
@@ -407,7 +407,7 @@ check(
   { expect: "green" }
 );
 
-// Case 29 (F-1476's motivating find): a raw cli/scripts/ file declared by NO
+// Case 29 (the motivating find): a raw cli/scripts/ file declared by NO
 // package.json script at all — make-unwired-fixture.mjs's exact shape — has
 // no script name for the npm-run regex to find, so it reds by its own path.
 check(

--- a/scripts/check-plugin-manifest-lists-every-skill.mjs
+++ b/scripts/check-plugin-manifest-lists-every-skill.mjs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-1226 — `.claude-plugin/plugin.json` must list every skill under `skills/`.
+// `.claude-plugin/plugin.json` must list every skill under `skills/`.
 //
 // What the manifest buys: the `skills` CLI reads it (README → "Plugin Manifest
 // Discovery") and groups the skills it names under one collapsible row. That
 // row carries its own radio, so `npx skills add pome-sh/digital-twins` opens
 // with the cursor already on "Pome Coach" and one space selects all six. The
 // flat list it renders without a manifest starts with nothing ticked and the
-// cursor on the first skill, which is how F-1226 was filed: a user takes the
+// cursor on the first skill, which is how the bug was filed: a user takes the
 // screen literally, installs one skill, and the coach dead-ends routing into a
 // skill that is not there.
 //
@@ -88,7 +88,7 @@ export async function check(repoRoot) {
 // Run as a script, not when imported by the regression test. Realpath'd on
 // both sides — a bare `resolve()` of argv[1] (with no realpath) misses
 // through a symlinked checkout (a worktree, or macOS's symlinked `/tmp`) in
-// the same silent shape F-1488 found in nine sibling gates, and a guard miss
+// the same silent shape found in nine sibling gates, and a guard miss
 // while invoked as this file throws rather than exits 0.
 const SELF = realpathSync(fileURLToPath(import.meta.url));
 const ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";

--- a/scripts/check-plugin-manifest-lists-every-skill.test.mjs
+++ b/scripts/check-plugin-manifest-lists-every-skill.test.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Regression suite for `check-plugin-manifest-lists-every-skill.mjs` (F-1226).
+// Regression suite for `check-plugin-manifest-lists-every-skill.mjs`.
 //
 // Case 2 is the reason this file exists: the drift the gate is built for is a
 // NEW skill nobody adds to the manifest, and a gate that only checked "every

--- a/scripts/check-twin-chunk-laziness.mjs
+++ b/scripts/check-twin-chunk-laziness.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// The gate that makes "each twin is a lazily-loaded chunk" a fact instead of a
-// comment (F-1306).
+// The gate that makes "each twin is a lazily-loaded chunk" a fact rather than
+// a comment.
 //
 // `cli/tsup.config.ts` and `cli/src/twin/registry.ts` both claim it, and
 // CHANGELOG 0.21.0 shipped it as a headline. It was false for three of the five

--- a/scripts/check-twin-chunk-laziness.test.mjs
+++ b/scripts/check-twin-chunk-laziness.test.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Regression suite for `check-twin-chunk-laziness.mjs` (F-1306).
+// Regression suite for `check-twin-chunk-laziness.mjs`.
 //
 // The gate exists because a laziness claim went five releases without anyone
 // checking it, so the thing most worth proving is that this gate CAN go red —
@@ -94,7 +94,7 @@ check("2. a direct package-root import is red", {
   contains: "package root",
 });
 
-check("3. an INDIRECT root import two CLI modules deep is red (the F-1306 shape)", {
+check("3. an INDIRECT root import two CLI modules deep is red (the original shape)", {
   files: {
     [MAIN]: `${CHECKS_IMPORT}import { parseTask } from "../task/parseTask.js";\nvoid parseTask;\n`,
     "cli/src/task/parseTask.ts": `import { schema } from "./taskSchema.js";\nexport const parseTask = () => schema;\n`,

--- a/scripts/check-twin-leaf-portability.mjs
+++ b/scripts/check-twin-leaf-portability.mjs
@@ -13,7 +13,7 @@
 // driver on the module-load path of a file whose own dependencies are zod and
 // a JSON fixture.
 //
-// That is exactly what F-1325 did. It moved every twin's tool table onto a
+// That is exactly what the fixture move did: every twin's tool table sits on a
 // shared, dependency-free loader — `packages/sdk/src/mcp-tool-fixture.ts`, no
 // imports at all — and each twin reached it through the barrel. The twins'
 // own suites run on Node, where `node:sqlite` exists, so all of them stayed
@@ -25,7 +25,7 @@
 //
 //   No module in ENTRIES may statically reach a builtin that non-Node runtimes
 //   do not implement. ENTRIES is every twin's MCP tool table (found by looking
-//   for the F-1325 loader call, so a new twin is covered with no hand edit)
+//   for the fixture loader call, so a new twin is covered with no hand edit)
 //   plus CROSS_RUNTIME_LEAVES, the named modules pome-cloud imports directly.
 //
 // A twin's SERVER is deliberately out of scope: `src/index.ts`, `src/db.ts` and
@@ -82,7 +82,7 @@ const CROSS_RUNTIME_LEAVES = [
   "packages/twin-linear/src/graphql/schema.ts",
 ];
 
-/** The F-1325 loader call. A module that makes it IS a twin's MCP tool table,
+/** The fixture loader call. A module that makes it IS a twin's MCP tool table,
  *  whatever the file is named (`tools.ts` on github/slack/stripe, `mcp.ts` on
  *  gmail/linear). */
 const TOOL_TABLE_MARKER = "loadMcpToolFixture(";
@@ -136,7 +136,7 @@ for (const dir of TWIN_DIRS) {
 
 if (twinsWithNoToolTable.length > 0) {
   // The cheap way to pass a reachability gate is to remove the thing it walks.
-  // Every first-party twin derives its tool table from a fixture (F-1325); a
+  // Every first-party twin derives its tool table from a fixture; a
   // twin that no longer calls the loader has either regressed to a hand-written
   // table or renamed the loader, and either way this gate just stopped checking
   // it.
@@ -146,7 +146,7 @@ if (twinsWithNoToolTable.length > 0) {
   );
   for (const dir of twinsWithNoToolTable) console.error(`  packages/${dir}`);
   console.error(
-    "\nEvery twin derives its MCP tool table from a fixture (F-1325). Restore the\n" +
+    "\nEvery twin derives its MCP tool table from a fixture. Restore the\n" +
       "loader call, or update TOOL_TABLE_MARKER in this script if the loader was renamed.\n",
   );
   process.exit(1);
@@ -211,7 +211,7 @@ if (violations.length > 0) {
     "The usual cause is an import of the `@pome-sh/sdk` ROOT barrel for a value a leaf\n" +
       "subpath already exports: the barrel re-exports `openTwinDatabase`, which is\n" +
       "`node:sqlite`. Import the leaf instead — `@pome-sh/sdk/mcp-tool-fixture` for the\n" +
-      "F-1325 tool-table loader, `@pome-sh/sdk/db` for the database types. Types are\n" +
+      "tool-table loader, `@pome-sh/sdk/db` for the database types. Types are\n" +
       "free either way: `import type` is erased and this gate ignores it.\n",
   );
   process.exit(1);

--- a/scripts/check-twin-leaf-portability.test.mjs
+++ b/scripts/check-twin-leaf-portability.test.mjs
@@ -6,7 +6,7 @@
 // The gate exists because a green twins CI shipped a change that could not be
 // LOADED by the runtime pome-cloud reads those files with, so the thing most
 // worth proving is that it goes red on the exact shape that shipped: a tool
-// table importing the `@pome-sh/sdk` ROOT for the F-1325 fixture loader, when
+// table importing the `@pome-sh/sdk` ROOT for the fixture loader, when
 // the root barrel re-exports the `node:sqlite`-backed database module.
 //
 // The rest of the cases guard the ways a gate like this quietly stops working:
@@ -127,7 +127,7 @@ check("1. the fixed shape is green: every tool table on the `/mcp-tool-fixture` 
   expect: "green",
 });
 
-check("2. a tool table importing the sdk ROOT is red (the shape F-1325 shipped)", {
+check("2. a tool table importing the sdk ROOT is red (the shape that shipped)", {
   files: {
     "packages/twin-stripe/src/tools.ts": [
       `import { loadMcpToolFixture } from "@pome-sh/sdk";`,

--- a/scripts/check-workspace-pins-match-workspace.mjs
+++ b/scripts/check-workspace-pins-match-workspace.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-1126 — fail CI when one `packages/*` package's `@pome-sh/*` pin disagrees
+// Fail CI when one `packages/*` package's `@pome-sh/*` pin disagrees
 // with the version of the sibling it names. Dependency-free and offline: it
 // reads JSON only, so it runs in ci.yml's cheap gate block before `npm ci`.
 //
@@ -19,11 +19,11 @@
 // passed against a five-month-old sdk. `twin-github`, whose pin matched, had no
 // nested copy at all. Nothing compared the two.
 //
-// It surfaced only when F-1126 imported `@pome-sh/sdk/checks`, a subpath 0.5.1
+// It surfaced only when a caller imported `@pome-sh/sdk/checks`, a subpath 0.5.1
 // does not export. A change that had merely CHANGED behaviour rather than added
 // an export would have been tested against the wrong artifact in silence.
 //
-// This is the sibling of `check-cli-pins-match-workspace.mjs` (F-1135), which
+// This is the sibling of `check-cli-pins-match-workspace.mjs`, which
 // made the same argument for `cli/`. That file and
 // `scripts/use-local-pome-tarballs.mjs` went in `6369379` (#237), and
 // `cli-ci.yml` / `cli-release.yml` in `a3c9441` (#239) — one restructure over
@@ -31,7 +31,7 @@
 // `@pome-sh/*` dep in `cli/package.json` became a workspace-resolved `"*"`,
 // precisely because an exact pin there had drifted (`shared-types@0.12.0`
 // against a local `0.12.2`, two zod schema identities at one runtime — the same
-// shape F-1126 above catches in `packages/`). `cli/` itself is not a sibling
+// shape described above catches in `packages/`). `cli/` itself is not a sibling
 // anything else pins against, so it was never in this script's `packages/`
 // scan — but nothing stopped `cli/package.json` from reintroducing the exact pin
 // that restructure deleted. This scan now covers it too, so that regression is
@@ -51,7 +51,7 @@
 // reintroduce an exact version pin between them"), which admits no exact pin at
 // all. Every internal pin in the tree is `"*"` today, so the tolerance is unused;
 // tightening the gate onto the prose rule would delete the version-comparison
-// branch below entirely. That is F-1126's contract to change, not F-1231's.
+// branch below entirely. That is the packages-sibling contract to change, not this one.
 
 import { globSync, readFileSync, realpathSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
@@ -68,7 +68,7 @@ const SCOPE = "@pome-sh/";
 // pair silently stops covering its subject the moment root grows a glob or the
 // CLI moves directory — which it has done twice (#237, #239). An empty result
 // throws rather than reporting a pass over nothing.
-// Shared with `scripts/check-example-pins-published.mjs` (F-1483): that gate
+// Shared with `scripts/check-example-pins-published.mjs`: that gate
 // needs the same sibling-name → workspace-version map to know which
 // `agent-examples/*` pins have a sibling to compare against, and duplicating this
 // walk would let the two derivations disagree about what a "sibling" is.
@@ -147,7 +147,7 @@ export function findPinViolations(repoRoot) {
 // Realpath'd on both sides — node resolves symlinks before deriving
 // `import.meta.url`, so a bare `pathToFileURL(resolve(...))` of argv[1]
 // misses through a symlinked checkout (a worktree, or macOS's symlinked
-// `/tmp`) in the same silent shape (F-1488), and a guard miss while invoked
+// `/tmp`) in the same silent shape, and a guard miss while invoked
 // as this file throws rather than exits 0.
 const SELF = realpathSync(fileURLToPath(import.meta.url));
 const ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";

--- a/scripts/check-workspace-pins-match-workspace.test.mjs
+++ b/scripts/check-workspace-pins-match-workspace.test.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Regression suite for `check-workspace-pins-match-workspace.mjs` (F-1126,
-// extended to `cli/` under F-1231).
+// Regression suite for `check-workspace-pins-match-workspace.mjs`, extended to
+// cover `cli/`.
 //
-// F-1231 investigated a 2026-08-03 failure where the CLI's build typechecked
+// A 2026-08-03 failure was investigated where the CLI's build typechecked
 // against a `@pome-sh/shared-types` version behind what `packages/` (and its
 // own source) actually used — a pin that had drifted out from under it. That
 // specific architecture (`cli-ci.yml`, `use-local-pome-tarballs.mjs`, an exact
@@ -24,7 +24,7 @@
 // The failure class through `agent-examples/*`'s deliberately-published pins is a
 // different rule (needs the registry, tolerates a pin equal to a version that
 // simply has not published yet) and is NOT this suite's subject — see
-// `scripts/check-example-pins-published.mjs` (F-1483) and its own regression
+// `scripts/check-example-pins-published.mjs` and its own regression
 // suite, wired from `scripts/gate-examples.mjs`.
 
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
@@ -125,9 +125,9 @@ expectGate(
   "green",
 );
 
-// 3. The original F-1126 shape: a packages/* sibling pins a stale exact version.
+// 3. The original shape: a packages/* sibling pins a stale exact version.
 expectGate(
-  "3. packages/* pin behind the workspace sibling reds (F-1126's own case)",
+  "3. packages/* pin behind the workspace sibling reds (the original case)",
   fixture({
     sdk: { name: "@pome-sh/sdk", version: "0.9.0" },
     "twin-slack": {
@@ -140,14 +140,14 @@ expectGate(
   ["packages/twin-slack", "0.5.1", "0.9.0"],
 );
 
-// 4. The F-1231 regression this file exists for: `cli/package.json` pins an
+// 4. The cli regression this file exists for: `cli/package.json` pins an
 // exact, stale version of a sibling instead of "*" — the exact shape #239
 // deleted from `cli/` and that this gate's `packages/`-only scan could not see
 // come back. `@pome-sh/wire`'s workspace version carries `parent_event_id`
-// (0.14.0); a cli pinned to the pre-F-1200 line (0.13.x) is the 2026-08-03
+// (0.14.0); a cli pinned to the older vocabulary line (0.13.x) is the 2026-08-03
 // incident's own version numbers.
 expectGate(
-  "4. cli/package.json reintroducing a stale exact pin reds (the F-1231 regression)",
+  "4. cli/package.json reintroducing a stale exact pin reds (the cli regression)",
   fixture(
     { wire: { name: "@pome-sh/wire", version: "0.14.0" } },
     { name: "@pome-sh/cli", version: "0.23.19", devDependencies: { "@pome-sh/wire": "0.13.4" } },

--- a/scripts/ci/allocate-release-versions.mjs
+++ b/scripts/ci/allocate-release-versions.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-1511 — THE NUMBER IS WRITTEN HERE, ON `main`, AFTER THE MERGE.
+// THE NUMBER IS WRITTEN HERE, ON `main`, AFTER THE MERGE.
 //
 // Every twins PR used to hand-write the shared version line, so every merge
 // invalidated every open PR that had pinned a consumed number — silently
@@ -241,7 +241,7 @@ export function planAllocations({ root = resolve(HERE, "../.."), date = today(),
     });
   }
 
-  // F-1520 — an example that pins a `@pome-sh/*` package from the registry
+  // An example that pins a `@pome-sh/*` package from the registry
   // (today only `agent-examples/support-triage`) must never fall out of sync with
   // that sibling's published version: two incidents (adapter 0.3.4 and 0.3.6,
   // both 2026-08-13) each reddened `check-example-pins-published.mjs` until a
@@ -323,7 +323,7 @@ function commitMessage(allocations, repins, head) {
     subject,
     "",
     ...allocations.map((a) => `- ${a.name} ${a.from} → ${a.to} (${a.level}, ${a.reason})`),
-    ...repins.map((r) => `- agent-examples/${r.example} ${r.dep} ${r.from} → ${r.to} (published pin re-pin, F-1520)`),
+    ...repins.map((r) => `- agent-examples/${r.example} ${r.dep} ${r.from} → ${r.to} (published pin re-pin)`),
     "",
     `Allocated from ${head.slice(0, 8)} by .github/workflows/allocate-version.yml.`,
     "The version number is written here, after the merge, and never in a PR.",
@@ -372,7 +372,7 @@ export function main(argv = process.argv.slice(2)) {
     if (a.relevantFiles.length > 10) console.log(`    … ${a.relevantFiles.length - 10} more`);
   }
   for (const r of plan.repins) {
-    console.log(`agent-examples/${r.example}: ${r.dep} ${r.from} → ${r.to}  (published pin drift, F-1520)`);
+    console.log(`agent-examples/${r.example}: ${r.dep} ${r.from} → ${r.to}  (published pin drift)`);
   }
 
   const planOut = flagValue("--plan-out");
@@ -400,7 +400,7 @@ export function main(argv = process.argv.slice(2)) {
 // Realpath'd on both sides — node resolves symlinks before deriving
 // `import.meta.url`, so a bare `pathToFileURL()` of argv[1] misses through a
 // symlinked checkout (a worktree, or macOS's symlinked `/tmp`) in the same
-// silent shape (F-1488), and a guard miss while invoked as this file throws
+// silent shape, and a guard miss while invoked as this file throws
 // rather than exits 0.
 const SELF = realpathSync(fileURLToPath(import.meta.url));
 const ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";

--- a/scripts/ci/allocate-release-versions.test.mjs
+++ b/scripts/ci/allocate-release-versions.test.mjs
@@ -84,7 +84,7 @@ function repo() {
 }
 
 /**
- * F-1520 — `repo()` has no root `package.json`/`agent-examples/`, so `planExample
+ * `repo()` has no root `package.json`/`agent-examples/`, so `planExample
  * Repins` is a no-op against it (proven in "the repin path is a no-op" below).
  * This adds the shape it needs: a root `workspaces` field naming
  * `ADAPTER.manifest`'s directory, and `agent-examples/support-triage` pinning the
@@ -471,7 +471,7 @@ console.log("the script's own surface");
   }
 }
 
-console.log("F-1520 — the repin path is a no-op without agent-examples/");
+console.log("repin — a no-op without agent-examples/");
 {
   const dir = repo();
   try {
@@ -484,7 +484,7 @@ console.log("F-1520 — the repin path is a no-op without agent-examples/");
   }
 }
 
-console.log("F-1520 — a broken example can never block a version allocation");
+console.log("repin — a broken example can never block a version allocation");
 {
   const dir = repo();
   try {
@@ -514,7 +514,7 @@ console.log("F-1520 — a broken example can never block a version allocation");
   }
 }
 
-console.log("F-1520 — a drifted pin against an already-published sibling is repinned");
+console.log("repin — a drifted pin against an already-published sibling is repinned");
 {
   const dir = repo();
   try {
@@ -545,7 +545,7 @@ console.log("F-1520 — a drifted pin against an already-published sibling is re
   }
 }
 
-console.log("F-1520 — the version THIS run allocates is never repinned to in the same run");
+console.log("repin — the version THIS run allocates is never repinned to in the same run");
 {
   const dir = repo();
   try {
@@ -581,7 +581,7 @@ console.log("F-1520 — the version THIS run allocates is never repinned to in t
   }
 }
 
-console.log("F-1520 — replays the two real incidents (adapter 0.3.4 and 0.3.6, both 2026-08-13)");
+console.log("repin — replays the two real incidents (adapter 0.3.4 and 0.3.6, both 2026-08-13)");
 for (const { from, to } of [
   { from: "0.3.3", to: "0.3.4" }, // #395
   { from: "0.3.5", to: "0.3.6" }, // #425

--- a/scripts/ci/assert-allocate-token-path.mjs
+++ b/scripts/ci/assert-allocate-token-path.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-1511 — THE VERSION-ALLOCATING PUSH CAN ONLY EVER HAPPEN WITH THE APP TOKEN.
+// THE VERSION-ALLOCATING PUSH CAN ONLY EVER HAPPEN WITH THE APP TOKEN.
 //
 // `allocate-version.yml`'s checkout carries a fallback:
 //
@@ -58,8 +58,8 @@
 //
 // Comment stripping is `list-scheduled-workflows.mjs`'s, not a third copy: its
 // stripper is quote-aware because a blanket `#.*$` once truncated two distinct
-// quoted values to the same mangled prefix and made a bijection compare two equal
-// wrecks (F-1471).
+// quoted values to the same mangled prefix and made a bijection compare two
+// equal wrecks.
 //
 // Usage: node scripts/ci/assert-allocate-token-path.mjs [repo root]
 
@@ -377,7 +377,7 @@ export function main(argv = process.argv.slice(2)) {
 // Realpath'd on both sides — node resolves symlinks before deriving
 // `import.meta.url`, so a bare `pathToFileURL()` of argv[1] misses through a
 // symlinked checkout (a worktree, or macOS's symlinked `/tmp`) in the same silent
-// shape (F-1488), and a guard miss while invoked as this file throws rather than
+// shape, and a guard miss while invoked as this file throws rather than
 // exits 0.
 const SELF = realpathSync(fileURLToPath(import.meta.url));
 const ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";

--- a/scripts/ci/assert-allocate-token-path.test.mjs
+++ b/scripts/ci/assert-allocate-token-path.test.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 /**
- * Regression coverage for scripts/ci/assert-allocate-token-path.mjs (F-1511).
+ * Regression coverage for scripts/ci/assert-allocate-token-path.mjs.
  *
  * Every case below MUTATES THE REAL `allocate-version.yml` rather than a
  * hand-written sample, because the claim under test is about the file that ships:

--- a/scripts/ci/assert-hardened-cdn-fetches.mjs
+++ b/scripts/ci/assert-hardened-cdn-fetches.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-1489 — every third-party network call `.github/workflows/**` makes on the
+// Every third-party network call `.github/workflows/**` makes on the
 // publish path must go through one hardened path, and a new one that does not
 // must red CI.
 //
@@ -9,12 +9,12 @@
 // killed the stripe twin-image job twice on 2026-08-12 (#390, #391), and on
 // `main` — where the cosign sign/attest steps do run — the same 503 fails an
 // image publish. The repo already knew the fix (ci.yml's actionlint loop,
-// F-1471) and had it in two hand-copied variants with a third install missing
+// the coverage check) and had it in two hand-copied variants with a third install missing
 // it entirely. A list of "the installs we hardened" is the same shape as the
 // bug: it stays green while a sixth install lands unhardened. So this is a
 // PROPERTY check over the workflow tree.
 //
-// F-1530 widened it from fetches to network calls, because the same shape found
+// It was widened from fetches to network calls, because the same shape found
 // a third instance: with both twin-image.yml fetches hardened, the REGISTRY
 // WRITE standing between them was still a single unretried `docker push`. On
 // 2026-08-14 GHCR answered `unknown blob` after every layer had reported
@@ -25,7 +25,7 @@
 // and this file's test for no property gained, and shapes (a) and (b)
 // are still what most of it does.
 //
-// F-1534 closed the residual this header used to record at the bottom. With (a)
+// The signing leg closed the residual this header used to record at the bottom. With (a)
 // and (c) hardened, `sign-image-digests.sh`'s cosign calls were the last
 // unretried GHCR interaction in that job, and on 2026-08-18 they were the ones
 // that broke: run 32144441622's stripe leg pushed both tags, signed them and
@@ -146,14 +146,14 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 /** The hardened fetch path, relative to the repo root. */
 export const HELPER = "scripts/ci/fetch-pinned-release.sh";
 
-/** The hardened registry-write path, relative to the repo root (F-1530). */
+/** The hardened registry-write path, relative to the repo root. */
 export const PUSH_HELPER = "scripts/ci/push-scanned-image.sh";
 
-/** The hardened sign/attest/verify path, relative to the repo root (F-1534). */
+/** The hardened sign/attest/verify path, relative to the repo root. */
 export const SIGN_HELPER = "scripts/ci/sign-image-digests.sh";
 
 /**
- * The F-1494 pattern is 2 escapable attempts + 1 fatal one. Fewer than three
+ * The retry pattern is 2 escapable attempts + 1 fatal one. Fewer than three
  * means a single transient 5xx can still reach the fatal attempt on its heels;
  * the ticket's own failure was two 503s minutes apart on consecutive PRs.
  */
@@ -162,7 +162,7 @@ export const MIN_ATTEMPTS = 3;
 const FETCH_COMMANDS = /(?:^|[\s(`$])(?:curl|wget|aria2c|gh\s+release\s+download)(?=\s|$)/;
 
 /**
- * Every way a `run:` block commits a manifest to a registry (F-1530). Writes
+ * Every way a `run:` block commits a manifest to a registry. Writes
  * only: `docker pull` and `docker buildx imagetools inspect` are reads, and a
  * read that fails cannot leave a tag behind — `imagetools inspect` is in fact
  * the read this repo's hardened push path and pome-cloud's
@@ -179,7 +179,7 @@ const REGISTRY_WRITE_COMMANDS = [
 ];
 
 /**
- * Every way a `run:` block reaches a registry through cosign (F-1534). ANY
+ * Every way a `run:` block reaches a registry through cosign. ANY
  * subcommand, not a list of the four sign-image-digests.sh runs: `sign` and
  * `attest` write, `verify` and `verify-attestation` read, `copy` writes,
  * `triangulate` reads, and `initialize` pulls the TUF root off a CDN. Every one
@@ -406,14 +406,14 @@ export function findFetchesInScript(script) {
   return findings;
 }
 
-/** Every registry-WRITE invocation in one shell script (F-1530). */
+/** Every registry-WRITE invocation in one shell script. */
 export function findRegistryWritesInScript(script) {
   return shellSegments(script).segments.filter((segment) =>
     REGISTRY_WRITE_COMMANDS.some((command) => command.test(segment)),
   );
 }
 
-/** Every cosign invocation in one shell script (F-1534). */
+/** Every cosign invocation in one shell script. */
 export function findSigningCallsInScript(script) {
   return shellSegments(script).segments.filter((segment) =>
     SIGNING_COMMANDS.some((command) => command.test(segment)),
@@ -456,7 +456,7 @@ export function findUnhardenedRunFetches(root) {
 }
 
 // ---------------------------------------------------------------------------
-// Shape (c): registry writes inside `run:` scripts (F-1530).
+// Shape (c): registry writes inside `run:` scripts.
 // ---------------------------------------------------------------------------
 
 /** `run:` blocks that write to a registry without using the hardened path. */
@@ -476,7 +476,7 @@ export function findUnhardenedRegistryWrites(root) {
         for (const segment of findRegistryWritesInScript(script)) {
           problems.push(
             `${file}:${step.line} (job ${job.name}) writes to a container registry outside ${PUSH_HELPER}: ` +
-              `${segment}. A single \`unknown blob\` from GHCR then fails the leg (F-1530), leaving a commit ` +
+              `${segment}. A single \`unknown blob\` from GHCR then fails the leg, leaving a commit ` +
               "with no image and nothing to re-run it.",
           );
         }
@@ -487,7 +487,7 @@ export function findUnhardenedRegistryWrites(root) {
 }
 
 // ---------------------------------------------------------------------------
-// Shape (d): cosign calls inside `run:` scripts (F-1534).
+// Shape (d): cosign calls inside `run:` scripts.
 // ---------------------------------------------------------------------------
 
 /** `run:` blocks that invoke cosign without using the hardened path. */
@@ -509,7 +509,7 @@ export function findUnhardenedSigningCalls(root) {
             `${file}:${step.line} (job ${job.name}) calls cosign outside ${SIGN_HELPER}: ${segment}. ` +
               "Every cosign subcommand talks to the registry, and this step runs after the image is " +
               "already published — a single `DENIED` from a degraded GHCR then reds the job over a correct, " +
-              "public artifact (F-1534). Reads are in scope here for exactly that reason, unlike shape (c).",
+              "public artifact. Reads are in scope here for exactly that reason, unlike shape (c).",
           );
         }
       }
@@ -610,7 +610,7 @@ export function findTableDefects(table, refs) {
   return problems;
 }
 
-/** One repeated-attempt group, checked against the F-1494 shape. */
+/** One repeated-attempt group, checked against the retry shape. */
 export function checkAttemptGroup(where, repo, attempts) {
   const problems = [];
   const at = (a) => `${where} step ${a.line}`;

--- a/scripts/ci/assert-hardened-cdn-fetches.test.mjs
+++ b/scripts/ci/assert-hardened-cdn-fetches.test.mjs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Regression coverage for scripts/ci/fetch-pinned-release.sh and
-// scripts/ci/assert-hardened-cdn-fetches.mjs (F-1489).
+// scripts/ci/assert-hardened-cdn-fetches.mjs.
 //
 // Two halves, and the second is the one that matters. A gate that has only
 // ever reported "all clear" on the tree it shipped with is a gate nobody has
-// seen fail — the F-1230 grep-based coverage check was defeated three separate
+// seen fail — an earlier grep-based coverage check was defeated three separate
 // times by shapes its author was sure it caught. So every rule here is
 // exercised against a PLANTED violation in a scratch `.github/workflows` tree
 // and asserted to red, by name:
@@ -14,8 +14,8 @@
 //   - a `run:` block curling a release CDN outside the hardened helper
 //   - a fetch whose target the resolver cannot work out (must red, not pass)
 //   - a `run:` block writing to a container registry outside the hardened push
-//     helper (F-1530), and a registry READ that must NOT red
-//   - a `run:` block invoking cosign outside the hardened sign helper (F-1534),
+//     helper, and a registry READ that must NOT red
+//   - a `run:` block invoking cosign outside the hardened sign helper,
 //     the READ subcommands included — unlike shape (c), a failed read here
 //     happens AFTER publication
 //   - a `uses:` action with no row in the classification table
@@ -32,10 +32,10 @@
 // runs against a local server that 503s on demand: retry-then-succeed,
 // exhaustion failing closed with the CDN HOST in the message, and a good
 // download with a wrong sha256 still refused. `push-scanned-image.sh` runs
-// against a fake `docker` that reproduces F-1530's GHCR answer — every layer
+// against a fake `docker` that reproduces the observed GHCR answer — every layer
 // `Pushed`, then `unknown blob` — and, separately, a push that exits 0 while
 // the manifest is never committed. `sign-image-digests.sh` runs against a fake
-// `cosign` that reproduces F-1534's — `DENIED: denied` off the GHCR token
+// `cosign` that reproduces the signing failure — `DENIED: denied` off the GHCR token
 // endpoint, injectable per subcommand, so the case that actually happened (both
 // tags pushed, signed and attested, dead on `verify-attestation`'s READ) is a
 // fixture rather than a paragraph.
@@ -147,7 +147,7 @@ const TABLE = {
 // ---------------------------------------------------------------------------
 
 // PLANTED FAILURE — a raw curl at a release CDN. This is the shape the two
-// hand-copied install loops had before F-1489, and the shape a third copy
+// hand-copied install loops had before the ladder landed, and the shape a third copy
 // would have.
 withScratchRoot(
   {
@@ -220,11 +220,11 @@ assert(findFetchesInScript("wget https://x.example/y").length === 1, "wget count
 assert(findFetchesInScript("gh release download v1 -R o/r").length === 1, "gh release download counts");
 
 // ---------------------------------------------------------------------------
-// Shape (c): registry WRITES in `run:` blocks (F-1530).
+// Shape (c): registry WRITES in `run:` blocks.
 //
 // `Push scanned image` was one bare `docker push` with no retry, sitting
-// between two `uses:` installs that had both been given three-attempt ladders
-// (F-1489, F-1494). On 2026-08-14 GHCR answered `unknown blob` after every
+// between two `uses:` installs that had both been given three-attempt ladders.
+// On 2026-08-14 GHCR answered `unknown blob` after every
 // layer had reported `Pushed`, the stripe leg died, and `stripe-bbf27bf` did
 // not exist — which failed four consecutive twin-snapshot-verify runs and
 // opened pome-cloud#752, because nothing re-ran that step for four days.
@@ -302,7 +302,7 @@ assert(findRegistryWritesInScript("echo 'docker pushes images'").length === 0, "
 assert(findRegistryWritesInScript("docker push ghcr.io/o/r:v1").length === 1, "a bare push counts");
 
 // ---------------------------------------------------------------------------
-// Shape (d): cosign calls in `run:` blocks (F-1534).
+// Shape (d): cosign calls in `run:` blocks.
 //
 // With shapes (a) and (c) closed, the sign/attest/verify step was the last
 // unretried GHCR interaction on the publish path — a single step at
@@ -314,7 +314,7 @@ assert(findRegistryWritesInScript("docker push ghcr.io/o/r:v1").length === 1, "a
 // ---------------------------------------------------------------------------
 
 // PLANTED FAILURE — the WRITE half, inline. This is the shape the sign step
-// had before F-1534.
+// had before the signing leg was hardened.
 withScratchRoot(
   {
     "planted.yml": wf(`      - name: Sign pushed image digests
@@ -448,7 +448,7 @@ assert(findTableDefects(loadTable(), new Map()).length === 0, "scripts/ci/cdn-fe
 // Shape (b): the repeated-attempt group.
 // ---------------------------------------------------------------------------
 
-assert(MIN_ATTEMPTS === 3, "the F-1494 pattern is 2 escapable attempts + 1 fatal one");
+assert(MIN_ATTEMPTS === 3, "the retry pattern is 2 escapable attempts + 1 fatal one");
 
 // PLANTED FAILURE — the exact state twin-image.yml's syft step was in.
 withScratchRoot(
@@ -596,7 +596,7 @@ mainThrows(
 );
 
 // And for shape (d): with the sign step deleted rather than hardened, the
-// signing half checked nothing. This is the guard that keeps F-1534's fix from
+// signing half checked nothing. This is the guard that keeps that fix from
 // being quietly reverted into a green gate.
 mainThrows(
   {
@@ -678,7 +678,7 @@ await new Promise((r) => server.listen(0, "127.0.0.1", r));
 const base = `http://127.0.0.1:${server.address().port}`;
 
 try {
-  // A transient 5xx cannot fail the fetch on the first attempt — F-1489's
+  // A transient 5xx cannot fail the fetch on the first attempt — the ladder's
   // first done-when, measured rather than asserted in a comment.
   const flaky = await runHelper(`${base}/flaky`, GOOD_SHA);
   assert(flaky.status === 0, `two 503s then a 200 must succeed, got ${flaky.status}\n${flaky.stderr}`);
@@ -714,7 +714,7 @@ try {
 }
 
 // ---------------------------------------------------------------------------
-// scripts/ci/push-scanned-image.sh itself (F-1530).
+// scripts/ci/push-scanned-image.sh itself.
 //
 // Driven against a fake `docker` on PATH rather than a real registry: the
 // failure to reproduce is GHCR accepting every layer and then refusing the
@@ -739,7 +739,7 @@ if [ "\${1:-}" = "push" ]; then
   echo "$tag" >> "\${state}/pushes"
   echo "5f70bf18a086: Pushed"
   if take "\${state}/pushfail_\${slug}"; then
-    # F-1530's answer from GHCR: every layer reports Pushed, then the manifest
+    # The observed answer from GHCR: every layer reports Pushed, then the manifest
     # PUT is refused because the registry cannot see a blob it just accepted.
     echo "unknown blob" >&2
     exit 1
@@ -756,7 +756,7 @@ if [ "\${1:-}" = "buildx" ] && [ "\${2:-}" = "imagetools" ] && [ "\${3:-}" = "in
   slug="\${tag//[^A-Za-z0-9]/_}"
   echo "$tag" >> "\${state}/inspects"
   # A degraded GHCR refuses the manifest READ as readily as the manifest PUT —
-  # F-1534's \`DENIED: denied\` off the token endpoint arrives here too. Only the
+  # A \`DENIED: denied\` off the token endpoint arrives here too. Only the
   # sign suite below sets this budget; the push cases above leave it unset,
   # where \`take\` on a missing file is a no-op.
   if take "\${state}/inspectfail_\${slug}"; then
@@ -843,7 +843,7 @@ function runPush(tags, plan = {}, { attempts = 3 } = {}) {
 
 // The PRODUCTION retry budget, pinned. Every other case here passes its own
 // `attempts`, so on its own this suite would stay green with the default
-// silently cut to 1 — which is the state F-1530 was reporting. Measured by
+// silently cut to 1 — which is the state the incident was reporting. Measured by
 // leaving the knob unset: four faults must be survivable and the fifth must not.
 {
   const survives = await runPush(PER_COMMIT, { [PER_COMMIT]: { pushFailures: 4 } }, { attempts: null });
@@ -854,7 +854,7 @@ function runPush(tags, plan = {}, { attempts = 3 } = {}) {
   assert(exhausts.stderr.includes("after 5 attempts"), `expected a 5-attempt budget, got: ${exhausts.stderr}`);
 }
 
-// F-1530's first done-when, measured rather than asserted in a comment: a
+// The first done-when, measured rather than asserted in a comment: a
 // single `unknown blob` no longer fails the leg.
 {
   const flaky = await runPush(`${ROLLING}\n${PER_COMMIT}`, { [PER_COMMIT]: { pushFailures: 1 } });
@@ -908,7 +908,7 @@ function runPush(tags, plan = {}, { attempts = 3 } = {}) {
   );
 }
 
-// F-1530's second done-when. A registry that never commits fails the step, by
+// The second done-when. A registry that never commits fails the step, by
 // name — and the per-commit tag pome-cloud resolves is left absent, which is
 // the "reports not found rather than resolving a partial manifest" half.
 {
@@ -987,7 +987,7 @@ for (const [label, tags] of [
 }
 
 // ---------------------------------------------------------------------------
-// scripts/ci/sign-image-digests.sh itself (F-1534).
+// scripts/ci/sign-image-digests.sh itself.
 //
 // Driven against a fake `cosign` alongside the fake `docker` above. The fault
 // to reproduce is a registry that authenticates fine for one call and answers
@@ -1118,7 +1118,7 @@ const opsFor = (calls, ref) => calls.filter((c) => c.endsWith(` ${ref}`)).map((c
   }
 }
 
-// F-1534's first done-when, one case per GHCR interaction the script makes. A
+// The signing leg's first done-when, one case per GHCR interaction the script makes. A
 // `DENIED` on ANY of them is the registry being degraded, not a verdict about
 // the artifact, so none may fail the leg on the first answer.
 for (const op of SIGN_OPS) {
@@ -1133,7 +1133,7 @@ for (const op of SIGN_OPS) {
   // `::warning::`: the retry itself warns before sleeping, so a bare
   // `/::warning::/` stays green with the succeeded-late notice deleted — and
   // that notice is the whole signal that GHCR is degrading before the day it
-  // is total, which is how F-1530 went unnoticed for four days.
+  // is total, which is how the incident went unnoticed for four days.
   assert(
     `${flaky.stdout}${flaky.stderr}`.includes("landed only on attempt 2"),
     `a flaky-but-passing \`cosign ${op}\` must SAY so, got: ${flaky.stdout}${flaky.stderr}`,
@@ -1149,7 +1149,7 @@ for (const op of SIGN_OPS) {
   assert(flaky.inspects.length === 2, `the digest read must be retried, got ${flaky.inspects.join(", ")}`);
 }
 
-// F-1534's second done-when. Exhaustion still fails closed — but by the time
+// The signing leg's second done-when. Exhaustion still fails closed — but by the time
 // anything here fails, push-scanned-image.sh has already published every tag,
 // so the message has to say which operation ran out, on which ref, and what
 // state that leaves public. `##[error]The process failed with exit code 1` is

--- a/scripts/ci/assert-repo-policy.test.mjs
+++ b/scripts/ci/assert-repo-policy.test.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * Offline regression coverage for scripts/ci/assert-repo-policy.sh (F-696).
- * F-1212 — the script now reads GET /repos/{owner}/{repo}/rules/branches/{branch}
+ * Offline regression coverage for scripts/ci/assert-repo-policy.sh.
+ * The script now reads GET /repos/{owner}/{repo}/rules/branches/{branch}
  * (metadata-scoped GITHUB_TOKEN, no PAT) instead of the legacy admin-scoped
  * .../protection + .../rulesets pair. Feeds fixture rules JSON (no live API).
  *
@@ -119,7 +119,7 @@ function main() {
   }
 
   {
-    // Missing deletion rule (F-1517: branch-deletion protection) must hard-fail,
+    // Missing deletion rule (branch-deletion protection) must hard-fail,
     // naming the policy — this is the red proof that the ruleset actually needs
     // the rule, not just that the script mentions it.
     const r = runAssert(baseRules().filter((rule) => rule.type !== "deletion"));
@@ -341,7 +341,7 @@ function main() {
 
   {
     // Green runs must name what is NOT watched live, so a reader is never
-    // told coverage is total. F-1517: deletion is now asserted live (the
+    // told coverage is total. Deletion is now asserted live (the
     // ruleset carries the rule), so bypass_actors is the only named gap and
     // the NOT-verified line must no longer mention deletion.
     const r = runAssert(baseRules());
@@ -362,7 +362,7 @@ function main() {
     assert(!/administration:\s*read/.test(y), "GITHUB_TOKEN cannot use administration scope");
     assert(
       !/secrets\.REPO_POLICY_TOKEN/.test(y),
-      "repo-policy must not read the REPO_POLICY_TOKEN secret anymore (F-1212)",
+      "repo-policy must not read the REPO_POLICY_TOKEN secret anymore",
     );
     assert(
       /assert-repo-policy\.test\.mjs/.test(y),

--- a/scripts/ci/assert-schedule-alarm-coverage.mjs
+++ b/scripts/ci/assert-schedule-alarm-coverage.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-1471 — the guard that keeps F-1230's alarm coverage true. F-1230 wired
+// The guard that keeps alarm coverage true. The alarm wiring covers
 // every scheduled workflow that exists TODAY to the reusable alarm; nothing
 // stopped a thirteenth from landing next month with no alarm at all, and
 // nothing stopped a wired-but-broken alarm (a typo'd `uses:` target, a
@@ -19,7 +19,7 @@
 // Right side (does a given workflow reach the alarm) parses PER JOB BLOCK,
 // anchored on both ends by indentation, rather than grepping lines — a
 // grep-based version of this exact check was defeated three separate times
-// during F-1230's own review, by a commented-out step, a
+// during its own review, by a commented-out step, a
 // `continue-on-error: true`, and a step-level `if:`. Comments are already
 // stripped before any of this runs (list-scheduled-workflows.mjs's
 // workflowLines()), so a commented-out job simply is not there to find.
@@ -38,7 +38,7 @@
 //     schedule-alarm.yml's OWN filing job requests — the alarm exists, runs,
 //     and either dies with a 403 at `gh issue create` or is refused by
 //     GitHub before it starts, which is the exact "fired, failed, told
-//     nobody" outcome F-1230 exists to prevent.
+//     nobody" outcome the alarm exists to prevent.
 //   - schedule-alarm.yml's own filing job not resolving `issues: write`. The
 //     caller's grant is a CEILING, not the effective set: a reusable
 //     workflow's own `permissions:` can only narrow what the caller handed

--- a/scripts/ci/assert-schedule-alarm-coverage.test.mjs
+++ b/scripts/ci/assert-schedule-alarm-coverage.test.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Regression coverage for scripts/ci/assert-schedule-alarm-coverage.mjs
-// (F-1471, and F-1493's effective-permissions check). Builds scratch
+// (and the effective-permissions check). Builds scratch
 // `.github/workflows` trees so every assertion is about the PARSER, not
 // about which alarms this repo happens to carry today.
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
@@ -178,7 +178,7 @@ withScratchRoot(
 // ── Break-on-purpose: a step-level if: false (deeper than the job's own
 // keys) must not be mistaken for the job-level if: that actually gates the
 // alarm call. This is one of the three shapes that defeated a grep-based
-// version of this exact check during F-1230's own review — a flat regex over
+// version of this exact check during its own review — a flat regex over
 // lines would see the nearer "if: false" and misread a healthy job-level
 // if: failure() as neutralised.
 withScratchRoot(
@@ -464,7 +464,7 @@ withScratchRoot(
   },
 );
 
-// ── F-1493: a calling job whose permissions map omits issues: write must
+// ── A calling job whose permissions map omits issues: write must
 // gap, naming both the workflow and the job.
 withScratchRoot(
   {

--- a/scripts/ci/changelog-entry.mjs
+++ b/scripts/ci/changelog-entry.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-1511 — THE CHANGELOG CONTRACT, now that the number is not the author's.
+// THE CHANGELOG CONTRACT, now that the number is not the author's.
 //
 // The old contract was one rule: a package's `CHANGELOG.md` top heading must
 // equal the version in the same PR. That rule is what made every open PR carry

--- a/scripts/ci/check-checks-tarball.mjs
+++ b/scripts/ci/check-checks-tarball.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Release gate for @pome-sh/checks' tarball (F-1308).
+// Release gate for @pome-sh/checks' tarball.
 //
 // This package exists for exactly one reason: pome-cloud grades every `[code]`
 // criterion out of these declarations, and it lives in a different repository.
@@ -23,7 +23,7 @@
 //      this is the assertion that keeps it that way.
 //   4. Bundling zod would be worse than a 404, because it succeeds: two copies
 //      of zod means two schema identities, `instanceof` fails and parsed results
-//      stop being interchangeable. That is the F-942 bug that dissolved
+//      stop being interchangeable. That is the bug that dissolved
 //      `@pome-sh/shared-types`, and nothing at runtime announces it.
 //   5. Bundling the twin ENGINE (hono, node:sqlite, @hono/node-server) would
 //      mean a "declarations only" package shipping an HTTP server and a database
@@ -163,7 +163,7 @@ if (manifest.peerDependencies?.zod === undefined) {
   failures.push(
     "packages/checks/package.json must declare `zod` as a peerDependency.\n" +
       "    The seed schemas and `defineCheck` are zod values. A bundled or duplicated zod means\n" +
-      "    two schema identities in the consumer's process (F-942) — and unlike a 404, it works\n" +
+      "    two schema identities in the consumer's process — and unlike a 404, it works\n" +
       "    just well enough to be found later.",
   );
 }
@@ -288,7 +288,7 @@ function auditTarball() {
       failures.push(
         "zod appears to be INLINED into the tarball rather than left external:\n" +
           zodInlined.map((file) => `      - ${file}`).join("\n") +
-          "\n    Two zod copies means two schema identities in the consumer's process (F-942).",
+          "\n    Two zod copies means two schema identities in the consumer's process.",
       );
     }
     const importsZod = [...sources.values()].some((text) => /from\s*['"]zod['"]/.test(text));

--- a/scripts/ci/check-release-note-required.mjs
+++ b/scripts/ci/check-release-note-required.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-1511 — THE PR-TIME HALF OF THE RELEASE CONTRACT, re-scoped from
+// THE PR-TIME HALF OF THE RELEASE CONTRACT, re-scoped from
 // scripts/ci/check-version-bump-required.mjs, whose history is under that path
 // (the rewrite is large enough that `--follow` will not bridge it).
 //

--- a/scripts/ci/check-release-note-required.test.mjs
+++ b/scripts/ci/check-release-note-required.test.mjs
@@ -9,24 +9,24 @@
  *
  * ── The cases inherited from the version-bump gate this file re-scopes ───────
  *
- * The publish-relevance table moved to `publish-relevance.mjs` (F-1511) but did
+ * The publish-relevance table moved to `publish-relevance.mjs` but did
  * not change, and neither did the bugs it has been taught. Each carve-out below
  * is a measured over-match, and every one has the same shape: a plain string
  * prefix matching files that ship in no tarball, so a PR was told to publish a
  * byte-identical artifact.
  *
- *   F-1375  `cli/` matched `cli/test/**` — no package's `files` array names a
+ *   1  `cli/` matched `cli/test/**` — no package's `files` array names a
  *           test directory. Carved out EXCEPT under `examples/`, `assets/` and
  *           `tasks/`, which the CLI's `files` really does publish verbatim.
- *   F-1455  `packages/twin-` matched a twin's own top-level `examples/`
- *           (PR #366 / F-1453). Not because of `files` — twin-github's and
+ *   2  `packages/twin-` matched a twin's own top-level `examples/`
+ *           (PR #366). Not because of `files` — twin-github's and
  *           twin-slack's `dist/examples/` really is packed — but because every
  *           twin is `private: true` and release.yml publishes only cli,
  *           adapter-claude-sdk, checks and wire. Same prefix, one directory
  *           over: a twin's top-level `.md`.
- *   F-1354  Same prefix again: a twin's own top-level `scripts/`, found on the
+ *   3  Same prefix again: a twin's own top-level `scripts/`, found on the
  *           PR whose whole job was wiring such a script into CI.
- *   F-1532  Same prefix, one file over: a twin's own `Dockerfile`. A GHCR image
+ *   4  Same prefix, one file over: a twin's own `Dockerfile`. A GHCR image
  *           is not an npm artifact, so patching a base image was demanding both
  *           a cli and a sandbox-domains release. Found on the PR that had to
  *           edit all five to clear a fixable base-image CVE.
@@ -36,7 +36,7 @@
  * a regex that widened to `.+` would pass every exemption test while quietly
  * stopping the demand for files that really do ship.
  *
- * ── The cases this file adds (F-1511) ───────────────────────────────────────
+ * ── The cases this file adds ────────────────────────────────────────────────
  *
  * The demand inverted: a PR must NOT write the number, and must carry the words.
  * Both directions are asserted, plus the two CHANGELOG properties that used to
@@ -223,7 +223,7 @@ console.log("check-release-note-required.mjs — publish relevance (inherited)")
 }
 
 {
-  // F-1354: a twin's own top-level scripts/ is dev/CI tooling in no tarball.
+  // A twin's own top-level scripts/ is dev/CI tooling in no tarball.
   const r = run({ changes: { "packages/twin-github/scripts/validate-mcp.ts": "// tooling\n" } });
   check("a change confined to a twin's scripts/ needs no entry", r.status === 0, r.out);
 }
@@ -262,7 +262,7 @@ console.log("check-release-note-required.mjs — publish relevance (inherited)")
 }
 
 {
-  // F-1532: a twin's Dockerfile builds its GHCR image, which no tarball carries.
+  // A twin's Dockerfile builds its GHCR image, which no tarball carries.
   // The real case was all five at once, to clear a fixable base-image CVE.
   const r = run({
     changes: {
@@ -491,7 +491,7 @@ console.log("the gate's own surface");
   // really reaches a consumer's tarball out of the relevance table, silently.
   //
   // Written as a property over `PUBLISHED_PACKAGES` rather than against any one
-  // package, because the way it breaks is a NAME. F-1526's package was called
+  // package, because the way it breaks is a NAME. The new package was called
   // `twin-domains` first, which put a published `README.md` (in its `files`) under
   // the `packages/twin-*` top-level-markdown carve-out; renaming it to
   // `sandbox-domains` is what actually fixed that, and the fix is invisible in
@@ -519,7 +519,7 @@ console.log("the gate's own surface");
       isPublishIrrelevantPath("packages/twin-github/scripts/validate-mcp.ts") !== null,
   );
 
-  // The shared declaration bundler moved to scripts/ (F-1526) so sandbox-domains
+  // The shared declaration bundler moved to scripts/ so sandbox-domains
   // could use it instead of copying ~300 lines. Both packages' `.d.ts` are
   // unresolvable for a consumer if it regresses, so it must stay publish-relevant
   // for both — the move must not have quietly dropped it out of the table.

--- a/scripts/ci/check-sandbox-domains-tarball.mjs
+++ b/scripts/ci/check-sandbox-domains-tarball.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Release gate for @pome-sh/sandbox-domains' tarball (F-1526).
+// Release gate for @pome-sh/sandbox-domains' tarball.
 //
 // This package exists for one reason: pome-cloud boots the twin domain layer
 // IN-PROCESS as its grading/authoring runtime (`lib/twin-state.ts`), and
@@ -70,7 +70,7 @@ const PACKAGE_DIRECTORY = join(ROOT, "packages", "sandbox-domains");
 const MANIFEST_PATH = join(PACKAGE_DIRECTORY, "package.json");
 
 /**
- * The export spec of F-1526, measured from pome-cloud's own imports rather than
+ * The export spec, measured from pome-cloud's own imports rather than
  * designed fresh: `apps/control-plane/src/lib/twin-state.ts`,
  * `checks-package-drift.test.ts`, `lib/twin-tape-pull.ts` and
  * `apps/mcp/src/lib/capture.ts`. A subpath that stops exporting one of these
@@ -245,7 +245,7 @@ if (manifest.peerDependencies?.zod === undefined) {
     "packages/sandbox-domains/package.json must declare `zod` as a peerDependency.\n" +
       "    The seed schemas are zod values and pome-cloud hands `parseSeed` a seed it built with\n" +
       "    its OWN zod. A bundled or duplicated zod means two schema identities in the consumer's\n" +
-      "    process (F-942) — and unlike a 404, it works just well enough to be found later.",
+      "    process — and unlike a 404, it works just well enough to be found later.",
   );
 }
 
@@ -289,7 +289,7 @@ for (const subpath of Object.keys(REQUIRED_EXPORTS)) {
   if (manifest.exports?.[subpath] === undefined) {
     failures.push(
       `packages/sandbox-domains/package.json has no \`exports\` entry for "${subpath}", which\n` +
-        `    F-1526's export spec requires (pome-cloud imports ${REQUIRED_EXPORTS[subpath].join(", ")} from it).`,
+        `    the export spec requires (pome-cloud imports ${REQUIRED_EXPORTS[subpath].join(", ")} from it).`,
     );
   }
 }
@@ -492,7 +492,7 @@ function auditTarball() {
       failures.push(
         "zod appears to be INLINED into the tarball rather than left external:\n" +
           zodInlined.map((file) => `      - ${relative(packageRoot, file)}`).join("\n") +
-          "\n    Two zod copies means two schema identities in the consumer's process (F-942).",
+          "\n    Two zod copies means two schema identities in the consumer's process.",
       );
     }
     const importsZod = [...sources.values()].some((text) => /from\s*['"]zod['"]/.test(text));
@@ -517,7 +517,7 @@ function auditTarball() {
       const absent = symbols.filter((symbol) => !new RegExp(`\\b${symbol}\\b`).test(text));
       if (absent.length > 0) {
         failures.push(
-          `${subpath} (${file}) does not export ${absent.join(", ")}, which F-1526's export spec\n` +
+          `${subpath} (${file}) does not export ${absent.join(", ")}, which the export spec\n` +
             "    requires because pome-cloud imports them from it.",
         );
       }

--- a/scripts/ci/check-sandbox-domains-tarball.test.mjs
+++ b/scripts/ci/check-sandbox-domains-tarball.test.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Regression suite for scripts/ci/check-sandbox-domains-tarball.mjs (F-1526).
+// Regression suite for scripts/ci/check-sandbox-domains-tarball.mjs.
 //
 // The gate's whole value is that it fails on things nobody can see from inside
 // this workspace, so the thing worth testing is that it FAILS — a gate asserted
@@ -127,7 +127,7 @@ check(
   leakedPeer.output,
 );
 
-// The F-942 bug, in a brand-new package: two zod identities in one process.
+// The two-schema-identity bug, in a brand-new package.
 const zodNotPeer = withMutatedManifest((m) => {
   delete m.peerDependencies.zod;
   m.dependencies.zod = "^4.4.3";
@@ -148,7 +148,7 @@ check(
   driftedAnchor.output,
 );
 
-// The export spec is F-1526's measured contract with pome-cloud.
+// The export spec is the measured contract with pome-cloud.
 const droppedSubpath = withMutatedManifest((m) => {
   delete m.exports["./server"];
 });
@@ -170,7 +170,7 @@ check(
 // ── The specifier scanner ───────────────────────────────────────────────────
 //
 // Not reachable by mutating a manifest, and the half that actually broke during
-// F-1526: the loose `\bfrom\s*"…"` form used on `.d.ts` reads SQL and English
+// The loose `\bfrom\s*"…"` form used on `.d.ts` reads SQL and English
 // inside bundled JS string literals as import specifiers. These pin both
 // directions so a future simplification back to one pattern reds here.
 console.log("\ncheck-sandbox-domains-tarball.mjs — specifier scanning");

--- a/scripts/ci/check-wire-tarball.mjs
+++ b/scripts/ci/check-wire-tarball.mjs
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Release gate for @pome-sh/wire's own tarball (F-949).
+// Release gate for @pome-sh/wire's own tarball.
 //
 // `scripts/clean-room-pack-test.mjs` audits the two npmjs tarballs — it asserts
 // they carry NO `@pome-sh/*` dependency, which is the assertion that keeps wire
 // inlined rather than installed. It says nothing about wire's own tarball,
-// because until F-949 wire had no tarball: it was `private: true` and reached
+// because wire used to have no tarball: it was `private: true` and reached
 // users only as bytes inside the CLI's and the adapter's `dist/`.
 //
 // Now it is also published to GitHub Packages for cross-repo consumers
@@ -148,7 +148,7 @@ function auditTarball() {
     // emitted `.js.map` would be a dangling map with no `sourcesContent`.
     // `files` excludes them (`!dist/**/*.map`). clean-room-pack-test.mjs
     // already treats a dangling map in a published tarball as a hard failure
-    // for the other two packages (F-943); wire holds to the same rule.
+    // for the other two packages; wire holds to the same rule.
     const sourcemaps = [...shipped].filter((path) => path.endsWith(".map"));
     if (sourcemaps.length > 0) {
       failures.push(

--- a/scripts/ci/decide-publish.test.mjs
+++ b/scripts/ci/decide-publish.test.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Regression coverage for scripts/ci/decide-publish.sh (F-949).
+ * Regression coverage for scripts/ci/decide-publish.sh.
  *
  * Mocks `npm` on PATH so every registry answer is exercised without a network:
  * unpublished (E404 ⇒ publish from a 0.0.0 baseline), unchanged (skip), ahead

--- a/scripts/ci/list-scheduled-workflows.mjs
+++ b/scripts/ci/list-scheduled-workflows.mjs
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-1230 — every workflow with a `schedule:` trigger needs a failure alarm
+// Every workflow with a `schedule:` trigger needs a failure alarm
 // (D5 · "every check runs somewhere that can fail"). The set of scheduled
 // workflows is DERIVED from `.github/workflows/*.yml` rather than typed into
 // a list anywhere: a hand-maintained list of "workflows with a schedule" is
 // exactly the shape D5 names as the bug — it stays green while a thirteenth
-// scheduled workflow lands uncovered. F-1471 (the follow-up that asserts
+// scheduled workflow lands uncovered. The follow-up that asserts
 // "every scheduled workflow reaches the alarm" as a property, not an
 // instance) reads this same derivation rather than re-parsing the tree with
 // its own rules.
@@ -73,7 +73,7 @@ export function findScheduledWorkflows(root) {
           throw new Error(
             `${file}: an \`on:\` flow mapping that spans more than one line is not parsed by ` +
               "this derivation, so a `schedule:` trigger inside it would be invisible to it and " +
-              "to the alarm-coverage check (F-1471) alike. Rewrite it in block form.",
+              "to the alarm-coverage check alike. Rewrite it in block form.",
           );
         }
         inOnBlock = inline === "";
@@ -153,7 +153,7 @@ export function findBrokenLocalUses(root) {
  * preceded by whitespace, and never inside a quoted scalar. A blanket strip
  * silently TRUNCATES values — `label: "schedule-alarm:x#1"` and
  * `label: "schedule-alarm:x#2"` both reduce to `"schedule-alarm:x`, so the
- * F-1471 title/label bijection compares two mangled values, finds them equal,
+ * The title/label bijection compares two mangled values, finds them equal,
  * and reports green on exactly the typo it exists to catch. Failing to strip a
  * real comment is the safer error, so an unterminated quote leaves the rest of
  * the line intact rather than guessing.
@@ -175,7 +175,7 @@ function stripComment(raw) {
 
 /**
  * Every workflow file as `[name, comment-stripped lines]`. Exported so
- * scripts/ci/assert-schedule-alarm-coverage.mjs (F-1471) reads the exact same
+ * scripts/ci/assert-schedule-alarm-coverage.mjs reads the exact same
  * file list and comment-stripping rule rather than re-implementing it — two
  * readers of ".github/workflows/*.yml with comments stripped" drifting apart
  * is the same shape of bug this file's `cron:`/`schedule:` cross-check exists
@@ -224,7 +224,7 @@ export function main(argv = process.argv.slice(2)) {
         `  cron: key but no on: schedule: -> ${onlyCron.join(", ") || "(none)"}\n` +
         "Fix the parser in list-scheduled-workflows.mjs, not this assertion — " +
         "a scheduled workflow it cannot see is a scheduled workflow the alarm " +
-        "coverage check (F-1471) cannot see either.",
+        "coverage check cannot see either.",
     );
   }
 

--- a/scripts/ci/list-scheduled-workflows.test.mjs
+++ b/scripts/ci/list-scheduled-workflows.test.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Regression coverage for scripts/ci/list-scheduled-workflows.mjs (F-1230).
+// Regression coverage for scripts/ci/list-scheduled-workflows.mjs.
 // Builds a scratch .github/workflows tree so the assertions do not depend on
 // which workflows this repo happens to carry today.
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";

--- a/scripts/ci/publish-relevance.mjs
+++ b/scripts/ci/publish-relevance.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-1511 — WHICH PUBLISHED ARTIFACTS DOES A SET OF CHANGED FILES MOVE?
+// WHICH PUBLISHED ARTIFACTS DOES A SET OF CHANGED FILES MOVE?
 //
 // One answer, two callers. This table used to live inside
 // `check-version-bump-required.mjs`, where it powered a PR-time demand ("bump
@@ -18,7 +18,7 @@
 //     are still the author's.
 //
 // Both import this file rather than each carrying a copy: a second
-// hand-maintained "which paths matter for which package" is the F-1135 shape —
+// hand-maintained "which paths matter for which package" is the brittle shape —
 // one goes stale while both still look like they are watching, and here the two
 // copies would disagree about whether a release was owed at all.
 //
@@ -47,7 +47,7 @@ function isUnpublishableTestPath(file) {
  * twin-slack's tsconfig.build.json compile `examples/**\/*.ts` into
  * `dist/examples/*.js` (rootDir "."), and `files: ["dist", ...]` names
  * `dist`. The actual load-bearing fact is `private: true` — release.yml
- * (F-1308, F-949, F-1526) publishes cli, adapter-claude-sdk, checks, wire and
+ * publishes cli, adapter-claude-sdk, checks, wire and
  * sandbox-domains, and no twin is any of those. Nothing in this repo currently
  * asserts a twin stays private, so if one were ever unprivated this exemption
  * would need re-checking; today it holds for all five. `@pome-sh/sandbox-domains`
@@ -63,7 +63,7 @@ function isUnpublishableTestPath(file) {
  * any other `src/` module and is publish-relevant if the CLI bundle imports
  * it.
  *
- * F-1455, reproduced by PR #366 (F-1453): a PR touching only
+ * Reproduced by PR #366: a PR touching only
  * packages/twin-stripe/examples/buyer-agent/ was told to bump @pome-sh/cli
  * for a republish that would be byte-identical.
  */
@@ -81,7 +81,7 @@ function isTwinExamplePath(file) {
  * tarballs inline twin SOURCE through tsup, and tsup cannot inline a markdown
  * file.
  *
- * Same shape of over-match as F-1455, one directory over: `packages/twin-` is a
+ * Same shape of over-match, one directory over: `packages/twin-` is a
  * plain prefix, so documentation that cannot change one byte of any published
  * artifact was demanding a `@pome-sh/cli` release — i.e. a republish that would
  * be byte-identical. The usual advice ("if your change doesn't warrant a
@@ -103,7 +103,7 @@ function isTwinTopLevelDocPath(file) {
 /**
  * A twin's own top-level `scripts/` is dev/CI tooling, run via tsx on the `.ts`
  * source. It ships in no tarball, and — as with the two carve-outs above — the
- * load-bearing fact is `private: true`: release.yml (F-1308, F-949, F-1526)
+ * load-bearing fact is `private: true`: release.yml
  * publishes cli, adapter-claude-sdk, checks, wire and sandbox-domains, and no twin
  * is any of those. That is deliberately the ONLY reason claimed here, because the tempting
  * second one is false for four of the five twins: only
@@ -119,10 +119,10 @@ function isTwinTopLevelDocPath(file) {
  * under `cli/src/`, `packages/sandbox-domains/src/` or any twin's own `src/`
  * imports a twin script — so tsup never sees these files.
  *
- * Third instance of the F-1455 over-match, one directory over from the
+ * Third instance of the same over-match, one directory over from the
  * `examples/` and top-level-`.md` carve-outs above: `packages/twin-` is a plain
  * prefix, so editing a validator that CI runs was demanding an `@pome-sh/cli`
- * release — a republish that would be byte-identical. Found on F-1354, which had
+ * release — a republish that would be byte-identical. Found on a PR that had
  * to touch `packages/twin-github/scripts/validate-mcp.ts` to wire that script
  * into CI at all, and "if your change doesn't warrant a release it shouldn't be
  * touching a publish-relevant path" has no answer: a twin's own validator has
@@ -150,11 +150,11 @@ function isTwinScriptPath(file) {
  * from each twin's package `exports`, which resolve into `src/` only, and a
  * Dockerfile is imported by nothing.
  *
- * Fourth instance of the F-1455 over-match, one file over from `examples/`,
+ * Fourth instance of the same over-match, one file over from `examples/`,
  * top-level `.md` and `scripts/`: `packages/twin-` is a plain prefix, so
  * patching a base image demanded BOTH a `@pome-sh/cli` and a
  * `@pome-sh/sandbox-domains` release — two republishes that would each be
- * byte-identical. Found on F-1532, where a fixable base-image CVE had frozen the
+ * byte-identical. Found where a fixable base-image CVE had frozen the
  * twin image publish deterministically and the remedy could only be applied in
  * these five files. "If your change doesn't warrant a release it shouldn't be
  * touching a publish-relevant path" has no answer here either: a twin's
@@ -169,7 +169,7 @@ function isTwinDockerfilePath(file) {
 }
 
 /**
- * F-1511 — a `CHANGELOG.md` is exempt, and this one is NOT the F-1455 shape:
+ * A `CHANGELOG.md` is exempt, and this one is NOT that over-match shape:
  * these bytes really do ship (`packages/checks/package.json` and
  * `packages/twin-linear/package.json` name `CHANGELOG.md` in `files`, and npm
  * packs a root CHANGELOG.md whether or not `files` asks it to). The exemption is
@@ -245,7 +245,7 @@ export const PUBLISHED_PACKAGES = [
     pathPrefixes: ["packages/adapter-claude-sdk/", "packages/wire/"],
   },
   {
-    // The grading vocabulary, published to npmjs for pome-cloud (F-1308).
+    // The grading vocabulary, published to npmjs for pome-cloud.
     //
     // Its publish-relevant paths are the DECLARATION layer of six other
     // packages, because that is what tsup inlines into its tarball: each twin's
@@ -269,7 +269,7 @@ export const PUBLISHED_PACKAGES = [
     pathPatterns: [
       /^packages\/twin-[a-z]+\/src\/(checks|check-[a-z-]+|seed|tape-assertable-tools)\.ts$/,
       /^packages\/sdk\/src\/(checks|check-state-path|check-discrimination|check-redaction|failure-injection)\.ts$/,
-      // The declaration bundler moved out of this package (F-1526) so
+      // The declaration bundler moved out of this package so
       // @pome-sh/sandbox-domains could share it instead of copying ~300 lines. It
       // is still what makes this tarball's `.d.ts` resolvable for a consumer,
       // so it is still publish-relevant here — the move must not quietly drop
@@ -279,13 +279,13 @@ export const PUBLISHED_PACKAGES = [
   },
   {
     // The twin domain layer — the in-process runtime pome-cloud's
-    // `lib/twin-state.ts` boots and a bound check reads (F-1526).
+    // `lib/twin-state.ts` boots and a bound check reads.
     //
     // `@pome-sh/checks` ships the DECLARATIONS, this ships what they read. The
     // two are the two legs of pome-cloud's `checks-package-drift.test.ts`, and
     // the reason they are separate entries on one lane is that both must be cut
     // from the SAME `main` commit: publishing a widened vocabulary whose runtime
-    // could not follow is precisely the wall F-1524 recorded.
+    // could not follow is precisely the wall that blocked the vocabulary widening.
     //
     // Its paths are WHOLE directories where the checks entry above names files,
     // and the difference is not an oversight. A twin's routes, tools and domain
@@ -309,7 +309,7 @@ export const PUBLISHED_PACKAGES = [
     pathPatterns: [/^scripts\/bundle-declarations\.mjs$/],
   },
   {
-    // Published to BOTH registries from one version line (F-949): npmjs for
+    // Published to BOTH registries from one version line: npmjs for
     // pome-cloud's migration off @pome-sh/shared-types, GitHub Packages for its
     // original cross-repo consumers. Its own independent version line and
     // therefore its own independent entry here.
@@ -332,13 +332,13 @@ export const PUBLISHED_PACKAGES = [
     // wire's own `version`. `check:trace-contract` (a required ci.yml gate) is a
     // byte compare, so a version moved without regenerating it reds `main` —
     // "Bumping wire's version also means re-running emit:trace-contract" was a
-    // human instruction from F-1201 until this table replaced it, and a human
+    // human instruction until this table replaced it, and a human
     // instruction is exactly what stops being followed when the version stops
     // being written by a human.
     //
     // `regenerate` runs the REAL emitter rather than patching the one key,
     // because that emitter also enumerates the event union out of zod and
-    // asserts a fixture per kind (F-1201) — a hand-patch would keep the byte
+    // asserts a fixture per kind — a hand-patch would keep the byte
     // compare green while silently dropping that assertion. It is the reason
     // allocate-version.yml has an `npm ci` at all, and it runs only when a
     // package in the plan names one.

--- a/scripts/ci/release-alarm.mjs
+++ b/scripts/ci/release-alarm.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-1350 — a failed release must reach a human without a human going looking.
+// A failed release must reach a human without a human going looking.
 //
 // On 2026-08-06 four consecutive push-triggered `release.yml` runs failed over
 // eleven hours (00:42, 01:26, 10:41, 11:28 UTC). Nothing fired. `release.yml`
@@ -9,7 +9,7 @@
 // — so a publish that died is indistinguishable from a merge that owed no
 // publish. The first signal was a human noticing two packages missing from npm,
 // and the recovery was that human dispatching the workflow by hand. Two of
-// those four runs were the merges of F-1308 and F-949's wire work: the packages
+// those four runs were the merges of the declaration-lane and wire work: the packages
 // the grading vocabulary now depends on, reporting themselves as merged while
 // publishing nothing.
 //
@@ -19,7 +19,7 @@
 // gave before it was deleted alongside the Changesets flow it watched
 // (`a3c9441`, "replace two release systems with one"). Deleting it with its
 // subject was right; not replacing it was the gap. An `if: failure()` step
-// inside `release.yml` cannot see the silence that bit F-1180: a release
+// inside `release.yml` cannot see the silence this alarm exists for: a release
 // workflow that never triggers at all takes an embedded check down with it.
 //
 // ── What it asserts ──────────────────────────────────────────────────────────
@@ -33,7 +33,7 @@
 // broken anyway, which the outcome check cannot see until the next bump.
 //
 //   UNALLOCATED — main carries a pending `## Unreleased` entry that no
-//                 allocation consumed (F-1511). The version number is written on
+//                 allocation consumed. The version number is written on
 //                 main after the merge by allocate-version.yml, so a broken or
 //                 unconfigured allocator produces a state the outcome check
 //                 CANNOT see: main declares the old version, the registry serves
@@ -48,7 +48,7 @@
 //                 decide-publish.sh armed to hard-fail the whole lane on the
 //                 next merge, taking that merge's unrelated publishes with it.
 //   NEVER_RAN   — main's HEAD has no `release.yml` run at all and is past the
-//                 grace window. The F-1180 silence: a push to main that
+//                 grace window. The silence: a push to main that
 //                 triggered nothing (a bot pushing with the ambient
 //                 GITHUB_TOKEN cannot trigger workflows), or Actions disabled.
 //   STUCK       — a run has been queued/in_progress past the stuck window.
@@ -275,7 +275,7 @@ function inspectReleaseRuns({ repo, head, runs, now, graceMinutes, stuckMinutes 
 }
 
 /**
- * The allocation leg (F-1511): is anything still WAITING for a number?
+ * The allocation leg: is anything still WAITING for a number?
  *
  * A pending `## Unreleased` entry on main is transient by construction —
  * allocate-version.yml consumes it on the push that created it — so one still
@@ -481,7 +481,7 @@ export function main(argv = process.argv.slice(2)) {
 // Realpath'd on both sides — node resolves symlinks before deriving
 // `import.meta.url`, so a bare `pathToFileURL()` of argv[1] (with no
 // realpath) misses through a symlinked checkout (a worktree, or macOS's
-// symlinked `/tmp`) in the same silent shape (F-1488), and a guard miss
+// symlinked `/tmp`) in the same silent shape, and a guard miss
 // while invoked as this file throws rather than exits 0.
 const SELF = realpathSync(fileURLToPath(import.meta.url));
 const ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";

--- a/scripts/ci/release-alarm.test.mjs
+++ b/scripts/ci/release-alarm.test.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 /**
- * Regression coverage for scripts/ci/release-alarm.mjs (F-1350).
+ * Regression coverage for scripts/ci/release-alarm.mjs.
  *
  * Both directions are asserted, and the silent one matters more. An alarm that
  * fires on a healthy release gets muted, and a muted alarm is exactly the state
@@ -49,7 +49,7 @@ const minutesAgo = (m) => new Date(NOW - m * 60_000).toISOString();
 
 /**
  * A CHANGELOG with nothing pending, for every published package — the state
- * every allocation leaves behind (F-1511). `pending` names packages that get an
+ * every allocation leaves behind. `pending` names packages that get an
  * `## Unreleased` section instead, which is the state a dead allocator leaves.
  */
 function writeChangelogs(dir, pending = {}) {
@@ -258,7 +258,7 @@ console.log("BEHIND — main is below the registry, so the next merge fails its 
   check_("no UNPUBLISHED for the same package", !kinds(r).includes("UNPUBLISHED"));
 }
 
-console.log("NEVER_RAN — a push to main that triggered nothing (the F-1180 silence)");
+console.log("NEVER_RAN — a push to main that triggered nothing (the release silence)");
 {
   const r = run({
     head: { sha: HEAD_SHA, ageMin: 600 },
@@ -290,7 +290,7 @@ console.log("FAILED — a broken release path with nothing owed");
   check_("a skipped run does not", !kinds(run({ runs: [{ ageMin: 200, conclusion: "skipped" }] })).includes("FAILED"));
 }
 
-console.log("UNALLOCATED — a number nobody wrote (F-1511)");
+console.log("UNALLOCATED — a number nobody wrote");
 {
   // The state a broken or unconfigured allocate-version.yml leaves: main carries
   // the words and not the number, main and the registry agree on the OLD version,
@@ -384,7 +384,7 @@ console.log("2026-08-06, replayed");
     }
     // Backfill any target the YAML names that the caller did not — `parseTargets`
     // hard-fails on a manifest that does not exist, so a hand-written map has to
-    // be re-edited every time release.yml gains a package. It was, once: F-1526's
+    // be re-edited every time release.yml gains a package. It was, once: a new
     // fifth target broke the replay below, which passes the REAL release.yml
     // against a four-entry map. The versions are what each replay is about, so
     // callers still name those; the rest only need to exist, and matching
@@ -397,7 +397,7 @@ console.log("2026-08-06, replayed");
     }
     // Today's CHANGELOGs even in a historical fixture: the allocation leg's
     // subject is the tree the alarm is checked out in, and the replay below is
-    // about the registry and the run list, not about F-1511's contract.
+    // about the registry and the run list, not about the allocation contract.
     writeChangelogs(dir);
     return dir;
   }
@@ -498,7 +498,7 @@ console.log("2026-08-06, replayed");
     // Anything this replay does not name is a package that did not exist on
     // 2026-08-06 and is answered in sync with the version `historical` backfilled
     // — the same `?? { version: "1.0.0" }` fallback `registryStub` uses. Without
-    // it the fifth target (F-1526) reads `undefined` and this replay reds over a
+    // it the fifth target reads `undefined` and this replay reds over a
     // package it is not about, which is the trap the fixture backfill above
     // exists to close on the other side.
     readVersion: (name, registry) =>

--- a/scripts/ci/wait-for-workflow.test.mjs
+++ b/scripts/ci/wait-for-workflow.test.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Regression coverage for scripts/ci/wait-for-workflow.sh (F-696).
+ * Regression coverage for scripts/ci/wait-for-workflow.sh.
  * Mocks curl on PATH and asserts success / failure / newest-run selection /
  * in-progress polling / timeout / cancelled. Also asserts twin-image.yml waits
  * on ci.yml, and on secret-scan.yml only where a run exists to wait for.

--- a/scripts/clean-room-pack-test.mjs
+++ b/scripts/clean-room-pack-test.mjs
@@ -3,7 +3,7 @@
 //
 // Clean-room release gate for the four npmjs-published packages. (`@pome-sh/wire`
 // is also published, but to GitHub Packages for cross-repo consumers, and is
-// audited separately by scripts/ci/check-wire-tarball.mjs — F-949. What matters
+// audited separately by scripts/ci/check-wire-tarball.mjs. What matters
 // HERE is the assertion below that neither npm tarball declares an `@pome-sh/*`
 // dependency: that is what keeps wire inlined rather than installed, and it must
 // keep holding now that wire is resolvable-but-401 rather than nonexistent.)
@@ -15,7 +15,7 @@
 // shipped none, npm trusted the declaration and skipped fetching them, the
 // install reported success, and the CLI died on its first command.
 //
-// Both packages also get a files-field tarball audit (F-943): the real `tar`
+// Both packages also get a files-field tarball audit: the real `tar`
 // listing is grepped for dangling `.map` files and a compiled `dist/examples/`
 // directory. tsup's `sourcemap: false` / `clean: true` config should already
 // make both impossible, but that was previously an unverified claim about the
@@ -112,7 +112,7 @@ function assertNoHardLinks(tarball) {
   }
 }
 
-// F-943 tarball-files-field audit: `npm pack` respects each package's `files`
+// Tarball-files-field audit: `npm pack` respects each package's `files`
 // field, but nothing previously asserted WHAT actually lands in the tgz.
 // tsup's `sourcemap: false` / `clean: true` config (Lane D) means a stray
 // `.map` or a leftover `dist/examples/` from a prior build shouldn't be
@@ -497,7 +497,7 @@ const twin: ChecksTwinName = CHECKS_TWIN_NAMES[0];
 const everyTwin: readonly unknown[] = TWIN_CHECKS[twin];
 
 // The seed schema must be a zod schema built from the CONSUMER's zod, or
-// composition fails at the boundary (F-942, two schema identities).
+// composition fails at the boundary (two schema identities).
 const composed = z.object({ seed: githubSeedSchema });
 const parsed = parseGitHubSeed(defaultGitHubSeed());
 const alsoParsed = parseSeed(defaultGitHubSeed());
@@ -550,7 +550,7 @@ console.log("  ✓ consumer file typechecks against the shipped declarations (sk
 
 // ── @pome-sh/sandbox-domains ───────────────────────────────────────────────────
 //
-// The grading RUNTIME (F-1526), and the one published package where "the import
+// The grading RUNTIME, and the one published package where "the import
 // resolves" is genuinely not enough: pome-cloud does not just read these
 // exports, it CONSTRUCTS them — opens a SQLite database, builds a domain over
 // it, and parses a seed through it. A tarball whose `open*Database` resolves and

--- a/scripts/emit-route-inputs.mjs
+++ b/scripts/emit-route-inputs.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-1179 — publish each twin's route input surface as a committed artifact.
+// Publish each twin's route input surface as a committed artifact.
 //
 // pome-cloud's declared-fidelity lane compares what a vendor declares it
 // accepts against what our twin accepts. It reads this repo through the
@@ -52,7 +52,7 @@ const TWINS = [
     // twin-linear's API layer is GraphQL: its operation ARGUMENTS come from the
     // executable schema it serves, not from an HTTP route declaration. Both
     // halves publish through this one artifact so pome-cloud has one seam for
-    // five twins rather than four plus a bespoke fixture of its own (F-1173).
+    // five twins rather than four plus a bespoke fixture of its own.
     graphql: {
       module: "dist/src/graphql/argument-surface.js",
       exportName: "linearGraphqlArgumentSurfaces",

--- a/scripts/example-tool-probe-driver.mjs
+++ b/scripts/example-tool-probe-driver.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-1152 probe driver — the child half of scripts/probe-example-tools.mjs.
+// Probe driver — the child half of scripts/probe-example-tools.mjs.
 //
 // Runs INSIDE one example's dependency tree (under that example's own `tsx`
 // when it has one, so a `.ts` tool table and its zod / `file:`-linked adapter

--- a/scripts/fixtures/probe-examples/refused/tools.mjs
+++ b/scripts/fixtures/probe-examples/refused/tools.mjs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// The F-1152 incident in miniature, for scripts/probe-example-tools.test.mjs.
+// The probe incident in miniature, for scripts/probe-example-tools.test.mjs.
 //
 // `comment_on_issue` wraps `add_issue_comment` at a number that has no issue
 // behind it — this fixture's seed carries `issues: []`, exactly as all four of

--- a/scripts/fixtures/probe-examples/sound/tools.mjs
+++ b/scripts/fixtures/probe-examples/sound/tools.mjs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// A throwaway example for scripts/probe-example-tools.test.mjs (F-1152). Its
+// A throwaway example for scripts/probe-example-tools.test.mjs. Its
 // tools all reach subjects the seed provides, so the gate must stay silent.
 //
 // Two shapes are deliberate. It calls the twin's MCP surface, which is where
-// F-1125 stamps the twin ACTION on the tape even for a failed call, so the
+// The twin stamps its ACTION on the tape even for a failed call, so the
 // end-to-end test can assert the action name reaches the report. And `twin()`
 // SWALLOWS a non-2xx and returns it as a value instead of throwing — copying
 // `agent-examples/merge-agent`'s `gh()` — so the fixture also exercises the path
@@ -23,7 +23,7 @@ export function buildTools(config) {
 
   return {
     list_open_issues: {
-      // `OPEN`, not `open` (F-1468): GitHub's MCP `list_issues` declares
+      // `OPEN`, not `open`: GitHub's MCP `list_issues` declares
       // `["OPEN","CLOSED"]` and the twin follows it. Its REST `GET /issues` is
       // the door that takes lowercase.
       execute: ({ owner, repo }) => twin("list_issues", { owner, repo, state: "OPEN" }),

--- a/scripts/gate-examples.mjs
+++ b/scripts/gate-examples.mjs
@@ -5,7 +5,7 @@
 // The bundled `agent-examples/*` projects are standalone npm packages (each with its
 // own lockfile), NOT workspaces, so neither the root `npm run typecheck` nor the
 // root `npm test` covers them. That gap is how a zod-4 / Claude Agent SDK
-// `tool()` typing regression sat latent until F-866.
+// `tool()` typing regression sat latent until this gate existed.
 //
 // The same gap had swallowed the examples' own TESTS for as long as they have
 // existed. Four examples declare `"test": "vitest run"` and 49 test cases across
@@ -33,7 +33,7 @@
 // standalone-fetchable via `npx degit`, which copies that subtree and nothing
 // above it, so a `file:` path out of the tree breaks its `npm install`. So this
 // gate typechecks that example against the registry artifact, NOT against the
-// adapter source next to it — and nothing compared the two until F-1483. It had
+// adapter source next to it — and nothing compared the two until this gate. It had
 // drifted twice already (#308 off 0.2.5, then 0.3.1 against a workspace 0.3.3,
 // which also dragged the retired `@pome-sh/shared-types` back into the
 // example's install graph as 0.3.1's declared runtime dep) before anything
@@ -130,7 +130,7 @@ if (failures.length > 0) {
   console.log(`\nAll ${examples.length} examples typechecked and tested clean.`);
 }
 
-// F-1483 — confirm each bundled example's exact `@pome-sh/*` pin still equals
+// Confirm each bundled example's exact `@pome-sh/*` pin still equals
 // the sibling workspace version wherever that version is published.
 //
 // Deliberately NOT behind the typecheck exit above. It used to be, and that

--- a/scripts/lib/static-import-graph.mjs
+++ b/scripts/lib/static-import-graph.mjs
@@ -3,7 +3,7 @@
 // The static import graph of this repo's TypeScript sources, read from the
 // sources themselves.
 //
-// Extracted from `check-twin-chunk-laziness.mjs` (F-1306) when a second gate
+// Extracted from `check-twin-chunk-laziness.mjs` when a second gate
 // needed the same walk: `check-twin-leaf-portability.mjs` asks which twin
 // modules can still be loaded by a runtime without `node:sqlite`. Both ask a
 // reachability question about the same graph, and two hand-rolled copies of an

--- a/scripts/lint-code-health.mjs
+++ b/scripts/lint-code-health.mjs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-679 code-health gates: barrel policy + file-size tripwire.
+// Code-health gates: barrel policy + file-size tripwire.
 import { readFile, readdir } from "node:fs/promises";
 import { dirname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -25,7 +25,7 @@ const BARREL_PATHS = [
   "cli/src/contract/index.ts",
 ];
 
-// Existing large modules — shrink this list as files are split (F-679).
+// Existing large modules — shrink this list as files are split.
 const FILE_SIZE_ALLOWLIST = new Set([
   "cli/src/cli/main.ts",
   "cli/src/cli/eval.ts",

--- a/scripts/lint-legacy-criterion-markers.mjs
+++ b/scripts/lint-legacy-criterion-markers.mjs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-778 legacy criterion-marker gate. The [D]/[P] authoring markers were
+// Legacy criterion-marker gate. The [D]/[P] authoring markers were
 // retired in favor of [code]/[model]; this gate fails on any reintroduced
 // legacy marker form ([D], [P], [D:<twin>], [P:<twin>]) anywhere in the repo.
 //

--- a/scripts/lint-no-bare-import-meta-main.mjs
+++ b/scripts/lint-no-bare-import-meta-main.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-1481: a bare `import.meta.main` entry guard is false on Node 24.0.0,
+// A bare `import.meta.main` entry guard is false on Node 24.0.0,
 // 24.0.1, 24.0.2 and 24.1.0 — the property landed in 24.2, root `engines`
 // allows `>=24`, so on those versions it silently reads `undefined` and a
 // guard built on it exits 0 having done nothing. `scripts/probe-twin-endpoints.mjs`
@@ -36,7 +36,7 @@
 // the exact shape this milestone (D5) targets: it stops covering its subject
 // the day a file is added and nothing notices.
 //
-// F-1488 extends this same walk with a second, related check rather than
+// The realpath check extends this same walk with a second, related check rather than
 // building a separate scanner: the SANCTIONED replacement for bare
 // `import.meta.main` — comparing `process.argv[1]` against `import.meta.url`
 // — has its own silent-skip shape when neither side (or only one side) is
@@ -67,7 +67,7 @@ const SOURCE_EXTENSIONS = new Set([".mjs", ".js", ".cjs", ".ts", ".mts", ".cts",
 // Every root that ships an entry point. This is `scripts/no-eval-in-oss.mjs`'s
 // root list plus `contract/` and `agent-examples/` — the two the narrower first cut
 // of this gate covered (`scripts`, `contract`) left the class open one
-// directory over, which is precisely how F-1481 itself happened: F-1353 fixed
+// directory over, which is precisely how this gate's own gap happened: one fix landed
 // `contract/run.mjs` and the same bug survived ten lines from `probe:examples`.
 // `agent-examples/` is load-bearing, not defensive: six examples were live instances.
 const SCAN_ROOTS = ["scripts", "contract", "cli/src", "cli/scripts", "packages", "agent-examples"];
@@ -76,9 +76,9 @@ const SCAN_ROOTS = ["scripts", "contract", "cli/src", "cli/scripts", "packages",
 // ~740 and parses third-party CJS, which reds spuriously.
 const PRUNED_DIRS = new Set(["node_modules", "dist", "build", ".git", "coverage", ".turbo", ".next"]);
 
-// The floor on how many entry-guard comparisons the F-1488 half must CLASSIFY
+// The floor on how many entry-guard comparisons the realpath half must CLASSIFY
 // before its "no gaps" verdict means anything. See the runner at the bottom of
-// this file. 12 is F-1488's own instance count, against 27 actually present.
+// this file. 12 is the instance count that motivated it, against 27 actually present.
 const MIN_ENTRY_GUARD_RELATIONS = 12;
 
 /**
@@ -220,7 +220,7 @@ export function findBareImportMetaMain(source, fileName = "input.mjs") {
  * `filename` and `dirname` are in here alongside `url` because Node ships all
  * three (they landed in 21.2), they are all derived AFTER symlink resolution,
  * and a guard comparing an unresolved argv0 against `import.meta.filename` has
- * exactly the F-1488 bug in a spelling the `url`-only check would call clean. */
+ * exactly the realpath bug in a spelling the `url`-only check would call clean. */
 const IMPORT_META_SELF_PATH_PROPS = new Set(["url", "filename", "dirname"]);
 function isImportMetaUrlNode(node) {
   return (
@@ -399,7 +399,7 @@ const EQUALITY_OPERATORS = new Set([
  *     file of that name anywhere on disk — it does not need a symlink to be
  *     wrong.
  *   "one-sided-realpath"  — exactly one side is wrapped in `realpathSync`.
- *     The narrow silent skip F-1353's first fix traded a wide one for: still
+ *     The narrow silent skip an earlier fix traded a wide one for: still
  *     defeated by a symlinked checkout, just through a smaller set of paths.
  *   "no-realpath"         — neither side is wrapped in `realpathSync` (this
  *     covers a bare compare, a `resolve()`-only compare, and a
@@ -492,7 +492,7 @@ export function parseErrorsIn(source, fileName) {
 /**
  * Scan every discovered file. Returns real `import.meta.main` references
  * (`findings`), entry guards that do not realpath both sides (`guardGaps`,
- * F-1488) and unparseable files (`unparseable`) SEPARATELY — a syntax error
+ * the realpath check) and unparseable files (`unparseable`) SEPARATELY — a syntax error
  * is not a broken entry guard, and reporting it as one sends the reader
  * looking for a guard that does not exist.
  */
@@ -541,7 +541,7 @@ export function scanRepo(repoRoot = REPO_ROOT, roots = SCAN_ROOTS) {
 // Realpath'd on both sides, never bare `import.meta.main` — this file is one
 // of the files it would scan, and using the property it forbids to guard its
 // own entry would be a fine irony but a broken gate. A guard miss while
-// invoked as this file throws rather than exits 0 (F-1481, same shape as
+// invoked as this file throws rather than exits 0 (same shape as
 // contract/run.mjs and scripts/smoke-examples.mjs).
 const SELF = realpathSync(fileURLToPath(import.meta.url));
 const ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";
@@ -581,14 +581,14 @@ if (invokedDirectly) {
     console.error(
       "\nNode resolves symlinks before deriving `import.meta.url`, so a guard missing realpathSync on either " +
         "side disagrees with argv0 through any symlinked invocation (a `git worktree`, or macOS's symlinked " +
-        "`/tmp`) and falls false, reading as a pass having checked nothing (F-1488). A `basename()` compare " +
+        "`/tmp`) and falls false, reading as a pass having checked nothing. A `basename()` compare " +
         "is weaker still — satisfied by any file of that name anywhere on disk, no symlink required. Realpath " +
         "BOTH sides: `realpathSync(resolve(process.argv[1]))` vs. `realpathSync(fileURLToPath(import.meta.url))`, " +
         "and throw rather than exit 0 on a guard miss while invoked as the file itself " +
         "(see contract/run.mjs or scripts/no-eval-in-oss.mjs)."
     );
   }
-  // The floor on the F-1488 half, and the counterpart to the per-root
+  // The floor on the realpath half, and the counterpart to the per-root
   // file-count floor inside scanRepo. An empty `guardGaps` is ambiguous on its
   // own: it means "every entry guard realpaths both sides" OR "the walk
   // recognized no entry guard at all", and only the first is a pass. The
@@ -600,7 +600,7 @@ if (invokedDirectly) {
   // `import.meta.url` inline; the other 26 are found through the
   // single-assignment alias deref, so a regression that broke only the deref
   // would leave the count at 1 and a `> 0` floor would still print a pass —
-  // the same vacuous pass one step down. The bound is the F-1488 instance
+  // the same vacuous pass one step down. The bound is the measured instance
   // count (12) against 27 actual, so it reds on a classifier regression
   // without reding on someone legitimately deleting a script.
   if (guardRelations < MIN_ENTRY_GUARD_RELATIONS) {
@@ -608,7 +608,7 @@ if (invokedDirectly) {
       `\nThe entry-guard check classified only ${guardRelations} argv[1]-vs-import.meta.url relation(s) across ` +
         `${filesScanned} file(s), below the floor of ${MIN_ENTRY_GUARD_RELATIONS}. Every runnable script in this ` +
         "repo has such a guard, so this is the checker having gone (partly) blind, not the repo being clean — " +
-        "refusing to report a pass (F-1488). If scripts were genuinely removed, lower the floor deliberately."
+        "refusing to report a pass. If scripts were genuinely removed, lower the floor deliberately."
     );
   }
   if (

--- a/scripts/lint-no-bare-import-meta-main.test.mjs
+++ b/scripts/lint-no-bare-import-meta-main.test.mjs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Regression coverage for scripts/lint-no-bare-import-meta-main.mjs
-// (F-1481, extended by F-1488 for the realpath-both-sides entry-guard shape).
+// (extended for the realpath-both-sides entry-guard shape).
 
 import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
@@ -59,7 +59,7 @@ for (const [label, source] of Object.entries(REAL_SHAPES)) {
   assert(hits.length > 0, `a real import.meta.main reference is caught: ${label} (source: ${JSON.stringify(source)})`);
 }
 
-// The live instances F-1481's first cut could not see were `.ts`, so the parser
+// The live instances the first cut could not see were `.ts`, so the parser
 // must read TypeScript syntax — not merely "not crash" on it. A JS-only parser
 // fails on the type annotations here and would report the file as unparseable
 // (or as clean), which is the silent skip this gate exists to prevent.
@@ -102,7 +102,7 @@ for (const [label, source] of Object.entries(FALSE_POSITIVES)) {
   assert(hits.length === 1, `a real reference is caught even alongside comment/string mentions (got ${hits.length})`);
 }
 
-// ── findEntryGuardRealpathGaps: the F-1488 shapes, each its own verdict ─────
+// ── findEntryGuardRealpathGaps: the realpath shapes, each its own verdict ───
 // The sanctioned replacement for bare `import.meta.main` — comparing
 // `process.argv[1]` against `import.meta.url` — has its own silent-skip shape
 // when either side is not realpath'd. Node resolves symlinks before deriving
@@ -275,7 +275,7 @@ for (const [label, source] of Object.entries(GUARD_GAP_CLEAN_CASES)) {
 }
 
 // ── the scan roots cannot silently narrow ──────────────────────────────────
-// F-1481's own history is the argument for this assertion: F-1353 fixed
+// This gate's own history is the argument for this assertion: one fix landed for
 // `contract/run.mjs`, the same bug survived ten lines away under `scripts/`,
 // and this gate's first cut then covered only those two roots while six live
 // instances sat in `agent-examples/*/src/*.ts`. A root dropping out of the walk must
@@ -289,7 +289,7 @@ for (const [label, source] of Object.entries(GUARD_GAP_CLEAN_CASES)) {
   const all = [...byRoot.values()].flat();
   assert(
     all.some((f) => /(^|\/)agent-examples\/[^/]+\/src\/index\.ts$/.test(f)),
-    "a bundled example's entry module is in scope — the six live F-1481 instances were exactly these files"
+    "a bundled example's entry module is in scope — the six live instances were exactly these files"
   );
   assert(all.some((f) => f.includes("/cli/src/")), "cli/src is in scope");
   assert(!all.some((f) => f.includes("node_modules")), "the walk never descends into node_modules");
@@ -400,7 +400,7 @@ for (const [label, source] of Object.entries(GUARD_GAP_CLEAN_CASES)) {
   }
 }
 
-// ── scanRepo: F-1488 break-on-purpose, one scratch file per shape ─────────
+// ── scanRepo: realpath break-on-purpose, one scratch file per shape ───────
 // The ticket's own break-on-purpose matrix: a one-sided-realpath guard, a
 // no-realpath guard, and a basename guard added to a scratch script each red
 // naming that exact file; a correct both-sides-realpath'd guard next to them
@@ -455,8 +455,8 @@ for (const [label, source] of Object.entries(GUARD_GAP_CLEAN_CASES)) {
 // ── the shipped repo is clean ────────────────────────────────────────────
 // The regression that matters most: what would have caught
 // scripts/probe-twin-endpoints.mjs and the six examples shipping a bare
-// guard (F-1481), and the ten entry-guard-realpath instances plus the two
-// basename ones (F-1488).
+// guard, and the ten entry-guard-realpath instances plus the two
+// basename ones.
 {
   const { filesScanned, findings, unparseable, guardGaps, guardRelations } = scanRepo(ROOT);
   assert(filesScanned > 0, "the real scan covers at least one file");
@@ -470,7 +470,7 @@ for (const [label, source] of Object.entries(GUARD_GAP_CLEAN_CASES)) {
   // exists. `guardGaps.length === 0` over the real repo is satisfied both by
   // "every guard realpaths both sides" and by "the classifier recognized no
   // guard at all", and the second is how two floors in this milestone shipped
-  // dead. The repo has one guard per runnable script; the twelve F-1488 fixed
+  // dead. The repo has one guard per runnable script; the twelve that were fixed
   // ones alone put the count above 12, so a bound well under the real number
   // reds on a classifier going blind without reding on someone deleting a
   // script.

--- a/scripts/lint-parent-vocab.mjs
+++ b/scripts/lint-parent-vocab.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-1200 — no emitter may write a bare `parent_id`.
+// No emitter may write a bare `parent_id`.
 //
 // `parent_id` used to mean four different things depending on which of five
 // writers produced the row: a spawning `event_id` (wrapQuery), a raw SDK
@@ -100,7 +100,7 @@ for (const pattern of ROOTS) {
 }
 
 if (violations.length > 0) {
-  console.error("parent-vocab gate failed (F-1200): a bare `parent_id` in emitter source.\n");
+  console.error("parent-vocab gate failed: a bare `parent_id` in emitter source.\n");
   for (const v of violations) console.error(`  ${v}`);
   console.error(
     "\n`parent_id` meant four different things and is no longer written by anything.\n" +

--- a/scripts/lint-parent-vocab.test.mjs
+++ b/scripts/lint-parent-vocab.test.mjs
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Regression suite for `lint-parent-vocab.mjs` (F-1200).
+// Regression suite for `lint-parent-vocab.mjs`.
 //
 // Case 2 is the reason this file exists: the first version of the gate stripped
 // string literals before scanning, so `{ "parent_id": null }` emitted the
 // forbidden field with the gate still green. A gate that cannot fail is worse
-// than no gate, because it reads as coverage — the same lesson F-1201 learned
+// than no gate, because it reads as coverage — the same lesson the fixture corpus taught
 // about the trace contract. Each case builds a throwaway source tree and runs
 // the real script against it.
 

--- a/scripts/lint-route-input-declarations.mjs
+++ b/scripts/lint-route-input-declarations.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-1179 — the gate that keeps a twin's published input surface COMPLETE.
+// The gate that keeps a twin's published input surface COMPLETE.
 //
 // # What it enforces
 //
@@ -291,7 +291,7 @@ const MIDDLEWARE_EXEMPTIONS = [
     file: "packages/twin-linear/src/twin.ts",
     expression: `const peek = new HonoRequest(c.req.raw.clone())`,
     reason:
-      "recorder plumbing, not a route input: F-1385's `extensions` gate answers ahead of " +
+      "recorder plumbing, not a route input: the `extensions` gate answers ahead of " +
       "`bearerAuth`, so it runs before the recorder — and the recorder captures `request_body` " +
       "with its own `c.req.raw.clone().json()`, which throws once the stream is disturbed and " +
       "records null instead. Parsing the original would blank the tape on every recorded " +

--- a/scripts/lint-route-input-declarations.test.mjs
+++ b/scripts/lint-route-input-declarations.test.mjs
@@ -223,7 +223,7 @@ const BASE = { ...SDK_FILES, ...EXEMPT_FIXTURES, ...cleanTwin("github"), ...clea
   check(
     "case 1: the pass names how many modules it walked, so zero coverage is visible",
     // The twin count tracks EXEMPT_FIXTURES, which has to carry every twin the
-    // real exemption list names — five since F-1385 added twin-linear's.
+    // real exemption list names — five, including twin-linear's.
     /OK — \d+ module\(s\) reachable from \d+ route registrar\(s\) across 5 twins/.test(output),
     output.trim()
   );

--- a/scripts/lint-task-class.mjs
+++ b/scripts/lint-task-class.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-1302 — every shipped task declares which POPULATION it belongs to.
+// Every shipped task declares which POPULATION it belongs to.
 //
 // The corpus holds two kinds of file under one heading, and until now nothing
 // in either repo could tell them apart:
@@ -35,7 +35,7 @@
 // comment but the per-corpus task counts pinned cloud-side, which go red the
 // moment the two disagree.
 //
-// THE SUBTREE, not just the direct children — F-1300's walker gap, picked up
+// THE SUBTREE, not just the direct children — the walker gap, picked up
 // here because both walkers were being written anyway. The rule used to be
 // "directly inside a directory named `tasks`", so `tasks/<topic>/x.md` was
 // invisible: a task could leave the corpus by being filed one directory deeper,
@@ -133,7 +133,7 @@ function main() {
     console.error(
       `No task files found under ${CORPORA.join(", ")}. Refusing to pass a zero-file scan: ` +
         `a corpus that stopped being found reads exactly like a corpus with nothing wrong ` +
-        `in it (F-989).`,
+        `in it.`,
     );
     process.exit(1);
   }
@@ -185,7 +185,7 @@ function main() {
 // is satisfied by any file of that name anywhere on disk, weaker even than
 // an unresolved full-path compare. Realpath'd on both sides instead — node
 // resolves symlinks before deriving `import.meta.url`, so a bare compare
-// misses through a symlinked checkout (F-1488) — and a guard miss while
+// misses through a symlinked checkout — and a guard miss while
 // invoked as this file throws rather than exits 0.
 const SELF = realpathSync(fileURLToPath(import.meta.url));
 const ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";

--- a/scripts/lint-task-class.test.mjs
+++ b/scripts/lint-task-class.test.mjs
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Regression suite for `lint-task-class.mjs` (F-1302).
+// Regression suite for `lint-task-class.mjs`.
 //
 // Case 5 is why this file exists rather than a "it went green once" note. The
 // gate's whole job is to refuse a task that declares no class — and the cheapest
 // way for it to stop doing that job is for the WALK to stop finding the file,
 // not for the check to break. A gate that scans nothing prints the same success
-// line as a gate that scanned everything, which is F-989 restated. So the suite
+// line as a gate that scanned everything, which is the vacuous-pass defect restated. So the suite
 // asserts the zero-file case is RED, and that a task nested one level deeper
 // than `tasks/` is still seen.
 //
@@ -123,7 +123,7 @@ check("6. an example task two levels below the corpus root is seen", {
   contains: "agent-examples/agent/tasks/01-unlabelled.md",
 });
 
-// F-1300's walker gap, asserted from the other side: a task nested UNDER a
+// The walker gap, asserted from the other side: a task nested UNDER a
 // `tasks/` directory must still be seen. `collectTaskFiles` reads `.md` at
 // depth 0 or in any directory literally named `tasks`, so a `tasks/<topic>/`
 // subdirectory is a live way to leave the corpus.

--- a/scripts/lint-task-format-doc.mjs
+++ b/scripts/lint-task-format-doc.mjs
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-1299 — the criterion grammar the authoring skill PROMISES must be the
+// The criterion grammar the authoring skill PROMISES must be the
 // grammar the parser RUNS.
 //
 // `skills/pome-author-task/references/task-format.md` is a byte-identical
 // mirror of pome-cloud's `apps/mcp/docs/task-format.md`, and pome-cloud gates
 // its own copy (`apps/mcp/test/task-format-doc.test.ts`). Nothing gated the
-// mirror, so it sat a whole marker keyword behind for the length of F-1296: the
+// mirror, so it sat a whole marker keyword behind while the cloud moved: the
 // doc published a grammar under which `- [code always-scored] …` is not a
 // criterion line at all, and a line the grammar does not match is skipped as
-// prose. That is the silent criterion drop F-1299 closes, promised to authors
+// prose. That is the silent criterion drop this gate closes, promised to authors
 // in writing.
 //
 // A cross-repo byte diff is not runnable from this repo's CI — the canonical
@@ -44,7 +44,7 @@ function main() {
   const parser = readFileSync(join(root, PARSER_PATH), "utf8");
 
   // A gate that shrugs when it cannot find its subject passes for the same
-  // reason a gate over a corpus that stopped being found passes (F-989).
+  // reason a gate over a corpus that stopped being found passes.
   const docMatch = doc.match(DOC_GRAMMAR_FENCE_RE);
   if (!docMatch) {
     console.error(
@@ -85,7 +85,7 @@ function main() {
 // is satisfied by any file of that name anywhere on disk, weaker even than
 // an unresolved full-path compare. Realpath'd on both sides instead — node
 // resolves symlinks before deriving `import.meta.url`, so a bare compare
-// misses through a symlinked checkout (F-1488) — and a guard miss while
+// misses through a symlinked checkout — and a guard miss while
 // invoked as this file throws rather than exits 0.
 const SELF = realpathSync(fileURLToPath(import.meta.url));
 const ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";

--- a/scripts/lint-task-format-doc.test.mjs
+++ b/scripts/lint-task-format-doc.test.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Regression suite for `lint-task-format-doc.mjs` (F-1299).
+// Regression suite for `lint-task-format-doc.mjs`.
 //
 // Cases 3 and 4 are why this file exists rather than a "it went green once"
 // note. The gate reads its two subjects out of two files by regex, and the
@@ -29,7 +29,7 @@ const doc = (grammar) =>
   `\`\`\`\n${grammar}\n\`\`\`\n\nThat is: a \`-\` or \`*\` bullet, …\n`;
 
 const parser = (grammar) =>
-  `// Criterion marker grammar (F-778).\nconst CRITERION_LINE_RE =\n  ${grammar};\n`;
+  `// Criterion marker grammar.\nconst CRITERION_LINE_RE =\n  ${grammar};\n`;
 
 function runAgainst({ doc: docText, parser: parserText }) {
   const root = mkdtempSync(join(tmpdir(), "task-format-doc-"));

--- a/scripts/mint-mcp-capture-token.mjs
+++ b/scripts/mint-mcp-capture-token.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-1329 — mint a one-shot bearer for an OAuth-gated MCP `tools/list` capture.
+// Mint a one-shot bearer for an OAuth-gated MCP `tools/list` capture.
 //
 // ── WHY THIS IS A SCRIPT AND NOT A RUNBOOK ─────────────────────────────────
 //
@@ -18,7 +18,7 @@
 // `scripts/capture-mcp-tools-list.mjs` is deliberately off-cron and CI runs it
 // `--check --offline`, so nothing automated ever reads these tokens. They are
 // one-shot: mint, capture, commit the golden, revoke. Storing one in a secret
-// store would buy nothing and would manufacture F-1104 — a lane that quietly
+// store would buy nothing and would manufacture a lane that quietly
 // stopped running behind a page that kept publishing — because all three vendors
 // issue expiring access tokens.
 //
@@ -74,9 +74,9 @@ const VENDORS = {
     register: "https://mcp.linear.app/register",
     resource: "https://mcp.linear.app/mcp",
     port: 16735,
-    // WAS `"read"`, AND THAT DEFAULT COST A GOLDEN (F-1394). This file's header
+    // WAS `"read"`, AND THAT DEFAULT COST A GOLDEN. This file's header
     // argues there is no safe default because the scopes decide what the
-    // LISTING contains — and then this line quietly supplied one. F-1329 ran
+    // LISTING contains — and then this line quietly supplied one. The capture ran
     // `mint-mcp-capture-token.mjs linear` with no `--scopes`, got a read-only
     // grant, and froze a golden of 36 tools without a single write in it; the
     // fidelity lane then reported six write tools twin-linear serves as tools

--- a/scripts/no-catch-and-continue.mjs
+++ b/scripts/no-catch-and-continue.mjs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// no-catch-and-continue gate (F-745 / D4) — §3.A code-health, SDK ENGINE ONLY.
+// no-catch-and-continue gate (D4) — §3.A code-health, SDK ENGINE ONLY.
 //
 // `packages/sdk` is the twin engine: the recorder, auth, MCP JSON-RPC, and
 // server plumbing every hosted twin runs on. A `catch` that logs-and-continues
@@ -22,7 +22,7 @@
 // out of the block and keeps going as if nothing broke. That is the exact bug
 // class this gate forbids.
 //
-// ALLOWLIST (D4) — target EMPTY, currently TWO entries. F-745's plan assumed
+// ALLOWLIST (D4) — target EMPTY, currently TWO entries. The original plan assumed
 // every engine catch would satisfy the rule literally; two do not, because they
 // handle the error by ASSIGNING an explicit error result to an outer-scoped
 // variable and FALLING THROUGH to a single shared record()/return below the
@@ -552,7 +552,7 @@ function stripCommentsAndLiterals(src) {
 // Run as a script (not when imported by the test). Realpath'd on both
 // sides — node resolves symlinks before deriving `import.meta.url`, so a
 // bare `resolve()` of argv[1] misses through a symlinked checkout (a
-// worktree, or macOS's symlinked `/tmp`) in the same silent shape (F-1488),
+// worktree, or macOS's symlinked `/tmp`) in the same silent shape,
 // and a guard miss while invoked as this file throws rather than exits 0.
 const SELF = realpathSync(fileURLToPath(import.meta.url));
 const ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";

--- a/scripts/no-eval-in-oss.mjs
+++ b/scripts/no-eval-in-oss.mjs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// no-eval-in-oss gate (FDRS-657 / F-692 / D9) — REPO-WIDE, consolidated.
+// no-eval-in-oss gate (D9) — REPO-WIDE, consolidated.
 //
 // pome-twins is capture-only: it must never compute a score, call a judge, or
 // correlate locally, anywhere in the OSS surface (cli/src/**, cli/scripts/**,
@@ -22,7 +22,7 @@
 //      side-effect `import "..."` — against the SPECIFIER, so prose/comments
 //      referencing the old design don't trip it.
 //
-// Promoted from `cli/scripts/no-eval-in-oss.mjs` (D9/F-692) — grown, not
+// Promoted from `cli/scripts/no-eval-in-oss.mjs` (D9) — grown, not
 // rewritten — and folds in the former `scripts/no-correlator-in-oss.mjs`
 // (deleted; its `packages/correlator` + `@pome-sh/correlator` checks are
 // subsumed by rules 1 and 3 above).
@@ -211,7 +211,7 @@ async function scanFileImports(file, root, violations) {
 // Run as a script (not when imported by the test). Realpath'd on both
 // sides — node resolves symlinks before deriving `import.meta.url`, so a
 // bare `resolve()` of argv[1] misses through a symlinked checkout (a
-// worktree, or macOS's symlinked `/tmp`) in the same silent shape F-1488
+// worktree, or macOS's symlinked `/tmp`) in the same silent shape found
 // found in ten CI gates: the guard falls false and this file exits 0 having
 // checked nothing, for the gate that exists specifically to keep evaluation
 // out of the OSS repo. A guard miss while invoked as this file throws rather

--- a/scripts/no-native-modules.mjs
+++ b/scripts/no-native-modules.mjs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-705 no-native-modules gate. "Zero native deps" (M2) is an invariant, not
+// no-native-modules gate. "Zero native deps" (M2) is an invariant, not
 // an event: no package in the PRODUCTION dependency closure of the published
 // packages may carry a node-gyp build step. Detection is by gyp markers —
 // a `binding.gyp` file or a truthy `gypfile` manifest field — NOT by
@@ -94,7 +94,7 @@ function hasPackagedNodeBinary(pkgDir) {
 // Run as a script (not when imported by the test). Realpath'd on both
 // sides — node resolves symlinks before deriving `import.meta.url`, so a
 // bare `resolve()` of argv[1] misses through a symlinked checkout (a
-// worktree, or macOS's symlinked `/tmp`) in the same silent shape (F-1488),
+// worktree, or macOS's symlinked `/tmp`) in the same silent shape,
 // and a guard miss while invoked as this file throws rather than exits 0.
 const SELF = realpathSync(fileURLToPath(import.meta.url));
 const ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";

--- a/scripts/probe-example-tools.mjs
+++ b/scripts/probe-example-tools.mjs
@@ -164,7 +164,7 @@ function resolveToken(token, ctx) {
 /**
  * Every `.seed.json` an example ships, sorted for a stable probe order.
  *
- * F-1163: `probe:examples` used to probe only the one seed each manifest entry
+ * `probe:examples` used to probe only the one seed each manifest entry
  * hand-named. `pr-summary-review` ships 3, both viktor examples ship 6 — 13 of
  * 20 seeds across the bundled examples were never probed at all, and a new
  * seed landed uncovered by construction, since nothing read the directory.
@@ -217,7 +217,7 @@ export function discoverExamplesWithSeeds(examplesDir) {
  * The first repo, PR number and issue number a seed carries, for `resolveArgs`
  * to fill probe argument templates with.
  *
- * F-1163: hand-writing six near-identical probe arg sets per viktor example
+ * Hand-writing six near-identical probe arg sets per viktor example
  * (one per seed) is the defect the ticket names, not a workaround for it — a
  * seventh seed would land with no probe arguments and nothing would say so.
  * Reading the subject straight off the seed means a new seed is covered by

--- a/scripts/probe-example-tools.test.mjs
+++ b/scripts/probe-example-tools.test.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Regression coverage for scripts/probe-example-tools.mjs (F-1152).
+ * Regression coverage for scripts/probe-example-tools.mjs.
  *
  * The gate exists because `comment_on_pull_request` in
  * agent-examples/pr-summary-agent and agent-examples/pr-summary-review wrapped
@@ -123,7 +123,7 @@ assertThrows(
   );
 }
 
-// ── deriveSeedFacts / resolveArgs (F-1163) ──────────────────────────────────
+// ── deriveSeedFacts / resolveArgs ───────────────────────────────────────────
 // The load-bearing half of the ticket: probe arguments come off the seed
 // itself, never a hand-written literal, so a sixth viktor seed needs no new
 // fixture and a repo with no PR/issue/file simply yields no bucket for it.
@@ -182,14 +182,14 @@ assertThrows(
   assert(facts.pr.last_number === 2 && facts.pr.number === 2, "a single-PR seed's first and last PR are the same");
 
   const resolved = resolveArgs(
-    { owner: "$repo.owner", repo: "$repo.name", pull_number: "$pr.number", body: "F-1152 probe." },
+    { owner: "$repo.owner", repo: "$repo.name", pull_number: "$pr.number", body: "literal probe." },
     facts,
   );
   assert(
     resolved.owner === "acme" && resolved.repo === "widgets" && resolved.pull_number === 2,
     "resolveArgs fills $repo.* and $pr.number from the derived facts",
   );
-  assert(resolved.body === "F-1152 probe.", "resolveArgs passes a non-$ literal through unchanged");
+  assert(resolved.body === "literal probe.", "resolveArgs passes a non-$ literal through unchanged");
 
   assert(
     resolveArgs({ issue_number: "$issue.number" }, noPr).issue_number === 1,
@@ -318,7 +318,7 @@ assertThrows(
   }
 }
 
-// ── discoverSeeds / discoverExamplesWithSeeds (F-1163) ──────────────────────
+// ── discoverSeeds / discoverExamplesWithSeeds ───────────────────────────────
 // Discovery, not a hand-kept list — a new .seed.json under an example's
 // tasks/ is covered with no edit anywhere in this repo.
 {
@@ -670,7 +670,7 @@ assert(
   );
 }
 
-// 4. stale-expect — the escape hatch expires loudly. Without this an F-1151-style
+// 4. stale-expect — the escape hatch expires loudly. Without this a regression
 // twin fix leaves a permanent exemption behind.
 {
   const probes = [
@@ -880,7 +880,7 @@ await withWireRuntime(async () => {
   const tape = store.events();
   assert(
     tape.some((event) => event.status === 404 && event.tool === "add_issue_comment"),
-    "the twin's own tape carries the 404 and stamps the action (F-1125, MCP surface)",
+    "the twin's own tape carries the 404 and stamps the action (MCP surface)",
   );
 });
 

--- a/scripts/probe-twin-endpoints.mjs
+++ b/scripts/probe-twin-endpoints.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-1305 declared-endpoint probe gate.
+// Declared-endpoint probe gate.
 //
-// `scripts/probe-example-tools.mjs` (F-1152) asks: does every tool a bundled
+// `scripts/probe-example-tools.mjs` asks: does every tool a bundled
 // EXAMPLE registers get answered by its twin? That gate's subject is the
 // example. Its reach over the twins is whatever seven examples happen to
 // expose — measured on `51b5efe`, its 43 probes reach 9 of the 137 tools the
@@ -20,7 +20,7 @@
 //    `{owner, repo, pull_number}` for `merge_pull_request` out of a JSON
 //    Schema — the arguments are a fact about the seeded world, not about the
 //    tool. So `config/twin-endpoint-probes.json` declares arguments and this
-//    gate declares the SET, from `tools/list`. The rot F-989 and F-1130
+//    gate declares the SET, from `tools/list`. The rot we
 //    produced twice — a hand-kept list that stops covering its subject while
 //    the gate reading the list stays green — cannot recur here, because the
 //    gate never reads the manifest to learn what exists.
@@ -30,12 +30,12 @@
 //    `result.isError` (`packages/sdk/src/mcp-jsonrpc.ts`), so the transport
 //    status is 200 on exactly the failure this gate exists to catch — the same
 //    shape of blindness as the examples swallowing a 4xx into
-//    `{ok: false, status}`, which is what F-1152's fetch hook was built to see
+//    `{ok: false, status}`, which is what the probe's fetch hook was built to see
 //    past. The recorder row the twin writes for its own call carries the real
 //    status, the twin's error text, and the METHOD + PATH, which is what lets a
 //    red name the route instead of naming the gate.
 //
-// 3. A STEP MAY BE A SETUP CALL RATHER THAN A PROBE (F-1376). Some declared
+// 3. A STEP MAY BE A SETUP CALL RATHER THAN A PROBE. Some declared
 //    tools only answer once something exists, and the write that creates it is
 //    not always a tool. twin-github's three release readers are the case: GitHub
 //    declares no `create_release` MCP tool, so the twin does not serve one, but
@@ -415,7 +415,7 @@ export async function runGate(opts = {}) {
 
   // A manifest declaring zero twins would otherwise fall straight through the
   // loop below to "0 findings, exit 0" — the exact "probed nothing but exited
-  // 0" shape this gate exists to prevent, just moved one file over (F-1481).
+  // 0" shape this gate exists to prevent, just moved one file over.
   if (ids.length === 0) {
     throw new Error(`${manifestPath} declares zero twins — refusing to report a pass having probed nothing`);
   }
@@ -457,11 +457,11 @@ export async function runGate(opts = {}) {
 // Realpath'd on both sides, never bare `import.meta.main`: that property
 // landed in Node 24.2, root `engines` allows `>=24`, and on 24.0.0/24.0.1/
 // 24.0.2/24.1.0 it is `undefined` — the guard is false, `runGate()` never
-// runs, and the script exits 0 having probed nothing (F-1481). Node resolves
+// runs, and the script exits 0 having probed nothing. Node resolves
 // symlinks before deriving `import.meta.url`, so realpathing only one side
 // misses through a symlinked checkout (a worktree, or macOS's symlinked
-// `/tmp`) in the same silent shape — the mistake F-1353's first fix made and
-// F-1481 revisits. A guard miss while invoked AS this file throws rather than
+// `/tmp`) in the same silent shape — the mistake an earlier fix made and the
+// entry-guard lint revisits. A guard miss while invoked AS this file throws rather than
 // exits 0.
 const SELF = realpathSync(fileURLToPath(import.meta.url));
 const ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";

--- a/scripts/probe-twin-endpoints.test.mjs
+++ b/scripts/probe-twin-endpoints.test.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 /**
- * Regression coverage for scripts/probe-twin-endpoints.mjs (F-1305).
+ * Regression coverage for scripts/probe-twin-endpoints.mjs.
  *
  * The gate exists because nothing called every endpoint a twin declares.
- * Measured on `51b5efe`: the five twins declare 137 MCP tools, the F-1152
+ * Measured on `51b5efe`: the five twins declare 137 MCP tools, the
  * example probe gate reached 9 of them (all github's), and 23 — slack's 8 and
  * linear's 15 — were reached by nothing over the MCP wire at all, including by
  * their own test suites, which exercise them through `executeTool()` on the
@@ -103,7 +103,7 @@ assert(
   "evaluateTwinProbeRun is silent on a clean run",
 );
 
-// 0. setup steps (F-1376): state-building, never coverage.
+// 0. setup steps: state-building, never coverage.
 //
 // twin-github's three release readers only answer once a release exists, and
 // GitHub declares no `create_release` MCP tool for the twin to serve — so the
@@ -259,7 +259,7 @@ assert(
 // No model, no API key, no Docker, no socket: each twin runs in this process on
 // `:memory:` SQLite and is driven through Hono's `app.request`.
 
-// The F-1151 regression, as a live fixture. `add_issue_comment` at a PULL
+// The PR-comment regression, as a live fixture. `add_issue_comment` at a PULL
 // REQUEST's number is the call that answered `404 Issue not found` for the
 // whole life of agent-examples/pr-summary-agent and agent-examples/pr-summary-review.
 {
@@ -301,7 +301,7 @@ assert(
 
 // The anti-drift clause, end to end, on the twin that most needs it: slack
 // declared 11 tools and its own suite reached 3 over the wire. It declares 18
-// now (F-1330 replaced the table with Slack's own), and the count below is
+// now (the table was replaced with Slack's own), and the count below is
 // derived from the twin rather than typed, so the clause survives the next one.
 {
   // Derived, not typed: an empty manifest reds one unprobed-endpoint per
@@ -363,7 +363,7 @@ if (failures > 0) {
 }
 console.log("probe-twin-endpoints: all assertions passed.");
 
-// resolvePath (F-1376): a setup step addresses state an earlier probe minted, so
+// resolvePath: a setup step addresses state an earlier probe minted, so
 // `$alias` resolves in a path SEGMENT — and only in a whole segment, so a
 // literal `$` cannot be mistaken for a reference.
 {

--- a/scripts/smoke-examples.mjs
+++ b/scripts/smoke-examples.mjs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-900 example-launch smoke. `tsc` cannot see a temporal-dead-zone crash:
-// F-866's examples typecheck gate was green while every real launch of
+// Example-launch smoke. `tsc` cannot see a temporal-dead-zone crash: the
+// examples typecheck gate was green while every real launch of
 // `agent-examples/triage-agent` died at startup with
 //   ReferenceError: Cannot access 'TwinMcpClient' before initialization
 // because the top-level `await main()` ran before the `class TwinMcpClient`
@@ -13,7 +13,7 @@
 // `main()` runs past the point where a launch-above-class TDZ would fire — and
 // fails if the module crashes on load with a TDZ ReferenceError.
 //
-// F-1478: for as long as this gate existed, an exit *inside* SETTLE_MS was
+// For as long as this gate existed, an exit *inside* SETTLE_MS was
 // unconditionally treated as OK, on the theory that a benign network/auth
 // failure (no live twin, no real model key in CI) is expected and must not be
 // a false red. That theory is right, but the implementation never checked it —
@@ -31,8 +31,8 @@
 //     during module evaluation, well under this window, so surviving it is
 //     real evidence, not silence.
 //   - exits before the settle with the TDZ signature in its output → FAIL,
-//     unconditionally. This is F-900's actual subject and must never become a
-//     skip or a pass no matter what else changes here.
+//     unconditionally. This is the crash this gate exists to catch, and must
+//     never become a skip or a pass no matter what else changes here.
 //   - exits before the settle WITHOUT the TDZ signature → only a network/auth
 //     failure this gate's own SMOKE_ENV deliberately manufactures (dead twin
 //     endpoints, invalid model keys) excuses this. That is asserted by
@@ -53,7 +53,7 @@
 // for what it does not (that the work was correct — `probe:examples` and the
 // scenario suites are the gates for that).
 //
-// F-1486: the REACHED-OUTBOUND leg above is the only thing any environment
+// The REACHED-OUTBOUND leg above is the only thing any environment
 // ever proves, because CI has no credentials and 0 of 8 examples are ever
 // "still running at the settle" here. `SMOKE_EXAMPLES_LIVE=1` switches this
 // same gate — same classifier, same discovery, same output-tail printing —
@@ -68,7 +68,7 @@
 // least one example was alive at the settle for real, naming what it
 // expected when it was not.
 //
-// F-1519: REACHED-OUTBOUND above was decided by matching the FAILURE TEXT
+// REACHED-OUTBOUND above was decided by matching the FAILURE TEXT
 // against BENIGN_FAILURE_SIGNATURES — an archaeology problem, not a proof.
 // `@anthropic-ai/claude-agent-sdk@0.3.221`'s query() picks between two error
 // shapes on a field (`lastErrorResultText`) set by a race between its own
@@ -81,7 +81,7 @@
 // the re-run was "8 of 8". No regex over the error text can be made
 // deterministic against a race that lives inside a dependency's internals,
 // and widening the signatures to catch "process exited with code" would
-// convert every pre-wiring crash into a pass — the exact defect F-1478
+// convert every pre-wiring crash into a pass — the exact defect this gate
 // already fixed once, reintroduced through the back door.
 //
 // The fix: classify on POSITIVE EVIDENCE THE EXAMPLE ITSELF EMITS, not on
@@ -147,11 +147,11 @@ const examplesDir = join(repoRoot, "agent-examples");
 export const SETTLE_MS = 5000;
 
 // The V8 message for accessing a `let`/`const`/`class` binding in its temporal
-// dead zone. This is the exact crash F-900 fixed and F-866's tsc gate missed.
+// dead zone. This is the exact crash the tsc gate missed.
 // A TDZ crash is a hard failure regardless of exit code or timing.
 export const TDZ_SIGNATURE = /(?:Cannot access '[^']+' before initialization|before initialization)/;
 
-// F-1519 — the positive-evidence marker. A fixed literal every example prints
+// The positive-evidence marker. A fixed literal every example prints
 // to stderr, synchronously, immediately before its first outbound (twin or
 // model) call — see the file header for why this replaced error-text
 // matching as the thing REACHED-OUTBOUND is decided on. Gated behind
@@ -196,14 +196,14 @@ const BENIGN_FAILURE_SIGNATURES = [
   ],
 ];
 
-// F-1519 — the marker proves the process REACHED its outbound call site; it
+// The marker proves the process REACHED its outbound call site; it
 // cannot prove a socket was ever written. Two crash classes were MEASURED to
 // print the marker and then die before any network syscall: the Agent SDK
 // failing to resolve the `claude` binary (`native binary not found at …` —
 // pure config, no request) and a malformed twin URL (`ERR_INVALID_URL`, thrown
 // by fetch while parsing, after the marker line). Both FAILED under the old
 // text classifier and would silently become passes on the marker alone —
-// F-1478's "a crash before real work reads as success" through the back door,
+// "a crash before real work reads as success" through the back door,
 // with the `claude` binary going unresolvable in CI converting all four
 // adapter-backed examples at once.
 //
@@ -241,7 +241,7 @@ function matchBenignFailure(output) {
 // of the eight (`gmail-retry-notify`, `merge-agent`, `minimal-viktor`,
 // `minimal-viktor-langgraph`) call `requiredEnv("POME_TASK")` and throw at
 // startup without it. It therefore applies on BOTH legs, and keeping it out of
-// SMOKE_DEAD_WIRING below is load-bearing: F-1486's first cut overlaid nothing
+// SMOKE_DEAD_WIRING below is load-bearing: the first cut of the live leg overlaid nothing
 // at all in LIVE mode, so those four died on `Error: POME_TASK is required`
 // and the gate classified them FAIL with "returned without evidence it did any
 // real work" — i.e. the credentialed nightly would have redded 4 of 8 on its
@@ -250,7 +250,7 @@ function matchBenignFailure(output) {
 // non-diagnosable red that trains a reader to ignore the alarm.
 const SMOKE_TASK = "Smoke run: triage/summarize the open items in acme/api.";
 
-// F-1486 — settings the credentialed leg supplies only when the caller has NOT.
+// Settings the credentialed leg supplies only when the caller has NOT.
 // Neither is a credential and neither is dead wiring: together they are what
 // decides whether a launched example has anything to do and whether it can
 // reach a model with the ONE secret this leg asks a human to provision. Both
@@ -288,10 +288,10 @@ const SMOKE_DEAD_WIRING = {
   POME_SLACK_REST_URL: "http://127.0.0.1:59321",
   // support-triage resolves BOTH twins' MCP URLs in resolveTwinWiring() before it
   // touches anything else, and throws naming every missing var. Without this the
-  // example this gate was extended to cover (F-1290) died in env resolution and
+  // example this gate was extended to cover died in env resolution and
   // the gate still printed OK — it proved the module evaluates and nothing more,
   // never reaching examineeOptions() or query(), which is where a launch-above-
-  // declaration TDZ of the F-900 shape would actually fire.
+  // declaration TDZ this gate exists to catch would actually fire.
   POME_SLACK_MCP_URL: "http://127.0.0.1:59321/s/smoke/mcp",
   POME_GMAIL_REST_URL: "http://127.0.0.1:59321",
   // triage-agent / pr-summary-* accept a pre-minted bearer token verbatim, so
@@ -316,7 +316,7 @@ export function launchEnv(baseEnv, live) {
   // exists to get off of. SMOKE_LIVE_DEFAULTS fill only what the caller left
   // unset — a caller-supplied value always wins, and a BLANK one counts as
   // unset so `requiredEnv`'s own trim-check never receives "".
-  // PR leg: unchanged from before F-1486 — the overlay wins unconditionally,
+  // PR leg: unchanged from before the live leg existed — the overlay wins unconditionally,
   // including the fake AI_GATEWAY_API_KEY that makes alibaba/* resolve there.
   const env = live
     ? { ...baseEnv }
@@ -327,14 +327,14 @@ export function launchEnv(baseEnv, live) {
     }
   }
   delete env.POME_PREFLIGHT; // ensure the real launch path, not the early return
-  // F-1519 — tells every example (directly, or via @pome-sh/adapter-claude-sdk's
+  // Tells every example (directly, or via @pome-sh/adapter-claude-sdk's
   // query()) to print OUTBOUND_MARKER before its first outbound call. Neither a
   // credential nor wiring, so it applies unconditionally on both legs.
   env[MARK_OUTBOUND_ENV] = "1";
   return env;
 }
 
-// F-1486 — the credentialed leg switch. Read once at module load (same as
+// The credentialed leg switch. Read once at module load (same as
 // SETTLE_MS/TDZ_SIGNATURE above) so both smokeOne() and main() agree on it
 // for the life of one process; the regression suite drives the exported pure
 // functions below directly rather than re-triggering this env read.
@@ -354,7 +354,7 @@ export function resolveLiveFlag(value) {
       `value "1" (unset or "" means the uncredentialed PR leg). Refusing to run: treating an ` +
       `unrecognised value as "not live" would silently run the PR leg — dead loopback ports, no ` +
       `credential check, no alive-at-settle floor — and report success, which is the exact ` +
-      `"proves nothing but looks like it does" failure this leg exists to prevent (F-1486).`,
+      `"proves nothing but looks like it does" failure this leg exists to prevent.`,
   };
 }
 
@@ -382,7 +382,7 @@ export const LIVE_REQUIRED_ENV = ["ANTHROPIC_API_KEY", "POME_AUTH_TOKEN"];
 // `!env[name]` alone is not enough. GitHub Actions substitutes an unset secret
 // as the EMPTY STRING rather than leaving the var absent (falsy, so caught), but
 // a secret whose stored value is blank-but-not-empty — a stray space or newline
-// pasted into the secret box, the shape F-1187/F-1184 found blank in Infisical —
+// pasted into the secret box, the shape we have found blank in Infisical —
 // is TRUTHY and would sail through, leaving the leg to launch every example with
 // a whitespace API key and report the resulting per-example crashes as "the
 // example is broken" instead of "the credential is blank". Trim, so present-but-
@@ -391,7 +391,7 @@ export function missingLiveEnv(env = process.env) {
   return LIVE_REQUIRED_ENV.filter((name) => !env[name]?.trim());
 }
 
-// The floor F-1486 asks for: on the credentialed leg, at least one example
+// The floor the credentialed leg asks for: at least one example
 // must be alive at the settle — zero-alive is the exact fact no environment
 // currently asserts. Deliberately >= 1, not a hardcoded count of examples or
 // a fraction of `total`: a literal tied to `total` is the milestone's own
@@ -417,7 +417,7 @@ export function assertAliveFloor({ live, okCount, total }) {
   };
 }
 
-// F-1518 — the counted-numerator property. `classifyLaunch()` already gives
+// The counted-numerator property. `classifyLaunch()` already gives
 // every launch one of three named, counted outcomes (ok / reached / fail); the
 // gap this closes is a DIFFERENT failure mode, one level up: an example that
 // never reaches `classifyLaunch()` at all and so never lands in any of the
@@ -460,7 +460,7 @@ export function discoverExamples(dir = examplesDir) {
   return found;
 }
 
-// F-1519 — asserts the PROPERTY, not the instance list: every discovered
+// Asserts the PROPERTY, not the instance list: every discovered
 // example must have SOME route to printing OUTBOUND_MARKER before its first
 // outbound call, or classifyLaunch()'s fail-closed rule means it can never
 // report "reached" again — silently, with nothing pointing at why. A
@@ -535,7 +535,7 @@ function sourceContainsMarker(srcDir) {
 // guards, and got far enough to open an outbound twin/model call) and printed
 // distinctly from "ok", which is the strictly stronger evidence.
 //
-// F-1519 — "reached" now hinges on OUTBOUND_MARKER being present in the
+// "reached" now hinges on OUTBOUND_MARKER being present in the
 // captured output, never on matching the failure TEXT. BENIGN_FAILURE_SIGNATURES
 // still runs, but only to decorate a marker-backed verdict with a human-readable
 // reason; a match there with no marker present classifies as FAIL, exactly like
@@ -577,7 +577,7 @@ export function classifyLaunch({ output, stillRunningAtSettle, exitCode, signal,
           `${how} after emitting ${OUTBOUND_MARKER}, but ${vetoed} — the marker proves the process ` +
           `reached its outbound call SITE, not that a call left it, and this crash's own error code ` +
           `says none did. Fix the wiring/config it names; a pre-outbound crash must not read as ` +
-          `REACHED-OUTBOUND (F-1519).`,
+          `REACHED-OUTBOUND.`,
       };
     }
     return {
@@ -596,8 +596,8 @@ export function classifyLaunch({ output, stillRunningAtSettle, exitCode, signal,
     // SMOKE_ENV's twin/model wiring cannot succeed on the PR leg — dead
     // loopback ports, invalid keys — so reaching the marker and still exiting
     // 0 means the failure was swallowed, not that the run actually worked.
-    // F-1478's defect verbatim, just proven by the marker instead of guessed
-    // from failure text.
+    // The defect this gate exists to prevent, verbatim — just proven by the
+    // marker instead of guessed from failure text.
     return {
       status: "fail",
       reason:
@@ -606,7 +606,7 @@ export function classifyLaunch({ output, stillRunningAtSettle, exitCode, signal,
         `was swallowed instead of propagated. Propagate it so the process exits non-zero.`,
     };
   }
-  // F-1486 — the third possibility exists ONLY on the credentialed leg, and the
+  // The third possibility exists ONLY on the credentialed leg, and the
   // reader has to be told about it or the first real nightly red is a mystery.
   // OK is "still alive at the settle", so with real twins and a real key a
   // GENUINELY CORRECT example that answers fast — the twin's default seed does
@@ -724,7 +724,7 @@ function smokeOne(name) {
 // without re-triggering a real launch of all eight examples. Realpath'd on
 // both sides (not `import.meta.main`: that landed in Node 24.2, root
 // `engines` allows `>=24`, and `undefined` there makes the guard false and
-// this file exit 0 having smoked nothing — same shape F-1353 fixed in
+// this file exit 0 having smoked nothing — the same shape fixed in
 // contract/run.mjs), and a guard miss while invoked as this file throws
 // rather than exits 0.
 const SELF = realpathSync(fileURLToPath(import.meta.url));
@@ -740,7 +740,7 @@ if (invokedDirectly) {
 }
 
 async function main() {
-  // F-1486 — fail closed, before anything launches. A credentialed leg
+  // Fail closed, before anything launches. A credentialed leg
   // missing a secret must never silently become a second uncredentialed
   // REACHED-OUTBOUND run that reports success; it must red, naming exactly
   // what is absent.
@@ -756,7 +756,7 @@ async function main() {
     if (missing.length > 0) {
       console.error(
         `SMOKE_EXAMPLES_LIVE=1 but missing required credential(s): ${missing.join(", ")}. ` +
-          `This is the credentialed leg (F-1486) — it must not fall back to SMOKE_ENV's dead ` +
+          `This is the credentialed leg — it must not fall back to SMOKE_ENV's dead ` +
           `loopback ports and invalid keys, which would report REACHED-OUTBOUND and pass while ` +
           `proving nothing. Provision the missing secret(s)/twin wiring before retrying.`,
       );
@@ -772,7 +772,7 @@ async function main() {
     process.exit(1);
   }
 
-  // F-1519 — before anything launches: every discovered example must have a
+  // Before anything launches: every discovered example must have a
   // route to the positive-evidence marker, or a run that never sees it is
   // indistinguishable from an example that was simply never wired for it.
   const markerCoverage = assertEveryExampleEmitsMarker(examplesDir, examples);
@@ -821,7 +821,7 @@ async function main() {
     }
   }
 
-  // F-1518 — the reported set is DERIVED from the three verdict buckets, never
+  // The reported set is DERIVED from the three verdict buckets, never
   // tracked alongside them. A separate `reportedNames.push(name)` next to the
   // `await` would mark a name reported before the ok/reached/fail dispatch had
   // put it anywhere, so the next silent-drop bug — a `continue` added inside
@@ -852,7 +852,7 @@ async function main() {
           failures.map((f) => `${f.name} (${f.reason})`).join("; "),
       );
     }
-    // F-1518 — a missing verdict is reported and reds independently of
+    // A missing verdict is reported and reds independently of
     // `failures`: it is a defect in THIS SCRIPT's own bookkeeping, not in the
     // example, and folding it into "Examples that crash on launch" above
     // would misname the fault.

--- a/scripts/smoke-examples.test.mjs
+++ b/scripts/smoke-examples.test.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Regression suite for `smoke-examples.mjs` (F-1478).
+// Regression suite for `smoke-examples.mjs`.
 //
 // The gate's whole job, before this ticket, was undermined by one gap: an
 // exit inside SETTLE_MS was ALWAYS "OK", so an example that returned having
@@ -11,9 +11,9 @@
 // timing-dependent — the real launches are exercised by `npm run
 // smoke:examples` itself in CI).
 //
-// Four cases are the break-on-purpose scenarios F-1478 names explicitly:
+// Four cases are the break-on-purpose scenarios this gate names explicitly:
 // exits 0 immediately with no evidence of work, exits 1 immediately with no
-// recognized benign reason, a module-body TDZ (F-900's subject — must never
+// recognized benign reason, a module-body TDZ (this gate's whole subject — must never
 // regress to a skip or a pass no matter what else changes here), and zero
 // examples discovered.
 import assert from "node:assert/strict";
@@ -87,7 +87,7 @@ function check(name, got, want) {
   );
 }
 
-// ── F-1519: an outbound-call failure is its own named verdict, distinct from
+// ── An outbound-call failure is its own named verdict, distinct from
 // ok — but ONLY once the positive-evidence marker is present. The marker is
 // what a real launch prints (either via @pome-sh/adapter-claude-sdk's query(),
 // or the literal print each non-adapter example carries) immediately before
@@ -112,7 +112,7 @@ function check(name, got, want) {
   check("marker + AI Gateway auth rejection before settle is 'reached'", v.status, "reached");
 }
 
-// ── F-1519 fail-closed: no marker means no "reached", no matter how benign
+// ── Fail-closed: no marker means no "reached", no matter how benign
 // the crash text looks. This is the ticket's central acceptance bar — a
 // pre-wiring crash whose message deliberately CONTAINS benign-looking text
 // ("ECONNREFUSED", "401 invalid x-api-key") must still FAIL, because the
@@ -136,12 +136,12 @@ function check(name, got, want) {
   }
 }
 
-// ── F-1519 the other direction: the marker is printed at the outbound call
+// ── The other direction: the marker is printed at the outbound call
 // SITE, so a crash between that line and the syscall prints it first. Both of
 // these were MEASURED on this branch (the adapter seam with an unresolvable
 // `claude` binary; `gmail-retry-notify` with a malformed twin URL) and both
 // FAILED under the old text classifier, so the marker alone must not convert
-// them into passes — that is F-1478's defect through the back door.
+// them into passes — that is the same defect through the back door.
 {
   for (const [label, output] of [
     [
@@ -163,7 +163,7 @@ function check(name, got, want) {
   }
 }
 
-// ── F-1519: both of the SDK's racing error shapes give the SAME verdict once
+// ── Both of the SDK's racing error shapes give the SAME verdict once
 // the marker is present. This is the exact nondeterminism the ticket names:
 // `@anthropic-ai/claude-agent-sdk@0.3.221`'s query() picks between
 // "Claude Code returned an error result: …" (lastErrorResultText won the
@@ -189,8 +189,8 @@ function check(name, got, want) {
 // ── the signature list is locked against REAL CI output, not invented text ──
 //
 // Every string below is copied verbatim from the `smoke:examples` job log of
-// the F-1478 PR run (github.com/pome-sh/digital-twins/actions/runs/31614212888),
-// with OUTBOUND_MARKER prepended — a real launch since F-1519 prints it before
+// a real PR run (github.com/pome-sh/digital-twins/actions/runs/31614212888),
+// with OUTBOUND_MARKER prepended — a real launch prints it before
 // any of this text. This is the case that matters: the list decides whether
 // the gate is usable in the only environment that gates anything, and a
 // tightened pattern that no longer matches what CI actually prints reds all
@@ -316,7 +316,7 @@ function check(name, got, want) {
   }
 }
 
-// ── F-1486: the credentialed leg's floor — zero alive is a hard failure ────
+// ── The credentialed leg's floor — zero alive is a hard failure ────────────
 {
   const zero = assertAliveFloor({ live: true, okCount: 0, total: 8 });
   check("zero alive on the live leg fails the floor", zero.ok, false);
@@ -337,7 +337,7 @@ function check(name, got, want) {
   check("a no-op floor carries no message", notLive.message, null);
 }
 
-// ── F-1486: an absent credential on the live leg must be named, not silent ─
+// ── An absent credential on the live leg must be named, not silent ─────────
 {
   check(
     "every required var is reported missing from an empty env",
@@ -362,7 +362,7 @@ function check(name, got, want) {
     [...LIVE_REQUIRED_ENV].sort(),
   );
   // Truthy but blank — a space or newline pasted into the secret box
-  // (F-1187/F-1184's blank-in-Infisical shape). Untrimmed, this sails through
+  // (the blank-in-Infisical shape). Untrimmed, this sails through
   // and the leg launches every example with a whitespace API key.
   check(
     "a whitespace-only secret is named as absent, not accepted",
@@ -376,7 +376,7 @@ function check(name, got, want) {
   );
 }
 
-// ── F-1486: an unrecognised SMOKE_EXAMPLES_LIVE must ERROR, never mean "PR leg"
+// ── An unrecognised SMOKE_EXAMPLES_LIVE must ERROR, never mean "PR leg"
 // A flag typo'd to `true` silently reverts to the uncredentialed leg: dead
 // loopback ports, no credential check, no floor, exit 0. That is a green
 // nightly proving nothing — this ticket's own subject, one character away.
@@ -398,7 +398,7 @@ function check(name, got, want) {
   }
 }
 
-// ── F-1486: the LIVE leg must still hand every example a task ───────────────
+// ── The LIVE leg must still hand every example a task ───────────────────────
 // Four of the eight `requiredEnv("POME_TASK")`. The first cut of the live leg
 // overlaid nothing at all, so those four died on `Error: POME_TASK is required`
 // and were classified FAIL ("returned without evidence it did any real work") —
@@ -477,7 +477,7 @@ function check(name, got, want) {
   check("the PR leg does not pin a model slug", pr.VIKTOR_MODEL, undefined);
   assert.ok(pr.POME_TASK?.trim(), "the PR leg must supply a non-blank POME_TASK");
   check("the PR leg never re-enables POME_PREFLIGHT", pr.POME_PREFLIGHT, undefined);
-  // F-1519: MARK_OUTBOUND_ENV is neither a credential nor twin/model wiring —
+  // MARK_OUTBOUND_ENV is neither a credential nor twin/model wiring —
   // it applies on BOTH legs unconditionally, or an example launched on
   // whichever leg forgot it never prints OUTBOUND_MARKER and can never be
   // classified as reached.
@@ -485,7 +485,7 @@ function check(name, got, want) {
   check("the PR leg tells examples to emit the marker too", pr[MARK_OUTBOUND_ENV], "1");
 }
 
-// ── F-1486: the fast-correct-completion edge must be named in the failure ───
+// ── The fast-correct-completion edge must be named in the failure ───────────
 // OK is "still alive at the settle", so on the credentialed leg a correct-but-
 // fast example exits 0 inside the settle and lands on FAIL. The verdict is
 // acceptable; a message insisting the example is broken is not, because the
@@ -502,7 +502,7 @@ function check(name, got, want) {
   assert.match(liveFast.reason, /CORRECT but FAST/);
 
   // Off the live leg the note must NOT appear — the PR leg's exit-0 examples
-  // really are do-nothing exits, and F-1478's message is the right one there.
+  // really are do-nothing exits, and the do-nothing message is right there.
   const prFast = classifyLaunch({
     output: "Triaged 0 open items in acme/api — nothing to do.",
     stillRunningAtSettle: false,
@@ -527,7 +527,7 @@ function check(name, got, want) {
   );
 }
 
-// ── F-1518: the counted-numerator property ──────────────────────────────────
+// ── The counted-numerator property ──────────────────────────────────────────
 // Measured on PR #417: the summary read "7 of 8" and named seven, and nothing
 // said the eighth (`pr-summary-agent`) had gone MISSING rather than FAILED —
 // classifyLaunch()'s three named outcomes (ok/reached/fail) are worthless if
@@ -577,7 +577,7 @@ function check(name, got, want) {
   check("nothing discovered, nothing reported is a pass", assertReportedCount([], []).ok, true);
 }
 
-// ── F-1519: the marker guard reds when a new example has no route to the
+// ── The marker guard reds when a new example has no route to the
 // marker at all — asserting the PROPERTY (does this example's source or its
 // @pome-sh/adapter-claude-sdk dependency give it a way to print
 // OUTBOUND_MARKER?), never a hand-kept list of the four that need it directly.
@@ -668,7 +668,7 @@ function check(name, got, want) {
   }
 }
 
-// ── F-1519: the real agent-examples/ directory in THIS repo passes the guard ─────
+// ── The real agent-examples/ directory in THIS repo passes the guard ─────────────
 // The synthetic fixtures above prove the guard's logic; this proves the
 // guard actually holds against the tree it will run against in CI.
 {


### PR DESCRIPTION
Third slice of the internal-reference cleanup: **445** tracker-id references across 82 files in the CI gates, lint scripts, and the black-box twin contract suite.

A meaningful share of these sat inside the strings these gates **print when they fail**. A contributor whose PR tripped a gate was handed a ticket number they cannot open, in place of the reason:

```
parent-vocab gate failed (F-1200): a bare `parent_id` in emitter source.
...reading as a pass having checked nothing (F-1488).
F-1325's lane must report this twin as not-compared.
```

Each now states what is actually wrong. That's the part of this slice with a user visible on the other end.

--- 
**Five synthetic test values carried ids** and were renamed in lockstep with every read site:

| value | file |
|---|---|
| `deferredTo: "F-1329"` | capture-producer suite |
| `F1329_DEFERRED_PROBE_TOKEN`, `F1329_BLANK_PROBE`, `F1326_TOKEN_THAT_IS_NOT_SET` | capture-producer suite |
| `body: "F-1152 probe."` | example-tool probe suite |

All test-local fixtures, not live config: `config/mcp-capture-sources.json` declares no `deferredTo`, and `authTokenEnv` is only read on a `capture: true` OAuth row.

**Two CHANGELOG stanzas.** `scripts/bundle-declarations.mjs` is a comment-only edit here, but `publish-relevance.mjs` maps that shared bundler into both `@pome-sh/checks` and `@pome-sh/sandbox-domains`, so the release-note gate requires a note. Added as "no consumer-visible change" entries.

## Verification

- `node --test` over every changed test file — all green
- Full vitest suite: **337 files, 3738 tests, all passing**
- 20 lint/gate scripts, including every gate this PR edits
- The **release-note gate**, run against the committed tree
- `node --check` on every changed `.mjs`
- Zero remaining matches for either id spelling (`F-1234` and `F1234_`) or bare `W3` under `scripts/` and `contract/`

## Remaining

The test tree (~1,100 references) is the last slice.