### PR TITLE
Cut the prose in .github/workflows to what a reader needs

### DIFF
--- a/.github/workflows/agent-trace-overhead-gate.yml
+++ b/.github/workflows/agent-trace-overhead-gate.yml
@@ -79,21 +79,17 @@ jobs:
       # resolve `withPome()` + the SDK's `tool()` at runtime, and so the pack
       # step below can build all publishable packages.
       - run: npm ci
-      # `cli/` is a root workspace member: the `npm ci` above already linked
-      # the @pome-sh/* packages out of packages/*, so the CLI builds straight
-      # from this checkout (no tarball pack + manifest rewrite, no second
-      # lockfile). The root chain builds the packages in dependency order and
-      # ends with the CLI.
+      # `cli/` is a root workspace member, so the `npm ci` above already linked the
+      # @pome-sh/* packages out of packages/* and the CLI builds straight from this
+      # checkout. The root chain builds in dependency order and ends with the CLI.
       - name: Build CLI
         run: npm run build
       - name: Run agent-trace overhead gate (PR/FAQ #1)
         env:
-          # Wired by `cli/scripts/overhead-gate.ts` (`gate:agent-trace-overhead`
-          # in cli/package.json — a named script so check-packages-scripts-
-          # wired.mjs's cli/ audit can see it wired, same `npm run <name> -w
-          # <pkg>` shape as everywhere else in this file). The budget is 5ms; N
-          # and the escalation pair count are calibrated for shared-runner noise.
-          # Overrideable for local triage runs.
+          # Wired by cli/scripts/overhead-gate.ts as `gate:agent-trace-overhead`, a
+          # named script so check-packages-scripts-wired.mjs can see it wired. The
+          # budget is 5ms; N and the escalation pair count are calibrated for
+          # shared-runner noise, and both are overrideable for local triage.
           OVERHEAD_BENCH_N: '1000'
           OVERHEAD_BENCH_PAIRS: '3'
           OVERHEAD_BENCH_BUDGET_MS: '5'

--- a/.github/workflows/allocate-version.yml
+++ b/.github/workflows/allocate-version.yml
@@ -1,119 +1,70 @@
 name: allocate version
 
-# The version number leaves the PR author's hands; this is the hand it lands in.
-# A number written in a PR is a claim about `main` that goes stale
+# The version number leaves the PR author's hands; this is the hand it lands
+# in. A number written in a PR is a claim about `main` that goes stale
 # silently: it invalidates every other open PR that pinned it, and those PRs
-# stay green, because their CI ran before the merge.
+# stay green because their CI ran before the merge.
 #
-# This workflow reads `main`'s tip, allocates the numbers that tip has earned
-# (`scripts/ci/allocate-release-versions.mjs` decides), writes them into the
-# manifests and the CHANGELOG headings, and pushes ONE commit back to `main`.
+# This reads main's tip, allocates the numbers that tip earned
+# (scripts/ci/allocate-release-versions.mjs decides), writes them into the
+# manifests and CHANGELOG headings, and pushes ONE commit back to main. It
+# does not publish: the bump commit is a push to main, so the publish is that
+# commit's own release.yml run.
 #
-# ── WHAT THIS DELIBERATELY DOES NOT DO ───────────────────────────────────────
+# The push uses an installation token from the org's `pome-ops-push` GitHub
+# App, not the ambient GITHUB_TOKEN, for two independent reasons either of
+# which is sufficient. First, main's live rules require a pull request, and a
+# direct push needs a bypass actor — `github-actions` can never be one, an App
+# installation can (`actor_type: Integration`). Second, GitHub refuses to let a
+# push made with GITHUB_TOKEN trigger workflows, so the number would land and
+# no release.yml run would ever see it. An App token is not event-suppressed.
 #
-# It does not publish, and `release.yml` is untouched by it. `release.yml` still
-# triggers on push to `main`, still compares each package's local manifest
-# against its registry, still hard-fails on behind-npm and still baselines a
-# never-seen package at 0.0.0. The bump commit is a push to `main`, so the
-# publish is that commit's own `release.yml` run. Two consequences worth stating:
-# the run on the HUMAN merge commit sees no version diff and publishes nothing
-# (correct — the number does not exist yet at that sha), and `release.yml`'s
-# `concurrency: release-${{ github.ref }}` with `cancel-in-progress: false` is
-# what serialises the publish half.
-#
-# Nothing here waits for a release PR and nothing batches. What this moves is
-# WHO WRITES THE NUMBER, not when a release happens.
-#
-# ── WHY AN APP TOKEN AND NOT THE AMBIENT GITHUB_TOKEN ────────────────────────
-#
-# The push is made with an installation token minted from the org's
-# `pome-ops-push` GitHub App (app_id 4582446, org installation 153466692,
-# Contents: RW). Two independent reasons the ambient `GITHUB_TOKEN` cannot do it,
-# either one sufficient:
-#
-#   1. `main`'s live rules (ruleset "main founder-bypass" 18797095, the ones
-#      scripts/ci/assert-repo-policy.sh asserts) require a pull request, resolved
-#      threads, strict required status checks, non-fast-forward and deletion, and classic
-#      branch protection sits underneath them. A direct push needs an actor those
-#      rules let bypass — and `github-actions` can NEVER be one: the UI and the
-#      API both refuse it, and org policy disables deploy keys. An App
-#      installation CAN (`actor_type: Integration`), which is why this app exists.
-#   2. GitHub refuses to let a push made with the ambient `GITHUB_TOKEN` trigger
-#      workflows. That push would land the number and no `release.yml` run would
-#      ever see it — a release that silently never happens, which is the failure
-#      class this whole apparatus exists to remove. (`release-alarm.mjs`'s
-#      NEVER_RAN leg names exactly this trap.) An App installation token is NOT
-#      event-suppressed: only `GITHUB_TOKEN` is.
-#
-# WHY AN APP AND NOT A FINE-GRAINED PAT. A PAT expires — and its expiry day is a
-# release-freeze day nobody scheduled — and it binds the release path to one
-# person's account. An App private key does not expire and rotates in one click.
-#
-# Either way, the credential must fail loud: a missing secret is a hard, named
-# failure and never a fallback, because falling back to `GITHUB_TOKEN` would push
-# nothing (reason 1) or publish nothing (reason 2), and both of those look like a
-# quiet green.
+# The credential must fail loud: a missing secret is a hard, named failure and
+# never a fallback, because falling back would push nothing or publish
+# nothing, and both look like a quiet green.
 on:
   push:
     branches: [main]
   workflow_dispatch:
-  # release.yml's `dispatch-allocate-version` job POSTs this event the
-  # moment a publish lands, which is the ONLY moment `planExampleRepins` can see
-  # the just-published sibling on the registry: the run on the human merge commit
-  # plans before the version exists, and the run on the bump commit it produces
-  # is the one the `[release-bump]` guard below skips. A NAMED type, never a bare
-  # `repository_dispatch:` — that accepts every event type anyone ever POSTs at
-  # this repository as a licence to push to `main`.
+  # release.yml's `dispatch-allocate-version` POSTs this the moment a publish
+  # lands, which is the only moment `planExampleRepins` can see the
+  # just-published sibling on the registry. A NAMED type, never a bare
+  # `repository_dispatch:` — that would accept every event type anyone POSTs at
+  # this repository as a licence to push to main.
   #
-  # `repository_dispatch` and not `workflow_dispatch`, which is what this shipped
-  # as first and could never have fired: `POST /repos/{owner}/{repo}/dispatches`
-  # needs `contents: write`, which the `pome-ops-push` installation already
-  # holds, while `POST /repos/…/actions/workflows/{id}/dispatches` needs
-  # `actions: write`, which it does not — that call 403s on every release until
-  # an org owner re-approves the app with a wider grant. (Both requirements are
-  # GitHub's documented fine-grained permission for the endpoint.)
-  #
-  # Three properties of this event make it behave identically to the push arm
-  # below, so nothing downstream needs a special case: GitHub only starts it from
-  # the workflow file on the DEFAULT BRANCH, `github.sha` is the last commit on
-  # the default branch, and `github.ref` is the default branch — so the checkout
-  # ref expression resolves to `main` exactly as on a push, and the concurrency
-  # group is the same `allocate-version-refs/heads/main`, which is what makes a
-  # dispatch queue behind an allocation already in flight instead of racing it.
+  # This event behaves identically to the push arm, so nothing downstream needs
+  # a special case: GitHub starts it only from the default branch's workflow
+  # file, and `github.sha` and `github.ref` both resolve there — same checkout
+  # ref, same concurrency group.
   repository_dispatch:
     types: [repin-examples]
-  # Changing the allocator or the table it reads must prove the job wiring still
-  # works on the PR that changes it — a syntax-valid workflow whose steps are
-  # broken belongs to the static workflow-file check in ci.yml. The PR arm plans
-  # and never writes or pushes.
+  # Changing the allocator or the table it reads must prove the job wiring
+  # still works on the PR that changes it. This arm plans, never writes or
+  # pushes.
   pull_request:
     paths:
       - "scripts/ci/allocate-release-versions.mjs"
       - "scripts/ci/allocate-release-versions.test.mjs"
       - "scripts/ci/changelog-entry.mjs"
       - "scripts/ci/publish-relevance.mjs"
-      # the allocator now imports planExampleRepins from here, so a
-      # change to it is a change to the allocator's own wiring, not just to
-      # the standalone gate that also uses it. The second entry is the TRANSITIVE
-      # half of that import: check-example-pins-published.mjs imports
-      # loadWorkspaceMembers from it, so the allocator's behaviour on main
-      # depends on it too — listing only the direct import would leave the arm
-      # blind to exactly the PR that changes how examples are discovered.
+      # The allocator imports planExampleRepins from here, and the next entry is
+      # the transitive half: check-example-pins-published.mjs imports
+      # loadWorkspaceMembers, so listing only the direct import would leave this
+      # arm blind to the PR that changes how examples are discovered.
       - "scripts/check-example-pins-published.mjs"
       - "scripts/lint/rules/workspace-pins.mjs"
       - ".github/workflows/allocate-version.yml"
 
-# One allocation at a time, and never cancelled mid-write: the number is a
-# side effect on `main`, so a cancelled run is a half-written release commit.
-# Serialising also means the retry loop below only ever races a human merge, not
-# another copy of itself.
+# One allocation at a time, never cancelled mid-write: the number is a side
+# effect on main, so a cancelled run is a half-written release commit.
+# Serialising also means the retry loop below only races a human merge.
 concurrency:
   group: allocate-version-${{ github.ref }}
   cancel-in-progress: false
 
-# The ambient token gets nothing. The push uses the `pome-ops-push` installation
-# token (see the header), so granting `contents: write` here would hand out a
-# capability nothing in this file uses — and could not do the job anyway.
+# The ambient token gets nothing. The push uses the pome-ops-push
+# installation token, so `contents: write` here would hand out a capability
+# nothing in this file uses and which could not do the job anyway.
 permissions:
   contents: read
 
@@ -122,37 +73,26 @@ jobs:
     name: write the version numbers this push earned
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # A cheap "don't even start" on the allocator's own commit — NOT the loop
-    # guard. The guard is structural and lives in the allocator: relevance is
-    # measured from the last commit that moved a package's version, and the bump
-    # commit is one, so its own diff is already inside the previous release. If
-    # this literal and BUMP_COMMIT_MARKER in the script ever drift apart, the job
-    # runs and finds nothing to do.
+    # A cheap "don't even start" on the allocator's own commit, NOT the loop
+    # guard — that is structural and lives in the allocator, which measures
+    # relevance from the last commit that moved a version.
     #
-    # SCOPED TO `push` EXPLICITLY, because `github.event.head_commit` exists on
-    # no other event. On `workflow_dispatch` and on `repository_dispatch` it is
-    # null, `contains` casts null to the empty string, and the guard therefore
-    # passes — the right answer (a dispatch is a deliberate request and must run
-    # even when main's tip IS a `[release-bump]` commit, which is precisely the
-    # tip release.yml dispatches from) arrived at by coercion. Naming the event
-    # makes it a decision, and stops the plausible "fix" for that null — widening
-    # the guard to cover every event — which would turn release.yml's dispatch
-    # into a silent no-op and reopen the deadlock it exists to close.
+    # Scoped to `push` explicitly, because `github.event.head_commit` exists on no
+    # other event. Widening this guard to every event is the plausible "fix" for
+    # that null and would turn release.yml's dispatch into a silent no-op: a
+    # dispatch must run even when main's tip IS a [release-bump] commit, which is
+    # precisely the tip it is dispatched from.
     #
-    # Termination does NOT rest on this guard for the dispatch arm, and must not:
-    # release.yml dispatches only after a real publish, and the single commit this
-    # run pushes can only cause another publish by MOVING a package version,
-    # which requires a pending `## Unreleased` entry — which this same run
-    # consumes. A re-pin-only commit touches `agent-examples/*` and their lockfiles, no
-    # package version, so release.yml's `plan` finds no diff against the registry,
-    # publishes nothing, and dispatches nothing. The chain is bounded by the
-    # number of pending entries and CI writes none.
+    # Termination does not rest on this guard for the dispatch arm. release.yml
+    # dispatches only after a real publish, and the commit this run pushes can
+    # cause another publish only by moving a version, which requires a pending
+    # `## Unreleased` entry that this same run consumes. CI writes none, so the
+    # chain is bounded.
     if: ${{ github.event_name != 'push' || !contains(github.event.head_commit.message, '[release-bump]') }}
     steps:
-      # Named before the mint step rather than left to it: the action's own
-      # failure on an empty input does not tell a reader which secret, on which
-      # repository, or what to do about it — and this is the message someone meets
-      # when releases have silently stopped.
+      # Named before the mint step: the action's own failure on an empty input does
+      # not say which secret, on which repository, or what to do — and this is the
+      # message someone meets when releases have silently stopped.
       - name: The pome-ops-push credentials must exist
         if: github.event_name != 'pull_request'
         env:
@@ -174,13 +114,10 @@ jobs:
           fi
 
       # An installation token, not a PAT: nothing to re-mint before an expiry
-      # nobody scheduled, and no binding of the release path to one person's
-      # account. `app-id` (not `client-id`) matches pome-cloud's call sites so both
-      # repos read the same way; v3.2.0 prints a deprecation warning for it, and
-      # migrating is a some-day for the two repos together, not a divergence to
-      # introduce here. No `owner`/`repositories` inputs: the default scopes the
-      # token to this repository through the org installation, which is exactly
-      # what the push needs.
+      # nobody scheduled, and no binding of the release path to one account.
+      # `app-id` (not `client-id`) matches pome-cloud's call sites so both repos
+      # read the same way. No `owner`/`repositories` inputs — the default scopes the
+      # token to this repository through the org installation.
       - name: Mint a pome-ops-push installation token
         id: app-token
         if: github.event_name != 'pull_request'
@@ -189,26 +126,20 @@ jobs:
           app-id: ${{ secrets.OPS_APP_ID }}
           private-key: ${{ secrets.OPS_APP_PRIVATE_KEY }}
 
-      # fetch-depth: 0 is load-bearing. The allocator asks "when did this
-      # package's version last move" and refuses to answer from a shallow clone,
-      # because a truncated walk silently mis-scopes which packages are owed a
-      # release.
+      # fetch-depth: 0 is load-bearing. The allocator asks when a package's version
+      # last moved and refuses to answer from a shallow clone, because a truncated
+      # walk silently mis-scopes which packages are owed a release.
       #
-      # THE REF IS PER ARM, and getting it wrong is how the first run of this
-      # workflow failed. On a push, `main` (not the event sha) because the number
-      # belongs to the TIP: if a second merge landed while this run queued, its
-      # entry is already on main and belongs in the same release. On a
-      # pull_request, `github.ref` — the merge ref — because that arm's whole job
-      # is to prove THIS PR's allocator still runs, and a checkout of `main` does
-      # not contain the PR's files at all — a checkout of `main` on that arm dies
-      # with `Cannot find module …/allocate-release-versions.test.mjs`. The merge
-      # ref is also the better preview: it is what main will look like.
+      # The ref is per arm. On a push, `main` rather than the event sha, because the
+      # number belongs to the TIP: a second merge that landed while this run queued
+      # has its entry on main and belongs in the same release. On a pull_request,
+      # `github.ref` — the merge ref — because that arm proves THIS PR's allocator
+      # runs, and a checkout of main does not contain the PR's files at all.
       #
-      # `|| github.token` is for the pull_request arm ONLY, where the mint step is
-      # skipped and its output is empty — a fork PR has no secrets at all. That
-      # arm plans and never pushes, so the ambient token is the right credential
-      # there and the wrong one everywhere else. That split is asserted
-      # structurally by scripts/ci/assert-allocate-token-path.mjs.
+      # `|| github.token` is for the pull_request arm only, where the mint step is
+      # skipped and a fork PR has no secrets. That arm never pushes, so the ambient
+      # token is right there and wrong everywhere else — asserted structurally by
+      # scripts/ci/assert-allocate-token-path.mjs.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event_name == 'pull_request' && github.ref || 'main' }}
@@ -220,9 +151,8 @@ jobs:
           cache: npm
           cache-dependency-path: package-lock.json
 
-      # Gate on the allocator's own tests before letting it write to main, the
-      # same ordering release-alarm.yml uses: a commit on main is not the place
-      # to discover the writer is broken.
+      # Gate on the allocator's own tests before letting it write to main: a commit
+      # on main is not the place to discover the writer is broken.
       - name: Regression-test the allocator
         run: node scripts/ci/allocate-release-versions.test.mjs
 
@@ -238,24 +168,19 @@ jobs:
           REGEN: ${{ runner.temp }}/allocation-regenerate.sh
         run: |
           set -euo pipefail
-          # The commit AUTHOR is cosmetic; what the ruleset bypass keys on is the
-          # PUSHER, which is the pome-ops-push installation whose token checkout
-          # stored above. Naming the workflow here means `git log` explains itself
-          # without anyone having to know that.
+          # The commit AUTHOR is cosmetic; the ruleset bypass keys on the PUSHER, which
+          # is the pome-ops-push installation whose token checkout stored above.
           git config user.name "pome release bot"
           git config user.email "release-bot@pome.sh"
 
-          # Three attempts, and each one RECOMPUTES rather than retrying a stale
-          # write: the allocator is a pure function of the tip, so re-planning
-          # after a rejected push is both correct and the only way to fold in the
-          # merge that beat us to it. `git reset --hard` discards the previous
-          # attempt's writes but not node_modules, which is untracked.
+          # Three attempts, each RECOMPUTING rather than retrying a stale write: the
+          # allocator is a pure function of the tip, so re-planning after a rejected
+          # push is the only way to fold in the merge that beat us to it.
           for attempt in 1 2 3; do
-            # Explicit destination refspec rather than a bare `git fetch origin
-            # main`: which remote-tracking ref that updates depends on the
-            # `remote.origin.fetch` refspec actions/checkout happened to
-            # configure, and resetting to a stale origin/main would re-plan
-            # against the tip we were trying to get away from.
+            # Explicit destination refspec rather than a bare `git fetch origin main`:
+            # which remote-tracking ref that updates depends on the refspec
+            # actions/checkout happened to configure, and resetting to a stale
+            # origin/main would re-plan against the tip we are trying to leave.
             git fetch --quiet --force origin main:refs/remotes/origin/main
             git reset --quiet --hard refs/remotes/origin/main
 
@@ -267,12 +192,12 @@ jobs:
               exit 0
             fi
 
-            # Committed artifacts that embed a package's own version and are
-            # byte-compared by a required gate — today only wire's shipped
-            # trace-contract.json. The command comes from the table next to the
-            # artifact (scripts/ci/publish-relevance.mjs), so a second one needs
-            # no edit here; an empty file means no package in this plan has one,
-            # which is why `npm ci` is inside the guard.
+            # Committed artifacts that embed their package's own version and are
+            # byte-compared by a required gate — today only wire's trace-contract.json.
+            # The command comes from the table beside the artifact
+            # (scripts/ci/publish-relevance.mjs), so a second one needs no edit here. An
+            # empty file means no package in this plan has one, which is why `npm ci` is
+            # inside the guard.
             if [[ -s "${REGEN}" ]]; then
               echo "Regenerating version-embedding artifacts:"
               cat "${REGEN}"
@@ -280,8 +205,8 @@ jobs:
               bash "${REGEN}"
             fi
 
-            # `-a` is safe and deliberate: this is a fresh checkout whose only
-            # writers are the allocator and the regeneration above.
+            # `-a` is safe here: a fresh checkout whose only writers are the allocator
+            # and the regeneration above.
             git commit --quiet -a --file "${MESSAGE}"
 
             push_err="${RUNNER_TEMP}/push-attempt-${attempt}.err"
@@ -292,14 +217,9 @@ jobs:
             fi
             cat "${push_err}" >&2
 
-            # A REFUSAL IS NOT A RACE, and this branch exists because the first
-            # live run of this workflow spent all three attempts pretending it
-            # was one. `main` answered `GH013 … 3 of 3 required status checks are
-            # expected` — classic branch protection still carried a duplicate
-            # required-checks rule, which no App can bypass and `enforce_admins`
-            # applies to everyone — and the loop reported "a merge landed first"
-            # three times before giving up. Retrying cannot fix a rule; the only
-            # useful thing to do is stop and name the layer that refused.
+            # A refusal is not a race. A rule violation (GH013) answers identically to a
+            # lost race from the loop's point of view, and retrying cannot fix a rule —
+            # the only useful move is to stop and name the layer that refused.
             if grep -qE 'GH013|GH006|rule violations|protected branch|refusing to allow' "${push_err}"; then
               echo "::error::main REFUSED this push on a RULE, not a race (attempt ${attempt}/3). Retrying cannot help, so this run stops here."
               echo "Nothing was published and nothing was lost: the pending CHANGELOG entries are still on"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,8 @@ jobs:
 
       # ---------------------------------------------------------------------
       # Always-on gates. Dependency-free, so they run before `npm ci` and cover
-      # docs-only PRs too. Several rules below exist precisely because the diff
-      # that drifts them touches only `skills/`, `docs/` or `.github/workflows/`,
-      # which the scope step classifies as docs-only — a heavy-block gate would
-      # be skipped by exactly the PR that breaks it.
+      # docs-only PRs too — several rules below exist precisely because the diff
+      # that drifts them is one the scope step calls docs-only.
       # ---------------------------------------------------------------------
 
       # actionlint parses every workflow for YAML shape and, with shellcheck on
@@ -64,12 +62,10 @@ jobs:
           archive="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
           tmp="$(mktemp -d)"
           trap 'rm -rf "$tmp"' EXIT
-          # This puts the REQUIRED check behind a third-party CDN, so the retry,
-          # the backoff and an unconditional sha256 check live in
-          # scripts/ci/fetch-pinned-release.sh — the one hardened fetch path for
-          # the whole workflow tree, enforced by assert-hardened-cdn-fetches.mjs
-          # below. Deliberately NOT cached: a cache hit would skip the sha256
-          # verification, which is the whole reason for fetching a pinned binary.
+          # Puts the required check behind a third-party CDN, so retry, backoff and an
+          # unconditional sha256 check live in scripts/ci/fetch-pinned-release.sh, the
+          # one hardened fetch path, enforced by assert-hardened-cdn-fetches.mjs below.
+          # Not cached: a cache hit would skip the sha256 verification.
           bash scripts/ci/fetch-pinned-release.sh actionlint \
             "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${archive}" \
             "$ACTIONLINT_SHA256" "$tmp/$archive"
@@ -81,17 +77,13 @@ jobs:
         run: actionlint -color
 
       # Every dependency-free lint rule, plus each rule's case table. `--offline`
-      # skips the three rules that need node_modules (two TypeScript-AST walks
-      # and the lockfile scan) and names them rather than dropping them silently;
-      # the heavy block below runs the same runner with no flag, so this is a
-      # subset and never the only run.
+      # skips the three rules needing node_modules and names them rather than
+      # dropping them silently; the heavy block runs the same runner with no flag.
       - run: npm run lint -- --offline
       - run: npm run lint:test -- --offline
 
       # Catches a `packages/*` script that produces no verdict because nothing
-      # reaches it — no verdict reads exactly like a pass. Every such script is
-      # a uniform lifecycle name, or wired as `npm run <script> ... -w <pkg>`, or
-      # carries a `pome:unwired-ok(<script>): <reason>` marker. Reads package.json
+      # reaches it — no verdict reads exactly like a pass. Reads package.json
       # scripts and workflow text only, so it runs before `npm ci`.
       - run: node scripts/check-packages-scripts-wired.mjs
       - run: node scripts/check-packages-scripts-wired.test.mjs
@@ -100,14 +92,11 @@ jobs:
       # back to reading as success. Pure functions, no install needed.
       - run: node scripts/smoke-examples.test.mjs
 
-      # Versions are written on main after the merge by allocate-version.yml, so
-      # what this demands of a PR is the WORDS and not the number: an
-      # `## Unreleased (patch|minor)` entry for every artifact the PR moves, no
-      # hand-written version line, no rewrite of a released entry. The base is
-      # derived from the checked-out history, NOT `pull_request.base.sha` — that
-      # field is pinned at the last synchronize while the checkout merges main as
-      # it is now, so the two disagree the moment main advances and main's own
-      # `[release-bump]` commit reads as PR-authored.
+      # Versions are written on main after the merge, so what this demands of a PR
+      # is the WORDS, not the number. The base comes from the checked-out history,
+      # NOT `pull_request.base.sha` — that field is pinned at the last synchronize
+      # while the checkout merges main as it is now, so the two disagree the moment
+      # main advances.
       - if: github.event_name == 'pull_request'
         run: node scripts/ci/check-release-note-required.mjs "$(git merge-base HEAD "origin/${{ github.base_ref }}")"
       - run: node scripts/ci/check-release-note-required.test.mjs
@@ -117,20 +106,18 @@ jobs:
       # and two merges inside one allocation window cannot double-allocate.
       - run: node scripts/ci/allocate-release-versions.test.mjs
 
-      # allocate-version.yml's `steps.app-token.outputs.token || github.token`
-      # fallback must be reachable ONLY on the plan-only pull_request arm. On a
-      # push it is a silent double failure: `github-actions` can never be a
-      # ruleset bypass actor, and a push made with GITHUB_TOKEN triggers no
-      # workflows, so a landed commit would publish nothing. Four one-line edits
-      # would each make it reachable, and a comment saying "PR-only" guards none.
+      # That fallback must be reachable only on the plan-only pull_request arm. On a
+      # push it is a silent double failure: `github-actions` can never be a ruleset
+      # bypass actor, and a push made with GITHUB_TOKEN triggers no workflows, so a
+      # landed commit would publish nothing. A comment saying "PR-only" guards none
+      # of the four one-line edits that would make it reachable.
       - run: node scripts/ci/assert-allocate-token-path.mjs
       - run: node scripts/ci/assert-allocate-token-path.test.mjs
 
-      # The two ways @pome-sh/wire silently stops publishing are both readable
-      # from its package.json: `private: true` makes `npm publish -w` skip the
-      # workspace and EXIT 0, and a wrong `publishConfig.registry` aims it at
-      # public npm, which cannot be undone after 72 hours. The tarball half needs
-      # a build and runs in release.yml's publish-wire job.
+      # Both ways @pome-sh/wire silently stops publishing are readable from its
+      # package.json: `private: true` makes `npm publish -w` skip and EXIT 0, and a
+      # wrong `publishConfig.registry` aims it at public npm, which cannot be undone
+      # after 72 hours. The tarball half runs in release.yml.
       - run: npm run gate:wire-manifest
 
       # Same two manifest-readable failure modes for @pome-sh/checks, plus one
@@ -138,11 +125,9 @@ jobs:
       # install, because those versions are on no registry.
       - run: npm run gate:checks-manifest
 
-      # Same for @pome-sh/sandbox-domains, which adds one the vocabulary package
-      # cannot have: its `dependencies` are load-bearing in BOTH directions,
-      # since declaring a package is what makes tsup leave it external. The test
-      # asserts the gate by BREAKING the manifest nine ways — a gate only ever
-      # run against a green tree is one that could have been `process.exit(0)`.
+      # Same for @pome-sh/sandbox-domains, plus one the vocabulary package cannot
+      # have: its `dependencies` are load-bearing in both directions, since
+      # declaring a package is what makes tsup leave it external.
       - run: npm run gate:sandbox-domains-manifest
       - run: node scripts/ci/check-sandbox-domains-tarball.test.mjs
 
@@ -157,42 +142,35 @@ jobs:
       - run: node scripts/ci/release-alarm.mjs --targets
       - run: node scripts/ci/release-alarm.test.mjs
 
-      # The derivation behind the schedule-alarm coverage property, read out of
-      # `.github/workflows/*.yml` rather than a hand-kept list. Asserts at least
-      # one workflow is scheduled (an alarm covering zero workflows passes
-      # forever), that the `on: schedule:` and `cron:` reads agree exactly, and
-      # that no workflow calls a local `uses: ./.github/workflows/…` that is not
-      # there — a workflow GitHub refuses to run is an alarm dead in production.
+      # The schedule-alarm coverage property, read out of `.github/workflows/*.yml`
+      # rather than a hand-kept list. Asserts at least one workflow is scheduled (an
+      # alarm covering zero passes forever), that the `schedule:` and `cron:` reads
+      # agree, and that no workflow calls a local `uses:` that is not there.
       - run: node scripts/ci/list-scheduled-workflows.mjs
       - run: node scripts/ci/list-scheduled-workflows.test.mjs
       - run: bash scripts/ci/file-schedule-alarm.test.sh
 
-      # Keeps the above true as a PROPERTY, not a fact about today's workflows:
-      # every scheduled workflow must reach a job calling schedule-alarm.yml with
-      # `outcome: failure`, unneutralised by continue-on-error or a dead `if:`,
-      # with the title/label pair agreeing between the failure and recovery calls
-      # (a mismatch files under one key and looks itself up under another).
-      # Permissions asserted in both directions: a caller's grant is a CEILING,
-      # and the filing job must itself resolve `issues: write`.
+      # Keeps the above true as a PROPERTY: every scheduled workflow must reach a
+      # job calling schedule-alarm.yml with `outcome: failure`, unneutralised by
+      # continue-on-error or a dead `if:`, with the title/label pair agreeing
+      # between the failure and recovery calls. Permissions checked both ways — a
+      # caller's grant is a CEILING, and the filing job must resolve `issues: write`.
       - run: node scripts/ci/assert-schedule-alarm-coverage.mjs
       - run: node scripts/ci/assert-schedule-alarm-coverage.test.mjs
 
-      # Every third-party network call `.github/workflows/**` makes on the publish
-      # path goes through ONE hardened path. Four shapes: a non-loopback `run:`
-      # fetch must call fetch-pinned-release.sh; a binary-installing `uses:` must
-      # appear as a repeated-attempt group with identical `uses:` and `with:`; a
-      # registry write must call push-scanned-image.sh; a cosign invocation must
-      # call sign-image-digests.sh. The last two exist because hardening a fetch
-      # does nothing for the bare registry write next to it. The SET of actions is
-      # read out of the workflows; the per-action verdict is a reviewed row in
+      # Every third-party network call on the publish path goes through one
+      # hardened path, in four shapes: a non-loopback `run:` fetch calls
+      # fetch-pinned-release.sh, a binary-installing `uses:` appears as a
+      # repeated-attempt group, a registry write calls push-scanned-image.sh, a
+      # cosign invocation calls sign-image-digests.sh. The set of actions is read
+      # out of the workflows; the per-action verdict is a reviewed row in
       # cdn-fetch-actions.json, and an action with no row reds.
       - run: node scripts/ci/assert-hardened-cdn-fetches.mjs
       - run: node scripts/ci/assert-hardened-cdn-fetches.test.mjs
 
       # The `agent-examples/*` half of the pin story: those install from the
-      # REGISTRY on purpose, so the `workspace-pins` lint rule leaves them alone
-      # and this covers them instead. Pure functions with an injected registry
-      # answer; the live registry check runs in gate:examples below.
+      # registry on purpose, so `workspace-pins` leaves them alone and this covers
+      # them. The live registry check runs in gate:examples below.
       - run: node scripts/check-example-pins-published.test.mjs
 
       - run: npm run lint:no-cloud-imports
@@ -203,9 +181,9 @@ jobs:
       # The upstream tools/list goldens are what the divergence lane compares a
       # twin against, so a hand edit would move the answer without moving the
       # question. `--offline` re-derives meta + canonical from the committed
-      # raw.json: no network, no Go toolchain, and it reds on an edited golden or
-      # a hand-typed sha. Re-capturing from the live substrate is a separate,
-      # human-reviewed lane (`npm run capture:mcp-tools-list`).
+      # raw.json, and reds on an edited golden or a hand-typed sha. Re-capturing
+      # from the live substrate is a separate, human-reviewed lane
+      # (`npm run capture:mcp-tools-list`).
       - run: npm run gate:mcp-tools-list
       - run: node scripts/capture-mcp-tools-list.test.mjs
 
@@ -259,10 +237,9 @@ jobs:
         if: steps.scope.outputs.heavy == 'true'
         run: npm run check:manifest-schema -w @pome-sh/cli
 
-      # Consumers import sibling packages through their published `exports` (e.g.
-      # `@pome-sh/sdk/server` → dist/server.d.ts), so the workspace is built in
-      # dependency order before typecheck, test, and every gate below that
-      # imports a twin's compiled declarations.
+      # Consumers import siblings through their published `exports`, so the
+      # workspace is built in dependency order before typecheck, test, and every
+      # gate below that imports a twin's compiled declarations.
       - name: Build workspaces
         if: steps.scope.outputs.heavy == 'true'
         run: npm run build
@@ -272,21 +249,19 @@ jobs:
         run: npm run typecheck
 
       # packages/twin-*/route-inputs.json is DERIVED from each twin's route
-      # declarations and read by pome-cloud through the POME_TWIN_SRC seam.
-      # Without this it is a hand-kept list of parameter names drifting from the
-      # handlers. Needs the build: the emitter imports compiled declarations
-      # rather than reading TypeScript with a regex.
+      # declarations and read by pome-cloud. Without this it is a hand-kept list of
+      # parameter names drifting from the handlers. Needs the build: the emitter
+      # imports compiled declarations rather than regexing TypeScript.
       - name: Route-inputs artifact
         if: steps.scope.outputs.heavy == 'true'
         run: npm run gate:route-inputs
 
       # Each fixture is a PROJECTION of the upstream capture, not a transcription,
-      # so this is what catches a producer diverging from the golden it claims to
-      # be. twin-slack subtracts the tools ruled unexposed; twin-gmail subtracts
-      # nothing; twin-github is the one that can also ADD, since two tools GitHub
-      # gates behind `X-MCP-Features` cannot appear in a flags-off golden and are
-      # carried forward — so this also catches a carried row GitHub has since
-      # started declaring. The sha in each meta.json only catches a hand edit to
+      # so this catches a producer diverging from the golden it claims to be.
+      # twin-slack subtracts unexposed tools, twin-gmail subtracts nothing, and
+      # twin-github can also ADD, since two tools GitHub gates behind
+      # `X-MCP-Features` cannot appear in a flags-off golden and are carried
+      # forward. The sha in each meta.json only catches a hand edit to
       # the raw file. Needs the build: the scripts import @pome-sh/sdk.
       - name: MCP fixture gates (slack, gmail, github)
         if: steps.scope.outputs.heavy == 'true'
@@ -422,10 +397,8 @@ jobs:
           npm run smoke -w @pome-sh/twin-slack
           npm run smoke -w @pome-sh/twin-stripe
 
-      # Same shape as twin-github's validate:mcp above. Its committed output
-      # artifact could never reproduce byte-for-byte (it embedded the ephemeral
-      # port each run bound to), so this script no longer writes one — deleted
-      # rather than regenerated, because nothing read it.
+      # Same shape as twin-github's validate:mcp above, with no committed output
+      # artifact — it would embed the ephemeral port each run binds to.
       - name: MCP wire protocol (twin-slack)
         if: steps.scope.outputs.heavy == 'true'
         run: npm run validate:mcp -w @pome-sh/twin-slack

--- a/.github/workflows/quickstart-smoke.yml
+++ b/.github/workflows/quickstart-smoke.yml
@@ -46,15 +46,11 @@ jobs:
   # checkout and run `twin start github` — the same in-process boot path the
   # published `npx @pome-sh/cli` front door uses.
   #
-  # the twins here are NOT the CLI's published @pome-sh/* deps: the
-  # "Build the CLI from this checkout" step below runs
-  # scripts/use-local-pome-tarballs.mjs, which overwrites those deps with
-  # tarballs packed from packages/. So this job exercises the boot path against
-  # WORKSPACE twins, and an npx user's declared pins are never installed by any
-  # lane in this repo — do not read this job as coverage of an npx user's
-  # published pins, because it is not. What keeps workspace @pome-sh edges
-  # honest is scripts/lint/rules/workspace-pins.mjs
-  # in ci.yml (exact pins between private packages are banned; deps are `"*"`).
+  # The twins here are NOT the CLI's published @pome-sh/* deps: the build step
+  # below packs tarballs from packages/ over them. So this exercises the boot
+  # path against WORKSPACE twins, and no lane in this repo installs an npx
+  # user's declared pins — do not read this job as coverage of those. What keeps
+  # workspace @pome-sh edges honest is scripts/lint/rules/workspace-pins.mjs.
   #
   # The agent mints a JWT from the shared TWIN_AUTH_SECRET env, probes the twin's
   # /tools with it in PREFLIGHT mode (POME_PREFLIGHT=1), and exits 0. That path
@@ -97,10 +93,9 @@ jobs:
         run: |
           npm ci
           npm test
-      # `cli/` is a root workspace member: the root `npm ci` above already
-      # linked the @pome-sh/* twins out of packages/*, so the CLI builds
-      # straight from this checkout (the tarball pack/rewrite dance is gone).
-      # The root build chain builds the packages in dependency order and ends
+      # `cli/` is a root workspace member, so the root `npm ci` already linked the
+      # @pome-sh/* twins out of packages/* and the CLI builds straight from this
+      # checkout. The root build chain builds packages in dependency order and ends
       # with the CLI.
       - name: Build the CLI from this checkout
         run: npm run build

--- a/.github/workflows/release-alarm.yml
+++ b/.github/workflows/release-alarm.yml
@@ -1,71 +1,38 @@
 name: release alarm
 
 # A failed release must reach a human without a human going looking.
-#
-# `release.yml` has no failure path of its own, so a publish that died reads
+# release.yml has no failure path of its own, so a publish that died reads
 # exactly like a merge that owed no publish, and the first signal is somebody
 # noticing a package missing from npm.
 #
-# ── Why this is a SEPARATE workflow file ─────────────────────────────────
+# A separate workflow file because the alarm has to survive the thing it
+# watches: an `if: failure()` step inside release.yml cannot see the worse
+# silence, a release workflow that never triggers at all.
 #
-# The alarm has to survive the thing it watches. An `if: failure()` step inside
-# `release.yml` cannot see the worse silence — a release workflow that never
-# triggers at all takes an embedded check down with it, and reports nothing.
+# It lives here rather than in the consuming repo because `issues: write` is
+# per-repo and every recovery (re-dispatch release.yml, repair the npm Trusted
+# Publisher) is a digital-twins operation, and because one of the five publish
+# targets — @pome-sh/wire on GitHub Packages — needs a token even to READ,
+# which the ambient `packages: read` below covers.
 #
-# ── Why it lives in digital-twins and not in pome-cloud ──────────────────────
-#
-# A real choice; pome-cloud is the consumer that CARES whether `@pome-sh/checks`
-# published, and an alarm in the repo whose CI is broken can be broken by the
-# same cause. Four reasons it belongs here anyway:
-#
-#   1. Shared fate does not actually favour pome-cloud. The causes that would
-#      take this workflow down with `release.yml` — Actions disabled, billing
-#      exhausted, the org suspended — are ORG-scoped, and pome-cloud is the same
-#      org and the same billing account. Moving the alarm one repo sideways buys
-#      protection only against someone disabling Actions on this repo alone,
-#      while costing everything below. The failure class this watches for — an
-#      npm Trusted Publishing identity mismatch, a publish step that throws —
-#      lives entirely inside `release.yml` and cannot touch a
-#      separately-triggered sibling.
-#   2. The issue has to be filed where the fix happens. `issues: write` is
-#      per-repo: filing into digital-twins from pome-cloud needs a long-lived
-#      cross-repo PAT in pome-cloud's secrets — the exact credential
-#      `vocabulary-parity.yml` refused to introduce in the other direction. The
-#      alternative, filing in pome-cloud, puts the alarm in the repo that cannot
-#      act on it: every recovery (re-dispatch `release.yml`, repair the npm
-#      Trusted Publisher) is a digital-twins operation.
-#   3. One of the five publish targets is only readable from here. `@pome-sh/wire`
-#      on GitHub Packages needs a token even to READ a version, and the ambient
-#      `packages: read` below covers it exactly as `release.yml`'s `plan-wire`
-#      job does. A pome-cloud alarm would need another PAT or would carry a
-#      blind spot on a fifth of what it watches, which is the whole point.
-#   4. This repo is public, so its Actions minutes are free; pome-cloud's are
-#      billed. Smallest of the four, but it points the same way.
-#
-# ── Both directions ──────────────────────────────────────────────────────────
-#
-# Everything green produces no issue, no comment, and a green run, and a
+# Both directions: everything green produces no issue and a green run, and a
 # recovered failure CLOSES the tracking issue. An alarm that cries wolf gets
-# muted, and a stale open issue teaches people to skim past the next real one.
+# muted, and a stale open issue teaches people to skim the next real one.
 on:
   schedule:
-    # Daily, off the top of the hour to dodge GitHub's cron-queue congestion.
-    # Daily rather than hourly because the bar in the ticket is "a signal a
-    # human receives within a day", and because the outcome this checks —
-    # is the package on the registry — does not become more true at 03:00.
+    # Daily, off the top of the hour to dodge cron-queue congestion. Daily rather
+    # than hourly because the bar is a signal a human receives within a day.
     #
-    # The one thing that can silence THIS file: GitHub disables scheduled
-    # workflows in a repository after 60 days with no commits. That is a
-    # property of the repo, not of the release, and it is why `--targets` and
-    # the regression suite also run in ci.yml on every PR — a repo quiet enough
-    # to lose its cron is a repo whose release nobody is triggering either.
+    # The one thing that can silence this file: GitHub disables scheduled workflows
+    # after 60 days with no commits. That is why `--targets` and the regression
+    # suite also run in ci.yml on every PR — a repo quiet enough to lose its cron
+    # is a repo whose release nobody is triggering either.
     - cron: "37 6 * * *"
   workflow_dispatch:
-  # Changing the checker or its subject must prove the checker still parses on
-  # the PR that changes it. ci.yml runs the same two commands in its always-on
-  # block (they need no network and cannot be skipped); this arm additionally
-  # proves THIS FILE's job wiring still works, which is the part a syntax-valid
-  # workflow can get wrong and only discover at the next cron.
+  # Changing the checker or its subject must prove it still parses on the PR
+  # that changes it. ci.yml runs the same two commands; this arm additionally
+  # proves THIS FILE's job wiring works, which a syntax-valid workflow can get
+  # wrong and otherwise only discover at the next cron.
   pull_request:
     paths:
       - "scripts/ci/release-alarm.mjs"
@@ -73,10 +40,10 @@ on:
       - ".github/workflows/release-alarm.yml"
       - ".github/workflows/release.yml"
       - "scripts/ci/decide-publish.sh"
-      # the alarm's UNALLOCATED leg reads these two: the CHANGELOG
-      # grammar it parses a pending entry with, and the table that says which
-      # CHANGELOG belongs to which published package. A change to either can
-      # blind that leg without touching a file above.
+      # The UNALLOCATED leg reads these two — the CHANGELOG grammar it parses a
+      # pending entry with, and the table saying which CHANGELOG belongs to which
+      # package. A change to either can blind that leg without touching a file
+      # above.
       - "scripts/ci/changelog-entry.mjs"
       - "scripts/ci/publish-relevance.mjs"
 
@@ -94,31 +61,20 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
-      # Declared even though this repo is public and its runs are publicly
-      # readable: a `permissions:` block sets every scope it omits to `none`,
-      # and an alarm that silently 403s on the run list is an alarm that
-      # reports the release path healthy because it could not see it.
+      # Declared explicitly because a `permissions:` block sets every scope it
+      # omits to `none`, and an alarm that silently 403s on the run list reports the
+      # release path healthy because it could not see it.
       actions: read
       issues: write # the tracking issue
       packages: read # @pome-sh/wire's GitHub Packages version, as plan-wire reads it
-    # whether this job's OWN mechanism ever reached a verdict, for
-    # the meta-alarm job below. 'success' or 'failure' both mean the mechanism
-    # worked and evaluated the release, whether or not it liked what it found.
-    #
-    # ANY OTHER VALUE means it never got that far, and the meta-alarm keys off
-    # exactly that — "not one of the two verdicts" — rather than off empty.
-    # There are two distinct non-verdict values and an earlier revision of this
-    # file only handled the rarer one:
-    #   'skipped' — the step was reached but its condition was false. A step
-    #     carrying an explicit `if:` still gets an implicit `success()`, so a
-    #     failed checkout / setup-node / regression suite / --targets dead-guard
-    #     SKIPS `check` and records 'skipped'. This is the common case, and the
-    #     one the meta-alarm exists for.
-    #   '' — `steps.check` is absent from the context entirely, i.e. the job
-    #     died before the runner got to that step at all (a "Set up job"
-    #     failure, a runner fault).
-    # Note also that `check` is `continue-on-error: true`, so `outcome` (not
-    # `conclusion`) is the field that carries the real verdict.
+    # Whether this job's own mechanism ever reached a verdict, for the meta-alarm
+    # below. 'success' or 'failure' both mean it evaluated the release. Any other
+    # value means it never got that far, and the meta-alarm keys off exactly that
+    # rather than off empty, because there are two such values: 'skipped' (the
+    # step was reached but its implicit `success()` was false, so a failed
+    # checkout or regression suite skips `check`) and '' (the job died before the
+    # runner reached the step at all). `check` is `continue-on-error: true`, so
+    # `outcome`, not `conclusion`, carries the real verdict.
     outputs:
       checked: ${{ steps.check.outcome }}
     steps:
@@ -130,8 +86,7 @@ jobs:
           node-version: 24
 
       # Gate on the checker's own tests BEFORE checking, so a red run is a real
-      # claim about the release and not a broken checker. Same ordering as the
-      # deleted check-release-staleness.yml.
+      # claim about the release and not a broken checker.
       - name: Regression-test the checker
         run: node scripts/ci/release-alarm.test.mjs
 
@@ -140,11 +95,10 @@ jobs:
       - name: The publish targets are still derivable from release.yml
         run: node scripts/ci/release-alarm.mjs --targets
 
-      # Auth for the GitHub Packages READ only — never a `@pome-sh:registry=`
-      # scope mapping, which would redirect every @pome-sh/* read (including
-      # cli's and the adapter's) to a registry where they do not exist and make
-      # each look brand new. `$HOME/.npmrc` so the token never sits in the
-      # workspace. Same shape as release.yml's plan-wire job.
+      # The GitHub Packages READ only — never a `@pome-sh:registry=` scope mapping,
+      # which would redirect every @pome-sh/* read to a registry where they do not
+      # exist and make each look brand new. In $HOME/.npmrc so the token never sits
+      # in the workspace.
       - name: Authenticate reads against GitHub Packages
         if: github.event_name != 'pull_request'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,82 +1,17 @@
 name: release
-# The single release pipeline for the five published packages, replacing
-# cli-release.yml (Changesets + a manual "publish the @pome-sh/* batch first"
-# gate that produced 16 batch releases in 14 days, 4 of them consecutive
-# failures) and sdk-publish.yml.
+# Version-diff on push to main: bump the version in a package's own
+# package.json, merge, and this workflow publishes it. The five published
+# packages version independently; there is no lockstep to enforce.
 #
-# Model: version-diff on push to main. Bump the version in the package's own
-# package.json, merge, and this workflow publishes it. Nothing to remember, no
-# version PR, no changeset files.
+# @pome-sh/wire publishes to BOTH registries from the same version line, on two
+# lanes, because the auth mechanism differs per registry: npmjs uses OIDC
+# Trusted Publishing (`id-token: write`, no token), GitHub Packages uses
+# GITHUB_TOKEN with an .npmrc auth line. Keeping them separate also keeps them
+# from breaking each other — GitHub Packages needs auth even to READ, and that
+# read failing must not skip the npmjs publishes.
 #
-# @pome-sh/cli, @pome-sh/adapter-claude-sdk and @pome-sh/checks version
-# INDEPENDENTLY (D11) and are diff-gated separately: the CLI bundles the internal
-# packages, the adapter bundles the wire types, @pome-sh/checks bundles the five
-# twins' declaration layer plus the sdk check DSL, and none depends on another's
-# published version. There is no lockstep to enforce and therefore no
-# sync-versions script.
-#
-# @pome-sh/checks is the npmjs lane's third matrix entry. It exists
-# because @pome-sh/sdk and the five @pome-sh/twin-* packages are `private: true`
-# and stay that way, which froze pome-cloud's grading vocabulary: it npm-installs
-# the check declarations and could no longer receive a correction. Publishing the
-# declaration layer on its own restores that path without reversing the
-# privatisation that keeps zod from resolving to two schema identities.
-#
-# @pome-sh/sandbox-domains is the matrix entry that takes it the rest of the
-# way, and the reason it takes a second package is worth stating once here.
-# @pome-sh/checks gives the DECLARATIONS a publish path; the RUNTIME needs its
-# own. pome-cloud boots the twin domain layer in-process, and
-# `checks-package-drift.test.ts` demands the two declare an identical binding
-# surface — so widening the vocabulary with only the declaration leg
-# publishable turns that gate red with no legal move available. Bundling the
-# domain layer the same way (tsup `noExternal`, zod as a peer) puts both legs on
-# THIS lane, cut from the same commit by the same allocator run, so a widening
-# is two pins moving in one pome-cloud PR. The twins and the sdk stay
-# `private: true`.
-#
-# @pome-sh/wire publishes to BOTH registries, independently, from the SAME
-# version line. GitHub Packages serves cross-repo internal consumers like
-# pome-cloud; npmjs is needed as well because a scope can only resolve from one
-# registry per consumer, and pome-cloud's
-# other unavoidable @pome-sh/* deps (sdk, twin-*) exist only on public npmjs, so
-# routing @pome-sh/wire there for GitHub Packages would break those. Public npm
-# has no confidentiality downside for wire — it is trace-vocabulary Zod schemas
-# with no domain logic or secrets, already audited clean when the GitHub
-# Packages target shipped. Publishing to npmjs is ADDITIVE: the GitHub Packages
-# target is untouched, and wire stays bundled-inlined into the two npmjs
-# tarballs exactly as before (tsup `noExternal`).
-#
-# Hence wire is now the npmjs lane's FOURTH matrix entry (`plan`/`publish`,
-# alongside cli/adapter/checks) AND still has its own GitHub Packages lane
-# (`plan-wire`/`publish-wire`) — not a replacement of one lane by the other:
-#
-#   - The auth MECHANISM differs per registry, not per package. npmjs uses OIDC
-#     Trusted Publishing (no token, `id-token: write`, provenance); GitHub
-#     Packages uses GITHUB_TOKEN with `packages: write` and an .npmrc auth line.
-#     One job cannot honestly do both, and a shared job would carry four pieces
-#     of OIDC cargo (the setup-node v6 pin for actions/setup-node#1551, the
-#     npm@11.5.1 pin for the provenance crash, `NPM_CONFIG_PROVENANCE`,
-#     `id-token: write`) under a comment explaining that none of it applies to
-#     the GitHub Packages publish.
-#   - The lanes must not be able to break each other. GitHub Packages requires
-#     auth even to READ, and a read failure is deliberately a hard failure (a
-#     401 must never be mistaken for "unpublished" — that would bypass the
-#     never-publish-behind-latest floor check). If that read lived in `plan`,
-#     any GitHub Packages 401/403/outage — or an org owner flipping the
-#     package's visibility settings — would fail `plan` and silently skip the
-#     @pome-sh/cli, @pome-sh/adapter-claude-sdk and @pome-sh/checks publishes,
-#     which have nothing to do with GitHub Packages. Blast radius now matches
-#     the artifact. Symmetrically, wire's npmjs decision/publish lives entirely
-#     in `plan`/`publish` so an npmjs outage cannot take down the GitHub
-#     Packages publish either.
-#   - Wire's own `publishConfig.registry` still points at GitHub Packages (and
-#     ci.yml's `gate:wire-manifest` still asserts that on every PR — it is what
-#     `publish-wire` relies on by default). The npmjs-lane `publish` step
-#     therefore passes an explicit `--registry https://registry.npmjs.org` for
-#     wire ONLY, which outranks `publishConfig`. See the comment on that step.
-#
-# The shared decision logic lives in scripts/ci/decide-publish.sh (tested by
-# scripts/ci/decide-publish.test.mjs) so the lanes cannot drift.
+# Shared decision logic is in scripts/ci/decide-publish.sh so the lanes cannot
+# drift.
 on:
   push:
     branches: [main]
@@ -106,11 +41,9 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      # Deliberately reads ONLY registry.npmjs.org (the `registry` argument is
-      # omitted below, including for wire). @pome-sh/wire's GitHub Packages diff
-      # lives separately in `plan-wire` so that a GitHub Packages 401/outage
-      # cannot skip the npmjs publishes: a failure here fails `plan`, and
-      # everything needing it is skipped. Blast radius matches the artifact.
+      # Reads ONLY registry.npmjs.org — the `registry` argument is omitted below,
+      # including for wire. wire's GitHub Packages diff lives in `plan-wire` so a
+      # GitHub Packages outage cannot skip the npmjs publishes.
       - name: Compare local versions against npm
         id: diff
         run: |
@@ -118,17 +51,13 @@ jobs:
           scripts/ci/decide-publish.sh "@pome-sh/cli" "cli/package.json" "cli"
           scripts/ci/decide-publish.sh "@pome-sh/adapter-claude-sdk" "packages/adapter-claude-sdk/package.json" "adapter"
           scripts/ci/decide-publish.sh "@pome-sh/checks" "packages/checks/package.json" "checks"
-          # @pome-sh/sandbox-domains — the grading RUNTIME, the other leg of
-          # pome-cloud's drift gate. Decided on the same lane and in
-          # the same step as @pome-sh/checks on purpose: the two are compared
-          # against each other in the consumer, so a release that moves one and
-          # not the other is exactly the failure this entry exists to prevent.
+          # Decided in the same step as @pome-sh/checks on purpose: the consumer
+          # compares the two against each other, so releasing one without the other is
+          # the failure this entry prevents.
           scripts/ci/decide-publish.sh "@pome-sh/sandbox-domains" "packages/sandbox-domains/package.json" "sandboxDomains"
-          # wire's npmjs decision — independent of, and output-named distinctly
-          # from, plan-wire's `wire` output below (that one reads GitHub
-          # Packages). Same manifest, same version line, two registries decided
-          # separately: wire could be publishable on npmjs while already
-          # up to date (or even behind) on GitHub Packages, or vice versa.
+          # wire's npmjs decision. Output-named `wireNpm`, distinct from plan-wire's
+          # `wire` (GitHub Packages): one registry can be behind while the other is
+          # current, so the two decisions cannot share a name.
           scripts/ci/decide-publish.sh "@pome-sh/wire" "packages/wire/package.json" "wireNpm"
 
   plan-wire:
@@ -136,10 +65,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      # GitHub Packages — unlike registry.npmjs.org — requires a token even to
-      # READ a version. Without this the read answers 401, and a 401 is a hard
-      # failure by design (never mistaken for "unpublished"), so this permission
-      # is what stands between the workflow and a permanently red wire release.
+      # GitHub Packages requires a token even to READ. Without this the read
+      # answers 401, which is a hard failure by design, never read as
+      # "unpublished".
       packages: read
     outputs:
       wire: ${{ steps.diff.outputs.wire }}
@@ -148,11 +76,9 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      # Auth for the GitHub Packages read, and nothing else. Deliberately ONLY
-      # the `//host/:_authToken` line and never a `@pome-sh:registry=` scope
-      # mapping — see the header of decide-publish.sh for why that distinction
-      # is load-bearing. `$HOME/.npmrc` rather than a project `.npmrc` so the
-      # token never sits inside the workspace.
+      # Only the `//host/:_authToken` line, never a `@pome-sh:registry=` scope
+      # mapping — see the header of decide-publish.sh for why. In $HOME/.npmrc so
+      # the token never sits inside the workspace.
       - name: Authenticate reads against GitHub Packages
         env:
           GITHUB_PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -180,44 +106,24 @@ jobs:
             enabled: ${{ needs.plan.outputs.cli }}
           - package: "@pome-sh/adapter-claude-sdk"
             enabled: ${{ needs.plan.outputs.adapter }}
-          # @pome-sh/checks — the grading vocabulary, for pome-cloud.
-          # Same lane, same OIDC trusted publishing, its own version line. It is
-          # the third npmjs package rather than a second GitHub Packages one
-          # because a scope can only route to one registry: pome-cloud's whole
-          # `@pome-sh` scope resolves from npmjs, so a GitHub Packages copy would
-          # need an .npmrc change it cannot make without breaking @pome-sh/cli.
+          # On the npmjs lane rather than GitHub Packages because a scope routes to
+          # one registry, and pome-cloud's whole @pome-sh scope resolves from npmjs.
           - package: "@pome-sh/checks"
             enabled: ${{ needs.plan.outputs.checks }}
-          # @pome-sh/sandbox-domains — the grading RUNTIME, and what keeps the
-          # drift gate's red a fixable condition rather than a wall.
-          # @pome-sh/checks carries the check DECLARATIONS to pome-cloud; this
-          # carries the in-process domain layer those declarations read, so
-          # `checks-package-drift.test.ts` has two legs that can both move.
-          # Both are cut from the same `main` commit by
-          # the same allocator run, which is what makes their binding surfaces
-          # agree by construction.
-          #
-          # It runs `gate:sandbox-domains-tarball` where checks runs
-          # `gate:checks-tarball`, and the two audits are NOT interchangeable —
-          # three of their assertions are deliberately inverted (this one
-          # REQUIRES the `node:sqlite` bytes the checks audit treats as an engine
-          # leak). See the header of scripts/ci/check-sandbox-domains-tarball.mjs.
+          # The runtime leg of pome-cloud's drift gate, cut from the same commit by
+          # the same allocator run as @pome-sh/checks. Its tarball audit is NOT
+          # interchangeable with the checks audit — three assertions are inverted (this
+          # one REQUIRES the node:sqlite bytes the checks audit treats as an engine
+          # leak). See scripts/ci/check-sandbox-domains-tarball.mjs.
           - package: "@pome-sh/sandbox-domains"
             enabled: ${{ needs.plan.outputs.sandboxDomains }}
-          # @pome-sh/wire — the odd one out twice over. It is on this
-          # npmjs lane ADDITIONALLY to (not instead of) its separate GitHub
-          # Packages jobs further down in this file: pome-cloud's migration off
-          # @pome-sh/shared-types needs to npm-install wire, and the rest of its
-          # unavoidable @pome-sh/* deps only exist on public npmjs, so wire has
-          # to resolve from there too. `enabled` is `wireNpm`, not `wire` — the
-          # latter is the OTHER job's GitHub Packages output; reusing that name
-          # here would silently wire this job to the wrong decision. wire's own
-          # `publishConfig.registry` still targets GitHub Packages, so its
-          # Publish step below (and only its) passes an explicit
-          # `--registry` to land on npmjs instead. It skips the
-          # `gate:checks-tarball` step (`matrix.package == '@pome-sh/checks'`
-          # only) since that audit is specific to `@pome-sh/checks`'s six-inlined-
-          # workspace tarball shape and has no wire equivalent.
+          # On this npmjs lane IN ADDITION TO its GitHub Packages jobs below, because
+          # consumers resolving the rest of the @pome-sh scope from npmjs need wire
+          # there too. `enabled` is `wireNpm`, not `wire` — the latter is the GitHub
+          # Packages output, and reusing it here wires this job to the wrong decision.
+          # wire's own publishConfig.registry targets GitHub Packages, so its Publish
+          # step below passes an explicit --registry. It skips gate:checks-tarball,
+          # which is specific to the @pome-sh/checks tarball shape.
           - package: "@pome-sh/wire"
             enabled: ${{ needs.plan.outputs.wireNpm }}
     permissions:
@@ -228,10 +134,9 @@ jobs:
         run: echo "${{ matrix.package }} version unchanged — skipping."
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: matrix.enabled == 'true'
-      # Carried over from cli-release.yml. setup-node MUST stay off v7+ for the
-      # OIDC path: v7 changed how `registry-url` writes .npmrc and breaks
-      # Trusted Publishing with ENEEDAUTH (actions/setup-node#1551). renovate.json
-      # disables major bumps for this action for the same reason.
+      # setup-node MUST stay off v7+ on the OIDC path: v7 changed how
+      # `registry-url` writes .npmrc and breaks Trusted Publishing with ENEEDAUTH
+      # (actions/setup-node#1551). renovate.json pins the major for this reason.
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v6.4.0
         if: matrix.enabled == 'true'
         with:
@@ -264,21 +169,17 @@ jobs:
       - name: Clean-room pack test
         if: matrix.enabled == 'true'
         run: npm run test:pack
-      # @pome-sh/checks is the only published package whose install would 404:
-      # it inlines six `private: true` workspace packages, so a leaked
-      # @pome-sh/* dependency is unresolvable rather than merely wrong. Also
-      # asserts the twin engine did not ride along and that zod stayed external
-      # (two zod copies = two schema identities).
+      # The only published package whose install would 404: it inlines six
+      # `private: true` workspace packages, so a leaked @pome-sh/* dependency is
+      # unresolvable. Also asserts zod stayed external — two copies means two
+      # schema identities.
       - name: Audit the @pome-sh/checks tarball
         if: matrix.enabled == 'true' && matrix.package == '@pome-sh/checks'
         run: npm run gate:checks-tarball
-      # @pome-sh/sandbox-domains inlines the same six `private: true` workspace
-      # packages, so the same leaked-dependency 404 applies — but the rest of
-      # this audit is the INVERSE of the one above: it requires the `node:sqlite`
-      # driver to be present (a runtime bundle without one has openers that
-      # cannot open), requires every bare specifier in the shipped bytes to be a
-      # declared dependency and every declared dependency to be imported, and
-      # asserts the package's export spec against the packed modules.
+      # Same leaked-dependency 404 applies, but the rest of this audit is the
+      # INVERSE of the one above: it requires the node:sqlite driver present (a
+      # runtime bundle without one has openers that cannot open), and requires
+      # every bare specifier shipped to be a declared dependency and back.
       - name: Audit the @pome-sh/sandbox-domains tarball
         if: matrix.enabled == 'true' && matrix.package == '@pome-sh/sandbox-domains'
         run: npm run gate:sandbox-domains-tarball
@@ -296,22 +197,13 @@ jobs:
             exit 1
           fi
           echo "E415 hard-link check OK: $tgz"
-      # @pome-sh/wire's own package.json sets `publishConfig.registry` to
-      # GitHub Packages (npm.pkg.github.com) as its DEFAULT — see
-      # publish-wire's "Publish to GitHub Packages" step — and ci.yml's
-      # `gate:wire-manifest` asserts that value on
-      # every PR, so it cannot be changed or removed here without failing that
-      # gate. `publishConfig` outranks the ambient registry that
-      # `registry-url: https://registry.npmjs.org` above configured, so
-      # publishing wire on THIS lane with no override would either silently
-      # attempt GitHub Packages (wrong registry, and this job never
-      # authenticates against it — ENEEDAUTH) or, if it somehow succeeded,
-      # publish wire to GitHub Packages twice while npmjs got nothing. An
-      # explicit `--registry` flag outranks `publishConfig` and is the only
-      # thing that reliably wins here — the same reasoning `publish-wire`
-      # applies in the opposite direction for defence-in-depth. cli, adapter
-      # and checks have no `publishConfig.registry`, so they fall through to
-      # the plain `npm publish` and pick up the registry `setup-node` wrote.
+      # wire's publishConfig.registry defaults to GitHub Packages, and
+      # gate:wire-manifest asserts that on every PR, so it cannot be changed here.
+      # publishConfig outranks the ambient registry setup-node configured, so
+      # publishing wire on this lane without an override would attempt GitHub
+      # Packages, which this job never authenticates against. An explicit
+      # --registry outranks publishConfig and is the only thing that wins. cli,
+      # adapter and checks have no publishConfig.registry and fall through.
       - name: Publish
         if: matrix.enabled == 'true'
         run: |
@@ -324,59 +216,37 @@ jobs:
         env:
           NPM_CONFIG_PROVENANCE: "true"
 
-      # "published" has to mean "the registry SERVES it" before anything
-      # downstream reads it, and one thing downstream reads it seconds later:
-      # `dispatch-allocate-version` fires at the end of this run, and the re-pin
-      # it triggers acts only on a version `npm view` already answers for. An
-      # answer of E404 is indistinguishable from "genuinely not published"
-      # (deliberately — see scripts/check-example-pins-published.mjs), so a read
-      # that lands before propagation makes `planExampleRepins` skip the pin, and
-      # its single-attempt budget is spent: the dispatched run no-ops, `main`
-      # stays red on the pin drift, and there is no later run to retry it,
-      # because the next PR's own required `typecheck-test` reds on the same
-      # drift. That is the deadlock this milestone exists to close, reopened by a
-      # race. So wait here, where the package and the version are known exactly,
-      # rather than sleeping blindly in the dispatch job.
+      # `dispatch-allocate-version` fires seconds after this step, and the re-pin
+      # it triggers acts only on a version `npm view` already answers for. E404 is
+      # indistinguishable from "genuinely not published", so a read landing before
+      # propagation makes the re-pin skip, spending its single-attempt budget: main
+      # stays red on the pin drift with no later run to retry it. So wait here,
+      # where the package and version are known exactly.
       #
-      # `--prefer-online` forces npm's staleness check: setup-node restored the
-      # npm HTTP cache above, and a packument is cacheable for minutes, so
-      # without it a cached copy predating this publish is a legitimate answer.
-      # Bounded at eighteen attempts × 10s ≈ 3 minutes, and it exits on the first
-      # attempt in the ordinary case: the budget is sized for the CDN's packument
-      # cache rather than for the write, which is why it is minutes and not
-      # seconds. A timeout reds a publish that already succeeded, which is the
-      # loud half of the choice — the alternative is a green run whose dispatch
-      # achieves nothing.
+      # `--prefer-online` forces npm's staleness check; setup-node restored the HTTP
+      # cache above and a packument stays cacheable for minutes. Bounded at 18
+      # attempts x 10s, sized for the CDN's packument cache rather than the write,
+      # and it exits on the first attempt in the ordinary case.
       #
-      # A TIMEOUT ALSO SUPPRESSES THE DISPATCH, and that coupling is deliberate
-      # rather than unnoticed: this is a step of `publish`, so its failure makes
-      # `needs.publish.result` 'failure' and the dispatch job below then fires
-      # only if `publish-wire` published. Decoupling it — plumbing a matrix
-      # output so the dispatch fires regardless — buys a dispatched run that
-      # would very likely no-op for the same reason this step timed out, in
-      # exchange for a job graph nobody can read. A registry that will not serve
-      # a version three minutes after accepting it is abnormal, worth a red, and
-      # the recovery is the single command this step prints.
+      # A timeout also suppresses the dispatch, deliberately: a registry that will
+      # not serve a version three minutes after accepting it is abnormal and worth a
+      # red, and the recovery is the single command this step prints.
       - name: The registry serves what we just published
         if: matrix.enabled == 'true'
         env:
           PKG: ${{ matrix.package }}
         run: |
           set -euo pipefail
-          # Asked of npm by workspace NAME, which is all the matrix carries —
-          # decide-publish.sh is handed a manifest path, and duplicating that
-          # table here is a second place for it to drift.
+          # Asked by workspace NAME, which is all the matrix carries; decide-publish.sh
+          # takes a manifest path, and duplicating that table here is a second place to
+          # drift.
           #
-          # BOTH JSON SHAPES ARE ACCEPTED, and that is not defensive padding:
-          # `npm pkg get version -w <name> --json` answers
-          # `{"<name>": "0.3.6"}` on the npm@11.5.1 this job pins two steps up
-          # (for the OIDC provenance crash) and `{"<name>": {"version": "0.3.6"}}`
-          # on npm 12. Reading only the nested shape yields `undefined`, and
-          # `npm view <pkg>@undefined` then 404s for the full budget below and
-          # reds a publish that succeeded — on every release, from a step whose
-          # whole job is to stop a silent no-op. The version is asserted to look
-          # like one rather than interpolated blind, so an npm that answers a
-          # third shape fails HERE, naming what it said.
+          # Both JSON shapes are accepted because `npm pkg get version -w <name> --json`
+          # answers {"<name>": "0.3.6"} on the npm@11.5.1 pinned two steps up and
+          # {"<name>": {"version": "0.3.6"}} on npm 12. Reading only the nested shape
+          # yields undefined, and `npm view <pkg>@undefined` then 404s for the full
+          # budget and reds a publish that succeeded. The version is asserted to look
+          # like one rather than interpolated blind, so a third shape fails HERE.
           version="$(npm pkg get version -w "${PKG}" --json | node -p 'const v=JSON.parse(require("node:fs").readFileSync(0,"utf8"))[process.env.PKG];const n=typeof v==="string"?v:v?.version;if(!/^\d+\.\d+\.\d+/.test(n??""))throw new Error("npm pkg get returned no version for "+process.env.PKG+": "+JSON.stringify(v));n')"
           for attempt in $(seq 1 18); do
             if npm view "${PKG}@${version}" version --prefer-online --registry https://registry.npmjs.org >/dev/null 2>&1; then
@@ -395,15 +265,10 @@ jobs:
           echo "to land the re-pin by hand."
           exit 1
 
-  # @pome-sh/wire → GitHub Packages. See the file header for why this is its own
-  # lane. On what it deliberately does NOT run: the `bundled-deps` lint rule and
-  # `test:pack` are assertions about the two npmjs TARBALLS (no leaked
-  # @pome-sh/* deps, five twins boot, a consumer typechecks against the shipped
-  # declarations). They say nothing about wire's own tarball, and they still run
-  # on every PR and on both npmjs publishes — which is what keeps wire's
-  # bundled-inlining role verified. Publishing wire does not change that role:
-  # cli/ and adapter/ depend on it as a devDependency and tsup inlines it, so no
-  # end user ever resolves it from a registry.
+  # @pome-sh/wire -> GitHub Packages. See the file header for why this is its
+  # own lane. It deliberately does not run `bundled-deps` or `test:pack`: those
+  # assert things about the two npmjs tarballs, not wire's own, and they still
+  # run on every PR and on both npmjs publishes.
   publish-wire:
     name: publish @pome-sh/wire (GitHub Packages)
     needs: plan-wire
@@ -414,20 +279,17 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # No `registry-url`: that would point the DEFAULT registry at GitHub
-      # Packages for the whole job and `npm ci` would try to fetch zod,
-      # typescript and vitest from there. Registry selection for wire is
-      # explicit at publish time instead.
+      # No `registry-url`: that would point the default registry at GitHub
+      # Packages for the whole job, and `npm ci` would try to fetch zod, typescript
+      # and vitest from there. Registry selection is explicit at publish time.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: npm
           cache-dependency-path: package-lock.json
       - run: npm ci
-      # wire has no internal @pome-sh/* dependency, so it is the first node in
-      # scripts/build.mjs's topological order and builds standalone. Explicit
-      # here (rather than relying on wire's own `prepublishOnly`) so a build
-      # failure reads as a build failure.
+      # Explicit rather than relying on wire's prepublishOnly, so a build failure
+      # reads as a build failure.
       - name: Build @pome-sh/wire
         run: npm run build -w @pome-sh/wire
       - name: Typecheck and test @pome-sh/wire
@@ -440,19 +302,16 @@ jobs:
       # descriptor claiming a different version than the package.json beside it.
       - name: Trace-contract descriptor matches the shipped version
         run: npm run check:trace-contract -w @pome-sh/wire
-      # wire's published dist is what a cross-repo consumer resolves through its
-      # `exports` map — an export pointing at a file the tarball does not carry
-      # is only observable from OUTSIDE the workspace, where npm's workspace
-      # symlink is not there to paper over it.
+      # An `exports` entry pointing at a file the tarball does not carry is only
+      # observable from outside the workspace, where npm's symlink cannot hide it.
       - name: Audit the wire tarball
         run: npm run gate:wire-tarball
-      # Two independent guarantees that this cannot land on registry.npmjs.org:
-      # `publishConfig.registry` in packages/wire/package.json, and this
-      # explicit `--registry`. `publishConfig` alone is enough on every npm
-      # version this repo pins, but a publish to the wrong registry is not an
-      # error you can take back — public npm has no unpublish after 72 hours.
-      # No `--access public`: on GitHub Packages access is a property of the
-      # package/repository, not a publish flag.
+      # Two independent guarantees this cannot land on registry.npmjs.org:
+      # publishConfig.registry in packages/wire/package.json, and this explicit
+      # --registry. publishConfig alone suffices on every npm version this repo
+      # pins, but a publish to the wrong registry cannot be taken back — public npm
+      # has no unpublish after 72 hours. No --access public: on GitHub Packages
+      # access is a property of the package, not a publish flag.
       - name: Publish to GitHub Packages
         env:
           GITHUB_PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -461,126 +320,60 @@ jobs:
           printf '//npm.pkg.github.com/:_authToken=%s\n' "${GITHUB_PACKAGES_TOKEN}" >> "$HOME/.npmrc"
           npm publish -w @pome-sh/wire --registry https://npm.pkg.github.com
 
-  # The moment a version lands on a registry is also the moment
-  # scripts/check-example-pins-published.mjs can go red on `main`:
-  # agent-examples/support-triage pins @pome-sh/adapter-claude-sdk from the
-  # registry, and allocate-version.yml is the only thing that re-pins it
-  # (planExampleRepins, which the allocator imports). But the two
-  # allocate-version.yml runs that bracket a publish both miss the window —
-  # the run on the human merge commit plans BEFORE the version exists on the
-  # registry, and the run on the bump commit it produces is deliberately
-  # skipped by that workflow's own `[release-bump]` guard. Nothing else is
-  # on a timer: allocate-version.yml only fires on a push to `main`, a manual
-  # dispatch, or the `repin-examples` repository_dispatch this job POSTs. So
-  # this job dispatches it at the one moment the published version demonstrably
-  # exists — right after this run's own publish, and after the step above has
-  # watched the registry actually serve it.
+  # A published version is also the moment check-example-pins-published.mjs can
+  # go red on main: agent-examples/support-triage pins from the registry, and
+  # allocate-version.yml is the only thing that re-pins it. Both
+  # allocate-version.yml runs bracketing a publish miss the window — one plans
+  # before the version exists, the other is skipped by the [release-bump] guard
+  # — so this job dispatches it at the one moment the version demonstrably
+  # exists.
   #
-  # Depends on `publish`/`publish-wire` ONLY, not `plan`/`plan-wire`: those two
-  # are what "did anything get published" is a fact about, and naming a plan job
-  # here would let a plan-side failure that already skipped its own publish job
-  # take this one down through a dependency it was never given. A failed dispatch
-  # can never reach backwards into publishing either: nothing downstream of
-  # `publish`/`publish-wire` consumes this job's outcome, so it cannot
-  # un-publish, retry, or block either lane — it can only fire, or fail loudly,
-  # after they are already done.
+  # Depends on `publish`/`publish-wire` only, not the plan jobs: those two are
+  # what "did anything get published" is a fact about. Nothing downstream
+  # consumes this job's outcome, so it cannot un-publish, retry or block either
+  # lane.
   #
-  # `if:` is deliberately OR, not AND, and reads only the two publish jobs'
-  # `.result` (not their per-package outputs): a matrix job's `.result` is
-  # 'success' as long as every ENABLED leg passed, so a matrix where most
-  # packages were skipped (nothing to publish for them) still reports
-  # 'success' and must not suppress this. Symmetrically, a job with nothing
-  # enabled at all is 'skipped', not 'success', so "nothing published" (both
-  # skipped) correctly evaluates to false.
+  # `if:` is OR and reads only `.result`, not per-package outputs: a matrix job
+  # whose enabled legs all passed is 'success' even when most packages were
+  # skipped, while a job with nothing enabled is 'skipped'. So "nothing
+  # published" correctly evaluates to false.
   #
-  # `!cancelled()` IS LOAD-BEARING AND IS NOT DECORATION. Without a status-check
-  # function anywhere in an `if:`, GitHub applies its default requirement that
-  # every job in `needs:` SUCCEEDED — and one of these two lanes is skipped on
-  # almost every release, because `publish-wire` only runs when wire's GitHub
-  # Packages version moved and `publish` only when an npmjs version did. So the
-  # OR below would never have been reached in the ordinary case: the job would
-  # have been dropped for depending on a skipped lane, reading as a clean
-  # "skipped" in the UI while the re-pin it exists to trigger silently never
-  # happened. `!cancelled()` is what makes this job's own condition the thing
-  # that decides. The consequence to state plainly, because it is a widening:
-  # `publish` FAILING no longer suppresses this job when `publish-wire`
-  # succeeded, and that is correct rather than tolerated — the matrix does not
-  # fail fast, so a run where the adapter published and the CLI failed has
-  # already put a version on the registry that `agent-examples/*` is now drifted from.
-  # Suppressing the re-pin there would leave `main` red on the drift as well as
-  # on the failure.
+  # `!cancelled()` is load-bearing. Without a status-check function in an `if:`,
+  # GitHub requires every `needs:` job to have SUCCEEDED — and one of these two
+  # lanes is skipped on almost every release, so this job would be dropped and
+  # read as a clean "skipped" while the re-pin silently never happened. The
+  # consequence is a widening: `publish` failing does not suppress this job when
+  # `publish-wire` succeeded. That is correct — the matrix does not fail fast, so
+  # a partial run has already put a version on the registry that
+  # agent-examples/* is drifted from.
   #
-  # LOOP TERMINATION, and it deliberately does not rest on the `[release-bump]`
-  # marker, because on the event this job POSTs that marker cannot be read at
-  # all: `github.event.head_commit` exists only on a push, so
-  # allocate-version.yml's guard is scoped to `push` explicitly and the dispatch
-  # arm ALWAYS runs — which is required, since the tip it is dispatched from is
-  # itself a `[release-bump]` commit. What terminates the chain is that a
-  # dispatch costs a publish:
+  # Loop termination rests on a dispatch costing a publish, not on the
+  # [release-bump] marker (github.event.head_commit exists only on a push, so
+  # the dispatch arm always runs). This job fires only when something published,
+  # which needs a local version differing from the registry's. The dispatched
+  # run pushes at most one commit; if it is re-pin-only it moves no package
+  # version, so the next run publishes nothing and this job's `if:` is false. If
+  # it does move a version it consumed a pending `## Unreleased` entry, and
+  # nothing in CI writes entries, so the chain is bounded by what a human
+  # merged.
   #
-  #   1. This job fires only when `publish`/`publish-wire` actually published,
-  #      which needs a local version differing from the registry's.
-  #   2. The dispatched run pushes at most ONE commit. If it is re-pin-only it
-  #      touches `agent-examples/*` manifests and their lockfiles — no package version
-  #      — so the `plan`/`plan-wire` of the run that commit triggers find every
-  #      version equal to the registry's (the wait step above proved it is
-  #      served), publish nothing, and this job's `if:` is false. Chain over.
-  #   3. If that commit DOES move a version, it did so by consuming a pending
-  #      `## Unreleased` entry, and nothing in CI writes entries. So each further
-  #      iteration strictly consumes one, and the chain is bounded by the entries
-  #      a human merged.
-  #
-  # allocate-version.yml's push arm still skips a `[release-bump]` head commit,
-  # so the commit the dispatched run pushes does not also start an allocation of
-  # its own through the push arm. The two mechanisms are independent and neither
-  # is load-bearing alone.
-  #
-  # allocate-version.yml's `concurrency: allocate-version-${{ github.ref }}`
-  # covers a `repository_dispatch` the same as a `push`: GitHub sets `ref` to the
-  # default branch on that event, so both resolve to the same
-  # `allocate-version-refs/heads/main` group and a dispatch queues behind any
-  # allocation already in flight on `main` rather than racing it.
-  #
-  # It does NOT mean nothing is ever cancelled, and the honest version matters
-  # more than the reassuring one: GitHub keeps only the NEWEST pending run per
-  # group, so a dispatch arriving while a run is in progress and another is
-  # already pending displaces that pending run — and is itself displaceable by a
-  # later merge. What makes that safe is not the queue, it is that the allocator
-  # is a pure function of `main`'s tip: whichever run does start re-derives both
-  # the allocations and the re-pins from the tip, so a displaced run's work is
-  # not lost, it is recomputed. A future reader who instead relies on "nothing is
-  # cancelled" will mis-reason about exactly this.
+  # allocate-version.yml's concurrency group covers a repository_dispatch the
+  # same as a push, so a dispatch queues behind an allocation in flight. It does
+  # not mean nothing is cancelled: GitHub keeps only the newest pending run per
+  # group. What makes that safe is that the allocator is a pure function of
+  # main's tip, so a displaced run's work is recomputed rather than lost.
   dispatch-allocate-version:
     name: dispatch allocate-version.yml after a publish
     needs: [publish, publish-wire]
     if: ${{ !cancelled() && (needs.publish.result == 'success' || needs.publish-wire.result == 'success') }}
     runs-on: ubuntu-latest
     steps:
-      # Same app, same mint step as allocate-version.yml's own. The
-      # `pome-ops-push` installation (app_id 4582446, org
-      # installation 153466692) holds exactly `contents: write` +
-      # `metadata: read`, and `POST /repos/{owner}/{repo}/dispatches` — GitHub's
-      # documented requirement for the repository_dispatch event — is a
-      # `contents: write` endpoint, so this works with the grant that already
-      # exists and needs no re-approval of the app.
-      #
-      # This is the whole reason the event below is a `repository_dispatch` and
-      # not the `workflow_dispatch` this job first shipped as: `POST
-      # /repos/…/actions/workflows/{id}/dispatches` needs `actions: write`, which
-      # this installation does not have, so that version would have 403'd on
-      # every single release — loud, but strictly worse than the drift it exists
-      # to fix, since it also reds release.yml.
-      #
-      # Why not the ambient `GITHUB_TOKEN` with a job-level `actions: write`,
-      # which would need no app at all: dispatch events are the ONE documented
-      # exception to `GITHUB_TOKEN` event suppression (GitHub changelog,
-      # 2022-09-08 — `workflow_dispatch` and `repository_dispatch` from
-      # `GITHUB_TOKEN` do start runs, unlike a push), so that would in fact
-      # work. It is not used because it would mean granting the ambient token
-      # write scope inside the publishing workflow to save minting a token this
-      # repository already mints for the release path — and because the release
-      # path resting on a carve-out to a rule the rest of this file depends on
-      # is a worse thing to have to remember. The app token needs no carve-out.
+      # Same app and mint step as allocate-version.yml's own. The pome-ops-push
+      # installation holds `contents: write` + `metadata: read`, and
+      # `POST /repos/{owner}/{repo}/dispatches` is a `contents: write` endpoint, so
+      # this needs no re-approval of the app. That is why the event below is a
+      # repository_dispatch: the workflow_dispatch endpoint needs `actions: write`,
+      # which this installation does not have.
       - name: Mint a pome-ops-push installation token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -588,10 +381,9 @@ jobs:
           app-id: ${{ secrets.OPS_APP_ID }}
           private-key: ${{ secrets.OPS_APP_PRIVATE_KEY }}
       # `gh api`, not `gh workflow run`: the latter is the `actions: write`
-      # endpoint. The `event_type` must match allocate-version.yml's
+      # endpoint. `event_type` must match allocate-version.yml's
       # `repository_dispatch: types:` exactly — a mismatch is a 204 that starts
-      # nothing, the silent no-op this job cannot afford, so the two are asserted
-      # against each other in scripts/ci/decide-publish.test.mjs.
+      # nothing, so the two are asserted against each other in decide-publish.test.mjs.
       - name: Dispatch allocate-version.yml
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,8 +288,10 @@ jobs:
           cache: npm
           cache-dependency-path: package-lock.json
       - run: npm ci
-      # Explicit rather than relying on wire's prepublishOnly, so a build failure
-      # reads as a build failure.
+      # wire has no internal @pome-sh/* dependency, so it is the first node in
+      # scripts/build.mjs's topological order and builds standalone — which is
+      # what makes a single-package build sufficient here. Explicit rather than
+      # relying on wire's prepublishOnly, so a build failure reads as one.
       - name: Build @pome-sh/wire
         run: npm run build -w @pome-sh/wire
       - name: Typecheck and test @pome-sh/wire

--- a/.github/workflows/repo-policy.yml
+++ b/.github/workflows/repo-policy.yml
@@ -27,7 +27,7 @@ on:
     paths:
       - "scripts/ci/assert-repo-policy.sh"
       - "scripts/ci/assert-repo-policy.test.mjs"
-      # the required-context list moved here; this script now reads it.
+      # The required-context list this script reads.
       - "config/required-checks.json"
       - ".github/workflows/repo-policy.yml"
       - ".github/workflows/dependency-review.yml"
@@ -53,15 +53,13 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: bash scripts/ci/assert-repo-policy.sh
 
-  # A cron that fires, fails and tells nobody is the failure this job closes:
-  # it sees the failure in the same run `assert` failed in. See
-  # schedule-alarm.yml for why an embedded failure() job, not a second
-  # separately-cron'd file, is the right shape here.
-  # Gated on the events that actually run the live drift check, rather than on
-  # `!= 'pull_request'`. The live check runs on every event, but stating the
-  # positive set here still means a future event
-  # (e.g. `push:`) cannot silently start filing (or, worse, CLOSING) this
-  # alarm before someone decides it should.
+  # A cron that fires, fails and tells nobody is the failure this job closes: it
+  # sees the failure in the same run `assert` failed in. See schedule-alarm.yml
+  # for why an embedded failure() job is the right shape here.
+  #
+  # Gated on the events that actually run the live drift check rather than on
+  # `!= 'pull_request'`, so a future event cannot silently start filing — or,
+  # worse, CLOSING — this alarm before someone decides it should.
   schedule-alarm:
     needs: assert
     if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')

--- a/.github/workflows/schedule-alarm.yml
+++ b/.github/workflows/schedule-alarm.yml
@@ -3,53 +3,23 @@ name: schedule alarm
 # A scheduled workflow that fails tells nobody: the error can be precise and
 # actionable and still cost a human reading Actions run history by hand.
 #
-# This is the reusable workflow every schedule-triggered workflow in this repo
-# calls from a `failure()`-guarded job: constant title, one long-lived tracking
-# issue reused across consecutive failures (never a new issue per run), one
-# label per alarm so unrelated alarms never collide on the same issue, and a
-# body naming what failed plus the run URL. Green is asserted as hard as red:
-# recovery CLOSES the tracking issue, the same stance
-# scripts/ci/release-alarm.mjs takes for the release path.
+# The reusable workflow every schedule-triggered workflow here calls from a
+# `failure()`-guarded job: constant title, one long-lived tracking issue reused
+# across consecutive failures, one label per alarm so unrelated alarms never
+# collide, and a body naming what failed plus the run URL. Green is asserted as
+# hard as red — recovery CLOSES the tracking issue.
 #
-# ── Why a `failure()`-guarded call here is enough, and NOT a second
-#    separately-cron'd file like release-alarm.yml ──────────────────────────
+# An embedded `failure()` job is enough here, where release-alarm.yml needs its
+# own cron, because the failure modes differ. release.yml is push-triggered and
+# a push that triggers no run at all is invisible to a step inside the workflow
+# that never ran. A cron that fires reliably and FAILS is visible in its own
+# run, with the step-level error text already in the job env.
 #
-# `release-alarm.yml` is a separate file on its OWN daily cron because
-# `release.yml` is PUSH-triggered and has no failure path of its own: a push
-# that triggers no run at all is invisible to an `if: failure()` step living
-# inside the workflow that never ran. The watcher has to survive the thing it
-# watches.
-#
-# `repo-policy.yml` is a different shape. Its failure mode is NOT "never
-# triggers" — its weekly cron fires reliably; the gap is that a run FIRES,
-# FAILS, and nobody is told. A `failure()`-guarded job inside the same workflow
-# file sees that failure in the same run, for free, with the actual step-level
-# error text available in its own job env to put in the alarm body. Embedding
-# is proportionate to that failure mode.
-#
-# The theoretical case release-alarm.yml's separateness DOES guard against —
-# GitHub disabling a repository's scheduled workflows after 60 days with no
-# commits — is a risk this repo already carries and has already accepted for
-# release-alarm.yml itself (see that file's own comment): a repo quiet enough
-# to lose its cron is a repo whose release path nobody is exercising either.
-# Embedding the alarm in repo-policy.yml does not make that pre-existing,
-# accepted risk any worse. The other half of "never fires" — a
-# future edit that deletes or breaks a workflow's own `schedule:` block or its
-# alarm job — is a code-review-time regression, not a runtime outage, and
-# belongs to the static CI check over the workflow files themselves, which gets
-# feedback on the PR that causes it rather than waiting for a missed cadence.
-#
-# `release-alarm.yml` is itself schedule-triggered and therefore inside this
-# same property, but its subject (does every version main declares reach its
-# registry) is unrelated to whether ITS OWN mechanism is intact — a checkout
-# failure, a broken regression suite, or a `release-alarm.mjs` throw before
-# it reaches a verdict is a different fact than "the release is not
-# delivering," and conflating the two would mean the mechanism's own outage
-# reports as a release problem. So release-alarm.yml calls this same reusable
-# workflow too, from a job gated on its `check` step never having been
-# reached at all (see the `meta-alarm` job there) — reusing this file rather
-# than inventing a second mechanism, per the same "no hand-maintained second
-# copy" reasoning as everything else in this milestone.
+# release-alarm.yml is itself schedule-triggered and so inside this property.
+# Its subject (does every version main declares reach its registry) is a
+# different fact from whether its own mechanism is intact, and conflating the
+# two would report a checkout failure as a release problem — so it calls this
+# same workflow from a job gated on its `check` step never having been reached.
 on:
   workflow_call:
     inputs:
@@ -75,13 +45,11 @@ permissions:
   contents: read
 
 jobs:
-  # Deliberately NO `if:` on the outcome value. An `if: inputs.outcome ==
-  # 'failure' || == 'success'` would look like input validation and act as the
-  # opposite: a caller that passes `Failure`, or an expression that resolves to
-  # '', would SKIP this job, render a green skipped check, and leave that alarm
-  # dead with no signal anywhere. Letting the job run means
-  # file-schedule-alarm.sh's own `exit 1` on an unrecognised OUTCOME is
-  # reachable and reds the run.
+  # Deliberately NO `if:` on the outcome value. Validating it here would act as
+  # the opposite: a caller passing `Failure`, or an expression resolving to '',
+  # would SKIP this job, render a green skipped check, and leave that alarm dead
+  # with no signal anywhere. Letting the job run keeps
+  # file-schedule-alarm.sh's own `exit 1` on an unrecognised OUTCOME reachable.
   alarm:
     name: file or close the tracking issue
     runs-on: ubuntu-latest

--- a/.github/workflows/twin-image.yml
+++ b/.github/workflows/twin-image.yml
@@ -195,24 +195,20 @@ jobs:
           exit-code: '1'
           ignore-unfixed: true
           trivyignores: .trivyignore
-      # anchore/sbom-action fetches the syft binary from the anchore
-      # release CDN (github.com/anchore/syft/releases) on every run, with no
-      # retry of its own, so a 503 there kills this job. On a PR that is noise,
-      # but on main the cosign sign/attest steps below DO run, so the same 503
-      # fails an image publish.
+      # anchore/sbom-action fetches the syft binary from the anchore release CDN on
+      # every run with no retry of its own, so a 503 there kills this job — and on
+      # main the cosign steps below do run, so it fails an image publish.
       #
-      # An action step cannot be wrapped in a shell retry loop, so the retry is
-      # the STEP, repeated. Attempts 1 and 2 are `continue-on-error`; each later
-      # attempt runs only `if:` the earlier ones actually FAILED (a skipped
-      # step's outcome is `skipped`, never `failure`, so the chain cannot
-      # self-trigger). The last attempt carries no escape hatch, so a genuinely
-      # unavailable CDN still refuses the publish — this is persistence, not a
-      # relaxed policy.
+      # An action step cannot be wrapped in a shell retry loop, so the retry is the
+      # STEP, repeated. Attempts 1 and 2 are `continue-on-error`; each later attempt
+      # runs only if the earlier ones actually FAILED (a skipped step's outcome is
+      # `skipped`, never `failure`, so the chain cannot self-trigger). The last
+      # attempt carries no escape hatch.
       #
       # Every copy MUST carry byte-identical `uses:` and `with:` — a retry that
-      # installs a different build, or writes a different output file, is not a
-      # retry. scripts/ci/assert-hardened-cdn-fetches.mjs enforces that, the
-      # attempt count, and the fatal last attempt.
+      # installs a different build is not a retry.
+      # scripts/ci/assert-hardened-cdn-fetches.mjs enforces that, the attempt count,
+      # and the fatal last attempt.
       - name: Generate image SBOM (attempt 1 of 3)
         id: sbom_1
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
@@ -262,30 +258,18 @@ jobs:
         run: |
           echo "::error::twin-${{ matrix.twin }}: could not generate the image SBOM after 3 attempts. anchore/sbom-action fetches the syft binary from the anchore release CDN (github.com/anchore/syft/releases), and that CDN is unavailable — this is not a failure of the twin, the build or the scan. Failing closed on purpose: an image with no SBOM is never signed, attested or pushed."
           exit 1
-      # cosign v2. The v3.0.6 bump (attempted RFC3161-timestamped signatures)
-      # was reverted: it gave no benefit — the pome-cloud deploy gate hard-gates
-      # only the image SIGNATURE, which verifies on un-timestamped v2 signatures
-      # too because the hashedrekord Rekor SET anchors the expired Fulcio cert
-      # (the SPDX attestation is best-effort there). And
-      # cosign v3 `attest --type spdx` rejected the anchore SBOM predicate
-      # ("invalid attestation: decoding json"), failing the sign step on every
-      # v3 run and producing NO attestation. v2 signs + attests cleanly.
+      # cosign MUST stay pinned to a v2.x binary: v3 `attest --type spdx` rejects
+      # the anchore SBOM predicate ("invalid attestation: decoding json"), failing
+      # the sign step and producing NO attestation. The installer action's default
+      # binary version tracks the action's own major, so bumping the action alone
+      # silently drifts the binary to v3 — pinning it here decouples the two.
       #
-      # `cosign-release` MUST stay pinned to a v2.x binary. The installer
-      # action's DEFAULT cosign version tracks the action major (v3.x installer
-      # → cosign v2 default; v4.x installer → cosign v3 default), so an automated
-      # bump of the action alone silently drifts the binary to v3 and
-      # reintroduces the failure above. Pinning the binary here decouples us
-      # from the action version.
-      #
-      # Repeated for the same reason as the SBOM group above: this
-      # installer's whole job is to pull the cosign binary off the sigstore
-      # release CDN, and it sits on the publish path one step before signing.
-      # ⚠️ ALL THREE COPIES MUST CARRY THE SAME `cosign-release: 'v2.6.4'`.
-      # A retry that installs a different cosign is not a retry, and v3 is the
-      # exact version the comment above rules out.
-      # scripts/ci/assert-hardened-cdn-fetches.mjs reds if the three `with:`
-      # blocks ever disagree.
+      # Repeated for the same reason as the SBOM group above: this installer's whole
+      # job is to pull cosign off the sigstore release CDN, one step before signing.
+      # All three copies must carry the same `cosign-release`; a retry that installs
+      # a different cosign is not a retry.
+      # scripts/ci/assert-hardened-cdn-fetches.mjs reds if the three `with:` blocks
+      # ever disagree.
       - name: Install cosign (attempt 1 of 3)
         id: cosign_install_1
         if: ${{ github.event_name != 'pull_request' }}
@@ -323,24 +307,21 @@ jobs:
         run: |
           echo "::error::twin-${{ matrix.twin }}: could not install cosign after 3 attempts. sigstore/cosign-installer fetches the pinned cosign v2.6.4 binary from the sigstore release CDN (github.com/sigstore/cosign/releases), and that CDN is unavailable — this is not a failure of the twin, the build or the scan. Failing closed on purpose: an image that cannot be signed and attested is not pushed."
           exit 1
-      # Push the EXACT image built + scanned above (already loaded into the local
-      # daemon under every steps.meta.outputs.tags) — no second build, so the
+      # Push the EXACT image built and scanned above — no second build, so the
       # published artifact is byte-identical to the one Trivy scanned. PR builds
-      # verify + scan but never push; only main / tag pushes publish. Without
-      # this gate the GITHUB_TOKEN from a fork or unauthorized actor could poison
-      # the image. `github.event_name` is the PR-vs-push signal that survives
-      # merge-queue retargeting.
+      # verify and scan but never push; without that gate a fork's GITHUB_TOKEN
+      # could poison the image. `github.event_name` is the PR-vs-push signal that
+      # survives merge-queue retargeting.
       #
-      # GHCR can log every layer as `Pushed`, then answer `unknown blob` and
-      # exit 1 — a tag that never existed, with a green-looking push behind it.
-      # So the retry, the per-tag manifest read-back and the fail-closed message
-      # live in scripts/ci/push-scanned-image.sh rather than inline here, and
-      # scripts/ci/assert-hardened-cdn-fetches.mjs (shape c) reds on a registry
-      # write that does not go through that helper.
+      # GHCR can log every layer as `Pushed`, then answer `unknown blob` and exit 1
+      # — a tag that never existed behind a green-looking push. So the retry, the
+      # per-tag manifest read-back and the fail-closed message live in
+      # scripts/ci/push-scanned-image.sh, and assert-hardened-cdn-fetches.mjs
+      # (shape c) reds on a registry write that skips that helper.
       #
-      # Tags arrive through `env:`, not `${{ }}` interpolated into the script,
-      # matching the sign step below: a registry/tag string spliced into a shell
-      # body is one metadata-action change away from being a shell body.
+      # Tags arrive through `env:`, not interpolated into the script: a registry/tag
+      # string spliced into a shell body is one metadata-action change away from
+      # being a shell body.
       - name: Push scanned image
         if: ${{ github.event_name != 'pull_request' }}
         env:


### PR DESCRIPTION
Stacked on #469, which touches the same `ci.yml`.

The CI config was **50% commentary** — 1,261 comment lines against 1,263 lines of YAML. It is now **8%**: 792 lines removed, ~110 written back.

There is no unused CI to remove. All 11 workflows are wired and trigger-reachable, and the three self-tests that run twice on a PR are deliberate — the second arm proves that workflow's own job wiring, which a syntax-valid workflow can get wrong and otherwise only discover at the next scheduled run. What was unused is the prose.

## Method

A classifier tracked block scalars and the heredocs inside them, so only comments **outside** a `run:` body were touched. The 48 shell comments inside block scalars are untouched, as is every heredoc. Then headers were written back from scratch rather than edited down — editing an essay down leaves an essay.

## What came back

One header per workflow, plus eight single-step notes for traps that would otherwise be deleted by someone who could not see why they mattered:

- `!cancelled()` on the dispatch job. Without a status-check function GitHub requires every `needs:` job to have SUCCEEDED, and one of those two lanes is skipped on almost every release — so the job would be dropped, read as a clean skip, and the re-pin it exists to trigger would silently never happen.
- The checkout ref is per arm: on a push it is main's moving tip, on a `pull_request` it is the merge ref, because a checkout of main contains none of the PR's own files.
- `setup-node` stays off v7 (ENEEDAUTH on the OIDC path) and npm stays pinned (provenance crash).
- GitHub Packages needs `packages: read` even to read, and that read failing is a hard failure by design.
- The publish matrix must not fail fast: a half-published set is worse than one failure.

## What did not come back

Paragraph-length step commentary, the case for which repository a file should live in, arguments against designs that were never shipped, and retrospective notes on triggers described against versions that no longer exist.

## Why this is safe

Comment-only, checked mechanically: **every non-comment, non-blank YAML line in all 11 workflows is byte-identical** to the base branch, verified file by file.

## Checks run

`actionlint`, and every gate that parses `.github/workflows/**` — scheduled-workflow enumeration, schedule-alarm coverage, hardened CDN fetches, the allocate token path, release-target derivation — each with its self-test.