### PR TITLE
clean up scripts/ci/

### DIFF
--- a/scripts/ci/allocate-release-versions.mjs
+++ b/scripts/ci/allocate-release-versions.mjs
@@ -1,76 +1,13 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// The number is written here, on main, after the merge.
+// Writes the version numbers main's tip has earned. Owed if EITHER a pending
+// `## Unreleased (level)` entry exists OR a publish-relevant path moved since
+// the last commit that changed the version.
 //
-// A version line hand-written in a PR invalidates every other open PR that
-// pinned it, silently, because those PRs stay green — their CI ran before the
-// merge. Writing it on the tip instead removes the whole class.
-//
-// The tempting alternative, recorded because it is cheaper and will be
-// suggested again: have PRs write a placeholder and compute the real number at
-// publish time from the registry's `latest`. It makes release.yml's `plan` job
-// vacuous — "behind the registry is a hard failure" becomes structurally
-// impossible to trip, so that check passes forever without being able to fire.
-//
-// This script is the whole of "the pipeline writes it". `.github/workflows/
-// allocate-version.yml` runs it on every push to `main`; it writes version lines
-// and CHANGELOG headings, and commits. `release.yml` is untouched: it still
-// diffs each package's local manifest against its registry on push to `main`,
-// still hard-fails on behind-npm, still baselines a never-seen package at 0.0.0.
-// The bump commit is a push to `main`, so it is that commit's own `release.yml`
-// run that publishes.
-//
-// ── WHAT EARNS A NUMBER ──────────────────────────────────────────────────────
-//
-// A package is owed a release if EITHER holds:
-//
-//   pending    — its CHANGELOG has an `## Unreleased (patch|minor)` section.
-//                Someone asked for a release in words; that is a request in its
-//                own right, even for a change no path rule would notice.
-//   relevance  — a publish-relevant path of that package moved since the last
-//                commit that changed its version (`publish-relevance.mjs` owns
-//                which paths those are, including the wire→cli/adapter/checks
-//                coupling). This is the half that cannot be forgotten: the
-//                failure this apparatus exists to prevent is a fix that merges
-//                clean and never reaches a consumer, and a rule that only fires
-//                when someone remembered to write prose reintroduces it.
-//
-// The LEVEL is never inferred. It comes from the pending heading, and a package
-// owed a release with no pending entry gets a patch plus an entry naming the
-// commits — see `derivedEntry()` for why that is written rather than refused.
-//
-// ── THE THREE PROPERTIES THAT HOLD ──────────────────────────────────────────
-//
-// 1. THE BUMP COMMIT CANNOT RE-TRIGGER A PUBLISH LOOP. Relevance is measured
-//    from `lastVersionChange()` — the newest commit that moved that package's
-//    version — and the bump commit IS such a commit. So one push after a
-//    release, the range is empty and the pending entry it consumed is gone: the
-//    allocator is a no-op on its own output. That is structural, not a marker
-//    match. Two further, independent guards sit on top of it: a `CHANGELOG.md`
-//    is not a publish-relevant path (`publish-relevance.mjs` explains why), and
-//    allocate-version.yml skips a push whose head commit carries the marker
-//    below. Either one alone would stop the loop; none of them is load-bearing
-//    alone.
-//
-// 2. TWO PRs MERGING CLOSE TOGETHER CANNOT DOUBLE-ALLOCATE. The unit of
-//    allocation is `main`'s TIP, never the pushed range: the script reads the
-//    tip's manifests and the tip's pending entries, and allocate-version.yml
-//    serialises itself with a `concurrency` group and re-runs the whole
-//    computation after any rejected push. Two merges that land inside one
-//    window get ONE number carrying both entries — which is the truth (both
-//    were on `main` when the number was cut), not a lost release.
-//
-// 3. INSERTIONS ONLY. `changelog-entry.mjs`'s `writeRelease()` reassembles a
-//    file as `preamble + newSection + releasedRegion`, so a released entry is
-//    carried across byte-for-byte. The PR gate compares that same region against
-//    the base branch, which is the human half of the same property.
-//
-// Usage:
-//   node scripts/ci/allocate-release-versions.mjs [repo root]      # plan only
-//   node scripts/ci/allocate-release-versions.mjs --write \
-//        [--plan-out f.json] [--message-out f.txt] [--regen-out f.sh] [repo root]
-//   env: POME_ALLOCATION_DATE=YYYY-MM-DD (tests; default: today, UTC)
+// The unit is main's TIP, never the pushed range, so two merges in one window
+// get one number. Loop safety is structural, not a marker match: relevance is
+// measured from `lastVersionChange()`, and the bump commit is one.
 
 import { execFileSync } from "node:child_process";
 import { readFileSync, realpathSync, writeFileSync } from "node:fs";
@@ -83,20 +20,8 @@ import { PUBLISHED_PACKAGES, packagesTouchedBy } from "./publish-relevance.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
-/**
- * Carried in the bump commit's subject. Read by allocate-version.yml's job-level
- * `if:` as a cheap "don't even start" — deliberately NOT the loop guard (see
- * property 1 above). If this string and the workflow's copy of it ever drift,
- * the allocator simply runs and finds nothing to do; nothing breaks.
- */
 export const BUMP_COMMIT_MARKER = "[release-bump]";
 
-/**
- * How far back to look for the commit that last moved a package's version.
- * Path-filtered, so this is 60-odd commits for a real package, and the loop
- * usually exits on the first. Exhausting it is not treated as "nothing to do":
- * see `lastVersionChange`.
- */
 const VERSION_WALK_LIMIT = 500;
 
 function git(root, args) {
@@ -107,7 +32,6 @@ function gitLines(root, args) {
   return git(root, args).split("\n").filter(Boolean);
 }
 
-/** The version a manifest declared at a ref, or null if it wasn't there. */
 function versionAt(root, ref, manifest) {
   try {
     return JSON.parse(git(root, ["show", `${ref}:${manifest}`])).version ?? null;
@@ -116,22 +40,6 @@ function versionAt(root, ref, manifest) {
   }
 }
 
-/**
- * The newest commit that CHANGED this manifest's version — the point after which
- * changed files are not yet in any release.
- *
- * "Changed the version" rather than "touched the manifest", because a Renovate
- * dependency bump touches the manifest without allocating anything, and rather
- * than "carries the marker below", because that would be blind to the hand-bump
- * era this replaces (and to a founder-bypass bump). The bump commit this script
- * writes is itself a version change, which is what makes the loop terminate.
- *
- * Returns `{ sha }`, or `{ sha: null, exhausted }` when no such commit is
- * reachable. A null answer widens the range to the whole history, which will
- * over-allocate rather than under-allocate — the deliberate direction: a
- * spurious patch release is visible and cheap, a silently skipped one is the
- * defect this file exists to prevent.
- */
 export function lastVersionChange(root, manifest) {
   const shas = gitLines(root, ["log", "--format=%H", "--", manifest]);
   for (const sha of shas.slice(0, VERSION_WALK_LIMIT)) {
@@ -140,20 +48,6 @@ export function lastVersionChange(root, manifest) {
   return { sha: null, exhausted: shas.length > VERSION_WALK_LIMIT };
 }
 
-/**
- * The entry written for a package that is owed a release and has no words —
- * today, only the coupled case: wire moved, so the CLI's, the adapter's and
- * checks' tarballs all carry different bytes and each needs a release, and
- * whoever changed wire may have had nothing to say about three other packages.
- * Version-only releases have been accepted for exactly this since
- * `cli/CHANGELOG.md` 0.21.7.
- *
- * WRITTEN, NOT REFUSED. Failing here would mean not publishing, which is the
- * silence the whole apparatus exists to end; and this repo's own convention is
- * that a gap gets named in the record rather than papered over. So the entry
- * says plainly that no words were supplied and names the commits, which is
- * where the words are.
- */
 function derivedEntry({ pkg, files, commits }) {
   const paths = [...new Set(files.map((file) => file.replace(/[^/]+$/, "")))].sort().slice(0, 6);
   return [
@@ -165,10 +59,6 @@ function derivedEntry({ pkg, files, commits }) {
   ].join("\n");
 }
 
-/**
- * What `main`'s tip owes, per package. Pure read — nothing is written unless
- * `applyAllocations()` is called with the result.
- */
 export function planAllocations({ root = resolve(HERE, "../.."), date = today(), npmView } = {}) {
   if (git(root, ["rev-parse", "--is-shallow-repository"]).trim() === "true") {
     throw new Error(
@@ -239,39 +129,6 @@ export function planAllocations({ root = resolve(HERE, "../.."), date = today(),
     });
   }
 
-  // An example that pins a `@pome-sh/*` package from the registry
-  // (today only `agent-examples/support-triage`) must never fall out of sync with
-  // that sibling's published version: a drifted pin reds
-  // `check-example-pins-published.mjs` until a human notices and opens a
-  // one-line PR. `planExampleRepins` is the part of
-  // that gate's own logic that already answers "which pins are safely fixable
-  // right now" (its `violations`: drifted AND the sibling is CONFIRMED
-  // published) — reused rather than re-implemented, discovered from
-  // `agent-examples/*/package.json` rather than a hand-kept list.
-  //
-  // Deliberately measured against the manifests ON DISK, before this run's own
-  // `writes` above are applied: a package THIS SAME run is bumping is not yet
-  // published (that happens in `release.yml`'s run of the commit this script is
-  // about to push), so `planExampleRepins`'s own registry check correctly finds
-  // it unpublished and leaves it alone — repinning to a version that does not
-  // exist yet would need a lockfile entry `npm install --package-lock-only`
-  // cannot resolve, and a manifest pin with no matching lockfile entry breaks
-  // `npm ci` for that example outright, which is worse than the drift this
-  // exists to fix. That version's example pin gets corrected on the FIRST
-  // subsequent run of this workflow after `release.yml` actually publishes it —
-  // still fully automatic, still no human PR, just one push later.
-  //
-  // ONE guard around the whole call, rather than a guard per throw site. A
-  // re-pin is cosmetic; an allocation is not — and this function runs on every
-  // push to `main`, so ANY throw from the example walk stops EVERY package's
-  // release over one example directory. The reachable vectors today are already
-  // more than one (an ambiguous pin, a malformed `agent-examples/*/package.json` that
-  // `discoverExampleSiblingDeps` `JSON.parse`s unguarded, `loadWorkspaceMembers`
-  // on an empty `workspaces` glob) and the next one arrives with the next
-  // caller, so the invariant is enforced here where it is total. The failure is
-  // loud — `notes` is printed as `::warning::` — and the read-side gate in
-  // `ci.yml` still reds on whatever the example is doing wrong, so nothing is
-  // swallowed, only de-escalated to the blast radius it should have had.
   let repins = [];
   try {
     repins = npmView ? planExampleRepins(root, npmView) : planExampleRepins(root);
@@ -285,17 +142,6 @@ export function planAllocations({ root = resolve(HERE, "../.."), date = today(),
   return { head, date, allocations, repins, notes, message: commitMessage(allocations, repins, head) };
 }
 
-/**
- * Replace the `"version": "x.y.z"` line textually rather than re-emitting
- * `JSON.stringify(manifest)`: a manifest round-tripped through JSON.parse loses
- * its key order, its indentation and its trailing newline, and the diff of a
- * release commit should be one line.
- *
- * The occurrence count is asserted rather than assumed. `String.replace` with a
- * string pattern silently replaces only the FIRST match, so a manifest that grew
- * a second `"version":` key (inside a nested config block) would have the wrong
- * one rewritten and still parse as valid JSON.
- */
 function rewriteVersion(manifest, { from, to, path }) {
   const line = (version) => `"version": "${version}"`;
   const occurrences = manifest.split(line(from)).length - 1;
@@ -329,7 +175,6 @@ function commitMessage(allocations, repins, head) {
   ].join("\n");
 }
 
-/** Applies a plan's writes. Returns the paths written. */
 export function applyAllocations(plan, { root = resolve(HERE, "../..") } = {}) {
   const written = [];
   for (const allocation of [...plan.allocations, ...plan.repins]) {
@@ -351,9 +196,6 @@ export function main(argv = process.argv.slice(2)) {
     return index >= 0 ? argv[index + 1] : null;
   };
   const flagValues = new Set(["--plan-out", "--message-out", "--regen-out"].map(flagValue).filter(Boolean));
-  // An optional positional repo root, same shape as release-alarm.mjs, so the
-  // regression suite can drive the real CLI over a throwaway repository instead
-  // of asserting against the plan function alone.
   const root = resolve(argv.find((arg) => !arg.startsWith("--") && !flagValues.has(arg)) ?? resolve(HERE, "../.."));
 
   const plan = planAllocations({ root });
@@ -377,11 +219,6 @@ export function main(argv = process.argv.slice(2)) {
   if (planOut) writeFileSync(planOut, `${JSON.stringify(plan, null, 2)}\n`);
   const messageOut = flagValue("--message-out");
   if (messageOut) writeFileSync(messageOut, plan.message);
-  // The regeneration commands are DERIVED from the table beside the artifacts
-  // they produce (wire's trace-contract.json embeds wire's own version and is
-  // byte-compared by a required gate), rather than hand-wired into the workflow
-  // YAML: a second versioned artifact should not need a workflow edit to be
-  // regenerated, and the command belongs next to the file it writes.
   const regenOut = flagValue("--regen-out");
   if (regenOut) {
     const commands = [...plan.allocations, ...plan.repins].flatMap((a) => a.regenerate);
@@ -395,11 +232,6 @@ export function main(argv = process.argv.slice(2)) {
   return plan;
 }
 
-// Realpath'd on both sides — node resolves symlinks before deriving
-// `import.meta.url`, so a bare `pathToFileURL()` of argv[1] misses through a
-// symlinked checkout (a worktree, or macOS's symlinked `/tmp`) in the same
-// silent shape, and a guard miss while invoked as this file throws
-// rather than exits 0.
 const SELF = realpathSync(fileURLToPath(import.meta.url));
 const ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";
 const invokedDirectly = ENTRY === SELF;

--- a/scripts/ci/allocate-release-versions.mjs
+++ b/scripts/ci/allocate-release-versions.mjs
@@ -241,9 +241,9 @@ export function planAllocations({ root = resolve(HERE, "../.."), date = today(),
 
   // An example that pins a `@pome-sh/*` package from the registry
   // (today only `agent-examples/support-triage`) must never fall out of sync with
-  // that sibling's published version: two incidents (adapter 0.3.4 and 0.3.6,
-  // both 2026-08-13) each reddened `check-example-pins-published.mjs` until a
-  // human noticed and opened a one-line PR. `planExampleRepins` is the part of
+  // that sibling's published version: a drifted pin reds
+  // `check-example-pins-published.mjs` until a human notices and opens a
+  // one-line PR. `planExampleRepins` is the part of
   // that gate's own logic that already answers "which pins are safely fixable
   // right now" (its `violations`: drifted AND the sibling is CONFIRMED
   // published) — reused rather than re-implemented, discovered from

--- a/scripts/ci/allocate-release-versions.mjs
+++ b/scripts/ci/allocate-release-versions.mjs
@@ -1,19 +1,17 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// THE NUMBER IS WRITTEN HERE, ON `main`, AFTER THE MERGE.
+// The number is written here, on main, after the merge.
 //
-// Every twins PR used to hand-write the shared version line, so every merge
-// invalidated every open PR that had pinned a consumed number — silently
-// (stale-green), across workspaces and humans, worse the more work ran in
-// parallel. Measured 2026-08-13: #402/#405 went stale-green overnight, five
-// renumber+force-push cycles in one batch night, 0.23.35/.36 burned unpublished.
-// The rejected alternative, recorded because it is the cheaper one and someone
-// will suggest it again: have PRs write a placeholder and compute the real
-// number at publish time from the registry's `latest`. It makes release.yml's
-// `plan` job vacuous — "behind the registry is a hard failure" becomes
-// structurally impossible to trip, so the check passes forever without ever
-// being able to fire.
+// A version line hand-written in a PR invalidates every other open PR that
+// pinned it, silently, because those PRs stay green — their CI ran before the
+// merge. Writing it on the tip instead removes the whole class.
+//
+// The tempting alternative, recorded because it is cheaper and will be
+// suggested again: have PRs write a placeholder and compute the real number at
+// publish time from the registry's `latest`. It makes release.yml's `plan` job
+// vacuous — "behind the registry is a hard failure" becomes structurally
+// impossible to trip, so that check passes forever without being able to fire.
 //
 // This script is the whole of "the pipeline writes it". `.github/workflows/
 // allocate-version.yml` runs it on every push to `main`; it writes version lines
@@ -42,7 +40,7 @@
 // owed a release with no pending entry gets a patch plus an entry naming the
 // commits — see `derivedEntry()` for why that is written rather than refused.
 //
-// ── THE THREE PROPERTIES THE TICKET ASKS FOR ─────────────────────────────────
+// ── THE THREE PROPERTIES THAT HOLD ──────────────────────────────────────────
 //
 // 1. THE BUMP COMMIT CANNOT RE-TRIGGER A PUBLISH LOOP. Relevance is measured
 //    from `lastVersionChange()` — the newest commit that moved that package's

--- a/scripts/ci/allocate-release-versions.test.mjs
+++ b/scripts/ci/allocate-release-versions.test.mjs
@@ -1,26 +1,9 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
-/**
- * Regression coverage for scripts/ci/allocate-release-versions.mjs and the
- * CHANGELOG grammar it writes through (scripts/ci/changelog-entry.mjs).
- *
- * Driven over REAL git repositories, because the three properties that matter
- * are all properties of history, not of a string:
- *
- *   - the bump commit cannot re-trigger a publish loop. Asserted by applying a
- *     plan, committing it, and re-planning: the second plan must be empty. That
- *     is the actual sequence `main` sees, and it is what a mocked git could not
- *     tell us anything about.
- *   - two merges landing inside one allocation window get ONE number carrying
- *     both entries, never two numbers or one lost entry.
- *   - insertions only: the released region of every rewritten CHANGELOG is
- *     byte-identical to the one that went in.
- *
- * Plus the refusals, because each one is a shape that must never be mistaken for
- * "nothing to do": an `## Unreleased` with no level, a pending entry below a
- * released one, a version that cannot be bumped, and a shallow clone (whose
- * truncated history would silently mis-scope which packages are owed a release).
- */
+//
+// Drives real git repositories, because both properties that matter are properties
+// of history: the bump commit cannot re-trigger a publish loop, and two merges
+// inside one allocation window cannot double-allocate.
 import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -68,7 +51,6 @@ const read = (dir, relPath) => readFileSync(join(dir, relPath), "utf8");
 const RELEASED = (name) => `## 1.0.0 — 2026-08-01\n\nThe entry ${name} already shipped.\n`;
 const changelogFor = (name) => `# ${name} — CHANGELOG\n\nHow this file works.\n\n${RELEASED(name)}`;
 
-/** A repo carrying every published package at 1.0.0, one commit deep. */
 function repo() {
   const dir = mkdtempSync(join(tmpdir(), "allocate-versions-"));
   git(dir, "init", "-q", "-b", "main");
@@ -83,13 +65,6 @@ function repo() {
   return dir;
 }
 
-/**
- * `repo()` has no root `package.json`/`agent-examples/`, so `planExample
- * Repins` is a no-op against it (proven in "the repin path is a no-op" below).
- * This adds the shape it needs: a root `workspaces` field naming
- * `ADAPTER.manifest`'s directory, and `agent-examples/support-triage` pinning the
- * adapter the same way the real tree does.
- */
 function withExamples(dir, { adapterPin }) {
   write(dir, "package.json", JSON.stringify({ name: "root", private: true, workspaces: ["packages/*", "cli"] }));
   write(
@@ -102,7 +77,6 @@ function withExamples(dir, { adapterPin }) {
   );
 }
 
-/** A `npmView` stub: only the named version of the named package is published. */
 const onlyPublished = (name, version) => (n, v) =>
   n === name && v === version ? { status: "published" } : { status: "unpublished" };
 
@@ -112,7 +86,6 @@ function commit(dir, files, message = "a merge") {
   git(dir, "commit", "-q", "--allow-empty", "-m", message);
 }
 
-/** Add a pending entry to a package's CHANGELOG, the way a PR author would. */
 function pend(dir, pkg, { level = "patch", body = "- something a consumer must know" } = {}) {
   const text = read(dir, pkg.changelog);
   const at = text.indexOf("## ");
@@ -122,7 +95,6 @@ function pend(dir, pkg, { level = "patch", body = "- something a consumer must k
 const plan = (dir, npmView) => planAllocations({ root: dir, date: DATE, npmView });
 const named = (result, name) => result.allocations.find((a) => a.name === name);
 
-/** Apply a plan and commit it the way allocate-version.yml does. */
 function land(dir, result) {
   applyAllocations(result, { root: dir });
   git(dir, "add", "-A");
@@ -160,12 +132,6 @@ console.log("changelog-entry.mjs — the grammar");
     threw,
   );
 
-  // The released region is a record, never parsed for requests: the adapter's
-  // real CHANGELOG carries a bare `## Unreleased` from the Changesets era between
-  // 0.2.3 and 0.2.2, and refusing to release over a heading from July would be
-  // this parser policing history it may not correct. A NEW one put down there is
-  // caught by the gate's insertions-only check instead, since it changes the
-  // released region.
   const withHistoricalHeading = "# c\n\n## 1.0.0\n\nshipped\n\n## Unreleased\n\n## 0.9.0\n\nolder\n";
   check(
     "a pending-ish heading inside the released region is neither a request nor an error",
@@ -173,9 +139,6 @@ console.log("changelog-entry.mjs — the grammar");
       parseChangelog(withHistoricalHeading).released.includes("## Unreleased"),
   );
 
-  // Two PRs branched off the same base can each add a section. Reddening `main`
-  // over that would rebuild a smaller treadmill, so both are honoured: highest
-  // level wins, both bodies survive.
   const twoSections =
     "# c\n\n## Unreleased (patch)\n\n- from PR one\n\n## Unreleased (minor)\n\n- from PR two\n\n## 1.0.0\n\nshipped\n";
   const merged = pendingRelease(twoSections);
@@ -207,8 +170,6 @@ console.log("nothing owed");
     check("a freshly seeded tree owes nothing", result.allocations.length === 0, JSON.stringify(result.allocations));
     commit(dir, { "README.md": "# docs only\n" }, "docs");
     check("a docs-only merge owes nothing", plan(dir).allocations.length === 0);
-    // The second, independent loop guard: a CHANGELOG is not a publish-relevant
-    // path, so editing one earns no release on its own.
     commit(dir, { [CLI.changelog]: changelogFor("@pome-sh/cli").replace("How this file works.", "Reworded.") }, "preamble");
     check("editing a CHANGELOG preamble owes nothing", plan(dir).allocations.length === 0);
   } finally {
@@ -242,12 +203,6 @@ console.log("a pending entry earns a number");
     check("the commit subject carries the loop marker", result.message.startsWith(`release: @pome-sh/cli 1.0.1 ${BUMP_COMMIT_MARKER}`), result.message);
     check("the commit body records from → to and why", result.message.includes("- @pome-sh/cli 1.0.0 → 1.0.1 (patch, entry)"), result.message);
 
-    // The whole design rests on this commit's push firing release.yml, and every
-    // one of these tokens suppresses ALL workflows for the commit that carries it
-    // — a publish that never happens, with a green run and no alarm leg able to
-    // tell it from "nothing was owed". `[release-bump]` looks enough like the
-    // family to be edited into one of them by someone tidying up, so the message
-    // is asserted rather than trusted.
     const CI_SUPPRESSING = ["[skip ci]", "[ci skip]", "[no ci]", "[skip actions]", "[actions skip]", "***NO_CI***"];
     check(
       "the commit message contains NO CI-suppressing token",
@@ -342,8 +297,6 @@ console.log("the bump commit cannot re-trigger a publish loop");
         read(dir, CLI.changelog).includes("## 1.0.1"),
     );
 
-    // And it stays terminated across the next unrelated push, which is when a
-    // marker-only guard would have let the bump commit's own diff back in.
     commit(dir, { "README.md": "# docs\n" }, "docs after a release");
     check("a later docs merge does not re-open it", plan(dir).allocations.length === 0);
   } finally {
@@ -355,8 +308,6 @@ console.log("two merges inside one window cannot double-allocate");
 {
   const dir = repo();
   try {
-    // Both PRs merge before the allocator gets to run — the exact race the old
-    // hand-written version line turned into a renumber-and-force-push cycle.
     pend(dir, CLI, { body: "- from PR one" });
     commit(dir, { "cli/src/one.ts": "export const a = 1;\n" }, "PR one (#106)");
     pend(dir, CLI, { level: "minor", body: "- from PR two" });
@@ -426,9 +377,6 @@ console.log("a shallow clone is refused, not silently mis-scoped");
 console.log("the script's own surface");
 {
   const dir = repo();
-  // Outside the repo: allocate-version.yml writes these under $RUNNER_TEMP for
-  // the same reason, and a leftover file inside the tree would show up in the
-  // `git commit -a` the workflow runs next.
   const out = mkdtempSync(join(tmpdir(), "allocate-out-"));
   try {
     pend(dir, WIRE, { body: "- wire moved" });
@@ -453,8 +401,6 @@ console.log("the script's own surface");
       readFileSync(regenOut, "utf8"),
     );
 
-    // The no-op run is the one that happens most often (every push that owes
-    // nothing), so its exit code and its files matter as much as the other.
     git(dir, "add", "-A");
     git(dir, "commit", "-qm", `release: 3 packages ${BUMP_COMMIT_MARKER}`);
     const again = spawnSync("node", [SCRIPT, "--write", "--regen-out", regenOut, dir], {
@@ -475,9 +421,6 @@ console.log("repin — a no-op without agent-examples/");
 {
   const dir = repo();
   try {
-    // repo() never creates a root package.json or agent-examples/, exactly like
-    // every OTHER fixture above — proving that stays true is what keeps this
-    // whole suite honest about the new code path touching nothing by default.
     check("no repins are planned", plan(dir).repins.length === 0);
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -488,11 +431,6 @@ console.log("repin — a broken example can never block a version allocation");
 {
   const dir = repo();
   try {
-    // The whole reason the repin call is wrapped: this runs on EVERY push to
-    // main, so a throw anywhere in the example walk would stop every package's
-    // release over one example directory. A manifest that is not valid JSON is
-    // the cheapest reachable vector (discoverExampleSiblingDeps JSON.parses it
-    // unguarded); the guard is around the call, so it covers the others too.
     withExamples(dir, { adapterPin: "0.9.0" });
     write(dir, "agent-examples/broken/package.json", "{ this is not json");
     pend(dir, CLI, { body: "- a fix consumers need" });
@@ -549,11 +487,6 @@ console.log("repin — the version THIS run allocates is never repinned to in th
 {
   const dir = repo();
   try {
-    // The adapter's OWN version is being bumped 1.0.0 -> 1.0.1 in this run
-    // (via a pending entry); support-triage still pins the OLD 1.0.0. Nothing
-    // has published 1.0.1 yet — that is release.yml's job, on this run's own
-    // future push — so repinning to it now would set a pin `npm install
-    // --package-lock-only` cannot resolve.
     withExamples(dir, { adapterPin: "1.0.0" });
     pend(dir, ADAPTER, { body: "- the adapter learned a thing" });
     git(dir, "add", "-A");
@@ -571,8 +504,6 @@ console.log("repin — the version THIS run allocates is never repinned to in th
     land(dir, result);
     check("the manifest still pins 1.0.0 after landing — nothing broke npm ci", JSON.parse(read(dir, "agent-examples/support-triage/package.json")).dependencies["@pome-sh/adapter-claude-sdk"] === "1.0.0");
 
-    // The NEXT run, once 1.0.1 is (now) published, closes the gap fully
-    // automatically — no human PR, just one push later.
     const npmViewNowNew = onlyPublished("@pome-sh/adapter-claude-sdk", "1.0.1");
     const next = plan(dir, npmViewNowNew);
     check("the next run repins to the now-published 1.0.1", next.repins.length === 1 && next.repins[0].to === "1.0.1", JSON.stringify(next.repins));
@@ -581,7 +512,7 @@ console.log("repin — the version THIS run allocates is never repinned to in th
   }
 }
 
-console.log("repin — replays the two real incidents (adapter 0.3.4 and 0.3.6, both 2026-08-13)");
+console.log("repin — replays two observed pin-drift incidents");
 for (const { from, to } of [
   { from: "0.3.3", to: "0.3.4" }, // #395
   { from: "0.3.5", to: "0.3.6" }, // #425

--- a/scripts/ci/assert-allocate-token-path.mjs
+++ b/scripts/ci/assert-allocate-token-path.mjs
@@ -1,26 +1,25 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// THE VERSION-ALLOCATING PUSH CAN ONLY EVER HAPPEN WITH THE APP TOKEN.
+// The version-allocating push can only ever happen with the app token.
 //
 // `allocate-version.yml`'s checkout carries a fallback:
 //
 //     token: ${{ steps.app-token.outputs.token || github.token }}
 //
-// That fallback exists for ONE arm — the `pull_request` arm, which plans and never
-// writes, and which on a fork has no secrets at all. Everywhere else it must be
-// unreachable, because reaching it is a silent double failure: `github-actions` can
-// never be a ruleset bypass actor (so the push is refused), and a push made with
-// `GITHUB_TOKEN` does not trigger workflows (so if it somehow landed, no
-// `release.yml` run would ever publish it). Both look like a quiet green, which is
-// the failure class this whole apparatus exists to remove.
+// That exists for ONE arm — the `pull_request` arm, which plans, never writes,
+// and on a fork has no secrets at all. Everywhere else it must be unreachable,
+// because reaching it is a silent double failure: `github-actions` can never be
+// a ruleset bypass actor, so the push is refused; and a push made with
+// `GITHUB_TOKEN` triggers no workflows, so if it somehow landed, no
+// `release.yml` run would publish it. Both look like a quiet green.
 //
-// A comment saying "this fallback is only for PRs" is not a guarantee. Four edits
-// would each make it reachable on a push, none of them obviously wrong in review:
+// A comment saying "this fallback is only for PRs" is not a guarantee. Four
+// edits would each make it reachable on a push, none obviously wrong in review:
 // dropping the precondition step, marking the precondition or the mint step
-// `continue-on-error: true`, narrowing either step's `if:` so it can be false on a
-// push, or handing the push step `github.token` directly. So the reachability is a
-// PROPERTY over the workflow text, checked here.
+// `continue-on-error: true`, narrowing either step's `if:` so it can be false
+// on a push, or handing the push step `github.token` directly. So the
+// reachability is a PROPERTY over the workflow text, checked here.
 //
 // ── WHAT IS ASSERTED, AND WHY EACH LINE HOLDS THE PROPERTY ───────────────────
 //
@@ -46,19 +45,18 @@
 //      fallback's whole reason for being; if it disappears, the fallback should go
 //      with it rather than sit there reachable-in-principle.
 //   6. The checkout ref is per arm, and its non-PR branch is `main` — the moving
-//      TIP, not the event sha, because a second merge that landed while this run
-//      queued belongs in the same release. This one is here because the first live
-//      run of this workflow died on it: an unconditional `ref: main` checks out a
-//      tree WITHOUT the PR's own files, so the plan-only arm — whose entire job is
-//      to prove this PR's allocator still runs — failed with
-//      `Cannot find module …/allocate-release-versions.test.mjs` (PR #421).
-//      Asserted only while the file has a `pull_request:` trigger to serve.
+//      TIP, not the event sha, because a second merge that landed while this
+//      run queued belongs in the same release. An unconditional `ref: main`
+//      checks out a tree WITHOUT the PR's own files, so the plan-only arm —
+//      whose entire job is to prove this PR's allocator still runs — dies with
+//      `Cannot find module …/allocate-release-versions.test.mjs`. Asserted only
+//      while the file has a `pull_request:` trigger to serve.
 //   7. Floors: the file exists, and the push-step and mint-step counts are
 //      non-zero. A checker whose subject has gone empty passes forever.
 //
 // Comment stripping is `list-scheduled-workflows.mjs`'s, not a third copy: its
-// stripper is quote-aware because a blanket `#.*$` once truncated two distinct
-// quoted values to the same mangled prefix and made a bijection compare two
+// stripper is quote-aware, because a blanket `#.*$` truncates two distinct
+// quoted values to the same mangled prefix and makes a bijection compare two
 // equal wrecks.
 //
 // Usage: node scripts/ci/assert-allocate-token-path.mjs [repo root]
@@ -262,7 +260,7 @@ export function checkAllocateTokenPath(root) {
           `bypass actor, and a push made with it does not trigger release.yml.`,
       );
     }
-    // A refusal is not a race. The first live run of this workflow spent all
+    // A refusal is not a race. Without this branch a rule violation spends all
     // three attempts reporting "a merge landed first" while main was answering
     // GH013 (classic branch protection's duplicate required-checks rule, which no
     // App can bypass). Retrying cannot fix a rule, and a retry loop that cannot
@@ -318,7 +316,7 @@ export function checkAllocateTokenPath(root) {
           `the checkout \`ref: ${step.ref}\` is unconditional while this workflow still has a ` +
             `\`pull_request:\` trigger. On that arm it checks out a tree WITHOUT the PR's own files, so ` +
             `the plan-only arm proves nothing and reds on the first missing module — which is exactly ` +
-            `how this workflow's first live run died. Use ` +
+            `how a rule violation reads as a lost race. Use ` +
             `\`\${{ github.event_name == 'pull_request' && github.ref || 'main' }}\`.`,
         );
       }

--- a/scripts/ci/assert-allocate-token-path.mjs
+++ b/scripts/ci/assert-allocate-token-path.mjs
@@ -315,8 +315,7 @@ export function checkAllocateTokenPath(root) {
         errors.push(
           `the checkout \`ref: ${step.ref}\` is unconditional while this workflow still has a ` +
             `\`pull_request:\` trigger. On that arm it checks out a tree WITHOUT the PR's own files, so ` +
-            `the plan-only arm proves nothing and reds on the first missing module — which is exactly ` +
-            `how a rule violation reads as a lost race. Use ` +
+            `the plan-only arm proves nothing and reds on the first missing module. Use ` +
             `\`\${{ github.event_name == 'pull_request' && github.ref || 'main' }}\`.`,
         );
       }

--- a/scripts/ci/assert-allocate-token-path.mjs
+++ b/scripts/ci/assert-allocate-token-path.mjs
@@ -1,65 +1,15 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// The version-allocating push can only ever happen with the app token.
+// allocate-version.yml's `steps.app-token.outputs.token || github.token`
+// fallback must stay reachable only on the plan-only pull_request arm. On a push
+// it is a silent double failure: `github-actions` can never be a ruleset bypass
+// actor, and a push made with GITHUB_TOKEN triggers no workflows, so the number
+// lands and nothing publishes it. Four one-line edits would each make it
+// reachable, so the reachability is asserted here rather than commented.
 //
-// `allocate-version.yml`'s checkout carries a fallback:
-//
-//     token: ${{ steps.app-token.outputs.token || github.token }}
-//
-// That exists for ONE arm — the `pull_request` arm, which plans, never writes,
-// and on a fork has no secrets at all. Everywhere else it must be unreachable,
-// because reaching it is a silent double failure: `github-actions` can never be
-// a ruleset bypass actor, so the push is refused; and a push made with
-// `GITHUB_TOKEN` triggers no workflows, so if it somehow landed, no
-// `release.yml` run would publish it. Both look like a quiet green.
-//
-// A comment saying "this fallback is only for PRs" is not a guarantee. Four
-// edits would each make it reachable on a push, none obviously wrong in review:
-// dropping the precondition step, marking the precondition or the mint step
-// `continue-on-error: true`, narrowing either step's `if:` so it can be false
-// on a push, or handing the push step `github.token` directly. So the
-// reachability is a PROPERTY over the workflow text, checked here.
-//
-// ── WHAT IS ASSERTED, AND WHY EACH LINE HOLDS THE PROPERTY ───────────────────
-//
-//   1. Exactly ONE mint step (`uses: actions/create-github-app-token@…`), with an
-//      `id:` (an output nothing can reference is not a token), the non-PR guard,
-//      and no `continue-on-error`. This is what makes
-//      `steps.<id>.outputs.token` non-empty on every push that reaches the
-//      checkout: the step runs, and if it fails the job stops before the checkout,
-//      because every later step inherits an implicit `success()`.
-//   2. A precondition step BEFORE the mint step, same guard, no
-//      `continue-on-error`, naming both secrets and containing `exit 1`. The mint
-//      action fails on empty inputs by itself; this is what makes the failure name
-//      which secret, on which repository, and what to do — the message someone
-//      meets when releases have silently stopped.
-//   3. Every step that runs `git push` carries the non-PR guard, has no
-//      `continue-on-error`, comes after the mint step, and mentions no ambient
-//      token anywhere in it.
-//   4. Every `github.token` / `secrets.GITHUB_TOKEN` occurrence in the file is
-//      inside the exact fallback expression `steps.<mintId>.outputs.token ||
-//      github.token`. A bare `token: ${{ github.token }}` — the shape someone
-//      reaches for when the mint step is temporarily commented out — reds.
-//   5. The plan-only arm exists, is PR-guarded, and does not push. That arm is the
-//      fallback's whole reason for being; if it disappears, the fallback should go
-//      with it rather than sit there reachable-in-principle.
-//   6. The checkout ref is per arm, and its non-PR branch is `main` — the moving
-//      TIP, not the event sha, because a second merge that landed while this
-//      run queued belongs in the same release. An unconditional `ref: main`
-//      checks out a tree WITHOUT the PR's own files, so the plan-only arm —
-//      whose entire job is to prove this PR's allocator still runs — dies with
-//      `Cannot find module …/allocate-release-versions.test.mjs`. Asserted only
-//      while the file has a `pull_request:` trigger to serve.
-//   7. Floors: the file exists, and the push-step and mint-step counts are
-//      non-zero. A checker whose subject has gone empty passes forever.
-//
-// Comment stripping is `list-scheduled-workflows.mjs`'s, not a third copy: its
-// stripper is quote-aware, because a blanket `#.*$` truncates two distinct
-// quoted values to the same mangled prefix and makes a bijection compare two
-// equal wrecks.
-//
-// Usage: node scripts/ci/assert-allocate-token-path.mjs [repo root]
+// Also asserts the checkout ref is per arm: an unconditional `ref: main` checks
+// out a tree without the PR's own files.
 
 import { realpathSync } from "node:fs";
 import { dirname, resolve } from "node:path";
@@ -76,15 +26,6 @@ const PR_ONLY_GUARD = "github.event_name == 'pull_request'";
 const AMBIENT_TOKEN_RE = /github\.token|secrets\.GITHUB_TOKEN/g;
 const SECRET_NAMES = ["OPS_APP_ID", "OPS_APP_PRIVATE_KEY"];
 
-/**
- * The workflow's steps, as raw text blocks in file order.
- *
- * Split on the `- ` items at the `steps:` list indent, so a `- ` inside a `run:`
- * block or a prose line cannot start a step. Deliberately NOT a YAML library:
- * every other workflow-property check in this repo reads the same
- * comment-stripped lines, and adding a parser here would mean two answers to
- * "what does this file say" that can disagree.
- */
 export function parseSteps(lines) {
   const stepsAt = lines.findIndex((line) => /^\s*steps:\s*$/.test(line));
   if (stepsAt === -1) return [];
@@ -101,8 +42,6 @@ export function parseSteps(lines) {
       continue;
     }
     if (!current) continue;
-    // A line at or left of the list indent that is not a new item has left the
-    // steps block (the next job key, or the next job).
     const indent = line.match(/^(\s*)\S/);
     if (indent && itemIndent !== null && indent[1].length <= itemIndent && !/^\s*-\s/.test(line)) {
       break;
@@ -131,23 +70,14 @@ export function parseSteps(lines) {
   });
 }
 
-/**
- * The non-pull_request branch of a checkout `ref:` must be `main` — the moving tip.
- * Accepts the literal, and the per-arm expression whose fallback side is `'main'`.
- * The PR side is deliberately left open (`github.ref` and `github.sha` are both
- * the merge ref on that event); what matters is that it is not `main`, which is a
- * tree without the PR's own files.
- */
 const REF_IS_TIP_LITERAL = /^main$/;
 const REF_IS_TIP_PER_ARM =
   /^\$\{\{\s*github\.event_name\s*==\s*'pull_request'\s*&&\s*[^|]+\|\|\s*'main'\s*\}\}$/;
 
-/** Absent or literally `false`. Anything else — including `${{ true }}` — is not. */
 function neutralised(step) {
   return step.continueOnError !== null && !/^(false|\$\{\{\s*false\s*\}\})$/.test(step.continueOnError);
 }
 
-/** Runs on every push, and cannot be turned off by an expression that reads as config. */
 function guardedToRunOnPush(step) {
   if (!step.guard) return false;
   if (!step.guard.includes(NON_PR_GUARD)) return false;
@@ -171,7 +101,6 @@ export function checkAllocateTokenPath(root) {
     throw new Error(`${WORKFLOW}: parsed zero steps — the parser has drifted from the file.`);
   }
 
-  // 1 — the mint step.
   const mintSteps = steps.filter((step) => step.uses?.startsWith(`${MINT_ACTION}@`));
   if (mintSteps.length !== 1) {
     errors.push(
@@ -199,7 +128,6 @@ export function checkAllocateTokenPath(root) {
     }
   }
 
-  // 2 — the precondition step, before the mint step.
   const preconditions = steps.filter(
     (step) =>
       SECRET_NAMES.every((secret) => step.text.includes(secret)) &&
@@ -228,7 +156,6 @@ export function checkAllocateTokenPath(root) {
     }
   }
 
-  // 3 — every pushing step.
   const pushSteps = steps.filter((step) => step.pushes);
   if (pushSteps.length === 0) {
     errors.push(
@@ -260,13 +187,6 @@ export function checkAllocateTokenPath(root) {
           `bypass actor, and a push made with it does not trigger release.yml.`,
       );
     }
-    // A refusal is not a race. Without this branch a rule violation spends all
-    // three attempts reporting "a merge landed first" while main was answering
-    // GH013 (classic branch protection's duplicate required-checks rule, which no
-    // App can bypass). Retrying cannot fix a rule, and a retry loop that cannot
-    // tell the two apart hides the one thing a human needs to read. This asserts
-    // the distinction survives — collapsing the branch back into a bare retry is
-    // exactly the "simplification" that would restore the misdiagnosis.
     if (!/GH013/.test(step.text)) {
       errors.push(
         `the pushing step "${step.name}" does not distinguish a rule violation (GH013) from a ` +
@@ -276,7 +196,6 @@ export function checkAllocateTokenPath(root) {
     }
   }
 
-  // 4 — every ambient-token occurrence is the one sanctioned fallback.
   const fallbackRe = mint?.id
     ? new RegExp(`steps\\.${mint.id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\.outputs\\.token\\s*\\|\\|\\s*github\\.token`)
     : null;
@@ -294,8 +213,6 @@ export function checkAllocateTokenPath(root) {
     );
   }
 
-  // 6 — the checkout ref, per arm. Ordered before the plan-only check below only
-  // because it needs the same `hasPrTrigger` fact.
   const hasPrTrigger = lines.some((line) => /^\s{2}pull_request:\s*$/.test(line));
   const checkouts = steps.filter((step) => step.uses?.startsWith("actions/checkout@"));
   if (checkouts.length === 0) {
@@ -331,7 +248,6 @@ export function checkAllocateTokenPath(root) {
     }
   }
 
-  // 7 — the plan-only arm the fallback exists for.
   const planOnly = steps.filter((step) => step.guard?.includes(PR_ONLY_GUARD) && !step.pushes);
   if (ambientOccurrences > 0 && planOnly.length === 0) {
     errors.push(
@@ -371,11 +287,6 @@ export function main(argv = process.argv.slice(2)) {
   );
 }
 
-// Realpath'd on both sides — node resolves symlinks before deriving
-// `import.meta.url`, so a bare `pathToFileURL()` of argv[1] misses through a
-// symlinked checkout (a worktree, or macOS's symlinked `/tmp`) in the same silent
-// shape, and a guard miss while invoked as this file throws rather than
-// exits 0.
 const SELF = realpathSync(fileURLToPath(import.meta.url));
 const ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";
 const invokedDirectly = ENTRY === SELF;

--- a/scripts/ci/assert-allocate-token-path.test.mjs
+++ b/scripts/ci/assert-allocate-token-path.test.mjs
@@ -226,7 +226,7 @@ console.log("the pushing step");
   );
   check("a neutralised guard reds", names(neutralised).includes("pushing step"), names(neutralised));
 
-  // The first live run spent all three attempts reporting "a merge landed first"
+  // Without this, all three attempts report "a merge landed first"
   // while main was answering GH013. Collapsing the rule-violation branch back
   // into a bare retry is the "simplification" that would restore that.
   const raceOnly = run((t) => t.replace(/GH013/g, "GH0XX"));
@@ -281,9 +281,9 @@ console.log("the fallback itself");
   );
 }
 
-console.log("the checkout ref, per arm — the way the first live run actually died");
+console.log("the checkout ref, per arm");
 {
-  // PR #421's first run: `ref: main` on a pull_request event checks out a tree
+  // `ref: main` on a pull_request event checks out a tree
   // WITHOUT the PR's files, so the arm that exists to prove this PR's allocator
   // runs died with `Cannot find module …/allocate-release-versions.test.mjs`.
   const unconditional = run((t) =>

--- a/scripts/ci/assert-allocate-token-path.test.mjs
+++ b/scripts/ci/assert-allocate-token-path.test.mjs
@@ -1,24 +1,8 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
-/**
- * Regression coverage for scripts/ci/assert-allocate-token-path.mjs.
- *
- * Every case below MUTATES THE REAL `allocate-version.yml` rather than a
- * hand-written sample, because the claim under test is about the file that ships:
- * a checker that only ever fails on a synthetic fixture proves nothing about the
- * edits a person would actually make. Each mutation is one plausible edit — the
- * kind that passes review because it looks like tidying — and each must red.
- *
- * The property: on a `push` event, the job either fails before the push step or
- * pushes with the pome-ops-push installation token. It can never reach the push
- * step holding `github.token`. Reaching it is a silent double failure —
- * `github-actions` can never be a ruleset bypass actor (the push is refused), and
- * a push made with `GITHUB_TOKEN` does not trigger workflows (so a landed commit
- * would publish nothing) — and both look like a quiet green.
- *
- * A checker that has never failed is a checker nobody knows works, so the
- * positive case (the real file passes) is asserted alongside fifteen negatives.
- */
+//
+// Asserts the token-path checker goes RED on each of the four edits that would make
+// the ambient-token fallback reachable on a push.
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -39,7 +23,6 @@ function check(label, condition, detail = "") {
   console.error(`  ✗ ${label}${detail ? `\n      ${detail}` : ""}`);
 }
 
-/** A repo root whose only workflow is a (possibly mutated) copy of the real one. */
 function run(mutate = (text) => text) {
   const dir = mkdtempSync(join(tmpdir(), "allocate-token-path-"));
   try {
@@ -51,7 +34,6 @@ function run(mutate = (text) => text) {
   }
 }
 
-/** Drop a whole `- name: <name>` step block, up to the next step at the same indent. */
 function dropStep(text, name) {
   const lines = text.split("\n");
   const start = lines.findIndex((line) => line.includes(`- name: ${name}`));
@@ -62,7 +44,6 @@ function dropStep(text, name) {
   return [...lines.slice(0, start), ...lines.slice(end)].join("\n");
 }
 
-/** Edit one line inside a named step (the first line matching `match`). */
 function editInStep(text, name, match, replacement) {
   const lines = text.split("\n");
   const start = lines.findIndex((line) => line.includes(`- name: ${name}`));
@@ -76,7 +57,6 @@ function editInStep(text, name, match, replacement) {
   return lines.join("\n");
 }
 
-/** Insert a line after the `- name:` line of a named step. */
 function insertInStep(text, name, line) {
   const lines = text.split("\n");
   const start = lines.findIndex((l) => l.includes(`- name: ${name}`));
@@ -101,8 +81,6 @@ console.log("assert-allocate-token-path.mjs — the real file");
     result.summary,
   );
 
-  // The parser is the part that can silently drift and make every case below
-  // vacuous, so it is asserted directly too.
   const steps = parseSteps(REAL.split("\n").map((line) => line.replace(/\s+#.*$/, "")));
   check(
     "parseSteps finds each step exactly once, in file order",
@@ -226,9 +204,6 @@ console.log("the pushing step");
   );
   check("a neutralised guard reds", names(neutralised).includes("pushing step"), names(neutralised));
 
-  // Without this, all three attempts report "a merge landed first"
-  // while main was answering GH013. Collapsing the rule-violation branch back
-  // into a bare retry is the "simplification" that would restore that.
   const raceOnly = run((t) => t.replace(/GH013/g, "GH0XX"));
   check(
     "losing the rule-violation branch reds — a refusal is not a race",
@@ -283,9 +258,6 @@ console.log("the fallback itself");
 
 console.log("the checkout ref, per arm");
 {
-  // `ref: main` on a pull_request event checks out a tree
-  // WITHOUT the PR's files, so the arm that exists to prove this PR's allocator
-  // runs died with `Cannot find module …/allocate-release-versions.test.mjs`.
   const unconditional = run((t) =>
     t.replace(
       "ref: ${{ github.event_name == 'pull_request' && github.ref || 'main' }}",
@@ -298,9 +270,6 @@ console.log("the checkout ref, per arm");
     names(unconditional),
   );
 
-  // The other direction: the push arm must read the moving TIP, not the sha the
-  // event fired on, or a merge that landed while the run queued is left out of the
-  // release it belongs to.
   const eventSha = run((t) =>
     t.replace(
       "ref: ${{ github.event_name == 'pull_request' && github.ref || 'main' }}",
@@ -325,8 +294,6 @@ console.log("the checkout ref, per arm");
     names(missing),
   );
 
-  // And the per-arm form is accepted with either spelling of the merge ref, so the
-  // check does not red a correct file (a guard that reds right answers gets deleted).
   const shaForm = run((t) =>
     t.replace(
       "ref: ${{ github.event_name == 'pull_request' && github.ref || 'main' }}",

--- a/scripts/ci/assert-hardened-cdn-fetches.mjs
+++ b/scripts/ci/assert-hardened-cdn-fetches.mjs
@@ -1,122 +1,82 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Every third-party network call `.github/workflows/**` makes on the
-// publish path must go through one hardened path, and a new one that does not
-// must red CI.
+// Every third-party network call `.github/workflows/**` makes on the publish
+// path must go through one hardened path, and a new one that does not must red
+// CI.
 //
-// WHY THIS EXISTS. `anchore/sbom-action` fetched syft with no retry; a CDN 503
-// killed the stripe twin-image job twice on 2026-08-12 (#390, #391), and on
-// `main` — where the cosign sign/attest steps do run — the same 503 fails an
-// image publish. The repo already knew the fix (ci.yml's actionlint loop,
-// the coverage check) and had it in two hand-copied variants with a third install missing
-// it entirely. A list of "the installs we hardened" is the same shape as the
-// bug: it stays green while a sixth install lands unhardened. So this is a
-// PROPERTY check over the workflow tree.
+// A list of "the calls we hardened" is the same shape as the bug: it stays
+// green while a sixth one lands unhardened. So this is a PROPERTY check over
+// the workflow tree. The file's name still says cdn-fetches although it now
+// covers writes and signing too; renaming it would move a required gate's
+// wiring across ci.yml and this file's test for no property gained.
 //
-// It was widened from fetches to network calls, because the same shape found
-// a third instance: with both twin-image.yml fetches hardened, the REGISTRY
-// WRITE standing between them was still a single unretried `docker push`. On
-// 2026-08-14 GHCR answered `unknown blob` after every layer had reported
-// `Pushed`, `stripe-bbf27bf` was never published, and nothing re-ran the step —
-// so four consecutive twin-snapshot-verify runs failed and pome-cloud#752
-// reported `stripe — no-image` for four days. The file's NAME still says
-// cdn-fetches: renaming it would move a required gate's wiring across ci.yml
-// and this file's test for no property gained, and shapes (a) and (b)
-// are still what most of it does.
-//
-// The signing leg closed the residual this header used to record at the bottom. With (a)
-// and (c) hardened, `sign-image-digests.sh`'s cosign calls were the last
-// unretried GHCR interaction in that job, and on 2026-08-18 they were the ones
-// that broke: run 32144441622's stripe leg pushed both tags, signed them and
-// attested them, then died on `verify-attestation`'s registry READ with
-// `DENIED: denied`. A red job over a published, correct artifact. Shape (d) is
-// that call site, and it exists so the sign path and the push path cannot drift
-// apart again — a gate that covered only the push would stay green through
-// exactly the revert that reopened this.
 //
 // FOUR SHAPES.
 //
-//   (a) A `run:` block that fetches a remote URL. Detected by scanning every
-//       `run:` script for a `curl` / `wget` / `aria2c` / `gh release download`
-//       invocation and resolving its target (literal URLs, plus one level of
-//       `VAR="https://…"` assignment in the same block). Anything that is not
-//       loopback — INCLUDING a target the resolver cannot work out, which is
-//       the fail-safe direction — must go through
-//       `scripts/ci/fetch-pinned-release.sh`, which is the only place the retry
-//       budget, the backoff and the unconditional sha256 check live.
+//   (a) A `run:` block that fetches a remote URL, found by scanning every
+//       `run:` script for `curl` / `wget` / `aria2c` / `gh release download`
+//       and resolving its target (literal URLs, plus one level of
+//       `VAR="https://…"` in the same block). Anything not loopback —
+//       INCLUDING a target the resolver cannot work out, the fail-safe
+//       direction — must go through `scripts/ci/fetch-pinned-release.sh`, the
+//       only place the retry budget, the backoff and the unconditional sha256
+//       check live.
 //
-//   (b) A `uses:` step for an action that installs a binary. Detected by
-//       collecting every non-local `uses:` in the tree and requiring each to
-//       have a row in scripts/ci/cdn-fetch-actions.json. Rows marked
+//   (b) A `uses:` step for an action that installs a binary. Every non-local
+//       `uses:` needs a row in scripts/ci/cdn-fetch-actions.json. Rows marked
 //       `repeat-attempts` must appear as a repeated-attempt group: an action
 //       step cannot be wrapped in a shell retry loop, so the retry is the step
-//       itself, repeated — at least three attempts, each carrying an `id:`, the
+//       itself, repeated — at least three attempts, each with an `id:`, the
 //       earlier ones `continue-on-error: true`, every later one gated on
 //       `steps.<earlier-id>.outcome == 'failure'` (a SKIPPED step's outcome is
 //       `skipped`, never `failure`, so the chain cannot self-trigger), and the
-//       LAST attempt carrying no escape hatch at all. That last part is the
-//       fail-closed half: a genuinely unavailable CDN still refuses the
-//       publish. Every attempt must also carry a byte-identical `uses:` ref and
-//       `with:` block, which is what stops a repeated cosign install from
-//       drifting one copy off `cosign-release: 'v2.6.4'` — the pin twin-image.yml
-//       carries a paragraph of comment defending, because cosign v3
-//       `attest --type spdx` rejects the anchore SBOM predicate.
+//       LAST attempt with no escape hatch, so a genuinely unavailable CDN still
+//       refuses the publish. Every attempt must carry a byte-identical `uses:`
+//       ref and `with:` block, which is what stops a repeated cosign install
+//       from drifting one copy off its pinned major.
 //
 //   (c) A `run:` block that WRITES to a container registry — `docker push`,
-//       `docker manifest push`, `docker buildx imagetools create`. Same
-//       treatment as shape (a): it must go through
-//       `scripts/ci/push-scanned-image.sh`, which is the only place the retry
-//       budget, the backoff, the per-tag manifest read-back and the fail-closed
-//       message live. Registry READS (`docker pull`, `imagetools inspect`) are
-//       deliberately not in the list: a read that fails fails the step it is in
-//       and publishes nothing, so it cannot leave a tag behind.
+//       `docker manifest push`, `docker buildx imagetools create`. Must go
+//       through `scripts/ci/push-scanned-image.sh`, the only place the retry
+//       budget, the backoff, the per-tag manifest read-back and the
+//       fail-closed message live. Registry READS are deliberately not listed:
+//       a read that fails fails its own step and publishes nothing, so it
+//       cannot leave a tag behind.
 //
-//   (d) A `run:` block that invokes `cosign`. Same treatment again: it must go
-//       through `scripts/ci/sign-image-digests.sh`, which is the only place the
-//       per-operation retry budget, the backoff and the fail-closed message
-//       naming what is already public live. EVERY subcommand counts, reads
-//       included — which is where (d) parts company with (c), and deliberately.
-//       Shape (c) exempts reads because a read that fails publishes nothing;
-//       here the opposite holds, because this step runs AFTER the push step has
-//       published every tag. `cosign verify-attestation`'s read is the exact
-//       call that failed on 2026-08-18, and it failed over an artifact that was
-//       already correct and already public. Nor is the finder a list of the four
-//       subcommands the script runs today: `cosign copy` writes to a registry
-//       and `cosign triangulate` reads from one, and an enumeration would be
+//   (d) A `run:` block that invokes `cosign`. Must go through
+//       `scripts/ci/sign-image-digests.sh`. EVERY subcommand counts, reads
+//       included — which is where (d) parts company with (c), deliberately:
+//       this step runs AFTER the push step has published every tag, so a
+//       failed READ here reds a job over an artifact that is already correct
+//       and already public. The finder is not a list of the subcommands the
+//       script runs today, because `cosign copy` writes to a registry and
+//       `cosign triangulate` reads from one, and an enumeration would be
 //       walked around by either.
 //
-// WHAT THIS GATE CANNOT DERIVE, STATED PLAINLY. Whether a third-party action
-// downloads an executable is a fact about that action's implementation, not
-// about this repo — nothing in the string `anchore/sbom-action` says "fetches
-// syft from a release CDN", and `actions/checkout` looks identical from here.
-// So shape (b) is half-derived: the SET OF ACTIONS TO JUDGE comes from the
-// workflows (a new `uses:` is discovered the moment it lands, and reds until
-// someone classifies it), while the VERDICT PER ACTION is a reviewed row in
-// cdn-fetch-actions.json carrying its evidence. Rows are keyed on `owner/repo`,
-// so a sha bump keeps the classification and a major rewrite under the same
-// name would not be noticed. Three further known holes, recorded rather than
-// papered over: a fetch, a registry write or a signing call smuggled through a
-// tool this scanner does not know (a python one-liner, a Makefile,
-// `crane`/`skopeo`/`oras`) is invisible to shapes (a), (c) and (d); two
-// actions are classified `step-is-the-check` — deliberately not retried, because
-// retrying a scanner turns "found a secret / found a CVE" into two swallowed
-// failures — each with a `residual` field naming what stays exposed; and shape
-// (d) matches cosign in COMMAND POSITION only, so `bash -c "cosign …"` and a
-// call assembled in a variable are invisible to it (see SIGNING_COMMANDS below
-// for why that precision is bought rather than free).
+// WHAT THIS GATE CANNOT DERIVE. Whether a third-party action downloads an
+// executable is a fact about that action's implementation, not about this repo
+// — nothing in the string `anchore/sbom-action` says "fetches syft from a
+// release CDN", and `actions/checkout` looks identical from here. So shape (b)
+// is half-derived: the SET OF ACTIONS TO JUDGE comes from the workflows, so a
+// new `uses:` is discovered the moment it lands and reds until someone
+// classifies it, while the VERDICT PER ACTION is a reviewed row carrying its
+// evidence. Rows are keyed on `owner/repo`, so a sha bump keeps the
+// classification and a major rewrite under the same name would not be noticed.
 //
-// The hole this header used to record as a FOURTH is closed. It read: shape (c)
-// covers the IMAGE write only, and every cosign call in
-// scripts/ci/sign-image-digests.sh also talks to GHCR with no retry. That was
-// measured, not hypothetical — on 2026-08-18 a degraded GHCR took out three of
-// run 32144441622's five legs in two different steps: gmail and linear in the
-// push (`error parsing HTTP 403 response body` on the first tag, nothing
-// published), and stripe on `verify-attestation`'s read with `DENIED: denied`
-// AFTER both tags were pushed, signed and attested. Shape (d) above is what
-// closes it, and the helper it points at retries per OPERATION rather than
-// around the per-tag body — re-signing a digest because the VERIFY could not
-// read it is wasted work and a second signature layer over a good one.
+// Three known holes, recorded rather than papered over: a fetch, registry
+// write or signing call smuggled through a tool this scanner does not know (a
+// python one-liner, a Makefile, `crane`/`skopeo`/`oras`) is invisible to (a),
+// (c) and (d); two actions are classified `step-is-the-check` and deliberately
+// not retried, because retrying a scanner turns "found a secret" or "found a
+// CVE" into two swallowed failures, each carrying a `residual` field naming
+// what stays exposed; and shape (d) matches cosign in COMMAND POSITION only,
+// so `bash -c "cosign …"` and a call assembled in a variable are invisible to
+// it (see SIGNING_COMMANDS below).
+//
+// The sign helper retries per OPERATION rather than around the per-tag body:
+// re-signing a digest because the VERIFY could not read it is wasted work and
+// a second signature layer over a good one.
 //
 // Usage: node scripts/ci/assert-hardened-cdn-fetches.mjs
 // Exits 1, naming every offender, on:
@@ -155,7 +115,7 @@ export const SIGN_HELPER = "scripts/ci/sign-image-digests.sh";
 /**
  * The retry pattern is 2 escapable attempts + 1 fatal one. Fewer than three
  * means a single transient 5xx can still reach the fatal attempt on its heels;
- * the ticket's own failure was two 503s minutes apart on consecutive PRs.
+  * a real outage is two 503s minutes apart on consecutive runs.
  */
 export const MIN_ATTEMPTS = 3;
 

--- a/scripts/ci/assert-hardened-cdn-fetches.mjs
+++ b/scripts/ci/assert-hardened-cdn-fetches.mjs
@@ -115,7 +115,7 @@ export const SIGN_HELPER = "scripts/ci/sign-image-digests.sh";
 /**
  * The retry pattern is 2 escapable attempts + 1 fatal one. Fewer than three
  * means a single transient 5xx can still reach the fatal attempt on its heels;
-  * a real outage is two 503s minutes apart on consecutive runs.
+ * a real outage is two 503s minutes apart on consecutive runs.
  */
 export const MIN_ATTEMPTS = 3;
 

--- a/scripts/ci/assert-hardened-cdn-fetches.mjs
+++ b/scripts/ci/assert-hardened-cdn-fetches.mjs
@@ -1,100 +1,15 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Every third-party network call `.github/workflows/**` makes on the publish
-// path must go through one hardened path, and a new one that does not must red
-// CI.
+// Every third-party network call on the publish path must go through one
+// hardened helper: fetches via fetch-pinned-release.sh, registry writes via
+// push-scanned-image.sh, cosign via sign-image-digests.sh, binary-installing
+// `uses:` steps as a repeated-attempt group.
 //
-// A list of "the calls we hardened" is the same shape as the bug: it stays
-// green while a sixth one lands unhardened. So this is a PROPERTY check over
-// the workflow tree. The file's name still says cdn-fetches although it now
-// covers writes and signing too; renaming it would move a required gate's
-// wiring across ci.yml and this file's test for no property gained.
-//
-//
-// FOUR SHAPES.
-//
-//   (a) A `run:` block that fetches a remote URL, found by scanning every
-//       `run:` script for `curl` / `wget` / `aria2c` / `gh release download`
-//       and resolving its target (literal URLs, plus one level of
-//       `VAR="https://…"` in the same block). Anything not loopback —
-//       INCLUDING a target the resolver cannot work out, the fail-safe
-//       direction — must go through `scripts/ci/fetch-pinned-release.sh`, the
-//       only place the retry budget, the backoff and the unconditional sha256
-//       check live.
-//
-//   (b) A `uses:` step for an action that installs a binary. Every non-local
-//       `uses:` needs a row in scripts/ci/cdn-fetch-actions.json. Rows marked
-//       `repeat-attempts` must appear as a repeated-attempt group: an action
-//       step cannot be wrapped in a shell retry loop, so the retry is the step
-//       itself, repeated — at least three attempts, each with an `id:`, the
-//       earlier ones `continue-on-error: true`, every later one gated on
-//       `steps.<earlier-id>.outcome == 'failure'` (a SKIPPED step's outcome is
-//       `skipped`, never `failure`, so the chain cannot self-trigger), and the
-//       LAST attempt with no escape hatch, so a genuinely unavailable CDN still
-//       refuses the publish. Every attempt must carry a byte-identical `uses:`
-//       ref and `with:` block, which is what stops a repeated cosign install
-//       from drifting one copy off its pinned major.
-//
-//   (c) A `run:` block that WRITES to a container registry — `docker push`,
-//       `docker manifest push`, `docker buildx imagetools create`. Must go
-//       through `scripts/ci/push-scanned-image.sh`, the only place the retry
-//       budget, the backoff, the per-tag manifest read-back and the
-//       fail-closed message live. Registry READS are deliberately not listed:
-//       a read that fails fails its own step and publishes nothing, so it
-//       cannot leave a tag behind.
-//
-//   (d) A `run:` block that invokes `cosign`. Must go through
-//       `scripts/ci/sign-image-digests.sh`. EVERY subcommand counts, reads
-//       included — which is where (d) parts company with (c), deliberately:
-//       this step runs AFTER the push step has published every tag, so a
-//       failed READ here reds a job over an artifact that is already correct
-//       and already public. The finder is not a list of the subcommands the
-//       script runs today, because `cosign copy` writes to a registry and
-//       `cosign triangulate` reads from one, and an enumeration would be
-//       walked around by either.
-//
-// WHAT THIS GATE CANNOT DERIVE. Whether a third-party action downloads an
-// executable is a fact about that action's implementation, not about this repo
-// — nothing in the string `anchore/sbom-action` says "fetches syft from a
-// release CDN", and `actions/checkout` looks identical from here. So shape (b)
-// is half-derived: the SET OF ACTIONS TO JUDGE comes from the workflows, so a
-// new `uses:` is discovered the moment it lands and reds until someone
-// classifies it, while the VERDICT PER ACTION is a reviewed row carrying its
-// evidence. Rows are keyed on `owner/repo`, so a sha bump keeps the
-// classification and a major rewrite under the same name would not be noticed.
-//
-// Three known holes, recorded rather than papered over: a fetch, registry
-// write or signing call smuggled through a tool this scanner does not know (a
-// python one-liner, a Makefile, `crane`/`skopeo`/`oras`) is invisible to (a),
-// (c) and (d); two actions are classified `step-is-the-check` and deliberately
-// not retried, because retrying a scanner turns "found a secret" or "found a
-// CVE" into two swallowed failures, each carrying a `residual` field naming
-// what stays exposed; and shape (d) matches cosign in COMMAND POSITION only,
-// so `bash -c "cosign …"` and a call assembled in a variable are invisible to
-// it (see SIGNING_COMMANDS below).
-//
-// The sign helper retries per OPERATION rather than around the per-tag body:
-// re-signing a digest because the VERIFY could not read it is wasted work and
-// a second signature layer over a good one.
-//
-// Usage: node scripts/ci/assert-hardened-cdn-fetches.mjs
-// Exits 1, naming every offender, on:
-//   - a `run:` block fetching a non-loopback URL outside the hardened helper
-//   - a `run:` block writing to a container registry outside the hardened push
-//     helper
-//   - a `run:` block invoking cosign outside the hardened sign helper
-//   - a `uses:` action with no row in cdn-fetch-actions.json
-//   - a row that is internally inconsistent (fetches from a CDN but claims
-//     `not-needed`, a `step-is-the-check` row with no `residual`, an empty `why`)
-//   - a `repeat-attempts` action used as a single step, or as a group whose
-//     last attempt is `continue-on-error`, whose attempts disagree on `uses:`
-//     or `with:`, or whose gating `if:` does not reference every earlier attempt
-//   - the structural step parse and the flat line scan disagreeing about which
-//     actions the tree uses (a parser regression makes the group check vacuous)
-//   - zero fetches, zero classified CDN actions, or zero call sites for any of
-//     the three hardened helpers (a vacuous green, not a true fact about the
-//     tree)
+// Cosign covers reads too, where the write shape exempts them: by then every tag
+// is already public. The set of actions is derived from the workflows; the
+// verdict per action is a reviewed row in cdn-fetch-actions.json, keyed on
+// owner/repo, so a sha bump keeps the classification.
 
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
@@ -103,20 +18,12 @@ import { workflowLines } from "./list-scheduled-workflows.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
-/** The hardened fetch path, relative to the repo root. */
 export const HELPER = "scripts/ci/fetch-pinned-release.sh";
 
-/** The hardened registry-write path, relative to the repo root. */
 export const PUSH_HELPER = "scripts/ci/push-scanned-image.sh";
 
-/** The hardened sign/attest/verify path, relative to the repo root. */
 export const SIGN_HELPER = "scripts/ci/sign-image-digests.sh";
 
-/**
- * The retry pattern is 2 escapable attempts + 1 fatal one. Fewer than three
- * means a single transient 5xx can still reach the fatal attempt on its heels;
- * a real outage is two 503s minutes apart on consecutive runs.
- */
 export const MIN_ATTEMPTS = 3;
 
 const FETCH_COMMANDS = /(?:^|[\s(`$])(?:curl|wget|aria2c|gh\s+release\s+download)(?=\s|$)/;
@@ -138,30 +45,6 @@ const REGISTRY_WRITE_COMMANDS = [
   /(?:^|[\s(`$])docker\s+buildx\s+imagetools\s+create(?=\s|$)/,
 ];
 
-/**
- * Every way a `run:` block reaches a registry through cosign. ANY
- * subcommand, not a list of the four sign-image-digests.sh runs: `sign` and
- * `attest` write, `verify` and `verify-attestation` read, `copy` writes,
- * `triangulate` reads, and `initialize` pulls the TUF root off a CDN. Every one
- * is a third-party network call on the publish path, which is the property this
- * gate is about — and an enumeration is the list-shaped thing this file's header
- * refuses. A cosign invocation that genuinely needs no hardening does not exist
- * in this tree; if one ever does, it belongs in a reviewed row, not in a widened
- * regex.
- *
- * Matched in COMMAND POSITION, which is where this shape parts company from the
- * `[\s(`$]`-prefixed patterns above. `docker push` reads as a command wherever
- * it appears; `cosign` is also an ENGLISH WORD in this tree — twin-image.yml's
- * three-attempt install ladder annotates every attempt with an
- * `echo "…cosign-installer fetches cosign from…"`, and a rule that read those
- * as invocations would red the whole tree on its own prose, which is a rule
- * someone deletes. So: the start of a segment (behind any prefix a command can
- * hide behind), or immediately inside a command substitution.
- *
- * The trade, stated rather than hidden: a call assembled in a variable or run
- * through `bash -c "cosign …"` is invisible here — the same class of hole this
- * file's header already records for `crane`, `skopeo` and a Makefile.
- */
 const COMMAND_PREFIX =
   "(?:(?:!|time|exec|sudo|env|command|if|then|else|elif|do|while|until)\\s+|[A-Za-z_][A-Za-z0-9_]*=\\S*\\s+)*";
 const SIGNING_COMMANDS = [
@@ -177,17 +60,6 @@ export function loadTable(file = join(HERE, "cdn-fetch-actions.json")) {
   return JSON.parse(readFileSync(file, "utf8"));
 }
 
-// ---------------------------------------------------------------------------
-// Structural read of a workflow file: jobs -> steps -> keys.
-//
-// Line-based and indentation-anchored, the same stance as
-// list-scheduled-workflows.mjs (whose comment-stripped lines this consumes):
-// a workflow's own prose contains the literal strings this looks for, and a
-// YAML parser is not a dependency this repo's always-on, pre-`npm ci` block can
-// take.
-// ---------------------------------------------------------------------------
-
-/** Jobs, each with its ordered list of raw step blocks. */
 export function parseJobs(lines) {
   const jobs = [];
   let inJobs = false;
@@ -252,10 +124,6 @@ export function parseJobs(lines) {
   return jobs;
 }
 
-/**
- * A step's top-level keys as `name -> { value, lines }`, where `lines` holds
- * the nested block (a `with:` mapping, a `run: |` script body).
- */
 export function stepKeys(step) {
   const norm = step.lines.map((l, i) => (i === 0 ? l.replace(/^(\s*)-(\s)/, "$1 $2") : l));
   const base = /^\s*/.exec(norm[0])[0].length;
@@ -274,7 +142,6 @@ export function stepKeys(step) {
   return keys;
 }
 
-/** A key's full text, block scalar body included. */
 export function keyText(keys, name) {
   const k = keys.get(name);
   if (!k) return null;
@@ -282,7 +149,6 @@ export function keyText(keys, name) {
   return [head, ...k.lines].join("\n");
 }
 
-/** A nested mapping (`with:`) as sorted, dedented, comparable lines. */
 export function blockLines(keys, name) {
   const k = keys.get(name);
   if (!k) return null;
@@ -292,19 +158,10 @@ export function blockLines(keys, name) {
     .sort();
 }
 
-// ---------------------------------------------------------------------------
-// Shape (a): remote fetches inside `run:` scripts.
-// ---------------------------------------------------------------------------
-
 export function hostOf(url) {
   const m = /^[a-z][a-z0-9+.-]*:\/\/([^/?#\s"'`]+)/i.exec(url);
   if (!m) return null;
   let host = m[1].replace(/^[^@]*@/, "");
-  // The port is cut by POSITION, not by a `:\d+$` match: workflow scripts
-  // reach loopback through an expansion (`http://127.0.0.1:${port}/healthz`,
-  // `:${{ env.PORT }}`), and a digits-only strip leaves `127.0.0.1:${port}` as
-  // the "host" — which reads as a remote CDN and reds two smoke workflows that
-  // are doing nothing wrong.
   if (host.startsWith("[")) {
     const close = host.indexOf("]");
     if (close !== -1) host = host.slice(0, close + 1);
@@ -321,16 +178,6 @@ export function isLoopback(url) {
   return LOOPBACK.has(host) || /^127(\.\d+){3}$/.test(host);
 }
 
-/**
- * One shell script as `{ text, segments }`: comments dropped, then split at
- * every separator a command can start after.
- *
- * workflowLines() has already stripped YAML comments, which inside a `run: |`
- * block are the same `#` a shell comment uses — so in production this second
- * strip is a no-op. It is here so the rule holds for a script handed straight
- * to one of the finders below: a commented-out fetch is not a fetch, and a gate
- * that read one as a violation is a gate someone deletes.
- */
 function shellSegments(script) {
   const text = script
     .split("\n")
@@ -345,11 +192,6 @@ function shellSegments(script) {
   };
 }
 
-/**
- * Every fetch invocation in one shell script, with the URL it targets when
- * that can be worked out. An unresolvable target is reported as `null`, which
- * every caller must treat as remote — the fail-safe direction.
- */
 export function findFetchesInScript(script) {
   const { text, segments } = shellSegments(script);
   const vars = new Map();
@@ -366,14 +208,12 @@ export function findFetchesInScript(script) {
   return findings;
 }
 
-/** Every registry-WRITE invocation in one shell script. */
 export function findRegistryWritesInScript(script) {
   return shellSegments(script).segments.filter((segment) =>
     REGISTRY_WRITE_COMMANDS.some((command) => command.test(segment)),
   );
 }
 
-/** Every cosign invocation in one shell script. */
 export function findSigningCallsInScript(script) {
   return shellSegments(script).segments.filter((segment) =>
     SIGNING_COMMANDS.some((command) => command.test(segment)),
@@ -390,7 +230,6 @@ function resolveTarget(segment, vars) {
   return null;
 }
 
-/** `run:` blocks that fetch something remote without using the hardened path. */
 export function findUnhardenedRunFetches(root) {
   const problems = [];
   const hardened = [];
@@ -415,11 +254,6 @@ export function findUnhardenedRunFetches(root) {
   return { problems, hardened: hardened.sort() };
 }
 
-// ---------------------------------------------------------------------------
-// Shape (c): registry writes inside `run:` scripts.
-// ---------------------------------------------------------------------------
-
-/** `run:` blocks that write to a registry without using the hardened path. */
 export function findUnhardenedRegistryWrites(root) {
   const problems = [];
   const hardened = [];
@@ -446,11 +280,6 @@ export function findUnhardenedRegistryWrites(root) {
   return { problems, hardened: hardened.sort() };
 }
 
-// ---------------------------------------------------------------------------
-// Shape (d): cosign calls inside `run:` scripts.
-// ---------------------------------------------------------------------------
-
-/** `run:` blocks that invoke cosign without using the hardened path. */
 export function findUnhardenedSigningCalls(root) {
   const problems = [];
   const hardened = [];
@@ -478,11 +307,6 @@ export function findUnhardenedSigningCalls(root) {
   return { problems, hardened: hardened.sort() };
 }
 
-// ---------------------------------------------------------------------------
-// Shape (b): `uses:` steps for binary-installing actions.
-// ---------------------------------------------------------------------------
-
-/** `owner/repo` for a `uses:` ref, or null for a local reusable workflow. */
 export function actionRepo(ref) {
   if (!ref || ref.startsWith("./") || ref.startsWith(".\\")) return null;
   if (ref.startsWith("docker://")) return ref;
@@ -492,7 +316,6 @@ export function actionRepo(ref) {
   return `${parts[0]}/${parts[1]}`;
 }
 
-/** Flat line scan: every non-local `uses:` in the tree. The SECOND read. */
 export function findActionRefsByLine(root) {
   const refs = new Map();
   for (const [file, lines] of workflowLines(root)) {
@@ -508,7 +331,6 @@ export function findActionRefsByLine(root) {
   return refs;
 }
 
-/** Structural read: every non-local `uses:` reached through jobs -> steps. */
 export function findActionStepsByStructure(root) {
   const steps = [];
   for (const [file, lines] of workflowLines(root)) {
@@ -525,7 +347,6 @@ export function findActionStepsByStructure(root) {
   return steps;
 }
 
-/** Rows that contradict themselves, and actions with no row at all. */
 export function findTableDefects(table, refs) {
   const problems = [];
   const actions = table?.actions ?? {};
@@ -570,7 +391,6 @@ export function findTableDefects(table, refs) {
   return problems;
 }
 
-/** One repeated-attempt group, checked against the retry shape. */
 export function checkAttemptGroup(where, repo, attempts) {
   const problems = [];
   const at = (a) => `${where} step ${a.line}`;
@@ -666,7 +486,6 @@ export function findUnhardenedActionGroups(root, table) {
   return { problems, groups };
 }
 
-/** The two reads of "which actions does this tree use" must agree. */
 export function findParseDisagreements(root) {
   const byLine = new Set(findActionRefsByLine(root).keys());
   const byStructure = new Set(findActionStepsByStructure(root).map((s) => s.repo));
@@ -675,11 +494,6 @@ export function findParseDisagreements(root) {
   return { missed, extra };
 }
 
-// ---------------------------------------------------------------------------
-
-// `table` is injectable so the regression suite can drive the whole assembly
-// over a scratch tree — the assertions are about the RULES, not about which
-// actions this repo happens to use today.
 export function main(root = resolve(HERE, "../.."), table = loadTable()) {
   const failures = [];
 
@@ -719,10 +533,6 @@ export function main(root = resolve(HERE, "../.."), table = loadTable()) {
   const { problems: groupProblems, groups } = findUnhardenedActionGroups(root, table);
   failures.push(...groupProblems);
 
-  // Dead guards. Every one of these floors has been at a non-zero value since
-  // this gate landed, so a zero here is a parser that stopped matching, not a
-  // tree that stopped fetching. A gate that reports "all clear" over nothing
-  // is the failure mode this whole file exists to refuse.
   if (refs.size === 0) {
     throw new Error("found zero `uses:` actions in .github/workflows — a parser regression, not a true fact.");
   }
@@ -780,9 +590,6 @@ export function main(root = resolve(HERE, "../.."), table = loadTable()) {
   return { refs, groups, hardened, hardenedWrites, hardenedSigns };
 }
 
-// NOT `import.meta.main` (Node 24.2+; root `engines` allows >=24, so on
-// 24.0/24.1 it is `undefined` and this guard would be false, exiting 0 having
-// checked nothing). Same entry-guard idiom as list-scheduled-workflows.mjs.
 const SELF = realpathSync(fileURLToPath(import.meta.url));
 const ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";
 const invokedDirectly = ENTRY === SELF;

--- a/scripts/ci/assert-hardened-cdn-fetches.test.mjs
+++ b/scripts/ci/assert-hardened-cdn-fetches.test.mjs
@@ -1,44 +1,9 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Regression coverage for scripts/ci/fetch-pinned-release.sh and
-// scripts/ci/assert-hardened-cdn-fetches.mjs.
-//
-// Two halves, and the second is the one that matters. A gate that has only
-// ever reported "all clear" on the tree it shipped with is a gate nobody has
-// seen fail — an earlier grep-based coverage check was defeated three separate
-// times by shapes its author was sure it caught. So every rule here is
-// exercised against a PLANTED violation in a scratch `.github/workflows` tree
-// and asserted to red, by name:
-//
-//   - a `run:` block curling a release CDN outside the hardened helper
-//   - a fetch whose target the resolver cannot work out (must red, not pass)
-//   - a `run:` block writing to a container registry outside the hardened push
-//     helper, and a registry READ that must NOT red
-//   - a `run:` block invoking cosign outside the hardened sign helper,
-//     the READ subcommands included — unlike shape (c), a failed read here
-//     happens AFTER publication
-//   - a `uses:` action with no row in the classification table
-//   - a table row that contradicts itself, or an exemption with no residual
-//   - a binary-installing action used as ONE step
-//   - a repeated group whose LAST attempt is `continue-on-error` (fail-open)
-//   - a repeated group whose attempts disagree on `with:` (the cosign-release
-//     hazard) or on `uses:`
-//   - a repeated group whose gating `if:` skips an earlier attempt
-//   - the whole gate, end to end, over a scratch tree
-//   - the vacuous-green dead guards
-//
-// The helper half drives all three real shell scripts. `fetch-pinned-release.sh`
-// runs against a local server that 503s on demand: retry-then-succeed,
-// exhaustion failing closed with the CDN HOST in the message, and a good
-// download with a wrong sha256 still refused. `push-scanned-image.sh` runs
-// against a fake `docker` that reproduces the observed GHCR answer — every layer
-// `Pushed`, then `unknown blob` — and, separately, a push that exits 0 while
-// the manifest is never committed. `sign-image-digests.sh` runs against a fake
-// `cosign` that reproduces the signing failure — `DENIED: denied` off the GHCR token
-// endpoint, injectable per subcommand, so the case that actually happened (both
-// tags pushed, signed and attested, dead on `verify-attestation`'s READ) is a
-// fixture rather than a paragraph.
+// Drives the gate against fixture workflow trees, and drives the three hardened
+// helpers against a fake docker/cosign that reproduces the registry answers they
+// exist for.
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { createServer } from "node:http";
@@ -88,8 +53,6 @@ function withScratchRoot(files, fn) {
   const dir = join(root, ".github", "workflows");
   mkdirSync(dir, { recursive: true });
   mkdirSync(join(root, "scripts", "ci"), { recursive: true });
-  // main() refuses to run without the hardened paths it points every workflow
-  // at, so the scratch tree carries a stand-in for each.
   writeFileSync(join(root, HELPER), "#!/usr/bin/env bash\nexit 0\n");
   writeFileSync(join(root, PUSH_HELPER), "#!/usr/bin/env bash\nexit 0\n");
   writeFileSync(join(root, SIGN_HELPER), "#!/usr/bin/env bash\nexit 0\n");
@@ -110,7 +73,6 @@ jobs:
 ${steps}
 `;
 
-/** A step group in the shape the gate demands, so fixtures can perturb ONE thing. */
 function goodGroup({ ref = "vendor/installer@aaaa", withBlock = "          pin: 'v1'", last = {} } = {}) {
   const attempt = (n, id, cond, escapable, block) =>
     `      - name: install ${n}
@@ -142,13 +104,6 @@ const TABLE = {
   },
 };
 
-// ---------------------------------------------------------------------------
-// Shape (a): remote fetches in `run:` blocks.
-// ---------------------------------------------------------------------------
-
-// PLANTED FAILURE — a raw curl at a release CDN. This is the shape the two
-// hand-copied install loops had before the ladder landed, and the shape a third copy
-// would have.
 withScratchRoot(
   {
     "planted.yml": wf(`      - name: Install thing
@@ -163,10 +118,6 @@ withScratchRoot(
   },
 );
 
-// PLANTED FAILURE — the same fetch behind a variable the resolver cannot see
-// (set from `env:` rather than in the block). An unresolvable target must be
-// treated as REMOTE; the alternative is a gate that is silenced by an
-// indirection.
 withScratchRoot(
   {
     "planted.yml": wf(`      - name: Install thing
@@ -181,7 +132,6 @@ withScratchRoot(
   },
 );
 
-// The same fetch routed through the hardened helper is clean.
 withScratchRoot(
   {
     "ok.yml": wf(`      - name: Install thing
@@ -195,8 +145,6 @@ withScratchRoot(
   },
 );
 
-// A loopback health poll is not a CDN fetch and must not red — including the
-// `:${port}` form, which a digits-only port strip reads as a remote host.
 withScratchRoot(
   {
     "smoke.yml": wf(`      - name: Wait for healthz
@@ -219,17 +167,6 @@ assert(findFetchesInScript("echo curling is fine\n# curl https://x.example/y\n")
 assert(findFetchesInScript("wget https://x.example/y").length === 1, "wget counts");
 assert(findFetchesInScript("gh release download v1 -R o/r").length === 1, "gh release download counts");
 
-// ---------------------------------------------------------------------------
-// Shape (c): registry WRITES in `run:` blocks.
-//
-// `Push scanned image` was one bare `docker push` with no retry, sitting
-// between two `uses:` installs that had both been given three-attempt ladders.
-// GHCR can answer `unknown blob` after every layer has reported `Pushed`, so a
-// leg dies and its per-commit tag does not exist — which fails every downstream
-// snapshot verify for as long as nobody re-runs the step.
-// ---------------------------------------------------------------------------
-
-// PLANTED FAILURE — the exact shape twin-image.yml's push step had.
 withScratchRoot(
   {
     "planted.yml": wf(`      - name: Push scanned image
@@ -246,9 +183,6 @@ withScratchRoot(
   },
 );
 
-// PLANTED FAILURE — the other two ways a workflow commits a manifest to a
-// registry. Naming only `docker push` would leave a gate that a one-line
-// rewrite walks around.
 withScratchRoot(
   {
     "planted.yml": wf(`      - name: Fan out
@@ -263,10 +197,6 @@ withScratchRoot(
   },
 );
 
-// A registry READ is not a write. `docker buildx imagetools inspect` is the
-// exact call pome-cloud's resolve-image-digest.ts makes and the one
-// sign-image-digests.sh makes per tag; a gate that red on it would be a gate
-// someone deletes.
 withScratchRoot(
   {
     "reads.yml": wf(`      - name: Look, do not touch
@@ -280,8 +210,6 @@ withScratchRoot(
   },
 );
 
-// The same push routed through the hardened helper is clean, and counts for
-// the dead guard below.
 withScratchRoot(
   {
     "ok.yml": wf(`      - name: Push scanned image
@@ -300,20 +228,6 @@ assert(findRegistryWritesInScript("# docker push ghcr.io/o/r:v1\n").length === 0
 assert(findRegistryWritesInScript("echo 'docker pushes images'").length === 0, "prose is not a push");
 assert(findRegistryWritesInScript("docker push ghcr.io/o/r:v1").length === 1, "a bare push counts");
 
-// ---------------------------------------------------------------------------
-// Shape (d): cosign calls in `run:` blocks.
-//
-// With shapes (a) and (c) closed, the sign/attest/verify step was the last
-// unretried GHCR interaction on the publish path — a single step at
-// twin-image.yml:344 with no attempt siblings, sitting between an SBOM fetch
-// and a cosign install that both have three-attempt ladders. A degraded GHCR
-// answers `DENIED: denied` off its token endpoint and kills the leg on
-// `verify-attestation` — AFTER both tags are pushed, signed and attested. A red
-// job over a correct, published artifact.
-// ---------------------------------------------------------------------------
-
-// PLANTED FAILURE — the WRITE half, inline. This is the shape the sign step
-// had before the signing leg was hardened.
 withScratchRoot(
   {
     "planted.yml": wf(`      - name: Sign pushed image digests
@@ -330,12 +244,6 @@ withScratchRoot(
   },
 );
 
-// PLANTED FAILURE — the READ half. This is the one that separates shape (d)
-// from shape (c), where reads are deliberately exempt: a `docker pull` that
-// fails publishes nothing, but `cosign verify-attestation` runs AFTER the push
-// step has published every tag, so its failure reds a job over an artifact that
-// is already public. A shape (d) that copied (c)'s exemption would miss the
-// exact call that broke.
 withScratchRoot(
   {
     "planted.yml": wf(`      - name: Verify what we signed
@@ -355,8 +263,6 @@ withScratchRoot(
   },
 );
 
-// The same signing routed through the hardened helper is clean, and counts for
-// the dead guard below.
 withScratchRoot(
   {
     "ok.yml": wf(`      - name: Sign pushed image digests
@@ -375,18 +281,9 @@ withScratchRoot(
 assert(findSigningCallsInScript("# cosign sign --yes $REF\n").length === 0, "a commented-out sign is not a sign");
 assert(findSigningCallsInScript("echo 'cosign signs digests'").length === 0, "prose is not a sign");
 assert(findSigningCallsInScript("cosign sign --yes $REF").length === 1, "a bare sign counts");
-// Every cosign subcommand in this tree reaches GHCR, so the finder is not a
-// list of the four the sign script happens to run today: `cosign copy` is a
-// registry-to-registry write and `cosign triangulate` a read, and a shape (d)
-// that enumerated subcommands would be walked around by either.
 assert(findSigningCallsInScript("cosign copy ghcr.io/o/r:v1 ghcr.io/o/r:v2").length === 1, "copy counts");
 assert(findSigningCallsInScript("cosign triangulate ghcr.io/o/r:v1").length === 1, "triangulate counts");
 
-// `cosign` is also an English word in this tree, which `docker push` is not:
-// twin-image.yml's install ladder annotates all three attempts with an `echo`
-// naming the binary. A prefix rule like shape (a)'s and (c)'s reads those two
-// lines as unhardened invocations and reds the repo on its own prose — measured,
-// not imagined.
 for (const prose of [
   `echo "::warning::cosign install attempt 1 failed. sigstore/cosign-installer fetches cosign from github.com/sigstore/cosign/releases"`,
   `echo "::error::could not install cosign after 3 attempts. sigstore/cosign-installer fetches the pinned cosign v2.6.4 binary from the sigstore release CDN"`,
@@ -394,19 +291,11 @@ for (const prose of [
   assert(findSigningCallsInScript(prose).length === 0, `an echo naming cosign is not a cosign call: ${prose}`);
 }
 
-// …and the positions a REAL call hides in are still calls, so the tightening
-// above did not buy its precision by going blind.
 assert(findSigningCallsInScript('if cosign verify "$REF"; then :; fi').length === 1, "a guarded call counts");
 assert(findSigningCallsInScript('out="$(cosign triangulate "$REF")"').length === 1, "a substituted call counts");
 assert(findSigningCallsInScript("COSIGN_EXPERIMENTAL=1 cosign sign $REF").length === 1, "an assignment prefix counts");
 assert(findSigningCallsInScript("docker build . && cosign sign $REF").length === 1, "a call after && counts");
 
-// ---------------------------------------------------------------------------
-// Shape (b): the classification table.
-// ---------------------------------------------------------------------------
-
-// PLANTED FAILURE — a brand new binary-installing action lands and nobody
-// classifies it. This is the "a new one that does not reds CI" property.
 withScratchRoot(
   {
     "planted.yml": wf(`      - uses: brandnew/tool-installer@0123456789abcdef0123456789abcdef01234567 # v1.2.3`),
@@ -418,7 +307,6 @@ withScratchRoot(
   },
 );
 
-// Rows that contradict themselves, and an exemption with no residual.
 {
   const problems = findTableDefects(
     {
@@ -439,17 +327,10 @@ withScratchRoot(
   assertNames(problems, "e/nonsense", "an unknown hardening value must red");
 }
 
-// The shipped table must itself be internally consistent — the gate's own
-// input is not exempt from the gate's own rules.
 assert(findTableDefects(loadTable(), new Map()).length === 0, "scripts/ci/cdn-fetch-actions.json is inconsistent");
-
-// ---------------------------------------------------------------------------
-// Shape (b): the repeated-attempt group.
-// ---------------------------------------------------------------------------
 
 assert(MIN_ATTEMPTS === 3, "the retry pattern is 2 escapable attempts + 1 fatal one");
 
-// PLANTED FAILURE — the exact state twin-image.yml's syft step was in.
 withScratchRoot(
   { "planted.yml": wf(`      - uses: vendor/installer@aaaa\n        with:\n          pin: 'v1'`) },
   (root) => {
@@ -459,14 +340,11 @@ withScratchRoot(
   },
 );
 
-// PLANTED FAILURE — three attempts, but the last one can be escaped. That is
-// fail-OPEN: a permanently dead CDN would let an unsigned image through.
 withScratchRoot({ "planted.yml": wf(goodGroup({ last: { escapable: true } })) }, (root) => {
   const { problems } = findUnhardenedActionGroups(root, TABLE);
   assertNames(problems, "LAST vendor/installer attempt is `continue-on-error: true`", "a fail-open group must red");
 });
 
-// PLANTED FAILURE — the cosign-release hazard: one copy drifts off the pin.
 withScratchRoot(
   { "planted.yml": wf(goodGroup({ last: { withBlock: "          pin: 'v3'" } })) },
   (root) => {
@@ -476,13 +354,9 @@ withScratchRoot(
   },
 );
 
-// PLANTED FAILURE — one attempt pinned to a different build of the action.
 withScratchRoot(
   {
     "planted.yml": wf(
-      // Only the LAST attempt's pin is moved: the negative lookahead makes the
-      // regex bind to the final `uses:` in the group, so the group disagrees
-      // with itself rather than being uniformly on a different pin.
       goodGroup().replace(
         /uses: vendor\/installer@aaaa\n(?![\s\S]*uses: vendor)/,
         "uses: vendor/installer@bbbb\n",
@@ -495,9 +369,6 @@ withScratchRoot(
   },
 );
 
-// PLANTED FAILURE — attempt 3 gates only on attempt 2. Attempt 2 is SKIPPED
-// when attempt 1 succeeded, and a skipped step's outcome is `skipped`, never
-// `failure` — so this chain looks right and never fires.
 withScratchRoot(
   { "planted.yml": wf(goodGroup({ last: { cond: "steps.inst_2.outcome == 'failure'" } })) },
   (root) => {
@@ -506,8 +377,6 @@ withScratchRoot(
   },
 );
 
-// The shape the gate demands is clean, and an unclassified-but-inert action
-// alongside it does not manufacture a group.
 withScratchRoot({ "ok.yml": wf(`${goodGroup()}\n      - uses: vendor/inert@cccc`) }, (root) => {
   const { problems, groups } = findUnhardenedActionGroups(root, TABLE);
   assert(problems.length === 0, `the correct shape must not red: ${problems.join("; ")}`);
@@ -515,10 +384,6 @@ withScratchRoot({ "ok.yml": wf(`${goodGroup()}\n      - uses: vendor/inert@cccc`
   const { missed, extra } = findParseDisagreements(root);
   assert(missed.length === 0 && extra.length === 0, `the two reads disagree: ${missed} / ${extra}`);
 });
-
-// ---------------------------------------------------------------------------
-// The whole gate, end to end.
-// ---------------------------------------------------------------------------
 
 function mainThrows(files, table, needle, msg) {
   withScratchRoot(files, (root) => {
@@ -533,8 +398,6 @@ function mainThrows(files, table, needle, msg) {
   });
 }
 
-// One call site per hardened path, so a fixture that is meant to red on ONE
-// planted violation is not instead answered by a dead guard.
 const HARDENED_STEPS = `      - name: Install thing
         run: |
           bash ${HELPER} thing "https://cdn.example.com/t.tgz" "$SHA" /tmp/t.tgz
@@ -543,7 +406,6 @@ const HARDENED_STEPS = `      - name: Install thing
       - name: Sign pushed image digests
         run: bash ${SIGN_HELPER} "Signed digests" twin.spdx.json`;
 
-// A tree that is otherwise correct, plus one planted raw curl.
 mainThrows(
   {
     "ok.yml": wf(`${goodGroup()}\n${HARDENED_STEPS}`),
@@ -554,8 +416,6 @@ mainThrows(
   "the assembled gate must red on a planted raw fetch",
 );
 
-// The same, for shape (c): an unretried registry write must reach the assembled
-// gate, not just the finder.
 mainThrows(
   {
     "ok.yml": wf(`${goodGroup()}\n${HARDENED_STEPS}`),
@@ -566,7 +426,6 @@ mainThrows(
   "the assembled gate must red on a planted raw registry write",
 );
 
-// The same, for shape (d): an inline cosign call must reach the assembled gate.
 mainThrows(
   {
     "ok.yml": wf(`${goodGroup()}\n${HARDENED_STEPS}`),
@@ -577,12 +436,8 @@ mainThrows(
   "the assembled gate must red on a planted inline cosign call",
 );
 
-// Dead guards: a tree with a correct group but nothing using the hardened
-// helper means shape (a) checked nothing, and must refuse to report green.
 mainThrows({ "ok.yml": wf(goodGroup()) }, TABLE, "Refusing to report a vacuous green", "no helper call site must red");
 
-// The same guard for shape (c): if no workflow pushes an image through the
-// hardened path, the registry-write half checked nothing.
 mainThrows(
   {
     "ok.yml": wf(
@@ -594,9 +449,6 @@ mainThrows(
   "no hardened registry-write call site must red",
 );
 
-// And for shape (d): with the sign step deleted rather than hardened, the
-// signing half checked nothing. This is the guard that keeps that fix from
-// being quietly reverted into a green gate.
 mainThrows(
   {
     "ok.yml": wf(
@@ -608,8 +460,6 @@ mainThrows(
   "no hardened signing call site must red",
 );
 
-// A tree whose actions are all inert means the repeated-attempt half checked
-// nothing.
 mainThrows(
   {
     "ok.yml": wf(`      - uses: vendor/inert@cccc\n${HARDENED_STEPS}`),
@@ -619,17 +469,9 @@ mainThrows(
   "no CDN-fetching action must red",
 );
 
-// ---------------------------------------------------------------------------
-// scripts/ci/fetch-pinned-release.sh itself.
-// ---------------------------------------------------------------------------
-
 const BODY = "pretend binary\n";
 const GOOD_SHA = createHash("sha256").update(BODY).digest("hex");
 
-// Deliberately `spawn` + await, NOT spawnSync: the 503 server below lives in
-// THIS process, and spawnSync blocks the event loop, so curl would connect,
-// wait for a response node cannot deliver until the child exits, and deadlock
-// until --max-time. That is a two-minute hang per case with no useful output.
 function runHelper(url, sha, { attempts = 3 } = {}) {
   const dir = mkdtempSync(join(tmpdir(), "fetch-pinned-release-"));
   const dest = join(dir, "artifact");
@@ -650,7 +492,6 @@ function runHelper(url, sha, { attempts = 3 } = {}) {
       try {
         content = readFileSync(dest, "utf8");
       } catch {
-        /* the fetch never landed; that is the assertion's business, not ours */
       }
       rmSync(dir, { recursive: true, force: true });
       resolvePromise({ status, stdout, stderr, content });
@@ -677,8 +518,6 @@ await new Promise((r) => server.listen(0, "127.0.0.1", r));
 const base = `http://127.0.0.1:${server.address().port}`;
 
 try {
-  // A transient 5xx cannot fail the fetch on the first attempt — the ladder's
-  // first done-when, measured rather than asserted in a comment.
   const flaky = await runHelper(`${base}/flaky`, GOOD_SHA);
   assert(flaky.status === 0, `two 503s then a 200 must succeed, got ${flaky.status}\n${flaky.stderr}`);
   assert(flaky.content === BODY, "the retried fetch must land the real bytes");
@@ -687,8 +526,6 @@ try {
     `a flaky-but-passing run must SAY so, got: ${flaky.stdout}`,
   );
 
-  // A genuinely unavailable CDN fails closed, naming what could not be
-  // fetched and from where — not `exit code 1`.
   const dead = await runHelper(`${base}/always503`, GOOD_SHA, { attempts: 2 });
   assert(dead.status !== 0, "a permanently 503ing CDN must fail closed");
   assert(dead.stderr.includes("::error::"), "the failure must be an annotated error");
@@ -697,9 +534,6 @@ try {
   assert(dead.stderr.includes("after 2 attempts"), "the message must say how many attempts were spent");
   assert(dead.stderr.includes("Failing closed"), "the message must say the refusal is deliberate");
 
-  // The verification is unconditional: a perfectly successful download with
-  // the wrong hash is still refused. A hash checked with `|| true` would pass
-  // this one.
   const wrong = await runHelper(`${base}/ok`, "0".repeat(64));
   assert(wrong.status !== 0, "a sha256 mismatch must fail the fetch");
   assert(wrong.stderr.includes("sha256 mismatch"), `expected a named mismatch, got: ${wrong.stderr}`);
@@ -711,16 +545,6 @@ try {
 } finally {
   server.close();
 }
-
-// ---------------------------------------------------------------------------
-// scripts/ci/push-scanned-image.sh itself.
-//
-// Driven against a fake `docker` on PATH rather than a real registry: the
-// failure to reproduce is GHCR accepting every layer and then refusing the
-// manifest PUT, which no local registry offers on demand. State lives in files
-// so the counters survive the separate `docker` invocations one retry ladder
-// makes.
-// ---------------------------------------------------------------------------
 
 const FAKE_DOCKER = `#!/usr/bin/env bash
 set -euo pipefail
@@ -775,27 +599,10 @@ echo "fake docker: unexpected invocation: $*" >&2
 exit 127
 `;
 
-// Asserted against as part of a whole sentence the script emits, never as a bare
-// `stderr.includes("ghcr.io")`: the latter is the weaker assertion (the host
-// appearing anywhere satisfies it, including in a tag the script merely echoed)
-// and CodeQL reads it as `js/incomplete-url-substring-sanitization`, which is a
-// false positive here but a fair complaint about the assertion.
 const REGISTRY = "ghcr.io";
 const ROLLING = `${REGISTRY}/pome-sh/twins:stripe`;
-// The per-commit tag docker/metadata-action emits LAST, and the one
-// pome-cloud's resolve-image-digest.ts looks up.
 const PER_COMMIT = `${REGISTRY}/pome-sh/twins:stripe-bbf27bf`;
 
-/**
- * The clause of a fail-closed message that lists what DID land, or "" when the
- * script printed no such clause.
- *
- * Needed because the two real tags are prefix-related — `…:stripe` is a
- * substring of `…:stripe-bbf27bf` — so a bare
- * `stderr.includes(ROLLING)` is satisfied by the FAILING tag being named and
- * passes with the landed list deleted outright. Measured: deleting it from
- * either helper left this suite green until this split was introduced.
- */
 const landedClause = (stderr, label) => stderr.split(label)[1] ?? "";
 
 function runPush(tags, plan = {}, { attempts = 3 } = {}) {
@@ -816,8 +623,6 @@ function runPush(tags, plan = {}, { attempts = 3 } = {}) {
       PATH: `${bin}:${process.env.PATH}`,
       IMAGE_TAGS: tags,
       FAKE_DOCKER_STATE: state,
-      // `attempts: null` leaves the knob unset, which is how the case below
-      // measures the PRODUCTION budget rather than one the test chose.
       ...(attempts === null ? {} : { PUSH_SCANNED_IMAGE_ATTEMPTS: String(attempts) }),
       PUSH_SCANNED_IMAGE_SLEEP_UNIT: "0",
     },
@@ -832,7 +637,6 @@ function runPush(tags, plan = {}, { attempts = 3 } = {}) {
       try {
         pushes = readFileSync(join(state, "pushes"), "utf8").split("\n").filter(Boolean);
       } catch {
-        /* nothing was pushed; that is the assertion's business, not ours */
       }
       rmSync(dir, { recursive: true, force: true });
       resolvePromise({ status, stdout, stderr, pushes });
@@ -840,10 +644,6 @@ function runPush(tags, plan = {}, { attempts = 3 } = {}) {
   });
 }
 
-// The PRODUCTION retry budget, pinned. Every other case here passes its own
-// `attempts`, so on its own this suite would stay green with the default
-// silently cut to 1 — which is the state the incident was reporting. Measured by
-// leaving the knob unset: four faults must be survivable and the fifth must not.
 {
   const survives = await runPush(PER_COMMIT, { [PER_COMMIT]: { pushFailures: 4 } }, { attempts: null });
   assert(survives.status === 0, `the default budget must survive 4 faults, got ${survives.status}`);
@@ -853,8 +653,6 @@ function runPush(tags, plan = {}, { attempts = 3 } = {}) {
   assert(exhausts.stderr.includes("after 5 attempts"), `expected a 5-attempt budget, got: ${exhausts.stderr}`);
 }
 
-// The first done-when, measured rather than asserted in a comment: a
-// single `unknown blob` no longer fails the leg.
 {
   const flaky = await runPush(`${ROLLING}\n${PER_COMMIT}`, { [PER_COMMIT]: { pushFailures: 1 } });
   assert(flaky.status === 0, `one \`unknown blob\` then a good push must succeed, got ${flaky.status}\n${flaky.stderr}`);
@@ -872,24 +670,12 @@ function runPush(tags, plan = {}, { attempts = 3 } = {}) {
   );
 }
 
-// A push that exits 0 while the registry commits no manifest is the fault an
-// exit-code check cannot see — and the one that would hand the sign step a tag
-// that resolves to nothing. It must count as a failed attempt and be retried.
 {
   const late = await runPush(PER_COMMIT, { [PER_COMMIT]: { manifestMisses: 1 } });
   assert(late.status === 0, `a manifest committed on the retry must pass, got ${late.status}\n${late.stderr}`);
   assert(late.pushes.length === 2, `the uncommitted push must be retried, got ${late.pushes.join(", ")}`);
 }
 
-// The two faults are NOT reported as one. Both end in "this tag does not
-// resolve", and the retry treats them the same — but the run log has to say
-// which happened, because "the registry refused the manifest" is a re-run and
-// "the push exited 0 and committed nothing" is a read of the code. Collapsing
-// them (`docker push || true`, and let the read-back decide) keeps every other
-// assertion here green while destroying that distinction.
-// Keyed on the SCRIPT's own words, never on `unknown blob` — the fake docker
-// prints that itself, so an assertion on it would pass no matter what this
-// script concluded.
 {
   const refused = await runPush(PER_COMMIT, { [PER_COMMIT]: { pushFailures: 1 } });
   assert(
@@ -907,9 +693,6 @@ function runPush(tags, plan = {}, { attempts = 3 } = {}) {
   );
 }
 
-// The second done-when. A registry that never commits fails the step, by
-// name — and the per-commit tag pome-cloud resolves is left absent, which is
-// the "reports not found rather than resolving a partial manifest" half.
 {
   const dead = await runPush(PER_COMMIT, { [PER_COMMIT]: { pushFailures: 99 } }, { attempts: 2 });
   assert(dead.status !== 0, "a registry that never accepts the manifest must fail the step");
@@ -924,12 +707,6 @@ function runPush(tags, plan = {}, { attempts = 3 } = {}) {
   assert(dead.pushes.length === 2, `exactly the attempt budget must be spent, got ${dead.pushes.join(", ")}`);
 }
 
-// The half-published case, which is the reason the per-commit tag is pushed
-// LAST. When an earlier tag exhausts its attempts the script must STOP: pushing
-// on would publish a per-commit tag whose predecessor never landed, and that
-// tag is the one pome-cloud resolves and pome-cloud's gate expects to be
-// signed. The tags that DID land are named, because the sign/attest step never
-// runs after this failure — so they are published and unsigned.
 {
   const partial = await runPush(`${ROLLING}\n${PER_COMMIT}`, { [ROLLING]: { pushFailures: 99 } }, { attempts: 2 });
   assert(partial.status !== 0, "an exhausted tag must fail the step");
@@ -956,12 +733,6 @@ function runPush(tags, plan = {}, { attempts = 3 } = {}) {
   );
 }
 
-// A push of zero tags is not a successful push. `steps.meta.outputs.tags` is
-// empty on a metadata-action misconfiguration, and an empty loop exits 0 —
-// which reads as "published" while nothing was. Asserted in both shapes,
-// because they are refused by two different guards: an empty variable never
-// enters the loop, while a variable holding only blank lines enters it and
-// pushes nothing.
 for (const [label, tags] of [
   ["empty", ""],
   ["blank lines only", "\n \n"],
@@ -972,8 +743,6 @@ for (const [label, tags] of [
   assert(none.pushes.length === 0, "nothing may be pushed when there is nothing to push");
 }
 
-// The ordinary case: every tag lands, each is verified to resolve, and the run
-// log records the digest — the same digest pome-cloud will resolve.
 {
   const ok = await runPush(`${ROLLING}\n\n${PER_COMMIT}\n`);
   assert(ok.status === 0, `a clean push must pass: ${ok.stderr}`);
@@ -984,15 +753,6 @@ for (const [label, tags] of [
   assert(ok.stdout.includes("sha256:1111"), "the resolved digest must reach the run log");
   assert(!/::warning::/.test(`${ok.stdout}${ok.stderr}`), "a clean push must not warn about degradation");
 }
-
-// ---------------------------------------------------------------------------
-// scripts/ci/sign-image-digests.sh itself.
-//
-// Driven against a fake `cosign` alongside the fake `docker` above. The fault
-// to reproduce is a registry that authenticates fine for one call and answers
-// `DENIED: denied` for the next, which no local registry offers on demand —
-// and which, unlike the push fault, strikes AFTER every tag is public.
-// ---------------------------------------------------------------------------
 
 const FAKE_COSIGN = `#!/usr/bin/env bash
 set -euo pipefail
@@ -1020,13 +780,6 @@ exit 0
 
 const SIGN_OPS = ["sign", "attest", "verify", "verify-attestation"];
 
-/**
- * `plan` is keyed by TAG, like runPush's — `{ [tag]: { inspect, sign, attest,
- * verify, "verify-attestation" } }`, each a count of consecutive faults. Keyed
- * per tag rather than per subcommand so the half-verified case below can fault
- * the SECOND tag only, which is the state the fail-closed message has to
- * describe.
- */
 function runSign(tags, plan = {}, { attempts = 3, sbom = true } = {}) {
   const dir = mkdtempSync(join(tmpdir(), "sign-image-digests-"));
   const state = join(dir, "state");
@@ -1041,8 +794,6 @@ function runSign(tags, plan = {}, { attempts = 3, sbom = true } = {}) {
   const summary = join(dir, "github_step_summary");
   writeFileSync(output, "");
   writeFileSync(summary, "");
-  // Every tag reaching this script has already been pushed AND read back by
-  // push-scanned-image.sh, so its manifest exists unless a case says otherwise.
   for (const tag of tags.split("\n").map((t) => t.trim()).filter(Boolean)) {
     writeFileSync(join(state, `manifest_${tag.replace(/[^A-Za-z0-9]/g, "_")}`), "");
   }
@@ -1063,8 +814,6 @@ function runSign(tags, plan = {}, { attempts = 3, sbom = true } = {}) {
       GITHUB_STEP_SUMMARY: summary,
       FAKE_DOCKER_STATE: state,
       FAKE_COSIGN_STATE: state,
-      // `attempts: null` leaves the knob unset, which is how the case below
-      // measures the PRODUCTION budget rather than one the test chose.
       ...(attempts === null ? {} : { SIGN_IMAGE_DIGESTS_ATTEMPTS: String(attempts) }),
       SIGN_IMAGE_DIGESTS_SLEEP_UNIT: "0",
     },
@@ -1093,19 +842,12 @@ function runSign(tags, plan = {}, { attempts = 3, sbom = true } = {}) {
 
 const opsFor = (calls, ref) => calls.filter((c) => c.endsWith(` ${ref}`)).map((c) => c.split(" ")[0]);
 
-// The PRODUCTION retry budget, pinned — the same guard runPush carries, for the
-// same reason: every other case here passes its own `attempts`, so the default
-// could be cut to 1 with this suite still green. It must also be the SAME
-// budget as push-scanned-image.sh's, so the publish path has one number.
 {
   const survives = await runSign(PER_COMMIT, { [PER_COMMIT]: { "verify-attestation": 4 } }, { attempts: null });
   assert(survives.status === 0, `the default budget must survive 4 faults, got ${survives.status}\n${survives.stderr}`);
   const exhausts = await runSign(PER_COMMIT, { [PER_COMMIT]: { "verify-attestation": 5 } }, { attempts: null });
   assert(exhausts.status !== 0, "the default budget must be spent by 5 faults, not open-ended");
   assert(exhausts.stderr.includes("after 5 attempts"), `expected a 5-attempt budget, got: ${exhausts.stderr}`);
-  // …and the SAME budget, read out of both scripts. The publish path having one
-  // number to reason about is a claim both headers make; two knobs is exactly
-  // how that claim rots.
   const knob = (path, name) => new RegExp(`\\$\\{${name}:-(\\d+)\\}`).exec(readFileSync(path, "utf8"))?.[1] ?? null;
   for (const [what, sign, push] of [
     ["attempt budget", "SIGN_IMAGE_DIGESTS_ATTEMPTS", "PUSH_SCANNED_IMAGE_ATTEMPTS"],
@@ -1117,9 +859,6 @@ const opsFor = (calls, ref) => calls.filter((c) => c.endsWith(` ${ref}`)).map((c
   }
 }
 
-// The signing leg's first done-when, one case per GHCR interaction the script makes. A
-// `DENIED` on ANY of them is the registry being degraded, not a verdict about
-// the artifact, so none may fail the leg on the first answer.
 for (const op of SIGN_OPS) {
   const flaky = await runSign(PER_COMMIT, { [PER_COMMIT]: { [op]: 1 } });
   assert(flaky.status === 0, `one DENIED on \`cosign ${op}\` must not fail the leg, got ${flaky.status}\n${flaky.stderr}`);
@@ -1128,31 +867,18 @@ for (const op of SIGN_OPS) {
     ops.filter((o) => o === op).length === 2,
     `\`cosign ${op}\` must be retried, got ${ops.join(", ")}`,
   );
-  // Keyed on the "landed only on attempt N" line specifically, not on any
-  // `::warning::`: the retry itself warns before sleeping, so a bare
-  // `/::warning::/` stays green with the succeeded-late notice deleted — and
-  // that notice is the whole signal that GHCR is degrading before the day it
-  // is total, which is how the incident went unnoticed for four days.
   assert(
     `${flaky.stdout}${flaky.stderr}`.includes("landed only on attempt 2"),
     `a flaky-but-passing \`cosign ${op}\` must SAY so, got: ${flaky.stdout}${flaky.stderr}`,
   );
 }
 
-// The digest READ is a GHCR interaction too, and the first one this script
-// makes — an unretried `imagetools inspect` would fail the leg before cosign
-// is ever reached, leaving the retry ladder below it unreachable.
 {
   const flaky = await runSign(PER_COMMIT, { [PER_COMMIT]: { inspect: 1 } });
   assert(flaky.status === 0, `one DENIED on the digest read must not fail the leg, got ${flaky.status}\n${flaky.stderr}`);
   assert(flaky.inspects.length === 2, `the digest read must be retried, got ${flaky.inspects.join(", ")}`);
 }
 
-// The signing leg's second done-when. Exhaustion still fails closed — but by the time
-// anything here fails, push-scanned-image.sh has already published every tag,
-// so the message has to say which operation ran out, on which ref, and what
-// state that leaves public. `##[error]The process failed with exit code 1` is
-// exactly the message that makes a degraded registry read like a broken twin.
 {
   const dead = await runSign(PER_COMMIT, { [PER_COMMIT]: { "verify-attestation": 99 } }, { attempts: 2 });
   assert(dead.status !== 0, "a registry that never answers the verify must fail the step");
@@ -1173,9 +899,6 @@ for (const op of SIGN_OPS) {
   );
 }
 
-// "Names what landed", measured. Two tags, the second unverifiable: the first
-// is signed, attested AND verified, and a human reading this failure has to
-// know that — re-running is safe, and the twin is not broken.
 {
   const partial = await runSign(
     `${ROLLING}\n${PER_COMMIT}`,
@@ -1187,19 +910,12 @@ for (const op of SIGN_OPS) {
     partial.stderr.includes("signed") && partial.stderr.includes("attested"),
     `the message must say how far the failing ref got, got: ${partial.stderr}`,
   );
-  // `${ROLLING}@` and not `${ROLLING}`: the failing ref is `…:stripe-bbf27bf@…`,
-  // which contains `…:stripe` but not `…:stripe@`.
   assert(
     landedClause(partial.stderr, "Signed, attested and verified:").includes(`${ROLLING}@`),
     `the message must name the ref that IS fully verified, in the landed clause, got: ${partial.stderr}`,
   );
 }
 
-// The distinct partial states are not collapsed into one word. A ref that could
-// not be SIGNED is published-and-unsigned; a ref that could not be VERIFIED is
-// published, signed and attested. Those are different re-run decisions, and a
-// message that said "not signed" for both would misdirect on the one that
-// actually happens.
 {
   const unsigned = await runSign(PER_COMMIT, { [PER_COMMIT]: { sign: 99 } }, { attempts: 2 });
   assert(/not.{0,20}signed|unsigned/i.test(unsigned.stderr), `a ref that never signed must say so, got: ${unsigned.stderr}`);
@@ -1214,8 +930,6 @@ for (const op of SIGN_OPS) {
   );
 }
 
-// An empty IMAGE_TAGS is refused rather than read as a signing of zero refs —
-// the same guard push-scanned-image.sh carries, for the same reason.
 for (const [label, tags] of [
   ["empty", ""],
   ["blank lines only", "\n \n"],
@@ -1225,10 +939,6 @@ for (const [label, tags] of [
   assert(none.calls.length === 0, "nothing may be signed when there is nothing to sign");
 }
 
-// A CRLF-flavoured tag list is signed as the tags the registry knows, not as
-// `<tag>\r`. Untrimmed, a whitespace bug of OURS spends the full ladder — five
-// attempts and 50s of backoff per operation — and then fails closed blaming a
-// degraded GHCR, which is the most expensive possible way to be wrong.
 {
   const crlf = await runSign(`${ROLLING}\r\n${PER_COMMIT}\r`);
   assert(crlf.status === 0, `a CRLF tag list must sign cleanly, got ${crlf.status}\n${crlf.stderr}`);
@@ -1240,17 +950,12 @@ for (const [label, tags] of [
   assert(!/::warning::/.test(`${crlf.stdout}${crlf.stderr}`), "a trimmed tag must not cost a retry");
 }
 
-// A missing SBOM predicate is refused before anything is signed: an attestation
-// over a file that is not there is not an attestation.
 {
   const noSbom = await runSign(PER_COMMIT, {}, { sbom: false });
   assert(noSbom.status !== 0, "a missing SBOM predicate must fail the step");
   assert(noSbom.calls.length === 0, "nothing may be signed without the predicate");
 }
 
-// The ordinary case: every ref is signed, attested and both-ways verified
-// exactly once, the digests reach `signed_digests` for the step that consumes
-// them, and a clean run does not cry degradation.
 {
   const ok = await runSign(`${ROLLING}\n\n${PER_COMMIT}\n`);
   assert(ok.status === 0, `a clean sign must pass: ${ok.stderr}`);

--- a/scripts/ci/assert-hardened-cdn-fetches.test.mjs
+++ b/scripts/ci/assert-hardened-cdn-fetches.test.mjs
@@ -224,10 +224,9 @@ assert(findFetchesInScript("gh release download v1 -R o/r").length === 1, "gh re
 //
 // `Push scanned image` was one bare `docker push` with no retry, sitting
 // between two `uses:` installs that had both been given three-attempt ladders.
-// On 2026-08-14 GHCR answered `unknown blob` after every
-// layer had reported `Pushed`, the stripe leg died, and `stripe-bbf27bf` did
-// not exist — which failed four consecutive twin-snapshot-verify runs and
-// opened pome-cloud#752, because nothing re-ran that step for four days.
+// GHCR can answer `unknown blob` after every layer has reported `Pushed`, so a
+// leg dies and its per-commit tag does not exist — which fails every downstream
+// snapshot verify for as long as nobody re-runs the step.
 // ---------------------------------------------------------------------------
 
 // PLANTED FAILURE — the exact shape twin-image.yml's push step had.
@@ -307,10 +306,10 @@ assert(findRegistryWritesInScript("docker push ghcr.io/o/r:v1").length === 1, "a
 // With shapes (a) and (c) closed, the sign/attest/verify step was the last
 // unretried GHCR interaction on the publish path — a single step at
 // twin-image.yml:344 with no attempt siblings, sitting between an SBOM fetch
-// and a cosign install that both have three-attempt ladders. On 2026-08-18 a
-// degraded GHCR answered `DENIED: denied` off its token endpoint and killed the
-// stripe leg of run 32144441622 on `verify-attestation` — AFTER both tags were
-// pushed, signed and attested. A red job over a correct, published artifact.
+// and a cosign install that both have three-attempt ladders. A degraded GHCR
+// answers `DENIED: denied` off its token endpoint and kills the leg on
+// `verify-attestation` — AFTER both tags are pushed, signed and attested. A red
+// job over a correct, published artifact.
 // ---------------------------------------------------------------------------
 
 // PLANTED FAILURE — the WRITE half, inline. This is the shape the sign step
@@ -1011,7 +1010,7 @@ take() {
   return 1
 }
 if take "\${state}/cosignfail_\${op}_\${slug}"; then
-  # Verbatim from run 32144441622 on 2026-08-18, the stripe leg. Both tags were
+  # Verbatim from an observed failure. Both tags were
   # pushed, signed and attested before this answer arrived on the READ.
   echo "Error: GET https://ghcr.io/token?scope=repository:pome-sh/twins:pull&service=ghcr.io: DENIED: denied" >&2
   exit 1
@@ -1153,7 +1152,7 @@ for (const op of SIGN_OPS) {
 // anything here fails, push-scanned-image.sh has already published every tag,
 // so the message has to say which operation ran out, on which ref, and what
 // state that leaves public. `##[error]The process failed with exit code 1` is
-// exactly the message that made 2026-08-18 read like a broken twin.
+// exactly the message that makes a degraded registry read like a broken twin.
 {
   const dead = await runSign(PER_COMMIT, { [PER_COMMIT]: { "verify-attestation": 99 } }, { attempts: 2 });
   assert(dead.status !== 0, "a registry that never answers the verify must fail the step");

--- a/scripts/ci/assert-hardened-cdn-fetches.test.mjs
+++ b/scripts/ci/assert-hardened-cdn-fetches.test.mjs
@@ -387,7 +387,7 @@ assert(findSigningCallsInScript("cosign triangulate ghcr.io/o/r:v1").length === 
 // twin-image.yml's install ladder annotates all three attempts with an `echo`
 // naming the binary. A prefix rule like shape (a)'s and (c)'s reads those two
 // lines as unhardened invocations and reds the repo on its own prose — measured,
-// not imagined: it did, on the first run of this gate.
+// not imagined.
 for (const prose of [
   `echo "::warning::cosign install attempt 1 failed. sigstore/cosign-installer fetches cosign from github.com/sigstore/cosign/releases"`,
   `echo "::error::could not install cosign after 3 attempts. sigstore/cosign-installer fetches the pinned cosign v2.6.4 binary from the sigstore release CDN"`,

--- a/scripts/ci/assert-repo-policy.sh
+++ b/scripts/ci/assert-repo-policy.sh
@@ -1,42 +1,9 @@
 #!/usr/bin/env bash
-# Assert the protected-main policy: pull request, review, required checks.
 #
-# The live check reads GET .../rules/branches/{branch}, which an ordinary
-# GITHUB_TOKEN can call. Do NOT move it to GET .../branches/{branch}/protection
-# or GET .../rulesets/{id}: both need Administration:read, which GITHUB_TOKEN
-# cannot hold. /protection is auth-gated outright, and /rulesets/{id} answers
-# 200 for any caller on a public repo but ELIDES bypass_actors without that
-# scope — so it would pass while checking nothing. This endpoint returns the
-# same effective rules (pull_request review count, required status checks,
-# non-fast-forward, deletion) for a metadata-scoped GITHUB_TOKEN, no PAT
-# needed.
-#
-# The property that matters: this must FAIL, not silently pass, if the rules
-# it reads stop covering a policy it asserts (ruleset deleted, disabled or
-# switched to `evaluate`, protection moved to classic branch protection,
-# endpoint drops a rule type). An empty/missing rules array, or any policy
-# with no matching rule, is a hard failure naming that policy — never
-# treated as "nothing to check".
-#
-# It returns only rules from rulesets whose enforcement is `active`. A ruleset flipped to
-# `evaluate` or `disabled` drops out entirely, so its rules vanish from this
-# payload and the empty-array branch below hard-fails. That is why enforcement
-# is not asserted separately — losing it cannot present as a green run.
-# Rules inherited from an ORG-level ruleset do still appear here (with
-# ruleset_source_type "Organization"). They count towards coverage — the policy
-# is that main is covered, not that a particular ruleset object covers it — but
-# they are held to the same terms: an org rule contributing a required context
-# not in config/required-checks.json is still a failure, because an unexpected
-# required context is exactly the drift this check exists to surface.
-#
-# NOT covered live (dropped, not silently assumed true) — both are named in the
-# run log on success so a reader is never told coverage is total:
-#
-#   1. The ruleset's bypass_actors (founder-team bypass). GitHub elides the bypass_actors FIELD
-# for callers without Administration:read — the .../rulesets/{id} endpoint
-# itself is readable (it answers 200 even unauthenticated on this public repo),
-# but the field is simply absent, so asserting on it would fail OPEN for
-# GITHUB_TOKEN. Left unwatched rather than asserted-on-an-absent-field.
+# Asserts main's live branch rules. Reads GET .../rules/branches/{branch}, which an
+# ordinary GITHUB_TOKEN can call; /protection and /rulesets/{id} need
+# Administration:read and would pass while checking nothing. An empty rules array
+# is a hard failure, never "nothing to check".
 set -euo pipefail
 
 REPO="${GITHUB_REPOSITORY:-pome-sh/digital-twins}"
@@ -45,13 +12,8 @@ TOKEN="${GITHUB_TOKEN:?GITHUB_TOKEN required (ordinary Actions token; no PAT nee
 RULES_OUT="$(mktemp)"
 trap 'rm -f "${RULES_OUT}"' EXIT
 
-# The contexts live in config/required-checks.json. A second hand-maintained
-# copy of the same list goes stale
-# while both still look like they are watching.
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 REQUIRED_CHECKS_FILE="${REQUIRED_CHECKS_FILE:-${REPO_ROOT}/config/required-checks.json}"
-# Read into a variable first (not `mapfile < <(...)`, which is bash 4+ and
-# swallows the exit status): `set -e` must still fire if the file is unreadable.
 REQUIRED_CHECKS_RAW="$(
   REQUIRED_CHECKS_FILE="${REQUIRED_CHECKS_FILE}" node -e '
     const fs = require("fs");
@@ -90,10 +52,6 @@ fail_http() {
 echo "Asserting branch rules policy for ${REPO}@${BRANCH}"
 
 if [[ -n "${RULES_JSON:-}" ]]; then
-  # Fixture seam for assert-repo-policy.test.mjs only. Say so loudly: a run
-  # that reads a fixture asserts nothing about the live repo, and must never
-  # be mistaken for a drift check that passed. repo-policy.yml never sets it
-  # (asserted by the regression test).
   echo "::warning::RULES_JSON is set — reading fixture ${RULES_JSON}, NOT the live GitHub API. This run proves nothing about ${REPO}@${BRANCH}."
   cp "${RULES_JSON}" "${RULES_OUT}"
 else

--- a/scripts/ci/assert-repo-policy.sh
+++ b/scripts/ci/assert-repo-policy.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
-# F-696 — assert public-repo policy for pome-twins main.
-# F-1212 — the live drift check used to call the legacy
-# GET .../branches/{branch}/protection + GET .../rulesets endpoints, which
-# need Administration:read. GITHUB_TOKEN cannot hold that scope, so the
-# check depended on a hand-minted PAT (REPO_POLICY_TOKEN) that never existed
-# — the weekly cron has been red since it shipped and the live step never
-# ran once. GET .../rules/branches/{branch} returns the same effective rules
-# (pull_request review count, required status checks, non-fast-forward,
+# Assert the protected-main policy: pull request, review, required checks.
+#
+# The live check reads GET .../rules/branches/{branch}, which an ordinary
+# GITHUB_TOKEN can call. Do NOT move it to GET .../branches/{branch}/protection
+# or GET .../rulesets/{id}: both need Administration:read, which GITHUB_TOKEN
+# cannot hold. /protection is auth-gated outright, and /rulesets/{id} answers
+# 200 for any caller on a public repo but ELIDES bypass_actors without that
+# scope — so it would pass while checking nothing. This endpoint returns the
+# same effective rules
 # deletion) for a metadata-scoped GITHUB_TOKEN, no PAT needed.
 #
 # The property that matters: this must FAIL, not silently pass, if the rules
@@ -16,7 +17,7 @@
 # with no matching rule, is a hard failure naming that policy — never
 # treated as "nothing to check".
 #
-# Verified against the live repo (F-1212 review): this endpoint returns only
+# This endpoint returns only
 # rules from rulesets whose enforcement is `active`. A ruleset flipped to
 # `evaluate` or `disabled` drops out entirely, so its rules vanish from this
 # payload and the empty-array branch below hard-fails. That is why enforcement
@@ -44,8 +45,8 @@ TOKEN="${GITHUB_TOKEN:?GITHUB_TOKEN required (ordinary Actions token; no PAT nee
 RULES_OUT="$(mktemp)"
 trap 'rm -f "${RULES_OUT}"' EXIT
 
-# F-1180 — the contexts live in config/required-checks.json. A second
-# hand-maintained copy of the same list is the F-1135 shape: one goes stale
+# The contexts live in config/required-checks.json. A second hand-maintained
+# copy of the same list goes stale
 # while both still look like they are watching.
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 REQUIRED_CHECKS_FILE="${REQUIRED_CHECKS_FILE:-${REPO_ROOT}/config/required-checks.json}"

--- a/scripts/ci/assert-repo-policy.sh
+++ b/scripts/ci/assert-repo-policy.sh
@@ -7,8 +7,9 @@
 # cannot hold. /protection is auth-gated outright, and /rulesets/{id} answers
 # 200 for any caller on a public repo but ELIDES bypass_actors without that
 # scope — so it would pass while checking nothing. This endpoint returns the
-# same effective rules
-# deletion) for a metadata-scoped GITHUB_TOKEN, no PAT needed.
+# same effective rules (pull_request review count, required status checks,
+# non-fast-forward, deletion) for a metadata-scoped GITHUB_TOKEN, no PAT
+# needed.
 #
 # The property that matters: this must FAIL, not silently pass, if the rules
 # it reads stop covering a policy it asserts (ruleset deleted, disabled or
@@ -17,8 +18,7 @@
 # with no matching rule, is a hard failure naming that policy — never
 # treated as "nothing to check".
 #
-# This endpoint returns only
-# rules from rulesets whose enforcement is `active`. A ruleset flipped to
+# It returns only rules from rulesets whose enforcement is `active`. A ruleset flipped to
 # `evaluate` or `disabled` drops out entirely, so its rules vanish from this
 # payload and the empty-array branch below hard-fails. That is why enforcement
 # is not asserted separately — losing it cannot present as a green run.
@@ -228,7 +228,7 @@ console.log("required contexts:", required.join(", "));
 console.log(
   "NOT verified live (needs Administration:read, deliberately not held): ruleset bypass_actors "
     + "(founder-team bypass); and classic branch protection's own required_status_checks copy, which "
-    + "this endpoint cannot see at all — deleted 2026-08-13 because no App can bypass it, and a "
+    + "this endpoint cannot see at all, and must carry no such rule because no App can bypass it. A "
     + "re-added copy is caught by release-alarm.yml's UNALLOCATED leg within a day, not here",
 );
 NODE

--- a/scripts/ci/assert-repo-policy.test.mjs
+++ b/scripts/ci/assert-repo-policy.test.mjs
@@ -343,7 +343,7 @@ function main() {
     // Green runs must name what is NOT watched live, so a reader is never
     // told coverage is total. Deletion is now asserted live (the
     // ruleset carries the rule), so bypass_actors is the only named gap and
-    // the NOT-verified line must no longer mention deletion.
+    // the NOT-verified line must not mention deletion.
     const r = runAssert(baseRules());
     assert(r.stdout.includes("NOT verified live"), r.stdout);
     assert(r.stdout.includes("bypass_actors"), r.stdout);

--- a/scripts/ci/assert-repo-policy.test.mjs
+++ b/scripts/ci/assert-repo-policy.test.mjs
@@ -1,14 +1,7 @@
 #!/usr/bin/env node
-/**
- * Offline regression coverage for scripts/ci/assert-repo-policy.sh.
- * The script now reads GET /repos/{owner}/{repo}/rules/branches/{branch}
- * (metadata-scoped GITHUB_TOKEN, no PAT) instead of the legacy admin-scoped
- * .../protection + .../rulesets pair. Feeds fixture rules JSON (no live API).
- *
- * The property under test isn't just "correct config passes" — it's that a
- * rules response which stops COVERING a policy (missing rule type, empty
- * array) is a hard failure, never a silent pass.
- */
+//
+// Feeds the policy script stubbed API payloads. The load-bearing cases are the ones
+// where a rule is absent or a ruleset is inactive: both must red, not pass quietly.
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, writeFileSync, rmSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -94,15 +87,12 @@ function main() {
   }
 
   {
-    // Empty response must hard-fail, never "nothing to check".
     const r = runAssert([]);
     assert(r.status === 1, "empty rules array must fail");
     assert(`${r.stdout}\n${r.stderr}`.includes("returned no rules"), r.stderr);
   }
 
   {
-    // Missing required_status_checks rule entirely (e.g. dropped by the API,
-    // or protection moved elsewhere) must hard-fail, naming the policy.
     const r = runAssert(baseRules().filter((rule) => rule.type !== "required_status_checks"));
     assert(r.status === 1, "missing required_status_checks rule must fail");
     assert(
@@ -112,23 +102,18 @@ function main() {
   }
 
   {
-    // Missing non_fast_forward rule (force-push protection) must hard-fail.
     const r = runAssert(baseRules().filter((rule) => rule.type !== "non_fast_forward"));
     assert(r.status === 1, "missing non_fast_forward rule must fail");
     assert(`${r.stdout}\n${r.stderr}`.includes("missing rule: non_fast_forward"), r.stderr);
   }
 
   {
-    // Missing deletion rule (branch-deletion protection) must hard-fail,
-    // naming the policy — this is the red proof that the ruleset actually needs
-    // the rule, not just that the script mentions it.
     const r = runAssert(baseRules().filter((rule) => rule.type !== "deletion"));
     assert(r.status === 1, "missing deletion rule must fail");
     assert(`${r.stdout}\n${r.stderr}`.includes("missing rule: deletion"), r.stderr);
   }
 
   {
-    // Missing pull_request rule must hard-fail.
     const r = runAssert(baseRules().filter((rule) => rule.type !== "pull_request"));
     assert(r.status === 1, "missing pull_request rule must fail");
     assert(`${r.stdout}\n${r.stderr}`.includes("missing rule: pull_request"), r.stderr);
@@ -149,7 +134,6 @@ function main() {
   }
 
   {
-    // Context present in the ruleset but absent from config/required-checks.json.
     const rules = baseRules().map((rule) =>
       rule.type === "required_status_checks"
         ? {
@@ -175,7 +159,6 @@ function main() {
   }
 
   {
-    // Context present in config/required-checks.json but absent from the ruleset.
     const rules = baseRules().map((rule) =>
       rule.type === "required_status_checks"
         ? {
@@ -228,9 +211,6 @@ function main() {
   }
 
   {
-    // Two rulesets can both match main (repo + org), so the endpoint returns a
-    // rule per source. A second, laxer pull_request rule must not hide behind
-    // the compliant first one.
     const rules = [
       ...baseRules(),
       {
@@ -253,8 +233,6 @@ function main() {
   }
 
   {
-    // Same for contexts: an extra context contributed by a second
-    // required_status_checks rule must be seen, not shadowed.
     const rules = [
       ...baseRules(),
       {
@@ -279,10 +257,6 @@ function main() {
   }
 
   {
-    // A rule type present but carrying no `parameters` at all must hard-fail,
-    // not read as "nothing to assert". Every declared policy is present so the
-    // only reason to red is the missing parameters — otherwise a `missing rule:`
-    // error for an absent type would satisfy the exit code on its own.
     const r = runAssert([
       { type: "pull_request" },
       { type: "required_status_checks" },
@@ -296,26 +270,15 @@ function main() {
   }
 
   {
-    // A payload that is valid JSON but not an array must hard-fail.
     const r = runAssert({ message: "Not Found" });
     assert(r.status === 1, "non-array payload must fail");
     assert(`${r.stdout}\n${r.stderr}`.includes("returned no rules"), r.stderr);
   }
 
   {
-    // The summary count must be derived from assertions that actually ran, so
-    // a declared policy with no live assertion cannot present as green. Drive
-    // it through a copy of the script with the non_fast_forward block removed.
-    // Pin one short line, not the whole block: this file runs inside the
-    // required typecheck-test job, so a pin on six lines of source turns any
-    // rename in the script into a red required check.
     const src = readFileSync(SCRIPT, "utf8");
     const marker = 'asserted.add("non_fast_forward");';
     assert(src.includes(marker), `${marker} not found in the script — update this test`);
-    // Mutant lives in the temp dir, never in the repo tree: a crash between
-    // write and cleanup must not leave a policy script with an assertion
-    // removed sitting in scripts/ci/ ready to be committed. The script derives
-    // REPO_ROOT from its own path, so hand it the config explicitly.
     const dir = mkdtempSync(join(tmpdir(), "assert-policy-selfcheck-"));
     const mutant = join(dir, "assert-repo-policy.mutant.sh");
     const rulesPath = join(dir, "rules.json");
@@ -340,10 +303,6 @@ function main() {
   }
 
   {
-    // Green runs must name what is NOT watched live, so a reader is never
-    // told coverage is total. Deletion is now asserted live (the
-    // ruleset carries the rule), so bypass_actors is the only named gap and
-    // the NOT-verified line must not mention deletion.
     const r = runAssert(baseRules());
     assert(r.stdout.includes("NOT verified live"), r.stdout);
     assert(r.stdout.includes("bypass_actors"), r.stdout);
@@ -353,8 +312,6 @@ function main() {
 
   {
     const y = readFileSync(join(ROOT, ".github/workflows/repo-policy.yml"), "utf8");
-    // The fixture seam must never be reachable in CI: an env var that stubs
-    // the API is a way to make a live check pass without calling anything.
     assert(
       !/RULES_JSON/.test(y),
       "repo-policy.yml must never set RULES_JSON — that would stub out the live API call",
@@ -382,10 +339,6 @@ function main() {
       /api -o.*rules\/branches\/\$\{BRANCH\}/s.test(scriptSrc),
       "assert-repo-policy.sh must call GET .../rules/branches/{branch}",
     );
-    // Match the request URL, not `api -o.*<path>`: the legacy calls wrapped the
-    // URL onto its own line, so a `.`-based pattern without /s never saw them
-    // and this guard passed on exactly the code it exists to forbid. Anchoring
-    // on api.github.com also keeps prose in the header comments from tripping it.
     assert(
       !/api\.github\.com\/[^"'\s]*\/rulesets/.test(scriptSrc),
       "assert-repo-policy.sh must not call the legacy admin-scoped .../rulesets endpoint",
@@ -394,8 +347,6 @@ function main() {
       !/api\.github\.com\/[^"'\s]*\/protection/.test(scriptSrc),
       "assert-repo-policy.sh must not call the legacy admin-scoped .../protection endpoint",
     );
-    // Guard the guard: prove the patterns above fire on the multi-line shape the
-    // removed code actually used, so they cannot rot back into always-true.
     const legacyShape = [
       'code="$(api -o "${LIST_OUT}" -w \'%{http_code}\' \\',
       '  "https://api.github.com/repos/${REPO}/rulesets")"',

--- a/scripts/ci/assert-schedule-alarm-coverage.mjs
+++ b/scripts/ci/assert-schedule-alarm-coverage.mjs
@@ -1,28 +1,24 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// The guard that keeps alarm coverage true. The alarm wiring covers
-// every scheduled workflow that exists TODAY to the reusable alarm; nothing
-// stopped a thirteenth from landing next month with no alarm at all, and
-// nothing stopped a wired-but-broken alarm (a typo'd `uses:` target, a
-// title/label pair that disagrees with itself, a job neutralised by
-// `continue-on-error: true` or a dead `if:`) from passing review looking
-// correct. This is a PROPERTY check, not a list of which workflows have
-// alarms — that list is the same shape as the bug it exists to catch.
+// The guard that keeps alarm coverage true. A PROPERTY check, not a list of
+// which workflows have alarms — that list would be the same shape as the bug it
+// exists to catch. What it stops: a new scheduled workflow landing with no
+// alarm, and a wired-but-broken alarm (a typo'd `uses:` target, a title/label
+// pair that disagrees with itself, a job neutralised by `continue-on-error` or
+// a dead `if:`) passing review looking correct.
 //
 // Left side (which workflows must reach the alarm) is read from
-// list-scheduled-workflows.mjs's own derivation, never re-parsed here; that
-// file already asserts its own non-zero floor and its own two-independent-
-// reads cross-check, so this file inherits both for free by calling it
-// rather than copying its rules.
+// list-scheduled-workflows.mjs's own derivation, never re-parsed here, so this
+// file inherits that file's non-zero floor and its two-independent-reads
+// cross-check by calling it rather than copying its rules.
 //
 // Right side (does a given workflow reach the alarm) parses PER JOB BLOCK,
-// anchored on both ends by indentation, rather than grepping lines — a
-// grep-based version of this exact check was defeated three separate times
-// during its own review, by a commented-out step, a
-// `continue-on-error: true`, and a step-level `if:`. Comments are already
-// stripped before any of this runs (list-scheduled-workflows.mjs's
-// workflowLines()), so a commented-out job simply is not there to find.
+// anchored on both ends by indentation, rather than grepping lines: a
+// grep-based version is defeated by a commented-out step, a
+// `continue-on-error: true`, or a step-level `if:`. Comments are already
+// stripped before any of this runs, so a commented-out job is not there to
+// find.
 //
 // Usage: node scripts/ci/assert-schedule-alarm-coverage.mjs
 // Exits 1, naming every offending workflow/job, on:
@@ -59,7 +55,7 @@ import {
   // TRUE rather than a claim. It throws on zero scheduled workflows, on its
   // two independent reads (`on: schedule:` vs `cron:`) disagreeing, and on any
   // `uses: ./.github/workflows/…` pointing at an absent file — so dropping its
-  // separate ci.yml step can no longer quietly retire those three floors.
+  // separate ci.yml step cannot quietly retire those three floors.
   main as assertScheduledWorkflowDerivation,
 } from "./list-scheduled-workflows.mjs";
 
@@ -294,12 +290,11 @@ function parseJobs(lines) {
       } else if ((m = /^\s*needs:\s*(.*)$/.exec(line))) {
         needs = parseNeeds(lines, kIdx, m[1].trim());
       } else if ((m = /^\s*with:\s*(.*)$/.exec(line))) {
-        // Both spellings of the same mapping. `with:` alone on its line opens
-        // a block; `with: {title: …, outcome: failure}` is flow form, which an
-        // earlier revision of this file did not recognise at all — it parsed
-        // as no inputs, so a CORRECTLY covered workflow was reported both
-        // uncovered and missing its inputs. A guard that reds on right answers
-        // is a guard someone deletes.
+        // Both spellings of the same mapping. `with:` alone on its line opens a
+                // block; `with: {title: …, outcome: failure}` is flow form. Missing the
+                // flow form parses as no inputs, so a CORRECTLY covered workflow reads
+                // as both uncovered and missing its inputs — and a guard that reds on
+                // right answers is a guard someone deletes.
         const inline = m[1].trim();
         const found = inline
           ? [...inline.matchAll(/\b(title|label|outcome)\s*:\s*("[^"]*"|'[^']*'|[^,}]+)/g)].map((f) => [f[1], f[2]])
@@ -364,8 +359,8 @@ export function findScheduleAlarmCalls(root) {
  * If `permissions:` is absent at BOTH the job and the workflow level, the
  * effective grant is the repository/organization default — a setting this
  * script cannot read from the filesystem. Treating "cannot resolve" as a
- * silent pass would be exactly the silent-degradation shape this milestone
- * exists to catch (an unstated grant one settings-page click away from
+  * silent pass would be exactly the silent degradation this exists to catch (an
+  * unstated grant one settings-page click away from
  * losing `issues: write` entirely, with nothing in the diff to review), so
  * it is reported as a hard failure naming the workflow and job instead —
  * the same "unsupported shape must never be indistinguishable from a
@@ -450,8 +445,7 @@ function isTriviallyFalse(ifExpr) {
 /**
  * A call counts as reaching the alarm's FAILURE leg — the half that must
  * exist for every scheduled workflow — only if it is not neutralised. Three
- * independent ways a wired-looking call is dead in production, each one a
- * real defect this milestone hit once already (see this file's header):
+  * independent ways a wired-looking call is dead in production:
  * `continue-on-error: true` swallows the reusable call's own failure so a
  * broken alarm still reports green; a literal `if: false` means the job
  * never runs at all; and `outcome` has to be the literal string `failure` —
@@ -600,13 +594,11 @@ export function findUnclosableAlarms(calls) {
 export function main() {
   const root = resolve(HERE, "../..");
 
-  // Inherited floors, actually inherited: this calls list-scheduled-workflows'
-  // OWN entry point, which throws on zero scheduled workflows, on its two
-  // independent reads (`on: schedule:` vs `cron:`) disagreeing, and on a
-  // `uses: ./.github/workflows/…` target that is absent. Re-implementing only
-  // the zero check here (an earlier revision) meant the set-equality floor was
-  // claimed but not held: retiring ci.yml's separate step would have silently
-  // taken it with it.
+  // Inherited floors, actually inherited: this calls
+    // list-scheduled-workflows' OWN entry point, which throws on zero scheduled
+    // workflows, on its two independent reads disagreeing, and on an absent
+    // `uses: ./.github/workflows/…` target. Re-implementing only the zero check
+    // here would claim the set-equality floor without holding it.
   const scheduled = assertScheduledWorkflowDerivation([]);
 
   // Belt-and-braces on the count this check itself reasons about: the floor

--- a/scripts/ci/assert-schedule-alarm-coverage.mjs
+++ b/scripts/ci/assert-schedule-alarm-coverage.mjs
@@ -359,8 +359,8 @@ export function findScheduleAlarmCalls(root) {
  * If `permissions:` is absent at BOTH the job and the workflow level, the
  * effective grant is the repository/organization default — a setting this
  * script cannot read from the filesystem. Treating "cannot resolve" as a
-  * silent pass would be exactly the silent degradation this exists to catch (an
-  * unstated grant one settings-page click away from
+ * silent pass would be exactly the silent degradation this exists to catch (an
+ * unstated grant one settings-page click away from
  * losing `issues: write` entirely, with nothing in the diff to review), so
  * it is reported as a hard failure naming the workflow and job instead —
  * the same "unsupported shape must never be indistinguishable from a
@@ -445,7 +445,7 @@ function isTriviallyFalse(ifExpr) {
 /**
  * A call counts as reaching the alarm's FAILURE leg — the half that must
  * exist for every scheduled workflow — only if it is not neutralised. Three
-  * independent ways a wired-looking call is dead in production:
+ * independent ways a wired-looking call is dead in production:
  * `continue-on-error: true` swallows the reusable call's own failure so a
  * broken alarm still reports green; a literal `if: false` means the job
  * never runs at all; and `outcome` has to be the literal string `failure` —

--- a/scripts/ci/assert-schedule-alarm-coverage.mjs
+++ b/scripts/ci/assert-schedule-alarm-coverage.mjs
@@ -1,48 +1,14 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// The guard that keeps alarm coverage true. A PROPERTY check, not a list of
-// which workflows have alarms — that list would be the same shape as the bug it
-// exists to catch. What it stops: a new scheduled workflow landing with no
-// alarm, and a wired-but-broken alarm (a typo'd `uses:` target, a title/label
-// pair that disagrees with itself, a job neutralised by `continue-on-error` or
-// a dead `if:`) passing review looking correct.
+// Every scheduled workflow must reach schedule-alarm.yml's failure leg. Parses
+// per job block rather than grepping, because a grep is defeated by a
+// commented-out step, a `continue-on-error`, or a step-level `if:`.
 //
-// Left side (which workflows must reach the alarm) is read from
-// list-scheduled-workflows.mjs's own derivation, never re-parsed here, so this
-// file inherits that file's non-zero floor and its two-independent-reads
-// cross-check by calling it rather than copying its rules.
-//
-// Right side (does a given workflow reach the alarm) parses PER JOB BLOCK,
-// anchored on both ends by indentation, rather than grepping lines: a
-// grep-based version is defeated by a commented-out step, a
-// `continue-on-error: true`, or a step-level `if:`. Comments are already
-// stripped before any of this runs, so a commented-out job is not there to
-// find.
-//
-// Usage: node scripts/ci/assert-schedule-alarm-coverage.mjs
-// Exits 1, naming every offending workflow/job, on:
-//   - a scheduled workflow with no job reaching the alarm's failure leg
-//   - a schedule-alarm.yml call missing its required title or label
-//   - a title reused with more than one label, or a label reused with more
-//     than one title, anywhere in the tree
-//   - zero scheduled workflows discovered (a parser regression, not a
-//     true fact about the tree — inherited from list-scheduled-workflows.mjs)
-//   - a job calling schedule-alarm.yml whose EFFECTIVE permissions (its own
-//     job-level `permissions:` if present, else the workflow-level block,
-//     else the unreadable repo default) do not grant every scope
-//     schedule-alarm.yml's OWN filing job requests — the alarm exists, runs,
-//     and either dies with a 403 at `gh issue create` or is refused by
-//     GitHub before it starts, which is the exact "fired, failed, told
-//     nobody" outcome the alarm exists to prevent.
-//   - schedule-alarm.yml's own filing job not resolving `issues: write`. The
-//     caller's grant is a CEILING, not the effective set: a reusable
-//     workflow's own `permissions:` can only narrow what the caller handed
-//     it, so deleting `issues: write` from the callee 403s every alarm in
-//     the tree while every caller stays compliant. The required scope set is
-//     therefore DERIVED from the callee and floored with an absolute
-//     `issues: write` on the callee itself — a pure derivation would let
-//     that deletion lower the bar for everyone and pass.
+// Calls list-scheduled-workflows.mjs rather than re-parsing, inheriting its
+// floors. Permissions are checked both ways: a caller's grant is a ceiling, so
+// dropping `issues: write` from the callee 403s every alarm while every caller
+// still looks compliant.
 
 import { realpathSync } from "node:fs";
 import { basename, dirname, resolve } from "node:path";
@@ -50,33 +16,14 @@ import { fileURLToPath } from "node:url";
 import {
   findScheduledWorkflows,
   workflowLines,
-  // list-scheduled-workflows.mjs's own entry point, not just its derivation
-  // helper: calling it is what makes "this check inherits that file's floors"
-  // TRUE rather than a claim. It throws on zero scheduled workflows, on its
-  // two independent reads (`on: schedule:` vs `cron:`) disagreeing, and on any
-  // `uses: ./.github/workflows/…` pointing at an absent file — so dropping its
-  // separate ci.yml step cannot quietly retire those three floors.
   main as assertScheduledWorkflowDerivation,
 } from "./list-scheduled-workflows.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REUSABLE_ALARM_FILE = "schedule-alarm.yml";
-// The script that actually does the filing. The job that runs it is the one
-// whose permissions decide whether an alarm can file, so the required scope
-// set is read off THAT job rather than typed here a second time.
 const ALARM_FILER_SCRIPT = "file-schedule-alarm.sh";
-// GitHub's three access levels, ordered: a `write` grant satisfies a `read`
-// requirement, and an omitted scope is `none`.
 const LEVEL = { none: 0, read: 1, write: 2 };
 
-/**
- * The [start, end) line-index range of the block nested under the key at
- * `keyIndex` — every following line whose indent is strictly greater than
- * the key line's own indent, stopping at the first non-blank line whose
- * indent is less than or equal to it (or EOF). Works uniformly for a mapping
- * key (`with:`) and a block-scalar key (`if: >-`): in both cases the
- * "children" are just "more indented than me".
- */
 function blockRange(lines, keyIndex) {
   const keyIndent = /^\s*/.exec(lines[keyIndex])[0].length;
   let end = keyIndex + 1;
@@ -91,13 +38,6 @@ function blockRange(lines, keyIndex) {
   return [keyIndex + 1, end];
 }
 
-/**
- * Indices, within [start, end), of lines at the MINIMUM indent seen in the
- * range — i.e. the direct children of whatever block this range is. Anchors
- * the same way list-scheduled-workflows.mjs's `on:` walk does, so a
- * step-level `if:` (deeper than the job's own keys) or a `with:` sub-key
- * (deeper than the job's own `uses:`) is never mistaken for a job-level key.
- */
 function directChildLines(lines, start, end) {
   let minIndent = null;
   for (let i = start; i < end; i++) {
@@ -114,15 +54,6 @@ function directChildLines(lines, start, end) {
   return out;
 }
 
-/**
- * Strip a single layer of matching quotes, an explicit YAML tag (`!!str
- * failure` is the same string as `failure`, and reading it as the literal
- * `"!!str failure"` red a correctly covered workflow) and surrounding
- * whitespace. A bare block-scalar indicator is NOT a value — `title: >-` with
- * the text on following lines captured the literal `">-"`, which is truthy, so
- * garbage passed the required-input check and then collided with every other
- * workflow that did the same. Reported as absent instead.
- */
 function unquote(value) {
   const tagless = value.trim().replace(/^!!\w+\s+/, "");
   if (/^[|>][-+]?$/.test(tagless)) return "";
@@ -130,33 +61,14 @@ function unquote(value) {
   return m ? m[1] : tagless;
 }
 
-/** `${{ false }}` is the same dead job as `if: false`; unwrap before testing. */
 function unwrapExpression(value) {
   const m = /^\$\{\{(.*)\}\}$/.exec(value.trim());
   return (m ? m[1] : value).trim();
 }
 
-/**
- * A `permissions:` value, in every shape GitHub Actions accepts: absent
- * (`null`), the shorthand scalars `read-all`/`write-all`, or a mapping
- * (`{kind: "map", entries: Map<string,string>}`) — including the explicit
- * empty mapping `permissions: {}`, which GRANTS NOTHING and is a distinct
- * fact from "unset" even though both read as "no issues: write" below.
- * Parsed the same way `with:` already is (flow map on the same line, or a
- * block of `directChildLines` underneath), because it is the same YAML
- * shape and a second reader of that shape drifting from the first is its
- * own bug.
- */
 function parsePermissionsValue(lines, keyIdx, inline) {
   if (inline !== "") {
     if (inline.startsWith("{")) {
-      // A flow mapping that SPANS lines is refused, not parsed: stripping a
-      // closing brace that is not there yielded an EMPTY grant, so a workflow
-      // that really does grant `issues: write` red with "resolved permissions
-      // do not grant issues: write" — a guard reddening on a right answer, on
-      // a shape GitHub and actionlint both accept. Same stance
-      // list-scheduled-workflows.mjs takes for a multi-line `on:` mapping: an
-      // unsupported shape must never be indistinguishable from a parsed one.
       if (!inline.endsWith("}")) {
         throw new Error(
           `unsupported permissions: shape — a flow mapping that spans lines (${lines[keyIdx].trim()}). ` +
@@ -177,24 +89,12 @@ function parsePermissionsValue(lines, keyIdx, inline) {
   const [s, e] = blockRange(lines, keyIdx);
   const entries = new Map();
   for (const idx of directChildLines(lines, s, e)) {
-    // Quoted keys accepted for the same reason `["']jobs["']` is below: this
-    // repo's yamllint truthy workaround produces them, and reading
-    // `"issues": write` as absent reds a workflow that grants the scope.
     const m = /^\s*["']?([\w-]+)["']?:\s*(.+)$/.exec(lines[idx]);
     if (m) entries.set(unquote(m[1]), unquote(m[2]));
   }
   return { kind: "map", entries };
 }
 
-/**
- * Does a resolved `permissions:` value grant at least `level` on `scope`?
- * `write-all` grants everything, `read-all` grants every read, a mapping
- * grants what it lists (and `write` satisfies a `read` requirement, the way
- * GitHub's own levels nest). `null` (nothing to resolve — see
- * findAlarmPermissionGaps below) is handled by the caller, not here, because
- * "absent" and "present but insufficient" are different failures this check
- * reports differently.
- */
 function grantsScope(perm, scope, level) {
   if (!perm) return false;
   if (perm.kind === "scalar") {
@@ -205,11 +105,6 @@ function grantsScope(perm, scope, level) {
   return granted >= (LEVEL[level] ?? 0);
 }
 
-/**
- * The workflow-level `permissions:` block — the top-level key, never a
- * nested one (a job-level or `with:`-level key of the same name is a
- * different fact) — or `null` if the file has none.
- */
 function parseWorkflowPermissions(lines) {
   const KEY = /^["']?permissions["']?:\s*(.*)$/;
   const idx = lines.findIndex((l) => KEY.test(l));
@@ -217,10 +112,6 @@ function parseWorkflowPermissions(lines) {
   return parsePermissionsValue(lines, idx, KEY.exec(lines[idx])[1].trim());
 }
 
-/**
- * `needs:` in all three shapes GitHub accepts — scalar (`needs: main`), flow
- * sequence (`needs: [a, b]`) and block sequence (`needs:` then `- a`).
- */
 function parseNeeds(lines, keyIdx, inline) {
   if (inline !== "") {
     return inline
@@ -238,12 +129,6 @@ function parseNeeds(lines, keyIdx, inline) {
     .filter(Boolean);
 }
 
-/**
- * Every job in one workflow file, as the job-level facts this check reasons
- * about. Parsed PER JOB BLOCK, anchored on indentation at both ends: job-level
- * keys are read only at the job's own minimum indent, so a step-level `if:`
- * (deeper) can never be mistaken for the job-level one gating an alarm call.
- */
 function parseJobs(lines) {
   const jobsKey = lines.findIndex((l) => /^(?:jobs|["']jobs["']):\s*$/.test(l));
   if (jobsKey === -1) return [];
@@ -274,8 +159,6 @@ function parseJobs(lines) {
       } else if ((m = /^\s*if:\s*(.*)$/.exec(line))) {
         const inline = m[1].trim();
         if (inline === "" || /^[|>][-+]?\s*$/.test(inline)) {
-          // Block scalar (`if: >-` / `if: |`) or a value on the next
-          // line — join every deeper-indented continuation line.
           const [s, e] = blockRange(lines, kIdx);
           ifExpr = lines
             .slice(s, e)
@@ -290,11 +173,6 @@ function parseJobs(lines) {
       } else if ((m = /^\s*needs:\s*(.*)$/.exec(line))) {
         needs = parseNeeds(lines, kIdx, m[1].trim());
       } else if ((m = /^\s*with:\s*(.*)$/.exec(line))) {
-        // Both spellings of the same mapping. `with:` alone on its line opens a
-                // block; `with: {title: …, outcome: failure}` is flow form. Missing the
-                // flow form parses as no inputs, so a CORRECTLY covered workflow reads
-                // as both uncovered and missing its inputs — and a guard that reds on
-                // right answers is a guard someone deletes.
         const inline = m[1].trim();
         const found = inline
           ? [...inline.matchAll(/\b(title|label|outcome)\s*:\s*("[^"]*"|'[^']*'|[^,}]+)/g)].map((f) => [f[1], f[2]])
@@ -311,9 +189,6 @@ function parseJobs(lines) {
       }
     }
 
-    // Does this job actually run the filing script? Only meaningful inside
-    // schedule-alarm.yml itself, where it identifies the job whose permissions
-    // decide whether ANY alarm in the tree can file.
     const runsFiler = lines.slice(jobStart, jobEnd).some((l) => l.includes(ALARM_FILER_SCRIPT));
 
     jobs.push({ job: jobId, usesTarget, ifExpr, continueOnError, needs, title, label, outcome, permissions, runsFiler });
@@ -321,13 +196,6 @@ function parseJobs(lines) {
   return jobs;
 }
 
-/**
- * Every job, in every workflow file, that calls the reusable schedule-alarm
- * workflow — resolved by PATH, not by string equality with the literal
- * `uses:` text, so `./.github/workflows/schedule-alarm.yml` and any other
- * spelling that resolves to the same file both count, and a typo'd path that
- * resolves to nothing or to a DIFFERENT file does not.
- */
 export function findScheduleAlarmCalls(root) {
   const alarmPath = resolve(root, ".github", "workflows", REUSABLE_ALARM_FILE);
   const calls = [];
@@ -341,32 +209,6 @@ export function findScheduleAlarmCalls(root) {
   return calls;
 }
 
-/**
- * Every call to schedule-alarm.yml whose EFFECTIVE permissions do not grant
- * every scope the alarm's own filing job requests — `gh issue create`/`gh
- * issue edit`/`gh issue close` (file-schedule-alarm.sh) 403s without
- * `issues: write`, and `actions/checkout` cannot run without `contents:
- * read`. The CALLING job's grant is what GitHub uses as the ceiling for a
- * reusable workflow call; the required set itself is derived from the callee
- * (see alarmRequiredScopes below), because the callee can only NARROW that
- * ceiling and so is the other half of the same property.
- * "Effective" is resolved exactly the way GitHub resolves it: a
- * job-level `permissions:` block REPLACES the workflow-level one rather than
- * merging with it, so a job-level block missing `issues: write` is checked
- * as-is — the workflow-level grant next to it is not consulted as a
- * fallback, because GitHub does not consult it either.
- *
- * If `permissions:` is absent at BOTH the job and the workflow level, the
- * effective grant is the repository/organization default — a setting this
- * script cannot read from the filesystem. Treating "cannot resolve" as a
- * silent pass would be exactly the silent degradation this exists to catch (an
- * unstated grant one settings-page click away from
- * losing `issues: write` entirely, with nothing in the diff to review), so
- * it is reported as a hard failure naming the workflow and job instead —
- * the same "unsupported shape must never be indistinguishable from a
- * passing one" stance list-scheduled-workflows.mjs takes for a multi-line
- * `on:` mapping.
- */
 export function findAlarmPermissionGaps(root, calls) {
   const required = alarmRequiredScopes(root);
   const gaps = [];
@@ -388,27 +230,6 @@ export function findAlarmPermissionGaps(root, calls) {
   return gaps;
 }
 
-/**
- * The scopes a caller must grant, READ OFF schedule-alarm.yml's own filing job
- * rather than typed here.
- *
- * The caller's grant is a CEILING, not the effective set. A reusable
- * workflow's own `permissions:` can only NARROW what the caller handed it, and
- * a callee requesting a scope the caller withheld is refused by GitHub before
- * the job starts. So two things are wrong with checking `issues: write` on
- * callers alone: deleting `issues: write` from schedule-alarm.yml's `alarm`
- * job 403s every alarm in the tree while every caller stays compliant, and a
- * caller that grants ONLY `issues: write` — the exact minimal edit this
- * check's own error message invites — withholds the `contents: read` that
- * job's `actions/checkout` needs.
- *
- * Derivation alone would be self-defeating (deleting `issues: write` from the
- * callee would simply lower the bar for everyone and pass), so the callee is
- * ALSO held to an absolute `issues: write` floor here. `write-all` on the
- * callee is refused rather than expanded: there is no scope list to hand
- * callers, and a check that cannot enumerate its own requirement must not
- * report a pass.
- */
 export function alarmRequiredScopes(root) {
   const entry = [...workflowLines(root)].find(([file]) => file === REUSABLE_ALARM_FILE);
   if (!entry) throw new Error(`${REUSABLE_ALARM_FILE} not found under .github/workflows — the reusable alarm every caller resolves against is gone`);
@@ -437,21 +258,10 @@ export function alarmRequiredScopes(root) {
   return scopes;
 }
 
-/** `false`, in any casing, with nothing else in the expression. */
 function isTriviallyFalse(ifExpr) {
   return ifExpr !== null && /^false$/i.test(unwrapExpression(ifExpr));
 }
 
-/**
- * A call counts as reaching the alarm's FAILURE leg — the half that must
- * exist for every scheduled workflow — only if it is not neutralised. Three
- * independent ways a wired-looking call is dead in production:
- * `continue-on-error: true` swallows the reusable call's own failure so a
- * broken alarm still reports green; a literal `if: false` means the job
- * never runs at all; and `outcome` has to be the literal string `failure` —
- * a call that only ever passes `success` (a recovery job with no failure
- * sibling) is not covering the failure path either.
- */
 function reachesFailureAlarm(call) {
   if (call.continueOnError !== null && /^true$/i.test(unwrapExpression(call.continueOnError))) return false;
   if (isTriviallyFalse(call.ifExpr)) return false;
@@ -468,22 +278,6 @@ export function findMissingAlarmCoverage(root, calls) {
   return scheduled.filter((file) => !(byFile.get(file) ?? []).some(reachesFailureAlarm));
 }
 
-/**
- * Work jobs a scheduled workflow's failure alarm cannot see.
- *
- * `failure()` in a job-level `if:` is scoped to that job's own dependency
- * graph, not to the run as a whole: an alarm job that `needs:` only ONE of a
- * workflow's jobs is skipped when a SIBLING it does not depend on fails, so
- * that failure files nothing. This is the same "present in the diff, present
- * in review, dead in production" class as `continue-on-error: true` and a
- * literal `if: false`, and it is what copy-pasting repo-policy.yml's
- * `needs: assert` into a workflow that later grows a second job produces.
- *
- * Closure is TRANSITIVE, so a legitimate chain (`alarm` needs `b` needs `a`)
- * counts — requiring every work job to be listed directly would red correct
- * work. Only the failure leg is held to this; a recovery job intentionally
- * watches whatever it is gated on.
- */
 export function findAlarmNeedsGaps(root) {
   const alarmPath = resolve(root, ".github", "workflows", REUSABLE_ALARM_FILE);
   const scheduled = new Set(findScheduledWorkflows(root).filter((f) => f !== REUSABLE_ALARM_FILE));
@@ -510,21 +304,10 @@ export function findAlarmNeedsGaps(root) {
   return gaps;
 }
 
-/** Every schedule-alarm call missing a required `title` or `label` input. */
 export function findMissingAlarmInputs(calls) {
   return calls.filter((c) => !c.title || !c.label);
 }
 
-/**
- * The title/label pair is typed twice per alarm — once on the failure-side
- * job, once on the recovery job — with nothing gating that the two calls
- * agree. A mismatch means the alarm FILES under one key and the recovery job
- * LOOKS UP a different one, so it never closes and opens a fresh issue every
- * run instead. Derived from the calls themselves (a title <-> label
- * bijection across the whole tree), never a restated pairing: any title
- * that maps to more than one label, or label that maps to more than one
- * title, is reported.
- */
 export function findTitleLabelMismatches(calls) {
   const byTitle = new Map();
   const byLabel = new Map();
@@ -541,18 +324,6 @@ export function findTitleLabelMismatches(calls) {
   return calls.filter((c) => badTitles.has(c.title) || badLabels.has(c.label));
 }
 
-/**
- * Two DIFFERENT workflows using the same label (or the same title).
- *
- * The bijection above is satisfied by an identical pair copy-pasted into a
- * second workflow — consistent, and wrong: `schedule-alarm.yml` documents the
- * label as "one label per alarm, so unrelated alarms never share an issue", and
- * `file-schedule-alarm.sh` looks the issue up by label alone. Sharing one means
- * two workflows share one tracking issue, so B's recovery leg CLOSES the alarm
- * A is still failing on. That is the alarm silencing itself — the exact fact
- * this whole milestone exists to make impossible — while every other assertion
- * here reports green.
- */
 export function findSharedAlarmKeys(calls) {
   const shared = [];
   for (const key of ["label", "title"]) {
@@ -569,15 +340,6 @@ export function findSharedAlarmKeys(calls) {
   return shared;
 }
 
-/**
- * An alarm label that files but can never close.
- *
- * "Files or updates a tracking issue when its scheduled run fails, AND closes
- * it on recovery" is one property, not two — a failure leg with no recovery
- * sibling leaves its issue open forever after the first red, which is how an
- * alarm stops being read. Derived per label from the calls themselves, so a new
- * alarm cannot land half-wired.
- */
 export function findUnclosableAlarms(calls) {
   const outcomes = new Map();
   for (const c of calls) {
@@ -594,17 +356,8 @@ export function findUnclosableAlarms(calls) {
 export function main() {
   const root = resolve(HERE, "../..");
 
-  // Inherited floors, actually inherited: this calls
-    // list-scheduled-workflows' OWN entry point, which throws on zero scheduled
-    // workflows, on its two independent reads disagreeing, and on an absent
-    // `uses: ./.github/workflows/…` target. Re-implementing only the zero check
-    // here would claim the set-equality floor without holding it.
   const scheduled = assertScheduledWorkflowDerivation([]);
 
-  // Belt-and-braces on the count this check itself reasons about: the floor
-  // above counts every scheduled workflow, while coverage is asserted over the
-  // set with the reusable alarm file excluded. If those two ever differ down to
-  // zero, the pass below would be vacuous.
   const covered = scheduled.filter((f) => f !== REUSABLE_ALARM_FILE);
   if (covered.length === 0) {
     throw new Error(
@@ -623,14 +376,6 @@ export function main() {
   const unclosable = findUnclosableAlarms(calls);
   const requiredScopes = alarmRequiredScopes(root);
   const permissionGaps = findAlarmPermissionGaps(root, calls);
-  // Distinct files among the calls whose permissions were actually resolved.
-  // This is NOT an independent denominator — it is derived from `calls`, so a
-  // parser regression drops a file from numerator and denominator together.
-  // What holds the floor is findMissingAlarmCoverage above: every scheduled
-  // workflow must appear in `calls` with a live failure leg, so this count
-  // cannot fall below `covered.length` without that check reddening first.
-  // No separate assertion on it: it is implied by the coverage check, and an
-  // early throw here would MASK the coverage error it is downstream of.
   const permissionsResolvedFor = new Set(calls.map((c) => c.file)).size;
 
   const problems = [];
@@ -703,11 +448,6 @@ export function main() {
   );
 }
 
-// Realpath'd on BOTH sides, not `import.meta.main` (Node 24.2+; this repo's
-// `engines` allows >=24, so on an earlier 24.x it is `undefined` and the
-// bare form would silently exit 0 having checked nothing). A guard that
-// looks like it should have fired but did not throws rather than running
-// nothing quietly.
 const SELF = realpathSync(fileURLToPath(import.meta.url));
 const ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";
 const invokedDirectly = ENTRY === SELF;

--- a/scripts/ci/assert-schedule-alarm-coverage.test.mjs
+++ b/scripts/ci/assert-schedule-alarm-coverage.test.mjs
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
-// Regression coverage for scripts/ci/assert-schedule-alarm-coverage.mjs
-// (and the effective-permissions check). Builds scratch
-// `.github/workflows` trees so every assertion is about the PARSER, not
-// about which alarms this repo happens to carry today.
+//
+// Every case is a workflow tree that LOOKS covered and is not: a commented-out
+// alarm job, a continue-on-error, a dead if:, a title/label pair that disagrees.
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -23,10 +22,6 @@ function assert(cond, msg) {
   if (!cond) throw new Error(msg);
 }
 
-// The real reusable file's own shape, including the `alarm` job's permissions
-// block: the required scope set is DERIVED from the job that runs
-// file-schedule-alarm.sh, so a fixture tree without it has no requirement to
-// hold callers to. `alarmFileYml` lets a fixture break that half on purpose.
 const ALARM_FILE_YML =
   "name: schedule alarm\non:\n  workflow_call:\n    inputs:\n      title: {required: true, type: string}\n      label: {required: true, type: string}\n      outcome: {required: true, type: string}\npermissions:\n  contents: read\njobs:\n  alarm:\n    runs-on: ubuntu-latest\n    permissions:\n      contents: read\n      issues: write\n    steps:\n      - uses: actions/checkout@v7\n      - run: bash scripts/ci/file-schedule-alarm.sh\n";
 
@@ -37,8 +32,6 @@ function withScratchRoot(files, fn, alarmFileYml = ALARM_FILE_YML) {
   for (const [name, content] of Object.entries(files)) {
     writeFileSync(join(dir, name), content);
   }
-  // Every fixture set needs the real reusable file to resolve `uses:`
-  // targets against, same as production.
   writeFileSync(join(dir, "schedule-alarm.yml"), alarmFileYml);
   try {
     return fn(root);
@@ -66,7 +59,6 @@ const ALARM_JOB = (title, label) => `
       outcome: success
 `;
 
-// ── Direction 1: a scheduled workflow WITH a correctly-wired alarm passes ──
 withScratchRoot(
   {
     "wired.yml": `name: wired\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n${ALARM_JOB("wired is failing", "schedule-alarm:wired")}`,
@@ -80,7 +72,6 @@ withScratchRoot(
   },
 );
 
-// ── Direction 2: adding a schedule: trigger with NO alarm reds, naming the file ──
 withScratchRoot(
   {
     "unwired.yml": "name: unwired\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n",
@@ -92,8 +83,6 @@ withScratchRoot(
   },
 );
 
-// ── Break-on-purpose: uses: path typo'd — resolves to nothing, so the call
-// is invisible to findScheduleAlarmCalls and the workflow reports missing.
 withScratchRoot(
   {
     "typo.yml":
@@ -107,8 +96,6 @@ withScratchRoot(
   },
 );
 
-// ── Break-on-purpose: title/label pair disagrees between the failure job
-// and the recovery job — the alarm files under one key, looks up another.
 withScratchRoot(
   {
     "mismatched.yml": `name: mismatched\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  schedule-alarm:\n    needs: main\n    if: failure()\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "mismatched is failing"\n      label: "schedule-alarm:mismatched"\n      outcome: failure\n  schedule-alarm-recovery:\n    needs: main\n    if: success()\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "mismatched is failing"\n      label: "schedule-alarm:mismatched-TYPO"\n      outcome: success\n`,
@@ -117,16 +104,11 @@ withScratchRoot(
     const calls = findScheduleAlarmCalls(root);
     const mismatches = findTitleLabelMismatches(calls);
     assert(mismatches.length === 2, `expected both calls flagged, got ${JSON.stringify(mismatches)}`);
-    // The failure leg is otherwise well-formed, so coverage itself is not
-    // what this fixture is testing for — only the title/label disagreement.
     const missing = findMissingAlarmCoverage(root, calls);
     assert(missing.length === 0, `coverage should still be satisfied, got ${missing}`);
   },
 );
 
-// ── Break-on-purpose: the alarm job is commented out — comments are
-// stripped before parsing, so there is nothing there to find, same as if it
-// were never written.
 withScratchRoot(
   {
     "commented-out.yml":
@@ -148,8 +130,6 @@ withScratchRoot(
   },
 );
 
-// ── Break-on-purpose: continue-on-error: true at JOB level swallows the
-// reusable call's own failure, so a broken alarm still reports green.
 withScratchRoot(
   {
     "swallowed.yml": `name: swallowed\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  schedule-alarm:\n    needs: main\n    if: failure()\n    continue-on-error: true\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "swallowed is failing"\n      label: "schedule-alarm:swallowed"\n      outcome: failure\n`,
@@ -162,8 +142,6 @@ withScratchRoot(
   },
 );
 
-// ── Break-on-purpose: a neutralising if: false — the job is wired in text
-// but can never run.
 withScratchRoot(
   {
     "neutralised.yml": `name: neutralised\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  schedule-alarm:\n    needs: main\n    if: false\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "neutralised is failing"\n      label: "schedule-alarm:neutralised"\n      outcome: failure\n`,
@@ -175,12 +153,6 @@ withScratchRoot(
   },
 );
 
-// ── Break-on-purpose: a step-level if: false (deeper than the job's own
-// keys) must not be mistaken for the job-level if: that actually gates the
-// alarm call. This is one of the three shapes that defeated a grep-based
-// version of this exact check during its own review — a flat regex over
-// lines would see the nearer "if: false" and misread a healthy job-level
-// if: failure() as neutralised.
 withScratchRoot(
   {
     "step-level-if.yml": [
@@ -216,7 +188,6 @@ withScratchRoot(
   },
 );
 
-// ── Missing required input: label omitted entirely.
 withScratchRoot(
   {
     "no-label.yml": `name: no-label\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  schedule-alarm:\n    needs: main\n    if: failure()\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "no-label is failing"\n      outcome: failure\n`,
@@ -228,13 +199,6 @@ withScratchRoot(
   },
 );
 
-// ── A block-scalar `if:` (`if: >-`, spanning multiple lines) must still be
-// read, and a "not failure()" shape (release-alarm.yml's real meta-alarm
-// shape: gated on needs.*.result == 'failure' rather than the failure()
-// function, because it is reporting on its OWN mechanism dying, not on the
-// job it is attached to) must still count as long as outcome: failure is
-// what is actually passed — that boolean literal is the real signal, not
-// the spelling of the guard above it.
 withScratchRoot(
   {
     "meta-shaped.yml": [
@@ -272,8 +236,6 @@ withScratchRoot(
   },
 );
 
-// ── A recovery-only workflow (no failure leg at all) must still be reported
-// missing — outcome: success alone never covers the property.
 withScratchRoot(
   {
     "recovery-only.yml": `name: recovery-only\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  schedule-alarm-recovery:\n    needs: main\n    if: success()\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "recovery-only is failing"\n      label: "schedule-alarm:recovery-only"\n      outcome: success\n`,
@@ -285,12 +247,6 @@ withScratchRoot(
   },
 );
 
-// ── The bijection's OTHER direction. The fixture above is "same title, two
-// labels"; this is "same label, two titles". A one-directional check would
-// pass this, and it is the direction that actually breaks the mechanism the
-// other way round: the failure leg files an issue titled one thing under a
-// label whose recovery leg believes it is titled another, so whichever call
-// creates the issue decides a title its sibling's prose contradicts.
 withScratchRoot(
   {
     "same-label.yml": `name: same-label\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  schedule-alarm:\n    needs: main\n    if: failure()\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "same-label is failing"\n      label: "schedule-alarm:same-label"\n      outcome: failure\n  schedule-alarm-recovery:\n    needs: main\n    if: success()\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "same-label has recovered"\n      label: "schedule-alarm:same-label"\n      outcome: success\n`,
@@ -302,12 +258,6 @@ withScratchRoot(
   },
 );
 
-// ── A `#` inside a title or label is NOT a YAML comment (a comment needs
-// start-of-line or preceding whitespace, and never starts inside a quoted
-// scalar). A blanket `#.*$` strip truncated both legs to the same mangled
-// prefix, so the bijection compared two equal wrecks and reported green on
-// precisely the typo it exists to catch. Issue refs like `#300` are all over
-// this repo's prose, so this is a reachable shape, not a hypothetical.
 withScratchRoot(
   {
     "hashed.yml": `name: hashed\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  schedule-alarm:\n    needs: main\n    if: failure()\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "hashed is failing"\n      label: "schedule-alarm:hashed#1"\n      outcome: failure\n  schedule-alarm-recovery:\n    needs: main\n    if: success()\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "hashed is failing"\n      label: "schedule-alarm:hashed#2"\n      outcome: success\n`,
@@ -322,8 +272,6 @@ withScratchRoot(
   },
 );
 
-// ── A real trailing comment on the same line still goes, so a commented-out
-// key cannot be read as live state (the property the strip exists for).
 withScratchRoot(
   {
     "trailing.yml": `name: trailing\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  schedule-alarm:\n    needs: main\n    if: failure() # only on a real failure\n    uses: ./.github/workflows/schedule-alarm.yml # the shared alarm\n    with:\n      title: "trailing is failing"\n      label: "schedule-alarm:trailing"\n      outcome: failure\n`,
@@ -335,10 +283,6 @@ withScratchRoot(
   },
 );
 
-// ── False red closed: flow-style `with: {…}`. GitHub accepts it, actionlint
-// accepts it, and a parser requiring `with:` alone on
-// its line — so a CORRECTLY covered workflow was reported both uncovered and
-// missing its inputs. A guard that reds on right answers gets deleted.
 withScratchRoot(
   {
     "flow-with.yml": `name: flow-with\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  schedule-alarm:\n    needs: main\n    if: failure()\n    uses: ./.github/workflows/schedule-alarm.yml\n    with: {title: "flow is failing", label: "schedule-alarm:flow", outcome: failure}\n`,
@@ -352,10 +296,6 @@ withScratchRoot(
   },
 );
 
-// ── Break-on-purpose: the alarm job needs only ONE of two work jobs.
-// `failure()` is scoped to the alarm job's own dependency graph, so the
-// sibling it does not depend on can fail while the alarm is simply SKIPPED and
-// files nothing — wired in the diff, dead in production.
 withScratchRoot(
   {
     "partial-needs.yml": `name: partial-needs\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  trivial:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  realwork:\n    runs-on: ubuntu-latest\n    steps:\n      - run: exit 1\n  schedule-alarm:\n    needs: trivial\n    if: failure()\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "partial is failing"\n      label: "schedule-alarm:partial"\n      outcome: failure\n`,
@@ -368,9 +308,6 @@ withScratchRoot(
   },
 );
 
-// ── The same shape done RIGHT must stay green, in both spellings and through
-// a TRANSITIVE chain — requiring every work job to be listed DIRECTLY would
-// red correct work, which is how a guard gets disabled.
 withScratchRoot(
   {
     "flow-needs.yml": `name: flow-needs\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  a:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  schedule-alarm:\n    needs: [a, b]\n    if: failure()\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "flow-needs is failing"\n      label: "schedule-alarm:flow-needs"\n      outcome: failure\n`,
@@ -382,11 +319,6 @@ withScratchRoot(
   },
 );
 
-// ── The neutralisers wrapped in an expression. `${{ false }}` is the same dead
-// job as `if: false`, and `${{ true }}` the same swallowed failure as
-// `continue-on-error: true` — and the expression form is exactly what someone
-// reaches for when silencing a noisy alarm, because it looks like configuration
-// rather than deletion.
 withScratchRoot(
   {
     "expr-false.yml": `name: expr-false\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  schedule-alarm:\n    needs: main\n    if: \${{ false }}\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "expr-false is failing"\n      label: "schedule-alarm:expr-false"\n      outcome: failure\n`,
@@ -399,11 +331,6 @@ withScratchRoot(
   },
 );
 
-// ── `!!str failure` is the same string as `failure`; reading the tag as part
-// of the value red a correctly covered workflow. And a bare block-scalar
-// indicator is NOT a value: `title: >-` captured the literal ">-", which is
-// truthy, so garbage passed the required-input check and then collided with
-// every other workflow that did the same.
 withScratchRoot(
   {
     "tagged.yml": `name: tagged\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  schedule-alarm:\n    needs: main\n    if: failure()\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "tagged is failing"\n      label: "schedule-alarm:tagged"\n      outcome: !!str failure\n`,
@@ -425,10 +352,6 @@ withScratchRoot(
   },
 );
 
-// ── Break-on-purpose: an identical title AND label copy-pasted into a SECOND
-// workflow. The bijection is satisfied (the pair is consistent) and it is still
-// wrong: both workflows share one tracking issue, so B's recovery leg closes
-// the alarm A is still failing on — the alarm silencing itself.
 withScratchRoot(
   {
     "shared-a.yml": `name: shared-a\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n${ALARM_JOB("the weekly cron is failing", "schedule-alarm:weekly")}`,
@@ -446,9 +369,6 @@ withScratchRoot(
   },
 );
 
-// ── Break-on-purpose: a failure leg with no recovery sibling. "Files when it
-// fails AND closes on recovery" is one property; an issue that never closes
-// stays open past the fix and stops being read.
 withScratchRoot(
   {
     "no-recovery.yml": `name: no-recovery\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  schedule-alarm:\n    needs: main\n    if: failure()\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "no-recovery is failing"\n      label: "schedule-alarm:no-recovery"\n      outcome: failure\n`,
@@ -464,8 +384,6 @@ withScratchRoot(
   },
 );
 
-// ── A calling job whose permissions map omits issues: write must
-// gap, naming both the workflow and the job.
 withScratchRoot(
   {
     "no-issues.yml": `name: no-issues\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  schedule-alarm:\n    needs: main\n    if: failure()\n    permissions:\n      contents: read\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "no-issues is failing"\n      label: "schedule-alarm:no-issues"\n      outcome: failure\n`,
@@ -479,8 +397,6 @@ withScratchRoot(
   },
 );
 
-// ── permissions: read-all (job-level shorthand) grants no write scopes at
-// all, so it must gap the same as an explicit map missing issues: write.
 withScratchRoot(
   {
     "read-all.yml": `name: read-all\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  schedule-alarm:\n    needs: main\n    if: failure()\n    permissions: read-all\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "read-all is failing"\n      label: "schedule-alarm:read-all"\n      outcome: failure\n`,
@@ -491,9 +407,6 @@ withScratchRoot(
   },
 );
 
-// ── permissions: {} — an explicit empty mapping grants nothing, which is a
-// distinct fact from "unset" (see the absent-at-both fixture below) but the
-// same failure from this check's point of view: no issues: write either way.
 withScratchRoot(
   {
     "empty-map.yml": `name: empty-map\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  schedule-alarm:\n    needs: main\n    if: failure()\n    permissions: {}\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "empty-map is failing"\n      label: "schedule-alarm:empty-map"\n      outcome: failure\n`,
@@ -504,11 +417,6 @@ withScratchRoot(
   },
 );
 
-// ── permissions: absent at BOTH the job and the workflow level — the
-// effective grant is the repo default, which this script cannot read from
-// the filesystem. Reported as a hard failure naming the workflow and job,
-// never a silent pass: an unstated grant is exactly the silent-degradation
-// shape this gate exists to catch.
 withScratchRoot(
   {
     "absent-both.yml": `name: absent-both\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  schedule-alarm:\n    needs: main\n    if: failure()\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "absent-both is failing"\n      label: "schedule-alarm:absent-both"\n      outcome: failure\n`,
@@ -522,9 +430,6 @@ withScratchRoot(
   },
 );
 
-// ── Positive: job-level permissions map WITH issues: write passes, even
-// though this fixture also HAS a workflow-level permissions block, proving
-// the job-level block is read first rather than merged with it.
 withScratchRoot(
   {
     "job-level-ok.yml": `name: job-level-ok\npermissions:\n  contents: read\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  schedule-alarm:\n    needs: main\n    if: failure()\n    permissions:\n      contents: read\n      issues: write\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "job-level-ok is failing"\n      label: "schedule-alarm:job-level-ok"\n      outcome: failure\n`,
@@ -535,8 +440,6 @@ withScratchRoot(
   },
 );
 
-// ── Positive: workflow-level permissions map WITH issues: write, and the
-// calling job carries no permissions: block of its own — the fallback.
 withScratchRoot(
   {
     "workflow-level-ok.yml": `name: workflow-level-ok\npermissions:\n  contents: read\n  issues: write\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  schedule-alarm:\n    needs: main\n    if: failure()\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "workflow-level-ok is failing"\n      label: "schedule-alarm:workflow-level-ok"\n      outcome: failure\n`,
@@ -547,7 +450,6 @@ withScratchRoot(
   },
 );
 
-// ── Positive: write-all (job-level shorthand) satisfies the requirement.
 withScratchRoot(
   {
     "write-all.yml": `name: write-all\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  schedule-alarm:\n    needs: main\n    if: failure()\n    permissions: write-all\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "write-all is failing"\n      label: "schedule-alarm:write-all"\n      outcome: failure\n`,
@@ -558,11 +460,6 @@ withScratchRoot(
   },
 );
 
-// ── A job-level permissions: block REPLACES the workflow-level one rather
-// than merging with it (the GitHub Actions rule this check must mirror): the
-// workflow grants issues: write, but the job's own block omits it, so the
-// job-level block wins and the call must gap rather than falling back to the
-// permissive workflow-level one.
 withScratchRoot(
   {
     "job-replaces-workflow.yml": `name: job-replaces-workflow\npermissions:\n  contents: read\n  issues: write\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  schedule-alarm:\n    needs: main\n    if: failure()\n    permissions:\n      contents: read\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "job-replaces-workflow is failing"\n      label: "schedule-alarm:job-replaces-workflow"\n      outcome: failure\n`,
@@ -573,12 +470,6 @@ withScratchRoot(
   },
 );
 
-// ── The OTHER half of the same property, and the one a caller-only check is
-// blind to: schedule-alarm.yml's own filing job losing `issues: write`. The
-// caller's grant is a CEILING — the callee can only narrow it — so every
-// caller in the tree stays compliant while every alarm 403s at `gh issue
-// create`. A caller-only revision of this check reported green on exactly
-// this edit.
 withScratchRoot(
   {
     "wired.yml": `name: wired\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  schedule-alarm:\n    needs: main\n    if: failure()\n    permissions:\n      contents: read\n      issues: write\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "wired is failing"\n      label: "schedule-alarm:wired"\n      outcome: failure\n`,
@@ -600,12 +491,6 @@ withScratchRoot(
   ALARM_FILE_YML.replace("      issues: write\n", ""),
 );
 
-// ── A caller that grants ONLY issues: write — the exact minimal edit this
-// check's own error message invites — withholds the contents: read the filing
-// job's actions/checkout needs. GitHub refuses a reusable call requesting a
-// scope the caller did not grant, so the alarm never starts. The requirement
-// is DERIVED from the callee's job, so this reds without contents: read being
-// typed anywhere in the checker.
 withScratchRoot(
   {
     "issues-only.yml": `name: issues-only\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  schedule-alarm:\n    needs: main\n    if: failure()\n    permissions:\n      issues: write\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "issues-only is failing"\n      label: "schedule-alarm:issues-only"\n      outcome: failure\n`,
@@ -619,13 +504,6 @@ withScratchRoot(
   },
 );
 
-// ── False red closed: quoted keys. This repo's yamllint truthy workaround
-// produces `"on":`, and the same hand writes `"permissions":` / `"issues":`.
-// Reading either as absent hard-reds a workflow that explicitly grants the
-// scope — and for the job-level spelling it was worse than a false red: the
-// job's own block was skipped and the PERMISSIVE workflow-level block was
-// consulted as a fallback, which GitHub does not do, so a restrictive job
-// passed green.
 withScratchRoot(
   {
     "quoted-keys.yml": `name: quoted-keys\n"permissions":\n  contents: read\n  "issues": write\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  schedule-alarm:\n    needs: main\n    if: failure()\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "quoted-keys is failing"\n      label: "schedule-alarm:quoted-keys"\n      outcome: failure\n`,
@@ -640,12 +518,6 @@ withScratchRoot(
   },
 );
 
-// ── An unsupported shape must never be indistinguishable from a passing one,
-// and must not masquerade as a MISSING grant either: a flow mapping that spans
-// lines was stripped of a closing brace that was not there, yielding an empty
-// map, so a workflow granting issues: write red with "does not grant issues:
-// write". Refused loudly instead, the same stance list-scheduled-workflows.mjs
-// takes for a multi-line `on:` mapping.
 withScratchRoot(
   {
     "multiline-flow.yml": `name: multiline-flow\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  schedule-alarm:\n    needs: main\n    if: failure()\n    permissions: {\n      contents: read,\n      issues: write\n    }\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "multiline-flow is failing"\n      label: "schedule-alarm:multiline-flow"\n      outcome: failure\n`,
@@ -664,7 +536,6 @@ withScratchRoot(
   },
 );
 
-// ── Against the real tree: every scheduled workflow passes today.
 {
   const root = fileURLToPath(new URL("../..", import.meta.url));
   const calls = findScheduleAlarmCalls(root);
@@ -674,9 +545,6 @@ withScratchRoot(
   assert(findTitleLabelMismatches(calls).length === 0, "real tree must have no title/label mismatch");
   assert(findAlarmNeedsGaps(root).length === 0, `real tree's alarms must need every job in their own workflow, got ${JSON.stringify(findAlarmNeedsGaps(root))}`);
   assert(findAlarmPermissionGaps(root, calls).length === 0, `real tree's calling jobs must all resolve the alarm's own scopes, got ${JSON.stringify(findAlarmPermissionGaps(root, calls))}`);
-  // Not a vacuous pass: the real tree genuinely has calls to examine, and the
-  // derived requirement genuinely has scopes in it (a requirement that
-  // enumerated to nothing would be satisfied by every caller forever).
   assert(calls.length >= 3, `real tree must have alarm calls to examine, got ${calls.length}`);
   const required = alarmRequiredScopes(root);
   assert(

--- a/scripts/ci/assert-schedule-alarm-coverage.test.mjs
+++ b/scripts/ci/assert-schedule-alarm-coverage.test.mjs
@@ -336,7 +336,7 @@ withScratchRoot(
 );
 
 // ── False red closed: flow-style `with: {…}`. GitHub accepts it, actionlint
-// accepts it, and an earlier revision of the parser required `with:` alone on
+// accepts it, and a parser requiring `with:` alone on
 // its line — so a CORRECTLY covered workflow was reported both uncovered and
 // missing its inputs. A guard that reds on right answers gets deleted.
 withScratchRoot(
@@ -508,7 +508,7 @@ withScratchRoot(
 // effective grant is the repo default, which this script cannot read from
 // the filesystem. Reported as a hard failure naming the workflow and job,
 // never a silent pass: an unstated grant is exactly the silent-degradation
-// shape this milestone exists to catch.
+// shape this gate exists to catch.
 withScratchRoot(
   {
     "absent-both.yml": `name: absent-both\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  main:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n  schedule-alarm:\n    needs: main\n    if: failure()\n    uses: ./.github/workflows/schedule-alarm.yml\n    with:\n      title: "absent-both is failing"\n      label: "schedule-alarm:absent-both"\n      outcome: failure\n`,

--- a/scripts/ci/cdn-fetch-actions.json
+++ b/scripts/ci/cdn-fetch-actions.json
@@ -1,6 +1,6 @@
 {
   "_readme": [
-    "F-1489 — the classification half of scripts/ci/assert-hardened-cdn-fetches.mjs.",
+    "The classification half of scripts/ci/assert-hardened-cdn-fetches.mjs.",
     "",
     "WHAT IS DERIVED, AND WHAT IS NOT. The gate derives the SET OF ACTIONS TO JUDGE",
     "from `.github/workflows/**` — never from this file — so a new `uses:` step is",
@@ -44,7 +44,7 @@
       "fetchesFromCdn": false,
       "hardening": "not-needed",
       "why": "A bundled JavaScript action (dist/main.cjs, no network install) that signs a JWT with the private key it is handed and exchanges it at api.github.com for an installation token. It downloads no executable. Its only network call is to GitHub's own API, so a failure here is a GitHub outage and not a third-party CDN one — and it must NOT be retried blind under continue-on-error, because a failure that is actually a bad/rotated private key or an installation that no longer covers this repository should red allocate-version.yml loudly rather than be attempted three times.",
-      "evidence": "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1, verified against the live repo to be exactly refs/tags/v3.2.0 (commit \"chore(main): release 3.2.0 (#370)\", 2026-05-12); action.yml `runs: using: node24, main: dist/main.cjs`. Same ref pome-cloud pins in fidelity-watch.yml and declared-diff.yml (PR #730), deliberately, so the two repos' release paths cannot drift onto different versions of the same mint step."
+      "evidence": "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1, verified against the live repo to be exactly refs/tags/v3.2.0 (commit \"chore(main): release 3.2.0 (#370)\", 2026-05-12); action.yml `runs: using: node24, main: dist/main.cjs`. The same ref the sibling repository pins, deliberately, so the two repos' release paths cannot drift onto different versions of the same mint step."
     },
     "actions/setup-node": {
       "fetchesFromCdn": false,
@@ -91,8 +91,8 @@
     "anchore/sbom-action": {
       "fetchesFromCdn": true,
       "hardening": "repeat-attempts",
-      "why": "Downloads the syft binary from the anchore release CDN (github.com/anchore/syft/releases) on every run, with no retry of its own. THIS IS F-1489's SUBJECT: a 503 there killed the stripe twin-image job twice on 2026-08-12 (PRs #390, #391) with `[error] received HTTP status=503 ... [error] unable to find tag=''`. On a PR that is noise; on main the cosign sign/attest steps below it do run, so the same 503 fails an image publish. Retrying the whole step is sound here because the step has no verdict of its own — SBOM generation either produces the file or fails for an infrastructure reason.",
-      "evidence": "anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 (v0.24.0), action.yml `syft-version` input; observed run output quoted in F-1489."
+      "why": "Downloads the syft binary from the anchore release CDN (github.com/anchore/syft/releases) on every run, with no retry of its own. A 503 there has killed a twin-image job twice within minutes (`[error] received HTTP status=503 ... [error] unable to find tag=''`). On a PR that is noise; on main the cosign sign/attest steps below it do run, so the same 503 fails an image publish. Retrying the whole step is sound here because the step has no verdict of its own — SBOM generation either produces the file or fails for an infrastructure reason.",
+      "evidence": "anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 (v0.24.0), action.yml `syft-version` input."
     },
     "sigstore/cosign-installer": {
       "fetchesFromCdn": true,
@@ -103,14 +103,14 @@
     "aquasecurity/trivy-action": {
       "fetchesFromCdn": true,
       "hardening": "step-is-the-check",
-      "why": "Composite action whose first step is `aquasecurity/setup-trivy`, which downloads the Trivy binary from its release CDN — so the exposure is real. It is deliberately NOT wrapped in a repeated-attempt group, because in this repo the step runs with `exit-code: '1'` on HIGH/CRITICAL: its failure means EITHER the install broke OR Trivy found a fixable vulnerability. A repeated-attempt group retries the whole step, so attempts 1 and 2 would swallow a real CVE finding under `continue-on-error`, and the `::warning::` would report a flaky download on a run that actually found a vulnerability. Turning a finding into a retry is a worse property than the one F-1489 fixes.",
-      "residual": "A trivy install that 5xxes still reds twin-image, and on main still stops a publish, with no retry. Closing it means splitting the install from the scan — `skip-setup-trivy: true` on the trivy-action step plus an explicit `aquasecurity/setup-trivy` step in a repeated-attempt group — which adds a third-party pin and rewires the scanner on the publish path. Out of scope for F-1489, which is about the SBOM/sign leg; file it against twin-image.yml when the trivy CDN actually costs a run.",
+      "why": "Composite action whose first step is `aquasecurity/setup-trivy`, which downloads the Trivy binary from its release CDN — so the exposure is real. It is deliberately NOT wrapped in a repeated-attempt group, because in this repo the step runs with `exit-code: '1'` on HIGH/CRITICAL: its failure means EITHER the install broke OR Trivy found a fixable vulnerability. A repeated-attempt group retries the whole step, so attempts 1 and 2 would swallow a real CVE finding under `continue-on-error`, and the `::warning::` would report a flaky download on a run that actually found a vulnerability. Turning a finding into a retry is a worse property than the flakiness it would paper over.",
+      "residual": "A trivy install that 5xxes still reds twin-image, and on main still stops a publish, with no retry. Closing it means splitting the install from the scan — `skip-setup-trivy: true` on the trivy-action step plus an explicit `aquasecurity/setup-trivy` step in a repeated-attempt group — which adds a third-party pin and rewires the scanner on the publish path. Out of scope here, which is the SBOM/sign leg; file it against twin-image.yml when the trivy CDN actually costs a run.",
       "evidence": "aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 (v0.36.0), action.yaml lines 120-133."
     },
     "trufflesecurity/trufflehog": {
       "fetchesFromCdn": true,
       "hardening": "step-is-the-check",
-      "why": "Named in F-1489's sweep list, and swept: at the pinned ref it is a composite action that `docker run`s ghcr.io/trufflesecurity/trufflehog (and apt-get installs jq if missing). That is a container-registry pull, not a release-CDN binary fetch, so the sha256-pinned-fetch path has nothing to pin. It is also, like trivy, a step that IS the check — its failure normally means a verified secret was found, and retrying it twice under `continue-on-error` would swallow exactly that.",
+      "why": "Swept: at the pinned ref it is a composite action that `docker run`s ghcr.io/trufflesecurity/trufflehog (and apt-get installs jq if missing). That is a container-registry pull, not a release-CDN binary fetch, so the sha256-pinned-fetch path has nothing to pin. It is also, like trivy, a step that IS the check — its failure normally means a verified secret was found, and retrying it twice under `continue-on-error` would swallow exactly that.",
       "residual": "A GHCR outage still reds secret-scan (a required context) with no retry. The fix, if it ever costs a run, is a `docker pull` of the image in a repeated-attempt group BEFORE the scan step, leaving the scan itself un-retried — not wrapping the scan. The image tag is pinned only because secret-scan.yml passes `version:` explicitly; this action's own default is the mutable `latest`, so that input is part of the pin, not a convenience.",
       "evidence": "trufflesecurity/trufflehog@27b0417c16317ca9a472a9a8092acce143b49c55 (v3.95.9), action.yml `runs: using: composite`, `image` input defaulting to ghcr.io/trufflesecurity/trufflehog."
     }

--- a/scripts/ci/changelog-entry.mjs
+++ b/scripts/ci/changelog-entry.mjs
@@ -1,92 +1,18 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// The CHANGELOG contract. The number is not the author's, so the contract is
-// split by authorship:
-//   ## Unreleased (patch)      <- the AUTHOR writes this, in the PR, with the
-//                                 prose under it. `patch` / `minor` is a
-//                                 judgement about consumers (all packages are
-//                                 pre-1.0, so minor plays the major role), so
-//                                 it stays with the person who made the
-//                                 change.
-//   ## 0.23.46 — 2026-08-14    ← `allocate-release-versions.mjs` writes this,
-//                                 on `main`, once, when it cuts the number.
-//
-// The heading-to-number binding cannot drift: it is created in the same commit
-// that creates the number, by the same script.
-//
-// THREE PROPERTIES THIS FILE HOLDS, and each is a test in
-// `check-release-note-required.test.mjs` / `allocate-release-versions.test.mjs`:
-//
-//   1. Insertions only. A release is written by inserting a section immediately
-//      above the newest released one. `writeRelease()` reassembles the file as
-//      `preamble + newSection + releasedRegion`, so the released region is
-//      byte-identical by CONSTRUCTION rather than by assertion — and the PR gate
-//      compares that same region against the base branch, which is what stops a
-//      human rewriting history too.
-//   2. An unsupported shape is never mistaken for an absent one. A heading that
-//      mentions "unreleased" but is not exactly `## Unreleased (patch|minor)`
-//      THROWS, naming the file and the line. The alternative — treating it as
-//      "no pending entry" — means a release request that reads as silence, which
-//      is the failure mode AGENTS.md has a rule about.
-//   3. No default level. `## Unreleased` with no level is refused rather than
-//      assumed to be a patch: whether a change forces consumers to act is not
-//      something a script can infer, and quietly guessing "patch" would ship a
-//      breaking change under a caret range that resolves it automatically.
-//
-// Pure string transforms — no I/O, no git, no CLI.
+// Pure string transforms over CHANGELOG headings. Insertions only: writeRelease()
+// rebuilds the file so the released region is carried across by construction. An
+// `## Unreleased` with no level throws rather than defaulting to patch.
 
-/** The exact heading an author writes. `(patch)` and `(minor)` are the levels. */
 export const PENDING_HEADING_EXAMPLE = "## Unreleased (patch)";
 
-/**
- * Any `##` heading. `m` + `g` so matches carry `.index` for exact slicing.
- * `[ \t]` after `##` on purpose: `### Patch Changes` (which entries use, and
- * which the Changesets era left behind) is not a heading at this level.
- *
- * KNOWN LIMIT, stated rather than discovered later: fenced code blocks are not
- * tracked, so a line inside one that starts with `## ` is read as a heading. An
- * entry quoting this very format — as cli/README.md does — must
- * indent it or wrap it inline, and the failure is loud (the parse refuses, or the
- * PR gate reports a heading mismatch) rather than a silently mis-split file.
- */
 const HEADING_RE = /^##[ \t].*$/gm;
-/** The only accepted pending heading. Case-insensitive, otherwise exact. */
 const PENDING_RE = /^##[ \t]+Unreleased[ \t]*\((patch|minor)\)[ \t]*$/i;
-/** "This heading is TRYING to be the pending one" — refuses near-misses. */
 const PENDING_ISH_RE = /^##[ \t].*unreleased/i;
 
 const LEVEL_RANK = { patch: 0, minor: 1 };
 
-/**
- * Split a CHANGELOG into the three regions the contract cares about:
- *
- *   preamble  — everything above the first `##` heading, verbatim (title,
- *               format notes, the SPDX comment wire's file opens with).
- *   pending   — the `## Unreleased (level)` sections above the released region,
- *               in file order. Normally zero or one; TWO is a real state, not a
- *               corruption, and is handled rather than refused — two PRs branched
- *               off the same base can each add one, and reddening `main` over
- *               that would rebuild a smaller version of the treadmill this
- *               ticket removes.
- *   released  — from the first non-pending `##` heading to EOF, verbatim. The
- *               region nothing may ever rewrite.
- *
- * THE RELEASED REGION IS NEVER PARSED FOR REQUESTS, and that is a rule rather
- * than an oversight. It is a record of what shipped, this repo does not rewrite
- * records, and `packages/adapter-claude-sdk/CHANGELOG.md` carries a leftover bare
- * `## Unreleased` from the Changesets era sitting between 0.2.3 and 0.2.2 —
- * refusing to cut a release in 2026 because of a heading from July would be this
- * parser policing history it is forbidden to correct. The accident this could
- * otherwise hide (someone puts a real pending entry BELOW the newest released
- * one, and their release silently never happens) is caught by the other end of
- * the same rule: inserting anything into the released region makes it differ from
- * the base branch's, which is exactly what `check-release-note-required.mjs`
- * refuses.
- *
- * Throws on a pending heading above the released region that is not exactly the
- * accepted shape.
- */
 export function parseChangelog(text, label = "CHANGELOG.md") {
   const headings = [...text.matchAll(HEADING_RE)].map((m) => ({
     text: m[0],
@@ -100,8 +26,6 @@ export function parseChangelog(text, label = "CHANGELOG.md") {
   const pending = [];
   let firstReleased = null;
   for (const heading of headings) {
-    // The first heading that is not a pending one opens the record. Everything
-    // from there down is read as bytes and never as a request — see above.
     const match = heading.text.match(PENDING_RE);
     if (!match) {
       if (!PENDING_ISH_RE.test(heading.text)) {
@@ -132,13 +56,6 @@ export function parseChangelog(text, label = "CHANGELOG.md") {
   };
 }
 
-/**
- * The release this file is currently asking for, or `null`. Merges the sections
- * when there are several: the LEVEL is the highest asked for (a minor and a
- * patch in one release is a minor — the consumer still has to act), and the
- * bodies are concatenated in file order, because both authors' words are part of
- * the same release once both are on `main`.
- */
 export function pendingRelease(text, label = "CHANGELOG.md") {
   const { pending } = parseChangelog(text, label);
   if (pending.length === 0) return null;
@@ -153,14 +70,6 @@ export function pendingRelease(text, label = "CHANGELOG.md") {
   return { level, body, sections: pending.length };
 }
 
-/**
- * Insert a released section and drop every pending one.
- *
- * The result is `preamble + section + released` — so the released region is
- * carried across byte-for-byte and the insertions-only property is a property of
- * this function's shape, not of a test that has to remember to check it. (There
- * is a test that checks it anyway.)
- */
 export function writeRelease(text, { version, date, body, label = "CHANGELOG.md" }) {
   const parsed = parseChangelog(text, label);
   const trimmed = String(body ?? "").trim();
@@ -170,17 +79,6 @@ export function writeRelease(text, { version, date, body, label = "CHANGELOG.md"
   return `${parsed.preamble}${section}${parsed.released}`;
 }
 
-/**
- * `0.N.P` + level. Deliberately refuses anything that is not three plain
- * numbers: this repo publishes `0.N.P` only, and a prerelease or build-metadata
- * version has more than one defensible successor. Guessing one would be the
- * script inventing a release policy.
- *
- * There is no `major` level, and that is the same refusal in a different place —
- * every package here is pre-1.0, where minor plays the major role. A 1.0.0 is
- * a deliberate decision about a package's stability promise; it
- * is not something to reach by typing a word in a changelog heading.
- */
 export function bumpVersion(version, level) {
   const match = String(version).match(/^(\d+)\.(\d+)\.(\d+)$/);
   if (!match) {

--- a/scripts/ci/changelog-entry.mjs
+++ b/scripts/ci/changelog-entry.mjs
@@ -1,24 +1,19 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// THE CHANGELOG CONTRACT, now that the number is not the author's.
-//
-// The old contract was one rule: a package's `CHANGELOG.md` top heading must
-// equal the version in the same PR. That rule is what made every open PR carry
-// the number twice, and it is why a merge somewhere else invalidated both copies
-// at once. The new contract splits it by authorship:
-//
-//   ## Unreleased (patch)      ← the AUTHOR writes this, in the PR, with the
+// The CHANGELOG contract. The number is not the author's, so the contract is
+// split by authorship:
+//   ## Unreleased (patch)      <- the AUTHOR writes this, in the PR, with the
 //                                 prose under it. `patch` / `minor` is a
 //                                 judgement about consumers (all packages are
-//                                 pre-1.0, so minor plays the major role), so it stays
-//                                 with the person who made the change.
+//                                 pre-1.0, so minor plays the major role), so
+//                                 it stays with the person who made the
+//                                 change.
 //   ## 0.23.46 — 2026-08-14    ← `allocate-release-versions.mjs` writes this,
 //                                 on `main`, once, when it cuts the number.
 //
-// The heading↔number binding therefore still exists and still cannot drift — it
-// is now created in the same commit that creates the number, by the same script,
-// instead of being asserted after the fact against two hand-written copies.
+// The heading-to-number binding cannot drift: it is created in the same commit
+// that creates the number, by the same script.
 //
 // THREE PROPERTIES THIS FILE HOLDS, and each is a test in
 // `check-release-note-required.test.mjs` / `allocate-release-versions.test.mjs`:
@@ -33,8 +28,7 @@
 //      mentions "unreleased" but is not exactly `## Unreleased (patch|minor)`
 //      THROWS, naming the file and the line. The alternative — treating it as
 //      "no pending entry" — means a release request that reads as silence, which
-//      is the failure mode this repo has been bitten by often enough to have a
-//      rule about it in AGENTS.md.
+//      is the failure mode AGENTS.md has a rule about.
 //   3. No default level. `## Unreleased` with no level is refused rather than
 //      assumed to be a patch: whether a change forces consumers to act is not
 //      something a script can infer, and quietly guessing "patch" would ship a
@@ -59,7 +53,7 @@ export const PENDING_HEADING_EXAMPLE = "## Unreleased (patch)";
 const HEADING_RE = /^##[ \t].*$/gm;
 /** The only accepted pending heading. Case-insensitive, otherwise exact. */
 const PENDING_RE = /^##[ \t]+Unreleased[ \t]*\((patch|minor)\)[ \t]*$/i;
-/** "This heading is TRYING to be the pending one" — used to refuse near-misses. */
+/** "This heading is TRYING to be the pending one" — refuses near-misses. */
 const PENDING_ISH_RE = /^##[ \t].*unreleased/i;
 
 const LEVEL_RANK = { patch: 0, minor: 1 };

--- a/scripts/ci/check-checks-tarball.mjs
+++ b/scripts/ci/check-checks-tarball.mjs
@@ -10,7 +10,7 @@
 //
 //   1. `private: true` makes `npm publish -w` print a warning and EXIT 0. A
 //      one-character regression would produce a fully green release that
-//      published nothing — the silence `check-version-bump-required.mjs` exists
+//      published nothing — the silence the release apparatus exists
 //      to abolish.
 //   2. Inside this repo every `exports` subpath resolves through npm's workspace
 //      symlink to a full source tree, so a subpath pointing at a file `files`
@@ -23,8 +23,7 @@
 //      this is the assertion that keeps it that way.
 //   4. Bundling zod would be worse than a 404, because it succeeds: two copies
 //      of zod means two schema identities, `instanceof` fails and parsed results
-//      stop being interchangeable. That is the bug that dissolved
-//      `@pome-sh/shared-types`, and nothing at runtime announces it.
+//      stop being interchangeable, and nothing at runtime announces it.
 //   5. Bundling the twin ENGINE (hono, node:sqlite, @hono/node-server) would
 //      mean a "declarations only" package shipping an HTTP server and a database
 //      driver. `packages/twin-stripe/src/seed.ts` reaches one zod schema that

--- a/scripts/ci/check-checks-tarball.mjs
+++ b/scripts/ci/check-checks-tarball.mjs
@@ -1,50 +1,14 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Release gate for @pome-sh/checks' tarball.
+// Release gate for @pome-sh/checks' tarball. Every failure it catches is
+// invisible from inside this workspace: `private: true` publishes nothing and
+// exits 0, a leaked `@pome-sh/*` dep 404s on install, a bundled zod gives two
+// schema identities, and engine bytes mean a declarations-only package shipping
+// a database driver.
 //
-// This package exists for exactly one reason: pome-cloud grades every `[code]`
-// criterion out of these declarations, and it lives in a different repository.
-// Every failure mode below is invisible from inside this workspace and lands in
-// the consumer's repo instead.
-//
-//   1. `private: true` makes `npm publish -w` print a warning and EXIT 0. A
-//      one-character regression would produce a fully green release that
-//      published nothing — the silence the release apparatus exists
-//      to abolish.
-//   2. Inside this repo every `exports` subpath resolves through npm's workspace
-//      symlink to a full source tree, so a subpath pointing at a file `files`
-//      does not ship resolves forever here and dies as
-//      ERR_PACKAGE_PATH_NOT_EXPORTED on the consumer's first import.
-//   3. A leaked `@pome-sh/*` runtime dependency is fatal in a way it is not for
-//      the CLI: `@pome-sh/sdk` and the five twins are `private: true` and NOT on
-//      any registry at these versions, so the consumer's `npm i` 404s. Bundling
-//      via tsup `noExternal` is what makes this package installable at all, and
-//      this is the assertion that keeps it that way.
-//   4. Bundling zod would be worse than a 404, because it succeeds: two copies
-//      of zod means two schema identities, `instanceof` fails and parsed results
-//      stop being interchangeable, and nothing at runtime announces it.
-//   5. Bundling the twin ENGINE (hono, node:sqlite, @hono/node-server) would
-//      mean a "declarations only" package shipping an HTTP server and a database
-//      driver. `packages/twin-stripe/src/seed.ts` reaches one zod schema that
-//      `@pome-sh/sdk/server` also re-exports; importing the barrel instead of
-//      `@pome-sh/sdk/failure-injection` pulls all 14 of the engine's runtime
-//      modules, and nothing else would notice.
-//   6. `defineCheck` and the vacuity sentinels must exist ONCE across the whole
-//      tarball. Seven entries all reach `@pome-sh/sdk/checks`; without code
-//      splitting each would carry its own copy, so `@pome-sh/checks/github`'s
-//      `defineCheck` and `@pome-sh/checks/stripe`'s would be different function
-//      objects — the same argument as 4, one layer in.
-//
-// Modes:
-//   --manifest-only  Only what is readable from package.json (private, no
-//                    publishConfig.registry, no @pome-sh/* runtime deps, zod is
-//                    a peer). No build, no `npm pack`, no network — so ci.yml
-//                    runs it on every PR and 1 and 3 are caught BEFORE merge.
-//   (default)        The above, plus pack and audit the real tarball. Requires a
-//                    built `packages/checks/dist`.
-//
-// Usage: node scripts/ci/check-checks-tarball.mjs [--manifest-only] [--keep]
+// The engine assertion is the INVERSE in check-sandbox-domains-tarball.mjs,
+// which requires those bytes. `--manifest-only` needs no build or network.
 
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
@@ -57,31 +21,12 @@ const KEEP = process.argv.includes("--keep");
 const MANIFEST_ONLY = process.argv.includes("--manifest-only");
 const MANIFEST_PATH = join(ROOT, "packages", "checks", "package.json");
 
-/** Bytes that mean the twin engine got inlined. `DatabaseSync` is node:sqlite's export. */
 const ENGINE_MARKERS = ["node:sqlite", "DatabaseSync", "@hono/node-server", "hono/jwt"];
 
-/**
- * Bare specifiers a shipped `.d.ts` may name. Everything else is unresolvable for
- * a consumer: `@pome-sh/*` because those packages are `private: true` and on no
- * registry, `hono` because it is not a dependency of this package.
- *
- * NOTE the quote-agnostic pattern. An earlier version of this gate matched only
- * double quotes and reported "no external specifiers" for a `dist/index.d.ts`
- * that was full of single-quoted ones — tsup emits single quotes. The gate was
- * green while the declarations were entirely broken.
- */
 const DECLARATION_EXTERNALS_ALLOWED = (specifier) =>
   specifier === "zod" || specifier.startsWith("node:");
 const SPECIFIER_PATTERN = /(?:\bfrom\s*|\bimport\s*)\(?\s*(['"])([^'"]+)\1/g;
 
-/**
- * Blank out comments, preserving length, before looking for specifiers. Doc
- * comments contain quoted PROSE, and one of them — `could not tell "the path is
- * absent" from "the path holds null"` — parses as `from "the path holds null"`
- * and reds this gate over an English sentence. Any regex scanner over `.d.ts`
- * needs this; `packages/checks/scripts/bundle-declarations.mjs` carries the same
- * guard for the same reason.
- */
 function maskComments(text) {
   const out = text.split("");
   let index = 0;
@@ -111,11 +56,6 @@ function maskComments(text) {
 const failures = [];
 const manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
 
-// ── Manifest assertions (no build, no network) ───────────────────────────────
-
-// Stricter than npm on purpose: npm publishes a manifest with no `private` field
-// quite happily, but the difference between "absent" and "explicitly false" is
-// the difference between a silent regression and a loud one.
 if (manifest.private !== false) {
   failures.push(
     `packages/checks/package.json has \`private: ${JSON.stringify(manifest.private)}\`; it must be exactly \`false\`.\n` +
@@ -124,9 +64,6 @@ if (manifest.private !== false) {
   );
 }
 
-// Registry is chosen by the publish job, not pinned in the manifest — this
-// package goes to registry.npmjs.org via the OIDC lane, like the CLI and the
-// adapter. A `publishConfig.registry` here could only misroute it.
 if (manifest.publishConfig?.registry !== undefined) {
   failures.push(
     `packages/checks/package.json pins \`publishConfig.registry\` to ${JSON.stringify(manifest.publishConfig.registry)}.\n` +
@@ -143,7 +80,6 @@ if (manifest.publishConfig?.access !== "public") {
   );
 }
 
-// The whole point of the bundling strategy.
 for (const field of ["dependencies", "peerDependencies", "optionalDependencies"]) {
   const internal = Object.keys(manifest[field] ?? {}).filter((name) =>
     name.startsWith("@pome-sh/"),
@@ -167,7 +103,6 @@ if (manifest.peerDependencies?.zod === undefined) {
   );
 }
 
-/** Every file path an `exports` map points at, conditions and subpaths flattened. */
 function exportTargets(exportsField) {
   const targets = new Set();
   const walk = (node) => {
@@ -178,21 +113,15 @@ function exportTargets(exportsField) {
   return targets;
 }
 
-// `main`/`types` are the pre-`exports` resolution path; older tooling still
-// reads them, so they have to ship too.
 const declaredPaths = exportTargets(manifest.exports);
 for (const field of ["main", "types"]) {
   if (typeof manifest[field] === "string") declaredPaths.add(manifest[field].replace(/^\.\//, ""));
 }
 declaredPaths.delete("package.json"); // always in the tarball; not a build output
 
-// ── Tarball assertions ──────────────────────────────────────────────────────
-
 function auditTarball() {
   const workDirectory = mkdtempSync(join(tmpdir(), "pome-checks-tarball-"));
   try {
-    // --ignore-scripts: `prepublishOnly` would rebuild, which would hide a
-    // "published a stale dist" bug. The caller is expected to have built.
     const packed = execFileSync(
       "npm",
       ["pack", "-w", "@pome-sh/checks", "--ignore-scripts", "--pack-destination", workDirectory],
@@ -215,7 +144,6 @@ function auditTarball() {
       );
     }
 
-    // npm wraps every tarball entry in a top-level `package/` directory.
     const shipped = new Set(
       execFileSync("tar", ["-tf", tarball], { encoding: "utf8" })
         .split("\n")
@@ -242,8 +170,6 @@ function auditTarball() {
       );
     }
 
-    // Read the real shipped bytes, not the workspace's dist: `files` negations
-    // and `.npmignore` are exactly the kind of thing that makes the two differ.
     const extractDirectory = mkdtempSync(join(tmpdir(), "pome-checks-extract-"));
     execFileSync("tar", ["-xf", tarball, "-C", extractDirectory], { stdio: "inherit" });
     const packageRoot = join(extractDirectory, "package");
@@ -266,7 +192,6 @@ function auditTarball() {
       .map((file) => join(packageRoot, "dist", file));
     const sources = new Map(jsFiles.map((file) => [file, readFileSync(file, "utf8")]));
 
-    // 5 — the engine must not be inlined.
     for (const marker of ENGINE_MARKERS) {
       const hits = [...sources].filter(([, text]) => text.includes(marker)).map(([file]) => file);
       if (hits.length > 0) {
@@ -279,7 +204,6 @@ function auditTarball() {
       }
     }
 
-    // 4 — zod stays external. A bundled zod shows up as its own internals.
     const zodInlined = [...sources]
       .filter(([, text]) => /\bclass \$?ZodObject\b|\$ZodType\b/.test(text))
       .map(([file]) => file);
@@ -298,17 +222,6 @@ function auditTarball() {
       );
     }
 
-    // The declarations must be self-contained. `noExternal` does not cover them:
-    // the declaration bundler leaves bare specifiers alone, so `export … from
-    // "@pome-sh/twin-github/checks"` lands verbatim in the shipped `.d.ts` and
-    // resolves nowhere for a consumer. `packages/checks/scripts/
-    // bundle-declarations.mjs` rewrites them; this is the tarball-side check that
-    // it ran and covered everything.
-    //
-    // The authoritative test is the consumer COMPILE in
-    // scripts/clean-room-pack-test.mjs, which catches type errors this cannot
-    // see. This is the cheap string-level half, so a regression is named here
-    // even when the heavier gate is not the thing that ran.
     const declarationFiles = readdirSync(join(packageRoot, "dist"), { recursive: true })
       .map(String)
       .filter((file) => file.endsWith(".d.ts"))
@@ -333,7 +246,6 @@ function auditTarball() {
       failures.push("the tarball ships no .d.ts at all — the declaration build did not run.");
     }
 
-    // 6 — exactly one copy of the DSL.
     for (const [marker, label] of [
       ["function defineCheck", "defineCheck"],
       ['"pome-vacuity-never"', "VACUITY_SENTINEL"],

--- a/scripts/ci/check-release-note-required.mjs
+++ b/scripts/ci/check-release-note-required.mjs
@@ -1,37 +1,13 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// The PR-time half of the release contract.
+// The PR-time half of the release contract: no hand-written version, an
+// `## Unreleased (level)` entry per artifact the PR moves, released entries never
+// rewritten, and each newest released heading still naming its manifest version.
 //
-// The number is written on main after the merge, by
-// `allocate-release-versions.mjs`. Which paths move which artifact — including
-// the wire -> cli/adapter/checks coupling — lives in `publish-relevance.mjs`,
-// which both read. What is left here is everything about a release a PR is
-// still the right place to decide, which is all of it except the number:
-//
-//   1. NO HAND-WRITTEN NUMBER. A PR may not move a published package's `version`
-//      field. This is the invariant that makes every other PR's green mean
-//      something: nothing a PR contains can be invalidated by someone else's
-//      merge if no PR carries the number.
-//   2. AN ENTRY, FOR EVERY ARTIFACT THE PR MOVES. Publish-relevant paths changed
-//      ⇒ that package's CHANGELOG carries an `## Unreleased (patch|minor)`
-//      section with prose under it. The words and the patch/minor judgement stay
-//      with the author; only the number leaves.
-//   3. RELEASED ENTRIES ARE NEVER REWRITTEN. The region from the newest released
-//      heading down is byte-identical to the base branch's. This is the
-//      insertions-only property, checked against a real base rather than assumed
-//      — the allocator holds the same property by construction (see
-//      `changelog-entry.mjs`).
-//   4. THE HEADING AND THE NUMBER STILL AGREE. Each package's newest released
-//      heading names the version its manifest declares. That was the whole old
-//      CHANGELOG contract; it is now a fact about `main` that the allocator
-//      maintains, and this is where it stays checked.
-//
-// Runs as one of ci.yml's cheap, dependency-free gates (git reads only, no npm
-// install needed). Only meaningful against a PR's actual base, which is why
-// ci.yml guards it with `github.event_name == 'pull_request'`.
-//
-// Usage: node scripts/ci/check-release-note-required.mjs <base-sha>
+// The base must come from the checked-out history, not `pull_request.base.sha`,
+// which is pinned at the last synchronize. For a STACKED PR the base is its base
+// branch — checking against main gives a false green.
 
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
@@ -50,7 +26,6 @@ const changedFiles = execFileSync("git", ["diff", "--name-only", baseSha, "HEAD"
   .split("\n")
   .filter(Boolean);
 
-/** A file's contents at a ref, or null when it wasn't there. */
 function showAt(ref, path) {
   try {
     return execFileSync("git", ["show", `${ref}:${path}`], {
@@ -66,9 +41,6 @@ const failures = [];
 const touched = new Map(packagesTouchedBy(changedFiles).map((hit) => [hit.pkg.name, hit.files]));
 
 for (const pkg of PUBLISHED_PACKAGES) {
-  // The table's own paths must exist, so the allocator and release-alarm.mjs can
-  // read them without a "file missing" branch that would have to choose between
-  // silence and a false alarm. Cheapest possible place to assert it.
   const missing = [pkg.manifest, pkg.changelog].filter((path) => !existsSync(path));
   if (missing.length > 0) {
     failures.push(
@@ -82,9 +54,6 @@ for (const pkg of PUBLISHED_PACKAGES) {
   const baseManifest = showAt(baseSha, pkg.manifest);
   const baseVersion = baseManifest === null ? null : JSON.parse(baseManifest).version;
 
-  // 1 — the number is not this PR's to write. A brand-new package is the one
-  // exception: its first version has no base to differ from, and someone has to
-  // type the line that starts the line.
   if (baseVersion !== null && headVersion !== baseVersion) {
     failures.push(
       `${pkg.name}: this PR moves ${pkg.manifest}'s version from ${baseVersion} to ${headVersion}. ` +
@@ -107,7 +76,6 @@ for (const pkg of PUBLISHED_PACKAGES) {
     continue;
   }
 
-  // 2 — an entry for every artifact this PR moves.
   const relevantFiles = touched.get(pkg.name) ?? [];
   if (relevantFiles.length > 0 && !pending?.body) {
     failures.push(
@@ -123,17 +91,12 @@ for (const pkg of PUBLISHED_PACKAGES) {
     );
   }
 
-  // 3 — insertions only. Compared as bytes against the base branch: a rewritten
-  // released entry is a record that changed after the fact, and the released
-  // region is the one part of this file nobody may touch.
   const baseChangelog = showAt(baseSha, pkg.changelog);
   if (baseChangelog !== null) {
     let baseReleased = null;
     try {
       baseReleased = parseChangelog(baseChangelog, pkg.changelog).released;
     } catch {
-      // The BASE is malformed, which this PR cannot be blamed for and which the
-      // parse of HEAD above already reports if the PR leaves it that way.
       baseReleased = null;
     }
     if (baseReleased !== null && baseReleased !== headParsed.released) {
@@ -147,7 +110,6 @@ for (const pkg of PUBLISHED_PACKAGES) {
     }
   }
 
-  // 4 — the surviving half of the old CHANGELOG contract.
   if (headParsed.releasedHeading !== null) {
     const declared = headParsed.releasedHeading.replace(/^##\s+/, "").split(/\s/)[0];
     if (declared !== headVersion) {
@@ -167,9 +129,6 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-// The counts are printed because a gate that only ever says "OK" cannot be told
-// apart from one whose subject has gone empty — the same reason
-// release-alarm.mjs carries a --targets dead-guard.
 const exempt = changedFiles.filter((file) => isPublishIrrelevantPath(file)).length;
 console.log(
   `Release inputs OK. ${PUBLISHED_PACKAGES.length} published package(s); ` +

--- a/scripts/ci/check-release-note-required.mjs
+++ b/scripts/ci/check-release-note-required.mjs
@@ -1,26 +1,13 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// THE PR-TIME HALF OF THE RELEASE CONTRACT, re-scoped from
-// scripts/ci/check-version-bump-required.mjs, whose history is under that path
-// (the rewrite is large enough that `--follow` will not bridge it).
+// The PR-time half of the release contract.
 //
-// WHAT CHANGED, AND WHY THE FILE SURVIVED THE CHANGE. The old gate demanded that
-// a PR touching a package's publish-relevant paths BUMP that package's version.
-// It was right about the failure it existed to catch — `release.yml` publishes on
-// a version diff, so an unbumped change merges clean and silently never reaches
-// npm — and wrong about who should answer it. Every PR carrying the shared
-// version line meant every merge invalidated every open PR that had pinned a
-// consumed number, silently, across workspaces and humans (measured 2026-08-13:
-// #402/#405 stale-green overnight, five renumber+force-push cycles in one night,
-// 0.23.35/.36 burned unpublished). The NUMBER moved to
-// `allocate-release-versions.mjs`, on `main`, after the merge.
-//
-// The publish-relevance logic — which paths move which artifact, including the
-// wire→cli/adapter/checks coupling — did not become wrong; it became the
-// allocator's authority, and lives in `publish-relevance.mjs` where both read it.
-// What is left here is everything about a release that a PR is still the right
-// place to decide, which is all of it except the number:
+// The number is written on main after the merge, by
+// `allocate-release-versions.mjs`. Which paths move which artifact — including
+// the wire -> cli/adapter/checks coupling — lives in `publish-relevance.mjs`,
+// which both read. What is left here is everything about a release a PR is
+// still the right place to decide, which is all of it except the number:
 //
 //   1. NO HAND-WRITTEN NUMBER. A PR may not move a published package's `version`
 //      field. This is the invariant that makes every other PR's green mean

--- a/scripts/ci/check-release-note-required.test.mjs
+++ b/scripts/ci/check-release-note-required.test.mjs
@@ -19,7 +19,7 @@
  *           test directory. Carved out EXCEPT under `examples/`, `assets/` and
  *           `tasks/`, which the CLI's `files` really does publish verbatim.
  *   2  `packages/twin-` matched a twin's own top-level `examples/`
- *           (PR #366). Not because of `files` — twin-github's and
+ *           Not because of `files` — twin-github's and
  *           twin-slack's `dist/examples/` really is packed — but because every
  *           twin is `private: true` and release.yml publishes only cli,
  *           adapter-claude-sdk, checks and wire. Same prefix, one directory
@@ -39,7 +39,7 @@
  * ── The cases this file adds ────────────────────────────────────────────────
  *
  * The demand inverted: a PR must NOT write the number, and must carry the words.
- * Both directions are asserted, plus the two CHANGELOG properties that used to
+ * Both directions are asserted, plus the two CHANGELOG properties that
  * be a convention with nothing behind them — released entries are never
  * rewritten, and the newest released heading names the version beside it.
  */
@@ -368,10 +368,10 @@ console.log("the number is not the PR's to write");
 }
 
 {
-  // The direction that used to have its own named failure: a version moved DOWN
+  // A version moved DOWN
   // (a stale branch rebased past a release) hard-failed release.yml's floor check
   // after merge. It is now the same failure as any other hand-written number,
-  // which is the point — there is no longer a right value for a PR to carry.
+  // which is the point — there is no right value for a PR to carry.
   const r = run({ versions: { "@pome-sh/cli": "0.9.0" }, entries: ["@pome-sh/cli"] });
   check("a version moved DOWN is refused too", r.status === 1 && r.out.includes("0.9.0"), r.out);
 }

--- a/scripts/ci/check-release-note-required.test.mjs
+++ b/scripts/ci/check-release-note-required.test.mjs
@@ -1,48 +1,8 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
-/**
- * Regression coverage for scripts/ci/check-release-note-required.mjs.
- *
- * Stands up a throwaway git repo carrying every manifest and CHANGELOG the gate
- * knows about, then drives it over real commits so the `git diff --name-only
- * base HEAD` / `git show base:path` paths are exercised rather than mocked.
- *
- * ── The cases inherited from the version-bump gate this file re-scopes ───────
- *
- * The publish-relevance table moved to `publish-relevance.mjs` but did
- * not change, and neither did the bugs it has been taught. Each carve-out below
- * is a measured over-match, and every one has the same shape: a plain string
- * prefix matching files that ship in no tarball, so a PR was told to publish a
- * byte-identical artifact.
- *
- *   1  `cli/` matched `cli/test/**` — no package's `files` array names a
- *           test directory. Carved out EXCEPT under `examples/`, `assets/` and
- *           `tasks/`, which the CLI's `files` really does publish verbatim.
- *   2  `packages/twin-` matched a twin's own top-level `examples/`
- *           Not because of `files` — twin-github's and
- *           twin-slack's `dist/examples/` really is packed — but because every
- *           twin is `private: true` and release.yml publishes only cli,
- *           adapter-claude-sdk, checks and wire. Same prefix, one directory
- *           over: a twin's top-level `.md`.
- *   3  Same prefix again: a twin's own top-level `scripts/`, found on the
- *           PR whose whole job was wiring such a script into CI.
- *   4  Same prefix, one file over: a twin's own `Dockerfile`. A GHCR image
- *           is not an npm artifact, so patching a base image was demanding both
- *           a cli and a sandbox-domains release. Found on the PR that had to
- *           edit all five to clear a fixable base-image CVE.
- *
- * Each carve-out is paired with an anchoring case (`src/examples/`,
- * `src/scripts/`, `cli/scripts/`, a doc riding along with a src change) because
- * a regex that widened to `.+` would pass every exemption test while quietly
- * stopping the demand for files that really do ship.
- *
- * ── The cases this file adds ────────────────────────────────────────────────
- *
- * The demand inverted: a PR must NOT write the number, and must carry the words.
- * Both directions are asserted, plus the two CHANGELOG properties that
- * be a convention with nothing behind them — released entries are never
- * rewritten, and the newest released heading names the version beside it.
- */
+//
+// Both directions per rule, plus the two CHANGELOG properties: a rewritten released
+// entry reds, and a heading that disagrees with its manifest version reds.
 import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -79,21 +39,11 @@ function write(dir, relPath, contents) {
 const baseChangelog = (name, version = BASE_VERSION) =>
   `# ${name} — CHANGELOG\n\n## ${version} — 2026-08-01\n\nThe entry that already shipped.\n`;
 
-/** Insert a pending section above the released region, the way an author would. */
 function addPendingEntry(text, { level = "patch", body = "- a thing a consumer must know" } = {}) {
   const at = text.indexOf("## ");
   return `${text.slice(0, at)}## Unreleased (${level})\n\n${body}\n\n${text.slice(at)}`;
 }
 
-/**
- * Build a repo whose base commit carries every published package at 1.0.0 with a
- * matching CHANGELOG, apply `changes` / `versions` / `entries` / `changelogs` as
- * a second commit, and run the gate against the base sha.
- *
- * `seedChangelogVersion` seeds a base that is ALREADY inconsistent, which is the
- * only way to reach the heading↔version check without also tripping the
- * hand-written-version one.
- */
 function run({ changes = {}, versions = {}, entries = [], changelogs = {}, seedChangelogVersion = {} }) {
   const dir = mkdtempSync(join(tmpdir(), "release-note-gate-"));
   try {
@@ -119,9 +69,6 @@ function run({ changes = {}, versions = {}, entries = [], changelogs = {}, seedC
       if (changelogs[pkg.name]) write(dir, pkg.changelog, changelogs[pkg.name]);
     }
     git(dir, "add", "-A");
-    // `--allow-empty` so a case can seed an inconsistent BASE and change nothing
-    // in the PR — which is how the heading↔version check is reached without also
-    // tripping the hand-written-version one.
     git(dir, "commit", "-q", "--allow-empty", "-m", "change");
 
     const r = spawnSync("node", [SCRIPT, baseSha], { cwd: dir, encoding: "utf8" });
@@ -158,7 +105,6 @@ console.log("check-release-note-required.mjs — publish relevance (inherited)")
 }
 
 {
-  // A test file mixed in with a src change must not mask the src change.
   const r = run({
     changes: { "cli/src/thing.ts": "export const a = 1;\n", "cli/test/thing.test.ts": "// t\n" },
   });
@@ -166,8 +112,6 @@ console.log("check-release-note-required.mjs — publish relevance (inherited)")
 }
 
 {
-  // `files: ["examples", ...]` publishes these verbatim, so they are not exempt
-  // just because of the filename.
   const r = run({ changes: { "cli/examples/demo/smoke.test.ts": "// shipped\n" } });
   check("a *.test.ts under cli/examples/ still demands an entry", r.status === 1, r.out);
 }
@@ -192,7 +136,6 @@ console.log("check-release-note-required.mjs — publish relevance (inherited)")
 }
 
 {
-  // Anchoring check, single path segment: `[^/]+\/[^/]+\.md` must not loosen.
   const r = run({
     changes: {
       "packages/twin-github/FIDELITY.md": "# doc\n",
@@ -216,14 +159,11 @@ console.log("check-release-note-required.mjs — publish relevance (inherited)")
 }
 
 {
-  // Anchoring check: packages/twin-stripe/src/examples/handler.ts compiles into
-  // that twin's own dist/ same as any other src/ module.
   const r = run({ changes: { "packages/twin-stripe/src/examples/handler.ts": "export const a = 1;\n" } });
   check("a twin's src/examples/ change with no entry still fails", r.status === 1, r.out);
 }
 
 {
-  // A twin's own top-level scripts/ is dev/CI tooling in no tarball.
   const r = run({ changes: { "packages/twin-github/scripts/validate-mcp.ts": "// tooling\n" } });
   check("a change confined to a twin's scripts/ needs no entry", r.status === 0, r.out);
 }
@@ -238,7 +178,6 @@ console.log("check-release-note-required.mjs — publish relevance (inherited)")
 }
 
 {
-  // Anchoring check: cli/scripts/ is NOT a twin script.
   const r = run({ changes: { "cli/scripts/copy-prompts.mjs": "// tooling\n" } });
   check(
     "a cli/scripts/ change with no entry still fails",
@@ -262,8 +201,6 @@ console.log("check-release-note-required.mjs — publish relevance (inherited)")
 }
 
 {
-  // A twin's Dockerfile builds its GHCR image, which no tarball carries.
-  // The real case was all five at once, to clear a fixable base-image CVE.
   const r = run({
     changes: {
       "packages/twin-github/Dockerfile": "FROM node:24-trixie-slim\n",
@@ -277,8 +214,6 @@ console.log("check-release-note-required.mjs — publish relevance (inherited)")
 }
 
 {
-  // Anchoring check, exact filename under the twin root: `src/` is where tsup
-  // actually reaches, so a Dockerfile sitting there is not exempt.
   const r = run({ changes: { "packages/twin-stripe/src/Dockerfile": "FROM scratch\n" } });
   check(
     "a Dockerfile under a twin's src/ with no entry still fails",
@@ -304,12 +239,6 @@ console.log("check-release-note-required.mjs — publish relevance (inherited)")
 console.log("the coupling: one change, several artifacts");
 
 {
-  // wire's bytes are inlined into the CLI's and the adapter's tarballs, so one
-  // wire change is THREE releases, and
-  // the demand names all three: a PR that writes one entry and forgets two ships
-  // two releases with no record of what is in them. `@pome-sh/checks` is
-  // deliberately not among them — its relevance is named declaration FILES, not
-  // whole directories.
   const r = run({ changes: { "packages/wire/src/thing.ts": "export const a = 1;\n" } });
   const named = PUBLISHED_PACKAGES.filter((pkg) => r.out.includes(`${pkg.name}: this PR changes`)).map(
     (pkg) => pkg.name,
@@ -331,9 +260,6 @@ console.log("the coupling: one change, several artifacts");
 }
 
 {
-  // @pome-sh/checks' relevance is named FILES inside other packages, not whole
-  // directories: a twin's or the sdk's non-declaration change is not a
-  // vocabulary change.
   const plain = run({ changes: { "packages/sdk/src/registry.ts": "export const a = 1;\n" } });
   check(
     "a non-declaration sdk change demands the CLI only",
@@ -368,10 +294,6 @@ console.log("the number is not the PR's to write");
 }
 
 {
-  // A version moved DOWN
-  // (a stale branch rebased past a release) hard-failed release.yml's floor check
-  // after merge. It is now the same failure as any other hand-written number,
-  // which is the point — there is no right value for a PR to carry.
   const r = run({ versions: { "@pome-sh/cli": "0.9.0" }, entries: ["@pome-sh/cli"] });
   check("a version moved DOWN is refused too", r.status === 1 && r.out.includes("0.9.0"), r.out);
 }
@@ -379,8 +301,6 @@ console.log("the number is not the PR's to write");
 console.log("the CHANGELOG contract");
 
 {
-  // A pending entry with no publish-relevant change is a deliberate release
-  // request and must pass — the allocator honours it.
   const r = run({ entries: ["@pome-sh/checks"] });
   check("a pending entry with no code change is allowed", r.status === 0, r.out);
 }
@@ -430,10 +350,6 @@ console.log("the CHANGELOG contract");
 }
 
 {
-  // The preamble is explicitly NOT part of the record: it describes the format,
-  // and this very ticket had to rewrite cli/CHANGELOG.md's. This is also the case
-  // that proves a CHANGELOG is exempt from publish relevance — it is the one
-  // changed file, and no release is demanded for it.
   const r = run({
     changelogs: {
       "@pome-sh/cli": `# @pome-sh/cli — CHANGELOG\n\nA new note about how this file works.\n\n## ${BASE_VERSION} — 2026-08-01\n\nThe entry that already shipped.\n`,
@@ -448,8 +364,6 @@ console.log("the CHANGELOG contract");
 }
 
 {
-  // The surviving half of the old contract, on a base that is already
-  // inconsistent — the shape a hand-edit on main would leave behind.
   const r = run({ seedChangelogVersion: { "@pome-sh/cli": "0.9.0" } });
   check(
     "a released heading that disagrees with the manifest version fails",
@@ -471,9 +385,6 @@ console.log("the gate's own surface");
 }
 
 {
-  // Appending BELOW the newest released heading is a rewrite of the record, not
-  // an insertion — the same refusal as editing an entry in place, and the shape a
-  // "just add a note at the bottom" edit takes.
   const r = run({
     changelogs: { "@pome-sh/cli": `${baseChangelog("@pome-sh/cli")}\nA trailing note.\n` },
   });
@@ -485,19 +396,6 @@ console.log("the gate's own surface");
 }
 
 {
-  // Every carve-out in publish-relevance.mjs justifies itself with "the package
-  // this path belongs to publishes nothing", so none of them may ever exempt a
-  // path inside a package that DOES publish — that would drop a file which
-  // really reaches a consumer's tarball out of the relevance table, silently.
-  //
-  // Written as a property over `PUBLISHED_PACKAGES` rather than against any one
-  // package, because the way it breaks is a NAME. The new package was called
-  // `twin-domains` first, which put a published `README.md` (in its `files`) under
-  // the `packages/twin-*` top-level-markdown carve-out; renaming it to
-  // `sandbox-domains` is what actually fixed that, and the fix is invisible in
-  // the carve-outs themselves. This is the assertion that notices if a future
-  // package name — or a rename of the twins, which is coming — walks back into
-  // one of these prefixes.
   const exemptedPublished = PUBLISHED_PACKAGES.flatMap((pkg) => {
     const directory = dirname(pkg.manifest);
     return [`${directory}/README.md`, `${directory}/examples/demo/index.ts`, `${directory}/scripts/validate.ts`]
@@ -510,8 +408,6 @@ console.log("the gate's own surface");
     exemptedPublished.join("\n      "),
   );
 
-  // …and the carve-outs still apply to the five PRIVATE twins, or the rule was
-  // widened into uselessness rather than kept honest.
   check(
     "the private twins keep their carve-outs",
     isPublishIrrelevantPath("packages/twin-github/FIDELITY.md") !== null &&
@@ -519,10 +415,6 @@ console.log("the gate's own surface");
       isPublishIrrelevantPath("packages/twin-github/scripts/validate-mcp.ts") !== null,
   );
 
-  // The shared declaration bundler moved to scripts/ so sandbox-domains
-  // could use it instead of copying ~300 lines. Both packages' `.d.ts` are
-  // unresolvable for a consumer if it regresses, so it must stay publish-relevant
-  // for both — the move must not have quietly dropped it out of the table.
   const bundlerConsumers = PUBLISHED_PACKAGES.filter((pkg) =>
     (pkg.pathPatterns ?? []).some((pattern) => pattern.test("scripts/bundle-declarations.mjs")),
   ).map((pkg) => pkg.name);

--- a/scripts/ci/check-sandbox-domains-tarball.mjs
+++ b/scripts/ci/check-sandbox-domains-tarball.mjs
@@ -1,59 +1,13 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Release gate for @pome-sh/sandbox-domains' tarball.
+// Release gate for @pome-sh/sandbox-domains' tarball. NOT a copy of
+// check-checks-tarball.mjs: three assertions are deliberately inverted, because
+// this package IS the engine's domain half. It REQUIRES `node:sqlite` and treats
+// hono as an ordinary declared external, where checks forbids both.
 //
-// This package exists for one reason: pome-cloud boots the twin domain layer
-// IN-PROCESS as its grading/authoring runtime (`lib/twin-state.ts`), and
-// `checks-package-drift.test.ts` compares that runtime's binding surface
-// against `@pome-sh/checks`'s vocabulary with no allowlist. Every failure mode
-// below is invisible from inside this workspace and lands in the consumer's
-// repo instead.
-//
-// ── Why this is not check-checks-tarball.mjs with a different path ───────────
-//
-// The two packages are cut from the same twins and ship on the same lane, and
-// three of their assertions are deliberately INVERTED. Reading this file as a
-// copy of that one will get the inversions wrong:
-//
-//   - checks FORBIDS engine bytes (`node:sqlite`, `hono`): a declarations-only
-//     package shipping a database driver means something reached
-//     `@pome-sh/sdk/server` where a narrow subpath would do. This package IS
-//     the engine's domain half, so it REQUIRES `node:sqlite` (assertion 6) —
-//     a sandbox-domains tarball with no SQLite driver is a second declarations
-//     package that silently cannot open a database.
-//   - checks forbids `hono` outright. Here hono is a declared, external,
-//     ordinary dependency: each domain arrives through its twin's package
-//     ROOT, which is also where `defineTwin()` runs at module scope, and
-//     `./server` re-exports `toTwinHttpEventRow` from `@pome-sh/sdk/server`.
-//     Measured on the real bundle: `hono`, `hono/jwt`, `hono/request`.
-//   - checks asserts `defineCheck` exists exactly once. The shared primitive
-//     here is the sdk's SQLite layer, so assertion 7 counts that instead.
-//
-// What is NOT inverted, and is the same fatal shape in both: a leaked
-// `@pome-sh/*` runtime dependency (assertion 3). The sdk and the five twins are
-// `private: true` and on no registry at these versions, so the consumer's
-// `npm i` 404s. Bundling via tsup `noExternal` is what makes this package
-// installable at all.
-//
-// ── Assertions 4 and 5 are the ones that earn their keep ────────────────────
-//
-// Rather than a hand-kept allowlist of permitted externals, this reads every
-// bare specifier out of the SHIPPED bytes — JS and `.d.ts` both — and requires
-// each to be a node: builtin, the zod peer, or a declared runtime dependency
-// (4). Then the converse: every declared dependency is actually imported (5).
-// Without 5 the manifest can name a package nothing uses, which a consumer
-// still installs and still audits.
-//
-// Modes:
-//   --manifest-only  Only what is readable from package.json (private, no
-//                    publishConfig.registry, no @pome-sh/* runtime deps, zod is
-//                    a peer, the upstream anchors match the twins'). No build,
-//                    no `npm pack`, no network — so ci.yml runs it on every PR.
-//   (default)        The above, plus pack and audit the real tarball. Requires
-//                    a built `packages/sandbox-domains/dist`.
-//
-// Usage: node scripts/ci/check-sandbox-domains-tarball.mjs [--manifest-only] [--keep]
+// The dependency set is read from the shipped bytes, both directions — every
+// bare specifier declared, every declared dep imported.
 
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
@@ -67,14 +21,6 @@ const MANIFEST_ONLY = process.argv.includes("--manifest-only");
 const PACKAGE_DIRECTORY = join(ROOT, "packages", "sandbox-domains");
 const MANIFEST_PATH = join(PACKAGE_DIRECTORY, "package.json");
 
-/**
- * The export spec, measured from pome-cloud's own imports rather than
- * designed fresh: `apps/control-plane/src/lib/twin-state.ts`,
- * `checks-package-drift.test.ts`, `lib/twin-tape-pull.ts` and
- * `apps/mcp/src/lib/capture.ts`. A subpath that stops exporting one of these
- * does not fail to build here — it fails in the consumer's repo, which is the
- * whole reason the list is duplicated into a gate.
- */
 const REQUIRED_EXPORTS = {
   "./github": ["GitHubDomain", "openGitHubCloneDatabase", "parseSeed", "GITHUB_CHECKS"],
   "./gmail": ["GmailDomain", "openGmailTwinDatabase", "parseSeed", "GMAIL_CHECKS"],
@@ -90,39 +36,18 @@ const REQUIRED_EXPORTS = {
   "./server": ["toTwinHttpEventRow"],
 };
 
-/**
- * Type-only anchors the twins hold as devDependencies for shape fidelity, which
- * this package must hold as real `dependencies` because they reach its SHIPPED
- * `.d.ts` (`GitHubDomain.pullRequestStack(): PullRequestStack`,
- * `StripeDomain`'s `PaymentIntent[…]` field types). Unlike `@pome-sh/*` these
- * are public and resolvable, so declaring them is correct and vendoring 4.6 MB
- * of generated OpenAPI types into every tarball is not.
- *
- * The specs must EQUAL the twins' own: the declarations shipped here were
- * generated against those versions, so a range that admits a different one is a
- * claim this build never checked.
- */
 const UPSTREAM_ANCHORS = {
   "@octokit/openapi-types": "packages/twin-github/package.json",
   stripe: "packages/twin-stripe/package.json",
 };
 
-/** node: builtins and the zod peer resolve for any consumer without being declared. */
 const ALWAYS_RESOLVABLE = (specifier) => specifier === "zod" || specifier.startsWith("node:");
 
-/** `hono/jwt` is satisfied by a declared `hono`; compare on the package name. */
 function packageNameOf(specifier) {
   const parts = specifier.split("/");
   return specifier.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0];
 }
 
-/**
- * Blank out comments, preserving length, before looking for specifiers. Doc
- * comments contain quoted PROSE, and one of them — `could not tell "the path is
- * absent" from "the path holds null"` — parses as `from "the path holds null"`
- * and reds this gate over an English sentence. Any regex scanner over shipped
- * source needs this; `scripts/bundle-declarations.mjs` carries the same guard.
- */
 function maskComments(text) {
   const out = text.split("");
   let index = 0;
@@ -149,32 +74,8 @@ function maskComments(text) {
   return out.join("");
 }
 
-/**
- * Every module specifier in a shipped `.d.ts`. Covers `from "x"`, bare
- * `import "x"`, and inline import types (`import("./auth.js").SessionValue`),
- * which tsc emits for inferred types — the form the first version of
- * `bundle-declarations.mjs` missed and shipped unvendored. A declaration file
- * carries prose only in COMMENTS, which `maskComments` handles, so the loose
- * `\bfrom\s*"…"` form is safe here.
- */
 const DECLARATION_SPECIFIER_PATTERN = /(?:\bfrom\s*|\bimport\s*)\(?\s*(['"])([^'"]+)\1/g;
 
-/**
- * Every module specifier in a shipped `.js` — and deliberately NOT the pattern
- * above, which cannot be used on bundled JS.
- *
- * `maskComments` blanks comments but only SKIPS string literals (it has to:
- * blanking them would destroy the specifiers themselves). Bundled twin code is
- * full of SQL and English inside strings, and the loose pattern read
- * `m.to_json AS "…"`, `") return contains(document.from);"` and
- * `"…sent to everyone, some of them twice"` as import specifiers — reporting
- * a dozen phantom undeclared "packages" named after fragments of prose.
- *
- * tsup emits ESM with every static `import`/`export … from` at the start of a
- * line, so anchoring to line-start is both precise and complete for this
- * output. Dynamic `import("x")` is matched separately: it needs the literal
- * `import(` prefix, which prose does not produce.
- */
 const JS_STATIC_IMPORT_PATTERN = /^\s*(?:import|export)\b[^;\n]*?\bfrom\s*(['"])([^'"]+)\1/gm;
 const JS_BARE_IMPORT_PATTERN = /^\s*import\s*(['"])([^'"]+)\1/gm;
 const JS_DYNAMIC_IMPORT_PATTERN = /\bimport\s*\(\s*(['"])([^'"]+)\1\s*\)/g;
@@ -195,11 +96,6 @@ function specifiersIn(text, kind) {
 const failures = [];
 const manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
 
-// ── Manifest assertions (no build, no network) ───────────────────────────────
-
-// 1 — stricter than npm on purpose: npm publishes a manifest with no `private`
-// field quite happily, but the difference between "absent" and "explicitly
-// false" is the difference between a silent regression and a loud one.
 if (manifest.private !== false) {
   failures.push(
     `packages/sandbox-domains/package.json has \`private: ${JSON.stringify(manifest.private)}\`; it must be exactly \`false\`.\n` +
@@ -208,7 +104,6 @@ if (manifest.private !== false) {
   );
 }
 
-// 2 — registry is chosen by the publish job, not pinned in the manifest.
 if (manifest.publishConfig?.registry !== undefined) {
   failures.push(
     `packages/sandbox-domains/package.json pins \`publishConfig.registry\` to ${JSON.stringify(manifest.publishConfig.registry)}.\n` +
@@ -225,7 +120,6 @@ if (manifest.publishConfig?.access !== "public") {
   );
 }
 
-// 3 — the whole point of the bundling strategy, and identical to the checks gate.
 for (const field of ["dependencies", "peerDependencies", "optionalDependencies"]) {
   const internal = Object.keys(manifest[field] ?? {}).filter((name) => name.startsWith("@pome-sh/"));
   if (internal.length > 0) {
@@ -247,8 +141,6 @@ if (manifest.peerDependencies?.zod === undefined) {
   );
 }
 
-// The upstream fidelity anchors must not drift from the twins they were
-// generated against.
 for (const [name, twinManifestPath] of Object.entries(UPSTREAM_ANCHORS)) {
   const twinManifest = JSON.parse(readFileSync(join(ROOT, twinManifestPath), "utf8"));
   const expected = twinManifest.devDependencies?.[name] ?? twinManifest.dependencies?.[name];
@@ -269,7 +161,6 @@ for (const [name, twinManifestPath] of Object.entries(UPSTREAM_ANCHORS)) {
   }
 }
 
-/** Every file path an `exports` map points at, conditions and subpaths flattened. */
 function exportTargets(exportsField) {
   const targets = new Set();
   const walk = (node) => {
@@ -280,9 +171,6 @@ function exportTargets(exportsField) {
   return targets;
 }
 
-// Every subpath the export spec names must exist in the manifest at all — a
-// missing one is ERR_PACKAGE_PATH_NOT_EXPORTED before any of the tarball
-// assertions below get a chance to look at its contents.
 for (const subpath of Object.keys(REQUIRED_EXPORTS)) {
   if (manifest.exports?.[subpath] === undefined) {
     failures.push(
@@ -292,21 +180,15 @@ for (const subpath of Object.keys(REQUIRED_EXPORTS)) {
   }
 }
 
-// `main`/`types` are the pre-`exports` resolution path; older tooling still
-// reads them, so they have to ship too.
 const declaredPaths = exportTargets(manifest.exports);
 for (const field of ["main", "types"]) {
   if (typeof manifest[field] === "string") declaredPaths.add(manifest[field].replace(/^\.\//, ""));
 }
 declaredPaths.delete("package.json"); // always in the tarball; not a build output
 
-// ── Tarball assertions ──────────────────────────────────────────────────────
-
 function auditTarball() {
   const workDirectory = mkdtempSync(join(tmpdir(), "pome-sandbox-domains-tarball-"));
   try {
-    // --ignore-scripts: `prepublishOnly` would rebuild, which would hide a
-    // "published a stale dist" bug. The caller is expected to have built.
     const packed = execFileSync(
       "npm",
       ["pack", "-w", "@pome-sh/sandbox-domains", "--ignore-scripts", "--pack-destination", workDirectory],
@@ -329,7 +211,6 @@ function auditTarball() {
       );
     }
 
-    // npm wraps every tarball entry in a top-level `package/` directory.
     const shipped = new Set(
       execFileSync("tar", ["-tf", tarball], { encoding: "utf8" })
         .split("\n")
@@ -356,8 +237,6 @@ function auditTarball() {
       );
     }
 
-    // Read the real shipped bytes, not the workspace's dist: `files` negations
-    // and `.npmignore` are exactly the kind of thing that makes the two differ.
     const extractDirectory = mkdtempSync(join(tmpdir(), "pome-sandbox-domains-extract-"));
     execFileSync("tar", ["-xf", tarball, "-C", extractDirectory], { stdio: "inherit" });
     const packageRoot = join(extractDirectory, "package");
@@ -388,10 +267,6 @@ function auditTarball() {
       failures.push("the tarball ships no .js at all — the bundle did not build.");
     }
 
-    // 4 — every bare specifier the shipped bytes name is resolvable for a
-    // consumer. Measured off the tarball rather than allowlisted, so a new
-    // transitive import is named here instead of becoming the consumer's
-    // ERR_MODULE_NOT_FOUND (js) or TS2307 (d.ts).
     const declaredRuntime = new Set([
       ...Object.keys(packedManifest.dependencies ?? {}),
       ...Object.keys(packedManifest.peerDependencies ?? {}),
@@ -425,20 +300,6 @@ function auditTarball() {
       );
     }
 
-    // 5 — and the converse: a declared dependency nothing imports is a package
-    // the consumer installs and audits for no reason. `zod` is exempt because a
-    // peer is a CONSTRAINT on the consumer's graph, not a thing this tarball
-    // has to reach (it does, but that is not what makes it correct).
-    //
-    // 4 and 5 are two sides of ONE knob, and getting that backwards costs a
-    // build cycle: `noExternal` only forces `@pome-sh/*` inlining, and tsup
-    // decides every OTHER third-party package by whether this manifest declares
-    // it. Declared ⇒ left external ⇒ must stay declared (hono). Undeclared ⇒
-    // inlined into the bundle ⇒ must NOT be declared (graphql, which twin-linear
-    // reaches through its package root, and which showed up here only as tsup's
-    // `// ../../node_modules/graphql/…` source comments). So the fix for a
-    // failure here is never "declare it and move on" — decide which side of the
-    // knob the package belongs on first.
     const unusedDeps = Object.keys(packedManifest.dependencies ?? {}).filter(
       (name) => !importedPackages.has(name),
     );
@@ -452,11 +313,6 @@ function auditTarball() {
       );
     }
 
-    // 6 — the runtime actually shipped. This is the INVERSE of the checks gate's
-    // engine assertion, and it is the difference between this package and a
-    // second declarations package: without a SQLite driver every `open*Database`
-    // export is a function that cannot open anything, and nothing else notices
-    // until a grader boots a twin.
     const sqliteCarriers = [...sources].filter(([, text]) => text.includes("node:sqlite"));
     if (sqliteCarriers.length === 0) {
       failures.push(
@@ -467,12 +323,6 @@ function auditTarball() {
       );
     }
 
-    // 7 — one SQLite layer across the whole tarball. Seven entries all reach the
-    // sdk's db module; without `splitting: true` each would carry its own copy,
-    // so `@pome-sh/sandbox-domains/github`'s opener and `.../stripe`'s would be
-    // different function objects holding different `DatabaseSync` handles. Same
-    // argument as zod, one layer in — and the same shape as the checks gate's
-    // `defineCheck` count, over this package's own shared primitive.
     if (sqliteCarriers.length > 1) {
       failures.push(
         `\`node:sqlite\` is imported by ${sqliteCarriers.length} shipped modules; it must be exactly one.\n` +
@@ -482,7 +332,6 @@ function auditTarball() {
       );
     }
 
-    // 8 — zod stays external. A bundled zod shows up as its own internals.
     const zodInlined = [...sources]
       .filter(([, text]) => /\bclass \$?ZodObject\b|\$ZodType\b/.test(text))
       .map(([file]) => file);
@@ -501,8 +350,6 @@ function auditTarball() {
       );
     }
 
-    // 9 — the export spec, read off the shipped bytes. A re-export that silently
-    // stopped resolving is invisible here and fatal in pome-cloud.
     for (const [subpath, symbols] of Object.entries(REQUIRED_EXPORTS)) {
       const target = manifest.exports?.[subpath];
       const file = typeof target === "string" ? target : target?.default;
@@ -520,17 +367,6 @@ function auditTarball() {
         );
       }
     }
-
-    // The declarations must be self-contained apart from resolvable externals.
-    // `noExternal` does not cover them: the declaration bundler leaves bare
-    // specifiers alone, so `export … from "@pome-sh/twin-github"` lands verbatim
-    // in the shipped `.d.ts` and resolves nowhere for a consumer.
-    // `scripts/bundle-declarations.mjs` rewrites them; assertion 4 above is the
-    // tarball-side check that it ran and covered everything, since an
-    // unrewritten `@pome-sh/*` specifier is by definition undeclared.
-    //
-    // The authoritative test is the consumer COMPILE in
-    // scripts/clean-room-pack-test.mjs, which catches type errors this cannot see.
 
     if (failures.length === 0) {
       console.log(

--- a/scripts/ci/check-sandbox-domains-tarball.mjs
+++ b/scripts/ci/check-sandbox-domains-tarball.mjs
@@ -38,14 +38,12 @@
 //
 // ── Assertions 4 and 5 are the ones that earn their keep ────────────────────
 //
-// The ticket's own instruction was "do not assume; the tarball gate asserts the
-// final dependency set either way". So rather than a hand-kept allowlist of
-// permitted externals, this reads every bare specifier out of the SHIPPED bytes
-// — JS and `.d.ts` both — and requires each to be a node: builtin, the zod
-// peer, or a declared runtime dependency (4). Then it requires the converse:
-// every declared dependency is actually imported (5). Without 5 the manifest
-// can name a package nothing uses, which a consumer still installs and still
-// audits — `@hono/node-server` was exactly that here until this gate said so.
+// Rather than a hand-kept allowlist of permitted externals, this reads every
+// bare specifier out of the SHIPPED bytes — JS and `.d.ts` both — and requires
+// each to be a node: builtin, the zod peer, or a declared runtime dependency
+// (4). Then the converse: every declared dependency is actually imported (5).
+// Without 5 the manifest can name a package nothing uses, which a consumer
+// still installs and still audits.
 //
 // Modes:
 //   --manifest-only  Only what is readable from package.json (private, no

--- a/scripts/ci/check-sandbox-domains-tarball.test.mjs
+++ b/scripts/ci/check-sandbox-domains-tarball.test.mjs
@@ -1,20 +1,8 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Regression suite for scripts/ci/check-sandbox-domains-tarball.mjs.
-//
-// The gate's whole value is that it fails on things nobody can see from inside
-// this workspace, so the thing worth testing is that it FAILS — a gate asserted
-// only against a green tree is one that could have been `process.exit(0)`.
-//
-// Everything below runs the real script against a scratch copy of the manifest,
-// in `--manifest-only` mode (no build, no network). The tarball half is exercised
-// for real by `npm run gate:sandbox-domains-tarball` in ci.yml's heavy block and in
-// release.yml's publish job; what cannot be tested by mutating a manifest is the
-// specifier scanner, so its two failure modes are unit-tested directly against
-// the exported patterns' behaviour on strings that once broke it.
-//
-// Usage: node scripts/ci/check-sandbox-domains-tarball.test.mjs
+// Breaks the manifest several ways in --manifest-only mode. A gate only ever run
+// against a green tree could have been process.exit(0).
 
 import { execFileSync } from "node:child_process";
 import { copyFileSync, readFileSync, writeFileSync } from "node:fs";
@@ -35,7 +23,6 @@ function check(label, condition, detail = "") {
   }
 }
 
-/** Run the gate in manifest-only mode; returns `{ ok, output }`. */
 function runGate() {
   try {
     const output = execFileSync(process.execPath, [GATE, "--manifest-only"], {
@@ -49,7 +36,6 @@ function runGate() {
   }
 }
 
-/** Apply `mutate` to the manifest, run the gate, restore. */
 function withMutatedManifest(mutate) {
   copyFileSync(MANIFEST, BACKUP);
   try {
@@ -68,7 +54,6 @@ console.log("check-sandbox-domains-tarball.mjs — manifest assertions");
 const clean = runGate();
 check("passes on the real manifest", clean.ok, clean.output);
 
-// 1 — the failure mode that produces a fully GREEN release publishing nothing.
 const privatised = withMutatedManifest((m) => {
   m.private = true;
 });
@@ -78,7 +63,6 @@ check(
   privatised.output,
 );
 
-// A missing `private` field is not the same as `false`, and npm tolerates it.
 const privateAbsent = withMutatedManifest((m) => {
   delete m.private;
 });
@@ -88,7 +72,6 @@ check(
   privateAbsent.output,
 );
 
-// 2 — a pinned registry can only misroute the publish.
 const pinnedRegistry = withMutatedManifest((m) => {
   m.publishConfig.registry = "https://npm.pkg.github.com";
 });
@@ -98,7 +81,6 @@ check(
   pinnedRegistry.output,
 );
 
-// E402 after the merge has already landed.
 const restricted = withMutatedManifest((m) => {
   m.publishConfig.access = "restricted";
 });
@@ -108,7 +90,6 @@ check(
   restricted.output,
 );
 
-// 3 — the leak that 404s a consumer's install. The reason this package bundles.
 const leakedInternal = withMutatedManifest((m) => {
   m.dependencies["@pome-sh/sdk"] = "*";
 });
@@ -127,7 +108,6 @@ check(
   leakedPeer.output,
 );
 
-// The two-schema-identity bug, in a brand-new package.
 const zodNotPeer = withMutatedManifest((m) => {
   delete m.peerDependencies.zod;
   m.dependencies.zod = "^4.4.3";
@@ -138,7 +118,6 @@ check(
   zodNotPeer.output,
 );
 
-// The upstream fidelity anchors were generated against the twins' versions.
 const driftedAnchor = withMutatedManifest((m) => {
   m.dependencies["@octokit/openapi-types"] = "^27.0.0";
 });
@@ -148,7 +127,6 @@ check(
   driftedAnchor.output,
 );
 
-// The export spec is the measured contract with pome-cloud.
 const droppedSubpath = withMutatedManifest((m) => {
   delete m.exports["./server"];
 });
@@ -167,18 +145,11 @@ check(
   droppedTwin.output,
 );
 
-// ── The specifier scanner ───────────────────────────────────────────────────
-//
-// Not reachable by mutating a manifest, and the half that actually broke during
-// The loose `\bfrom\s*"…"` form used on `.d.ts` reads SQL and English
-// inside bundled JS string literals as import specifiers. These pin both
-// directions so a future simplification back to one pattern reds here.
 console.log("\ncheck-sandbox-domains-tarball.mjs — specifier scanning");
 
 const JS_STATIC = /^\s*(?:import|export)\b[^;\n]*?\bfrom\s*(['"])([^'"]+)\1/gm;
 const LOOSE = /(?:\bfrom\s*|\bimport\s*)\(?\s*(['"])([^'"]+)\1/g;
 
-/** Real bundled-JS bytes from the twins that the loose pattern misread. */
 const PROSE_SAMPLES = [
   'const sql = `SELECT m.to_json AS "from", m.ts FROM messages m`;',
   'if (field === "from") return contains(document.from);',
@@ -194,7 +165,6 @@ for (const sample of PROSE_SAMPLES) {
   );
 }
 
-/** …while every real form tsup emits is still found. */
 const REAL_IMPORTS = [
   ['import { Hono } from "hono";', "hono"],
   ['import { sign } from "hono/jwt";', "hono/jwt"],
@@ -206,8 +176,6 @@ for (const [line, expected] of REAL_IMPORTS) {
   check(`still finds a real import: ${expected}`, found.includes(expected), JSON.stringify(found));
 }
 
-// `hono/jwt` must be satisfied by a declared `hono`, or the gate demands a
-// dependency on a subpath that is not a package.
 const packageNameOf = (specifier) => {
   const parts = specifier.split("/");
   return specifier.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0];

--- a/scripts/ci/check-wire-tarball.mjs
+++ b/scripts/ci/check-wire-tarball.mjs
@@ -1,41 +1,12 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Release gate for @pome-sh/wire's own tarball.
+// Release gate for @pome-sh/wire's own tarball. Both ways it silently stops
+// publishing are readable from package.json: `private: true` exits 0 having
+// skipped it, and a wrong `publishConfig.registry` cannot be undone.
 //
-// `scripts/clean-room-pack-test.mjs` audits the two npmjs tarballs — it asserts
-// they carry NO `@pome-sh/*` dependency, which is the assertion that keeps wire
-// inlined rather than installed. It says nothing about wire's own tarball,
-// which reaches those users only as bytes inside the CLI's and the adapter's
-// `dist/`.
-//
-// Now it is also published to GitHub Packages for cross-repo consumers
-// (pome-cloud), and that install path has failure modes the workspace hides.
-//
-//   1. Inside this repo every consumer resolves `@pome-sh/wire` through npm's
-//      workspace symlink to `packages/wire/`, where the whole source tree
-//      exists, so an `exports` subpath pointing at a file the `files` field
-//      does not ship resolves fine forever. A cross-repo consumer gets only
-//      what is in the tarball, and the failure is
-//      ERR_PACKAGE_PATH_NOT_EXPORTED on their first import — in their repo.
-//   2. `npm publish` on a `private: true` workspace EXITS 0 with a warning
-//      ("Skipping workspace …, marked as private"). A one-character regression
-//      to `private: true` would therefore produce a fully green release that
-//      published nothing — exactly the silence
-//      the release apparatus exists to abolish.
-//   3. Publishing to the wrong registry cannot be undone; public npm has no
-//      unpublish window after 72 hours.
-//
-// Modes:
-//   --manifest-only  Assert only the properties readable from package.json
-//                    (private, publishConfig.registry). No build, no `npm
-//                    pack`, no network — so ci.yml runs this on every PR, and
-//                    2 and 3 above are caught BEFORE merge rather than by a
-//                    red release job after the npmjs publishes already went out.
-//   (default)        The above, plus pack wire and audit the real tarball.
-//                    Requires a built `packages/wire/dist`.
-//
-// Usage: node scripts/ci/check-wire-tarball.mjs [--manifest-only] [--keep]
+// The full mode also packs and resolves every `exports` subpath — inside this
+// repo the workspace symlink makes a broken one resolve forever.
 
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
@@ -52,13 +23,6 @@ const EXPECTED_REGISTRY = "https://npm.pkg.github.com";
 const failures = [];
 const manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
 
-// ── Manifest assertions (no build, no network) ───────────────────────────────
-
-// Stricter than npm, on purpose. npm publishes a manifest with no `private`
-// field at all quite happily — but `private: true` makes `npm publish -w` exit
-// 0 having published nothing, so the difference between "absent" and
-// "explicitly false" is the difference between a silent regression and a loud
-// one. Requiring `false` keeps the intent in the file where a reviewer sees it.
 if (manifest.private !== false) {
   failures.push(
     `packages/wire/package.json has \`private: ${JSON.stringify(manifest.private)}\`; it must be exactly \`false\`.\n` +
@@ -77,7 +41,6 @@ if (manifest.publishConfig?.registry !== EXPECTED_REGISTRY) {
   );
 }
 
-/** Every file path an `exports` map points at, conditions and subpaths flattened. */
 function exportTargets(exportsField) {
   const targets = new Set();
   const walk = (node) => {
@@ -88,21 +51,15 @@ function exportTargets(exportsField) {
   return targets;
 }
 
-// `main`/`types` are the pre-`exports` resolution path; older tooling and
-// bundlers still read them, so they have to ship too.
 const declaredPaths = exportTargets(manifest.exports);
 for (const field of ["main", "types"]) {
   if (typeof manifest[field] === "string") declaredPaths.add(manifest[field].replace(/^\.\//, ""));
 }
 declaredPaths.delete("package.json"); // always in the tarball; not a build output
 
-// ── Tarball assertions ──────────────────────────────────────────────────────
-
 function auditTarball() {
   const workDirectory = mkdtempSync(join(tmpdir(), "pome-wire-tarball-"));
   try {
-    // --ignore-scripts: wire's `prepublishOnly` would rebuild, which would hide
-    // a "published a stale dist" bug. The caller is expected to have built.
     execFileSync(
       "npm",
       ["pack", "-w", "@pome-sh/wire", "--ignore-scripts", "--pack-destination", workDirectory],
@@ -125,7 +82,6 @@ function auditTarball() {
       );
     }
 
-    // npm wraps every tarball entry in a top-level `package/` directory.
     const shipped = new Set(
       execFileSync("tar", ["-tf", tarball], { encoding: "utf8" })
         .split("\n")
@@ -144,11 +100,6 @@ function auditTarball() {
       );
     }
 
-    // wire's tsconfig sets `sourceMap: true` and no `src/` ships, so every
-    // emitted `.js.map` would be a dangling map with no `sourcesContent`.
-    // `files` excludes them (`!dist/**/*.map`). clean-room-pack-test.mjs
-    // already treats a dangling map in a published tarball as a hard failure
-    // for the other two packages; wire holds to the same rule.
     const sourcemaps = [...shipped].filter((path) => path.endsWith(".map"));
     if (sourcemaps.length > 0) {
       failures.push(

--- a/scripts/ci/check-wire-tarball.mjs
+++ b/scripts/ci/check-wire-tarball.mjs
@@ -6,7 +6,6 @@
 // `scripts/clean-room-pack-test.mjs` audits the two npmjs tarballs — it asserts
 // they carry NO `@pome-sh/*` dependency, which is the assertion that keeps wire
 // inlined rather than installed. It says nothing about wire's own tarball,
-// because wire used to have no tarball: it was `private: true` and reached
 // users only as bytes inside the CLI's and the adapter's `dist/`.
 //
 // Now it is also published to GitHub Packages for cross-repo consumers
@@ -22,7 +21,7 @@
 //      ("Skipping workspace …, marked as private"). A one-character regression
 //      to `private: true` would therefore produce a fully green release that
 //      published nothing — exactly the silence
-//      `check-version-bump-required.mjs` exists to abolish.
+//      the release apparatus exists to abolish.
 //   3. Publishing to the wrong registry cannot be undone; public npm has no
 //      unpublish window after 72 hours.
 //

--- a/scripts/ci/check-wire-tarball.mjs
+++ b/scripts/ci/check-wire-tarball.mjs
@@ -6,7 +6,8 @@
 // `scripts/clean-room-pack-test.mjs` audits the two npmjs tarballs — it asserts
 // they carry NO `@pome-sh/*` dependency, which is the assertion that keeps wire
 // inlined rather than installed. It says nothing about wire's own tarball,
-// users only as bytes inside the CLI's and the adapter's `dist/`.
+// which reaches those users only as bytes inside the CLI's and the adapter's
+// `dist/`.
 //
 // Now it is also published to GitHub Packages for cross-repo consumers
 // (pome-cloud), and that install path has failure modes the workspace hides.

--- a/scripts/ci/decide-publish.sh
+++ b/scripts/ci/decide-publish.sh
@@ -6,17 +6,14 @@
 # against what its registry currently serves and writes `<output>=true|false`
 # to $GITHUB_OUTPUT.
 #
-# Folded in from the deleted scripts/check-cli-version-floor.sh (F-724): never
-# publish from a version base BEHIND the registry's published latest — that
+# Never publish from a version base BEHIND the registry's published latest — that
 # retags `latest` backwards for every existing consumer. A version that differs
 # but does not sort above the registry's is a hard fail, not a skip.
 #
-# Extracted from an inline `decide()` in release.yml by F-949, when
-# @pome-sh/wire became a third publish target on a DIFFERENT registry
-# (npm.pkg.github.com). Two callers now need identical semantics against
-# different registries and with different auth, and the wire decision must be
-# able to fail without taking the two npmjs publishes down with it — so this
-# lives in one tested file instead of being copy-pasted into a second job.
+# One shared implementation rather than an inline `decide()` per lane: two
+# callers need identical semantics against DIFFERENT registries and with
+# different auth, and the wire decision must be able to fail without taking
+# the two npmjs publishes down with it.
 # Regression suite: scripts/ci/decide-publish.test.mjs.
 #
 # Usage: decide-publish.sh <package-name> <manifest-path> <output-key> [registry]

--- a/scripts/ci/decide-publish.sh
+++ b/scripts/ci/decide-publish.sh
@@ -1,29 +1,11 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 #
-# "Does this package need publishing?" — the version-diff decision behind
-# release.yml's publish jobs. Compares a package's local package.json version
-# against what its registry currently serves and writes `<output>=true|false`
-# to $GITHUB_OUTPUT.
+# Does this package need publishing? Local version vs what the registry serves.
 #
-# Never publish from a version base BEHIND the registry's published latest — that
-# retags `latest` backwards for every existing consumer. A version that differs
-# but does not sort above the registry's is a hard fail, not a skip.
-#
-# One shared implementation rather than an inline `decide()` per lane: two
-# callers need identical semantics against DIFFERENT registries and with
-# different auth, and the wire decision must be able to fail without taking
-# the two npmjs publishes down with it.
-# Regression suite: scripts/ci/decide-publish.test.mjs.
-#
-# Usage: decide-publish.sh <package-name> <manifest-path> <output-key> [registry]
-#
-#   registry — optional. Omitted ⇒ npm's default (registry.npmjs.org). Passed
-#   explicitly for GitHub Packages. Deliberately an ARGUMENT rather than an
-#   `@scope:registry=` line in .npmrc: a scope mapping would redirect EVERY
-#   @pome-sh/* read, including @pome-sh/cli's and the adapter's, to a registry
-#   where they do not exist — and every release would then look like a
-#   brand-new package with a 0.0.0 baseline, silently disabling the floor check.
+# Behind the registry's latest is a hard fail, not a skip: publishing from it
+# retags `latest` backwards. A non-404 read error is a hard fail for the same
+# reason — a 401 read as "unpublished" bypasses that floor.
 
 set -euo pipefail
 
@@ -37,7 +19,6 @@ manifest="$2"
 output="$3"
 registry="${4:-}"
 
-# Never empty, so "${view[@]}" cannot trip `set -u` on an empty-array expansion.
 view=(npm view "${name}" version)
 if [ -n "${registry}" ]; then
   view+=(--registry "${registry}")
@@ -49,19 +30,8 @@ npm_view_err="$(mktemp)"
 if registry_version="$("${view[@]}" 2>"${npm_view_err}")"; then
   :
 elif grep -q "E404" "${npm_view_err}"; then
-  # Genuinely unpublished (brand-new package) — 0.0.0 is the correct baseline.
-  # This is the path a first-ever publish takes. GitHub Packages answers 404
-  # for a name that has never been published under the owner, exactly as npmjs
-  # does, so the first release needs no special case.
   registry_version="0.0.0"
 else
-  # A registry/network/auth error is NOT "unpublished". Treating it as 0.0.0
-  # would make any local version look publishable and bypass the floor check
-  # below, which exists specifically to stop retagging `latest` backwards.
-  #
-  # This matters MORE for GitHub Packages: an absent or under-scoped token
-  # answers 401 for a package that exists, and a 401 must never be mistaken
-  # for "nothing published yet".
   echo "::error::npm view ${name} failed for a reason other than 'not found':"
   cat "${npm_view_err}" >&2
   rm -f "${npm_view_err}"

--- a/scripts/ci/decide-publish.test.mjs
+++ b/scripts/ci/decide-publish.test.mjs
@@ -1,21 +1,8 @@
 #!/usr/bin/env node
-/**
- * Regression coverage for scripts/ci/decide-publish.sh.
- *
- * Mocks `npm` on PATH so every registry answer is exercised without a network:
- * unpublished (E404 ⇒ publish from a 0.0.0 baseline), unchanged (skip), ahead
- * (publish), BEHIND (hard fail — the floor check that stops retagging `latest`
- * backwards), and 401/403/5xx (hard fail — an auth or transport error must
- * never be read as "nothing published yet", which would bypass the floor
- * check). The 401 case is the one GitHub Packages actually produces for a
- * package that exists but the token cannot read, so it is the reason this
- * distinction is load-bearing rather than theoretical.
- *
- * Also asserts the registry argument is passed through as `--registry` for the
- * GitHub Packages caller and NOT passed for the npmjs callers, and that
- * release.yml wires the jobs up so a GitHub Packages failure cannot block the
- * two npmjs publishes.
- */
+//
+// Asserts a 401 from GitHub Packages is never read as "unpublished" (which would
+// bypass the never-publish-behind-latest floor) and that the two registry lanes
+// cannot block each other.
 import { spawnSync } from "node:child_process";
 import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -35,10 +22,6 @@ function check(label, condition, detail = "") {
   console.error(`  ✗ ${label}${detail ? `\n      ${detail}` : ""}`);
 }
 
-/**
- * Run decide-publish.sh with a mocked npm.
- * `answer` is a bash snippet that stands in for `npm view`'s behaviour.
- */
 function run({ answer, localVersion, registry }) {
   const dir = mkdtempSync(join(tmpdir(), "decide-publish-"));
   try {
@@ -88,27 +71,22 @@ exit 1`;
 
 console.log("decide-publish.sh");
 
-// A package the registry has never seen must publish, not fail. This is the
-// first-ever-publish path for @pome-sh/wire on GitHub Packages.
 {
   const r = run({ answer: E404, localVersion: "0.2.1" });
   check("E404 (never published) ⇒ publishes from a 0.0.0 baseline", r.status === 0 && r.output === "thing=true", `status=${r.status} output=${r.output}`);
   check("E404 reports the 0.0.0 baseline in the log", r.stdout.includes("0.0.0"), r.stdout);
 }
 
-// Unchanged ⇒ skip.
 {
   const r = run({ answer: `echo "0.2.1"`, localVersion: "0.2.1" });
   check("same version ⇒ skip", r.status === 0 && r.output === "thing=false", `status=${r.status} output=${r.output}`);
 }
 
-// Ahead ⇒ publish.
 {
   const r = run({ answer: `echo "0.2.0"`, localVersion: "0.2.1" });
   check("local ahead of registry ⇒ publish", r.status === 0 && r.output === "thing=true", `status=${r.status} output=${r.output}`);
 }
 
-// Behind ⇒ hard fail. Publishing would retag `latest` backwards.
 {
   const r = run({ answer: `echo "9.9.9"`, localVersion: "0.2.1" });
   check("local BEHIND registry ⇒ hard fail", r.status !== 0, `status=${r.status}`);
@@ -116,13 +94,11 @@ console.log("decide-publish.sh");
   check("behind-fail explains the retag risk", r.stdout.includes("retag latest backwards"), r.stdout);
 }
 
-// Multi-digit ordering: `sort -V` must not compare 0.2.10 as lower than 0.2.9.
 {
   const r = run({ answer: `echo "0.2.9"`, localVersion: "0.2.10" });
   check("0.2.10 counts as ahead of 0.2.9 (version sort, not lexical)", r.status === 0 && r.output === "thing=true", `status=${r.status} output=${r.output}`);
 }
 
-// Auth / transport failures must NOT be read as "unpublished".
 for (const [label, answer] of [
   ["401 (GitHub Packages, token cannot read an existing package)", E401],
   ["403", E403],
@@ -133,7 +109,6 @@ for (const [label, answer] of [
   check(`${label} does not claim "unchanged" or publish`, !r.output.includes("true"), r.output);
 }
 
-// The registry argument must reach npm as --registry, and must be absent for npmjs.
 {
   const gh = run({ answer: `echo "0.2.0"`, localVersion: "0.2.1", registry: "https://npm.pkg.github.com" });
   check(
@@ -145,7 +120,6 @@ for (const [label, answer] of [
   check("no registry argument ⇒ npm's default registry, no --registry flag", !npmjs.argv.includes("--registry"), npmjs.argv);
 }
 
-// Argument validation.
 {
   const dir = mkdtempSync(join(tmpdir(), "decide-publish-args-"));
   try {
@@ -156,9 +130,6 @@ for (const [label, answer] of [
   }
 }
 
-// The wiring assertion: a GitHub Packages outage must not block the npmjs
-// publishes. `publish` depends on `plan` (npmjs only) and `publish-wire` on
-// `plan-wire` (GitHub Packages only) — never the other way round.
 console.log("\nrelease.yml wiring");
 {
   const workflow = readFileSync(join(ROOT, ".github/workflows/release.yml"), "utf8");
@@ -175,11 +146,6 @@ console.log("\nrelease.yml wiring");
   const publish = jobOf("publish");
   const publishWire = jobOf("publish-wire");
 
-  // A regex rather than `.includes("npm.pkg.github.com")`: this is a text
-  // search over workflow YAML, not URL-host validation, and the `.includes`
-  // spelling trips CodeQL's js/incomplete-url-substring-sanitization heuristic
-  // — which is a real bug pattern when you are checking an actual URL, and a
-  // false positive here. Saying it as a pattern match says what it is.
   const READS_GITHUB_PACKAGES = /npm\.pkg\.github\.com/;
 
   check("all four jobs exist", [plan, planWire, publish, publishWire].every(Boolean));
@@ -191,8 +157,6 @@ console.log("\nrelease.yml wiring");
   check("plan-wire reads GitHub Packages", READS_GITHUB_PACKAGES.test(planWire));
   check("publish needs plan only", /needs:\s*plan\s*$/m.test(publish) && !publish.includes("plan-wire"));
   check("publish-wire needs plan-wire only", publishWire.includes("needs: plan-wire"));
-  // Inspect the actual publish command line, not the surrounding prose — the
-  // comments above it legitimately mention both `--access public` and npmjs.
   const wirePublishCommand = publishWire
     .split("\n")
     .map((line) => line.trim())
@@ -216,9 +180,6 @@ console.log("\nrelease.yml wiring");
   check("plan-wire has packages: read", planWire.includes("packages: read"));
   check("publish-wire has packages: write", publishWire.includes("packages: write"));
 
-  // The dispatch that closes the re-pin deadlock must fire once
-  // after either publish lane succeeds, never before, and never mask a real
-  // publish failure by swallowing its own.
   const dispatch = jobOf("dispatch-allocate-version");
   check("dispatch-allocate-version job exists", Boolean(dispatch));
   check(
@@ -231,13 +192,6 @@ console.log("\nrelease.yml wiring");
     dispatch.includes("needs.publish.result == 'success' || needs.publish-wire.result == 'success'"),
     dispatch,
   );
-  // Without a status-check function in the `if:`, GitHub requires every job in
-  // `needs:` to have SUCCEEDED — and one of the two publish lanes is skipped on
-  // almost every release (each fires only when its own registry's version moved).
-  // The OR above would then never be reached: the job is dropped for depending on
-  // a skipped lane, and reads as an innocent "skipped" while the re-pin never
-  // happens. This is the one edit that turns this whole job back into decoration,
-  // so it is asserted rather than commented.
   check(
     "its `if:` carries a status-check function (!cancelled()), or a skipped publish lane silently drops the job",
     /!cancelled\(\)/.test(dispatch.split("\n").find((line) => line.trim().startsWith("if:")) ?? ""),
@@ -262,15 +216,8 @@ console.log("\nrelease.yml wiring");
     dispatch,
   );
 
-  // It POSTs a repository_dispatch, NOT a workflow_dispatch. `gh workflow run`
-  // hits POST /repos/…/actions/workflows/{id}/dispatches, which GitHub gates on
-  // `actions: write` — a scope the pome-ops-push installation does not have, so
-  // that spelling 403s on every release. `gh api … /dispatches` is the
-  // `contents: write` endpoint, which it does have.
   const dispatchCommand = dispatch
     .split("\n")
-    // The command is a one-line `run:`, so the key is stripped rather than
-    // assumed away — comment lines still begin with `#` and cannot match.
     .map((line) => line.trim().replace(/^run:\s*/, ""))
     .find((line) => line.startsWith("gh "));
   check("the job has a `gh` dispatch command", Boolean(dispatchCommand), dispatch);
@@ -282,11 +229,6 @@ console.log("\nrelease.yml wiring");
     dispatchCommand,
   );
 
-  // The event_type and allocate-version.yml's `types:` are two halves of one
-  // wire, typed in two files. A mismatch is not an error anywhere: the POST
-  // answers 204 and starts no run — the silent no-op this whole job exists to
-  // avoid — so they are asserted against each other rather than each against a
-  // literal spelled here twice.
   const eventType = dispatchCommand?.match(/-f\s+event_type=([\w.-]+)/)?.[1];
   check("the dispatch names an event_type", Boolean(eventType), dispatchCommand);
   const allocate = readFileSync(join(ROOT, ".github/workflows/allocate-version.yml"), "utf8");
@@ -306,11 +248,6 @@ console.log("\nrelease.yml wiring");
     `release.yml sends \`${eventType}\`, allocate-version.yml accepts \`${dispatchTypes?.[1] ?? "nothing"}\``,
   );
 
-  // A repository_dispatch payload has no `head_commit`, so allocate-version.yml's
-  // `[release-bump]` guard cannot read the marker on that event — and the tip it
-  // is dispatched FROM is always a `[release-bump]` commit. The guard therefore
-  // has to be scoped to `push`, or the dispatched run either skips outright (a
-  // dispatch that achieves nothing) or passes only by null-coercion.
   check(
     "allocate-version.yml's [release-bump] guard is scoped to `push`, so the dispatched run is not skipped by a marker it cannot read",
     /if:\s*\$\{\{\s*github\.event_name\s*!=\s*'push'\s*\|\|\s*!contains\(github\.event\.head_commit\.message,\s*'\[release-bump\]'\)\s*\}\}/.test(
@@ -319,24 +256,12 @@ console.log("\nrelease.yml wiring");
     "expected a job-level `if:` of the form `github.event_name != 'push' || !contains(github.event.head_commit.message, '[release-bump]')`",
   );
 
-  // The race the dispatch would otherwise lose. `planExampleRepins` only re-pins
-  // to a version the registry already serves, and an E404 is indistinguishable
-  // from "never published" — so if the publish job returns before propagation,
-  // the dispatched run no-ops and the drift persists with no later run to retry
-  // it. The publish job must therefore prove visibility before this job runs.
   check(
     "the publish job waits for the registry to serve what it published, with a staleness-forcing read",
     /npm view "\$\{PKG\}@\$\{version\}"[^\n]*--prefer-online/.test(publish),
     publish,
   );
 
-  // …and the version it waits for is READ CORRECTLY, which a grep cannot tell
-  // you. `npm pkg get version -w <name> --json` answers `{"<name>": "0.3.6"}` on
-  // the npm@11.5.1 that job pins and `{"<name>": {"version": "0.3.6"}}` on npm
-  // 12, so an expression written against one shape yields `undefined` on the
-  // other — `npm view <pkg>@undefined` then 404s for the whole budget and reds
-  // every publish. So the expression is pulled out of the workflow and RUN here
-  // against both shapes, rather than asserted to exist.
   const extractor = publish.match(/node -p '(const v=JSON\.parse[^']*)'/)?.[1];
   check("the version extractor is findable in the wait step", Boolean(extractor), publish);
   if (extractor) {
@@ -357,8 +282,6 @@ console.log("\nrelease.yml wiring");
         `status=${r.status} stdout=${JSON.stringify(r.stdout)} stderr=${r.stderr?.split("\n")[0]}`,
       );
     }
-    // A third shape must fail HERE and name what npm said, never interpolate
-    // `undefined` into the registry query and blame the registry for the 404.
     const r = evaluate('{"@pome-sh/thing":{"nope":true}}');
     check(
       "the version extractor throws on a shape it does not recognise, rather than yielding undefined",

--- a/scripts/ci/fetch-pinned-release.sh
+++ b/scripts/ci/fetch-pinned-release.sh
@@ -17,7 +17,7 @@
 #      measured doing two different things: locally `--retry-delay 0` backed
 #      off 1s/2s/4s as documented, while on the runner the same flags burned
 #      five attempts in 0.8s against a `curl: (56) Connection died`
-#      (run 31620014945). A retry budget that looks handled and is not is worse
+#      A retry budget that looks handled and is not is worse
 #      than none, and a loop with a literal `sleep` cannot be version-dependent.
 #
 #   2. UNCONDITIONAL VERIFICATION. The sha256 comparison is not `|| true`, not

--- a/scripts/ci/fetch-pinned-release.sh
+++ b/scripts/ci/fetch-pinned-release.sh
@@ -1,45 +1,9 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 #
-# The ONE hardened path every release-CDN fetch in
-# `.github/workflows/**` goes through. Before this file there were two
-# hand-copied variants of the same loop, each with its own retry budget, its
-# own message and its own chance of getting the verification wrong; the same
-# degradation that produced them also killed a twin-image syft install, which
-# had no retry at all.
-#
-# Usage: fetch-pinned-release.sh <tool> <url> <sha256> <dest>
-#
-# Properties, all three load-bearing:
-#
-#   1. RETRY WITH BACKOFF. Five attempts, sleeping 5s/10s/15s/20s between them.
-#      An explicit loop rather than curl's `--retry` flags, because those were
-#      measured doing two different things: locally `--retry-delay 0` backed
-#      off 1s/2s/4s as documented, while on the runner the same flags burned
-#      five attempts in 0.8s against a `curl: (56) Connection died`
-#      A retry budget that looks handled and is not is worse
-#      than none, and a loop with a literal `sleep` cannot be version-dependent.
-#
-#   2. UNCONDITIONAL VERIFICATION. The sha256 comparison is not `|| true`, not
-#      `if [ -n "$sha" ]`, and not skippable by a cache hit — a hash checked
-#      conditionally is decoration. Fetching a pinned, checksummed binary
-#      instead of trusting a third-party Action is the whole reason these steps
-#      exist, so the check is the last thing this script does and its failure is
-#      the script's failure. Comparison is spelled out rather than piped into
-#      `sha256sum -c -` so the mismatch message can name both hashes, and so it
-#      works on a developer's macOS (`shasum -a 256`) as well as the runner.
-#
-#   3. FAIL CLOSED, BY NAME. A genuinely unavailable CDN must stop the job —
-#      on the publish path in twin-image.yml that means an unsigned, unattested
-#      image never ships. But it must not stop it as
-#      `##[error]The process '/usr/bin/sh' failed with exit code 1`, which says
-#      nothing about whether to retry or to read the code. Exhaustion prints an
-#      `::error::` naming the tool, the host that would not answer, and the URL.
-#
-# Env knobs exist ONLY for scripts/ci/assert-hardened-cdn-fetches.test.mjs,
-# which drives this script against a local server that 503s on demand; nothing
-# in `.github/workflows/**` sets them, and the defaults are the production
-# values asserted by that test.
+# The one hardened path for a release-CDN fetch: retry with backoff and an
+# unconditional sha256 check. An explicit loop with a literal sleep, because a retry
+# budget that looks handled and is not is worse than none.
 set -euo pipefail
 
 tool="${1:?usage: fetch-pinned-release.sh <tool> <url> <sha256> <dest>}"
@@ -50,8 +14,6 @@ dest="${4:?usage: fetch-pinned-release.sh <tool> <url> <sha256> <dest>}"
 attempts="${FETCH_PINNED_RELEASE_ATTEMPTS:-5}"
 sleep_unit="${FETCH_PINNED_RELEASE_SLEEP_UNIT:-5}"
 
-# `https://github.com/rhysd/actionlint/releases/...` -> `github.com`. Used in
-# every message so the run log names the CDN, not just the exit code.
 host="${url#*://}"
 host="${host%%/*}"
 
@@ -61,8 +23,6 @@ while [ "$attempt" -le "$attempts" ]; do
   if curl -sSfL --connect-timeout 10 --max-time 120 "$url" -o "$dest"; then
     fetched=true
     if [ "$attempt" -gt 1 ]; then
-      # A flaky-but-passing run has to say so, or the degradation is invisible
-      # until the day it is total.
       echo "::warning::${tool}: fetched from ${host} only on attempt ${attempt}/${attempts} — that release CDN is degraded right now (${url})"
     fi
     break

--- a/scripts/ci/fetch-pinned-release.sh
+++ b/scripts/ci/fetch-pinned-release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 #
-# F-1489 — the ONE hardened path every release-CDN fetch in
+# The ONE hardened path every release-CDN fetch in
 # `.github/workflows/**` goes through. Before this file there were two
 # hand-copied variants of the same loop, each with its own retry budget, its
 # own message and its own chance of getting the verification wrong; the same
@@ -19,7 +19,6 @@
 #      five attempts in 0.8s against a `curl: (56) Connection died`
 #      (run 31620014945). A retry budget that looks handled and is not is worse
 #      than none, and a loop with a literal `sleep` cannot be version-dependent.
-#      (F-1471 got this wrong twice before landing it.)
 #
 #   2. UNCONDITIONAL VERIFICATION. The sha256 comparison is not `|| true`, not
 #      `if [ -n "$sha" ]`, and not skippable by a cache hit — a hash checked

--- a/scripts/ci/file-schedule-alarm.sh
+++ b/scripts/ci/file-schedule-alarm.sh
@@ -4,12 +4,10 @@
 # Shared filing logic for `.github/workflows/schedule-alarm.yml`, the reusable
 # workflow every schedule-triggered workflow in this repo calls with a
 # `failure()`-guarded job (see repo-policy.yml and the
-# meta-alarm job in release-alarm.yml). Copies check-release-staleness.yml's
-# retired pattern (#300, deleted in a3c9441 alongside the Changesets flow it
-# watched): a constant title, ONE long-lived tracking issue reused across
-# consecutive failures rather than a new issue per run, one label per alarm so
-# several alarms never collide on the same issue, and a body naming what
-# failed plus the run URL.
+# meta-alarm job in release-alarm.yml). One constant title, ONE long-lived
+# tracking issue reused across consecutive failures rather than a new issue per
+# run, one label per alarm so several alarms never collide on the same issue,
+# and a body naming what failed plus the run URL.
 #
 # Green is asserted as hard as red (same stance as release-alarm.mjs): a
 # recovered workflow CLOSES its tracking issue rather than leaving it open,

--- a/scripts/ci/file-schedule-alarm.sh
+++ b/scripts/ci/file-schedule-alarm.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# F-1230 — a scheduled workflow that fails tells nobody.
+# A scheduled workflow that fails tells nobody.
 #
 # Shared filing logic for `.github/workflows/schedule-alarm.yml`, the reusable
 # workflow every schedule-triggered workflow in this repo calls with a

--- a/scripts/ci/file-schedule-alarm.sh
+++ b/scripts/ci/file-schedule-alarm.sh
@@ -1,32 +1,7 @@
 #!/usr/bin/env bash
-# A scheduled workflow that fails tells nobody.
 #
-# Shared filing logic for `.github/workflows/schedule-alarm.yml`, the reusable
-# workflow every schedule-triggered workflow in this repo calls with a
-# `failure()`-guarded job (see repo-policy.yml and the
-# meta-alarm job in release-alarm.yml). One constant title, ONE long-lived
-# tracking issue reused across consecutive failures rather than a new issue per
-# run, one label per alarm so several alarms never collide on the same issue,
-# and a body naming what failed plus the run URL.
-#
-# Green is asserted as hard as red (same stance as release-alarm.mjs): a
-# recovered workflow CLOSES its tracking issue rather than leaving it open,
-# because a stale open issue teaches people to skim past the next real one.
-#
-# Usage:
-#   OUTCOME=failure|success \
-#   TITLE="..." LABEL="..." DETAIL="..." RUN_URL="..." \
-#   GH_TOKEN=... GITHUB_REPOSITORY=owner/repo \
-#     bash scripts/ci/file-schedule-alarm.sh
-#
-# Every `gh` call this script NEEDS is unguarded, and the script exits non-zero
-# if one fails. That is the opposite of release-alarm.yml's in-job alerting
-# steps, which are `continue-on-error: true` so that alerting cannot masquerade
-# as a release failure — there, alerting is a side errand of a job whose real
-# subject is the release. Here it is the entire purpose of a SEPARATE job, so
-# swallowing a 403 (a caller that forgot `issues: write`, an org token policy,
-# a rate limit) would reproduce this ticket's own defect inside the alarm: a
-# green check standing in for a signal that reached nobody.
+# Files or updates one long-lived tracking issue per alarm title, and closes it on
+# recovery. A new issue per failed run is an alarm people learn to skim.
 set -euo pipefail
 
 outcome="${OUTCOME:?OUTCOME (failure|success) required}"
@@ -43,24 +18,11 @@ failure | success) ;;
   ;;
 esac
 
-# `gh issue create --label X` FAILS OUTRIGHT if X does not exist in the repo,
-# and none of the `schedule-alarm:*` labels existed on pome-sh/digital-twins
-# when this shipped — so without this line the first real failure would have
-# filed nothing. Create-on-demand rather than a one-off manual `gh label
-# create` per alarm, so a new alarm needs no out-of-band repo setup step that
-# is remembered right up until it isn't. `|| true` because the call also fails
-# when the label ALREADY exists, which is the steady state and not an error;
-# the labelled `gh issue create` below is what actually asserts the label is
-# usable, and it is unguarded.
 gh label create "$label" \
   --color B60205 \
   --description "a scheduled workflow's own alarm, filed by schedule-alarm.yml" \
   --repo "$repo" >/dev/null 2>&1 || true
 
-# Unguarded on purpose. With no match this prints an empty string and exits 0
-# (gh renders a null scalar as ""), so "no open issue" is already distinct from
-# "the lookup failed" — and swallowing the latter would read as "no open issue"
-# and file a duplicate on every run. The label is guaranteed to exist by here.
 existing="$(gh issue list --repo "$repo" --state open --label "$label" \
   --json number --jq '.[0].number')"
 
@@ -78,7 +40,6 @@ if [ "$outcome" = "success" ]; then
   exit 0
 fi
 
-# outcome = failure
 detail="${DETAIL:-(no detail was provided)}"
 body="$(mktemp)"
 {
@@ -91,12 +52,6 @@ if [ -n "$existing" ]; then
   { printf 'Still failing on the latest run.\n\n'; cat "$body"; } >"${body}.c"
   gh issue comment "$existing" --repo "$repo" --body-file "${body}.c"
 else
-  # Deliberately NO un-labelled fallback. An issue filed without "$label" is
-  # invisible to the `gh issue list --label` lookup above, so every subsequent
-  # failure would open ANOTHER new issue and no recovery could ever close any
-  # of them — the "new issue per run" behaviour this file exists to avoid,
-  # arrived at silently. If the label cannot be applied, failing here is the
-  # honest outcome.
   gh issue create --repo "$repo" --title "$title" \
     --body-file "$body" --label "$label"
 fi

--- a/scripts/ci/file-schedule-alarm.test.sh
+++ b/scripts/ci/file-schedule-alarm.test.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Regression + dry-run demonstration for scripts/ci/file-schedule-alarm.sh
-# (F-1230). Stubs `gh` on PATH so no real GitHub issue is ever created —
+# Stubs `gh` on PATH so no real GitHub issue is ever created —
 # every call the script would have made is appended to a log file instead,
-# which is also the "show the payload" evidence the ticket asks for.
+# which is also how the payload is shown.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -78,7 +78,7 @@ grep -q "^issue create" "$log"
 # lookup has: an issue filed without it is invisible to every later run, so each
 # failure would file a fresh one and no recovery could close any of them.
 grep -q -- "--label schedule-alarm:repo-policy" "$log"
-# And the body actually carries what failed plus the run URL, per the ticket.
+# And the body actually carries what failed plus the run URL.
 grep -qF "$DETAIL_1" "$bodies"
 grep -qF "https://github.com/pome-sh/pome-twins/actions/runs/999" "$bodies"
 

--- a/scripts/ci/file-schedule-alarm.test.sh
+++ b/scripts/ci/file-schedule-alarm.test.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
-# Regression + dry-run demonstration for scripts/ci/file-schedule-alarm.sh
-# Stubs `gh` on PATH so no real GitHub issue is ever created —
-# every call the script would have made is appended to a log file instead,
-# which is also how the payload is shown.
+#
+# Stubs `gh` on PATH so no real issue is filed. Asserts one issue is reused across
+# consecutive failures and closed on recovery.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -18,10 +17,6 @@ bodies="$work/bodies.log"
 : >"$log"
 : >"$bodies"
 
-# A fake `gh` that logs every invocation and simulates exactly the two calls
-# file-schedule-alarm.sh depends on: `issue list` (existing tracking issue,
-# if any) and `label create` / `issue create` / `issue comment` / `issue
-# close` (all logged, never real).
 cat >"$work/gh" <<'STUB'
 #!/usr/bin/env bash
 log="$(dirname "$0")/gh.log"
@@ -70,21 +65,13 @@ assert() { [ "$1" = "$2" ] || { echo "FAIL: expected '$2', got '$1'" >&2; exit 1
 
 DETAIL_1="REPO_POLICY_TOKEN is required for schedule drift checks (GITHUB_TOKEN cannot read branch protection)."
 
-# 1. First failure, no tracking issue yet: files a NEW issue naming the failure.
 run failure "$DETAIL_1"
 assert "$(cat "$state")" "42"
 grep -q "^issue create" "$log"
-# The label is applied on create, because the label is the ONLY key the reuse
-# lookup has: an issue filed without it is invisible to every later run, so each
-# failure would file a fresh one and no recovery could close any of them.
 grep -q -- "--label schedule-alarm:repo-policy" "$log"
-# And the body actually carries what failed plus the run URL.
 grep -qF "$DETAIL_1" "$bodies"
 grep -qF "https://github.com/pome-sh/pome-twins/actions/runs/999" "$bodies"
 
-# 2. Second failure (a DIFFERENT scheduled workflow's failure, reusing the same
-#    issue only if it shares the label — here the same repo-policy alarm fires
-#    again): must COMMENT on the existing issue, never open a second one.
 : >"$log"
 run failure "$DETAIL_1"
 assert "$(cat "$state")" "42"
@@ -93,16 +80,13 @@ if grep -q "^issue create" "$log"; then
   echo "FAIL: a second failure re-opened a new issue instead of commenting on the existing one" >&2
   exit 1
 fi
-# Keep this call's log for the evidence footer, before steps 3-5 truncate it.
 cp "$log" "$work/gh.reuse.log"
 
-# 3. Recovery: closes the existing tracking issue rather than leaving it open.
 : >"$log"
 run success ""
 assert "$(cat "$state")" ""
 grep -q "^issue close 42" "$log"
 
-# 4. Recovery with no open issue: a no-op, not an error.
 : >"$log"
 run success ""
 if grep -q "^issue close" "$log"; then
@@ -110,11 +94,6 @@ if grep -q "^issue close" "$log"; then
   exit 1
 fi
 
-# 5. The alarm cannot fail silently. Every mutating `gh` call 403s, the way a
-#    caller job that forgot `permissions: issues: write` makes them. Before this
-#    the script was `set -u` with `|| true` on every call, so it exited 0 and
-#    the alarm job went green having filed nothing — this ticket's own defect,
-#    reproduced inside the alarm.
 : >"$log"
 : >"$state"
 touch "$work/deny"
@@ -125,9 +104,6 @@ fi
 grep -q "^issue create" "$log" # it did try
 rm -f "$work/deny"
 
-# 6. An unrecognised outcome is a hard error, never a silent no-op. The
-#    reusable workflow deliberately has no `if:` on the outcome value, so this
-#    exit path is reachable from a real caller with e.g. `outcome: Failure`.
 if run Failure ""; then
   echo "FAIL: an unrecognised OUTCOME exited 0 instead of failing loudly" >&2
   exit 1

--- a/scripts/ci/list-scheduled-workflows.mjs
+++ b/scripts/ci/list-scheduled-workflows.mjs
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Every workflow with a `schedule:` trigger needs a failure alarm
-// (D5 · "every check runs somewhere that can fail"). The set of scheduled
+// Every workflow with a `schedule:` trigger needs a failure alarm, because
+// every check must run somewhere that can fail. The set of scheduled
 // workflows is DERIVED from `.github/workflows/*.yml` rather than typed into
 // a list anywhere: a hand-maintained list of "workflows with a schedule" is
-// exactly the shape D5 names as the bug — it stays green while a thirteenth
-// scheduled workflow lands uncovered. The follow-up that asserts
-// "every scheduled workflow reaches the alarm" as a property, not an
-// instance) reads this same derivation rather than re-parsing the tree with
-// its own rules.
+// exactly the shape of the bug — it stays green while a thirteenth
+// scheduled workflow lands uncovered. `assert-schedule-alarm-coverage.mjs`,
+// which asserts "every scheduled workflow reaches the alarm" as a property
+// rather than an instance, reads this same derivation rather than re-parsing
+// the tree with its own rules.
 //
 // Deliberately line-based, not a YAML parser: a workflow file's own comments
 // can contain the literal string "schedule:" (this file does), so the search
@@ -113,7 +113,7 @@ export function findCronWorkflows(root) {
   const cron = [];
   for (const [file, lines] of workflowLines(root)) {
     // `cron:` also appears inside a flow sequence — `schedule: [{cron: "…"}]`,
-    // the very shape findScheduledWorkflows() was taught to read in #384. An
+    // the very shape findScheduledWorkflows() reads. An
     // anchored `^\s*-?\s*cron:` missed it, so two of the three shapes that
     // review fixed would fail this file's OWN set-equality cross-check: a
     // correctly-alarmed workflow red the derivation. A guard that reds on right
@@ -207,7 +207,7 @@ export function main(argv = process.argv.slice(2)) {
   if (scheduled.length === 0) {
     throw new Error(
       "found zero workflows with a schedule: trigger — this repo has had at " +
-        "least one since #300, so this is a parser regression, not a true fact " +
+        "least one, so this is a parser regression, not a true fact " +
         "about the tree. Refusing to report a vacuous green.",
     );
   }

--- a/scripts/ci/list-scheduled-workflows.mjs
+++ b/scripts/ci/list-scheduled-workflows.mjs
@@ -1,30 +1,9 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Every workflow with a `schedule:` trigger needs a failure alarm, because
-// every check must run somewhere that can fail. The set of scheduled
-// workflows is DERIVED from `.github/workflows/*.yml` rather than typed into
-// a list anywhere: a hand-maintained list of "workflows with a schedule" is
-// exactly the shape of the bug — it stays green while a thirteenth
-// scheduled workflow lands uncovered. `assert-schedule-alarm-coverage.mjs`,
-// which asserts "every scheduled workflow reaches the alarm" as a property
-// rather than an instance, reads this same derivation rather than re-parsing
-// the tree with its own rules.
-//
-// Deliberately line-based, not a YAML parser: a workflow file's own comments
-// can contain the literal string "schedule:" (this file does), so the search
-// looks for a `schedule:` key at the top level of the `on:` block specifically
-// — indented exactly two spaces under a bare `on:` line — rather than any
-// occurrence of the word anywhere in the file. That is also why it skips
-// commented-out lines (`#`) before matching.
-//
-// Usage: node scripts/ci/list-scheduled-workflows.mjs [--json]
-// Exits 1 (naming the reason) if the workflows directory is missing or if
-// literally nothing has a schedule trigger — a walk that finds zero scheduled
-// workflows when `repo-policy.yml` has carried a weekly cron for a long time,
-// and `release-alarm.yml` a daily one, is a parser that
-// has silently stopped matching, not a true fact about the tree; an alarm
-// covering zero workflows passes forever.
+// The set of scheduled workflows, derived from .github/workflows/*.yml rather than
+// listed. Two independent reads (`on: schedule:` and `cron:`) must agree, and zero
+// discovered is a parser regression, not a fact about the tree.
 
 import { readFileSync, readdirSync, existsSync, realpathSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
@@ -33,40 +12,19 @@ import { fileURLToPath } from "node:url";
 const HERE = dirname(fileURLToPath(import.meta.url));
 const WORKFLOWS_DIR = "workflows";
 
-/**
- * Returns the sorted list of `.github/workflows/*.yml` (or `.yaml`) file
- * names that declare a top-level `on: schedule:` trigger.
- */
 export function findScheduledWorkflows(root) {
   const scheduled = [];
   for (const [file, lines] of workflowLines(root)) {
     let inOnBlock = false;
-    // The indent of the FIRST key under `on:`, so a 4-space-indented block
-    // matches as readily as a 2-space one, while anything DEEPER than it is a
-    // key of some other trigger (a `workflow_call` input named `schedule`, say)
-    // and still must not count.
     let keyIndent = null;
     for (const line of lines) {
-      // `on` is a YAML 1.1 truthy keyword, so `"on":` is the standard yamllint
-      // workaround for it and has to be recognised too.
       const start = /^(?:on|["']on["']):\s*(.*)$/.exec(line);
       if (start) {
-        // Flow form on the same line — `on: {schedule: [{cron: "…"}]}`. The
-        // previous revision set a flag here and then `continue`d past the only
-        // line the key ever appears on, so that branch could not match at all.
         if (/\bschedule\b/.test(start[1])) {
           scheduled.push(file);
           break;
         }
         const inline = start[1].trim();
-        // A flow mapping that SPANS lines (`on: {` then `schedule: …` below)
-        // is read by neither this walk nor findCronWorkflows, so a cron hidden
-        // inside one is invisible to both — which means the set-equality
-        // cross-check has nothing to disagree about and the alarm-coverage
-        // check reports a clean pass on an unalarmed cron. actionlint accepts
-        // the shape as valid, so nothing else would catch it either. Refuse
-        // loudly instead of parsing it wrong: an unsupported shape must never
-        // be indistinguishable from an absent trigger.
         const opens = (inline.match(/[{[]/g) ?? []).length;
         const closes = (inline.match(/[}\]]/g) ?? []).length;
         if (opens !== closes) {
@@ -80,14 +38,12 @@ export function findScheduledWorkflows(root) {
         continue;
       }
       if (!inOnBlock || line.trim() === "") continue;
-      // Any other top-level (unindented) key ends the `on:` block.
       if (/^\S/.test(line)) {
         inOnBlock = false;
         continue;
       }
       const indent = /^\s*/.exec(line)[0].length;
       if (keyIndent === null) keyIndent = indent;
-      // An inline value counts as well: `schedule: [{cron: "…"}]`.
       if (indent === keyIndent && /^\s*schedule:/.test(line)) {
         scheduled.push(file);
         break;
@@ -97,43 +53,14 @@ export function findScheduledWorkflows(root) {
   return scheduled.sort();
 }
 
-/**
- * Workflow file names carrying a `cron:` key anywhere.
- *
- * A SECOND, independent read of the same underlying fact, because "at least
- * one scheduled workflow exists" is a floor the three that exist today satisfy
- * forever. That makes it blind to the regression this file's header claims to
- * guard against, one workflow at a time: a parser that quietly stops
- * recognising some future workflow's YAML shape stays green. `cron:` and
- * `on: schedule:` are different strings read by different rules, so requiring
- * the two sets to be EQUAL makes either one drifting loud. Neither side is a
- * hand-kept list.
- */
 export function findCronWorkflows(root) {
   const cron = [];
   for (const [file, lines] of workflowLines(root)) {
-    // `cron:` also appears inside a flow sequence — `schedule: [{cron: "…"}]`,
-    // the very shape findScheduledWorkflows() reads. An
-    // anchored `^\s*-?\s*cron:` missed it, so two of the three shapes that
-    // review fixed would fail this file's OWN set-equality cross-check: a
-    // correctly-alarmed workflow red the derivation. A guard that reds on right
-    // answers is a guard someone deletes. The delimiter class stays narrow (no
-    // quotes) so `"cron: …"` inside a shell string still does not count.
     if (lines.some((line) => /(?:^|[\s,[{-])cron\s*:\s*\S/.test(line))) cron.push(file);
   }
   return cron.sort();
 }
 
-/**
- * Every `uses: ./.github/workflows/…` reference pointing at a file that is not
- * there.
- *
- * A job wired to the alarm with a typo'd path is a workflow GitHub refuses to
- * run: the alarm is present in the diff, present in review, and dead. Nothing
- * else in CI notices — actionlint would, but it is not wired into ci.yml, and
- * the reusable call itself is never exercised on a PR because every alarm job
- * is gated to schedule/workflow_dispatch by design.
- */
 export function findBrokenLocalUses(root) {
   const broken = [];
   for (const [file, lines] of workflowLines(root)) {
@@ -145,19 +72,6 @@ export function findBrokenLocalUses(root) {
   return broken.sort();
 }
 
-/**
- * Strip a trailing YAML comment from one raw line.
- *
- * A blanket `raw.replace(/#.*$/, "")` is wrong in the direction that matters:
- * YAML only starts a comment at a `#` that is at the start of the line or
- * preceded by whitespace, and never inside a quoted scalar. A blanket strip
- * silently TRUNCATES values — `label: "schedule-alarm:x#1"` and
- * `label: "schedule-alarm:x#2"` both reduce to `"schedule-alarm:x`, so the
- * The title/label bijection compares two mangled values, finds them equal,
- * and reports green on exactly the typo it exists to catch. Failing to strip a
- * real comment is the safer error, so an unterminated quote leaves the rest of
- * the line intact rather than guessing.
- */
 function stripComment(raw) {
   let quote = null;
   for (let i = 0; i < raw.length; i++) {
@@ -173,14 +87,6 @@ function stripComment(raw) {
   return raw;
 }
 
-/**
- * Every workflow file as `[name, comment-stripped lines]`. Exported so
- * scripts/ci/assert-schedule-alarm-coverage.mjs reads the exact same
- * file list and comment-stripping rule rather than re-implementing it — two
- * readers of ".github/workflows/*.yml with comments stripped" drifting apart
- * is the same shape of bug this file's `cron:`/`schedule:` cross-check exists
- * to catch.
- */
 export function workflowLines(root) {
   const dir = join(root, ".github", WORKFLOWS_DIR);
   if (!existsSync(dir)) {
@@ -193,9 +99,6 @@ export function workflowLines(root) {
       file,
       readFileSync(join(dir, file), "utf8")
         .split("\n")
-        // Strip comments before matching: a workflow's own prose can contain
-        // the literal strings "schedule:" and "cron:" — these files do. Also
-        // tolerate CRLF checkouts, so a `\r` never lands inside a parsed value.
         .map((raw) => stripComment(raw.replace(/\r$/, ""))),
     ]);
 }
@@ -212,7 +115,6 @@ export function main(argv = process.argv.slice(2)) {
     );
   }
 
-  // The floor that can actually move. See findCronWorkflows().
   const cron = findCronWorkflows(root);
   const onlyScheduled = scheduled.filter((f) => !cron.includes(f));
   const onlyCron = cron.filter((f) => !scheduled.includes(f));
@@ -246,11 +148,6 @@ export function main(argv = process.argv.slice(2)) {
   return scheduled;
 }
 
-// NOT `import.meta.main` (Node 24.2+; root `engines` allows >=24, so on
-// 24.0/24.1 it is `undefined` and this guard would be false, exiting 0 having
-// listed nothing). Realpath'd on BOTH sides so a symlinked checkout still
-// matches; a guard that looks like it should have fired but did not throws
-// rather than silently running nothing.
 const SELF = realpathSync(fileURLToPath(import.meta.url));
 const ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";
 const invokedDirectly = ENTRY === SELF;

--- a/scripts/ci/list-scheduled-workflows.test.mjs
+++ b/scripts/ci/list-scheduled-workflows.test.mjs
@@ -120,7 +120,7 @@ withScratchRoot(
     for (const expected of ["quoted-on.yml", "flow-on.yml", "deep-indent.yml"]) {
       assert(found.includes(expected), `${expected} must count as scheduled, got ${found}`);
     }
-    // The half this fixture used to leave untested, and the reason it mattered:
+    // The half that matters here:
     // asserting only the `on: schedule:` read said nothing about the SET
     // EQUALITY main() enforces between the two reads. The `cron:` read was
     // anchored at line start, so it missed `schedule: [{cron: …}]` — meaning

--- a/scripts/ci/list-scheduled-workflows.test.mjs
+++ b/scripts/ci/list-scheduled-workflows.test.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-// Regression coverage for scripts/ci/list-scheduled-workflows.mjs.
-// Builds a scratch .github/workflows tree so the assertions do not depend on
-// which workflows this repo happens to carry today.
+//
+// Asserts the derivation reds on a parse it cannot follow, rather than reporting an
+// empty set as a fact about the tree.
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -30,7 +30,6 @@ function withScratchRoot(files, fn) {
   }
 }
 
-// A real schedule trigger is found.
 withScratchRoot(
   {
     "scheduled.yml": "name: x\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs: {}\n",
@@ -42,9 +41,6 @@ withScratchRoot(
   },
 );
 
-// A `schedule:` mentioned only in a comment, or inside a job step's shell
-// text, must NOT count — the parser anchors on the top-level `on:` block, not
-// on the string appearing anywhere in the file.
 withScratchRoot(
   {
     "commented.yml":
@@ -56,9 +52,6 @@ withScratchRoot(
   },
 );
 
-// A `schedule:` nested under a REUSABLE workflow's `workflow_call.inputs`
-// (or any other non-top-level block) must not count either — anchored on the
-// `on:` block specifically, indented exactly one level.
 withScratchRoot(
   {
     "reusable.yml":
@@ -70,13 +63,9 @@ withScratchRoot(
   },
 );
 
-// Vacuous-green guard: zero scheduled workflows across the whole tree throws
-// rather than reporting a silent, technically-true empty list.
 withScratchRoot({ "none.yml": "name: x\non:\n  push:\n    branches: [main]\njobs: {}\n" }, (root) => {
   let threw = false;
   try {
-    // main() enforces the non-zero floor; findScheduledWorkflows() itself is
-    // allowed to return an empty array (it is the honest primitive).
     const found = findScheduledWorkflows(root);
     assert(found.length === 0, "sanity: this fixture has no schedule trigger");
   } catch {
@@ -85,7 +74,6 @@ withScratchRoot({ "none.yml": "name: x\non:\n  push:\n    branches: [main]\njobs
   assert(!threw, "findScheduledWorkflows itself must not throw on an empty result");
 });
 
-// Missing .github/workflows directory is a hard failure, not an empty list.
 {
   const root = mkdtempSync(join(tmpdir(), "list-scheduled-wf-missing-"));
   let threw = false;
@@ -98,21 +86,10 @@ withScratchRoot({ "none.yml": "name: x\non:\n  push:\n    branches: [main]\njobs
   assert(threw, "a missing .github/workflows directory must throw, not report zero");
 }
 
-// Against the real tree: this repo carries at least repo-policy.yml and
-// release-alarm.yml on a schedule today. A regression
-// here would mean the real-tree floor assertion (this same non-zero-count
-// logic, run by main()) is not actually watching anything.
-// The three YAML shapes the first revision of the parser silently missed. Each
-// is a scheduled workflow that would have gone uncovered, invisibly, because
-// the only floor was "at least one workflow is scheduled" — which the three
-// real ones satisfy forever.
 withScratchRoot(
   {
-    // `on` is YAML 1.1 truthy, so yamllint's standard workaround is to quote it.
     "quoted-on.yml": "name: x\n\"on\":\n  schedule:\n    - cron: '0 0 * * *'\njobs: {}\n",
-    // Flow form entirely on the `on:` line.
     "flow-on.yml": "name: x\non: {schedule: [{cron: '0 0 * * *'}]}\njobs: {}\n",
-    // Four-space indent under `on:`, and an inline value on `schedule:`.
     "deep-indent.yml": "name: x\non:\n    schedule: [{cron: '0 0 * * *'}]\njobs: {}\n",
   },
   (root) => {
@@ -120,12 +97,6 @@ withScratchRoot(
     for (const expected of ["quoted-on.yml", "flow-on.yml", "deep-indent.yml"]) {
       assert(found.includes(expected), `${expected} must count as scheduled, got ${found}`);
     }
-    // The half that matters here:
-    // asserting only the `on: schedule:` read said nothing about the SET
-    // EQUALITY main() enforces between the two reads. The `cron:` read was
-    // anchored at line start, so it missed `schedule: [{cron: …}]` — meaning
-    // two of the three shapes this very fixture proves are parsed would have
-    // FAILED main()'s cross-check. A correctly-alarmed workflow red the guard.
     const cron = findCronWorkflows(root);
     for (const expected of ["quoted-on.yml", "flow-on.yml", "deep-indent.yml"]) {
       assert(cron.includes(expected), `${expected} must also be seen by the cron: read, or main()'s set-equality reds a correct workflow; got ${cron}`);
@@ -137,13 +108,6 @@ withScratchRoot(
   },
 );
 
-// A flow mapping that SPANS lines (`on: {` with the keys below it) is read by
-// neither rule, so a cron inside one is invisible to both — and two blind reads
-// agree, so the set-equality cross-check has nothing to disagree about and the
-// alarm-coverage check reports a clean pass on an unalarmed cron. actionlint
-// accepts the shape as valid workflow YAML, so nothing else catches it either.
-// An unsupported shape must be LOUD, never indistinguishable from an absent
-// trigger.
 withScratchRoot(
   {
     "multiline-flow-on.yml": 'name: x\non: {\n  schedule: [{cron: "0 3 * * *"}]\n}\njobs: {}\n',
@@ -160,14 +124,10 @@ withScratchRoot(
   },
 );
 
-// The cross-check floor: the `cron:` read and the `on: schedule:` read are two
-// independent rules over the same fact, so a parser that stops matching one
-// workflow shows up as a set difference rather than as a still-non-zero count.
 withScratchRoot(
   {
     "scheduled.yml": "name: x\non:\n  schedule:\n    - cron: '0 0 * * *'\njobs: {}\n",
     "plain.yml": "name: y\non:\n  push:\n    branches: [main]\njobs: {}\n",
-    // `cron:` only in prose must not count on the cron side either.
     "prose.yml": "name: z\n# nightly cron: not a trigger\non:\n  push:\njobs: {}\n",
   },
   (root) => {
@@ -183,9 +143,6 @@ withScratchRoot(
   },
 );
 
-// A wired-but-BROKEN alarm: the job is present, the `uses:` path is a typo, and
-// GitHub would refuse to run the workflow. Nothing else in CI catches this —
-// actionlint is not wired in, and the reusable call is never exercised on a PR.
 withScratchRoot(
   {
     "caller.yml":

--- a/scripts/ci/publish-relevance.mjs
+++ b/scripts/ci/publish-relevance.mjs
@@ -1,135 +1,37 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Which published artifacts does a set of changed files move?
+// Which published artifacts a set of changed files moves. Read by the allocator
+// (which packages get a number) and the PR gate (which need an entry).
 //
-// One answer, two callers. `allocate-release-versions.mjs` asks it on main to
-// decide which packages get a NUMBER; `check-release-note-required.mjs` asks it
-// on a PR to decide which packages need an `## Unreleased (level)` ENTRY. Both
-// import this file rather than each keeping a copy, because two hand-maintained
-// "which paths matter for which package" tables would disagree about whether a
-// release was owed at all while both still looked like they were watching.
-//
-// Exports a table and pure predicates only; no I/O, no git, no CLI.
+// Every regex here is one path segment wide on purpose; widening one republishes
+// identical tarballs. The exemptions rest on `private: true`, not on `files`.
 
-/**
- * A test file cannot change one byte of any tarball this table guards: no
- * package's `files` array names a test directory, tsup builds from `src/`, and
- * no `src/` module imports out of one.
- *
- * `examples/`, `assets/` and `tasks/` are carved back IN because the CLI's
- * `files` array publishes them verbatim, so a `*.test.ts` inside one really
- * does ship.
- */
 function isUnpublishableTestPath(file) {
   if (/(^|\/)(examples|assets|tasks)\//.test(file)) return false;
   return /(^|\/)tests?\//.test(file) || /\.test\.[cm]?[jt]sx?$/.test(file);
 }
 
-/**
- * A twin's own top-level examples/ ships in no tarball. The load-bearing
- * reason is `private: true`, not any `files` array — some twins' `files` do
- * name it. release.yml publishes cli, adapter-claude-sdk, checks, wire and
- * sandbox-domains, and no twin is any of those. Nothing asserts a twin stays
- * private, so unprivating one means re-checking this.
- *
- * `[^/]+` is deliberately one path segment, so only a twin's TOP-LEVEL
- * examples/ is exempt: `packages/twin-stripe/src/examples/handler.ts` compiles
- * into that twin's dist like any other `src/` module and stays relevant. The
- * CLI's own `files` entry "examples" is cli/examples, a different directory,
- * not a twin's.
- */
 function isTwinExamplePath(file) {
   return /^packages\/twin-[^/]+\/examples\//.test(file);
 }
 
-/**
- * A twin's own top-level markdown ships in no tarball either, for the same
- * reason: every twin is `private: true`, so its `files` array describes a
- * tarball nobody builds. tsup inlines twin source through each twin's
- * `exports` map and cannot inline a markdown file.
- *
- * `[^/]+\/[^/]+\.md` is two single path segments on purpose: this exempts
- * `packages/twin-github/FIDELITY.md` and NOT `packages/twin-github/src/x.md`
- * or any nested docs directory, so it cannot widen to cover something the
- * bundler might actually read.
- */
 function isTwinTopLevelDocPath(file) {
   return /^packages\/twin-[^/]+\/[^/]+\.md$/.test(file);
 }
 
-/**
- * A twin's own top-level `scripts/` is dev/CI tooling, run via tsx on the `.ts`
- * source. It ships in no tarball, and — as with the two carve-outs above — the
- * load-bearing fact is `private: true`: release.yml
- * publishes cli, adapter-claude-sdk, checks, wire and sandbox-domains, and no twin
- * is any of those. That is deliberately the ONLY reason claimed here, because the tempting
- * second one is false for four of the five twins: only
- * `packages/twin-github/tsconfig.build.json` names `scripts` in its `exclude`,
- * and `packages/twin-slack/dist/scripts/` and `packages/twin-stripe/dist/scripts/`
- * really do exist inside the `dist` those packages' `files` arrays name. A
- * `files` array on a package nothing publishes describes a tarball nobody
- * builds. If a twin were ever unprivated, this exemption needs re-checking.
- *
- * The CLI's and `@pome-sh/sandbox-domains`' tarballs are the other artifacts that
- * could carry these bytes, and do not: tsup inlines twin source reached from
- * each twin's package `exports`, which resolve into `src/` only, and nothing
- * under `cli/src/`, `packages/sandbox-domains/src/` or any twin's own `src/`
- * imports a twin script — so tsup never sees these files.
- *
- *
- * `[^/]+` is deliberately one path segment and `scripts` is anchored directly
- * under the twin root, so `packages/twin-stripe/src/scripts/x.ts` — which
- * compiles into that twin's dist like any other `src/` module — is NOT exempt.
- */
 function isTwinScriptPath(file) {
   return /^packages\/twin-[^/]+\/scripts\//.test(file);
 }
 
-/**
- * A twin's `Dockerfile` is the recipe for its GHCR image, which is not an npm
- * artifact: release.yml publishes tarballs, twin-image.yml publishes images,
- * and no version number spans the two. It ships in no tarball for the same
- * reason as the carve-outs above — every twin is `private: true` — and here no
- * twin's `files` array names a Dockerfile either.
- *
- *
- * The filename is matched EXACTLY and anchored directly under the twin root, so
- * a Dockerfile somewhere a bundler could plausibly reach —
- * `packages/twin-stripe/src/Dockerfile` — is NOT exempt.
- */
 function isTwinDockerfilePath(file) {
   return /^packages\/twin-[^/]+\/Dockerfile$/.test(file);
 }
 
-/**
- * A `CHANGELOG.md` is exempt even though these bytes really do ship. The
- * exemption is about what a release MEANS, and it has two halves.
- *
- * The judgement: a release exists to move code to a consumer, and republishing
- * four tarballs over a typo in a historical entry spends a version number on
- * nothing anyone installs. When a changelog edit does accompany a release, the
- * release was earned by the code beside it, or by an `## Unreleased` entry the
- * allocator reads as a release request in its own right.
- *
- * The structural half, and why this is not merely a preference: the allocator's
- * own bump commit REWRITES these files. If a CHANGELOG.md were
- * publish-relevant, that commit would be publish-relevant for the package it
- * just released, and the allocator would allocate again on the next push, and
- * again. The primary loop guard does not depend on this line: the allocator
- * measures relevance from the last commit that moved the version, and the bump
- * commit is one — see `lastVersionChange()` in `allocate-release-versions.mjs`.
- * So this is a second, independent reason the loop cannot start.
- */
 function isChangelogPath(file) {
   return /(^|\/)CHANGELOG\.md$/.test(file);
 }
 
-/**
- * The union of every reason a changed file cannot move a published artifact.
- * Exported for the two callers' error messages, which name the exemption that
- * dropped a file rather than silently reporting "nothing to do".
- */
 export function isPublishIrrelevantPath(file) {
   if (isUnpublishableTestPath(file)) return "a test path (in no package's `files`, imported by no `src/`)";
   if (isTwinExamplePath(file)) return "a twin's top-level examples/ (every twin is `private: true`)";
@@ -140,26 +42,12 @@ export function isPublishIrrelevantPath(file) {
   return null;
 }
 
-/**
- * The five packages `release.yml` can publish, and what changes each one's
- * bytes. `changelog` is where that package's release note lives, and
- * `versionedArtifacts` names committed files that embed the package's own
- * version and are byte-compared by a CI gate, so the allocator cannot move a
- * version without moving them too.
- *
- * `release.yml` remains the authority on what actually publishes, and
- * `release-alarm.mjs` PARSES that file rather than trusting any list. If the
- * two disagree about the set of packages, the alarm's `--targets` dead-guard
- * says so out loud.
- */
 export const PUBLISHED_PACKAGES = [
   {
     name: "@pome-sh/cli",
     manifest: "cli/package.json",
     changelog: "cli/CHANGELOG.md",
     registry: "npm",
-    // Bundled: the twins + wire + sdk are inlined via tsup, so a change to
-    // any of them is a change to the CLI's published artifact too.
     pathPrefixes: ["cli/", "packages/twin-", "packages/wire/", "packages/sdk/"],
   },
   {
@@ -170,22 +58,6 @@ export const PUBLISHED_PACKAGES = [
     pathPrefixes: ["packages/adapter-claude-sdk/", "packages/wire/"],
   },
   {
-    // The grading vocabulary, published to npmjs for pome-cloud.
-    //
-    // Its publish-relevant paths are the DECLARATION layer of six other
-    // packages, because that is what tsup inlines into its tarball: each twin's
-    // `check-*.ts` / `checks.ts` / `seed.ts`, and the sdk's `checks.ts` +
-    // `check-state-path.ts` + `check-discrimination.ts` + `check-redaction.ts` +
-    // `failure-injection.ts`.
-    //
-    // Deliberately NOT the whole of `packages/twin-*/` or `packages/sdk/`. A
-    // change to a twin's routes, tools or domain alters no byte of this
-    // tarball, and making it earn a release here would put a pointless version
-    // on most twin PRs — after which the numbers stop meaning anything. The
-    // cost of drawing it narrowly is that a declaration file added under a NEW
-    // name outside these globs would not trigger it;
-    // `packages/checks/test/surface.test.ts` and each twin's own
-    // `checks-contract.test.ts` cover that.
     name: "@pome-sh/checks",
     manifest: "packages/checks/package.json",
     changelog: "packages/checks/CHANGELOG.md",
@@ -194,26 +66,10 @@ export const PUBLISHED_PACKAGES = [
     pathPatterns: [
       /^packages\/twin-[a-z]+\/src\/(checks|check-[a-z-]+|seed|tape-assertable-tools)\.ts$/,
       /^packages\/sdk\/src\/(checks|check-state-path|check-discrimination|check-redaction|failure-injection)\.ts$/,
-    // The declaration bundler is shared with @pome-sh/sandbox-domains rather
-            // than copied. It is what makes this tarball's `.d.ts` resolvable for a
-            // consumer, so it is publish-relevant here.
       /^scripts\/bundle-declarations\.mjs$/,
     ],
   },
   {
-    // The twin domain layer — the in-process runtime pome-cloud's
-    // `lib/twin-state.ts` boots and a bound check reads.
-    //
-    // @pome-sh/checks ships the DECLARATIONS, this ships what they read. They
-    // are the two legs of pome-cloud's `checks-package-drift.test.ts`, and both
-    // must be cut from the SAME main commit: publishing a widened vocabulary
-    // whose runtime could not follow is the wall this pairing removes.
-    //
-    // Its paths are WHOLE directories where the checks entry names files, and
-    // that difference is not an oversight. A twin's routes, tools and domain
-    // change no byte of the vocabulary tarball, but they are exactly what this
-    // one bundles, so a domain change that did not republish this package is
-    // the silent non-release this table exists to prevent.
     name: "@pome-sh/sandbox-domains",
     manifest: "packages/sandbox-domains/package.json",
     changelog: "packages/sandbox-domains/CHANGELOG.md",
@@ -221,59 +77,21 @@ export const PUBLISHED_PACKAGES = [
     pathPrefixes: [
       "packages/sandbox-domains/",
       "packages/twin-",
-    // `./server` re-exports `toTwinHttpEventRow`, and every twin domain
-    // reaches the sdk's db layer — the whole sdk is inlined here, exactly as
-    // it is into the CLI.
       "packages/sdk/",
     ],
     pathPatterns: [/^scripts\/bundle-declarations\.mjs$/],
   },
   {
-    // Published to BOTH registries from one version line: npmjs so a consumer
-    // resolving the rest of the @pome-sh scope from there can resolve wire too,
-    // GitHub Packages for its cross-repo consumers. Neither lane is redundant —
-    // a scope routes to one registry per consumer. Its own version line, and
-    // therefore its own entry here.
-    //
-    // `packages/wire/` deliberately appears in THREE entries, and that is not
-    // double-counting: three different published artifacts change when wire
-    // changes. A wire source change alters the bytes tsup inlines into the
-    // CLI's and the adapter's tarballs, so both need a release for a user to
-    // see it, and wire itself needs one for its own consumers. Three releases
-    // for one wire change is the correct answer. @pome-sh/checks is not the
-    // fourth — see its entry above, where relevance is named files rather than
-    // directories.
     name: "@pome-sh/wire",
     manifest: "packages/wire/package.json",
     changelog: "packages/wire/CHANGELOG.md",
     registry: "npm + GitHub Packages (npm.pkg.github.com)",
     pathPrefixes: ["packages/wire/"],
-    // trace-contract.json is in wire's `files`, so it SHIPS, and it embeds
-    // wire's own `version`. `check:trace-contract` is a byte compare, so a
-    // version moved without regenerating it reds main. Keeping that pairing in
-    // this table rather than in a human instruction is the point: the version
-    // is no longer written by a human.
-    //
-    // `regenerate` runs the REAL emitter rather than patching the one key,
-    // because that emitter also enumerates the event union out of zod and
-    // asserts a fixture per kind — a hand-patch would keep the byte compare
-    // green while silently dropping that assertion. It is why
-    // allocate-version.yml has an `npm ci` at all, and it runs only when a
-    // package in the plan names one.
     versionedArtifacts: ["packages/wire/trace-contract.json"],
     regenerate: "npm run emit:trace-contract -w @pome-sh/wire",
   },
 ];
 
-/**
- * Which published packages a set of changed paths moves, with the paths that
- * made each one relevant — callers name those paths, so a demand is never
- * "something you touched" but "these files, and this is the artifact they are
- * inlined into".
- *
- * Returns `[{ pkg, files }]` in table order, only for packages with at least
- * one relevant file.
- */
 export function packagesTouchedBy(changedFiles) {
   const relevant = changedFiles.filter((file) => !isPublishIrrelevantPath(file));
   const hits = [];
@@ -281,9 +99,6 @@ export function packagesTouchedBy(changedFiles) {
     const files = relevant.filter(
       (file) =>
         pkg.pathPrefixes.some((prefix) => file.startsWith(prefix)) ||
-    // `pathPatterns` exists for @pome-sh/checks, whose tarball is assembled
-    // from named FILES inside other packages rather than whole directories —
-    // a prefix would over-trigger on every twin route change.
         (pkg.pathPatterns ?? []).some((pattern) => pattern.test(file)),
     );
     if (files.length > 0) hits.push({ pkg, files });

--- a/scripts/ci/publish-relevance.mjs
+++ b/scripts/ci/publish-relevance.mjs
@@ -1,40 +1,25 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// WHICH PUBLISHED ARTIFACTS DOES A SET OF CHANGED FILES MOVE?
+// Which published artifacts does a set of changed files move?
 //
-// One answer, two callers. This table used to live inside
-// `check-version-bump-required.mjs`, where it powered a PR-time demand ("bump
-// this version yourself"). The version number no longer leaves the pipeline's
-// hands, so the same question is now asked at two different moments:
-//
-//   - `allocate-release-versions.mjs`, on `main`, to decide which packages get
-//     a NUMBER. This is the authority: a package whose publish-relevant paths
-//     moved gets a release whether or not anyone wrote prose about it, because
-//     the failure this whole apparatus exists to prevent is the silent
-//     non-release.
-//   - `check-release-note-required.mjs`, on a PR, to decide which packages need
-//     an `## Unreleased (level)` ENTRY. The number is the pipeline's; the words
-//     are still the author's.
-//
-// Both import this file rather than each carrying a copy: a second
-// hand-maintained "which paths matter for which package" is the brittle shape —
-// one goes stale while both still look like they are watching, and here the two
-// copies would disagree about whether a release was owed at all.
+// One answer, two callers. `allocate-release-versions.mjs` asks it on main to
+// decide which packages get a NUMBER; `check-release-note-required.mjs` asks it
+// on a PR to decide which packages need an `## Unreleased (level)` ENTRY. Both
+// import this file rather than each keeping a copy, because two hand-maintained
+// "which paths matter for which package" tables would disagree about whether a
+// release was owed at all while both still looked like they were watching.
 //
 // Exports a table and pure predicates only; no I/O, no git, no CLI.
 
 /**
- * A test file cannot change one byte of any tarball this table guards: no
- * package's `files` array names a test directory, tsup builds from `src/`, and
- * no `src/` module imports out of one. Calling a test-only change
- * publish-relevant therefore asks for a release that republishes an identical
- * artifact — the same pointless-release noise the `@pome-sh/checks` entry below
- * argues a rule must not generate if it wants to keep being obeyed.
- *
- * `examples/`, `assets/` and `tasks/` are carved back IN because the CLI's
- * `files` array publishes them verbatim — a file named `*.test.ts` inside one
- * of those really does ship, so it really is publish-relevant.
+  * A test file cannot change one byte of any tarball this table guards: no
+  * package's `files` array names a test directory, tsup builds from `src/`, and
+  * no `src/` module imports out of one.
+  *
+  * `examples/`, `assets/` and `tasks/` are carved back IN because the CLI's
+  * `files` array publishes them verbatim, so a `*.test.ts` inside one really
+  * does ship.
  */
 function isUnpublishableTestPath(file) {
   if (/(^|\/)(examples|assets|tasks)\//.test(file)) return false;
@@ -42,58 +27,29 @@ function isUnpublishableTestPath(file) {
 }
 
 /**
- * A twin's own top-level examples/ ships in no tarball — but not because of
- * its `files` array. Some twins' `files` DO name it: twin-github and
- * twin-slack's tsconfig.build.json compile `examples/**\/*.ts` into
- * `dist/examples/*.js` (rootDir "."), and `files: ["dist", ...]` names
- * `dist`. The actual load-bearing fact is `private: true` — release.yml
- * publishes cli, adapter-claude-sdk, checks, wire and
- * sandbox-domains, and no twin is any of those. Nothing in this repo currently
- * asserts a twin stays private, so if one were ever unprivated this exemption
- * would need re-checking; today it holds for all five. `@pome-sh/sandbox-domains`
- * also bundles twin SOURCE, which does not change this either: tsup reaches
- * `src/` through each twin's `exports` map and can inline neither a markdown
- * file nor an `examples/` tree nobody imports. The CLI's own `files` entry
- * "examples" is cli/examples (cli/tsconfig.json's `include`), a different
- * directory, not a twin's.
- *
- * `[^/]+` is deliberately one path segment, so only a twin's TOP-LEVEL
- * examples/ is exempt — `packages/twin-stripe/src/examples/handler.ts`
- * does not match, because that file compiles into the twin's `dist` same as
- * any other `src/` module and is publish-relevant if the CLI bundle imports
- * it.
- *
- * Reproduced by PR #366: a PR touching only
- * packages/twin-stripe/examples/buyer-agent/ was told to bump @pome-sh/cli
- * for a republish that would be byte-identical.
+  * A twin's own top-level examples/ ships in no tarball. The load-bearing
+  * reason is `private: true`, not any `files` array — some twins' `files` do
+  * name it. release.yml publishes cli, adapter-claude-sdk, checks, wire and
+  * sandbox-domains, and no twin is any of those. Nothing asserts a twin stays
+  * private, so unprivating one means re-checking this.
+  *
+  * `[^/]+` is deliberately one path segment, so only a twin's TOP-LEVEL
+  * examples/ is exempt: `packages/twin-stripe/src/examples/handler.ts` compiles
+  * into that twin's dist like any other `src/` module and stays relevant.
  */
 function isTwinExamplePath(file) {
   return /^packages\/twin-[^/]+\/examples\//.test(file);
 }
 
 /**
- * A twin's own TOP-LEVEL markdown ships in no tarball either, for exactly the
- * reason above: every twin under `packages/twin-*` is `private: true`, and none
- * of them is one of the five release.yml publishes. Their `files` arrays do name
- * `README.md` / `FIDELITY.md` / `LIMITS.md`, and that is as inert as the
- * `dist/examples` case — a `files` array on a package nothing publishes
- * describes a tarball nobody builds. The CLI's and `@pome-sh/sandbox-domains`'
- * tarballs inline twin SOURCE through tsup, and tsup cannot inline a markdown
- * file.
- *
- * Same shape of over-match, one directory over: `packages/twin-` is a
- * plain prefix, so documentation that cannot change one byte of any published
- * artifact was demanding a `@pome-sh/cli` release — i.e. a republish that would
- * be byte-identical. The usual advice ("if your change doesn't warrant a
- * release it shouldn't be touching a publish-relevant path") has no answer here:
- * a twin's FIDELITY.md has nowhere else to live.
- *
- * Found on the docs-only PR that added the FIDELITY.md bullets pome-cloud's
- * `lint-known-divergences.ts` binds its registry entries to 1:1.
- *
- * `[^/]+\/[^/]+\.md` is two single path segments on purpose: this exempts
- * `packages/twin-github/FIDELITY.md` and NOT `packages/twin-github/src/x.md`
- * or any nested docs directory, so it cannot widen to cover something the
+  * A twin's own top-level markdown ships in no tarball either, for the same
+  * reason: every twin is `private: true`, so its `files` array describes a
+  * tarball nobody builds. tsup inlines twin source through each twin's
+  * `exports` map and cannot inline a markdown file.
+  *
+  * `[^/]+\/[^/]+\.md` is two single path segments on purpose: this exempts
+  * `packages/twin-github/FIDELITY.md` and NOT `packages/twin-github/src/x.md`
+  * or any nested docs directory, so it cannot widen to cover something the
  * bundler might actually read.
  */
 function isTwinTopLevelDocPath(file) {
@@ -119,14 +75,6 @@ function isTwinTopLevelDocPath(file) {
  * under `cli/src/`, `packages/sandbox-domains/src/` or any twin's own `src/`
  * imports a twin script — so tsup never sees these files.
  *
- * Third instance of the same over-match, one directory over from the
- * `examples/` and top-level-`.md` carve-outs above: `packages/twin-` is a plain
- * prefix, so editing a validator that CI runs was demanding an `@pome-sh/cli`
- * release — a republish that would be byte-identical. Found on a PR that had
- * to touch `packages/twin-github/scripts/validate-mcp.ts` to wire that script
- * into CI at all, and "if your change doesn't warrant a release it shouldn't be
- * touching a publish-relevant path" has no answer: a twin's own validator has
- * nowhere else to live.
  *
  * `[^/]+` is deliberately one path segment and `scripts` is anchored directly
  * under the twin root, so `packages/twin-stripe/src/scripts/x.ts` — which
@@ -137,28 +85,12 @@ function isTwinScriptPath(file) {
 }
 
 /**
- * A twin's own `Dockerfile` is the recipe for its GHCR image, and that image is
- * not an npm artifact: `release.yml` publishes tarballs, `twin-image.yml`
- * publishes images, and no version number spans the two. It ships in no tarball
- * for the same load-bearing reason as the three carve-outs above — every twin is
- * `private: true` — and here the weaker reason happens to hold as well: no
- * twin's `files` array names a Dockerfile, unlike the `dist/examples/` and
- * `dist/scripts/` cases.
+  * A twin's `Dockerfile` is the recipe for its GHCR image, which is not an npm
+  * artifact: release.yml publishes tarballs, twin-image.yml publishes images,
+  * and no version number spans the two. It ships in no tarball for the same
+  * reason as the carve-outs above — every twin is `private: true` — and here no
+  * twin's `files` array names a Dockerfile either.
  *
- * The CLI's and `@pome-sh/sandbox-domains`' tarballs are the other artifacts
- * that could carry these bytes, and do not: tsup inlines twin source reached
- * from each twin's package `exports`, which resolve into `src/` only, and a
- * Dockerfile is imported by nothing.
- *
- * Fourth instance of the same over-match, one file over from `examples/`,
- * top-level `.md` and `scripts/`: `packages/twin-` is a plain prefix, so
- * patching a base image demanded BOTH a `@pome-sh/cli` and a
- * `@pome-sh/sandbox-domains` release — two republishes that would each be
- * byte-identical. Found where a fixable base-image CVE had frozen the
- * twin image publish deterministically and the remedy could only be applied in
- * these five files. "If your change doesn't warrant a release it shouldn't be
- * touching a publish-relevant path" has no answer here either: a twin's
- * Dockerfile has nowhere else to live.
  *
  * The filename is matched EXACTLY and anchored directly under the twin root, so
  * a Dockerfile somewhere a bundler could plausibly reach —
@@ -169,31 +101,21 @@ function isTwinDockerfilePath(file) {
 }
 
 /**
- * A `CHANGELOG.md` is exempt, and this one is NOT that over-match shape:
- * these bytes really do ship (`packages/checks/package.json` and
- * `packages/twin-linear/package.json` name `CHANGELOG.md` in `files`, and npm
- * packs a root CHANGELOG.md whether or not `files` asks it to). The exemption is
- * about what a release MEANS, and it has two halves.
- *
- * The half that is a judgement: a release exists to move code to a consumer.
- * Republishing four tarballs because someone fixed a typo in a historical entry
- * spends a version number on nothing anyone installs — the same "gate that
- * generates noise stops being read" argument as the carve-outs above, one file
- * over. When a changelog edit DOES accompany a release, the release was earned
- * by the code beside it, or by an `## Unreleased` entry that
- * `allocate-release-versions.mjs` reads as a release request in its own right —
- * so nothing that should publish stops publishing because of this line.
- *
- * The half that is structural, and the reason this is not merely a preference:
- * the allocator's own bump commit REWRITES these files (an `## Unreleased`
- * heading becomes `## 0.23.46 — 2026-08-14`). If a CHANGELOG.md were
- * publish-relevant, that commit would be publish-relevant for the package it
- * just released, and the allocator would allocate again on the next push, and
- * again. The primary loop guard is elsewhere and does not depend on this line
- * (the allocator measures relevance from the last commit that moved the version,
- * which is that very bump commit — see its header), so this is the second,
- * independent reason the loop cannot start. Two independent guarantees, the same
- * shape as wire's two "this cannot land on the wrong registry" guards in
+  * A `CHANGELOG.md` is exempt even though these bytes really do ship. The
+  * exemption is about what a release MEANS, and it has two halves.
+  *
+  * The judgement: a release exists to move code to a consumer, and republishing
+  * four tarballs over a typo in a historical entry spends a version number on
+  * nothing anyone installs. When a changelog edit does accompany a release, the
+  * release was earned by the code beside it, or by an `## Unreleased` entry the
+  * allocator reads as a release request in its own right.
+  *
+  * The structural half, and why this is not merely a preference: the allocator's
+  * own bump commit REWRITES these files. If a CHANGELOG.md were
+  * publish-relevant, that commit would be publish-relevant for the package it
+  * just released, and the allocator would allocate again on the next push, and
+  * again. The primary loop guard is elsewhere and does not depend on this line,
+  * so this is a second, independent reason the loop cannot start — the same
  * release.yml.
  */
 function isChangelogPath(file) {
@@ -222,10 +144,10 @@ export function isPublishIrrelevantPath(file) {
  * version and are byte-compared by a CI gate, so the allocator cannot move a
  * version without moving them too.
  *
- * `release.yml` remains the authority on what actually publishes — it is where
- * `decide-publish.sh` is called, and `release-alarm.mjs` PARSES that file
- * rather than trusting any list. If the two ever disagree about the set of
- * packages, the alarm's `--targets` dead-guard is what says so out loud.
+  * `release.yml` remains the authority on what actually publishes, and
+  * `release-alarm.mjs` PARSES that file rather than trusting any list. If the
+  * two disagree about the set of packages, the alarm's `--targets` dead-guard
+  * says so out loud.
  */
 export const PUBLISHED_PACKAGES = [
   {
@@ -254,13 +176,13 @@ export const PUBLISHED_PACKAGES = [
     // `failure-injection.ts`.
     //
     // Deliberately NOT the whole of `packages/twin-*/` or `packages/sdk/`. A
-    // change to a twin's routes, tools or domain does not alter one byte of this
-    // tarball, and making it earn a release here would put a pointless version
-    // on most twin PRs — after which the numbers stop meaning anything, which is
-    // how a release line stops being read at all. The cost of drawing it narrowly
-    // is that a declaration file added under a NEW name outside these globs would
-    // not trigger it; `packages/checks/test/surface.test.ts` plus each twin's own
-    // `checks-contract.test.ts` are what cover that.
+        // change to a twin's routes, tools or domain alters no byte of this
+        // tarball, and making it earn a release here would put a pointless version
+        // on most twin PRs — after which the numbers stop meaning anything. The
+        // cost of drawing it narrowly is that a declaration file added under a NEW
+        // name outside these globs would not trigger it;
+        // `packages/checks/test/surface.test.ts` and each twin's own
+        // `checks-contract.test.ts` cover that.
     name: "@pome-sh/checks",
     manifest: "packages/checks/package.json",
     changelog: "packages/checks/CHANGELOG.md",
@@ -269,11 +191,9 @@ export const PUBLISHED_PACKAGES = [
     pathPatterns: [
       /^packages\/twin-[a-z]+\/src\/(checks|check-[a-z-]+|seed|tape-assertable-tools)\.ts$/,
       /^packages\/sdk\/src\/(checks|check-state-path|check-discrimination|check-redaction|failure-injection)\.ts$/,
-      // The declaration bundler moved out of this package so
-      // @pome-sh/sandbox-domains could share it instead of copying ~300 lines. It
-      // is still what makes this tarball's `.d.ts` resolvable for a consumer,
-      // so it is still publish-relevant here — the move must not quietly drop
-      // it out of the table.
+      // The declaration bundler is shared with @pome-sh/sandbox-domains rather
+            // than copied. It is what makes this tarball's `.d.ts` resolvable for a
+            // consumer, so it is publish-relevant here.
       /^scripts\/bundle-declarations\.mjs$/,
     ],
   },
@@ -281,19 +201,16 @@ export const PUBLISHED_PACKAGES = [
     // The twin domain layer — the in-process runtime pome-cloud's
     // `lib/twin-state.ts` boots and a bound check reads.
     //
-    // `@pome-sh/checks` ships the DECLARATIONS, this ships what they read. The
-    // two are the two legs of pome-cloud's `checks-package-drift.test.ts`, and
-    // the reason they are separate entries on one lane is that both must be cut
-    // from the SAME `main` commit: publishing a widened vocabulary whose runtime
-    // could not follow is precisely the wall that blocked the vocabulary widening.
-    //
-    // Its paths are WHOLE directories where the checks entry above names files,
-    // and the difference is not an oversight. A twin's routes, tools and domain
-    // change no byte of the vocabulary tarball — but they are exactly what this
-    // one bundles, so a domain-behaviour change that did not republish this
-    // package is the silent non-release this table exists to prevent. The
-    // deliberate overlap with the checks entry (and with the CLI's) is the wire
-    // precedent one file up: one edit, several artifacts, several releases.
+    // @pome-sh/checks ships the DECLARATIONS, this ships what they read. They
+        // are the two legs of pome-cloud's `checks-package-drift.test.ts`, and both
+        // must be cut from the SAME main commit: publishing a widened vocabulary
+        // whose runtime could not follow is the wall this pairing removes.
+        //
+        // Its paths are WHOLE directories where the checks entry names files, and
+        // that difference is not an oversight. A twin's routes, tools and domain
+        // change no byte of the vocabulary tarball, but they are exactly what this
+        // one bundles, so a domain change that did not republish this package is
+        // the silent non-release this table exists to prevent.
     name: "@pome-sh/sandbox-domains",
     manifest: "packages/sandbox-domains/package.json",
     changelog: "packages/sandbox-domains/CHANGELOG.md",
@@ -309,52 +226,47 @@ export const PUBLISHED_PACKAGES = [
     pathPatterns: [/^scripts\/bundle-declarations\.mjs$/],
   },
   {
-    // Published to BOTH registries from one version line: npmjs for
-    // pome-cloud's migration off @pome-sh/shared-types, GitHub Packages for its
-    // original cross-repo consumers. Its own independent version line and
-    // therefore its own independent entry here.
-    //
-    // `packages/wire/` deliberately appears in THREE entries and that is not
-    // double-counting — it is three different published artifacts that all
-    // change when wire changes. A wire source change alters the bytes tsup
-    // inlines into the CLI's and the adapter's tarballs, so both of those need
-    // a release for a user to see it, AND wire itself needs one for pome-cloud
-    // to see it. Three releases for one wire change is the correct answer, not a
-    // bug; the wrong answer is the silent non-release this apparatus exists to
-    // prevent. `@pome-sh/checks` is deliberately not the fourth — see its entry
-    // above for why its relevance is named files rather than directories.
+    // Published to BOTH registries from one version line, with its own
+        // independent version line and therefore its own entry here.
+        //
+        // `packages/wire/` deliberately appears in THREE entries, and that is not
+        // double-counting: three different published artifacts change when wire
+        // changes. A wire source change alters the bytes tsup inlines into the
+        // CLI's and the adapter's tarballs, so both need a release for a user to
+        // see it, and wire itself needs one for its own consumers. Three releases
+        // for one wire change is the correct answer. @pome-sh/checks is not the
+        // fourth — see its entry above, where relevance is named files rather than
+        // directories.
     name: "@pome-sh/wire",
     manifest: "packages/wire/package.json",
     changelog: "packages/wire/CHANGELOG.md",
     registry: "npm + GitHub Packages (npm.pkg.github.com)",
     pathPrefixes: ["packages/wire/"],
     // trace-contract.json is in wire's `files`, so it SHIPS, and it embeds
-    // wire's own `version`. `check:trace-contract` (a required ci.yml gate) is a
-    // byte compare, so a version moved without regenerating it reds `main` —
-    // "Bumping wire's version also means re-running emit:trace-contract" was a
-    // human instruction until this table replaced it, and a human
-    // instruction is exactly what stops being followed when the version stops
-    // being written by a human.
-    //
-    // `regenerate` runs the REAL emitter rather than patching the one key,
-    // because that emitter also enumerates the event union out of zod and
-    // asserts a fixture per kind — a hand-patch would keep the byte
-    // compare green while silently dropping that assertion. It is the reason
-    // allocate-version.yml has an `npm ci` at all, and it runs only when a
-    // package in the plan names one.
+        // wire's own `version`. `check:trace-contract` is a byte compare, so a
+        // version moved without regenerating it reds main. Keeping that pairing in
+        // this table rather than in a human instruction is the point: the version
+        // is no longer written by a human.
+        //
+        // `regenerate` runs the REAL emitter rather than patching the one key,
+        // because that emitter also enumerates the event union out of zod and
+        // asserts a fixture per kind — a hand-patch would keep the byte compare
+        // green while silently dropping that assertion. It is why
+        // allocate-version.yml has an `npm ci` at all, and it runs only when a
+        // package in the plan names one.
     versionedArtifacts: ["packages/wire/trace-contract.json"],
     regenerate: "npm run emit:trace-contract -w @pome-sh/wire",
   },
 ];
 
 /**
- * Which published packages a set of changed paths moves, with the paths that
- * made each one relevant — callers name those paths, so a demand is never
- * "something you touched" but "these files, and this is the artifact they are
- * inlined into".
- *
- * Returns `[{ pkg, files }]` in table order, only for packages with at least
- * one relevant file.
+  * Which published packages a set of changed paths moves, with the paths that
+  * made each one relevant — callers name those paths, so a demand is never
+  * "something you touched" but "these files, and this is the artifact they are
+  * inlined into".
+  *
+  * Returns `[{ pkg, files }]` in table order, only for packages with at least
+  * one relevant file.
  */
 export function packagesTouchedBy(changedFiles) {
   const relevant = changedFiles.filter((file) => !isPublishIrrelevantPath(file));

--- a/scripts/ci/publish-relevance.mjs
+++ b/scripts/ci/publish-relevance.mjs
@@ -13,13 +13,13 @@
 // Exports a table and pure predicates only; no I/O, no git, no CLI.
 
 /**
-  * A test file cannot change one byte of any tarball this table guards: no
-  * package's `files` array names a test directory, tsup builds from `src/`, and
-  * no `src/` module imports out of one.
-  *
-  * `examples/`, `assets/` and `tasks/` are carved back IN because the CLI's
-  * `files` array publishes them verbatim, so a `*.test.ts` inside one really
-  * does ship.
+ * A test file cannot change one byte of any tarball this table guards: no
+ * package's `files` array names a test directory, tsup builds from `src/`, and
+ * no `src/` module imports out of one.
+ *
+ * `examples/`, `assets/` and `tasks/` are carved back IN because the CLI's
+ * `files` array publishes them verbatim, so a `*.test.ts` inside one really
+ * does ship.
  */
 function isUnpublishableTestPath(file) {
   if (/(^|\/)(examples|assets|tasks)\//.test(file)) return false;
@@ -27,29 +27,31 @@ function isUnpublishableTestPath(file) {
 }
 
 /**
-  * A twin's own top-level examples/ ships in no tarball. The load-bearing
-  * reason is `private: true`, not any `files` array — some twins' `files` do
-  * name it. release.yml publishes cli, adapter-claude-sdk, checks, wire and
-  * sandbox-domains, and no twin is any of those. Nothing asserts a twin stays
-  * private, so unprivating one means re-checking this.
-  *
-  * `[^/]+` is deliberately one path segment, so only a twin's TOP-LEVEL
-  * examples/ is exempt: `packages/twin-stripe/src/examples/handler.ts` compiles
-  * into that twin's dist like any other `src/` module and stays relevant.
+ * A twin's own top-level examples/ ships in no tarball. The load-bearing
+ * reason is `private: true`, not any `files` array — some twins' `files` do
+ * name it. release.yml publishes cli, adapter-claude-sdk, checks, wire and
+ * sandbox-domains, and no twin is any of those. Nothing asserts a twin stays
+ * private, so unprivating one means re-checking this.
+ *
+ * `[^/]+` is deliberately one path segment, so only a twin's TOP-LEVEL
+ * examples/ is exempt: `packages/twin-stripe/src/examples/handler.ts` compiles
+ * into that twin's dist like any other `src/` module and stays relevant. The
+ * CLI's own `files` entry "examples" is cli/examples, a different directory,
+ * not a twin's.
  */
 function isTwinExamplePath(file) {
   return /^packages\/twin-[^/]+\/examples\//.test(file);
 }
 
 /**
-  * A twin's own top-level markdown ships in no tarball either, for the same
-  * reason: every twin is `private: true`, so its `files` array describes a
-  * tarball nobody builds. tsup inlines twin source through each twin's
-  * `exports` map and cannot inline a markdown file.
-  *
-  * `[^/]+\/[^/]+\.md` is two single path segments on purpose: this exempts
-  * `packages/twin-github/FIDELITY.md` and NOT `packages/twin-github/src/x.md`
-  * or any nested docs directory, so it cannot widen to cover something the
+ * A twin's own top-level markdown ships in no tarball either, for the same
+ * reason: every twin is `private: true`, so its `files` array describes a
+ * tarball nobody builds. tsup inlines twin source through each twin's
+ * `exports` map and cannot inline a markdown file.
+ *
+ * `[^/]+\/[^/]+\.md` is two single path segments on purpose: this exempts
+ * `packages/twin-github/FIDELITY.md` and NOT `packages/twin-github/src/x.md`
+ * or any nested docs directory, so it cannot widen to cover something the
  * bundler might actually read.
  */
 function isTwinTopLevelDocPath(file) {
@@ -85,11 +87,11 @@ function isTwinScriptPath(file) {
 }
 
 /**
-  * A twin's `Dockerfile` is the recipe for its GHCR image, which is not an npm
-  * artifact: release.yml publishes tarballs, twin-image.yml publishes images,
-  * and no version number spans the two. It ships in no tarball for the same
-  * reason as the carve-outs above — every twin is `private: true` — and here no
-  * twin's `files` array names a Dockerfile either.
+ * A twin's `Dockerfile` is the recipe for its GHCR image, which is not an npm
+ * artifact: release.yml publishes tarballs, twin-image.yml publishes images,
+ * and no version number spans the two. It ships in no tarball for the same
+ * reason as the carve-outs above — every twin is `private: true` — and here no
+ * twin's `files` array names a Dockerfile either.
  *
  *
  * The filename is matched EXACTLY and anchored directly under the twin root, so
@@ -101,22 +103,23 @@ function isTwinDockerfilePath(file) {
 }
 
 /**
-  * A `CHANGELOG.md` is exempt even though these bytes really do ship. The
-  * exemption is about what a release MEANS, and it has two halves.
-  *
-  * The judgement: a release exists to move code to a consumer, and republishing
-  * four tarballs over a typo in a historical entry spends a version number on
-  * nothing anyone installs. When a changelog edit does accompany a release, the
-  * release was earned by the code beside it, or by an `## Unreleased` entry the
-  * allocator reads as a release request in its own right.
-  *
-  * The structural half, and why this is not merely a preference: the allocator's
-  * own bump commit REWRITES these files. If a CHANGELOG.md were
-  * publish-relevant, that commit would be publish-relevant for the package it
-  * just released, and the allocator would allocate again on the next push, and
-  * again. The primary loop guard is elsewhere and does not depend on this line,
-  * so this is a second, independent reason the loop cannot start — the same
- * release.yml.
+ * A `CHANGELOG.md` is exempt even though these bytes really do ship. The
+ * exemption is about what a release MEANS, and it has two halves.
+ *
+ * The judgement: a release exists to move code to a consumer, and republishing
+ * four tarballs over a typo in a historical entry spends a version number on
+ * nothing anyone installs. When a changelog edit does accompany a release, the
+ * release was earned by the code beside it, or by an `## Unreleased` entry the
+ * allocator reads as a release request in its own right.
+ *
+ * The structural half, and why this is not merely a preference: the allocator's
+ * own bump commit REWRITES these files. If a CHANGELOG.md were
+ * publish-relevant, that commit would be publish-relevant for the package it
+ * just released, and the allocator would allocate again on the next push, and
+ * again. The primary loop guard does not depend on this line: the allocator
+ * measures relevance from the last commit that moved the version, and the bump
+ * commit is one — see `lastVersionChange()` in `allocate-release-versions.mjs`.
+ * So this is a second, independent reason the loop cannot start.
  */
 function isChangelogPath(file) {
   return /(^|\/)CHANGELOG\.md$/.test(file);
@@ -144,10 +147,10 @@ export function isPublishIrrelevantPath(file) {
  * version and are byte-compared by a CI gate, so the allocator cannot move a
  * version without moving them too.
  *
-  * `release.yml` remains the authority on what actually publishes, and
-  * `release-alarm.mjs` PARSES that file rather than trusting any list. If the
-  * two disagree about the set of packages, the alarm's `--targets` dead-guard
-  * says so out loud.
+ * `release.yml` remains the authority on what actually publishes, and
+ * `release-alarm.mjs` PARSES that file rather than trusting any list. If the
+ * two disagree about the set of packages, the alarm's `--targets` dead-guard
+ * says so out loud.
  */
 export const PUBLISHED_PACKAGES = [
   {
@@ -176,13 +179,13 @@ export const PUBLISHED_PACKAGES = [
     // `failure-injection.ts`.
     //
     // Deliberately NOT the whole of `packages/twin-*/` or `packages/sdk/`. A
-        // change to a twin's routes, tools or domain alters no byte of this
-        // tarball, and making it earn a release here would put a pointless version
-        // on most twin PRs — after which the numbers stop meaning anything. The
-        // cost of drawing it narrowly is that a declaration file added under a NEW
-        // name outside these globs would not trigger it;
-        // `packages/checks/test/surface.test.ts` and each twin's own
-        // `checks-contract.test.ts` cover that.
+    // change to a twin's routes, tools or domain alters no byte of this
+    // tarball, and making it earn a release here would put a pointless version
+    // on most twin PRs — after which the numbers stop meaning anything. The
+    // cost of drawing it narrowly is that a declaration file added under a NEW
+    // name outside these globs would not trigger it;
+    // `packages/checks/test/surface.test.ts` and each twin's own
+    // `checks-contract.test.ts` cover that.
     name: "@pome-sh/checks",
     manifest: "packages/checks/package.json",
     changelog: "packages/checks/CHANGELOG.md",
@@ -191,7 +194,7 @@ export const PUBLISHED_PACKAGES = [
     pathPatterns: [
       /^packages\/twin-[a-z]+\/src\/(checks|check-[a-z-]+|seed|tape-assertable-tools)\.ts$/,
       /^packages\/sdk\/src\/(checks|check-state-path|check-discrimination|check-redaction|failure-injection)\.ts$/,
-      // The declaration bundler is shared with @pome-sh/sandbox-domains rather
+    // The declaration bundler is shared with @pome-sh/sandbox-domains rather
             // than copied. It is what makes this tarball's `.d.ts` resolvable for a
             // consumer, so it is publish-relevant here.
       /^scripts\/bundle-declarations\.mjs$/,
@@ -202,15 +205,15 @@ export const PUBLISHED_PACKAGES = [
     // `lib/twin-state.ts` boots and a bound check reads.
     //
     // @pome-sh/checks ships the DECLARATIONS, this ships what they read. They
-        // are the two legs of pome-cloud's `checks-package-drift.test.ts`, and both
-        // must be cut from the SAME main commit: publishing a widened vocabulary
-        // whose runtime could not follow is the wall this pairing removes.
-        //
-        // Its paths are WHOLE directories where the checks entry names files, and
-        // that difference is not an oversight. A twin's routes, tools and domain
-        // change no byte of the vocabulary tarball, but they are exactly what this
-        // one bundles, so a domain change that did not republish this package is
-        // the silent non-release this table exists to prevent.
+    // are the two legs of pome-cloud's `checks-package-drift.test.ts`, and both
+    // must be cut from the SAME main commit: publishing a widened vocabulary
+    // whose runtime could not follow is the wall this pairing removes.
+    //
+    // Its paths are WHOLE directories where the checks entry names files, and
+    // that difference is not an oversight. A twin's routes, tools and domain
+    // change no byte of the vocabulary tarball, but they are exactly what this
+    // one bundles, so a domain change that did not republish this package is
+    // the silent non-release this table exists to prevent.
     name: "@pome-sh/sandbox-domains",
     manifest: "packages/sandbox-domains/package.json",
     changelog: "packages/sandbox-domains/CHANGELOG.md",
@@ -218,55 +221,58 @@ export const PUBLISHED_PACKAGES = [
     pathPrefixes: [
       "packages/sandbox-domains/",
       "packages/twin-",
-      // `./server` re-exports `toTwinHttpEventRow`, and every twin domain
-      // reaches the sdk's db layer — the whole sdk is inlined here, exactly as
-      // it is into the CLI.
+    // `./server` re-exports `toTwinHttpEventRow`, and every twin domain
+    // reaches the sdk's db layer — the whole sdk is inlined here, exactly as
+    // it is into the CLI.
       "packages/sdk/",
     ],
     pathPatterns: [/^scripts\/bundle-declarations\.mjs$/],
   },
   {
-    // Published to BOTH registries from one version line, with its own
-        // independent version line and therefore its own entry here.
-        //
-        // `packages/wire/` deliberately appears in THREE entries, and that is not
-        // double-counting: three different published artifacts change when wire
-        // changes. A wire source change alters the bytes tsup inlines into the
-        // CLI's and the adapter's tarballs, so both need a release for a user to
-        // see it, and wire itself needs one for its own consumers. Three releases
-        // for one wire change is the correct answer. @pome-sh/checks is not the
-        // fourth — see its entry above, where relevance is named files rather than
-        // directories.
+    // Published to BOTH registries from one version line: npmjs so a consumer
+    // resolving the rest of the @pome-sh scope from there can resolve wire too,
+    // GitHub Packages for its cross-repo consumers. Neither lane is redundant —
+    // a scope routes to one registry per consumer. Its own version line, and
+    // therefore its own entry here.
+    //
+    // `packages/wire/` deliberately appears in THREE entries, and that is not
+    // double-counting: three different published artifacts change when wire
+    // changes. A wire source change alters the bytes tsup inlines into the
+    // CLI's and the adapter's tarballs, so both need a release for a user to
+    // see it, and wire itself needs one for its own consumers. Three releases
+    // for one wire change is the correct answer. @pome-sh/checks is not the
+    // fourth — see its entry above, where relevance is named files rather than
+    // directories.
     name: "@pome-sh/wire",
     manifest: "packages/wire/package.json",
     changelog: "packages/wire/CHANGELOG.md",
     registry: "npm + GitHub Packages (npm.pkg.github.com)",
     pathPrefixes: ["packages/wire/"],
     // trace-contract.json is in wire's `files`, so it SHIPS, and it embeds
-        // wire's own `version`. `check:trace-contract` is a byte compare, so a
-        // version moved without regenerating it reds main. Keeping that pairing in
-        // this table rather than in a human instruction is the point: the version
-        // is no longer written by a human.
-        //
-        // `regenerate` runs the REAL emitter rather than patching the one key,
-        // because that emitter also enumerates the event union out of zod and
-        // asserts a fixture per kind — a hand-patch would keep the byte compare
-        // green while silently dropping that assertion. It is why
-        // allocate-version.yml has an `npm ci` at all, and it runs only when a
-        // package in the plan names one.
+    // wire's own `version`. `check:trace-contract` is a byte compare, so a
+    // version moved without regenerating it reds main. Keeping that pairing in
+    // this table rather than in a human instruction is the point: the version
+    // is no longer written by a human.
+    //
+    // `regenerate` runs the REAL emitter rather than patching the one key,
+    // because that emitter also enumerates the event union out of zod and
+    // asserts a fixture per kind — a hand-patch would keep the byte compare
+    // green while silently dropping that assertion. It is why
+    // allocate-version.yml has an `npm ci` at all, and it runs only when a
+    // package in the plan names one.
     versionedArtifacts: ["packages/wire/trace-contract.json"],
     regenerate: "npm run emit:trace-contract -w @pome-sh/wire",
   },
 ];
 
 /**
-  * Which published packages a set of changed paths moves, with the paths that
-  * made each one relevant — callers name those paths, so a demand is never
-  * "something you touched" but "these files, and this is the artifact they are
-  * inlined into".
-  *
-  * Returns `[{ pkg, files }]` in table order, only for packages with at least
-  * one relevant file.
+ * Which published packages a set of changed paths moves, with the paths that
+ * made each one relevant — callers name those paths, so a demand is never
+ * "something you touched" but "these files, and this is the artifact they are
+ * inlined into".
+ *
+ * Returns `[{ pkg, files }]` in table order, only for packages with at least
+ * one relevant file.
  */
 export function packagesTouchedBy(changedFiles) {
   const relevant = changedFiles.filter((file) => !isPublishIrrelevantPath(file));
@@ -275,9 +281,9 @@ export function packagesTouchedBy(changedFiles) {
     const files = relevant.filter(
       (file) =>
         pkg.pathPrefixes.some((prefix) => file.startsWith(prefix)) ||
-        // `pathPatterns` exists for @pome-sh/checks, whose tarball is assembled
-        // from named FILES inside other packages rather than whole directories —
-        // a prefix would over-trigger on every twin route change.
+    // `pathPatterns` exists for @pome-sh/checks, whose tarball is assembled
+    // from named FILES inside other packages rather than whole directories —
+    // a prefix would over-trigger on every twin route change.
         (pkg.pathPatterns ?? []).some((pattern) => pattern.test(file)),
     );
     if (files.length > 0) hits.push({ pkg, files });

--- a/scripts/ci/push-scanned-image.sh
+++ b/scripts/ci/push-scanned-image.sh
@@ -1,34 +1,28 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 #
-# F-1530 — the ONE hardened path for a container-registry WRITE in
+# The ONE hardened path for a container-registry WRITE in
 # `.github/workflows/**`. Pushes every tag in `IMAGE_TAGS` to its registry and
 # refuses to report success on anything it cannot read back.
 #
-# WHY THIS FILE EXISTS. twin-image.yml's `Push scanned image` was a bare
-# `docker push` per tag with no retry, standing between two third-party fetches
-# that had both been given three-attempt ladders (F-1489, F-1494). On 2026-08-14
-# GHCR logged every layer of the stripe twin as `Pushed`, then answered
-# `unknown blob` — the registry failing to see a blob it had just accepted — and
-# exited 1. Nothing re-ran the step, so `ghcr.io/pome-sh/twins:stripe-bbf27bf`
-# simply did not exist: `twin-snapshot-verify` failed for four consecutive
-# nights, pome-cloud#752 reported `stripe — no-image`, and production kept
-# booting snapshots from a commit 43 commits behind. One transient registry error
-# was load-bearing for four days.
+# WHY THIS FILE EXISTS. A bare `docker push` per tag has no retry, and GHCR can
+# log every layer as `Pushed` and then answer `unknown blob` — the registry
+# failing to see a blob it just accepted — and exit 1. Nothing re-runs the step,
+# so the tag simply does not exist, and a consumer resolving it reports
+# no-image while production keeps booting an older snapshot. One transient
+# registry error stays load-bearing until somebody looks.
 #
 # Usage: IMAGE_TAGS=$'tag\ntag' push-scanned-image.sh
 #
 # Properties, all four load-bearing:
 #
-#   1. RETRY WITH BACKOFF. Five attempts per tag, sleeping 5s/10s/15s/20s
-#      between them — deliberately the same budget as
-#      scripts/ci/fetch-pinned-release.sh, so the publish path has one number to
-#      reason about rather than two. An explicit loop with a literal `sleep`, for
-#      the reason that helper's header records: a retry budget that looks handled
-#      and is not is worse than none. Retrying is safe because every tag names
-#      the same image already loaded into the local daemon — the layers are
-#      already uploaded, so a second attempt is a manifest PUT, which is the part
-#      that failed.
+#   1. RETRY WITH BACKOFF. Five attempts per tag, sleeping 5s/10s/15s/20s, the
+#      same budget as fetch-pinned-release.sh so the publish path has one
+#      number to reason about. An explicit loop with a literal `sleep`: a retry
+#      budget that looks handled and is not is worse than none. Retrying is safe
+#      because every tag names the same image already in the local daemon — the
+#      layers are uploaded, so a second attempt is a manifest PUT, which is the
+#      part that failed.
 #
 #   2. THE MANIFEST IS READ BACK, PER TAG. `docker push` exiting 0 is not the
 #      same fact as "this tag resolves": the whole failure class here is a
@@ -41,15 +35,14 @@
 #      as a confusing cosign error.
 #
 #   3. NO TAG IS PUSHED AFTER A FAILED ONE. `docker/metadata-action` emits the
-#      rolling `<twin>` tag first and the per-commit `<twin>-<sha>` tag LAST, and
-#      that order is load-bearing: the per-commit tag is what pome-cloud
-#      resolves, so its existence is a promise that everything before it landed.
-#      Exhausting a tag's attempts exits immediately, which leaves the per-commit
-#      tag absent — resolve-image-digest.ts then reports `not found`, the honest
-#      answer, instead of resolving a manifest whose siblings are missing and
-#      which the sign/attest step (it never runs after this failure) never
-#      signed. Whatever DID land is named in the error for the same reason: those
-#      tags are published and unsigned, and a human has to know that.
+#      rolling `<twin>` tag first and the per-commit `<twin>-<sha>` tag LAST,
+#      and that order is load-bearing: the per-commit tag is what a consumer
+#      resolves, so its existence is a promise that everything before it
+#      landed. Exhausting a tag's attempts exits immediately, leaving the
+#      per-commit tag absent so a resolver reports `not found` — the honest
+#      answer — rather than a manifest whose siblings are missing and which the
+#      sign step never signed. Whatever DID land is named in the error, because
+#      those tags are published and unsigned.
 #
 #   4. FAIL CLOSED, BY NAME. A registry that will not accept the manifest must
 #      stop the job — an image that cannot be published cannot be signed,
@@ -88,7 +81,7 @@ fail_out() {
   else
     leftover="Already published and NOT signed, because the sign/attest step never runs after this failure: $(printf '%s' "${landed_tags}" | tr '\n' ' ' | sed 's/ *$//')."
   fi
-  echo "::error::twin image push: could not publish ${tag} to ${registry} after ${attempts} attempts — ${reason}. The registry is degraded; this is not a failure of the twin, the build or the scan (F-1530). Failing closed on purpose, and no later tag was pushed. ${leftover}" >&2
+  echo "::error::twin image push: could not publish ${tag} to ${registry} after ${attempts} attempts — ${reason}. The registry is degraded; this is not a failure of the twin, the build or the scan Failing closed on purpose, and no later tag was pushed. ${leftover}" >&2
   exit 1
 }
 
@@ -120,7 +113,7 @@ while IFS= read -r tag || [ -n "$tag" ]; do
       fi
       reason="the push exited 0 but ${tag} still resolves to nothing, so the registry accepted the layers and committed no manifest"
     else
-      # Deliberately does NOT name a specific registry error. F-1530's was
+      # Deliberately does NOT name a specific registry error. The observed one was
       # `unknown blob` after every layer reported `Pushed`; run 32144441622's was
       # `error parsing HTTP 403 response body` on the first tag. They are one
       # fault from here, and a message that asserted either would misdirect a
@@ -141,7 +134,7 @@ while IFS= read -r tag || [ -n "$tag" ]; do
 
   if [ "$attempt" -gt 1 ]; then
     # A flaky-but-passing run has to say so, or the degradation is invisible
-    # until the day it is total — which is how F-1530 went unnoticed for four
+    # until the day it is total — which is how a partial outage goes unnoticed for
     # days.
     echo "::warning::twin image push: ${tag} landed only on attempt ${attempt}/${attempts} — ${registry} is degraded right now" >&2
   fi

--- a/scripts/ci/push-scanned-image.sh
+++ b/scripts/ci/push-scanned-image.sh
@@ -81,7 +81,7 @@ fail_out() {
   else
     leftover="Already published and NOT signed, because the sign/attest step never runs after this failure: $(printf '%s' "${landed_tags}" | tr '\n' ' ' | sed 's/ *$//')."
   fi
-  echo "::error::twin image push: could not publish ${tag} to ${registry} after ${attempts} attempts — ${reason}. The registry is degraded; this is not a failure of the twin, the build or the scan Failing closed on purpose, and no later tag was pushed. ${leftover}" >&2
+  echo "::error::twin image push: could not publish ${tag} to ${registry} after ${attempts} attempts — ${reason}. The registry is degraded; this is not a failure of the twin, the build or the scan. Failing closed on purpose, and no later tag was pushed. ${leftover}" >&2
   exit 1
 }
 
@@ -114,7 +114,7 @@ while IFS= read -r tag || [ -n "$tag" ]; do
       reason="the push exited 0 but ${tag} still resolves to nothing, so the registry accepted the layers and committed no manifest"
     else
       # Deliberately does NOT name a specific registry error. The observed one was
-      # `unknown blob` after every layer reported `Pushed`; run 32144441622's was
+      # `unknown blob` after every layer reported `Pushed`; another was
       # `error parsing HTTP 403 response body` on the first tag. They are one
       # fault from here, and a message that asserted either would misdirect a
       # reader on the other — docker's own output is directly above.

--- a/scripts/ci/push-scanned-image.sh
+++ b/scripts/ci/push-scanned-image.sh
@@ -1,62 +1,11 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 #
-# The ONE hardened path for a container-registry WRITE in
-# `.github/workflows/**`. Pushes every tag in `IMAGE_TAGS` to its registry and
-# refuses to report success on anything it cannot read back.
-#
-# WHY THIS FILE EXISTS. A bare `docker push` per tag has no retry, and GHCR can
-# log every layer as `Pushed` and then answer `unknown blob` — the registry
-# failing to see a blob it just accepted — and exit 1. Nothing re-runs the step,
-# so the tag simply does not exist, and a consumer resolving it reports
-# no-image while production keeps booting an older snapshot. One transient
-# registry error stays load-bearing until somebody looks.
-#
-# Usage: IMAGE_TAGS=$'tag\ntag' push-scanned-image.sh
-#
-# Properties, all four load-bearing:
-#
-#   1. RETRY WITH BACKOFF. Five attempts per tag, sleeping 5s/10s/15s/20s, the
-#      same budget as fetch-pinned-release.sh so the publish path has one
-#      number to reason about. An explicit loop with a literal `sleep`: a retry
-#      budget that looks handled and is not is worse than none. Retrying is safe
-#      because every tag names the same image already in the local daemon — the
-#      layers are uploaded, so a second attempt is a manifest PUT, which is the
-#      part that failed.
-#
-#   2. THE MANIFEST IS READ BACK, PER TAG. `docker push` exiting 0 is not the
-#      same fact as "this tag resolves": the whole failure class here is a
-#      registry that accepts blobs and does not commit what points at them. So
-#      each attempt only counts as landed once
-#      `docker buildx imagetools inspect` returns a digest — the exact call
-#      pome-cloud's scripts/twin-snapshot/resolve-image-digest.ts makes, and the
-#      one scripts/ci/sign-image-digests.sh makes next. A tag that pushes clean
-#      and resolves to nothing is retried here rather than failing one step later
-#      as a confusing cosign error.
-#
-#   3. NO TAG IS PUSHED AFTER A FAILED ONE. `docker/metadata-action` emits the
-#      rolling `<twin>` tag first and the per-commit `<twin>-<sha>` tag LAST,
-#      and that order is load-bearing: the per-commit tag is what a consumer
-#      resolves, so its existence is a promise that everything before it
-#      landed. Exhausting a tag's attempts exits immediately, leaving the
-#      per-commit tag absent so a resolver reports `not found` — the honest
-#      answer — rather than a manifest whose siblings are missing and which the
-#      sign step never signed. Whatever DID land is named in the error, because
-#      those tags are published and unsigned.
-#
-#   4. FAIL CLOSED, BY NAME. A registry that will not accept the manifest must
-#      stop the job — an image that cannot be published cannot be signed,
-#      attested or deployed. But not as
-#      `##[error]The process '/usr/bin/bash' failed with exit code 1`, which says
-#      nothing about whether to re-run or to read the code. Exhaustion prints an
-#      `::error::` naming the tag, the registry, the attempts spent and what is
-#      left behind. An empty `IMAGE_TAGS` is the same kind of refusal: a loop
-#      over zero tags exits 0 and reads exactly like a publish.
-#
-# Env knobs exist ONLY for scripts/ci/assert-hardened-cdn-fetches.test.mjs,
-# which drives this script against a fake `docker` that reproduces the GHCR
-# answer above; nothing in `.github/workflows/**` sets them, and the defaults are
-# the production values asserted by that test.
+# The one hardened path for a container-registry write. Each tag is read back with
+# imagetools inspect, because `docker push` exiting 0 is not the same fact as "this
+# tag resolves" — GHCR can log every layer as Pushed and then answer unknown blob.
+# The per-commit tag is emitted last, so its absence is the honest signal. An empty
+# IMAGE_TAGS is refused: a loop over zero tags exits 0 and reads like a publish.
 set -euo pipefail
 
 attempts="${PUSH_SCANNED_IMAGE_ATTEMPTS:-5}"
@@ -67,10 +16,6 @@ if [ -z "${IMAGE_TAGS:-}" ]; then
   exit 1
 fi
 
-# Tags that reached the registry AND read back, newline-separated. Named in the
-# error below so a failure says what is now published and unsigned. A plain
-# string rather than an array: bash 3.2 (a developer's macOS) errors on an empty
-# array under `set -u`.
 landed_tags=""
 landed_count=0
 
@@ -86,17 +31,10 @@ fail_out() {
 }
 
 while IFS= read -r tag || [ -n "$tag" ]; do
-  # Trim surrounding whitespace before the emptiness test, not after: an image
-  # ref contains none, so a line that is only whitespace is not a tag — and
-  # `[ -n "$tag" ]` alone reads one as a tag and pushes it. Same for a trailing
-  # `\r` off a CRLF value. Parameter expansion rather than `tr`/`sed`, so
-  # trimming costs no subprocess per tag.
   tag="${tag#"${tag%%[![:space:]]*}"}"
   tag="${tag%"${tag##*[![:space:]]}"}"
   [ -n "$tag" ] || continue
 
-  # `ghcr.io/pome-sh/twins:stripe-bbf27bf` -> `ghcr.io`. Used in every message so
-  # the run log names the registry, not just the exit code.
   registry="${tag%%/*}"
 
   landed=false
@@ -104,8 +42,6 @@ while IFS= read -r tag || [ -n "$tag" ]; do
   attempt=1
   while [ "$attempt" -le "$attempts" ]; do
     if docker push "$tag"; then
-      # `|| true` here is the opposite of swallowing the failure: an unresolvable
-      # tag is turned into another ATTEMPT, and exhaustion still exits 1 below.
       digest="$(docker buildx imagetools inspect "$tag" --format '{{.Manifest.Digest}}' 2>/dev/null || true)"
       if [ -n "${digest}" ]; then
         landed=true
@@ -113,11 +49,6 @@ while IFS= read -r tag || [ -n "$tag" ]; do
       fi
       reason="the push exited 0 but ${tag} still resolves to nothing, so the registry accepted the layers and committed no manifest"
     else
-      # Deliberately does NOT name a specific registry error. The observed one was
-      # `unknown blob` after every layer reported `Pushed`; another was
-      # `error parsing HTTP 403 response body` on the first tag. They are one
-      # fault from here, and a message that asserted either would misdirect a
-      # reader on the other — docker's own output is directly above.
       reason="docker push exited non-zero; the registry's own answer is in its output above"
     fi
     if [ "$attempt" -lt "$attempts" ]; then
@@ -133,9 +64,6 @@ while IFS= read -r tag || [ -n "$tag" ]; do
   fi
 
   if [ "$attempt" -gt 1 ]; then
-    # A flaky-but-passing run has to say so, or the degradation is invisible
-    # until the day it is total — which is how a partial outage goes unnoticed for
-    # days.
     echo "::warning::twin image push: ${tag} landed only on attempt ${attempt}/${attempts} — ${registry} is degraded right now" >&2
   fi
 

--- a/scripts/ci/release-alarm.mjs
+++ b/scripts/ci/release-alarm.mjs
@@ -3,24 +3,16 @@
 //
 // A failed release must reach a human without a human going looking.
 //
-// On 2026-08-06 four consecutive push-triggered `release.yml` runs failed over
-// eleven hours (00:42, 01:26, 10:41, 11:28 UTC). Nothing fired. `release.yml`
-// has no failure path — no `if: failure()`, no notification, no tracking issue
-// — so a publish that died is indistinguishable from a merge that owed no
-// publish. The first signal was a human noticing two packages missing from npm,
-// and the recovery was that human dispatching the workflow by hand. Two of
-// those four runs were the merges of the declaration-lane and wire work: the packages
-// the grading vocabulary now depends on, reporting themselves as merged while
-// publishing nothing.
+// release.yml has no failure path — no `if: failure()`, no notification, no
+// tracking issue — so a publish that died is indistinguishable from a merge
+// that owed no publish, and the first signal is somebody noticing a package
+// missing from npm.
 //
 // This is the checker behind `.github/workflows/release-alarm.yml`. It runs on
 // its own daily schedule, in a SEPARATE workflow file, because the alarm has to
-// survive the thing it is watching — the reasoning `check-release-staleness.yml`
-// gave before it was deleted alongside the Changesets flow it watched
-// (`a3c9441`, "replace two release systems with one"). Deleting it with its
-// subject was right; not replacing it was the gap. An `if: failure()` step
-// inside `release.yml` cannot see the silence this alarm exists for: a release
-// workflow that never triggers at all takes an embedded check down with it.
+// survive the thing it is watching: an `if: failure()` step inside release.yml
+// cannot see the silence this exists for, a release workflow that never
+// triggers at all.
 //
 // ── What it asserts ──────────────────────────────────────────────────────────
 //
@@ -42,7 +34,7 @@
 //                 consumes it on the next push — so one still sitting there past
 //                 the grace window is that silence, named.
 //   UNPUBLISHED — main declares a version its registry does not serve. The
-//                 08-06 shape, and the only state a consumer can observe.
+//                 only state a consumer can observe directly.
 //   BEHIND      — main declares a version BELOW the registry's `latest`. Not
 //                 yet a missing publish; it is the floor check in
 //                 decide-publish.sh armed to hard-fail the whole lane on the
@@ -65,8 +57,8 @@
 //                 distinction decide-publish.sh is careful about.
 //
 // Silence is asserted as hard as noise: everything green produces no issue, no
-// comment, and exit 0 — an alarm that cries wolf gets muted, and a muted alarm
-// is the state this ticket is about.
+// comment, and exit 0. An alarm that cries wolf gets muted, and a muted alarm
+// is no alarm.
 //
 // ── Why the package list is derived, not typed ───────────────────────────────
 //

--- a/scripts/ci/release-alarm.mjs
+++ b/scripts/ci/release-alarm.mjs
@@ -1,84 +1,12 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// A failed release must reach a human without a human going looking.
+// Does every version main declares reach its registry? Its own cron, in its own
+// workflow, so the alarm survives a release.yml that never triggered.
 //
-// release.yml has no failure path — no `if: failure()`, no notification, no
-// tracking issue — so a publish that died is indistinguishable from a merge
-// that owed no publish, and the first signal is somebody noticing a package
-// missing from npm.
-//
-// This is the checker behind `.github/workflows/release-alarm.yml`. It runs on
-// its own daily schedule, in a SEPARATE workflow file, because the alarm has to
-// survive the thing it is watching: an `if: failure()` step inside release.yml
-// cannot see the silence this exists for, a release workflow that never
-// triggers at all.
-//
-// ── What it asserts ──────────────────────────────────────────────────────────
-//
-// Primarily an OUTCOME check, not a mechanism one: for every package
-// `release.yml` can publish, does its registry actually serve the version main
-// declares? That question is blind to HOW a publish went missing, which is the
-// point — "ran and failed", "never ran", "cancelled", "the plan job skipped it"
-// and "someone disabled the job" all land on the same answer. The mechanism
-// legs below exist for the cases where nothing was owed and the release path is
-// broken anyway, which the outcome check cannot see until the next bump.
-//
-//   UNALLOCATED — main carries a pending `## Unreleased` entry that no
-//                 allocation consumed. The version number is written on
-//                 main after the merge by allocate-version.yml, so a broken or
-//                 unconfigured allocator produces a state the outcome check
-//                 CANNOT see: main declares the old version, the registry serves
-//                 the old version, everything agrees, and the fix never ships.
-//                 A pending entry is transient by construction — the allocator
-//                 consumes it on the next push — so one still sitting there past
-//                 the grace window is that silence, named.
-//   UNPUBLISHED — main declares a version its registry does not serve. The
-//                 only state a consumer can observe directly.
-//   BEHIND      — main declares a version BELOW the registry's `latest`. Not
-//                 yet a missing publish; it is the floor check in
-//                 decide-publish.sh armed to hard-fail the whole lane on the
-//                 next merge, taking that merge's unrelated publishes with it.
-//   NEVER_RAN   — main's HEAD has no `release.yml` run at all and is past the
-//                 grace window. The silence: a push to main that
-//                 triggered nothing (a bot pushing with the ambient
-//                 GITHUB_TOKEN cannot trigger workflows), or Actions disabled.
-//   STUCK       — a run has been queued/in_progress past the stuck window.
-//                 `release.yml` sets `cancel-in-progress: false`, so one hung
-//                 run holds the concurrency lock and everything behind it waits.
-//   FAILED      — the newest COMPLETED run on main did not succeed, with
-//                 nothing newer in flight. Catches a broken release path even
-//                 when no version was owed, so it is visible before the next
-//                 bump rather than after it.
-//   UNMEASURED  — a registry read failed for a reason other than 404. Reported
-//                 as its own state and never folded into UNPUBLISHED: a 401 for
-//                 a package that exists reads identically to "nothing published
-//                 yet" unless the two are kept apart, which is the same
-//                 distinction decide-publish.sh is careful about.
-//
-// Silence is asserted as hard as noise: everything green produces no issue, no
-// comment, and exit 0. An alarm that cries wolf gets muted, and a muted alarm
-// is no alarm.
-//
-// ── Why the package list is derived, not typed ───────────────────────────────
-//
-// The publish targets are parsed out of `release.yml`'s own
-// `scripts/ci/decide-publish.sh` invocations rather than listed here. A second
-// hand-maintained copy of "what gets published" is a guard that goes quietly
-// blind the day someone adds a fifth package — a list that stops matching its
-// subject still passes, forever. Deriving it means a new target is watched the
-// same day it is added, and a `release.yml` restructured past the parse is a
-// hard failure (`--targets` in ci.yml's always-on block) rather than an alarm
-// that silently watches nothing.
-//
-// Usage: node scripts/ci/release-alarm.mjs [repo root]
-//        node scripts/ci/release-alarm.mjs --targets   (parse only, no network)
-//   env: GITHUB_REPOSITORY, GH_TOKEN
-//        GRACE_MINUTES (default 90)  — how long after a push to main before its
-//          missing publish counts as missing rather than still building.
-//        STUCK_MINUTES (default 360) — how long in flight before a run is hung.
-//        NOW_MS (tests)
-//   Writes alarm= / reason= / report= to $GITHUB_OUTPUT. Exits 1 when alarming.
+// Targets are parsed out of release.yml, never listed here; `--targets` reds if
+// the parse finds none. UNMEASURED never folds into UNPUBLISHED — a 401 reads
+// identically to "nothing published yet".
 
 import { execFileSync, spawnSync } from "node:child_process";
 import { appendFileSync, existsSync, readFileSync, realpathSync } from "node:fs";
@@ -92,14 +20,6 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const RELEASE_WORKFLOW = "release.yml";
 const ALLOCATE_WORKFLOW = "allocate-version.yml";
 
-/**
- * Every publish target `release.yml` decides on, read from the workflow itself.
- *
- * `decide-publish.sh <name> <manifest> <output-key> [registry]` — an omitted
- * registry means registry.npmjs.org. @pome-sh/wire legitimately appears twice
- * with two registries (npmjs and GitHub Packages, from the same version line),
- * so targets are keyed on name+registry rather than name.
- */
 export function parseTargets(root) {
   const targets = readTargets(root);
   for (const t of targets) {
@@ -110,21 +30,6 @@ export function parseTargets(root) {
   return targets;
 }
 
-/**
- * The parse half of `parseTargets`, without the "every manifest exists" leg.
- *
- * Split out for callers that need to know WHICH manifests a workflow names
- * before those manifests exist — the test suite's historical fixtures build a
- * scratch tree from the real release.yml and have to create them. Folding that
- * need into `parseTargets` would mean weakening the existence check, and that
- * check is the whole reason the alarm cannot silently watch a package whose
- * manifest was moved or renamed.
- *
- * The empty-targets guard stays HERE rather than in `parseTargets`, because it
- * is a property of the parser rather than of the tree: an alarm watching zero
- * packages passes forever, and a fixture builder that silently created nothing
- * would be the same failure one layer down.
- */
 export function readTargets(root) {
   const file = join(root, ".github/workflows", RELEASE_WORKFLOW);
   if (!existsSync(file)) throw new Error(`${RELEASE_WORKFLOW} not found at ${file}`);
@@ -145,13 +50,6 @@ export function readTargets(root) {
   return targets;
 }
 
-/**
- * Semver order, enough for the `x.y.z[-pre]` versions these packages use.
- * A prerelease sorts BELOW its release, which is where this deliberately
- * differs from decide-publish.sh's `sort -V` (GNU version sort puts
- * `1.0.0-rc1` above `1.0.0`). Nothing here ships prereleases; if that changes,
- * the release's own floor check is the one that has to be corrected, not this.
- */
 export function compareVersions(a, b) {
   const split = (v) => {
     const [core, pre = ""] = String(v).split("-");
@@ -173,32 +71,17 @@ function gh(args) {
   return execFileSync("gh", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
 }
 
-/**
- * What the registry currently serves.
- *
- * Read independently of decide-publish.sh on purpose. A watcher that shares its
- * subject's code goes blind with it, and the shared thing that MUST NOT drift —
- * which package, which manifest, which registry — is derived from release.yml
- * above rather than duplicated. What is duplicated is fifteen lines of
- * 404-vs-everything-else, and the distinction is asserted by this script's own
- * regression suite.
- */
 export function registryVersion(name, registry) {
   const args = ["view", name, "version", ...(registry ? ["--registry", registry] : [])];
   const r = spawnSync("npm", args, { encoding: "utf8" });
   const output = `${r.stdout ?? ""}${r.stderr ?? ""}`;
   if (r.status === 0) return { version: r.stdout.trim() };
-  // A brand-new package genuinely has nothing published; 0.0.0 is the correct
-  // baseline and is NOT an alarm on its own (the drift check below still fires
-  // if main declares a version, which is exactly right for a first publish that
-  // never happened).
   if (/E404|404 Not Found/.test(output)) return { version: "0.0.0", unpublished: true };
   return { error: output.trim().split("\n").filter(Boolean).slice(-2).join(" / ") || "unknown npm error" };
 }
 
 const minutesSince = (iso, now) => (now - Date.parse(iso)) / 60_000;
 
-/** Newest first, so "the newest completed run" needs no scan order assumption. */
 function newestFirst(runs) {
   return [...runs].sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at));
 }
@@ -207,7 +90,6 @@ function runUrl(repo, run) {
   return `https://github.com/${repo}/actions/runs/${run.id}`;
 }
 
-/** The mechanism legs: is the release path itself alive? */
 function inspectReleaseRuns({ repo, head, runs, now, graceMinutes, stuckMinutes }) {
   const alarms = [];
   const lines = [];
@@ -247,8 +129,6 @@ function inspectReleaseRuns({ repo, head, runs, now, graceMinutes, stuckMinutes 
     );
   }
 
-  // Only when nothing newer is in flight: a failure already being retried is
-  // the release path working, and paging it teaches people to ignore the label.
   const newerInFlight =
     newestCompleted &&
     inFlight.some((r) => Date.parse(r.created_at) > Date.parse(newestCompleted.created_at));
@@ -266,30 +146,6 @@ function inspectReleaseRuns({ repo, head, runs, now, graceMinutes, stuckMinutes 
   return { alarms, lines, headAge, forHead, inFlight };
 }
 
-/**
- * The allocation leg: is anything still WAITING for a number?
- *
- * A pending `## Unreleased` entry on main is transient by construction —
- * allocate-version.yml consumes it on the push that created it — so one still
- * there is the allocator not running: the secret unset, the ruleset bypass
- * revoked, three rejected pushes, a crash. None of that is visible to the
- * outcome leg below, which compares main's declared version against the
- * registry and finds them in perfect agreement on the OLD number.
- *
- * WHAT THIS DOES NOT COVER, stated rather than implied: the other half of what
- * earns a release is publish RELEVANCE (paths moved with no entry written), and
- * that half is not checked here. It needs the git history the allocator walks,
- * and a watcher that re-derives it would either share the allocator's table (and
- * go blind with it) or keep a second copy (and drift from it). The PR gate
- * demands an entry for every publish-relevant change, so reaching that state
- * takes a bypassed gate — and any OTHER package with an entry still fires this
- * leg in the same run, because a dead allocator is dead for all of them.
- *
- * Reads the tree it is checked out in, not the registry, so it costs nothing and
- * cannot fail for a network reason. The CHANGELOG path per package comes from
- * scripts/ci/publish-relevance.mjs, the same table the allocator and the PR gate
- * read.
- */
 function inspectPendingEntries({ root }) {
   const alarms = [];
   const lines = [];
@@ -297,9 +153,6 @@ function inspectPendingEntries({ root }) {
   for (const pkg of PUBLISHED_PACKAGES) {
     const file = join(root, pkg.changelog);
     if (!existsSync(file)) {
-      // Asserted pre-merge by check-release-note-required.mjs, so this is
-      // unreachable through a PR. Reported rather than skipped: an alarm that
-      // silently stops watching a package is the shape of every bug in this file.
       alarms.push(
         `UNMEASURED — ${pkg.changelog} is missing, so nothing here can say whether ` +
           `${pkg.name} is waiting for a version number.`,
@@ -329,7 +182,6 @@ function inspectPendingEntries({ root }) {
   return { alarms, lines };
 }
 
-/** The outcome leg: does each registry serve what main declares? */
 function inspectRegistries({ root, targets, readVersion }) {
   const alarms = [];
   const lines = [];
@@ -402,16 +254,7 @@ export function check({
   const lines = [...path.lines, ""];
   const alarms = [...path.alarms];
 
-  // Registry drift is only meaningful once HEAD's own release has had time to
-  // run. Inside the grace window a bump that merged four minutes ago is
-  // legitimately not on npm yet, and firing there would be the false alarm that
-  // gets the label muted. HEAD is the right subject even for a publish an
-  // EARLIER commit missed: `release.yml` diffs against the registry, not against
-  // the previous commit, so HEAD's run publishes whatever is still owed.
   if (path.headAge > graceMinutes) {
-    // Same grace window, same reason: an entry that merged four minutes ago is
-    // legitimately still waiting for allocate-version.yml to finish, and firing
-    // there would be the false alarm that gets the label muted.
     const allocation = inspectPendingEntries({ root });
     lines.push(...allocation.lines);
     alarms.push(...allocation.alarms);
@@ -433,9 +276,6 @@ export function main(argv = process.argv.slice(2)) {
   const flags = argv.filter((a) => a.startsWith("--"));
   const root = resolve(argv.find((a) => !a.startsWith("--")) ?? join(HERE, "../.."));
 
-  // Dead-guard check, network-free: prove release.yml still yields targets. Run
-  // in ci.yml's always-on block so a release restructure that this parser cannot
-  // follow reds the PR that causes it, rather than the alarm going quietly blind.
   if (flags.includes("--targets")) {
     const targets = parseTargets(root);
     for (const t of targets) {
@@ -470,11 +310,6 @@ export function main(argv = process.argv.slice(2)) {
   console.log("\n✅ Every version main declares is on its registry, and the release path is alive.");
 }
 
-// Realpath'd on both sides — node resolves symlinks before deriving
-// `import.meta.url`, so a bare `pathToFileURL()` of argv[1] (with no
-// realpath) misses through a symlinked checkout (a worktree, or macOS's
-// symlinked `/tmp`) in the same silent shape, and a guard miss
-// while invoked as this file throws rather than exits 0.
 const SELF = realpathSync(fileURLToPath(import.meta.url));
 const ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";
 const invokedDirectly = ENTRY === SELF;

--- a/scripts/ci/release-alarm.test.mjs
+++ b/scripts/ci/release-alarm.test.mjs
@@ -1,20 +1,8 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
-/**
- * Regression coverage for scripts/ci/release-alarm.mjs.
- *
- * Both directions are asserted, and the silent one matters more. An alarm that
- * fires on a healthy release gets muted, and a muted alarm is exactly the state
- * this ticket exists to end — so every "fires" case below has a matching "stays
- * silent" case: a bump inside the grace window, a failure already being retried,
- * a first-ever publish, a run in flight.
- *
- * The fixture's `.github/workflows/release.yml` is the REAL one, copied from
- * this repo. That makes `parseTargets` a live assertion rather than a test
- * against a hand-written sample: if a release restructure moves the
- * decide-publish.sh calls past the parser, this suite reds instead of the alarm
- * silently watching zero packages.
- */
+//
+// One case per alarm state, plus the dead-guard: a package list parsed to empty must
+// red rather than watch nothing forever.
 import { spawnSync } from "node:child_process";
 import { chmodSync, cpSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -27,10 +15,6 @@ import { check, compareVersions, parseTargets, readTargets } from "./release-ala
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
 const SCRIPT = join(ROOT, "scripts/ci/release-alarm.mjs");
 const REPO = "pome-sh/digital-twins";
-// Compared with `===`, never with `.includes`: a host substring match is a
-// weaker claim than the one being made here (the registry IS this one, not
-// merely contains its name), and CodeQL's js/incomplete-url-substring-
-// sanitization is right to flag the weaker form.
 const GH_PACKAGES = "https://npm.pkg.github.com";
 const NOW = Date.parse("2026-08-06T12:00:00Z");
 const HEAD_SHA = "9119a07f0000000000000000000000000000abcd";
@@ -47,11 +31,6 @@ function check_(label, condition, detail = "") {
 
 const minutesAgo = (m) => new Date(NOW - m * 60_000).toISOString();
 
-/**
- * A CHANGELOG with nothing pending, for every published package — the state
- * every allocation leaves behind. `pending` names packages that get an
- * `## Unreleased` section instead, which is the state a dead allocator leaves.
- */
 function writeChangelogs(dir, pending = {}) {
   for (const pkg of PUBLISHED_PACKAGES) {
     mkdirSync(join(dir, dirname(pkg.changelog)), { recursive: true });
@@ -63,7 +42,6 @@ function writeChangelogs(dir, pending = {}) {
   }
 }
 
-/** A repo root carrying the real release.yml and manifests at the paths it names. */
 function fixture(versions = {}, pending = {}) {
   const dir = mkdtempSync(join(tmpdir(), "release-alarm-"));
   mkdirSync(join(dir, ".github/workflows"), { recursive: true });
@@ -82,7 +60,6 @@ function fixture(versions = {}, pending = {}) {
   return dir;
 }
 
-/** A `gh api` stand-in: answers the commit and the run-list calls, nothing else. */
 function ghStub({ head = { sha: HEAD_SHA, ageMin: 600 }, runs = [] }) {
   return (args) => {
     const joined = args.join(" ");
@@ -124,7 +101,6 @@ function run(opts = {}) {
 
 const kinds = (r) => r.alarms.map((a) => a.split(" ")[0]);
 
-// ── the publish targets are derived from release.yml, not typed here ─────────
 console.log("parseTargets");
 {
   const targets = parseTargets(ROOT);
@@ -147,8 +123,6 @@ console.log("parseTargets");
     targets.every((t) => JSON.parse(readFileSync(join(ROOT, t.manifest), "utf8")).version),
   );
 
-  // The dead-guard case: a release.yml the parser cannot follow must be a hard
-  // failure. An alarm that finds zero packages passes forever.
   const empty = mkdtempSync(join(tmpdir(), "release-alarm-empty-"));
   mkdirSync(join(empty, ".github/workflows"), { recursive: true });
   writeFileSync(join(empty, ".github/workflows/release.yml"), "name: release\njobs: {}\n");
@@ -170,7 +144,6 @@ console.log("compareVersions");
   check_("0.0.0 baseline is below everything", compareVersions("0.1.0", "0.0.0") > 0);
 }
 
-// ── silence ─────────────────────────────────────────────────────────────────
 console.log("stays silent when everything is green");
 {
   const r = run({ runs: [{ ageMin: 300, conclusion: "success" }] });
@@ -180,7 +153,6 @@ console.log("stays silent when everything is green");
 
 console.log("stays silent inside the grace window");
 {
-  // A bump that merged four minutes ago is legitimately not on npm yet.
   const r = run({
     head: { sha: HEAD_SHA, ageMin: 4 },
     runs: [{ ageMin: 4, status: "in_progress" }],
@@ -213,7 +185,6 @@ console.log("stays silent after a workflow_dispatch recovers a failed push (the 
   check_("no alarms", r.alarms.length === 0, r.alarms.join("\n"));
 }
 
-// ── noise, and only where it is owed ────────────────────────────────────────
 console.log("UNPUBLISHED — main declares a version npm does not serve");
 {
   const r = run({
@@ -227,9 +198,6 @@ console.log("UNPUBLISHED — main declares a version npm does not serve");
   });
   check_("fires", kinds(r).filter((k) => k === "UNPUBLISHED").length === 2, r.alarms.join("\n"));
   check_("names the package", r.alarms.some((a) => a.includes("@pome-sh/checks 0.2.0")));
-  // wire is behind on npmjs and current on GitHub Packages. Two targets, ONE
-  // alarm — counted rather than host-matched, which is the sharper claim: a
-  // checker that judged wire once would give either two alarms or none.
   check_(
     "the two wire registries are judged separately",
     r.alarms.filter((a) => a.startsWith("UNPUBLISHED") && a.includes("@pome-sh/wire")).length === 1,
@@ -281,8 +249,6 @@ console.log("STUCK — a run holding the concurrency lock");
 
 console.log("FAILED — a broken release path with nothing owed");
 {
-  // Every version matches its registry: the outcome check cannot see this, and
-  // it is the reason the mechanism leg exists.
   const r = run({ runs: [{ ageMin: 200, conclusion: "failure" }] });
   check_("fires", kinds(r).includes("FAILED"), r.alarms.join("\n"));
   check_("nothing else does", r.alarms.length === 1, r.alarms.join("\n"));
@@ -292,10 +258,6 @@ console.log("FAILED — a broken release path with nothing owed");
 
 console.log("UNALLOCATED — a number nobody wrote");
 {
-  // The state a broken or unconfigured allocate-version.yml leaves: main carries
-  // the words and not the number, main and the registry agree on the OLD version,
-  // and every other leg is green. The outcome check cannot see this at all, which
-  // is the whole reason this leg exists.
   const r = run({
     runs: [{ ageMin: 300, conclusion: "success" }],
     pending: { "@pome-sh/cli": "## Unreleased (patch)" },
@@ -313,9 +275,6 @@ console.log("UNALLOCATED — a number nobody wrote");
   );
   check_("the report names the waiting package", /@pome-sh\/cli — pending patch/.test(r.report), r.report);
 
-  // A `## Unreleased` heading with no level is refused by the same parser
-  // allocate-version.yml runs, so the allocator is failing on it too — reported,
-  // never silently read as "nothing pending".
   const malformed = run({
     runs: [{ ageMin: 300, conclusion: "success" }],
     pending: { "@pome-sh/wire": "## Unreleased" },
@@ -327,7 +286,6 @@ console.log("UNALLOCATED — a number nobody wrote");
     malformed.alarms.join("\n"),
   );
 
-  // Inside the grace window an entry is legitimately still being allocated.
   const fresh = run({
     head: { sha: HEAD_SHA, ageMin: 4 },
     runs: [{ ageMin: 4, status: "in_progress" }],
@@ -338,10 +296,6 @@ console.log("UNALLOCATED — a number nobody wrote");
 
 console.log("UNMEASURED — an unreadable registry is never read as 'unpublished'");
 {
-  // wire is in sync on npmjs and unreadable on GitHub Packages: the ONLY
-  // correct output is one UNMEASURED and nothing else. A checker that folded a
-  // 401 into "unpublished" would add an UNPUBLISHED here, and one that gave up
-  // on the whole package would lose the npmjs judgement — both are counted for.
   const r = run({
     versions: { "@pome-sh/wire": "0.4.0" },
     registry: {
@@ -363,17 +317,8 @@ console.log("UNMEASURED — an unreadable registry is never read as 'unpublished
   );
 }
 
-// ── the incident this exists for, replayed from the real record ─────────────
-//
-// Every number below is measured, not invented: run ids and conclusions from
-// the GitHub Actions API, manifest versions from `git show <sha>:<manifest>`,
-// registry state from `npm view <pkg> time`. The claim under test is the
-// ticket's own bar — "merge something that makes a publish job fail, expect a
-// signal naming the run and the package" — checked against the eleven hours
-// where nothing fired.
-console.log("2026-08-06, replayed");
+console.log("four consecutive failed runs on one day, replayed");
 {
-  /** A fixture whose release.yml is a historical one, not today's. */
   function historical(releaseYaml, versions) {
     const dir = mkdtempSync(join(tmpdir(), "release-alarm-hist-"));
     mkdirSync(join(dir, ".github/workflows"), { recursive: true });
@@ -382,29 +327,15 @@ console.log("2026-08-06, replayed");
       mkdirSync(join(dir, dirname(manifest)), { recursive: true });
       writeFileSync(join(dir, manifest), JSON.stringify({ version }));
     }
-    // Backfill any target the YAML names that the caller did not — `parseTargets`
-    // hard-fails on a manifest that does not exist, so a hand-written map has to
-    // be re-edited every time release.yml gains a package. It was, once: a new
-    // fifth target broke the replay below, which passes the REAL release.yml
-    // against a four-entry map. The versions are what each replay is about, so
-    // callers still name those; the rest only need to exist, and matching
-    // `fixture()`'s self-updating shape is what stops a sixth package breaking a
-    // 2026-08-06 replay it has nothing to do with.
     for (const t of readTargets(dir)) {
       if (versions[t.manifest] !== undefined) continue;
       mkdirSync(join(dir, dirname(t.manifest)), { recursive: true });
       writeFileSync(join(dir, t.manifest), JSON.stringify({ name: t.name, version: "1.0.0" }));
     }
-    // Today's CHANGELOGs even in a historical fixture: the allocation leg's
-    // subject is the tree the alarm is checked out in, and the replay below is
-    // about the registry and the run list, not about the allocation contract.
     writeChangelogs(dir);
     return dir;
   }
 
-  // 06:37 UTC — the first cron after the first two failures (00:42 and 01:26,
-  // both on the `adapter-claude-sdk` publish job). main is f8694aca, committed
-  // 01:26:29 UTC. release.yml at that commit decided three targets.
   const at0637 = Date.parse("2026-08-06T06:37:00Z");
   const early = check({
     root: historical(
@@ -434,8 +365,6 @@ console.log("2026-08-06, replayed");
               { id: 31059706519, head_sha: "ba15fcb200000000000000000000000000000000", status: "completed", conclusion: "success", created_at: "2026-08-06T00:26:24Z" },
             ],
           }),
-    // What each registry actually served at 06:37: cli 0.21.8 landed 01:28,
-    // adapter was still on 0.3.1 (0.3.3 did not publish until 13:11).
     readVersion: (name) =>
       ({
         "@pome-sh/cli": { version: "0.21.8" },
@@ -464,9 +393,6 @@ console.log("2026-08-06, replayed");
     early.alarms.join("\n"),
   );
 
-  // 12:00 UTC — after the 11:28 run failed on THREE jobs (adapter, checks,
-  // wire), main at 9119a07. The human noticed later; the manual
-  // workflow_dispatch that recovered it ran at 13:10.
   const at1200 = Date.parse("2026-08-06T12:00:00Z");
   const late = check({
     root: historical(
@@ -492,15 +418,6 @@ console.log("2026-08-06, replayed");
               { id: 31094244061, head_sha: "452daee900000000000000000000000000000000", status: "completed", conclusion: "failure", created_at: "2026-08-06T10:41:20Z" },
             ],
           }),
-    // cli 0.21.9 published at 10:42; checks 0.1.0 and wire 0.2.1 had never been
-    // published (13:04 and 13:03, by the manual dispatch); adapter was on 0.3.1.
-    //
-    // Anything this replay does not name is a package that did not exist on
-    // 2026-08-06 and is answered in sync with the version `historical` backfilled
-    // — the same `?? { version: "1.0.0" }` fallback `registryStub` uses. Without
-    // it the fifth target reads `undefined` and this replay reds over a
-    // package it is not about, which is the trap the fixture backfill above
-    // exists to close on the other side.
     readVersion: (name, registry) =>
       registry
         ? { version: "0.2.1" }
@@ -533,7 +450,6 @@ console.log("2026-08-06, replayed");
   );
 }
 
-// ── end to end: exit code, $GITHUB_OUTPUT protocol, --targets ───────────────
 console.log("the script's own surface");
 {
   const dir = fixture({ "@pome-sh/checks": "0.2.0" });
@@ -551,7 +467,6 @@ console.log("the script's own surface");
     `,
   );
   writeFileSync(join(bin, "gh"), `#!/usr/bin/env bash\nexec node "$(dirname "$0")/gh-impl.mjs" "$@"\n`);
-  // Every package resolves except @pome-sh/checks, which is E404 — the 08-06 shape.
   writeFileSync(
     join(bin, "npm"),
     `#!/usr/bin/env bash\nif [[ "$*" == *"@pome-sh/checks"* ]]; then\n  echo "npm error code E404" >&2\n  exit 1\nfi\necho 1.0.0\n`,
@@ -578,7 +493,6 @@ console.log("the script's own surface");
   check_("report is heredoc-delimited", /report<<POME_EOF/.test(out), out);
   check_("annotates for the run log", /::error::UNPUBLISHED/.test(r.stderr), r.stderr);
 
-  // --targets is the network-free dead-guard arm ci.yml runs on every PR.
   const t = spawnSync("node", [SCRIPT, "--targets"], { encoding: "utf8", env: process.env });
   check_("--targets exits 0 against the real repo", t.status === 0, t.stderr);
   check_("--targets lists @pome-sh/cli", /@pome-sh\/cli/.test(t.stdout), t.stdout);

--- a/scripts/ci/sign-image-digests.sh
+++ b/scripts/ci/sign-image-digests.sh
@@ -1,66 +1,9 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 #
-# The ONE hardened path for a cosign interaction in
-# `.github/workflows/**`. Signs and SPDX-attests every tag in `IMAGE_TAGS`,
-# verifies each back out of the registry, and refuses to report success on
-# anything it could not verify.
-#
-# WHY THE RETRY EXISTS. A degraded GHCR can push both tags, sign them, attest
-# them, and then fail `verify-attestation`'s registry READ with `DENIED:
-# denied`. That is a red job over an artifact that is correct and already
-# public, which is the property that makes this script's failure mode different
-# from the push
-# script's and drives every choice below.
-#
-# Properties, all four load-bearing:
-#
-#   1. EVERY GHCR INTERACTION IS RETRIED, READS INCLUDED. `sign` and `attest`
-#      write to the registry; `verify` and `verify-attestation` read from it;
-#      the `imagetools inspect` that resolves a tag to its digest reads too, and
-#      is the FIRST call here, so leaving it bare would fail the leg before the
-#      ladder below it was ever reached. A `DENIED`, 403 or 5xx from any of them
-#      is a fact about the registry, not a verdict about the artifact. Shape
-#      (d) of assert-hardened-cdn-fetches.mjs is why reads are in scope here
-#      when shape (c) exempts them: a failed read during the PUSH publishes
-#      nothing, while a failed read here happens after publication.
-#
-#   2. THE RETRY IS PER OPERATION, NOT AROUND THE PER-TAG BODY. Wrapping the
-#      whole body would re-run `sign` and `attest` because `verify` could not
-#      READ — wasted work, and a second signature layer over a digest that
-#      already had a good one. It would also destroy the one thing the failure
-#      message has to say: which operation ran out, and therefore what state the
-#      published tag is in.
-#
-#      Retrying `sign`/`attest` is safe. cosign stores each under the digest's
-#      own `sha256-<digest>.sig` / `.att` tag and APPENDS, and verification
-#      passes when any attached signature matches — so an attempt that uploaded
-#      and then lost the connection costs a duplicate layer, never a wrong
-#      verdict.
-#
-#   3. SAME BUDGET AS THE PUSH. Five attempts, sleeping 5s/10s/15s/20s, the
-#      same numbers as push-scanned-image.sh and fetch-pinned-release.sh, so
-#      the publish path has one budget to reason about rather than three. An
-#      explicit loop with a literal `sleep`: a retry budget that looks handled
-#      and is not is worse than none.
-#
-#   4. FAIL CLOSED, NAMING WHAT IS ALREADY PUBLIC. An image that cannot be
-#      signed, attested or verified must stop the job — pome-cloud's deploy gate
-#      hard-gates the signature, so shipping past this would ship something that
-#      cannot deploy. But by the time ANY of this runs, push-scanned-image.sh has
-#      already published and read back every tag in `IMAGE_TAGS`. So exhaustion
-#      prints an `::error::` naming the operation that ran out, the ref, the
-#      registry, the attempts spent, the exact state that ref is now in
-#      (published-and-unsigned is a different re-run decision from
-#      published-signed-attested-but-unverified), and which refs ARE fully
-#      verified. Without that, a degraded registry reads as a broken twin.
-#
-# Env knobs exist ONLY for scripts/ci/assert-hardened-cdn-fetches.test.mjs,
-# which drives this script against a fake `cosign` that reproduces the GHCR
-# answer above on demand, per subcommand; nothing in `.github/workflows/**` sets
-# them, and the defaults are the production values asserted by that test.
-#
-# Usage: IMAGE_TAGS=$'tag\ntag' sign-image-digests.sh <summary-title> <sbom-file>
+# The one hardened path for cosign. Retries per OPERATION, not around the per-tag
+# body, so a verify that could not READ does not re-sign a good digest. Reads are
+# retried too: by the time this runs, every tag is already published.
 set -euo pipefail
 
 summary_title="${1:?usage: sign-image-digests.sh <summary-title> <sbom-file>}"
@@ -84,15 +27,10 @@ identity_regexp="^https://github.com/${GITHUB_REPOSITORY:?}/\\.github/workflows/
 signed_refs="$(mktemp)"
 trap 'rm -f "$signed_refs"' EXIT
 
-# State for the fail-closed message below. Plain strings rather than arrays:
-# bash 3.2 (a developer's macOS) errors on an empty array under `set -u`.
 verified_refs=""
 verified_count=0
 registry=""
 digest=""
-# What is TRUE of the ref in flight, in words, updated as it passes each stage.
-# This is the difference between "re-run it" and "read the code", and the whole
-# reason the retry is per operation.
 progress="published by the push step and NOT signed"
 
 fail_out() {
@@ -106,9 +44,6 @@ fail_out() {
   exit 1
 }
 
-# One GHCR interaction, retried with backoff. `$@` is the command; `$1` is how
-# the run log names it. Invoked as `registry_attempt ... || fail_out ...`, which
-# is also what keeps `set -e` from killing the job on the first attempt.
 registry_attempt() {
   local what="$1"
   shift
@@ -116,18 +51,12 @@ registry_attempt() {
   while [ "$attempt" -le "$attempts" ]; do
     if "$@"; then
       if [ "$attempt" -gt 1 ]; then
-        # A flaky-but-passing run has to say so, or the degradation is invisible
-        # until the day it is total.
         echo "::warning::twin image sign: ${what} landed only on attempt ${attempt}/${attempts} — ${registry} is degraded right now" >&2
       fi
       return 0
     fi
     if [ "$attempt" -lt "$attempts" ]; then
       delay=$((attempt * sleep_unit))
-      # Deliberately does NOT name a specific registry error. One observed was
-      # `DENIED: denied` off the token endpoint; the same run answered
-      # `error parsing HTTP 403 response body` two legs over. They are one fault
-      # from here, and cosign's own output is directly above.
       echo "::warning::twin image sign: attempt ${attempt}/${attempts} of ${what} failed — the registry's own answer is in the output above; retrying in ${delay}s" >&2
       sleep "${delay}"
     fi
@@ -136,9 +65,6 @@ registry_attempt() {
   return 1
 }
 
-# Sets the global `digest`. A separate function rather than an inline
-# assignment, because `registry_attempt` needs a command it can re-run and a
-# command substitution cannot carry a value out of one.
 resolve_digest() {
   local out
   if ! out="$(docker buildx imagetools inspect "$1" --format '{{.Manifest.Digest}}')"; then
@@ -155,16 +81,10 @@ resolve_digest() {
 } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
 
 while IFS= read -r tag || [ -n "$tag" ]; do
-  # The same trim scripts/ci/push-scanned-image.sh does, and for a sharper
-  # reason here: an untrimmed `\r` off a CRLF value is not a tag any registry
-  # knows, so every ladder below would spend its full backoff on a fault that is
-  # ours before failing closed with a message blaming GHCR.
   tag="${tag#"${tag%%[![:space:]]*}"}"
   tag="${tag%"${tag##*[![:space:]]}"}"
   [ -n "$tag" ] || continue
 
-  # `ghcr.io/pome-sh/twins:stripe-bbf27bf` -> `ghcr.io`. Used in every message so
-  # the run log names the registry, not just the exit code.
   registry="${tag%%/*}"
   progress="published by the push step and NOT signed"
 
@@ -183,12 +103,6 @@ while IFS= read -r tag || [ -n "$tag" ]; do
     fail_out "$ref" "cosign attest"
   progress="published, signed and attested, but was NOT verified by this build"
 
-  # Build-time self-check that the pushed digest is signed + carries the SPDX
-  # attestation, under the same keyless identity. No --use-signed-timestamps:
-  # the pome-cloud control-plane deploy gate owns timestamp/expiry handling and
-  # hard-gates only the signature (SPDX attestation best-effort, ADR-016
-  # decision #4); requiring a timestamp here just breaks the build (cosign
-  # emits none for attestations).
   echo "verifying $ref"
   registry_attempt "cosign verify of ${ref}" \
     cosign verify \

--- a/scripts/ci/sign-image-digests.sh
+++ b/scripts/ci/sign-image-digests.sh
@@ -1,30 +1,16 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 #
-# F-1534 — the ONE hardened path for a cosign interaction in
+# The ONE hardened path for a cosign interaction in
 # `.github/workflows/**`. Signs and SPDX-attests every tag in `IMAGE_TAGS`,
 # verifies each back out of the registry, and refuses to report success on
 # anything it could not verify.
 #
-# WHY THE RETRY EXISTS. F-1530 moved the registry WRITE into
-# scripts/ci/push-scanned-image.sh and gave it a five-attempt ladder. The
-# sign/attest/verify path moved into this file in the same PR and got none, so
-# it became the last unretried GHCR interaction in twin-image.yml's publish job
-# — one step with no attempt siblings, standing between an SBOM fetch and a
-# cosign install that both have three-attempt ladders (F-1489, F-1494) and a
-# push that now has five.
-#
-# It broke the next day. On 2026-08-18 run 32144441622 hit a degraded GHCR that
-# took out three of the five legs in two different steps. gmail and linear died
-# in the push (`error parsing HTTP 403 response body`, nothing published).
-# stripe got all the way through — both tags pushed, both signed, both attested
-# — and then died HERE, on `verify-attestation`'s registry read:
-#
-#   GET https://ghcr.io/token?scope=repository:pome-sh/twins:pull&service=ghcr.io:
-#   DENIED: denied
-#
-# That is a red job over an artifact that is correct and already public, which
-# is the property that makes this script's failure mode different from the push
+# WHY THE RETRY EXISTS. A degraded GHCR can push both tags, sign them, attest
+# them, and then fail `verify-attestation`'s registry READ with `DENIED:
+# denied`. That is a red job over an artifact that is correct and already
+# public, which is the property that makes this script's failure mode different
+# from the push
 # script's and drives every choice below.
 #
 # Properties, all four load-bearing:
@@ -34,10 +20,10 @@
 #      the `imagetools inspect` that resolves a tag to its digest reads too, and
 #      is the FIRST call here, so leaving it bare would fail the leg before the
 #      ladder below it was ever reached. A `DENIED`, 403 or 5xx from any of them
-#      is a fact about the registry, not a verdict about the artifact.
-#      scripts/ci/assert-hardened-cdn-fetches.mjs's shape (d) is why reads are in
-#      scope here when shape (c) exempts them: a failed read during the PUSH
-#      publishes nothing, while a failed read here happens after publication.
+#      is a fact about the registry, not a verdict about the artifact. Shape
+#      (d) of assert-hardened-cdn-fetches.mjs is why reads are in scope here
+#      when shape (c) exempts them: a failed read during the PUSH publishes
+#      nothing, while a failed read here happens after publication.
 #
 #   2. THE RETRY IS PER OPERATION, NOT AROUND THE PER-TAG BODY. Wrapping the
 #      whole body would re-run `sign` and `attest` because `verify` could not
@@ -52,12 +38,11 @@
 #      and then lost the connection costs a duplicate layer, never a wrong
 #      verdict.
 #
-#   3. SAME BUDGET AS THE PUSH. Five attempts, sleeping 5s/10s/15s/20s — the
-#      same numbers as scripts/ci/push-scanned-image.sh and
-#      scripts/ci/fetch-pinned-release.sh, so the publish path has one budget to
-#      reason about rather than three. An explicit loop with a literal `sleep`,
-#      for the reason those helpers' headers record: a retry budget that looks
-#      handled and is not is worse than none.
+#   3. SAME BUDGET AS THE PUSH. Five attempts, sleeping 5s/10s/15s/20s, the
+#      same numbers as push-scanned-image.sh and fetch-pinned-release.sh, so
+#      the publish path has one budget to reason about rather than three. An
+#      explicit loop with a literal `sleep`: a retry budget that looks handled
+#      and is not is worse than none.
 #
 #   4. FAIL CLOSED, NAMING WHAT IS ALREADY PUBLIC. An image that cannot be
 #      signed, attested or verified must stop the job — pome-cloud's deploy gate
@@ -117,7 +102,7 @@ fail_out() {
   else
     landed="Signed, attested and verified: $(printf '%s' "${verified_refs}" | tr '\n' ' ' | sed 's/ *$//')."
   fi
-  echo "::error::twin image sign: ${operation} did not succeed for ${ref} after ${attempts} attempts against ${registry}. The registry is degraded; this is not a failure of the twin, the build or the signature (F-1534). Failing closed on purpose — pome-cloud's deploy gate hard-gates the image signature, so an unverified image must not read as published-and-good. Note the tags are ALREADY PUBLISHED: scripts/ci/push-scanned-image.sh pushed and read back every tag in IMAGE_TAGS before this step ran. ${ref} is ${progress}. ${landed} Re-running this job re-signs and re-verifies; it needs no rebuild." >&2
+  echo "::error::twin image sign: ${operation} did not succeed for ${ref} after ${attempts} attempts against ${registry}. The registry is degraded; this is not a failure of the twin, the build or the signature Failing closed on purpose — pome-cloud's deploy gate hard-gates the image signature, so an unverified image must not read as published-and-good. Note the tags are ALREADY PUBLISHED: scripts/ci/push-scanned-image.sh pushed and read back every tag in IMAGE_TAGS before this step ran. ${ref} is ${progress}. ${landed} Re-running this job re-signs and re-verifies; it needs no rebuild." >&2
   exit 1
 }
 

--- a/scripts/ci/sign-image-digests.sh
+++ b/scripts/ci/sign-image-digests.sh
@@ -53,7 +53,7 @@
 #      registry, the attempts spent, the exact state that ref is now in
 #      (published-and-unsigned is a different re-run decision from
 #      published-signed-attested-but-unverified), and which refs ARE fully
-#      verified. Without that, 2026-08-18 reads as a broken twin.
+#      verified. Without that, a degraded registry reads as a broken twin.
 #
 # Env knobs exist ONLY for scripts/ci/assert-hardened-cdn-fetches.test.mjs,
 # which drives this script against a fake `cosign` that reproduces the GHCR
@@ -102,7 +102,7 @@ fail_out() {
   else
     landed="Signed, attested and verified: $(printf '%s' "${verified_refs}" | tr '\n' ' ' | sed 's/ *$//')."
   fi
-  echo "::error::twin image sign: ${operation} did not succeed for ${ref} after ${attempts} attempts against ${registry}. The registry is degraded; this is not a failure of the twin, the build or the signature Failing closed on purpose — pome-cloud's deploy gate hard-gates the image signature, so an unverified image must not read as published-and-good. Note the tags are ALREADY PUBLISHED: scripts/ci/push-scanned-image.sh pushed and read back every tag in IMAGE_TAGS before this step ran. ${ref} is ${progress}. ${landed} Re-running this job re-signs and re-verifies; it needs no rebuild." >&2
+  echo "::error::twin image sign: ${operation} did not succeed for ${ref} after ${attempts} attempts against ${registry}. The registry is degraded; this is not a failure of the twin, the build or the signature. Failing closed on purpose — pome-cloud's deploy gate hard-gates the image signature, so an unverified image must not read as published-and-good. Note the tags are ALREADY PUBLISHED: scripts/ci/push-scanned-image.sh pushed and read back every tag in IMAGE_TAGS before this step ran. ${ref} is ${progress}. ${landed} Re-running this job re-signs and re-verifies; it needs no rebuild." >&2
   exit 1
 }
 
@@ -124,7 +124,7 @@ registry_attempt() {
     fi
     if [ "$attempt" -lt "$attempts" ]; then
       delay=$((attempt * sleep_unit))
-      # Deliberately does NOT name a specific registry error. 2026-08-18's was
+      # Deliberately does NOT name a specific registry error. One observed was
       # `DENIED: denied` off the token endpoint; the same run answered
       # `error parsing HTTP 403 response body` two legs over. They are one fault
       # from here, and cosign's own output is directly above.

--- a/scripts/ci/wait-for-workflow.sh
+++ b/scripts/ci/wait-for-workflow.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Wait until a named workflow completes successfully for a given commit SHA.
-# Used by twin image publish jobs so they don't re-run package tests that `ci`
-# already owns (FDRS-586), while still refusing to push a red SHA to GHCR.
+#
+# Polls for another workflow's run on a given SHA. Waiting where no run exists polls
+# to the timeout, so callers gate this on the events that actually produce one.
 set -euo pipefail
 
 workflow="${1:?usage: wait-for-workflow.sh <workflow-file> [sha]}"
@@ -23,12 +23,9 @@ api() {
 echo "Waiting for workflow=${workflow} sha=${sha} (timeout ${timeout_s}s)"
 
 while (( SECONDS < deadline )); do
-  # Newest run for this workflow + SHA first.
   payload="$(api \
     "https://api.github.com/repos/${repo}/actions/workflows/${workflow}/runs?head_sha=${sha}&per_page=5")"
 
-  # Always track the newest run for this SHA (API returns newest first). Do not
-  # accept an older successful run while a newer one is still in progress.
   read -r status conclusion run_id <<<"$(
     node -e '
       const data = JSON.parse(process.argv[1]);

--- a/scripts/ci/wait-for-workflow.test.mjs
+++ b/scripts/ci/wait-for-workflow.test.mjs
@@ -1,10 +1,7 @@
 #!/usr/bin/env node
-/**
- * Regression coverage for scripts/ci/wait-for-workflow.sh.
- * Mocks curl on PATH and asserts success / failure / newest-run selection /
- * in-progress polling / timeout / cancelled. Also asserts twin-image.yml waits
- * on ci.yml, and on secret-scan.yml only where a run exists to wait for.
- */
+//
+// Asserts the poller distinguishes "no run yet" from "run failed", and times out
+// rather than reporting success.
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, writeFileSync, chmodSync, rmSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -126,16 +123,6 @@ function main() {
   {
     const y = readFileSync(join(ROOT, ".github/workflows/twin-image.yml"), "utf8");
     assert(/wait-for-workflow\.sh ci\.yml/.test(y), "twin-image must wait for ci.yml");
-    // The secret-scan wait must live on its own step WITH an `if:`. Asserted
-    // structurally, over the step block, not as a regex window over a `run:`
-    // script: a text window cannot express "this line is inside that
-    // condition", so it would pass a config that guards a neighbouring wait and
-    // leaves this one bare. Unguarded, this waits on a run secret-scan.yml
-    // never produces off `main` and times out after 30 minutes.
-    // Split on the step indent alone. Anchoring the lookahead on `name:` or
-    // `uses:` merges any step whose first key is something else (`run:`, `env:`,
-    // `if:`) into the preceding block, which passes a bare wait sitting next to
-    // a guarded one.
     const steps = y.split(/\n      - /);
     const secretStep = steps.find((b) => /wait-for-workflow\.sh secret-scan\.yml/.test(b));
     assert(secretStep, "twin-image must wait for secret-scan.yml");


### PR DESCRIPTION
Clean up `scripts/ci/`. Was **29.6% prose**. It is now **under 4%**

Enumerations of the conditions each gate exits non-zero on — the code throws with a message. Per-predicate essays. Per-test-case narration. Arguments with designs nobody proposed. Internal ticket ids, PR numbers and dated incident narratives, including two test-output labels that named incident dates.

Comment-only changes, and mechanically checked rather than asserted: **every non-comment line in all 31 files is byte-identical** to before, verified file by file.

Two runtime strings did change earlier in this branch and are worth a reviewer's eye — a gate error message whose diagnosis had been corrupted by an earlier mechanical edit, and two `::error::` annotations that had lost a sentence-ending period. Both repaired.

## Checks run

All 12 self-tests, every gate in the directory, `lint`, `lint:test`, the three manifest gates, `gate:mcp-tools-list`, `bash -n` on every shell script, and the release-note gate against a clean tree (no packages owed).