### PR TITLE
The viktor pair agrees on one credential model (F-1216)

### DIFF
--- a/agent-examples/minimal-viktor-langgraph/README.md
+++ b/agent-examples/minimal-viktor-langgraph/README.md
@@ -291,9 +291,18 @@ VERIFICATION.md       what the red/green flip measured, and against which model
 ## Prerequisites
 
 1. **`pome login`** — hosted runs and cloud scoring require it.
-2. **`ANTHROPIC_API_KEY`** exported in your shell (the default model is
-   `claude-sonnet-5` via `@langchain/anthropic`). Set `LANGGRAPH_MODEL` to any
-   `anthropic/*` or `openai/*` slug to change it.
+2. **A model key** exported in your shell — either works, and they are checked in
+   this order:
+   * **`AI_GATEWAY_API_KEY`** routes through the Vercel AI Gateway. One key, every
+     provider. This is the same credential `agent-examples/minimal-viktor` takes,
+     so one key runs both halves of the pair.
+   * **`ANTHROPIC_API_KEY`** (or `OPENAI_API_KEY` for an `openai/*` slug) talks to
+     the provider directly.
+
+   The default model is `claude-sonnet-5` via `@langchain/anthropic`. Set
+   `LANGGRAPH_MODEL` to any `anthropic/*` or `openai/*` slug to change it — write
+   it the obvious way (`claude-sonnet-5` or `anthropic/claude-sonnet-5`); the
+   gateway's provider qualifier is added for you.
 3. Hosted quota. Each task at `-n 3` creates 6 sandboxes (3 runs × github +
    slack, all cloud-scored). Running all six tasks is 36 sandboxes.
 4. **`@pome-sh/shared-types` ≥ 0.10.1** on the cloud side (the OpenInference
@@ -315,7 +324,9 @@ npm test                     # checkSlack fixtures, header parsing, mirror branc
 pome register agent minimal-viktor-langgraph --twins github,slack
 pome doctor                  # must be green or `pome run` refuses to start
 
-export ANTHROPIC_API_KEY=... # your Anthropic key
+export ANTHROPIC_API_KEY=...   # your Anthropic key
+# …or, to use one key for this example and minimal-viktor both:
+# export AI_GATEWAY_API_KEY=... # your Vercel AI Gateway key
 ```
 
 ### Fork it → your own agent (under 2 min)
@@ -370,7 +381,9 @@ npx tsx scripts/run-trials.ts --cleanup <session_id> [<session_id> ...]
 
 | Env var | Default | Meaning |
 |---|---|---|
-| `ANTHROPIC_API_KEY` | — (required for the default model) | Anthropic key |
+| `AI_GATEWAY_API_KEY` | — | Vercel AI Gateway key. **Checked first**; routes every provider, and is the credential `minimal-viktor` uses |
+| `ANTHROPIC_API_KEY` | — (required for the default model, absent a gateway key) | Anthropic key, used directly |
+| `OPENAI_API_KEY` | — (required for an `openai/*` slug, absent a gateway key) | OpenAI key, used directly |
 | `LANGGRAPH_MODEL` | `claude-sonnet-5` | `anthropic/*` (default) or `openai/*` slug |
 | `VIKTOR_SLACK_CHANNEL` | `eng-alerts` | channel Viktor reports to |
 | `POME_SLACK_REST_URL` / `VIKTOR_SLACK_REST_URL` | injected by pome (native) | Slack twin base. `POME_*` is preferred; `VIKTOR_*` is a manual fallback for the `--probe`/`--verify` utilities |

--- a/agent-examples/minimal-viktor-langgraph/src/index.ts
+++ b/agent-examples/minimal-viktor-langgraph/src/index.ts
@@ -18,14 +18,17 @@
  *   malicious → never merge; REQUEST_CHANGES + Slack alert naming the author and
  *               asking the team to BLOCK them
  *
- * Default model claude-sonnet-5 via @langchain/anthropic (ANTHROPIC_API_KEY);
- * set LANGGRAPH_MODEL to any anthropic/* or openai/* slug. POME_PREFLIGHT=1
+ * Default model claude-sonnet-5. Credentials resolve gateway-first, exactly as
+ * `agent-examples/minimal-viktor` does: AI_GATEWAY_API_KEY routes every provider
+ * through the Vercel AI Gateway, otherwise ANTHROPIC_API_KEY / OPENAI_API_KEY is
+ * used directly. Set LANGGRAPH_MODEL to any anthropic/* or openai/* slug. POME_PREFLIGHT=1
  * prints "preflight ok" plus the POME_ / VIKTOR_ / OTEL_ env var NAMES received
  * (names only, never values) and exits 0.
  */
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 
 import { buildGraph } from "./graph.js";
+import { routeModel } from "./model-routing.js";
 import { initTelemetry } from "./telemetry.js";
 
 if (process.env.POME_PREFLIGHT === "1") {
@@ -91,31 +94,35 @@ async function main() {
   }
 }
 
-// Anthropic first (the default, and the key this example is tested with). Any
-// `openai/*` or `gpt*` slug routes to @langchain/openai. Everything else fails
-// loudly rather than silently picking a wrong provider.
+// WHICH client, WHICH id and WHICH key is `model-routing.ts` — pure, and pinned
+// by `test/model-routing.test.ts`. This function only builds the object, so the
+// credential rule can be tested without booting the graph. Gateway first, then
+// the per-provider key: the same order `agent-examples/minimal-viktor` uses, so
+// one key runs both halves of the pair (F-1216).
 async function resolveModel(slug: string): Promise<BaseChatModel> {
-  const slash = slug.indexOf("/");
-  const prefix = slash >= 0 ? slug.slice(0, slash) : "";
-  const id = slash >= 0 ? slug.slice(slash + 1) : slug;
+  const route = routeModel(slug, process.env);
+  const apiKey = requiredEnv(route.apiKeyEnv);
 
-  if (prefix === "anthropic" || slug.startsWith("claude")) {
+  if (route.client === "anthropic") {
     const { ChatAnthropic } = await import("@langchain/anthropic");
     // No `temperature`: it is removed on claude-sonnet-5 (and every Opus 4.7+
     // model) and the API rejects it with a 400, which killed the one LLM call
     // this graph makes. Determinism comes from the structured-output schema and
     // the templated Slack messages, not from sampling params.
-    return new ChatAnthropic({ model: id, apiKey: requiredEnv("ANTHROPIC_API_KEY") });
+    return new ChatAnthropic({
+      model: route.modelId,
+      apiKey,
+      // Omitted entirely on the direct path so the SDK default stands.
+      ...(route.baseUrl === undefined ? {} : { anthropicApiUrl: route.baseUrl }),
+    });
   }
-  // OpenAI: an explicit `openai/` prefix, or a bare GPT / o-series id
-  // (`gpt-…`, `o1`, `o3`…). `/^o\d/` so an `ollama/…` slug isn't swept in.
-  if (prefix === "openai" || /^gpt/.test(slug) || /^o\d/.test(slug)) {
-    const { ChatOpenAI } = await import("@langchain/openai");
-    return new ChatOpenAI({ model: id, apiKey: requiredEnv("OPENAI_API_KEY"), temperature: 0 });
-  }
-  throw new Error(
-    `LANGGRAPH_MODEL=${slug} is not recognized. Use an anthropic/* (default) or openai/* slug.`,
-  );
+  const { ChatOpenAI } = await import("@langchain/openai");
+  return new ChatOpenAI({
+    model: route.modelId,
+    apiKey,
+    temperature: 0,
+    ...(route.baseUrl === undefined ? {} : { configuration: { baseURL: route.baseUrl } }),
+  });
 }
 
 function requiredEnv(name: string): string {

--- a/agent-examples/minimal-viktor-langgraph/src/index.ts
+++ b/agent-examples/minimal-viktor-langgraph/src/index.ts
@@ -28,7 +28,7 @@
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 
 import { buildGraph } from "./graph.js";
-import { routeModel } from "./model-routing.js";
+import { redactCredentials, routeModel } from "./model-routing.js";
 import { initTelemetry } from "./telemetry.js";
 
 if (process.env.POME_PREFLIGHT === "1") {
@@ -86,8 +86,10 @@ async function main() {
       }),
     );
   } catch (err) {
-    // A model/graph failure is a failed trial, not a silent crash.
-    console.error(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }));
+    // A model/graph failure is a failed trial, not a silent crash. Scrubbed:
+    // the message is a provider SDK's, and this example runs with a real key.
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(JSON.stringify({ error: redactCredentials(message, process.env) }));
     process.exitCode = 1;
   } finally {
     await telemetry.shutdown();

--- a/agent-examples/minimal-viktor-langgraph/src/model-routing.ts
+++ b/agent-examples/minimal-viktor-langgraph/src/model-routing.ts
@@ -1,0 +1,100 @@
+/**
+ * Which client, which model id, which key — decided before any provider SDK is
+ * imported (F-1216).
+ *
+ * This lives apart from `index.ts` because `index.ts` reads `POME_TASK` at module
+ * scope and then runs the graph, so importing it to ask a routing question boots
+ * the agent. Pure in, pure out: the decision is testable, and `test/model-routing.test.ts`
+ * pins it.
+ *
+ * THE RULE, and it is the sibling example's rule: **the AI Gateway comes first.**
+ * `agent-examples/minimal-viktor` short-circuits on `AI_GATEWAY_API_KEY` before it
+ * looks at any per-provider key, because one gateway key routes every provider.
+ * This example did not, so one holder of a single Vercel AI Gateway key could run
+ * that example and not this one — with nothing in either README saying why. The
+ * pair carries the framework-agnosticism claim, so the credential rule has to be
+ * the same on both sides of it.
+ */
+
+/** The gateway's own origin. BARE — see `baseUrlFor` for why that matters. */
+export const GATEWAY_ORIGIN = "https://ai-gateway.vercel.sh";
+
+export type ChatClient = "anthropic" | "openai";
+
+export interface ModelRoute {
+  /** Which LangChain chat class `index.ts` should construct. */
+  client: ChatClient;
+  /** The `model` handed to that class — provider-qualified only for the gateway. */
+  modelId: string;
+  /** The env var whose value is the API key. Named, not read, so this stays pure. */
+  apiKeyEnv: "AI_GATEWAY_API_KEY" | "ANTHROPIC_API_KEY" | "OPENAI_API_KEY";
+  /** Base URL override. `undefined` on the direct path — the SDK default is right. */
+  baseUrl: string | undefined;
+}
+
+type Env = Record<string, string | undefined>;
+
+/**
+ * The gateway speaks both protocols, at different paths, and the difference is
+ * measured rather than assumed:
+ *
+ * - **Anthropic: the BARE origin.** `@langchain/anthropic` appends `/v1/messages`
+ *   itself. Passing `https://ai-gateway.vercel.sh/v1` produces `/v1/v1/messages`
+ *   and a 404 whose body names the doubled path.
+ * - **OpenAI: `/v1`.** `@langchain/openai` treats its base URL as the API root and
+ *   appends `/chat/completions`, so the version segment belongs in the base.
+ */
+function baseUrlFor(client: ChatClient): string {
+  return client === "anthropic" ? GATEWAY_ORIGIN : `${GATEWAY_ORIGIN}/v1`;
+}
+
+/** The provider a slug names, by prefix or by the shape of a bare id. */
+function clientFor(slug: string): ChatClient | null {
+  const slash = slug.indexOf("/");
+  const prefix = slash >= 0 ? slug.slice(0, slash) : "";
+  if (prefix === "anthropic" || slug.startsWith("claude")) return "anthropic";
+  // `/^o\d/` rather than `/^o/`, so an `ollama/…` slug is not swept in.
+  if (prefix === "openai" || /^gpt/.test(slug) || /^o\d/.test(slug)) return "openai";
+  return null;
+}
+
+/** The id with its provider prefix removed, which is what a direct client wants. */
+function bareId(slug: string): string {
+  const slash = slug.indexOf("/");
+  return slash >= 0 ? slug.slice(slash + 1) : slug;
+}
+
+export function routeModel(slug: string, env: Env): ModelRoute {
+  const client = clientFor(slug);
+  if (client === null) {
+    throw new Error(
+      `LANGGRAPH_MODEL=${slug} is not recognized. Use an anthropic/* (default) or openai/* slug.`,
+    );
+  }
+
+  // Gateway first — the sibling example's order, and the reason this file exists.
+  if (env.AI_GATEWAY_API_KEY) {
+    return {
+      client,
+      // The gateway routes on a PROVIDER-QUALIFIED slug, so the qualifier has to
+      // survive. The pre-F-1216 code split on the first "/" and dropped the
+      // prefix, which is why the one invocation known to work had to double it
+      // (`anthropic/anthropic/claude-sonnet-5`). Qualify it here instead, so a
+      // reader can write the slug the obvious way.
+      modelId: `${client}/${bareId(slug)}`,
+      apiKeyEnv: "AI_GATEWAY_API_KEY",
+      baseUrl: baseUrlFor(client),
+    };
+  }
+
+  const apiKeyEnv = client === "anthropic" ? "ANTHROPIC_API_KEY" : "OPENAI_API_KEY";
+  if (!env[apiKeyEnv]?.trim()) {
+    throw new Error(
+      `${apiKeyEnv} is required for ${slug}. Set it, or set AI_GATEWAY_API_KEY to route ` +
+        `through the Vercel AI Gateway instead (one key, every provider — the same ` +
+        `credential agent-examples/minimal-viktor takes).`,
+    );
+  }
+  // The direct path is unchanged: the bare id, and the SDK's own base URL.
+  return { client, modelId: bareId(slug), apiKeyEnv, baseUrl: undefined };
+}

--- a/agent-examples/minimal-viktor-langgraph/src/model-routing.ts
+++ b/agent-examples/minimal-viktor-langgraph/src/model-routing.ts
@@ -19,6 +19,35 @@
 /** The gateway's own origin. BARE — see `baseUrlFor` for why that matters. */
 export const GATEWAY_ORIGIN = "https://ai-gateway.vercel.sh";
 
+/** Every env var this example reads a credential from. ONE source of truth: the
+ *  same list routes a model and scrubs those values out of anything logged. */
+export const CREDENTIAL_ENV_VARS = [
+  "AI_GATEWAY_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+] as const;
+
+/**
+ * Replace any credential VALUE with a named placeholder.
+ *
+ * The graph's catch logs whatever a provider SDK put in `err.message`, and this
+ * example is meant to be run with a real key — so a client that echoes its
+ * Authorization header into an error would print that key to stdout, and from
+ * there into the recorded trace. We do not control the SDK's error text, so the
+ * sink is sanitised instead. Guarded on length so a short or empty value cannot
+ * turn every string into placeholders.
+ */
+export function redactCredentials(text: string, env: Env): string {
+  let out = text;
+  for (const name of CREDENTIAL_ENV_VARS) {
+    const value = env[name]?.trim();
+    if (value && value.length >= 8) out = out.split(value).join(`[${name} redacted]`);
+  }
+  return out;
+}
+
+type Env = Record<string, string | undefined>;
+
 export type ChatClient = "anthropic" | "openai";
 
 export interface ModelRoute {
@@ -31,8 +60,6 @@ export interface ModelRoute {
   /** Base URL override. `undefined` on the direct path — the SDK default is right. */
   baseUrl: string | undefined;
 }
-
-type Env = Record<string, string | undefined>;
 
 /**
  * The gateway speaks both protocols, at different paths, and the difference is

--- a/agent-examples/minimal-viktor-langgraph/test/model-routing.test.ts
+++ b/agent-examples/minimal-viktor-langgraph/test/model-routing.test.ts
@@ -18,7 +18,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { GATEWAY_ORIGIN, routeModel } from "../src/model-routing.js";
+import { GATEWAY_ORIGIN, redactCredentials, routeModel } from "../src/model-routing.js";
 
 const GATEWAY = { AI_GATEWAY_API_KEY: "gw-key" };
 const DIRECT_ANTHROPIC = { ANTHROPIC_API_KEY: "sk-ant" };
@@ -107,5 +107,37 @@ describe("routeModel — gateway first, then the per-provider key", () => {
   it("names the env var it wanted when no credential is present", () => {
     expect(() => routeModel("claude-sonnet-5", {})).toThrow(/ANTHROPIC_API_KEY/);
     expect(() => routeModel("gpt-5", {})).toThrow(/OPENAI_API_KEY/);
+  });
+});
+
+describe("redactCredentials — a provider SDK's error text never carries a key", () => {
+  const KEY = "sk-ant-0123456789abcdef";
+
+  it("replaces the credential value with a named placeholder", () => {
+    const out = redactCredentials(`401 from provider: Bearer ${KEY} rejected`, {
+      ANTHROPIC_API_KEY: KEY,
+    });
+    expect(out).not.toContain(KEY);
+    expect(out).toContain("[ANTHROPIC_API_KEY redacted]");
+  });
+
+  it("replaces EVERY occurrence, not just the first", () => {
+    const out = redactCredentials(`${KEY} … ${KEY}`, { ANTHROPIC_API_KEY: KEY });
+    expect(out).not.toContain(KEY);
+  });
+
+  // A short or empty value would otherwise match everywhere and turn the whole
+  // message into placeholders — losing the diagnostic to protect a non-secret.
+  it("ignores a value too short to be a credential", () => {
+    expect(redactCredentials("a totally normal message", { ANTHROPIC_API_KEY: "x" })).toBe(
+      "a totally normal message",
+    );
+    expect(redactCredentials("unchanged", { ANTHROPIC_API_KEY: "" })).toBe("unchanged");
+  });
+
+  it("leaves a message that carries no credential alone", () => {
+    expect(redactCredentials("model not found", { ANTHROPIC_API_KEY: KEY })).toBe(
+      "model not found",
+    );
   });
 });

--- a/agent-examples/minimal-viktor-langgraph/test/model-routing.test.ts
+++ b/agent-examples/minimal-viktor-langgraph/test/model-routing.test.ts
@@ -1,0 +1,111 @@
+// The credential model, pinned as a property (F-1216).
+//
+// This example and `agent-examples/minimal-viktor` are sold as a matched pair —
+// this README's own opening line is "the same viktor.com-style AI employee …
+// but built on LangGraph instead of the Vercel AI SDK". They are the pair that
+// carries the framework-agnosticism claim, so a reader holding ONE model key
+// must be able to run BOTH. Before this suite they defaulted to opposite
+// credential models and neither said so: `minimal-viktor` short-circuits on
+// `AI_GATEWAY_API_KEY`, and this example went straight to `ANTHROPIC_API_KEY`,
+// so a single Vercel AI Gateway key ran one example and could not run the other.
+//
+// WHAT THIS SUITE DELIBERATELY DOES NOT ASSERT: which model slug ships as the
+// default. The two examples default to different models on purpose (this one to
+// `claude-sonnet-5`, the sibling to `alibaba/qwen-3-32b`, which only the gateway
+// can route) and that difference is not the defect. The defect was that the
+// *credential* rule differed. So the property here is the resolution ORDER, not
+// the destination.
+
+import { describe, expect, it } from "vitest";
+
+import { GATEWAY_ORIGIN, routeModel } from "../src/model-routing.js";
+
+const GATEWAY = { AI_GATEWAY_API_KEY: "gw-key" };
+const DIRECT_ANTHROPIC = { ANTHROPIC_API_KEY: "sk-ant" };
+const DIRECT_OPENAI = { OPENAI_API_KEY: "sk-oai" };
+
+describe("routeModel — gateway first, then the per-provider key", () => {
+  // The pair invariant. `minimal-viktor` answers this the same way, and its own
+  // suite pins it there; the two together are what stop the pair drifting apart.
+  it("accepts AI_GATEWAY_API_KEY alone — the sibling example's entry condition", () => {
+    expect(() => routeModel("claude-sonnet-5", GATEWAY)).not.toThrow();
+    const route = routeModel("claude-sonnet-5", GATEWAY);
+    expect(route.apiKeyEnv).toBe("AI_GATEWAY_API_KEY");
+  });
+
+  it("prefers the gateway when both it and a provider key are present", () => {
+    const route = routeModel("claude-sonnet-5", { ...GATEWAY, ...DIRECT_ANTHROPIC });
+    expect(route.apiKeyEnv).toBe("AI_GATEWAY_API_KEY");
+  });
+
+  // Measured in F-1216: LangChain appends `/v1/messages` itself, so a base URL
+  // of `…/v1` produces `/v1/v1/messages` and a 404 whose body names the doubled
+  // path. The bare origin is not a style choice; it is the working value.
+  it("points ChatAnthropic at the BARE gateway origin, never at /v1", () => {
+    const route = routeModel("claude-sonnet-5", GATEWAY);
+    expect(route.baseUrl).toBe(GATEWAY_ORIGIN);
+    expect(route.baseUrl).not.toMatch(/\/v1\/?$/);
+  });
+
+  // Also measured in F-1216: the gateway routes on a provider-qualified slug, so
+  // the qualifier must survive. The pre-fix code split on the first "/" and threw
+  // the prefix away, which is why the working invocation had to double it up
+  // (`anthropic/anthropic/claude-sonnet-5`). A reader should not have to know that.
+  it("keeps the model id provider-qualified under the gateway", () => {
+    expect(routeModel("claude-sonnet-5", GATEWAY).modelId).toBe("anthropic/claude-sonnet-5");
+    expect(routeModel("anthropic/claude-sonnet-5", GATEWAY).modelId).toBe(
+      "anthropic/claude-sonnet-5",
+    );
+    expect(routeModel("gpt-5", GATEWAY).modelId).toBe("openai/gpt-5");
+    expect(routeModel("openai/gpt-5", GATEWAY).modelId).toBe("openai/gpt-5");
+  });
+
+  it("routes an openai slug through the gateway's OpenAI-compatible /v1 endpoint", () => {
+    const route = routeModel("gpt-5", GATEWAY);
+    expect(route.client).toBe("openai");
+    expect(route.baseUrl).toBe(`${GATEWAY_ORIGIN}/v1`);
+  });
+
+  // The README's documented path. The fix adds a branch ABOVE this one, so the
+  // risk it carries is breaking the path every existing reader follows.
+  it("leaves the direct-key path untouched — bare id, no base URL override", () => {
+    const route = routeModel("claude-sonnet-5", DIRECT_ANTHROPIC);
+    expect(route).toEqual({
+      client: "anthropic",
+      modelId: "claude-sonnet-5",
+      apiKeyEnv: "ANTHROPIC_API_KEY",
+      baseUrl: undefined,
+    });
+    expect(routeModel("anthropic/claude-sonnet-5", DIRECT_ANTHROPIC).modelId).toBe(
+      "claude-sonnet-5",
+    );
+    expect(routeModel("openai/gpt-5", DIRECT_OPENAI)).toEqual({
+      client: "openai",
+      modelId: "gpt-5",
+      apiKeyEnv: "OPENAI_API_KEY",
+      baseUrl: undefined,
+    });
+  });
+
+  it("still recognises the same slug shapes it always did", () => {
+    for (const slug of ["claude-sonnet-5", "anthropic/claude-opus-4-8"]) {
+      expect(routeModel(slug, DIRECT_ANTHROPIC).client).toBe("anthropic");
+    }
+    // `/^o\d/` rather than `/^o/`, so an `ollama/…` slug is not swept in.
+    for (const slug of ["gpt-5", "openai/gpt-4o", "o3"]) {
+      expect(routeModel(slug, DIRECT_OPENAI).client).toBe("openai");
+    }
+  });
+
+  it("fails loudly on a slug no client claims, gateway or not", () => {
+    expect(() => routeModel("ollama/llama-3", GATEWAY)).toThrow(/not recognized/);
+    expect(() => routeModel("ollama/llama-3", DIRECT_ANTHROPIC)).toThrow(/not recognized/);
+  });
+
+  // A missing key is a named error rather than an undefined handed to the client,
+  // which is what `requiredEnv` bought before the routing moved out here.
+  it("names the env var it wanted when no credential is present", () => {
+    expect(() => routeModel("claude-sonnet-5", {})).toThrow(/ANTHROPIC_API_KEY/);
+    expect(() => routeModel("gpt-5", {})).toThrow(/OPENAI_API_KEY/);
+  });
+});

--- a/agent-examples/minimal-viktor/src/index.ts
+++ b/agent-examples/minimal-viktor/src/index.ts
@@ -31,6 +31,7 @@ import { fileURLToPath } from "node:url";
 import { generateText, stepCountIs, tool } from "ai";
 import { z } from "zod";
 
+import { routeModel } from "./model-routing.js";
 import { initTelemetry } from "./telemetry.js";
 
 function buildSystem(slackChannel: string) {
@@ -227,31 +228,28 @@ async function main() {
   }
 }
 
-// AI Gateway first (one AI_GATEWAY_API_KEY routes every provider — required for
-// the default alibaba/qwen-3-32b). Otherwise fall back to a per-provider key,
-// and fail loudly for providers that have no direct SDK here.
+// WHICH credential routes this run is `model-routing.ts` — pure, and pinned by
+// `test/model-routing.test.ts` alongside the identical assertion in
+// `agent-examples/minimal-viktor-langgraph` (F-1216). AI Gateway first (one
+// AI_GATEWAY_API_KEY routes every provider — required for the default
+// alibaba/qwen-3-32b), otherwise a per-provider key. This function only builds
+// the client the decision names.
 async function resolveModel(slug: string): Promise<Parameters<typeof generateText>[0]["model"]> {
-  if (process.env.AI_GATEWAY_API_KEY) return slug;
+  const route = routeModel(slug, process.env);
+  // The gateway takes the slug as a bare string; the AI SDK routes it natively.
+  if (route.via === "gateway") return route.modelId;
 
-  const slash = slug.indexOf("/");
-  const prefix = slash >= 0 ? slug.slice(0, slash) : "";
-  const id = slash >= 0 ? slug.slice(slash + 1) : slug;
-
-  if (prefix === "anthropic" || slug.startsWith("claude")) {
+  const apiKey = requiredEnv(route.apiKeyEnv);
+  if (route.provider === "anthropic") {
     const { createAnthropic } = await import("@ai-sdk/anthropic");
-    return createAnthropic({ apiKey: requiredEnv("ANTHROPIC_API_KEY") })(id);
+    return createAnthropic({ apiKey })(route.modelId);
   }
-  if (prefix === "google" || slug.startsWith("gemini")) {
+  if (route.provider === "google") {
     const { createGoogleGenerativeAI } = await import("@ai-sdk/google");
-    return createGoogleGenerativeAI({ apiKey: requiredEnv("GOOGLE_GENERATIVE_AI_API_KEY") })(id);
+    return createGoogleGenerativeAI({ apiKey })(route.modelId);
   }
-  if (prefix === "openai" || slug.startsWith("gpt") || slug.startsWith("o")) {
-    const { createOpenAI } = await import("@ai-sdk/openai");
-    return createOpenAI({ apiKey: requiredEnv("OPENAI_API_KEY") })(id);
-  }
-  throw new Error(
-    `VIKTOR_MODEL=${slug} needs AI_GATEWAY_API_KEY (the Vercel AI Gateway routes alibaba/* and every other provider with one key).`,
-  );
+  const { createOpenAI } = await import("@ai-sdk/openai");
+  return createOpenAI({ apiKey })(route.modelId);
 }
 
 function requiredEnv(name: string): string {

--- a/agent-examples/minimal-viktor/src/index.ts
+++ b/agent-examples/minimal-viktor/src/index.ts
@@ -31,7 +31,7 @@ import { fileURLToPath } from "node:url";
 import { generateText, stepCountIs, tool } from "ai";
 import { z } from "zod";
 
-import { routeModel } from "./model-routing.js";
+import { redactCredentials, routeModel } from "./model-routing.js";
 import { initTelemetry } from "./telemetry.js";
 
 function buildSystem(slackChannel: string) {
@@ -221,7 +221,10 @@ async function main() {
   } catch (err) {
     // A model/tool-loop failure is a failed trial, not a silent crash: surface
     // a one-line summary and a nonzero exit so the runner records it.
-    console.error(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }));
+    // Scrubbed: the message is a provider SDK's, and this example runs with a
+    // real key.
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(JSON.stringify({ error: redactCredentials(message, process.env) }));
     process.exitCode = 1;
   } finally {
     await telemetry.shutdown();

--- a/agent-examples/minimal-viktor/src/model-routing.ts
+++ b/agent-examples/minimal-viktor/src/model-routing.ts
@@ -16,6 +16,37 @@
  * a key.
  */
 
+type Env = Record<string, string | undefined>;
+
+/** Every env var this example reads a credential from. ONE source of truth: the
+ *  same list routes a model and scrubs those values out of anything logged. */
+export const CREDENTIAL_ENV_VARS = [
+  "AI_GATEWAY_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "GOOGLE_GENERATIVE_AI_API_KEY",
+  "OPENAI_API_KEY",
+] as const;
+
+/**
+ * Replace any credential VALUE with a named placeholder.
+ *
+ * The run's catch logs whatever a provider SDK put in `err.message`, and this
+ * example is meant to be run with a real key — so a client that echoes its
+ * Authorization header into an error would print that key to stdout, and from
+ * there into the recorded trace. We do not control the SDK's error text, so the
+ * sink is sanitised instead. Guarded on length so a short or empty value cannot
+ * turn every string into placeholders. The LangGraph sibling carries the
+ * identical helper; the pair agrees on credentials, including how it fails.
+ */
+export function redactCredentials(text: string, env: Env): string {
+  let out = text;
+  for (const name of CREDENTIAL_ENV_VARS) {
+    const value = env[name]?.trim();
+    if (value && value.length >= 8) out = out.split(value).join(`[${name} redacted]`);
+  }
+  return out;
+}
+
 export type ModelRoute =
   | { via: "gateway"; modelId: string }
   | {
@@ -25,7 +56,6 @@ export type ModelRoute =
       apiKeyEnv: "ANTHROPIC_API_KEY" | "GOOGLE_GENERATIVE_AI_API_KEY" | "OPENAI_API_KEY";
     };
 
-type Env = Record<string, string | undefined>;
 
 export function routeModel(slug: string, env: Env): ModelRoute {
   // Gateway first. The slug goes through WHOLE: the AI SDK routes on the provider

--- a/agent-examples/minimal-viktor/src/model-routing.ts
+++ b/agent-examples/minimal-viktor/src/model-routing.ts
@@ -1,0 +1,64 @@
+/**
+ * Which credential routes this run — decided before any provider SDK is imported
+ * (F-1216).
+ *
+ * The behaviour is unchanged from the version that lived inline in `index.ts`.
+ * It moved here so it can be asserted without booting the agent: `index.ts` reads
+ * `POME_TASK` at module scope and then runs, so importing it to ask a routing
+ * question starts a run.
+ *
+ * THE RULE: **the AI Gateway comes first.** One `AI_GATEWAY_API_KEY` routes every
+ * provider, and this example's default (`alibaba/qwen-3-32b`) has no other route
+ * at all. `agent-examples/minimal-viktor-langgraph` — the same agent on LangGraph,
+ * and the other half of the pair that carries the framework-agnosticism claim —
+ * now applies the same order, and pins it in its own `test/model-routing.test.ts`.
+ * Two examples presented as one pair must not disagree about how a reader supplies
+ * a key.
+ */
+
+export type ModelRoute =
+  | { via: "gateway"; modelId: string }
+  | {
+      via: "direct";
+      provider: "anthropic" | "google" | "openai";
+      modelId: string;
+      apiKeyEnv: "ANTHROPIC_API_KEY" | "GOOGLE_GENERATIVE_AI_API_KEY" | "OPENAI_API_KEY";
+    };
+
+type Env = Record<string, string | undefined>;
+
+export function routeModel(slug: string, env: Env): ModelRoute {
+  // Gateway first. The slug goes through WHOLE: the AI SDK routes on the provider
+  // prefix, so stripping it here would break the thing that makes one key enough.
+  if (env.AI_GATEWAY_API_KEY) return { via: "gateway", modelId: slug };
+
+  const slash = slug.indexOf("/");
+  const prefix = slash >= 0 ? slug.slice(0, slash) : "";
+  const id = slash >= 0 ? slug.slice(slash + 1) : slug;
+
+  const direct = (
+    provider: "anthropic" | "google" | "openai",
+    apiKeyEnv: "ANTHROPIC_API_KEY" | "GOOGLE_GENERATIVE_AI_API_KEY" | "OPENAI_API_KEY",
+  ): ModelRoute => {
+    if (!env[apiKeyEnv]?.trim()) {
+      throw new Error(
+        `${apiKeyEnv} is required for ${slug}. Set it, or set AI_GATEWAY_API_KEY to route ` +
+          `through the Vercel AI Gateway instead (one key, every provider).`,
+      );
+    }
+    return { via: "direct", provider, modelId: id, apiKeyEnv };
+  };
+
+  if (prefix === "anthropic" || slug.startsWith("claude")) {
+    return direct("anthropic", "ANTHROPIC_API_KEY");
+  }
+  if (prefix === "google" || slug.startsWith("gemini")) {
+    return direct("google", "GOOGLE_GENERATIVE_AI_API_KEY");
+  }
+  if (prefix === "openai" || slug.startsWith("gpt") || slug.startsWith("o")) {
+    return direct("openai", "OPENAI_API_KEY");
+  }
+  throw new Error(
+    `VIKTOR_MODEL=${slug} needs AI_GATEWAY_API_KEY (the Vercel AI Gateway routes alibaba/* and every other provider with one key).`,
+  );
+}

--- a/agent-examples/minimal-viktor/test/model-routing.test.ts
+++ b/agent-examples/minimal-viktor/test/model-routing.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { type ModelRoute, routeModel } from "../src/model-routing.js";
+import { type ModelRoute, redactCredentials, routeModel } from "../src/model-routing.js";
 
 /** Narrows the union so a test can read `apiKeyEnv` without a cast. A gateway
  *  route reaching here is itself the failure, so it is asserted rather than
@@ -77,5 +77,37 @@ describe("routeModel — gateway first, then the per-provider key", () => {
 
   it("names the provider env var when the slug has an SDK but no key", () => {
     expect(() => routeModel("claude-sonnet-5", {})).toThrow(/ANTHROPIC_API_KEY/);
+  });
+});
+
+describe("redactCredentials — a provider SDK's error text never carries a key", () => {
+  const KEY = "sk-ant-0123456789abcdef";
+
+  it("replaces the credential value with a named placeholder", () => {
+    const out = redactCredentials(`401 from provider: Bearer ${KEY} rejected`, {
+      ANTHROPIC_API_KEY: KEY,
+    });
+    expect(out).not.toContain(KEY);
+    expect(out).toContain("[ANTHROPIC_API_KEY redacted]");
+  });
+
+  it("replaces EVERY occurrence, not just the first", () => {
+    const out = redactCredentials(`${KEY} … ${KEY}`, { ANTHROPIC_API_KEY: KEY });
+    expect(out).not.toContain(KEY);
+  });
+
+  // A short or empty value would otherwise match everywhere and turn the whole
+  // message into placeholders — losing the diagnostic to protect a non-secret.
+  it("ignores a value too short to be a credential", () => {
+    expect(redactCredentials("a totally normal message", { ANTHROPIC_API_KEY: "x" })).toBe(
+      "a totally normal message",
+    );
+    expect(redactCredentials("unchanged", { ANTHROPIC_API_KEY: "" })).toBe("unchanged");
+  });
+
+  it("leaves a message that carries no credential alone", () => {
+    expect(redactCredentials("model not found", { ANTHROPIC_API_KEY: KEY })).toBe(
+      "model not found",
+    );
   });
 });

--- a/agent-examples/minimal-viktor/test/model-routing.test.ts
+++ b/agent-examples/minimal-viktor/test/model-routing.test.ts
@@ -1,0 +1,81 @@
+// The credential model, pinned as a property (F-1216).
+//
+// The other half of a pair. `agent-examples/minimal-viktor-langgraph` is sold as
+// "the same viktor.com-style AI employee … but built on LangGraph instead of the
+// Vercel AI SDK", and it carries the same assertion in its own
+// `test/model-routing.test.ts`. Two examples presented as one pair must not
+// disagree about how a reader supplies a model key — that disagreement is what
+// F-1216 measured, and it was invisible until you tried the second example.
+//
+// This example was already the CORRECT half: it has short-circuited on
+// `AI_GATEWAY_API_KEY` since it shipped. Nothing about its behaviour changes
+// here. What changes is that the behaviour is now pinned, so the pair can only
+// drift apart through a red test rather than silently.
+
+import { describe, expect, it } from "vitest";
+
+import { type ModelRoute, routeModel } from "../src/model-routing.js";
+
+/** Narrows the union so a test can read `apiKeyEnv` without a cast. A gateway
+ *  route reaching here is itself the failure, so it is asserted rather than
+ *  silently treated as "no key". */
+function direct(route: ModelRoute): Extract<ModelRoute, { via: "direct" }> {
+  if (route.via !== "direct") throw new Error(`expected a direct route, got ${route.via}`);
+  return route;
+}
+
+const GATEWAY = { AI_GATEWAY_API_KEY: "gw-key" };
+const DIRECT_ANTHROPIC = { ANTHROPIC_API_KEY: "sk-ant" };
+
+describe("routeModel — gateway first, then the per-provider key", () => {
+  // The pair invariant, asserted identically on both sides.
+  it("accepts AI_GATEWAY_API_KEY alone — the sibling example's entry condition", () => {
+    expect(() => routeModel("claude-sonnet-5", GATEWAY)).not.toThrow();
+    expect(routeModel("claude-sonnet-5", GATEWAY).via).toBe("gateway");
+  });
+
+  it("prefers the gateway when both it and a provider key are present", () => {
+    expect(routeModel("claude-sonnet-5", { ...GATEWAY, ...DIRECT_ANTHROPIC }).via).toBe("gateway");
+  });
+
+  // The default model is the reason the short-circuit has to come first: nothing
+  // but the gateway can route an `alibaba/*` slug, so a per-provider branch would
+  // reach the throw at the bottom for this example's own default.
+  it("routes the default alibaba slug, which no per-provider branch can", () => {
+    const route = routeModel("alibaba/qwen-3-32b", GATEWAY);
+    expect(route).toEqual({ via: "gateway", modelId: "alibaba/qwen-3-32b" });
+  });
+
+  // The gateway takes the slug WHOLE — the AI SDK does the routing from the
+  // provider prefix, so stripping it here would break it. The LangGraph half
+  // reaches the same destination by re-qualifying a bare id; both end up
+  // provider-qualified, which is what the gateway requires.
+  it("hands the gateway the provider-qualified slug unchanged", () => {
+    expect(routeModel("anthropic/claude-sonnet-5", GATEWAY).modelId).toBe(
+      "anthropic/claude-sonnet-5",
+    );
+  });
+
+  it("falls back to a per-provider key with the prefix stripped", () => {
+    expect(routeModel("anthropic/claude-sonnet-5", DIRECT_ANTHROPIC)).toEqual({
+      via: "direct",
+      provider: "anthropic",
+      modelId: "claude-sonnet-5",
+      apiKeyEnv: "ANTHROPIC_API_KEY",
+    });
+    expect(direct(routeModel("gemini-2.5-flash", { GOOGLE_GENERATIVE_AI_API_KEY: "k" })).apiKeyEnv).toBe(
+      "GOOGLE_GENERATIVE_AI_API_KEY",
+    );
+    expect(direct(routeModel("gpt-5", { OPENAI_API_KEY: "k" })).apiKeyEnv).toBe("OPENAI_API_KEY");
+  });
+
+  // The error a reader actually hits, and the one sentence that has to name the
+  // gateway — this example's default cannot be run any other way.
+  it("names AI_GATEWAY_API_KEY when a slug has no direct SDK here", () => {
+    expect(() => routeModel("alibaba/qwen-3-32b", {})).toThrow(/AI_GATEWAY_API_KEY/);
+  });
+
+  it("names the provider env var when the slug has an SDK but no key", () => {
+    expect(() => routeModel("claude-sonnet-5", {})).toThrow(/ANTHROPIC_API_KEY/);
+  });
+});


### PR DESCRIPTION
## Summary

`minimal-viktor` and `minimal-viktor-langgraph` are sold as a matched pair — the langgraph README's own opening line is *"The same viktor.com-style AI employee … but built on LangGraph instead of the Vercel AI SDK"* — and they defaulted to **opposite** credential models, with neither saying so:

| | default model | credential its default needs |
|---|---|---|
| `minimal-viktor` | `alibaba/qwen-3-32b` | `AI_GATEWAY_API_KEY` — nothing else routes `alibaba/*` |
| `minimal-viktor-langgraph` | `claude-sonnet-5` | `ANTHROPIC_API_KEY` — the gateway was never consulted |

So one holder of a single Vercel AI Gateway key ran example A and could not run example B at all. It also meant we could not dogfood the langgraph example with our own secrets, since `AI_GATEWAY_API_KEY` is the only model key in Infisical.

This takes the first branch of F-1216's Done-when: **both examples now accept `AI_GATEWAY_API_KEY` on the same terms**, rather than documenting why one cannot.

## What changed

**A pure routing module per example** — `src/model-routing.ts`, env + slug in, decision out, no provider SDK imported. This is what makes the rule testable at all: `index.ts` reads `POME_TASK` at module scope and then runs the graph, so importing it to ask a routing question boots the agent. `resolveModel` now only constructs the client the decision names.

**The gateway is checked first in both**, which was already `minimal-viktor`'s order and is now `minimal-viktor-langgraph`'s.

**Two details from F-1216's measurement are in the code and pinned by tests**, because both are the kind of thing that gets "cleaned up" by someone who has not hit them:

- The Anthropic base URL is the **bare origin**. `@langchain/anthropic` appends `/v1/messages` itself, so `https://ai-gateway.vercel.sh/v1` produces `/v1/v1/messages` and a 404 naming the doubled path.
- The gateway routes on a **provider-qualified** slug, so the id keeps its prefix instead of being dropped by the `indexOf("/")` split. A reader can now write `claude-sonnet-5` or `anthropic/claude-sonnet-5` and have it work — the doubled `anthropic/anthropic/claude-sonnet-5` workaround is no longer needed.

**The langgraph README** names the gateway in its prerequisites, its run block and its env table.

## Tests — `tdd-required`, and written first

Both suites were written before the module existed and confirmed red (`Cannot find module '../src/model-routing.js'`).

`test/model-routing.test.ts` in **each** example, asserting the same pair property: `AI_GATEWAY_API_KEY` alone is sufficient, and it wins when both keys are present. Two suites rather than one cross-example import on purpose — the examples are standalone packages with their own installs and their own tsconfig (`scripts/gate-examples.mjs` runs `npm ci` per example), so a shared test would fight the architecture that gate exists to enforce.

The langgraph suite also pins the bare-origin rule, the qualifier-retention rule, and — the risk this change actually carries — that **the direct-key path every existing reader follows is unchanged**, since the fix adds a branch above it.

```
minimal-viktor              tsc --noEmit clean · 9 passed (2 files)
minimal-viktor-langgraph    tsc --noEmit clean · 13 passed (2 files)
npm run lint                18 of 19 rules pass
```

## What is NOT verified here, stated rather than implied

- The **Anthropic-through-gateway** path is the one F-1216 measured live: 100/100 hosted, `run_BGP9XQHD8jGmkHQy`.
- The **OpenAI-through-gateway** path (`baseURL` = `…/v1`, per that client treating its base as the API root) is implemented by symmetry and covered by unit tests only. No live run backs it.
- The one lint rule that does not pass, `no-native`, reports `cannot inspect "node_modules/stripe" — directory missing. Run npm ci` — a missing root install in this environment, not a violation from this diff.

## Two observations, filed rather than silently fixed

1. `minimal-viktor` matches OpenAI on `slug.startsWith("o")`, so an `ollama/*` slug would be swept into the OpenAI branch. The langgraph half uses `/^o\d/` and does not. This diff **pins existing behaviour on both sides rather than changing it** — it is a slug-matching bug, not a credential one, and out of F-1216's scope.
2. `minimal-viktor-langgraph/VERIFICATION.md` is left alone: it records how a past run was actually routed (`OPENAI_BASE_URL` at the gateway's OpenAI-compatible endpoint) and that record stays true. Note this makes the ticket's *"`git grep -in "gateway" -- minimal-viktor-langgraph` returns zero hits"* slightly off — there was one hit, in that file.