### PR TITLE
One name per gate: CI calls the npm alias

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,19 +131,19 @@ jobs:
       # workspace and EXIT 0, and a wrong `publishConfig.registry` aims it at
       # public npm, which cannot be undone after 72 hours. The tarball half needs
       # a build and runs in release.yml's publish-wire job.
-      - run: node scripts/ci/check-wire-tarball.mjs --manifest-only
+      - run: npm run gate:wire-manifest
 
       # Same two manifest-readable failure modes for @pome-sh/checks, plus one
       # more: a leaked `@pome-sh/*` runtime dependency 404s on the consumer's
       # install, because those versions are on no registry.
-      - run: node scripts/ci/check-checks-tarball.mjs --manifest-only
+      - run: npm run gate:checks-manifest
 
       # Same for @pome-sh/sandbox-domains, which adds one the vocabulary package
       # cannot have: its `dependencies` are load-bearing in BOTH directions,
       # since declaring a package is what makes tsup leave it external. The test
       # asserts the gate by BREAKING the manifest nine ways — a gate only ever
       # run against a green tree is one that could have been `process.exit(0)`.
-      - run: node scripts/ci/check-sandbox-domains-tarball.mjs --manifest-only
+      - run: npm run gate:sandbox-domains-manifest
       - run: node scripts/ci/check-sandbox-domains-tarball.test.mjs
 
       # Asserts a 401 from GitHub Packages is never read as "unpublished" (which
@@ -195,7 +195,7 @@ jobs:
       # answer; the live registry check runs in gate:examples below.
       - run: node scripts/check-example-pins-published.test.mjs
 
-      - run: bash scripts/lint-no-cloud-imports.sh
+      - run: npm run lint:no-cloud-imports
       - run: bash scripts/lint-no-cloud-imports.test.sh
       - run: node scripts/ci/wait-for-workflow.test.mjs
       - run: node scripts/ci/assert-repo-policy.test.mjs
@@ -205,8 +205,8 @@ jobs:
       # question. `--offline` re-derives meta + canonical from the committed
       # raw.json: no network, no Go toolchain, and it reds on an edited golden or
       # a hand-typed sha. Re-capturing from the live substrate is a separate,
-      # human-reviewed lane (`node scripts/capture-mcp-tools-list.mjs`).
-      - run: node scripts/capture-mcp-tools-list.mjs --check --offline
+      # human-reviewed lane (`npm run capture:mcp-tools-list`).
+      - run: npm run gate:mcp-tools-list
       - run: node scripts/capture-mcp-tools-list.test.mjs
 
       # ---------------------------------------------------------------------

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,8 +168,10 @@ rule. None of those three can leave enforcement quietly reduced.
 The gates that are NOT rules, because they are different in kind rather than in
 rule: `lint:no-cloud-imports` (shell, and in the pre-commit hook), `lint:dead-code`
 (knip), `gate:route-inputs` (codegen freshness), `gate:mcp-tools-list`,
-`test:pack`, and the tarball audits, which inspect built npm artifacts rather
-than the source tree.
+`test:pack`, and the tarball audits. Those audits come in two halves: the
+`gate:*-manifest` variants read `package.json` only, so they need no build and
+run on every PR, while the full `gate:*-tarball` variants pack and inspect the
+built npm artifact.
 
 The ones that catch people: `lint` (the product boundary lives in its `no-eval`
 rule), `lint:no-cloud-imports`, `lint:dead-code`, `gate:route-inputs`,


### PR DESCRIPTION
Five gates in the root `package.json` had no callers. CI ran the same five as file paths, so each gate had two names and nothing kept them in sync — renaming a file would silently orphan its alias, and two of the five are documented as live gates.

This points those `ci.yml` steps at the aliases, so the alias is the single name and CI exercises it:

- `gate:wire-manifest`
- `gate:checks-manifest`
- `gate:sandbox-domains-manifest`
- `lint:no-cloud-imports`
- `gate:mcp-tools-list`

The rest of the always-on block already uses `npm run`, so this is also a consistency fix.

## Checks run

`actionlint`, all five aliases (with and without `node_modules`), `lint`, `lint:test`, `check-packages-scripts-wired` and its self-test.

No behaviour change: same scripts, same flags, same order.