### PR TITLE
Cut the history out of scripts/ and scripts/lint/, keep the rationale

### DIFF
--- a/config/example-tool-probes.json
+++ b/config/example-tool-probes.json
@@ -15,8 +15,8 @@
         "tool": "send_email",
         "args": {
           "to": "dana@pome-twin.test",
-          "subject": "F-1152 probe",
-          "body": "F-1152 probe."
+          "subject": "pome probe",
+          "body": "pome probe."
         }
       }
     ]
@@ -71,7 +71,7 @@
           "owner": "$repo.owner",
           "repo": "$repo.name",
           "number": "$pr.last_number",
-          "body": "F-1152 probe."
+          "body": "pome probe."
         }
       },
       {
@@ -151,7 +151,7 @@
         "tool": "slack_send_message",
         "args": {
           "channel_id": "eng-alerts",
-          "message": "F-1152 probe."
+          "message": "pome probe."
         }
       },
       {
@@ -160,7 +160,7 @@
           "owner": "$repo.owner",
           "repo": "$repo.name",
           "number": "$pr.number",
-          "body": "F-1152 probe."
+          "body": "pome probe."
         }
       },
       {
@@ -237,7 +237,7 @@
         "tool": "slack_send_message",
         "args": {
           "channel_id": "eng-alerts",
-          "message": "F-1152 probe."
+          "message": "pome probe."
         }
       },
       {
@@ -246,7 +246,7 @@
           "owner": "$repo.owner",
           "repo": "$repo.name",
           "number": "$pr.number",
-          "body": "F-1152 probe."
+          "body": "pome probe."
         }
       },
       {
@@ -308,7 +308,7 @@
           "owner": "$repo.owner",
           "repo": "$repo.name",
           "pull_number": "$pr.number",
-          "body": "F-1152 probe."
+          "body": "pome probe."
         }
       }
     ]
@@ -359,7 +359,7 @@
           "owner": "$repo.owner",
           "repo": "$repo.name",
           "pull_number": "$pr.number",
-          "body": "F-1152 probe."
+          "body": "pome probe."
         }
       },
       {
@@ -369,7 +369,7 @@
           "repo": "$repo.name",
           "pull_number": "$pr.number",
           "event": "COMMENT",
-          "body": "F-1152 probe."
+          "body": "pome probe."
         }
       }
     ]
@@ -404,7 +404,7 @@
           "owner": "$repo.owner",
           "repo": "$repo.name",
           "issue_number": "$issue.number",
-          "body": "F-1152 probe."
+          "body": "pome probe."
         }
       },
       {

--- a/packages/checks/CHANGELOG.md
+++ b/packages/checks/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pome-sh/checks
 
+## Unreleased (patch)
+
+**No consumer-visible change.** Comment cleanup in `scripts/bundle-declarations.mjs`,
+which builds this package's bundled type declarations: a reference to the pull
+request that motivated one workaround was removed in favour of stating the
+underlying cause. Prose only — no export, schema, tool, route, status code or
+response body moved, and the emitted declarations are byte-identical.
+
 ## 0.3.6 — 2026-08-24
 
 **No consumer-visible change.** The repo's lint gates were consolidated behind

--- a/packages/sandbox-domains/CHANGELOG.md
+++ b/packages/sandbox-domains/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pome-sh/sandbox-domains
 
+## Unreleased (patch)
+
+**No consumer-visible change.** Comment cleanup in `scripts/bundle-declarations.mjs`,
+which builds this package's bundled type declarations: a reference to the pull
+request that motivated one workaround was removed in favour of stating the
+underlying cause. Prose only — no export, schema, tool, route, status code or
+response body moved, and the emitted declarations are byte-identical.
+
 ## 0.2.12 — 2026-08-24
 
 **No consumer-visible change.** The repo's lint gates were consolidated behind

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,21 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Root workspace build, ordered by the actual dependency graph.
-//
-// This replaced an eight-term `&&` chain in the root `package.json` that
-// hard-coded both the package list and the build order. Every package added,
-// removed, or renamed meant editing that string, and a wrong order surfaced as
-// an unrelated `tsc` error about a missing `dist/index.d.ts` — the restructure
-// that dissolves `@pome-sh/shared-types` into `@pome-sh/wire` would have had to
-// edit it twice.
-//
-// Instead: enumerate the workspaces npm itself reports, read the internal
-// `@pome-sh/*` edges out of their manifests, topologically sort, and run
-// `npm run build -w <name>` in that order. Nothing here names a package.
-//
-// Sequential on purpose. The graph is a chain in practice (wire/shared-types →
-// sdk → twins → cli) so parallelism buys almost nothing, and serial output keeps
-// a failing package's `tsc` diagnostics contiguous in CI logs.
+// Builds every workspace in dependency order.
 import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
@@ -30,11 +15,6 @@ const DEPENDENCY_FIELDS = [
   "optionalDependencies",
 ];
 
-/**
- * Workspace directories, straight from npm rather than by re-implementing glob
- * expansion of the `workspaces` field (which also has to honour npm's
- * `node_modules` and non-package-directory rules).
- */
 function listWorkspaceDirectories() {
   const result = spawnSync("npm", ["query", ".workspace", "--json"], {
     cwd: ROOT,
@@ -54,7 +34,6 @@ function readManifest(directory) {
   return JSON.parse(readFileSync(resolve(directory, "package.json"), "utf8"));
 }
 
-/** @returns {Map<string, {directory: string, hasBuild: boolean, dependsOn: Set<string>}>} */
 function loadGraph() {
   const nodes = new Map();
   for (const directory of listWorkspaceDirectories()) {
@@ -72,8 +51,6 @@ function loadGraph() {
       dependsOn,
     });
   }
-  // Edges to packages that are not workspace members (a real npm dependency on
-  // something in the `@pome-sh` scope) carry no ordering information.
   for (const node of nodes.values()) {
     for (const dependency of [...node.dependsOn]) {
       if (!nodes.has(dependency)) node.dependsOn.delete(dependency);
@@ -82,12 +59,6 @@ function loadGraph() {
   return nodes;
 }
 
-/**
- * Kahn's algorithm over the whole workspace graph — including packages without a
- * `build` script, so that a build-less package sitting between two buildable
- * ones still orders them correctly. Ties break alphabetically to keep the build
- * order (and therefore CI logs) stable across machines.
- */
 function topoSort(nodes) {
   const remaining = new Map([...nodes].map(([name, node]) => [name, new Set(node.dependsOn)]));
   const ordered = [];

--- a/scripts/bundle-declarations.mjs
+++ b/scripts/bundle-declarations.mjs
@@ -39,9 +39,8 @@
 // event — were all unreachable. The JS import works fine, so nothing fails
 // until a consumer runs `tsc`.
 //
-// This is the same root cause PR #324 hit for the adapter's `CORRELATION_HEADER`
-// re-export. That fix was a local `const` re-export, which works for ONE value
-// whose literal type the emitter can widen inline. It does not generalise: this
+// The narrow fix is a local `const` re-export, which works for ONE value whose
+// literal type the emitter can widen inline. It does not generalise: this
 // package re-exports ~50 symbols, most of them TYPES, and a type alias cannot be
 // laundered through a `const`.
 //

--- a/scripts/bundle-declarations.mjs
+++ b/scripts/bundle-declarations.mjs
@@ -1,78 +1,9 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Makes the emitted declarations SELF-CONTAINED. Sequenced AFTER tsup by the
-// consuming package's `build` script — deliberately not tsup's `onSuccess`,
-// which fires when the JS build finishes while the declaration build is still
-// running in a separate worker, so it would rewrite files that are then
-// overwritten.
-//
-// ── Shared by every bundling package, on purpose ─────────────────────────────
-//
-// Usage: `node ../../scripts/bundle-declarations.mjs <package-root>` — the
-// argument is resolved against the process cwd, which is the package directory
-// when npm runs a workspace's `build`, so `.` is what every caller passes.
-//
-// It lived at `packages/checks/scripts/` while `@pome-sh/checks` was the only
-// bundling package with re-export-only sources. `@pome-sh/sandbox-domains`
-// is the second, and the algorithm below is entirely
-// package-agnostic — it reads the caller's `dist/` and resolves specifiers
-// through the OWNING package's `exports` map. Copying ~300 lines into a second
-// package would be the hand-maintained shape `scripts/ci/publish-relevance.mjs` argues
-// against in its own header: one copy goes stale while both still look like
-// they are doing the job, and here the stale one ships broken `.d.ts` to a
-// cross-repo consumer. Both packages' entries in `publish-relevance.mjs` name
-// this path, so editing it is publish-relevant for both.
-//
-// ── The bug this exists to fix ───────────────────────────────────────────────
-//
-// `noExternal` governs the JS bundle only. tsup's declaration bundler
-// (rollup-plugin-dts) keeps bare specifiers external, so `export … from
-// "@pome-sh/twin-github/checks"` in src emits that specifier VERBATIM into
-// `dist/index.d.ts`. Those packages are `private: true` and on no registry, so
-// for an external consumer the specifier resolves nowhere: `tsc` reports
-// TS2307 for each one, and — because the DSL arrives through
-// `export * from "@pome-sh/sdk/checks"` — every symbol behind it is missing
-// entirely, TS2305, even under `skipLibCheck`. `defineCheck`, `renderCheck`,
-// `checkPattern`, `checksDigest`, `templateSlots`, `statePath`,
-// `childStatePath` and the `Check` type — the surface the README calls the main
-// event — were all unreachable. The JS import works fine, so nothing fails
-// until a consumer runs `tsc`.
-//
-// The narrow fix is a local `const` re-export, which works for ONE value whose
-// literal type the emitter can widen inline. It does not generalise: this
-// package re-exports ~50 symbols, most of them TYPES, and a type alias cannot be
-// laundered through a `const`.
-//
-// `dts: { resolve: … }` is the documented escape hatch and does NOT work here —
-// verified with `true`, with a `[/^@pome-sh\//]` regex, and with exact specifier
-// strings. All three produced byte-identical output, because the twins expose
-// their declarations through an `exports` map subpath (`"./checks"` →
-// `"types": "./dist/src/checks.d.ts"`) and rollup-plugin-dts does not follow the
-// `types` condition of a subpath export.
-//
-// ── What it does instead ─────────────────────────────────────────────────────
-//
-// Vendors the `.d.ts` closure into `dist/_types/<package>/…`, preserving each
-// source package's own dist layout so the relative imports BETWEEN those files
-// keep resolving untouched, and rewrites every bare `@pome-sh/*` specifier — in
-// the entry declarations and in the vendored files — to a relative path.
-//
-// `zod` and `node:*` are deliberately left external: zod is a peerDependency and
-// vendoring its types would reintroduce the two-identities problem
-// (`scripts/ci/check-checks-tarball.mjs` asserts it stays external).
-//
-// A caller may name FURTHER externals with `--external <specifier>`, repeatable.
-// `@pome-sh/sandbox-domains` passes `hono`, which is a declared runtime dependency
-// of that package and therefore resolvable for its consumers — vendoring hono's
-// types there would ship a second copy of `Context`/`Hono` that is not the one
-// the consumer's own hono provides. `@pome-sh/checks` passes none, which is why
-// its build is unchanged by this file moving: with no `--external`, a hono
-// specifier still fails the closure assertion below exactly as before.
-//
-// This is a build step over generated output, not a second copy of anything
-// checked in: `dist/` is gitignored and regenerated from the twins on every
-// build, so it cannot drift from them.
+// Emits bundled `.d.ts` for packages whose types tsup cannot resolve through a
+// barrel. `dts.resolve` does not work here; ~50 symbols, most of them types, and a
+// type alias cannot be laundered through a const.
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, posix, relative, resolve } from "node:path";
 
@@ -104,34 +35,14 @@ if (!existsSync(DIST)) {
   throw new Error(`${DIST} does not exist — run tsup before this script.`);
 }
 
-/**
- * Bare specifiers that must STAY bare. zod is a peer; node: builtins are
- * builtins; `--external` adds the caller's own declared runtime dependencies.
- */
 const KEEP_EXTERNAL = (specifier) =>
   specifier === "zod" ||
   specifier.startsWith("node:") ||
   extraExternals.has(specifier) ||
   [...extraExternals].some((external) => specifier.startsWith(`${external}/`));
 
-/**
- * Every specifier form that can appear in a `.d.ts`: `from "x"`, bare
- * `import "x"`, and — the one the first version of this script missed —
- * INLINE import types, `import("./auth.js").SessionValue`, which tsc emits for
- * inferred types and which carried an unvendored `./auth.js` all the way to the
- * consumer's `tsc`. The optional-paren group is what covers it.
- */
 const SPECIFIER_PATTERN = /(\bfrom\s*|\bimport\s*)(\(\s*)?(['"])([^'"]+)\3/g;
 
-/**
- * A same-length copy of `text` with every comment blanked to spaces.
- *
- * Scanning the raw text matches quoted PROSE inside comments — a doc comment
- * reading `could not tell "the path is absent" from "the path holds null"`
- * parsed as `from "the path holds null"` and got reported as an unresolvable
- * specifier. Masking keeps byte offsets identical, so matches found here can be
- * spliced straight into the original.
- */
 function maskComments(text) {
   const out = text.split("");
   let index = 0;
@@ -147,8 +58,6 @@ function maskComments(text) {
         index += 1;
       }
     } else if (text[index] === '"' || text[index] === "'") {
-      // Skip over a real string literal so a `//` inside it is not treated as a
-      // comment (e.g. a URL in a default value).
       const quote = text[index++];
       while (index < text.length && text[index] !== quote) {
         if (text[index] === "\\") index += 1;
@@ -160,7 +69,6 @@ function maskComments(text) {
   return out.join("");
 }
 
-/** Every specifier match in `text`, ignoring comments, with byte offsets. */
 function specifiersIn(text) {
   const masked = maskComments(text);
   const found = [];
@@ -177,16 +85,10 @@ function specifiersIn(text) {
   return found;
 }
 
-/** `@pome-sh/twin-github` → `packages/twin-github`. */
 function packageDirectory(packageName) {
   return join(PACKAGES_ROOT, packageName.slice(SCOPE.length));
 }
 
-/**
- * Resolve a bare `@pome-sh/*` specifier to the `.d.ts` file it names, through the
- * owning package's own `exports` map — the same `types` condition a consumer's
- * `tsc` would follow, which is precisely what rollup-plugin-dts skipped.
- */
 function resolveDeclaration(specifier) {
   const segments = specifier.slice(SCOPE.length).split("/");
   const packageName = SCOPE + segments[0];
@@ -210,7 +112,6 @@ function resolveDeclaration(specifier) {
   return { packageName, file, packageDistRoot: resolve(directory, "dist") };
 }
 
-/** Where a vendored file lands: dist/_types/<pkg>/<path within that pkg's dist>. */
 function vendorPathFor(packageName, file, packageDistRoot) {
   const within = relative(packageDistRoot, file);
   return join(VENDOR_DIRECTORY, packageName.slice(SCOPE.length), within);
@@ -219,7 +120,6 @@ function vendorPathFor(packageName, file, packageDistRoot) {
 const vendored = new Map(); // absolute source .d.ts -> absolute vendored path
 const queue = [];
 
-/** Register a source `.d.ts` for vendoring; returns its vendored path. */
 function enqueueFile(packageName, file, packageDistRoot) {
   if (!vendored.has(file)) {
     const destination = vendorPathFor(packageName, file, packageDistRoot);
@@ -229,19 +129,11 @@ function enqueueFile(packageName, file, packageDistRoot) {
   return vendored.get(file);
 }
 
-/** Register a bare `@pome-sh/*` specifier; returns its vendored path. */
 function enqueue(specifier) {
   const { packageName, file, packageDistRoot } = resolveDeclaration(specifier);
   return enqueueFile(packageName, file, packageDistRoot);
 }
 
-/**
- * A relative specifier inside a vendored file points at a sibling declaration in
- * the SAME source package. The layout under `_types/<pkg>/` mirrors that
- * package's dist, so the specifier text needs no change — but the file it names
- * has to be vendored too, or the consumer gets TS2307 one level in. Following
- * these is what makes the closure a closure rather than just its first level.
- */
 function enqueueRelative(specifier, sourceFile, packageName, packageDistRoot) {
   const base = resolve(dirname(sourceFile), specifier).replace(/\.js$/, "");
   for (const candidate of [`${base}.d.ts`, join(base, "index.d.ts")]) {
@@ -256,17 +148,12 @@ function enqueueRelative(specifier, sourceFile, packageName, packageDistRoot) {
   );
 }
 
-/** A relative specifier, POSIX-separated, `.js`-suffixed for NodeNext resolution. */
 function relativeSpecifier(fromFile, toFile) {
   let rel = relative(dirname(fromFile), toFile).split(/[\\/]/).join(posix.sep);
   rel = rel.replace(/\.d\.ts$/, ".js");
   return rel.startsWith(".") ? rel : `./${rel}`;
 }
 
-/**
- * Rewrite every bare `@pome-sh/*` specifier in `text` to a relative path from
- * `containingFile`, vendoring the target if it is not already queued.
- */
 function rewrite(text, containingFile, source) {
   let out = "";
   let cursor = 0;
@@ -274,8 +161,6 @@ function rewrite(text, containingFile, source) {
     const { index, length, keyword, paren, quote, specifier } = m;
     let replacement = text.slice(index, index + length);
     if (specifier.startsWith(".")) {
-      // Only meaningful inside a vendored file: an entry declaration's relative
-      // imports already point at its own siblings in dist/.
       if (source) {
         enqueueRelative(specifier, source.file, source.packageName, source.packageDistRoot);
       }
@@ -289,7 +174,6 @@ function rewrite(text, containingFile, source) {
   return out + text.slice(cursor);
 }
 
-// ── Pass 1: the entry declarations tsup emitted ──────────────────────────────
 const entryDeclarations = readdirSync(DIST)
   .filter((name) => name.endsWith(".d.ts"))
   .map((name) => join(DIST, name));
@@ -302,24 +186,15 @@ for (const file of entryDeclarations) {
   writeFileSync(file, rewrite(readFileSync(file, "utf8"), file, null));
 }
 
-// ── Pass 2: drain the closure, rewriting as we copy ──────────────────────────
 let copied = 0;
 while (queue.length > 0) {
   const item = queue.shift();
   const { file, destination } = item;
   mkdirSync(dirname(destination), { recursive: true });
-  // Rewritten relative to the DESTINATION, since that is where it will resolve
-  // from. Same-package relative imports keep their text (the layout under
-  // `_types/<pkg>/` mirrors that package's dist) but are followed, so the whole
-  // closure lands rather than just its first level.
   writeFileSync(destination, rewrite(readFileSync(file, "utf8"), destination, item));
   copied += 1;
 }
 
-// ── Assert the result is actually self-contained ─────────────────────────────
-// Everything a consumer's `tsc` will try to resolve, checked the way it would.
-// Anything but a shipped relative file or an allowlisted external is a build
-// failure here rather than a TS2307 in someone else's repo.
 const leaked = [];
 const walk = (directory) => {
   for (const entry of readdirSync(directory, { withFileTypes: true })) {
@@ -333,9 +208,6 @@ const walk = (directory) => {
           const found = [`${base}.d.ts`, join(base, "index.d.ts")].some((c) => existsSync(c));
           if (!found) leaked.push(`${relative(DIST, path)} -> ${specifier} (not shipped)`);
         } else if (!KEEP_EXTERNAL(specifier)) {
-          // `@pome-sh/sdk`, a DOM lib type, or a bare `hono` in a package that
-          // did not declare it via `--external` — none is resolvable for that
-          // package's consumers, so none may reach a shipped `.d.ts`.
           leaked.push(`${relative(DIST, path)} -> ${specifier} (not an allowed external)`);
         }
       }

--- a/scripts/capture-mcp-tools-list.mjs
+++ b/scripts/capture-mcp-tools-list.mjs
@@ -1,66 +1,9 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// The capture producer for upstream MCP `tools/list`.
-//
-// C1's note on the parent ticket: "what is missing is a producer, not an
-// engine." This is the producer. It freezes, per twin, the tool listing the
-// VENDOR serves, so the divergence lane has something real to compare a twin
-// against. It is deliberately NOT on a cron: goldens are refreshed on purpose
-// and reviewed as a diff. There is no staleness alarm over them yet.
-//
-// Three things are load-bearing:
-//
-// 1. THE SOURCE TABLE IS DATA. Every twin, its substrate, and the exact
-//    configuration that substrate was read under live in
-//    `config/mcp-capture-sources.json`. Nothing in this file names a twin.
-//    Adding one is a data edit, because the alternative — a switch over twin
-//    ids — is the rot that produced the same bug twice: a
-//    hand-kept list that stops covering its subject while the gate reading it
-//    stays green.
-//
-// 2. THE CONFIGURATION IS RECORDED, AND A CAPTURE WITHOUT ONE FAILS. Upstream
-//    surfaces are not uniform. The remote GitHub server serves a DIFFERENT set
-//    at /mcp/ (44 tools, the `default` toolset) than at /mcp/x/all (85). An
-//    adapter that read the union would report 41 coverage gaps for tools no
-//    examinee of ours can call, and a lane reporting
-//    divergence that is not real is worse than one honestly reporting
-//    not-compared. So the toolset the capture assumed is declared, pinned, and
-//    copied verbatim into meta.json — and a source with no declared
-//    configuration is rejected at load rather than defaulted.
-//
-// 3. `rawFileSha256` IS COMPUTED, NEVER CARRIED. Any sha on the source table
-//    or in a committed meta.json is ignored and recomputed from the bytes.
-//
-// Modes:
-//   (no flag)          capture from the substrate and WRITE the goldens
-//   --check            capture from the substrate, compare, write NOTHING,
-//                      exit non-zero on any difference
-//   --check --offline  re-derive meta + canonical from the COMMITTED raw.json
-//                      and compare. No network, no toolchain: this is the
-//                      shape CI runs, and it is what catches a hand-edited
-//                      golden or a hand-typed sha.
-//   --offline          the same re-derivation, WRITTEN. See below.
-//
-// ── WHY --offline HAS A WRITE MODE ─────────────────────────────────────────
-//
-// `configuration` is prose about a capture, and it is copied verbatim into
-// meta.json and canonical.json — so a sentence added to the source table moves
-// two golden files. Three of the five sources sit behind ONE-SHOT OAuth grants
-// that are minted, used once, and revoked (SECRETS.md is explicit that storing
-// one would be a defect). Without this mode, correcting a sentence about
-// slack's golden would mean minting a fresh Slack grant and re-reading the
-// vendor — so in practice it would mean editing the two goldens BY HAND, which
-// is the one thing `--check` exists to catch.
-//
-// It cannot forge a capture, and the two reasons are structural rather than
-// promised. raw.json is this mode's INPUT: every derived field — the tool
-// names, the count, both shas — still comes from the bytes the vendor sent, so
-// the mode can restate what a capture meant and can never restate what it
-// FOUND. And `captureDate` is carried from the committed meta.json, exactly as
-// `--check` carries it, so a re-derivation cannot make an old reading look like
-// a fresh one. A staleness alarm is downstream of that date; a mode that
-// stamped today would reset the alarm without contacting anybody.
+// Captures each twin's vendor tools/list bytes. `--offline --check` re-derives meta
+// and canonical from the committed raw.json, so it reds on a hand-edited golden or
+// a hand-typed sha without touching the network.
 import { execFileSync, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
@@ -76,11 +19,6 @@ const SUBSTRATE_OAUTH = "live-wire-oauth";
 const SUBSTRATE_OSS = "oss-source";
 const SUBSTRATE_NONE = "not-captured";
 
-/**
- * The provenance contract. Every field here must be present in a meta.json for
- * the golden to be usable: a listing whose endpoint, protocol version, capture
- * date, substrate or assumed configuration is missing cannot be argued with.
- */
 export const REQUIRED_META_FIELDS = [
   "twin",
   "substrate",
@@ -100,14 +38,6 @@ export function sha256(text) {
   return createHash("sha256").update(text, "utf8").digest("hex");
 }
 
-// ── adapters ────────────────────────────────────────────────────────────────
-// `live-wire-oauth` is the SAME reader as `live-wire-unauth` plus a bearer, so
-// An OAuth-gated substrate adds a token to the source table, not an adapter to
-// this file. The
-// test asserts the two entries hold the identical function reference, because
-// "same code path" is only true for as long as nobody forks it.
-
-/** Unauthenticated (or bearer-authenticated) JSON-RPC POST against the vendor endpoint. */
 async function readLiveWire(source) {
   const headers = { ...(source.configuration.requestHeaders ?? {}) };
   if (source.substrate === SUBSTRATE_OAUTH) {
@@ -115,17 +45,6 @@ async function readLiveWire(source) {
     if (!envName) {
       throw new Error(`${source.twin}: substrate ${SUBSTRATE_OAUTH} requires \`authTokenEnv\` on the source table`);
     }
-    // BLANK AND ABSENT ARE DIFFERENT FACTS, AND SO IS WHITESPACE.
-    //
-    // A value blanked in the secret store must not reach
-    // a runner as an empty string and READ AS "no credential configured" — the
-    // operator who blanked it and the operator who never set it need different
-    // instructions. The previous guard was `if (!token)` with the message "is
-    // not set", which fails closed for `""` (right) while naming the wrong cause
-    // (wrong), and lets `"   "` through entirely: a whitespace-only value is
-    // truthy, so `Bearer    ` went on the wire and came back as the vendor's own
-    // 401. That reads as "your token is bad" and sends whoever just minted one
-    // back to the OAuth flow, when the fault is in the secret store.
     const raw = process.env[envName];
     if (raw === undefined) {
       throw new Error(
@@ -151,13 +70,6 @@ async function readLiveWire(source) {
   if (!res.ok) {
     throw new Error(`${source.twin}: ${source.endpoint} answered HTTP ${res.status}: ${text.slice(0, 200)}`);
   }
-  // The framing is a DECLARED assumption that is then CHECKED, never a derived
-  // value copied into the golden. `configuration` is copied verbatim into
-  // meta.json and `--check --offline` re-derives meta from the committed
-  // raw.json with no substrate to observe, so a field filled in from the live
-  // response would make the offline gate disagree with the online capture.
-  // Declaring it keeps the gate deterministic AND makes a vendor that silently
-  // switches framing a loud failure rather than a silent re-shape.
   const observed = isEventStream(text) ? "text/event-stream" : "application/json";
   const declared = source.configuration.responseFraming ?? "application/json";
   if (observed !== declared) {
@@ -172,28 +84,6 @@ async function readLiveWire(source) {
 
 const isEventStream = (text) => /^(event|data|id|retry):/m.test(text.trimStart().split("\n", 1)[0] ?? "");
 
-/**
- * MCP's Streamable HTTP transport lets a server answer a POST with EITHER a JSON
- * body or an SSE stream, and the two are both correct. Measured 2026-08-09:
- * gmail, slack and stripe answer `application/json`; **linear answers SSE**
- * (`event: message` / `data: {…}`), so `JSON.parse` on the wire bytes throws and
- * the twin's capture fails with "the substrate did not answer JSON" — a message
- * that reads like a broken endpoint or a bad token rather than a framing the
- * reader never handled.
- *
- * The `data:` payload is unwrapped and stored as `raw.json`, and this is the one
- * place the golden is not byte-verbatim from the wire. That is deliberate and it
- * is declared: `raw.json` must be a `tools/list` envelope, because
- * `parseMcpToolTable` on the pome-cloud side parses it and hashes it, and a
- * golden nothing can read is not a golden. The framing is recorded in the
- * capture's `configuration.responseFraming` instead, so the fact is kept rather
- * than lost.
- *
- * Per RFC 8895/the SSE spec a single event's `data:` may span several lines, and
- * a stream may carry several events. The first event that parses to a JSON-RPC
- * object carrying `result` or `error` wins — a heartbeat or a `ping` before the
- * real message must not be mistaken for the answer.
- */
 export function unwrapEventStream(text) {
   if (!isEventStream(text)) return text;
   const events = text.split(/\r?\n\r?\n/);
@@ -226,13 +116,6 @@ function requireBinary(bin, versionArgs, why) {
   }
 }
 
-/**
- * Build the vendor's public server from a pinned commit and ask it. This is the
- * only faithful read of a surface whose live endpoint is credential-gated: the
- * server's own inventory answers `tools/list`, so the capture is whatever the
- * pinned code actually serves under the pinned flags — not a hand transcription
- * of a Go slice, and not the union of every toolset.
- */
 async function readOssSource(source) {
   const spec = source.source;
   requireBinary(
@@ -261,7 +144,6 @@ async function readOssSource(source) {
   return { rawText };
 }
 
-/** Speak MCP over stdio to a freshly built server and return its `tools/list` line verbatim. */
 function driveStdioToolsList(bin, source) {
   const args = source.configuration.serverArgs ?? [];
   const env = { ...process.env, ...(source.configuration.serverEnv ?? {}) };
@@ -322,18 +204,6 @@ const SUBSTRATES = {
   [SUBSTRATE_NONE]: { capturable: false, read: null },
 };
 
-/**
- * The substrate vocabulary this producer accepts, exported so the other
- * validator of the same field can be checked against it.
- *
- * `packages/sdk/src/mcp-tool-fixture.ts` validates `substrate` on the
- * PER-TWIN tool-table fixtures. Two validators of one field name, in
- * two languages, in two trees, with no import between them is how a vocabulary
- * forks without anyone noticing — and the divergence lane has to read both
- * trees. The SDK's
- * enum is required to be a superset of this list; its
- * `substrate-vocabulary.test.ts` imports this array and asserts it.
- */
 export const KNOWN_SUBSTRATES = Object.freeze(Object.keys(SUBSTRATES));
 
 export function adapterFor(substrate) {
@@ -346,32 +216,7 @@ export function adapterFor(substrate) {
   return adapter;
 }
 
-/**
- * The vocabulary of `configuration.completeness` — the relation between the
- * listing this producer CAPTURED and the listing an examinee's own client
- * reaches. The source table's `$comment` defines each class; this array is what
- * makes declaring one non-optional.
- *
- * A GOLDEN THAT STATES NO CLASS STILL MAKES A CLAIM — it just makes it silently,
- * and the consumer supplies the missing half. pome-cloud's promotion-gate
- * criterion 9 refuses a twin for serving a tool the golden does not declare, and
- * its own reasoning turns on this field: it is sound against `exact`, and against
- * `subset-of-remote` only because github's golden ENUMERATES its delta from the
- * remote with written evidence. An undeclared class has already cost us one
- * false report: linear's golden was captured under a read-only grant, said
- * nothing about completeness, and the gate reported six write tools that
- * mcp.linear.app really
- * serves — `save_issue`, `save_comment`, `delete_comment`, `create_issue_label`,
- * `save_project`, `save_document` — as tools twin-linear had invented. Fabricated
- * findings are the one thing that lane must never produce.
- *
- * So it is required at LOAD, beside `configuration` itself and for the same
- * reason: an unstated assumption about what a capture covers fails here rather
- * than defaulting to the flattering answer.
- */
 export const COMPLETENESS_CLASSES = Object.freeze(["exact", "subset-of-remote", "credential-scoped"]);
-
-// ── the declared source table ───────────────────────────────────────────────
 
 export function loadSources({ repoRoot = REPO_ROOT, sourcesPath, table } = {}) {
   const parsed = table ?? JSON.parse(readFileSync(sourcesPath ?? join(repoRoot, DEFAULT_SOURCES), "utf8"));
@@ -437,17 +282,10 @@ export function goldenPaths({ repoRoot = REPO_ROOT, sources, twin }) {
   };
 }
 
-// ── derivation ──────────────────────────────────────────────────────────────
-
 function pretty(value) {
   return `${JSON.stringify(value, null, 2)}\n`;
 }
 
-/**
- * raw.json verbatim, canonical.json derived from it, meta.json derived from
- * both. Nothing here reads the committed files, so a golden can never be
- * "confirmed" by the copy of itself that is already on disk.
- */
 export function deriveGolden({ source, rawText, captureDate }) {
   if (!captureDate) throw new Error(`${source.twin}: a capture must be dated`);
   let envelope;
@@ -504,18 +342,6 @@ export function deriveGolden({ source, rawText, captureDate }) {
   return { raw: rawText, meta, canonical };
 }
 
-/**
- * The record for a twin this producer does NOT capture. A twin honestly marked
- * not-captured is an acceptable outcome; a twin silently missing from the
- * golden directory is not, because a consumer cannot tell it from an oversight.
- *
- * `configuration` and `authTokenEnv` are written here for the same reason they
- * are written into a captured meta.json. A deferred twin's declared
- * configuration is the thing a credentialed capture will ASSUME — it is the whole
- * content of "a token, not an adapter" — so leaving it out of the
- * recorded artefact would let someone change what that capture reads while
- * this gate stayed green.
- */
 export function deriveStatus({ source }) {
   return pretty({
     twin: source.twin,
@@ -533,8 +359,6 @@ export function deriveStatus({ source }) {
       "The divergence lane must report this twin as not-compared. It must never report it as zero coverage.",
   });
 }
-
-// ── the run ─────────────────────────────────────────────────────────────────
 
 function compareFile(path, produced) {
   if (!existsSync(path)) return `missing: ${path}`;
@@ -596,23 +420,6 @@ export async function runCapture(options = {}) {
 
     let captureDate = today;
     if (check || offline) {
-      // The date is a fact about the COMMITTED capture, so `--check` must not
-      // red merely because the calendar moved — and an `--offline` re-derivation,
-      // which reads the same committed bytes and contacts nobody, must not move
-      // it either. `today` belongs to a run that actually read the substrate.
-      //
-      // KNOWN AND UNAVOIDABLE: this makes captureDate self-referential. The
-      // gate reads the date out of the committed meta.json and feeds it back
-      // into the derivation, so a forgery that is CONSISTENT across meta.json
-      // and canonical.json — edit both, recompute both shas — passes. Offline
-      // there is nothing to corroborate it against: the bytes cannot say when
-      // they were fetched. Every other field is derived from the raw response
-      // and so cannot be forged this way; captureDate is the one that can.
-      //
-      // This matters to a staleness alarm that reads meta.captureDate
-      // is reading the one field in the golden that this gate cannot check.
-      // It should date a golden from git history (the commit that last touched
-      // <twin>.raw.json) and treat the JSON field as a label, not evidence.
       let committed;
       try {
         committed = JSON.parse(readFileSync(paths.meta, "utf8"));
@@ -644,16 +451,6 @@ export async function runCapture(options = {}) {
         compareFile(paths.meta, golden.meta),
         compareFile(paths.canonical, golden.canonical),
       ].filter(Boolean);
-      // A LEFTOVER status.json SILENTLY BEATS THE GOLDEN BESIDE IT.
-      //
-      // pome-cloud's `loadUpstreamMcpGolden` resolves `<twin>.status.json`
-      // FIRST and returns not-compared without ever looking at raw/meta — the
-      // recorded refusal is meant to outrank a file that simply is not there.
-      // This producer only ever WRITES status.json; nothing deletes it when
-      // a twin became capturable. So the first credentialed capture of slack,
-      // linear or stripe would commit a real golden and the lane would go on
-      // publishing "401 missing_token", with no red anywhere. That is the whole
-      // credentialed capture landing and reading as if it had not.
       if (existsSync(paths.status)) {
         problems.push(
           `${twin}: both a golden and ${twin}.status.json exist. Every consumer resolves the status file ` +
@@ -668,16 +465,11 @@ export async function runCapture(options = {}) {
       writeFileSync(paths.raw, golden.raw);
       writeFileSync(paths.meta, golden.meta);
       writeFileSync(paths.canonical, golden.canonical);
-      // Retire the recorded refusal in the same step that supersedes it, so the
-      // capture cannot land half-applied. `force` makes this a no-op for a twin
-      // that was always capturable.
       const retired = existsSync(paths.status);
       rmSync(paths.status, { force: true });
       const toolCount = JSON.parse(golden.meta).liveToolCount;
       log(
         `${twin}: ${source.substrate} — ` +
-          // An --offline run says what it did NOT do, because the two modes
-          // write the same three files and only one of them contacted a vendor.
           (offline
             ? `re-derived ${toolCount} tools from the committed ${twin}.raw.json — nothing was read from ` +
               `${source.endpoint}, and captureDate stays ${captureDate}`
@@ -714,23 +506,6 @@ function parseArgv(argv) {
   return opts;
 }
 
-// Run as a script (not when imported by the test).
-//
-// This compares argv against the module URL rather than reading the `main`
-// flag off `import.meta`, and that is deliberate, not stylistic. This gate
-// runs in ci.yml's always-on block, which sits ABOVE `actions/setup-node`
-// (a step itself gated on the heavy suite), so it executes on whatever Node
-// the runner image ships. That flag landed in Node 24.2 / 22.16; on anything
-// older it reads `undefined`, this block never runs, and the gate exits 0
-// having checked nothing — the exact vacuous green the rest of this file
-// exists to prevent. The two scripts in this repo that do read that flag both
-// run after setup-node@24 in the heavy block, so they have a floor this one
-// does not. A test asserts the flag stays out of here.
-// Realpath'd on both sides — node resolves symlinks before deriving
-// `import.meta.url`, so a bare `pathToFileURL(resolve(...))` of argv[1]
-// misses through a symlinked checkout (a worktree, or macOS's symlinked
-// `/tmp`) in the same silent shape, and a guard miss while invoked
-// as this file throws rather than exits 0.
 const SELF = realpathSync(fileURLToPath(import.meta.url));
 const ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";
 const invokedDirectly = ENTRY === SELF;

--- a/scripts/capture-mcp-tools-list.mjs
+++ b/scripts/capture-mcp-tools-list.mjs
@@ -649,7 +649,7 @@ export async function runCapture(options = {}) {
       // pome-cloud's `loadUpstreamMcpGolden` resolves `<twin>.status.json`
       // FIRST and returns not-compared without ever looking at raw/meta — the
       // recorded refusal is meant to outrank a file that simply is not there.
-      // But this producer only ever WROTE status.json; nothing deleted it when
+      // This producer only ever WRITES status.json; nothing deletes it when
       // a twin became capturable. So the first credentialed capture of slack,
       // linear or stripe would commit a real golden and the lane would go on
       // publishing "401 missing_token", with no red anywhere. That is the whole

--- a/scripts/capture-mcp-tools-list.test.mjs
+++ b/scripts/capture-mcp-tools-list.test.mjs
@@ -384,7 +384,7 @@ function sandboxWithDeferredTwin() {
 
   // 5. a not-captured / deferred twin whose recorded reason no longer matches
   //    the table is a red too — an unexplained `not-captured` is the failure
-  //    mode this ticket exists to avoid.
+  //    mode this gate exists to avoid.
   {
     const { dir, twin, sources: sandboxSources } = sandboxWithDeferredTwin();
     const paths = goldenPaths({ repoRoot: dir, sources: sandboxSources, twin });

--- a/scripts/capture-mcp-tools-list.test.mjs
+++ b/scripts/capture-mcp-tools-list.test.mjs
@@ -1,18 +1,8 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Regression coverage for scripts/capture-mcp-tools-list.mjs.
-//
-// No network, no `go`, no clone: every case here drives the producer through
-// its injected `readSubstrate` seam, or through `--offline`, which re-derives
-// meta + canonical from the COMMITTED raw.json. The committed raw.json IS the
-// fixture of the upstream response — a second copy of the same bytes under
-// scripts/fixtures/ would be one more thing to drift.
-//
-// The block that matters most is "the guard fires": a --check that
-// has never been watched go red is not a guard. Each of the four ways a
-// golden can be wrong — edited raw, edited canonical, edited meta provenance,
-// hand-typed sha — gets its own red here.
+// Case table for capture-mcp-tools-list. Every case asserts the RED direction: a rule that has
+// quietly stopped failing prints the same line as one with nothing to report.
 import { cpSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -59,8 +49,6 @@ function assertThrows(fn, match, msg) {
 }
 
 const quiet = () => {};
-// Silence the producer's own stderr in the guard-fires block: those reds are the
-// assertion, not a failure of this suite.
 const SILENT = { log: quiet, err: quiet };
 
 function sandbox() {
@@ -72,19 +60,6 @@ function sandbox() {
   return dir;
 }
 
-
-/**
- * A sandbox whose source table carries one SYNTHETIC uncaptured twin.
- *
- * The last three deferred twins are captured, so `sources.twins` now has no
- * `capture: false` row at all. The guards below cover the not-captured path —
- * the recorded-reason gate and the declared-configuration round-trip — and if
- * they simply iterated the real table they would now iterate NOTHING and report
- * the same green as a satisfied guard. That is this repo's vacuous-green rule,
- * and the
- * fix is a fixture rather than a weakened assertion: the behaviour is still
- * reachable the moment a sixth twin is added deferred, so it stays tested.
- */
 function sandboxWithDeferredTwin() {
   const dir = sandbox();
   const twin = "deferred-probe";
@@ -111,9 +86,6 @@ function sandboxWithDeferredTwin() {
   return { dir, twin, source, sources };
 }
 
-// ── the declared source table ───────────────────────────────────────────────
-// Adding a twin is a data edit, never a new `case:`. The gate
-// on that is that nothing in the producer enumerates twin ids.
 {
   const sources = loadSources({ repoRoot: ROOT });
   const ids = Object.keys(sources.twins);
@@ -130,32 +102,6 @@ function sandboxWithDeferredTwin() {
     );
   }
 
-  // This producer's entry guard follows the sanctioned form (positive
-  // assertion: THIS file's guard really is process.argv[1] vs.
-  // import.meta.url, not just "not import.meta.main" — a guard rewritten into
-  // some other broken shape would still pass an absence check). The absence
-  // of a bare `import.meta.main` ANYWHERE under scripts/**/contract/** —
-  // including in this file — is asserted repo-wide by
-  // scripts/lint/rules/import-meta-main.mjs, which subsumes what
-  // used to be a second, narrower copy of that same assertion here: two
-  // checks asserting one property in different places is the shape D5 warns
-  // about, and the repo-wide one covers strictly more (every file, not just
-  // this producer) with no hand-kept list of which files to watch.
-  //
-  // Two independent, ORDER-INDEPENDENT assertions, one per side. The single
-  // regex these replace was `/process\.argv\[1\][\s\S]{0,120}import\.meta\.url/`,
-  // which encodes source ORDER rather than the guard: this guard was rewritten
-  // into the sanctioned realpath-both-sides form, which declares the
-  // `import.meta.url` const first, and the old regex failed on a guard that had
-  // just been made strictly STRONGER.
-  //
-  // Deliberately still a text match and NOT the repo-wide gate's AST
-  // classifier, tempting as reusing it is: `findEntryGuardRealpathGaps` lives
-  // in `import-meta-main.mjs`, which imports `typescript`, and
-  // THIS test runs in ci.yml's CHEAP block, which has no `npm ci`. Importing it
-  // here crashes the job with ERR_MODULE_NOT_FOUND — a dependency-free test
-  // must stay dependency-free. The AST version of this property is asserted
-  // repo-wide in the heavy block, over this file among all the others.
   assert(
     /realpathSync\(\s*fileURLToPath\(\s*import\.meta\.url\s*\)\s*\)/.test(producerText),
     "the CLI entry guard realpaths its own side (realpathSync(fileURLToPath(import.meta.url)))"
@@ -166,10 +112,6 @@ function sandboxWithDeferredTwin() {
   );
 }
 
-// ── every capturable source declares the configuration it assumed ───────────
-// "A capture without one FAILS rather than defaulting." The failure has to be
-// at load, not at write: a producer that defaults is a producer that records a
-// configuration nobody chose.
 {
   assertThrows(
     () =>
@@ -223,10 +165,6 @@ function sandboxWithDeferredTwin() {
   );
 }
 
-// ── A credential adds a token, not an adapter ───────────────────────────────
-// live-wire-oauth and live-wire-unauth must resolve to the SAME reader. If they
-// ever diverge, "a token, not an adapter" stops being true and nobody finds out
-// until the next credentialed capture.
 {
   assert(
     adapterFor("live-wire-oauth").read === adapterFor("live-wire-unauth").read,
@@ -246,7 +184,6 @@ function sandboxWithDeferredTwin() {
   );
 }
 
-// ── derivation: sha is computed, never carried ──────────────────────────────
 {
   const rawText = JSON.stringify({
     jsonrpc: "2.0",
@@ -282,8 +219,6 @@ function sandboxWithDeferredTwin() {
     "canonical.result is the raw result, verbatim"
   );
 
-  // A capture whose sha was hand-typed cannot survive: derivation ignores any
-  // sha present on the source table.
   const tampered = deriveGolden({
     source: { ...source, rawFileSha256: "0".repeat(64) },
     rawText,
@@ -295,9 +230,6 @@ function sandboxWithDeferredTwin() {
   );
 }
 
-// ── substrate + configuration round-trip into meta.json ─────────────────────
-// One case per adapter, driven off the REAL committed source table so a twin
-// whose configuration stops reaching meta.json reds here.
 {
   const sources = loadSources({ repoRoot: ROOT });
   for (const [twin, source] of Object.entries(sources.twins)) {
@@ -320,21 +252,17 @@ function sandboxWithDeferredTwin() {
   }
 }
 
-// ── the committed goldens are what the producer derives ─────────────────────
 {
   const code = await runCapture({ repoRoot: ROOT, check: true, offline: true, ...SILENT });
   assert(code === 0, "`--check --offline` is green against the committed goldens");
 }
 
-// ── the guard fires ─────────────────────────────────────────────────────────
-// Four independent edits, four reds, and nothing written back.
 {
   const sources = loadSources({ repoRoot: ROOT });
   const captured = Object.entries(sources.twins).filter(([, s]) => s.capture);
   assert(captured.length > 0, "at least one twin is captured (otherwise the guard guards nothing)");
 
   for (const [twin] of captured) {
-    // 1. canonical edited
     {
       const dir = sandbox();
       const paths = goldenPaths({ repoRoot: dir, sources, twin });
@@ -347,7 +275,6 @@ function sandboxWithDeferredTwin() {
       assert(readFileSync(paths.canonical, "utf8") === before, `${twin}: --check wrote nothing`);
       rmSync(dir, { recursive: true, force: true });
     }
-    // 2. raw edited (canonical + sha both stop matching)
     {
       const dir = sandbox();
       const paths = goldenPaths({ repoRoot: dir, sources, twin });
@@ -358,7 +285,6 @@ function sandboxWithDeferredTwin() {
       assert(code !== 0, `${twin}: --check reds when raw.json loses a tool`);
       rmSync(dir, { recursive: true, force: true });
     }
-    // 3. meta provenance edited — the substrate claim itself
     {
       const dir = sandbox();
       const paths = goldenPaths({ repoRoot: dir, sources, twin });
@@ -369,7 +295,6 @@ function sandboxWithDeferredTwin() {
       assert(code !== 0, `${twin}: --check reds when meta.json misstates the substrate`);
       rmSync(dir, { recursive: true, force: true });
     }
-    // 4. sha hand-typed to something plausible
     {
       const dir = sandbox();
       const paths = goldenPaths({ repoRoot: dir, sources, twin });
@@ -382,9 +307,6 @@ function sandboxWithDeferredTwin() {
     }
   }
 
-  // 5. a not-captured / deferred twin whose recorded reason no longer matches
-  //    the table is a red too — an unexplained `not-captured` is the failure
-  //    mode this gate exists to avoid.
   {
     const { dir, twin, sources: sandboxSources } = sandboxWithDeferredTwin();
     const paths = goldenPaths({ repoRoot: dir, sources: sandboxSources, twin });
@@ -403,11 +325,6 @@ function sandboxWithDeferredTwin() {
     rmSync(dir, { recursive: true, force: true });
   }
 
-  // 7. the DEFERRED twins' declared configuration is the thing a credentialed
-  //    capture will assume, so it has to be recorded and gated exactly like a
-  //    captured twin's. Without this, someone could change which header
-  //    Slack's future capture sends, or which env var holds its token, and
-  //    every gate would stay green.
   {
     const { dir: statusDir, twin, source, sources: sandboxSources } = sandboxWithDeferredTwin();
     const paths = goldenPaths({ repoRoot: statusDir, sources: sandboxSources, twin });
@@ -457,7 +374,6 @@ function sandboxWithDeferredTwin() {
     rmSync(statusDir, { recursive: true, force: true });
   }
 
-  // 6. a missing golden is a red, not a silent skip.
   {
     const dir = sandbox();
     const [twin] = captured[0];
@@ -468,7 +384,6 @@ function sandboxWithDeferredTwin() {
   }
 }
 
-// ── --check never writes, even when it would be green ───────────────────────
 {
   const dir = sandbox();
   const sources = loadSources({ repoRoot: dir });
@@ -482,9 +397,6 @@ function sandboxWithDeferredTwin() {
   rmSync(dir, { recursive: true, force: true });
 }
 
-// ── write mode round-trips through an injected substrate reader ─────────────
-// The write path is exercised without a socket: the fake reader stands in for
-// whichever adapter the substrate names.
 {
   const dir = sandbox();
   const sources = loadSources({ repoRoot: dir });
@@ -511,16 +423,6 @@ function sandboxWithDeferredTwin() {
   rmSync(dir, { recursive: true, force: true });
 }
 
-// ── --offline WRITES the re-derivation, and cannot forge a capture ───────────
-//
-// The mode exists because `configuration` is prose about a capture that is
-// copied into two derived files, and three of the five sources sit behind
-// one-shot OAuth grants — so without it, a corrected sentence about slack's
-// golden means either minting a fresh Slack grant or hand-editing the goldens.
-//
-// What has to stay true is that it re-states what a capture MEANT and never
-// what it FOUND. Both halves get a red of their own below: the derived fields
-// still come from the committed raw bytes, and `captureDate` does not move.
 {
   const dir = sandbox();
   const sources = loadSources({ repoRoot: dir });
@@ -534,14 +436,12 @@ function sandboxWithDeferredTwin() {
   table.twins[twin].configuration.matchesExaminee = "re-stated by an offline re-derivation, not by a capture";
   writeFileSync(cfgPath, `${JSON.stringify(table, null, 2)}\n`);
 
-  // The edit alone reds the gate — the whole reason the mode has to exist.
   const stale = await runCapture({ repoRoot: dir, sourcesPath: cfgPath, check: true, offline: true, ...SILENT });
   assert(stale !== 0, "--check reds while the source table's configuration and the goldens disagree");
 
   const code = await runCapture({
     repoRoot: dir,
     sourcesPath: cfgPath,
-    // A date that is nothing like the committed one, so carrying it is visible.
     today: "2099-12-31",
     offline: true,
     ...SILENT,
@@ -565,7 +465,6 @@ function sandboxWithDeferredTwin() {
   rmSync(dir, { recursive: true, force: true });
 }
 
-// ── --offline has nothing to re-derive FROM, and says so rather than inventing ──
 {
   const dir = sandbox();
   const sources = loadSources({ repoRoot: dir });
@@ -579,9 +478,6 @@ function sandboxWithDeferredTwin() {
   rmSync(dir, { recursive: true, force: true });
 }
 {
-  // An undated golden cannot be re-derived either: `today` belongs to a run
-  // that read a substrate, and stamping it here would reset any staleness
-  // clock without anybody having contacted the vendor.
   const dir = sandbox();
   const sources = loadSources({ repoRoot: dir });
   const twin = Object.keys(sources.twins).find((id) => sources.twins[id].capture);
@@ -599,13 +495,6 @@ function sandboxWithDeferredTwin() {
   rmSync(dir, { recursive: true, force: true });
 }
 
-// ── every capturable source states what its capture COVERS ──────────────────
-//
-// The field is required at load, beside `configuration` itself. linear's golden
-// was captured under a read-only grant, declared no completeness class, and
-// pome-cloud's promotion-gate went on to report six write tools that
-// mcp.linear.app really serves as tools the twin had invented — the fabricated
-// finding that lane must never produce.
 {
   const sources = loadSources({ repoRoot: ROOT });
   for (const [id, source] of Object.entries(sources.twins)) {
@@ -623,7 +512,6 @@ function sandboxWithDeferredTwin() {
   for (const [label, value] of [
     ["absent", undefined],
     ["an unknown class", "probably-fine"],
-    // The flattering default a missing field would otherwise mean.
     ["the empty string", ""],
   ]) {
     const mutated = structuredClone(table);
@@ -637,11 +525,6 @@ function sandboxWithDeferredTwin() {
   }
 }
 
-// ── a substrate read that comes back malformed fails loudly ─────────────────
-// Four shapes an upstream read can come back wrong in. Each must refuse to
-// become a golden: an empty listing written as a golden is the worst outcome
-// available here, because it reads as "the vendor serves nothing" and turns
-// every tool a twin has into a divergence.
 {
   const sources = loadSources({ repoRoot: ROOT });
   const twin = Object.keys(sources.twins).find((id) => sources.twins[id].capture);
@@ -667,32 +550,8 @@ function sandboxWithDeferredTwin() {
   }
 }
 
-// ── a deferred oauth row is CAPTURE-READY, not merely declared ───────────────
-// The whole content of "a token, not an adapter" is that the errand
-// is one env var away. It was not: slack and linear declared no
-// `protocolVersion`, which `loadSources` requires on every capturable source, so
-// flipping `capture` threw `must declare protocolVersion` before opening a
-// socket — a schema error, read by whoever had just finished an OAuth flow, in
-// the one moment they have every reason to blame their own credential.
-//
-// Asserted over EVERY deferred oauth row rather than the two that exist today,
-// so a sixth twin added the same way is caught by this file and not by a human
-// mid-errand.
 {
   const table = JSON.parse(readFileSync(join(ROOT, "config/mcp-capture-sources.json"), "utf8"));
-  // Every oauth row, captured or deferred. All three are captured, so keying
-  // this on `!row.capture` would now select NOTHING and report the same green as
-  // a satisfied guard — the shape the flip-throws bug hid behind in the first
-  // place. The durable invariant is the one that made the flip safe: an oauth
-  // row carries the two fields a capture needs, whether or not it is capturing
-  // today.
-  //
-  // Named `gatedSources`, not `oauth`: CodeQL's `js/clear-text-logging` treats a
-  // binding whose IDENTIFIER matches an auth keyword as a sensitive source, and
-  // this suite's `assert()` helper ends in `console.error`. Nothing here holds a
-  // secret — the source table stores env var NAMES, never values — but a
-  // name-based heuristic cannot know that, and a suppression comment would sit
-  // there long after anyone remembers why.
   const gatedSources = Object.entries(table.twins).filter(([, row]) => row.substrate === "live-wire-oauth");
   assert(gatedSources.length > 0, "the source table has live-wire-oauth rows for this guard to cover");
   for (const [twin, row] of gatedSources) {
@@ -703,8 +562,6 @@ function sandboxWithDeferredTwin() {
         `error before the socket opens, at whoever has just finished an OAuth flow`
     );
 
-    // …and a row that is NOT capturing must be one env var away from capturing.
-    // Proven by flipping it, on a deep copy, for real.
     const flipped = JSON.parse(JSON.stringify(table));
     flipped.twins[twin].capture = true;
     delete flipped.twins[twin].reason;
@@ -716,17 +573,10 @@ function sandboxWithDeferredTwin() {
   }
 }
 
-// ── the recorded refusal is RETIRED by the capture that supersedes it ────────
-// pome-cloud's `loadUpstreamMcpGolden` resolves `<twin>.status.json` FIRST and
-// never looks at the raw/meta beside it. Nothing used to delete that file, so
-// The first credentialed capture would have committed a real golden while
-// the lane went on publishing "401 missing_token" — the errand landing and
-// reading as though it had not, with nothing red anywhere.
 {
   const sources = loadSources({ repoRoot: ROOT });
   const twin = Object.keys(sources.twins).find((id) => sources.twins[id].capture);
 
-  // (a) --check reds when both artefacts exist, and says which one wins.
   {
     const dir = sandbox();
     const paths = goldenPaths({ repoRoot: dir, sources, twin });
@@ -748,7 +598,6 @@ function sandboxWithDeferredTwin() {
     rmSync(dir, { recursive: true, force: true });
   }
 
-  // (b) a real capture deletes it, so the commit cannot land half-applied.
   {
     const dir = sandbox();
     const paths = goldenPaths({ repoRoot: dir, sources, twin });
@@ -766,13 +615,6 @@ function sandboxWithDeferredTwin() {
   }
 }
 
-// ── SET-BUT-BLANK is not UNSET ──────────────────────────────────────────────
-// A value blanked in the secret store must not reach a runner and read
-// as "no credential configured" — the operator who blanked it and the operator
-// who never set it need different instructions. `if (!token)` said "is not set"
-// for both, and let whitespace through entirely: `Bearer    ` went on the wire
-// and came back as the VENDOR's 401, which reads as a bad token and sends
-// whoever just minted one back through the OAuth flow.
 {
   const ENV = "BLANK_PROBE";
   const source = {
@@ -795,12 +637,6 @@ function sandboxWithDeferredTwin() {
   delete process.env[ENV];
 }
 
-// ── the Streamable HTTP transport may frame the answer as SSE ───────────────
-// MCP lets a server answer a POST with either a JSON body or an SSE stream, and
-// both are correct. Measured 2026-08-09: gmail, slack and stripe answer
-// application/json; LINEAR answers SSE. Before this, `JSON.parse` on the wire
-// bytes threw "the substrate did not answer JSON" — a message that reads like a
-// broken endpoint or a bad token rather than a framing nothing handled.
 {
   const envelope = { jsonrpc: "2.0", id: 1, result: { tools: [{ name: "get_issue" }] } };
   const payload = JSON.stringify(envelope);
@@ -815,14 +651,10 @@ function sandboxWithDeferredTwin() {
     "CRLF-framed SSE is unwrapped (the spec allows either line ending)"
   );
 
-  // A heartbeat or a `ping` BEFORE the real message must not be mistaken for the
-  // answer: the first event carrying `result` or `error` wins, not the first
-  // event that parses.
   const withNoise =
     `event: ping\ndata: {"jsonrpc":"2.0","method":"ping"}\n\n` + `event: message\ndata: ${payload}\n\n`;
   assert(unwrapEventStream(withNoise) === payload, "a leading ping event is skipped, not returned as the answer");
 
-  // Multi-line data is one payload, per the SSE spec.
   const split = `event: message\ndata: {"jsonrpc":"2.0","id":1,\ndata: "result":{"tools":[{"name":"get_issue"}]}}\n\n`;
   assert(
     JSON.parse(unwrapEventStream(split)).result.tools.length === 1,
@@ -836,12 +668,6 @@ function sandboxWithDeferredTwin() {
   );
 }
 
-// ── the framing is DECLARED and then CHECKED, never inferred ────────────────
-// `configuration` is copied verbatim into meta.json and `--check --offline`
-// re-derives it with no substrate to observe, so a framing filled in from the
-// live response would make the offline gate disagree with the online capture.
-// Declaring it keeps the gate deterministic AND makes a vendor that silently
-// switches transport framing a loud failure instead of a silent re-shape.
 {
   const envelope = JSON.stringify({ jsonrpc: "2.0", id: 1, result: { tools: [{ name: "t" }] } });
   const realFetch = globalThis.fetch;

--- a/scripts/check-example-pins-published.mjs
+++ b/scripts/check-example-pins-published.mjs
@@ -1,69 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// `agent-examples/*` pins a PUBLISHED `@pome-sh/*` version on purpose
-// (`agent-examples/support-triage` documents why in `gate-examples.mjs`'s
-// header: it is `npx degit`-fetchable as a standalone subtree, so a `file:`
-// link out of its own directory would break its `npm install`). Nothing
-// watched that pin drift out from under the sibling workspace version, which
-// has happened twice — the second time dragging a retired package back into
-// the example's install graph as a runtime dependency, giving two schema
-// identities in one process, in the one example that
-// exists to demonstrate
-// a correctly-joined trace).
-//
-// `workspace-pins.mjs` cannot own this: it runs OFFLINE
-// before `npm ci`, and its rule ("a `@pome-sh/*` dep must resolve to the
-// workspace") is the wrong rule for a pin that is published on purpose. This
-// gate needs the registry, so it lives where `agent-examples/*` are already
-// installed — `gate-examples.mjs` already runs `npm ci` per example in
-// CI's heavy (networked) job — rather than standing up a second CI mechanism.
-//
-// THE RULE, in two parts:
-//   1. If the sibling WORKSPACE version is published to the registry, the
-//      example's pin must equal it exactly. A published sibling version is
-//      the only artifact anyone could have meant to pin, so any other exact
-//      value is drift.
-//   2. If the workspace version is NOT yet published (the ordinary cloud-first
-//      state — `packages/` bumps and merges before its release job runs),
-//      that is a named, counted SKIP, never a silent pass and never treated as
-//      a violation.
-//
-// A registry answer that is neither "found" nor "genuinely unpublished" (a
-// 401, a 5xx, a timeout, a rate limit) is a HARD FAILURE, not a skip — treating
-// it as unpublished would let a transient registry outage wave through a real
-// drift. This mirrors `scripts/ci/decide-publish.sh`'s own stance: `npm view`
-// exiting non-zero with `E404` in its stderr means "not found", anything else
-// means "ask again", and only the former may stand in for "unpublished".
-//
-// Only EXACT semver pins can be COMPARED against the registry. But "cannot be
-// compared" must never mean "silently uncounted" — that is the D5 failure shape
-// this gate exists to close, and the first draft of it had exactly that hole:
-// discovery `continue`d past every non-exact pin, so re-pinning
-// `agent-examples/support-triage` to `^0.3.3` made its watch evaporate while the
-// report still printed a clean pass. (It only reddened at all because
-// support-triage happens to own the sole exact pin in the tree, so the
-// zero-eligible-pins floor caught it by arithmetic accident; add one more
-// exact pin anywhere under `agent-examples/*` and the range pin goes silent.)
-//
-// So every `@pome-sh/*` dep that HAS a workspace sibling is classified, and all
-// three classes are reported:
-//   - `exact`       — an exact semver: this gate's subject, checked against the
-//                     registry below.
-//   - `linked`      — `file:`/`link:`: resolves from the source next to it and
-//                     cannot reach a registry at all, so it cannot swap in a
-//                     stale published artifact. Out of scope on purpose, but
-//                     COUNTED and named, so the report never claims a
-//                     denominator it does not have.
-//   - `unwatchable` — anything else (a caret/tilde/range, `"*"`, a dist-tag,
-//                     `npm:`): resolves FROM the registry, so it carries the
-//                     very risk this gate watches for, yet has no single
-//                     version to compare. That is a VIOLATION, not a skip.
-//                     A pin nobody can check must not read as a pin nobody
-//                     needs to check.
-//
-// Discovery, not a list: every `agent-examples/*/package.json`, walked fresh each
-// run, is the corpus — so a new example shipping its own published pin is
-// covered with no edit here.
+// `agent-examples/*` pin published versions on purpose, so `workspace-pins` skips
+// them and this covers them instead. A degraded registry must not read as
+// unpublished.
 
 import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
@@ -71,26 +10,11 @@ import { join } from "node:path";
 
 import { loadWorkspaceMembers } from "./lib/workspace-members.mjs";
 
-// Prerelease/build metadata included: `0.4.0-rc.1` is an exact, registry-
-// resolvable version, and rejecting it would drop the first rc into
-// `unwatchable` with advice ("re-pin to 0.4.0-rc.1") that names the value it
-// already has — an unfixable red.
 const EXACT_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
-// `../foo` with no protocol is a directory dep to npm exactly as `file:../foo`
-// is; classing it `unwatchable` would red a legitimate local link while telling
-// the author it "resolves from the registry", which is false.
 const WORKSPACE_LINK = /^(?:file:|link:|\.{1,2}[\\/])/;
 const SCOPE = "@pome-sh/";
 const INSTALL_FIELDS = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"];
 
-/**
- * Every `@pome-sh/*` dep under `agent-examples/*` that has a same-named sibling among
- * the root workspace members, classified into `exact` / `linked` /
- * `unwatchable` (see this file's header for why all three are reported and none
- * is dropped). One walk, so the three classes cannot disagree about what a
- * sibling is. Discovered fresh each run, never a hand-kept list of examples or
- * packages.
- */
 export function discoverExampleSiblingDeps(repoRoot) {
   const examplesDir = join(repoRoot, "agent-examples");
   const siblingsByName = new Map(
@@ -119,41 +43,6 @@ export function discoverExampleSiblingDeps(repoRoot) {
   return { exact, linked, unwatchable };
 }
 
-/**
- * `npm view <name>@<version> version` against the real registry. Returns
- * `{ status: "published" }`, `{ status: "unpublished" }` (E404 — genuinely no
- * such version), or `{ status: "error", detail }` for anything else (auth,
- * network, rate-limit, 5xx) — the same three-way split
- * `scripts/ci/decide-publish.sh` draws, because only an E404 may stand in for
- * "not published yet".
- *
- * The `timeout` is load-bearing, not decoration: without it a registry that
- * accepts the connection and then stalls hangs this call indefinitely (npm's
- * own `fetch-timeout` defaults to five minutes PER attempt, times its retries),
- * so a degraded registry stalls the whole heavy job instead of answering. A
- * killed call has no `E404` in its stderr, so it lands in `error` — the
- * conservative side, and the same side a 401 or a 5xx lands on.
- *
- * `--prefer-online` forces npm's staleness check instead of accepting a cached
- * packument, and it is load-bearing on the write side: both the workflow
- * that calls this and the one that publishes restore npm's HTTP cache via
- * `setup-node`'s `cache: npm`, keyed on the root lockfile — which a release
- * commit changes, so the run immediately BEFORE a publish takes the miss and
- * saves a fresh cache whose adapter packument predates that publish. The
- * dispatched re-pin run then restores it, and inside the packument's max-age
- * `npm view <pkg>@<just-published>` answers E404 — indistinguishable, by design,
- * from "never published", so `planExampleRepins` skips the pin it exists to fix
- * and no later run retries. A read that is allowed to answer from cache cannot
- * prove a version is absent.
- *
- * Retried, because "any non-E404 answer is a hard failure" puts the REQUIRED
- * `typecheck-test` check behind a third-party registry: one transient 5xx or
- * ECONNRESET would red it. `ci.yml`'s own actionlint install carries a
- * five-attempt loop for exactly this reason, with a comment recording three
- * 503s during this PR's review. An `E404` returns immediately — it is a real
- * answer, not a failure to get one — so retrying never delays the ordinary
- * unpublished path.
- */
 export function defaultNpmView(name, version, { attempts = 3, delayMs = 2000 } = {}) {
   let lastDetail = "";
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
@@ -168,8 +57,6 @@ export function defaultNpmView(name, version, { attempts = 3, delayMs = 2000 } =
       const stderr = String(err.stderr ?? err.message ?? "");
       if (/\bE404\b/.test(stderr)) return { status: "unpublished" };
       lastDetail = stderr.trim() || String(err);
-      // Synchronous backoff: this whole gate is sync (`execFileSync`), so there
-      // is no event loop to await on.
       if (attempt < attempts && delayMs > 0) {
         Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs * attempt);
       }
@@ -178,20 +65,6 @@ export function defaultNpmView(name, version, { attempts = 3, delayMs = 2000 } =
   return { status: "error", detail: lastDetail, attempts };
 }
 
-/**
- * Apply the rule to a discovered pin list. `npmView` is injectable so the
- * regression suite can exercise all three registry outcomes without a
- * network.
- *
- * Returns:
- *   - `violations`: pin !== workspace version, where the workspace version IS
- *     published — a real drift, naming the example, the pin, and the
- *     workspace version.
- *   - `skips`: workspace version is not (yet) published — the legitimate
- *     cloud-first ordering, counted and named, never rendered as a pass.
- *   - `errors`: the registry answered something other than found/E404 — a
- *     hard failure, never downgraded to a skip.
- */
 export function checkExamplePinsPublished(pins, npmView = defaultNpmView) {
   const violations = [];
   const skips = [];
@@ -209,43 +82,8 @@ export function checkExamplePinsPublished(pins, npmView = defaultNpmView) {
   return { checked: pins.length, violations, skips, errors };
 }
 
-/**
- * The write side's registry budget, deliberately ONE attempt where the read
- * side takes three. `defaultNpmView`'s retry exists because the gate is a
- * REQUIRED status check that must not flake on a transient 5xx. The re-pin has
- * the opposite cost function: it runs inside `allocate-version.yml`'s three-
- * attempt push loop, synchronously, per exact pin, in a `timeout-minutes: 20`
- * job that also runs `npm ci` — so three attempts × a 60s timeout × the backoff
- * × the push retries is minutes of stalling in the release path, and it buys
- * nothing, because a missed re-pin costs exactly one cycle and the next run
- * plans it again. Cheap to lose, expensive to wait for.
- */
 const writeSideNpmView = (name, version) => defaultNpmView(name, version, { attempts: 1 });
 
-/**
- * The write-side of this gate's own read-side logic. `checkExample
- * PinsPublished`'s `violations` ARE, by construction, the only pins safe to
- * rewrite automatically: the sibling is confirmed PUBLISHED (an `npm view`
- * that just returned a real answer), so `npm install --package-lock-only`
- * against it can succeed for real, unlike a version this same push is still in
- * the middle of allocating (see the header of `allocate-release-versions.mjs`'s
- * `planAllocations` for why a freshly-bumped-in-this-run version must NOT be
- * repinned to here — it isn't on the registry yet).
- *
- * Returns one entry per example whose pin can be safely corrected: the
- * rewritten `package.json` text (a plain textual substitution, matching
- * `allocate-release-versions.mjs`'s own `rewriteVersion` — round-tripping
- * through `JSON.stringify` would lose formatting) plus the shell command that
- * regenerates that example's lockfile against the now-confirmed-published
- * version. Nothing here executes the command or writes the file; the caller
- * (`allocate-release-versions.mjs`) folds both into the same commit it already
- * builds.
- *
- * Silently produces nothing when `repoRoot` has no `package.json` or no
- * `agent-examples/` — the throwaway git fixtures `allocate-release-versions.test.mjs`
- * builds are neither, and this function is called unconditionally from every
- * plan, not just ones that touch examples.
- */
 export function planExampleRepins(repoRoot, npmView = writeSideNpmView) {
   if (!existsSync(join(repoRoot, "package.json")) || !existsSync(join(repoRoot, "agent-examples"))) return [];
 
@@ -253,32 +91,14 @@ export function planExampleRepins(repoRoot, npmView = writeSideNpmView) {
   const { violations, errors } = checkExamplePinsPublished(exact, npmView);
 
   if (errors.length > 0) {
-    // `checkExamplePinsPublished` is emphatic that a non-E404 answer is a hard
-    // failure and never a skip. The write side cannot honour that literally — a
-    // registry outage must not stop a release — but it must not launder it into
-    // "nothing drifted" either, which is what silently dropping `errors` would
-    // do. Say so; the read-side gate is the one that hard-fails.
     console.warn(
       `::warning::${errors.length} example pin(s) could not be checked against the registry, so they are NOT ` +
         `re-pinned in this run: ${errors.map((e) => `agent-examples/${e.example} ${e.dep}@${e.workspaceVersion} (${e.detail})`).join("; ")}`,
     );
   }
 
-  // A regex rather than a literal-string match (unlike this file's siblings'
-  // `"version": "x"` searches): a hand-formatted `package.json` always has a
-  // space after the colon, but nothing in npm requires one, so matching only
-  // the formatted shape would silently find zero occurrences on a compact file
-  // instead of one — a formatting failure no author intended. The capture
-  // groups mean only the pin's own bytes are replaced, never a coincidental
-  // earlier occurrence of the same string inside the matched text.
   const escape = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
-  // One example can carry TWO drifted `@pome-sh/*` pins, and `applyAllocations`
-  // writes entries in order, so last write wins per path: each entry's
-  // `contents` must therefore already carry every EARLIER substitution to the
-  // same manifest, or the first repin is silently dropped while the commit
-  // message still claims it — the read-side gate would then keep reddening on a
-  // drift the commit says it fixed.
   const latest = new Map();
   const repins = [];
   for (const v of violations) {
@@ -287,13 +107,6 @@ export function planExampleRepins(repoRoot, npmView = writeSideNpmView) {
     const pattern = new RegExp(`("${escape(v.dep)}"\\s*:\\s*")${escape(v.pin)}(")`, "g");
     const occurrences = contents.match(pattern)?.length ?? 0;
     if (occurrences !== 1) {
-      // Deliberately NOT a throw. This runs inside `planAllocations`, on every
-      // push to `main`, so throwing would stop EVERY package's release over one
-      // ambiguous example manifest (a `"@pome-sh/x": "<pin>"` repeated in
-      // `overrides`, or in a second install field) — a repo-wide release outage
-      // caused by the thing meant to remove a one-line PR. Skip this one pin
-      // instead: `reportExamplePinParity` still reds on it, so it cannot go
-      // silent, and a human re-pins it the way they did before the repin path existed.
       console.warn(
         `::warning::${manifestRelPath}: expected exactly one \`"${v.dep}": "${v.pin}"\`, found ${occurrences} — ` +
           "refusing to guess which one is the pin, so it is NOT re-pinned automatically. " +
@@ -309,15 +122,6 @@ export function planExampleRepins(repoRoot, npmView = writeSideNpmView) {
       from: v.pin,
       to: v.workspaceVersion,
       writes: [{ path: manifestRelPath, contents: replacement }],
-      // `--package-lock-only`: this workflow never runs the example itself, so
-      // there is nothing to gain from a real `node_modules` and a real install
-      // would need dev toolchains (tsx, vitest) this job has no other use for.
-      // The path is QUOTED: `v.example` is a directory name off `readdirSync`,
-      // and this string is `bash`ed by a job holding a write-capable App token.
-      // `--prefer-online` for the same reason the view above carries it: this
-      // resolves the version that was published minutes ago, and a cached
-      // packument that predates it makes the install fail on a version the
-      // registry really does serve.
       regenerate: [
         `(cd "agent-examples/${v.example}" && npm install --package-lock-only --no-audit --no-fund --prefer-online)`,
       ],
@@ -326,22 +130,8 @@ export function planExampleRepins(repoRoot, npmView = writeSideNpmView) {
   return repins;
 }
 
-/**
- * Run discovery + the registry check and print a report in the shape
- * `gate-examples.mjs` expects: throws on zero eligible pins (a check
- * examining nothing must not report a pass), prints the skip count even when
- * everything else is green, and returns `true`/`false` for the caller to fold
- * into its own exit code.
- */
 export function reportExamplePinParity(repoRoot, npmView = defaultNpmView) {
   const { exact, linked, unwatchable } = discoverExampleSiblingDeps(repoRoot);
-  // The floor counts EXACT pins only. Counting `linked` here would have let a
-  // tree whose examples are all `file:` links report a green pass having made
-  // zero registry calls — and converting `agent-examples/support-triage` to a `file:`
-  // link is a plausible edit (three other examples already are one), so that
-  // would delete this gate's only watch silently, which is the whole shape it
-  // exists to catch. `unwatchable` reds on its own below, so it does not need
-  // to satisfy a floor either.
   if (exact.length === 0) {
     throw new Error(
       "check-example-pins-published found zero exact-version @pome-sh/* pins with a workspace sibling under " +

--- a/scripts/check-example-pins-published.mjs
+++ b/scripts/check-example-pins-published.mjs
@@ -4,10 +4,10 @@
 // (`agent-examples/support-triage` documents why in `gate-examples.mjs`'s
 // header: it is `npx degit`-fetchable as a standalone subtree, so a `file:`
 // link out of its own directory would break its `npm install`). Nothing
-// watched that pin drift out from under the sibling workspace version twice
-// (#308 off 0.2.5, then off 0.3.1 — the second time dragging the retired
-// `@pome-sh/shared-types` back into the example's install graph as a runtime
-// dependency — two schema identities in one process, in the one example that
+// watched that pin drift out from under the sibling workspace version, which
+// has happened twice — the second time dragging a retired package back into
+// the example's install graph as a runtime dependency, giving two schema
+// identities in one process, in the one example that
 // exists to demonstrate
 // a correctly-joined trace).
 //

--- a/scripts/check-example-pins-published.test.mjs
+++ b/scripts/check-example-pins-published.test.mjs
@@ -1,12 +1,8 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Regression suite for `check-example-pins-published.mjs`. Pure
-// functions, no network and no `npm ci` needed: `checkExamplePinsPublished`
-// takes an injected `npmView`, and `discoverExampleSiblingDeps` runs against
-// a throwaway fixture tree built the same way
-// `workspace-pins.test.mjs` builds one, since both
-// gates read the same root `workspaces` shape.
+// Case table for check-example-pins-published. Every case asserts the RED direction: a rule that has
+// quietly stopped failing prints the same line as one with nothing to report.
 
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -28,9 +24,6 @@ function pass(name) {
   console.log(`✓ ${name}`);
 }
 
-/** A throwaway root with one workspace package and one example, mirroring the
- * real tree's `packages/adapter-claude-sdk` + `agent-examples/support-triage`
- * shape. */
 function fixture({ workspaceVersion, examplePin, exampleField = "dependencies", extraExamples = {} }) {
   const root = mkdtempSync(join(tmpdir(), "example-pins-"));
   writeFileSync(join(root, "package.json"), JSON.stringify({ name: "root", workspaces: ["packages/*"] }));
@@ -54,8 +47,6 @@ function fixture({ workspaceVersion, examplePin, exampleField = "dependencies", 
   return root;
 }
 
-// 1. Discovery: an exact pin with a matching sibling is picked up, with the
-// field it lives in and the workspace version to compare against.
 {
   const root = fixture({ workspaceVersion: "0.3.3", examplePin: "0.3.1" });
   const { exact } = discoverExampleSiblingDeps(root);
@@ -73,9 +64,6 @@ function fixture({ workspaceVersion, examplePin, exampleField = "dependencies", 
   }
 }
 
-// 2. A `file:`/`link:` workspace link resolves from the source next to it and
-// cannot reach a registry, so it is not this gate's subject — but it is COUNTED,
-// not dropped, so the report cannot claim a denominator it does not have.
 for (const pin of ["file:../../packages/adapter-claude-sdk", "link:../../packages/adapter-claude-sdk"]) {
   const root = fixture({ workspaceVersion: "0.3.3", examplePin: pin });
   const { exact, linked, unwatchable } = discoverExampleSiblingDeps(root);
@@ -86,11 +74,6 @@ for (const pin of ["file:../../packages/adapter-claude-sdk", "link:../../package
   }
 }
 
-// 3. THE HOLE THE FIRST DRAFT HAD: a range/`*`/dist-tag pin resolves FROM the
-// registry — the exact risk this gate watches — but has no single version to
-// compare. It must be reported as UNWATCHABLE, never silently dropped, or
-// re-pinning the hero example to `^0.3.3` deletes its watch while the report
-// still reads as a pass.
 for (const pin of ["*", "^0.3.3", "~0.3.1", "0.3.x", ">=0.3.0", "latest", "npm:@pome-sh/adapter-claude-sdk@0.3.3"]) {
   const root = fixture({ workspaceVersion: "0.3.3", examplePin: pin });
   const { exact, linked, unwatchable } = discoverExampleSiblingDeps(root);
@@ -101,10 +84,6 @@ for (const pin of ["*", "^0.3.3", "~0.3.1", "0.3.x", ">=0.3.0", "latest", "npm:@
   }
 }
 
-// 3b. …and an unwatchable pin makes `reportExamplePinParity` return false even
-// when every OTHER pin in the tree is a clean exact match. This is the case the
-// zero-pins floor below CANNOT catch: with a second exact pin present the floor
-// is satisfied by arithmetic and the range pin's silence is invisible.
 {
   const root = fixture({
     workspaceVersion: "0.3.3",
@@ -118,12 +97,6 @@ for (const pin of ["*", "^0.3.3", "~0.3.1", "0.3.x", ">=0.3.0", "latest", "npm:@
   else fail("3b. an unwatchable pin reds even when another exact pin matches cleanly", `returned ${ok}`);
 }
 
-// 4. Zero EXACT pins under `agent-examples/*` must throw rather than report a pass
-// having made no registry call. Asserted on the MESSAGE, not merely "something
-// threw": with an empty `packages/` the fixture used to throw
-// `no workspace manifests found` out of `loadWorkspaceMembers` before the floor
-// was ever reached, so a bare `catch {}` passed this case while the floor itself
-// had no coverage at all.
 {
   const root = fixture({
     workspaceVersion: "0.3.3",
@@ -143,8 +116,6 @@ for (const pin of ["*", "^0.3.3", "~0.3.1", "0.3.x", ">=0.3.0", "latest", "npm:@
   }
 }
 
-// 4b. A `@pome-sh/*` dep naming no workspace sibling is out of scope in all
-// three classes — nothing in the tree to compare it against.
 {
   const root = fixture({ workspaceVersion: "0.3.3", examplePin: "0.3.3" });
   writeFileSync(
@@ -161,7 +132,6 @@ for (const pin of ["*", "^0.3.3", "~0.3.1", "0.3.x", ">=0.3.0", "latest", "npm:@
 
 const pin = { example: "support-triage", field: "dependencies", dep: "@pome-sh/adapter-claude-sdk" };
 
-// 5. Published sibling version, pin already matches — green, no skip.
 {
   const result = checkExamplePinsPublished(
     [{ ...pin, pin: "0.3.3", workspaceVersion: "0.3.3" }],
@@ -174,8 +144,6 @@ const pin = { example: "support-triage", field: "dependencies", dep: "@pome-sh/a
   }
 }
 
-// 6. THE LIVE-DEFECT SHAPE, break-on-purpose: published sibling version, pin
-// STALE — must red, naming the example, the pin, and the workspace version.
 {
   const result = checkExamplePinsPublished(
     [{ ...pin, pin: "0.3.1", workspaceVersion: "0.3.3" }],
@@ -197,8 +165,6 @@ const pin = { example: "support-triage", field: "dependencies", dep: "@pome-sh/a
   }
 }
 
-// 7. Workspace version NOT published (E404) — a named, counted SKIP, never a
-// violation and never folded into "checked clean".
 {
   const result = checkExamplePinsPublished(
     [{ ...pin, pin: "0.3.1", workspaceVersion: "9.9.9" }],
@@ -216,9 +182,6 @@ const pin = { example: "support-triage", field: "dependencies", dep: "@pome-sh/a
   }
 }
 
-// 8. A registry error that is NOT "not found" (401/5xx/timeout) is a HARD
-// FAILURE — never downgraded to a skip, even though it also means "cannot
-// confirm the pin is current".
 {
   const result = checkExamplePinsPublished(
     [{ ...pin, pin: "0.3.1", workspaceVersion: "0.3.3" }],
@@ -231,10 +194,6 @@ const pin = { example: "support-triage", field: "dependencies", dep: "@pome-sh/a
   }
 }
 
-// 9. `defaultNpmView`'s own E404 classification, exercised through a mocked
-// `npm` on PATH rather than the real registry — same technique
-// `decide-publish.test.mjs` uses. A 404 (unpublished) must NOT be confused
-// with a 401/5xx (hard error).
 {
   const { chmodSync, mkdtempSync: mkdtemp, readFileSync, writeFileSync: write } = await import("node:fs");
   const { defaultNpmView } = await import("./check-example-pins-published.mjs");
@@ -271,9 +230,6 @@ const pin = { example: "support-triage", field: "dependencies", dep: "@pome-sh/a
     else fail("9c. defaultNpmView classifies a clean exit as published", JSON.stringify(result));
   });
 
-  // 9d. A failure with EMPTY stderr — the shape a killed call (the `timeout`
-  // in `defaultNpmView`) and some network aborts take. No `E404` to match on,
-  // so it must land in `error`, never fall through to "unpublished".
   withMockNpm("exit 1", () => {
     const result = defaultNpmView("@pome-sh/adapter-claude-sdk", "0.3.3", { attempts: 1 });
     if (result.status === "error" && result.detail) {
@@ -283,8 +239,6 @@ const pin = { example: "support-triage", field: "dependencies", dep: "@pome-sh/a
     }
   });
 
-  // 9e. A TRANSIENT 5xx is retried rather than reddening the required check on
-  // the first blip: this mock 503s twice, then succeeds.
   {
     const counter = join(mkdtemp(join(tmpdir(), "npm-attempts-")), "n");
     withMockNpm(
@@ -298,8 +252,6 @@ const pin = { example: "support-triage", field: "dependencies", dep: "@pome-sh/a
     );
   }
 
-  // 9f. …but a PERSISTENT error still ends as an error once the attempts are
-  // spent. Retrying must not become a way to eventually pass.
   withMockNpm('echo "npm error code E503" >&2; exit 1', () => {
     const result = defaultNpmView("@pome-sh/adapter-claude-sdk", "0.3.3", { attempts: 3, delayMs: 0 });
     if (result.status === "error" && result.attempts === 3) {
@@ -309,8 +261,6 @@ const pin = { example: "support-triage", field: "dependencies", dep: "@pome-sh/a
     }
   });
 
-  // 9g. An E404 returns on the FIRST attempt — the ordinary unpublished path
-  // must not pay the retry budget.
   {
     const counter = join(mkdtemp(join(tmpdir(), "npm-404-attempts-")), "n");
     withMockNpm(
@@ -326,16 +276,10 @@ const pin = { example: "support-triage", field: "dependencies", dep: "@pome-sh/a
   }
 }
 
-// PlanExampleRepins is the write-side of this same gate: a pin that
-// this file's own `violations` classifier already calls drifted-against-a-
-// published-sibling is exactly the set safe to rewrite automatically.
 {
   const published = (name, version) => (n, v) =>
     n === name && v === version ? { status: "published" } : { status: "unpublished" };
 
-  // 11. A genuinely drifted, published pin produces a repin: the manifest
-  // text is rewritten (old pin -> new pin, nothing else touched) and a
-  // lockfile-regeneration command names the right example directory.
   {
     const root = fixture({ workspaceVersion: "0.3.6", examplePin: "0.3.5" });
     const repins = planExampleRepins(root, published("@pome-sh/adapter-claude-sdk", "0.3.6"));
@@ -359,10 +303,6 @@ const pin = { example: "support-triage", field: "dependencies", dep: "@pome-sh/a
     }
   }
 
-  // 12. The exact incident shape: the sibling is NOT yet published (this run's
-  // own bump, or a `release.yml` publish still in flight) — must not repin.
-  // Repinning here would set a pin to a version `npm install
-  // --package-lock-only` cannot resolve, breaking `npm ci` outright.
   {
     const root = fixture({ workspaceVersion: "0.3.7", examplePin: "0.3.6" });
     const repins = planExampleRepins(root, () => ({ status: "unpublished" }));
@@ -370,7 +310,6 @@ const pin = { example: "support-triage", field: "dependencies", dep: "@pome-sh/a
     else fail("12. an unpublished sibling produces no repin, ever", JSON.stringify(repins));
   }
 
-  // 13. Already matching: no-op, no write planned — idempotence.
   {
     const root = fixture({ workspaceVersion: "0.3.6", examplePin: "0.3.6" });
     const repins = planExampleRepins(root, published("@pome-sh/adapter-claude-sdk", "0.3.6"));
@@ -378,7 +317,6 @@ const pin = { example: "support-triage", field: "dependencies", dep: "@pome-sh/a
     else fail("13. a pin that already matches the published sibling is a no-op", JSON.stringify(repins));
   }
 
-  // 14. A registry error (not E404) must not be read as "go ahead and repin".
   {
     const root = fixture({ workspaceVersion: "0.3.6", examplePin: "0.3.5" });
     const repins = planExampleRepins(root, () => ({ status: "error", detail: "ECONNRESET" }));
@@ -386,8 +324,6 @@ const pin = { example: "support-triage", field: "dependencies", dep: "@pome-sh/a
     else fail("14. a registry error produces no repin (never treated as published)", JSON.stringify(repins));
   }
 
-  // 15. Replays two observed incidents (adapter 0.3.4, adapter 0.3.6)
-  // — the exact state right after each release, before the human PR.
   for (const { was, published: newVersion } of [
     { was: "0.3.3", published: "0.3.4" },
     { was: "0.3.5", published: "0.3.6" },
@@ -402,11 +338,6 @@ const pin = { example: "support-triage", field: "dependencies", dep: "@pome-sh/a
     }
   }
 
-  // 16b. TWO drifted pins in ONE example. `applyAllocations` writes a plan's
-  // entries in order and last write wins per path, so the LAST entry for a
-  // manifest must already carry every earlier substitution — otherwise the
-  // first repin is silently dropped while the commit message still claims it,
-  // and the read-side gate keeps reddening on a drift the commit says it fixed.
   {
     const root = mkdtempSync(join(tmpdir(), "example-pins-two-"));
     writeFileSync(join(root, "package.json"), JSON.stringify({ name: "root", workspaces: ["packages/*"] }));
@@ -426,7 +357,6 @@ const pin = { example: "support-triage", field: "dependencies", dep: "@pome-sh/a
       }),
     );
     const repins = planExampleRepins(root, () => ({ status: "published" }));
-    // Whichever entry lands last for that path is what ends up on disk.
     const lastForPath = repins.filter((r) => r.writes[0].path === "agent-examples/support-triage/package.json").at(-1);
     const onDisk = JSON.parse(lastForPath?.writes[0].contents ?? "{}");
     if (
@@ -440,12 +370,6 @@ const pin = { example: "support-triage", field: "dependencies", dep: "@pome-sh/a
     }
   }
 
-  // 16c. An ambiguous manifest — the same `"<dep>": "<pin>"` bytes repeated in
-  // an `overrides` block, which npm accepts and this gate does not read as a
-  // second install field. `planExampleRepins` runs inside `planAllocations` on
-  // EVERY push to main, so throwing here would stop every package's release
-  // over one example manifest. It must skip that pin and keep going, leaving
-  // the read-side gate to red on it.
   {
     const root = mkdtempSync(join(tmpdir(), "example-pins-ambig-"));
     writeFileSync(join(root, "package.json"), JSON.stringify({ name: "root", workspaces: ["packages/*"] }));
@@ -470,8 +394,6 @@ const pin = { example: "support-triage", field: "dependencies", dep: "@pome-sh/a
     } catch (e) {
       threw = e;
     }
-    // The gate itself must still call it drift — skipping the WRITE must never
-    // skip the READ.
     const { violations } = checkExamplePinsPublished(discoverExampleSiblingDeps(root).exact, () => ({
       status: "published",
     }));
@@ -482,7 +404,6 @@ const pin = { example: "support-triage", field: "dependencies", dep: "@pome-sh/a
     }
   }
 
-  // 16d. …and one ambiguous pin must not cost a DIFFERENT example its repin.
   {
     const root = fixture({
       workspaceVersion: "0.3.6",
@@ -503,8 +424,6 @@ const pin = { example: "support-triage", field: "dependencies", dep: "@pome-sh/a
     }
   }
 
-  // 16. No `package.json` at the repo root (a throwaway fixture, like
-  // allocate-release-versions.test.mjs's) — must return empty, not throw.
   {
     const root = mkdtempSync(join(tmpdir(), "no-root-manifest-"));
     let threw = null;
@@ -522,9 +441,6 @@ const pin = { example: "support-triage", field: "dependencies", dep: "@pome-sh/a
   }
 }
 
-// 10. Aimed at the REAL tree, not only fixtures: `agent-examples/*` must still carry
-// at least one exact `@pome-sh/*` pin with a workspace sibling, and nothing
-// unwatchable. No fixture can prove the gate points at the live corpus.
 {
   const { dirname, resolve } = await import("node:path");
   const { fileURLToPath } = await import("node:url");

--- a/scripts/check-example-pins-published.test.mjs
+++ b/scripts/check-example-pins-published.test.mjs
@@ -386,7 +386,7 @@ const pin = { example: "support-triage", field: "dependencies", dep: "@pome-sh/a
     else fail("14. a registry error produces no repin (never treated as published)", JSON.stringify(repins));
   }
 
-  // 15. Replays the real incidents (#395: adapter 0.3.4, #425: adapter 0.3.6)
+  // 15. Replays two observed incidents (adapter 0.3.4, adapter 0.3.6)
   // — the exact state right after each release, before the human PR.
   for (const { was, published: newVersion } of [
     { was: "0.3.3", published: "0.3.4" },

--- a/scripts/check-packages-scripts-wired.mjs
+++ b/scripts/check-packages-scripts-wired.mjs
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Closes a class we found one instance of: a `packages/*` npm
-// script that names itself a check (`validate:mcp`) declared in a
-// package.json and invoked by NOTHING. It went red for weeks with no
-// verdict, and no verdict reads exactly like a pass.
+// A `packages/*` npm script that names itself a check but is invoked by NOTHING
+// produces no verdict, and no verdict reads exactly like a pass.
 //
 // The rule is a TOTAL partition, not a prefix list. Every
 // `packages/*/package.json` script is either
@@ -19,24 +17,18 @@
 //
 // Anything else fails this gate by name.
 //
-// This gate started life as an allowlist of check-NAME prefixes
-// (`validate:*`, `check:*`, `lint:*`, `gate:*`, `test:*`, `assert:*`) — the
-// vocabulary originally specified. That vocabulary could not see
-// `verify:cloud-token`, a real check that had also never run, and the audit
-// found it by hand instead. A prefix list of what counts as a check is itself
-// a hand-maintained list, which is the exact shape D5 names as the bug: it
-// covers its subject until someone names a script something new, and then it
-// silently stops, with nothing red. So the partition is inverted — the
-// DENOMINATOR is every script, the only fixed list is npm's own lifecycle
-// names, and a script that is neither wired nor reasoned-about is a red.
+// The partition is inverted on purpose: the DENOMINATOR is every script, and
+// the only fixed list is npm's own lifecycle names. A prefix list of what
+// counts as a check (`validate:*`, `check:*`, `gate:*` …) is itself
+// hand-maintained, so it covers its subject until someone names a script
+// something new and then silently stops, with nothing red. Under this shape
 // `smoke`, `review:harness`, `verify:cloud-token` and `preview:drift` are all
-// inside the gate's reach under this shape and were all outside it before.
+// inside the gate's reach.
 //
-// NO CENTRAL ALLOWLIST. A script deliberately exempt from this gate carries
-// its own reason inline, in the source file its package.json command invokes
-// — a line matching `pome:unwired-ok(<script>): <reason>` — and this gate
-// reads that file rather than a list here. A list of which checks are exempt is the same
-// shape as the bug the milestone is about.
+// NO CENTRAL ALLOWLIST. A script deliberately exempt carries its own reason
+// inline, in the source file its package.json command invokes — a line matching
+// `pome:unwired-ok(<script>): <reason>` — and this gate reads that file. A list
+// of which checks are exempt is the same shape as the bug.
 //
 // Textual, not semantic: this reads workflow YAML and root scripts as text
 // looking for `npm run <name> ... -w <package>`. A caller that reaches a
@@ -50,48 +42,34 @@
 //
 // Usage: node scripts/check-packages-scripts-wired.mjs
 //
-// The `cli/` extension. This gate was first scoped to `packages/*`; `cli/`
-// is a root workspace member too (AGENTS.md) and had the identical shape:
-// `gate:no-eval`, `gate:no-native`, `gate:recorder-overhead` and `test:e2e`
-// declared, only `check:manifest-schema` reached. Same total partition, same
-// three-way split (lifecycle / wired / marker), same marker syntax — no
-// second mechanism, no exemption list, just a second package.json to read.
+// `cli/` is a root workspace member too, with the identical shape, so it gets
+// the same total partition, the same three-way split and the same marker
+// syntax — no second mechanism, just a second package.json to read.
 //
-// `cli/` also has raw executable files under `cli/scripts/*` that are not
-// declared as ANY npm script. The motivating instance was
-// `cli/scripts/make-unwired-fixture.mjs` (since deleted, so do not go
-// looking for it): broken on `main` — a stale exact-text replacement threw
-// before it did anything — reached by nothing, and invisible to a denominator
-// built only from npm SCRIPT NAMES. So `cli/`'s denominator is the union of
-// (a) `cli/package.json`'s own non-lifecycle scripts, audited exactly like
-// `packages/*`, and (b) every file under `cli/scripts/**` that is neither the
-// invoked file of a declared `cli/package.json` script NOR imported by a
-// sibling file in `cli/scripts/**` — an imported file is a library module,
-// covered by whatever imports it, and if THAT importer is itself dead, IT is
-// what shows up here, which is the more actionable diagnosis. A file in (b)
-// has no script name for the `npm run <name> -w <pkg>` regex to find, so the
-// only coverage it can have is being one of (a)'s invoked files (already
-// excluded) or being imported by a sibling — anything left is wired via its
-// own `pome:unwired-ok(<relpath>): <reason>` marker or it fails, the same
-// marker mechanism as everywhere else in this file, keyed by the file's path
-// instead of a script name. Note what that does NOT say: a file invoked
-// DIRECTLY by a workflow step is not covered either, see the next paragraph.
+// `cli/` also has raw executable files under `cli/scripts/*` declared as no npm
+// script at all, which are invisible to a denominator built from script NAMES.
+// So `cli/`'s denominator is the union of (a) `cli/package.json`'s own
+// non-lifecycle scripts, audited exactly like `packages/*`, and (b) every file
+// under `cli/scripts/**` that is neither the invoked file of a declared script
+// NOR imported by a sibling in `cli/scripts/**`. An imported file is a library
+// module covered by whatever imports it, and if THAT importer is dead, IT shows
+// up here — the more actionable diagnosis. A file in (b) has no script name for
+// the `npm run <name> -w <pkg>` regex to find, so its only coverage is its own
+// `pome:unwired-ok(<relpath>): <reason>` marker, keyed by path instead of
+// script name. Note what that does NOT cover: a file a workflow step invokes
+// directly, see below.
 //
-// ONE CALLING CONVENTION, AND IT IS A FALSE RED, NOT A BLIND SPOT. `isWired`
-// recognises `npm run <name> ... -w <pkg>` and nothing else. A workflow that
-// invokes a declared script's FILE directly — `run: npx tsx
-// scripts/overhead-gate.ts` — is a real, running check that this gate reds
-// anyway, by name, saying "no workflow reaches it". Verified by hand against
-// that exact shape. Three of `agent-trace-overhead-gate.yml`'s steps were
-// written that way and all three were converted to `npm run <name> -w
-// @pome-sh/cli` rather than teach the gate a second wiring shape, because one
-// detection mechanism is the whole reason the marker path can be trusted.
-// The cost is real and is accepted deliberately: the NEXT person who adds a
-// direct `tsx <path>` step gets a red whose diagnosis names the fix (declare
-// it as a script and call it the standard way), so the failure is loud and
-// self-correcting rather than silent. If that ever stops being the right
-// trade, the fix is to also scan the corpus for the script's resolved file
-// path — not to add an exemption list.
+// ONE CALLING CONVENTION, AND IT IS A FALSE RED RATHER THAN A BLIND SPOT.
+// `isWired` recognises `npm run <name> ... -w <pkg>` and nothing else, so a
+// workflow invoking a declared script's FILE directly (`run: npx tsx
+// scripts/overhead-gate.ts`) is a real, running check that this gate reds
+// anyway, by name. That cost is accepted deliberately: the next person who adds
+// a direct `tsx <path>` step gets a red whose diagnosis names the fix — declare
+// it as a script and call it the standard way — so the failure is loud and
+// self-correcting rather than silent, and one detection mechanism is the whole
+// reason the marker path can be trusted. If that stops being the right trade,
+// the fix is to also scan for the script's resolved file path, not to add an
+// exemption list.
 
 import { existsSync, readdirSync, readFileSync, realpathSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
@@ -479,7 +457,7 @@ function resolveRelativeImport(fromFile, specifier) {
  * file of a declared `cli/package.json` script (any of them, including
  * LIFECYCLE ones — `prepublishOnly` reaching `assert-publishable.mjs` counts
  * as reached) nor imported by a sibling file in the same tree. What is left
- * is a candidate entry point exactly like the deleted `make-unwired-fixture.mjs`: no
+ * is a candidate entry point: no
  * script name names it, so it cannot be "wired" the way a package.json
  * script can — it can only carry its own exemption marker or fail.
  */
@@ -551,7 +529,7 @@ export function run(root) {
   // zero-entry scan exits 0 having asserted nothing; the cli/ half had no
   // equivalent, so renaming `cli/` or `cli/scripts/` would have dropped eight
   // entries and stayed green — coverage silently shrinking, which is the shape
-  // this milestone exists to kill and which `the `import-meta-main` lint rule` already
+  // this gate exists to kill and which the `import-meta-main` lint rule already
   // makes a hard failure PER ROOT. Derived, not listed: if the root
   // `workspaces` array names `cli`, the cli/ denominator must be non-empty. A
   // repo whose workspaces do not name `cli` legitimately contributes nothing.
@@ -628,7 +606,7 @@ export function run(root) {
   }
 
   // Cli/scripts/** files nothing declares as a script at all
-  // (the deleted make-unwired-fixture.mjs's shape). No script name exists for these, so
+  // (a generator with no npm script name). No script name exists for these, so
   // the only way to clear one is the marker, read straight from the file.
   for (const entry of fileEntries) {
     const reason = readMarkerFromFile(entry.filePath, entry.scriptName);

--- a/scripts/check-packages-scripts-wired.mjs
+++ b/scripts/check-packages-scripts-wired.mjs
@@ -1,75 +1,11 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// A `packages/*` npm script that names itself a check but is invoked by NOTHING
-// produces no verdict, and no verdict reads exactly like a pass.
-//
-// The rule is a TOTAL partition, not a prefix list. Every
-// `packages/*/package.json` script is either
-//
-//   (a) an npm LIFECYCLE script (the fixed set below — names npm itself
-//       defines, wired uniformly through `--workspaces --if-present` or an
-//       explicit `-w` list, a different and already-solved problem), or
-//   (b) reachable from a workflow or a root aggregate script — textually, as
-//       `npm run <script> ... -w <package-name>`, or
-//   (c) carrying a `pome:unwired-ok(<script>): <reason>` marker in the file its
-//       command invokes.
-//
-// Anything else fails this gate by name.
-//
-// The partition is inverted on purpose: the DENOMINATOR is every script, and
-// the only fixed list is npm's own lifecycle names. A prefix list of what
-// counts as a check (`validate:*`, `check:*`, `gate:*` …) is itself
-// hand-maintained, so it covers its subject until someone names a script
-// something new and then silently stops, with nothing red. Under this shape
-// `smoke`, `review:harness`, `verify:cloud-token` and `preview:drift` are all
-// inside the gate's reach.
-//
-// NO CENTRAL ALLOWLIST. A script deliberately exempt carries its own reason
-// inline, in the source file its package.json command invokes — a line matching
-// `pome:unwired-ok(<script>): <reason>` — and this gate reads that file. A list
-// of which checks are exempt is the same shape as the bug.
-//
-// Textual, not semantic: this reads workflow YAML and root scripts as text
-// looking for `npm run <name> ... -w <package>`. A caller that reaches a
-// script through a programmatic argv array (`spawnSync("npm", ["run", name,
-// "-w", pkg])`) rather than a composed string is invisible to it — no caller
-// in this repo does that today, so it is a documented limitation, not a
-// silent gap. Same reasoning as the wired-check regex above: literal text,
-// not an npm/AST-aware resolver.
-//
-// Dependency-free, so it runs in ci.yml's always-on block before `npm ci`.
-//
-// Usage: node scripts/check-packages-scripts-wired.mjs
-//
-// `cli/` is a root workspace member too, with the identical shape, so it gets
-// the same total partition, the same three-way split and the same marker
-// syntax — no second mechanism, just a second package.json to read.
-//
-// `cli/` also has raw executable files under `cli/scripts/*` declared as no npm
-// script at all, which are invisible to a denominator built from script NAMES.
-// So `cli/`'s denominator is the union of (a) `cli/package.json`'s own
-// non-lifecycle scripts, audited exactly like `packages/*`, and (b) every file
-// under `cli/scripts/**` that is neither the invoked file of a declared script
-// NOR imported by a sibling in `cli/scripts/**`. An imported file is a library
-// module covered by whatever imports it, and if THAT importer is dead, IT shows
-// up here — the more actionable diagnosis. A file in (b) has no script name for
-// the `npm run <name> -w <pkg>` regex to find, so its only coverage is its own
-// `pome:unwired-ok(<relpath>): <reason>` marker, keyed by path instead of
-// script name. Note what that does NOT cover: a file a workflow step invokes
-// directly, see below.
-//
-// ONE CALLING CONVENTION, AND IT IS A FALSE RED RATHER THAN A BLIND SPOT.
-// `isWired` recognises `npm run <name> ... -w <pkg>` and nothing else, so a
-// workflow invoking a declared script's FILE directly (`run: npx tsx
-// scripts/overhead-gate.ts`) is a real, running check that this gate reds
-// anyway, by name. That cost is accepted deliberately: the next person who adds
-// a direct `tsx <path>` step gets a red whose diagnosis names the fix — declare
-// it as a script and call it the standard way — so the failure is loud and
-// self-correcting rather than silent, and one detection mechanism is the whole
-// reason the marker path can be trusted. If that stops being the right trade,
-// the fix is to also scan for the script's resolved file path, not to add an
-// exemption list.
+// A packages/* or cli/ script that names itself a check and is invoked by nothing
+// produces no verdict, and no verdict reads like a pass. Total partition: lifecycle,
+// wired as `npm run <name> -w <pkg>`, or carrying its own `pome:unwired-ok` marker.
+// Only that one calling convention is recognised, so a direct `tsx <path>` step is a
+// deliberate false red whose fix is to declare it as a script.
 
 import { existsSync, readdirSync, readFileSync, realpathSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
@@ -77,32 +13,6 @@ import { fileURLToPath } from "node:url";
 
 const ROOT = process.cwd();
 
-/**
- * The uniform lifecycle scripts, matched by EXACT name. `test`, `start`,
- * `prepare`, `prepack`, `prepublishOnly` and `postinstall` are npm's own;
- * `build`, `dev` and `typecheck` are this repo's convention, not something npm
- * defines, and it is worth saying so rather than claiming npm closes the set.
- *
- * What makes the list safe is not who owns the names but that each is reached
- * WITHOUT the `-w <package>` shape below, uniformly across every workspace:
- * root `typecheck` is `npm run typecheck --workspaces --if-present`, root
- * `test` is a bare `vitest run` against the one root `vitest.config.ts` whose
- * project list is DISCOVERED from `packages/*` (so a new package's tests are
- * picked up without an edit there or here), root `build` is
- * `scripts/build.mjs` over the whole
- * workspace graph, `prepack`/`prepare`/`prepublishOnly`/`postinstall` are npm's
- * own pack/publish/install hooks, and `dev`/`start` are runtime entry points
- * that assert nothing.
- *
- * It is still a list, and that is the residual: a check smuggled in under the
- * exact name `dev` or `typecheck` would be skipped. It is a far smaller and
- * far less load-bearing list than the check-name PREFIX vocabulary it replaced
- * — nine exact names that already exist in every package, versus an open set of
- * every prefix someone might invent for a new check — but it is not zero. The
- * set is shared by `packages/*` and `cli/` (the denominator was widened to
- * both), so adding `pome` for `cli/`'s sake also exempts that exact name in a
- * `packages/*` member; same accepted residual, one more name.
- */
 const LIFECYCLE_SCRIPTS = new Set([
   "build",
   "dev",
@@ -113,45 +23,14 @@ const LIFECYCLE_SCRIPTS = new Set([
   "prepare",
   "prepublishOnly",
   "postinstall",
-  // `pome` is cli/package.json's own equivalent of npm's `start` — it runs
-  // the BUILT tarball entry point (`node dist/src/cli/main.js`) with no
-  // assertion, the identical reasoning `dev`/`start` get above. Scoped into
-  // this shared set rather than a per-package list because that residual
-  // ("a check smuggled in under an exempt name is skipped") is already
-  // accepted for the other nine, and this repo has exactly one `cli/`.
   "pome",
 ]);
 
-/**
- * A marker NAMES the script it exempts — `pome:unwired-ok(<script>): <reason>`
- * — and the reason must be on the same line and non-blank.
- *
- * Two holes this closes, both found by breaking the first version on purpose:
- *
- * 1. `/pome:unwired-ok:\s*(.+)/` let a marker with NO reason through. `\s`
- *    matches a newline, so a bare `// pome:unwired-ok:` consumed the line
- *    break and captured the next line of the file as its justification — it
- *    reported a stray `import` statement as the reason someone chose not to
- *    run a check. An exemption with no reason is what this gate forbids.
- *
- * 2. An unnamed marker exempts EVERY script in the package whose command
- *    names that file, and three files here implement two scripts each: a write
- *    mode nothing runs plus a `--check` mode that IS wired
- *    (`fixture:mcp`/`gate:mcp-fixture`, `regenerate:`/`gate:mcp-tool-fixture`,
- *    `emit:`/`check:trace-contract`). One unnamed marker for the write half
- *    would silently pre-authorise the check half going unwired — which is the
- *    original defect, granted in advance.
- */
 function exemptionMarkerFor(scriptName) {
   return new RegExp(`pome:unwired-ok\\(${escapeRe(scriptName)}\\):[ \\t]*(\\S[^\\n]*)`);
 }
 
-/** Every `packages/*` script that is not an npm lifecycle script. */
 export function findCheckScripts(root) {
-  // Never `return []` on a missing packages/ — this gate runs from the repo
-  // root in ci.yml, and a wrong cwd would otherwise print `OK — 0 scripts` and
-  // exit 0, asserting nothing. Same reasoning as contract/run.mjs, which
-  // throws on an empty discovery rather than exiting 0 having found no tests.
   const packagesDir = join(root, "packages");
   if (!existsSync(packagesDir)) {
     throw new Error(
@@ -184,16 +63,6 @@ export function findCheckScripts(root) {
   return found;
 }
 
-/**
- * The same enumeration as `findCheckScripts`, for `cli/`'s own
- * `package.json` instead of every `packages/*` member. `cli/` is a single
- * root workspace member (AGENTS.md), not a directory of them, so this reads
- * one file rather than looping a directory. Returns `[]` if `cli/package.json`
- * is absent — real for this repo's own `cli/` never happens (it is a
- * committed root workspace member), and the "wrong cwd" failure mode this
- * gate must never silently pass on is already caught by `findCheckScripts`'s
- * hard throw on a missing `packages/` dir, which runs from the same root.
- */
 export function findCliPackageScripts(root) {
   const pkgJsonPath = join(root, "cli", "package.json");
   if (!existsSync(pkgJsonPath)) return [];
@@ -221,13 +90,6 @@ function escapeRe(text) {
   return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-/**
- * Does the ROOT manifest declare `cli` a workspace member? This is what makes
- * the cli/ floor in `run()` derived rather than hardcoded: the same source npm
- * itself reads decides whether cli/ is expected to contribute entries, so a
- * `packages/*`-only repo (and this suite's own cases 1-24, which write no root
- * package.json) is not held to a floor it has no subject for.
- */
 function declaresCliWorkspace(root) {
   const rootPkgJson = join(root, "package.json");
   if (!existsSync(rootPkgJson)) return false;
@@ -240,33 +102,12 @@ function declaresCliWorkspace(root) {
   }
 }
 
-/**
- * A script is "wired" if some corpus of text (workflow YAML, root
- * package.json, root scripts/) contains `npm run <script> ... -w
- * <package>` on one line — the shape every existing wired check in this
- * repo uses (see ci.yml's `npm run validate:mcp -w @pome-sh/twin-github`).
- */
 export function isWired(entry, corpus) {
   const script = escapeRe(entry.scriptName);
   const pkg = escapeRe(entry.pkgName);
-  // `(?![\w:.-])`, never `\b`: `-` and `:` are non-word characters, so `\b`
-  // after `gate:mcp` matches inside `gate:mcp-fixture`. A package declaring
-  // both would have had the longer script's real CI line certify the shorter
-  // one as wired while nothing ran it — the original shape, produced by the gate
-  // meant to catch it. Same guard on the package name, so `@pome-sh/twin-slack`
-  // is not wired by a line naming `@pome-sh/twin-slack-legacy`.
   const nameEnd = "(?![\\w:.-])";
   const pkgEnd = "(?![\\w:./@-])";
-  // `npm run` and `npm run-script` are the same command; the workspace can be
-  // `-w X` or `--workspace X` or `--workspace=X`, and can come BEFORE or AFTER
-  // the script name. Accepting only one of those six spellings meant a
-  // genuinely-wired check went red the first time someone reformatted the line
-  // — a false red with a diagnosis pointing at the wrong thing. ci.yml's
-  // 180-char five-workspace `fidelity:parity` line is the obvious candidate.
   const ws = `(?:-w|--workspace)[=\\s]+${pkg}${pkgEnd}`;
-  // A `--` ends npm's own options: in `npm run x -- -w pkg` the `-w` is passed
-  // to the SCRIPT, npm selects no workspace, and the command runs in the root.
-  // That is not wiring, so the gap before the workspace must not contain `--`.
   const gap = "(?:(?!--)[^\\n])*";
   const re = new RegExp(
     `npm run(?:-script)? (?:${ws}${gap}${script}${nameEnd}|${script}${nameEnd}${gap}${ws})`,
@@ -274,17 +115,6 @@ export function isWired(entry, corpus) {
   return re.test(corpus);
 }
 
-/**
- * Reads the exemption reason straight from the file the script's own command
- * invokes, never from a list here. Returns null if the command names no
- * resolvable file, the file doesn't exist, or it carries no marker.
- *
- * The resolved path must stay INSIDE the script's own package. `[\w./-]+`
- * matches `..`, so a command whose first file token escaped the package
- * (`node ../beta/scripts/other.mjs && node scripts/foo.mjs`) let an unrelated
- * file's marker exempt this script — an exemption satisfied by a reason
- * written about something else.
- */
 export function findExemptionReason(entry, root) {
   const scriptPath = invokedFile(entry, root);
   if (!scriptPath) return null;
@@ -296,15 +126,6 @@ const SELF_EXCLUDED = new Set([
   "check-packages-scripts-wired.test.mjs",
 ]);
 
-/**
- * Drops whole-line comments before the corpus is searched. Commenting a check
- * out — "# disabled, flaky" — is the single most common way a check stops
- * producing a verdict, and a plain text scan counted the dead line as proof it
- * still ran. Handles the three comment leaders in this corpus: `#` (YAML, sh)
- * and `//` (mjs/js). Deliberately whole-line only: a trailing comment after a
- * real command does not make the command not run, and a block-comment-aware
- * parser is a JS/YAML parser, which this dependency-free gate is not.
- */
 function stripCommentLines(text) {
   return text
     .split("\n")
@@ -328,13 +149,6 @@ function readCorpus(root) {
     const walk = (dir) => {
       for (const entry of readdirSync(dir, { withFileTypes: true })) {
         if (entry.name === "node_modules") continue;
-        // This gate and its own regression suite are NOT wiring. Both are
-        // inside the corpus they scan and both quote `npm run <name> -w <pkg>`
-        // strings — this file in its docstrings, the suite in its fixtures. A
-        // gate that accepts its own prose as proof a check runs is the bug it
-        // exists to catch, and a future fixture that used a REAL package name
-        // instead of `@pome-sh/alpha` would silently wire that package's
-        // script. Excluded by name so it cannot happen by accident.
         if (SELF_EXCLUDED.has(entry.name)) continue;
         const abs = join(dir, entry.name);
         if (entry.isDirectory()) {
@@ -355,36 +169,15 @@ function readCorpus(root) {
   return stripCommentLines(parts.join("\n"));
 }
 
-/**
- * The file a script's command invokes, resolved inside its own package, or
- * null. Shared with the exemption reader so the two agree on what file a
- * script means.
- */
 export function invokedFile(entry, root) {
-  // Whole-token, never a substring. Unanchored, `[\w./-]+\.(?:ts|mjs|js|sh)`
-  // matches `tsconfig.js` INSIDE the literal `tsconfig.json`, so
-  // `tsx --tsconfig tsconfig.json scripts/x.ts` resolved to a config file
-  // instead of the script. Under the narrow scope that only cost a missed
-  // exemption marker; under the widened one it also keeps the real script out of
-  // `invokedByScript`, so the file reds as an orphan with a diagnosis
-  // pointing at the wrong file entirely.
   const fileMatch = entry.command.match(/(?:^|\s)([\w./-]+\.(?:ts|mts|cts|tsx|mjs|cjs|js|sh))(?=\s|$)/);
   if (!fileMatch) return null;
-  // `cli/` is a single workspace member at `cli/`, not one of many
-  // under `packages/<name>`, so it resolves against a different base.
   const pkgRoot = entry.pkgKind === "cli" ? resolve(root, "cli") : resolve(root, "packages", entry.pkgDir);
   const scriptPath = resolve(pkgRoot, fileMatch[1]);
   if (scriptPath !== pkgRoot && !scriptPath.startsWith(`${pkgRoot}/`)) return null;
   return existsSync(scriptPath) ? scriptPath : null;
 }
 
-/**
- * Reads the `pome:unwired-ok(<name>): <reason>` marker straight out of a
- * file's own bytes, shared by both the script-command path
- * (`findExemptionReason`, below) and the raw-file path (the
- * `cli/scripts/**` entries, which have no command to derive a file from —
- * the file IS the entry).
- */
 function readMarkerFromFile(filePath, name) {
   let content;
   try {
@@ -396,17 +189,8 @@ function readMarkerFromFile(filePath, name) {
   return marker ? marker[1].trim() : null;
 }
 
-// `.mts`/`.cts` included deliberately: `import-meta-main.mjs`
-// next door scans them, and a file this pattern misses is invisible to the
-// denominator — the exact class the file-level pass exists to close, so the
-// two extension sets must not disagree.
 const SCRIPT_FILE_RE = /\.(?:mjs|js|cjs|ts|mts|cts|tsx|sh)$/;
 const TEST_FILE_RE = /\.test\.[mc]?[jt]sx?$/;
-// All four specifier forms, not just `from "…"`: a side-effect `import "./x"`,
-// a dynamic `await import("./x")` and `require("./x")` each make the target a
-// live library module just as much as a named import does, and treating one as
-// an orphan is a FALSE red whose suggested remedy (add an unwired-ok marker)
-// would be a lie recorded in the file.
 const RELATIVE_IMPORT_RE =
   /\bfrom\s*["'](\.[^"']+)["']|\b(?:require|import)\(\s*["'](\.[^"']+)["']\s*\)|\bimport\s+["'](\.[^"']+)["']/g;
 
@@ -424,9 +208,6 @@ function listScriptFilesRecursive(dir) {
   return out;
 }
 
-/** Resolve a relative import specifier against the extensionless-.ts-behind-.js
- * convention this codebase's scripts use (`import ... from "./overhead-stats.js"`
- * resolving to the committed `overhead-stats.ts`). */
 function resolveRelativeImport(fromFile, specifier) {
   const base = resolve(dirname(fromFile), specifier);
   const candidates = [
@@ -435,10 +216,6 @@ function resolveRelativeImport(fromFile, specifier) {
     base.replace(/\.(?:js|mjs|cjs)$/, ".tsx"),
     base.replace(/\.(?:js|mjs|cjs)$/, ".mts"),
     base.replace(/\.(?:js|mjs|cjs)$/, ".cts"),
-    // Extensionless and directory/index specifiers. Without these a live
-    // `from "./overhead-stats"` or `from "./lib"` leaves its target looking
-    // like a dead entry point — a false red, and the marker it would prompt
-    // for would be a false statement in the file.
     ...(/\.[a-z]+$/.test(base)
       ? []
       : [".ts", ".tsx", ".mts", ".cts", ".mjs", ".cjs", ".js"].flatMap((ext) => [
@@ -452,15 +229,6 @@ function resolveRelativeImport(fromFile, specifier) {
   return null;
 }
 
-/**
- * Every file under `cli/scripts/**` that is neither the invoked
- * file of a declared `cli/package.json` script (any of them, including
- * LIFECYCLE ones — `prepublishOnly` reaching `assert-publishable.mjs` counts
- * as reached) nor imported by a sibling file in the same tree. What is left
- * is a candidate entry point: no
- * script name names it, so it cannot be "wired" the way a package.json
- * script can — it can only carry its own exemption marker or fail.
- */
 export function findCliOrphanFileEntries(root) {
   const scriptsDir = join(root, "cli", "scripts");
   if (!existsSync(scriptsDir)) return [];
@@ -476,19 +244,11 @@ export function findCliOrphanFileEntries(root) {
         if (filePath) invokedByScript.add(filePath);
       }
     } catch {
-      // not this gate's problem — package.json validity is checked elsewhere
     }
   }
 
   const importedBySibling = new Set();
   for (const file of files) {
-    // Same `stripCommentLines` the corpus gets, and for the same reason:
-    // commenting a line out is how a thing stops happening, and a plain text
-    // scan otherwise counts the dead line as proof it still does. Here the
-    // consequence is a file-level exemption — a commented-out
-    // `// import { x } from "./dead.js";` would certify `dead.js` as a live
-    // library module covered by its importer, which is exactly the
-    // no-verdict-reads-as-a-pass shape this gate exists to catch.
     const text = stripCommentLines(readFileSync(file, "utf8"));
     RELATIVE_IMPORT_RE.lastIndex = 0;
     let match;
@@ -517,22 +277,8 @@ export function findCliOrphanFileEntries(root) {
 }
 
 export function run(root) {
-  // Cli/'s own non-lifecycle scripts join packages/*'s in ONE array,
-  // so the derived write/--check coverage below (same `pkgDir`, same command
-  // shape) applies to cli/'s `emit:manifest-schema`/`check:manifest-schema`
-  // pair with no new code — it is the identical shape three packages/* pairs
-  // already use.
   const cliPackageScripts = findCliPackageScripts(root);
   const fileEntries = findCliOrphanFileEntries(root);
-  // A FLOOR for the cli/ half, derived from the root manifest rather than
-  // assumed. `findCheckScripts` hard-throws on a missing `packages/` because a
-  // zero-entry scan exits 0 having asserted nothing; the cli/ half had no
-  // equivalent, so renaming `cli/` or `cli/scripts/` would have dropped eight
-  // entries and stayed green — coverage silently shrinking, which is the shape
-  // this gate exists to kill and which the `import-meta-main` lint rule already
-  // makes a hard failure PER ROOT. Derived, not listed: if the root
-  // `workspaces` array names `cli`, the cli/ denominator must be non-empty. A
-  // repo whose workspaces do not name `cli` legitimately contributes nothing.
   if (cliPackageScripts.length + fileEntries.length === 0 && declaresCliWorkspace(root)) {
     throw new Error(
       `root package.json declares "cli" a workspace member, but the cli/ half of this gate's ` +
@@ -544,44 +290,12 @@ export function run(root) {
   const entries = [...findCheckScripts(root), ...cliPackageScripts];
   const corpus = readCorpus(root);
 
-  // A write mode whose WIRED sibling runs the same command PLUS more is
-  // covered by derivation, not by a hand-written reason. Three files here have
-  // exactly that shape — `tsx scripts/adopt-upstream-mcp-fixture.ts` versus
-  // `... --check`, and the same for regenerate-mcp-tool-fixture and
-  // emit-trace-contract — so the write half's coverage is a fact this gate can
-  // read off the manifest plus the corpus, rather than a sentence someone has
-  // to keep true by hand. Deriving it also keeps the marker out of
-  // `packages/wire/scripts/` and `packages/sdk/scripts/`, which unlike
-  // `packages/twin-*/scripts/` are publish-relevant paths: a comment there
-  // would demand version-only bumps of three published packages for a
-  // byte-identical republish.
-  //
-  // DIRECTIONAL on purpose. Only the strict-superset direction holds: the
-  // `--check` mode runs everything the write mode does and then asserts, so a
-  // wired `--check` covers the write half's file. The reverse is false — a
-  // wired WRITE mode regenerates the artifact and asserts nothing, so it must
-  // never certify the `--check` verdict as covered. Sharing a file alone is
-  // not enough; the argv is the difference between a verdict and a rewrite.
   const wired = entries.filter((e) => isWired(e, corpus));
   const coveredByWiredSuperset = (entry) =>
     wired.some(
       (w) =>
-        // Same package. `wiredCommands` was flat, and twin-gmail and twin-slack
-        // both declare `fixture:mcp = tsx scripts/adopt-upstream-mcp-fixture.ts`
-        // — two DIFFERENT files with one command string — so unwiring gmail's
-        // `gate:mcp-fixture` left gmail's write half certified by slack's file.
-        // `pkgKind` too, not `pkgDir` alone: `cli/` entries carry
-        // `pkgDir: "cli"`, so a future `packages/cli` member would collide with
-        // it and each one's wired `--check` half would certify the OTHER's
-        // write half — the same cross-package certification hole the
-        // twin-gmail/twin-slack `fixture:mcp` case put this guard here for.
         w.pkgKind === entry.pkgKind &&
         w.pkgDir === entry.pkgDir &&
-        // Exactly `--check`, not "any extra argv". The claim being made is that
-        // the verdict mode runs everything the write mode does and then
-        // asserts; `startsWith(cmd + " ")` also let a wired
-        // `dev:foo = node scripts/foo.mjs --watch` certify an unwired
-        // `check:foo`, which asserts nothing.
         w.command === `${entry.command} --check`,
     );
 
@@ -605,9 +319,6 @@ export function run(root) {
     failures.push(entry);
   }
 
-  // Cli/scripts/** files nothing declares as a script at all
-  // (a generator with no npm script name). No script name exists for these, so
-  // the only way to clear one is the marker, read straight from the file.
   for (const entry of fileEntries) {
     const reason = readMarkerFromFile(entry.filePath, entry.scriptName);
     if (reason) {
@@ -620,11 +331,6 @@ export function run(root) {
   return { total: entries.length + fileEntries.length, failures, exemptions };
 }
 
-// Never `import.meta.main` (Node 24.2+; `undefined` on an earlier permitted
-// `engines` version silently disables this whole gate) and never a bare
-// `process.argv[1] === import.meta.url` string compare — node resolves
-// symlinks before deriving `import.meta.url`, so an unresolved argv misses
-// through a symlinked checkout. Both sides realpath'd.
 const isMain =
   process.argv[1] !== undefined &&
   realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));

--- a/scripts/check-packages-scripts-wired.mjs
+++ b/scripts/check-packages-scripts-wired.mjs
@@ -132,7 +132,7 @@ const LIFECYCLE_SCRIPTS = new Set([
  *    matches a newline, so a bare `// pome:unwired-ok:` consumed the line
  *    break and captured the next line of the file as its justification — it
  *    reported a stray `import` statement as the reason someone chose not to
- *    run a check. An exemption with no reason is what the milestone forbids.
+ *    run a check. An exemption with no reason is what this gate forbids.
  *
  * 2. An unnamed marker exempts EVERY script in the package whose command
  *    names that file, and three files here implement two scripts each: a write

--- a/scripts/check-packages-scripts-wired.test.mjs
+++ b/scripts/check-packages-scripts-wired.test.mjs
@@ -1,19 +1,8 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Regression suite for `check-packages-scripts-wired.mjs`.
-//
-// The motivating bug was a `packages/*` script named like a check
-// that sat unreachable for weeks with no verdict. The thing most worth
-// proving here is that this gate CAN go red on that exact shape — a fresh
-// `check:foo` with no caller — and that it can also go GREEN correctly: on a
-// script that IS reached, and on a script that is deliberately exempt with
-// its reason living in the file it invokes rather than in a list here.
-//
-// Each case builds a throwaway tree (a `packages/<name>/package.json`, an
-// optional `.github/workflows/ci.yml`, and any script files the package.json
-// commands name) and runs the real script against it via a different cwd —
-// same pattern as twin-chunks.test.mjs.
+// Case table for check-packages-scripts-wired. Every case asserts the RED direction: a rule that has
+// quietly stopped failing prints the same line as one with nothing to report.
 
 import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
@@ -53,8 +42,6 @@ function check(name, files, { expect, contains }) {
 
 const pkgJson = (name, scripts) => JSON.stringify({ name, scripts });
 
-// Case 1: a vocab-matching script reached by a workflow line in the exact
-// shape every real wired check in this repo uses. Must stay green.
 check(
   "wired check:foo passes",
   {
@@ -65,8 +52,6 @@ check(
   { expect: "green" }
 );
 
-// Case 2: an unreferenced check:foo
-// must red the gate BY NAME.
 check(
   "unwired check:foo reds, naming it",
   {
@@ -76,9 +61,6 @@ check(
   { expect: "red", contains: '@pome-sh/alpha "check:foo"' }
 );
 
-// Case 3: exemption reason lives in the script the command invokes, never in
-// a list here. Reading it must clear the red and print the reason, not
-// silently pass with no trace.
 check(
   "unwired script with an inline pome:unwired-ok exemption passes and prints the reason",
   {
@@ -88,10 +70,6 @@ check(
   { expect: "green", contains: "manual dev tool, needs a live credential CI lacks" }
 );
 
-// Case 4 (the inversion): a script whose NAME matches no check prefix is in
-// scope anyway. Under the original prefix vocabulary `smoke` was invisible,
-// which is how three twins' smoke scripts and `verify:cloud-token` sat unrun.
-// The partition is total: wired, lifecycle, or reasoned-about.
 check(
   "unwired non-prefixed script (smoke) IS flagged — the vocabulary is not a prefix list",
   {
@@ -101,11 +79,6 @@ check(
   { expect: "red", contains: '@pome-sh/alpha "smoke"' }
 );
 
-// Case 5: a bare "test" is an npm LIFECYCLE name — the one fixed set this
-// gate carries. No `packages/*` member declares one any more (root `test` is a
-// bare `vitest run` over the root config's discovered project list), but the
-// name stays exempt: a package that reintroduces one is not a check this gate
-// should demand wiring for, and its tests run either way.
 check(
   "unwired bare 'test' (no colon) is not flagged",
   {
@@ -114,9 +87,6 @@ check(
   { expect: "green" }
 );
 
-// Case 6: a script invoked by a root aggregate (not a workflow) counts as
-// wired too — the corpus includes root scripts/, not only workflow YAML. The
-// invocation has to be live CODE, not a comment about it (case 12).
 check(
   "reached only from a root script (root aggregate) passes",
   {
@@ -127,11 +97,6 @@ check(
   { expect: "green" }
 );
 
-// Case 7 (break-on-purpose): a marker with NO reason must be REJECTED. The
-// first version used `/pome:unwired-ok:\s*(.+)/`, and `\s` matches a newline —
-// so a bare marker consumed the line break and reported the NEXT LINE of the
-// file as its justification. An exemption with no reason is exactly what the
-// this gate forbids.
 check(
   "a marker with no reason text is rejected, not satisfied by the next line",
   {
@@ -141,7 +106,6 @@ check(
   { expect: "red", contains: '@pome-sh/alpha "validate:foo"' }
 );
 
-// Case 8 (break-on-purpose): whitespace-only reason, same rule.
 check(
   "a marker with a whitespace-only reason is rejected",
   {
@@ -151,10 +115,6 @@ check(
   { expect: "red", contains: '@pome-sh/alpha "validate:foo"' }
 );
 
-// Case 9 (break-on-purpose): a marker in an UNRELATED file must not satisfy
-// the exemption. `[\w./-]+` matches `..`, so before the containment check the
-// first file token in a compound command could escape the package entirely and
-// borrow a reason written about something else.
 check(
   "a marker in another package's file does not exempt this script",
   {
@@ -167,12 +127,6 @@ check(
   { expect: "red", contains: '@pome-sh/alpha "validate:foo"' }
 );
 
-// Case 10 (break-on-purpose): a marker must name the script it exempts. Three
-// files in this repo implement a write mode AND a wired `--check` verdict
-// (fixture:mcp/gate:mcp-fixture, regenerate:/gate:mcp-tool-fixture,
-// emit:/check:trace-contract). An unnamed marker for the write half would
-// pre-authorise the check half going unwired — the original defect, granted in
-// advance.
 check(
   "a marker naming a DIFFERENT script does not exempt this one",
   {
@@ -186,10 +140,6 @@ check(
   { expect: "red", contains: '@pome-sh/alpha "gate:mcp-fixture"' }
 );
 
-// Case 11 (break-on-purpose): this gate and its own regression suite are not
-// wiring. Both sit inside the corpus they scan and both quote `npm run <x> -w
-// <pkg>` strings; a gate that accepts its own prose as proof a check runs is
-// the bug it exists to catch.
 check(
   "the gate's own file is not corpus — its docstrings cannot wire anything",
   {
@@ -200,9 +150,6 @@ check(
   { expect: "red", contains: '@pome-sh/alpha "check:foo"' }
 );
 
-// Case 12 (break-on-purpose): commenting a check out is the commonest way one
-// stops producing a verdict — "# disabled, flaky" — and a plain text scan of
-// the corpus counted the dead line as proof it still ran.
 check(
   "a commented-out CI invocation is NOT wiring",
   {
@@ -213,10 +160,6 @@ check(
   { expect: "red", contains: '@pome-sh/alpha "gate:foo"' }
 );
 
-// Case 13 (break-on-purpose): a longer script's real CI line must not certify
-// a shorter prefix-named one. `\b` after `gate:mcp` matches inside
-// `gate:mcp-fixture` because `-` is a non-word character, so the gate meant to
-// catch the original shape would have produced it.
 check(
   "a prefix-named sibling is not wired by the longer script's line",
   {
@@ -231,8 +174,6 @@ check(
   { expect: "red", contains: '@pome-sh/alpha "gate:mcp"' }
 );
 
-// Case 14: the same guard on the PACKAGE side — a scoped-name prefix
-// (`@pome-sh/twin-slack` vs `@pome-sh/twin-slack-legacy`) must not cross-wire.
 check(
   "a prefix-named package is not wired by the longer package's line",
   {
@@ -243,20 +184,12 @@ check(
   { expect: "red", contains: '@pome-sh/alpha "gate:foo"' }
 );
 
-// Case 15 (break-on-purpose): run from the wrong cwd. Returning [] made this
-// print `OK — 0 scripts` and exit 0 — a gate asserting nothing, reported as a
-// pass. contract/run.mjs throws on an empty discovery for the same reason.
 check(
   "no packages/ directory is a hard failure, not a green 0-script scan",
   { "README.md": "not a repo root\n" },
   { expect: "red", contains: "must run from the repo root" }
 );
 
-// Case 16: a write mode whose wired sibling runs the same command plus
-// `--check` is covered by derivation, not by a hand-written reason — the shape
-// three real files here have (fixture:mcp/gate:mcp-fixture and friends).
-// Case 10 above is the same pair with the wiring on the OTHER script, and must
-// stay red: a wired write mode asserts nothing and cannot cover a verdict.
 check(
   "a write mode whose file a wired sibling already runs needs no marker",
   {
@@ -270,11 +203,6 @@ check(
   { expect: "green", contains: "wired sibling runs with --check" }
 );
 
-// Case 17 (break-on-purpose): the superset rule must be SAME-PACKAGE.
-// twin-gmail and twin-slack both declare `fixture:mcp = tsx
-// scripts/adopt-upstream-mcp-fixture.ts` — one command string, two different
-// files — so a flat command list let gmail's write half be certified by
-// slack's file after gmail's own verdict line was deleted.
 check(
   "another package's wired --check does not cover this package's write half",
   {
@@ -291,8 +219,6 @@ check(
   { expect: "red", contains: '@pome-sh/alpha "fixture:mcp"' }
 );
 
-// Case 18 (break-on-purpose): the extra argv must be `--check`, not just MORE.
-// `startsWith(cmd + " ")` let a wired watch-mode dev script certify a verdict.
 check(
   "a wired sibling with --watch does not cover an unwired check",
   {
@@ -306,9 +232,6 @@ check(
   { expect: "red", contains: '@pome-sh/alpha "check:foo"' }
 );
 
-// Case 19 (break-on-purpose): a JSDoc line is not wiring. This repo's house
-// style puts `Usage: npm run <script> -w <package>` in a script header, so a
-// comment ABOUT running a check was counting as running it.
 check(
   "a JSDoc ` *` line mentioning the command is NOT wiring",
   {
@@ -319,9 +242,6 @@ check(
   { expect: "red", contains: '@pome-sh/alpha "check:foo"' }
 );
 
-// Case 20 (break-on-purpose): `--` ends npm's own options, so in
-// `npm run x -- -w pkg` the `-w` goes to the SCRIPT, npm selects no workspace,
-// and the command runs in the root. Not wiring.
 check(
   "a workspace flag after `--` is not wiring — npm selects no workspace",
   {
@@ -332,11 +252,6 @@ check(
   { expect: "red", contains: '@pome-sh/alpha "check:foo"' }
 );
 
-// Cases 21-24: the syntaxes npm really accepts must all read as wired. Only
-// one spelling was accepted before, so a genuinely-wired check went red the
-// first time someone reformatted its line — a false red pointing at the wrong
-// thing. ci.yml's 180-char five-workspace fidelity:parity line is the
-// candidate.
 for (const [label, line] of [
   ["workspace before the script name", "        run: npm run -w @pome-sh/alpha check:foo\n"],
   ["--workspace= form", "        run: npm run check:foo --workspace=@pome-sh/alpha\n"],
@@ -354,12 +269,6 @@ for (const [label, line] of [
   );
 }
 
-// Cases 25+: the cli/ extension. cli/ is a single workspace member
-// at `cli/`, not a directory of many under `packages/*`, so it needs its own
-// coverage — same mechanisms, different base path.
-
-// Case 25: a cli/package.json script wired the standard way passes, exactly
-// like a packages/* one.
 check(
   "wired cli/package.json check passes",
   {
@@ -371,8 +280,6 @@ check(
   { expect: "green" }
 );
 
-// Case 26: an unreferenced cli/ check reds by name —
-// the exact break-on-purpose to verify by hand against the real repo.
 check(
   "unwired cli/package.json check reds, naming it",
   {
@@ -383,8 +290,6 @@ check(
   { expect: "red", contains: '@pome-sh/cli "gate:foo"' }
 );
 
-// Case 27: cli/'s own exemption marker, read from the file the command
-// invokes — same syntax as packages/*.
 check(
   "unwired cli/package.json script with a marker passes",
   {
@@ -395,9 +300,6 @@ check(
   { expect: "green", contains: "manual dev tool" }
 );
 
-// Case 28: `pome` (cli/'s own equivalent of npm's `start` — runs the built
-// tarball, asserts nothing) must not be flagged, the same reasoning as `dev`/
-// `start` in the shared lifecycle set.
 check(
   "cli/package.json's 'pome' runtime alias is not flagged",
   {
@@ -407,9 +309,6 @@ check(
   { expect: "green" }
 );
 
-// Case 29 (the motivating find): a raw cli/scripts/ file declared by NO
-// package.json script at all has
-// no script name for the npm-run regex to find, so it reds by its own path.
 check(
   "an orphan cli/scripts/ file invoked by no script and imported by nothing reds by path",
   {
@@ -420,8 +319,6 @@ check(
   { expect: "red", contains: "cli/scripts/orphan.mjs" }
 );
 
-// Case 30: the same orphan file, marked with its own reason, passes — keyed
-// by its relative path rather than a script name, since it has none.
 check(
   "an orphan cli/scripts/ file with a pome:unwired-ok(<path>) marker passes",
   {
@@ -433,9 +330,6 @@ check(
   { expect: "green", contains: "spawned via a resolved path" }
 );
 
-// Case 31: a file that IS the invoked file of a declared cli/package.json
-// script — including a LIFECYCLE one, e.g. prepublishOnly — is covered by
-// that script's own status and must not also be flagged as an orphan.
 check(
   "a file invoked by a lifecycle script (prepublishOnly) is not treated as an orphan",
   {
@@ -446,10 +340,6 @@ check(
   { expect: "green" }
 );
 
-// Case 32: a file imported by a sibling script is a library module, covered
-// by whatever imports it — it must not be flagged as its own orphan entry.
-// If the importer itself were dead, THAT file is what should show up, which
-// case 29 above already proves.
 check(
   "a cli/scripts/ file imported by a sibling is not its own orphan entry",
   {
@@ -462,9 +352,6 @@ check(
   { expect: "green" }
 );
 
-// Case 33: cli/'s own write/--check pair is covered by the SAME derivation
-// packages/* pairs use (case 16) — no new code, just entries sharing one
-// pkgDir in one combined array.
 check(
   "cli/'s own write mode is covered by its wired --check sibling",
   {
@@ -479,9 +366,6 @@ check(
   { expect: "green", contains: "wired sibling runs with --check" }
 );
 
-// Case 34: no cli/ directory at all (every case above but this one) must not
-// throw or otherwise misbehave — packages/*-only repos (and this suite's own
-// fixtures for cases 1-24) stay green with zero cli/ entries.
 check(
   "a repo with no cli/ directory is unaffected",
   {
@@ -492,11 +376,6 @@ check(
   { expect: "green" }
 );
 
-// Case 35: a COMMENTED-OUT sibling import must not certify the file it names
-// as a live library module. Commenting a line out is how a thing stops
-// happening, and the corpus scan already strips whole-line comments for
-// exactly this reason; the sibling-import derivation gets the same treatment,
-// or a dead file stays exempt on the strength of a dead import line.
 check(
   "a commented-out sibling import does not exempt the file it names",
   {
@@ -509,11 +388,6 @@ check(
   { expect: "red", contains: "cli/scripts/lib.ts" }
 );
 
-// Case 36: the cli/ FLOOR. A root manifest that declares `cli` a workspace
-// member while the cli/ half of the denominator is empty is a hard failure,
-// not a green pass — the same reasoning as findCheckScripts's throw on a
-// missing packages/ dir. Renaming cli/ or cli/scripts/ must red, never
-// silently drop eight entries out of coverage.
 check(
   "cli declared a workspace but contributing zero entries is a hard failure",
   {
@@ -523,9 +397,6 @@ check(
   { expect: "red", contains: "denominator is EMPTY" }
 );
 
-// Case 37: the floor is DERIVED from the root manifest, so a repo whose
-// workspaces do not name `cli` is not held to it (this is what keeps cases
-// 1-24, which write no root package.json at all, green).
 check(
   "a root manifest that does not declare cli is not held to the cli floor",
   {

--- a/scripts/check-packages-scripts-wired.test.mjs
+++ b/scripts/check-packages-scripts-wired.test.mjs
@@ -65,7 +65,7 @@ check(
   { expect: "green" }
 );
 
-// Case 2 (the "do" in the ticket's "done when"): an unreferenced check:foo
+// Case 2: an unreferenced check:foo
 // must red the gate BY NAME.
 check(
   "unwired check:foo reds, naming it",
@@ -371,7 +371,7 @@ check(
   { expect: "green" }
 );
 
-// Case 26 (the ticket's own "do"): an unreferenced cli/ check reds by name —
+// Case 26: an unreferenced cli/ check reds by name —
 // the exact break-on-purpose the PR verifies by hand against the real repo.
 check(
   "unwired cli/package.json check reds, naming it",
@@ -408,7 +408,7 @@ check(
 );
 
 // Case 29 (the motivating find): a raw cli/scripts/ file declared by NO
-// package.json script at all — make-unwired-fixture.mjs's exact shape — has
+// package.json script at all has
 // no script name for the npm-run regex to find, so it reds by its own path.
 check(
   "an orphan cli/scripts/ file invoked by no script and imported by nothing reds by path",

--- a/scripts/check-packages-scripts-wired.test.mjs
+++ b/scripts/check-packages-scripts-wired.test.mjs
@@ -131,7 +131,7 @@ check(
 // first version used `/pome:unwired-ok:\s*(.+)/`, and `\s` matches a newline —
 // so a bare marker consumed the line break and reported the NEXT LINE of the
 // file as its justification. An exemption with no reason is exactly what the
-// milestone forbids.
+// this gate forbids.
 check(
   "a marker with no reason text is rejected, not satisfied by the next line",
   {
@@ -372,7 +372,7 @@ check(
 );
 
 // Case 26: an unreferenced cli/ check reds by name —
-// the exact break-on-purpose the PR verifies by hand against the real repo.
+// the exact break-on-purpose to verify by hand against the real repo.
 check(
   "unwired cli/package.json check reds, naming it",
   {

--- a/scripts/clean-room-pack-test.mjs
+++ b/scripts/clean-room-pack-test.mjs
@@ -1,56 +1,8 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Clean-room release gate for the four npmjs-published packages. (`@pome-sh/wire`
-// is also published, but to GitHub Packages for cross-repo consumers, and is
-// audited separately by scripts/ci/check-wire-tarball.mjs. What matters
-// HERE is the assertion below that neither npm tarball declares an `@pome-sh/*`
-// dependency: that is what keeps wire inlined rather than installed, and it must
-// keep holding now that wire is resolvable-but-401 rather than nonexistent.)
-//
-// Packs `@pome-sh/cli` and `@pome-sh/adapter-claude-sdk`, installs each tarball
-// into a throwaway directory with NO access to this workspace, and drives them
-// the way a user would. This is the gate that would have caught the failure the
-// restructure was built around: `bundleDependencies` declared seven packages and
-// shipped none, npm trusted the declaration and skipped fetching them, the
-// install reported success, and the CLI died on its first command.
-//
-// Both packages also get a files-field tarball audit: the real `tar`
-// listing is grepped for dangling `.map` files and a compiled `dist/examples/`
-// directory. tsup's `sourcemap: false` / `clean: true` config should already
-// make both impossible, but that is an unverified claim about the
-// build config, not an asserted property of the artifact actually published.
-//
-// The CLI checks:
-//   - packed manifest declares no `@pome-sh/*` and no `file:` dependency
-//   - no hard-link entries (npm registry rejects those with E415)
-//   - no dangling `.map` files, no compiled `dist/examples/` directory
-//   - `assets/` shipped (the fix-prompt system prompt is read at module scope)
-//   - `pome --help` and `pome --version` run
-//   - EVERY twin boots from the tarball and answers `/healthz` 200. All five,
-//     not a sample: each twin is its own lazily-loaded chunk, so each is an
-//     independent failure mode — a missing chunk or an unresolvable third-party
-//     import (twin-linear needs `graphql`) only shows up on that twin's boot.
-//
-// The adapter checks:
-//   - packed manifest declares no `@pome-sh/*` dependency (its wire types are
-//     bundled; `@pome-sh/wire` is not installable by an end user)
-//   - no dangling `.map` files, no compiled `dist/examples/` directory
-//   - runtime import of `flushPomeTelemetry` with the peer installed
-//   - a real consumer file TYPECHECKS against the shipped `dist/index.d.ts`.
-//     Runtime-import-only would pass even if dts bundling dropped or
-//     mis-resolved the bundled wire types: only the consumer's tsc breaks.
-//
-// `@pome-sh/checks` and `@pome-sh/sandbox-domains` get their own sections at the
-// bottom — the two packages whose only consumer is in another repository, and
-// the two where a runtime import proves the least. checks needs the consumer
-// COMPILE (its whole job is re-exported declarations); sandbox-domains needs the
-// consumer CONSTRUCTION (its openers must actually open a database), and its
-// install deliberately names nothing but the tarball, its zod peer and
-// typescript, so anything else it needs has to arrive through its own
-// `dependencies`.
-//
-// Usage: node scripts/clean-room-pack-test.mjs [--keep]
+// Installs both tarballs in a clean room and boots every twin from them, which is
+// the only place a missing `files` entry or a leaked dep actually shows up.
 
 import { execFileSync, spawn } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
@@ -95,7 +47,6 @@ function fail(message) {
 
 function pack(workspace, destination) {
   mkdirSync(destination, { recursive: true });
-  // --ignore-scripts: prepublishOnly would rebuild; the caller already built.
   run("npm", ["pack", "-w", workspace, "--ignore-scripts", "--pack-destination", destination], {
     cwd: ROOT,
   });
@@ -112,20 +63,11 @@ function assertNoHardLinks(tarball) {
   }
 }
 
-// Tarball-files-field audit: `npm pack` respects each package's `files`
-// field, and nothing else asserts WHAT actually lands in the tgz.
-// tsup's `sourcemap: false` / `clean: true` config (Lane D) means a stray
-// `.map` or a leftover `dist/examples/` from a prior build shouldn't be
-// possible today — but that's exactly the kind of invariant that silently
-// stops holding the day someone flips a tsup option or a stale `dist/` gets
-// packed without a clean rebuild. Grep the real tarball listing so a
-// regression fails CI instead of shipping.
 function assertNoStrayTarballArtifacts(tarball, label) {
   const listing = run("tar", ["-tf", tarball])
     .split("\n")
     .map((line) => line.trim())
     .filter(Boolean)
-    // npm wraps every entry in a top-level `package/` directory.
     .map((line) => line.replace(/^package\//, ""));
 
   const sourcemaps = listing.filter((path) => path.endsWith(".map"));
@@ -133,11 +75,6 @@ function assertNoStrayTarballArtifacts(tarball, label) {
     fail(`${label}: tarball contains dangling sourcemaps:\n${sourcemaps.join("\n")}`);
   }
 
-  // A compiled `agent-examples/` directory under `dist/` would mean the top-level
-  // workspace `agent-examples/` (standalone demo projects, never meant to publish)
-  // got swept into the bundle output. `cli/examples/**` (raw .ts demo
-  // agents) is a deliberate, separate top-level `files` entry — this only
-  // guards the BUILD OUTPUT, not the package's own declared source examples.
   const compiledExamples = listing.filter((path) => /^dist\/.*\bexamples\//.test(path));
   if (compiledExamples.length > 0) {
     fail(`${label}: tarball's dist/ contains a compiled examples/ directory:\n${compiledExamples.join("\n")}`);
@@ -179,7 +116,6 @@ async function waitForHealth(port, child, twin) {
         return null;
       }
     } catch {
-      /* not listening yet */
     }
     await new Promise((r) => setTimeout(r, 250));
   }
@@ -214,7 +150,6 @@ async function bootTwinFromTarball(room, cliBin, twin, port) {
   }
 }
 
-// ── @pome-sh/cli ────────────────────────────────────────────────────────────
 console.log("\n@pome-sh/cli — clean-room pack test");
 const cliRoom = makeRoom("cli");
 const cliTarball = pack("@pome-sh/cli", join(cliRoom, "tarballs"));
@@ -257,7 +192,6 @@ for (const { name, port } of TWINS) {
   await bootTwinFromTarball(cliInstall, cliBin, name, port);
 }
 
-// ── @pome-sh/adapter-claude-sdk ─────────────────────────────────────────────
 console.log("\n@pome-sh/adapter-claude-sdk — clean-room pack test");
 const adapterRoom = makeRoom("adapter");
 const adapterTarball = pack("@pome-sh/adapter-claude-sdk", join(adapterRoom, "tarballs"));
@@ -307,9 +241,6 @@ writeFileSync(
 run(process.execPath, [join(adapterInstall, "runtime-check.mjs")], { cwd: adapterInstall });
 console.log("  ✓ runtime import + flushPomeTelemetry()");
 
-// Type-level check: the shipped dist/index.d.ts must typecheck for a real
-// consumer. `tool()`'s generic binds through the peer SDK's zod-shaped
-// `AnyZodRawShape`/`InferShape`, which is where bundled-dts breakage shows up.
 writeFileSync(
   join(adapterInstall, "consumer.ts"),
   `import {
@@ -351,9 +282,6 @@ writeFileSync(
   JSON.stringify(
     {
       compilerOptions: {
-        // ESNext + DOM + @types/node because the peer SDK's OWN declarations
-        // reference Response/AbortSignal/NodeJS/Symbol.dispose. A consumer that
-        // could not compile those could not use the SDK at all.
         target: "ES2022",
         lib: ["ESNext", "DOM"],
         types: ["node"],
@@ -361,10 +289,6 @@ writeFileSync(
         moduleResolution: "NodeNext",
         strict: true,
         noEmit: true,
-        // Deliberately NOT skipLibCheck: the point is to check the SHIPPED
-        // declarations, including the wire types dts bundling inlined into
-        // them. With skipLibCheck the whole check degrades to "does the import
-        // resolve", which the runtime check above already covers.
         skipLibCheck: false,
       },
       files: ["consumer.ts"],
@@ -373,7 +297,6 @@ writeFileSync(
     2,
   ),
 );
-// zod is the peer SDK's own dependency; install it for the consumer's schema.
 run("npm", ["install", "zod", "--no-audit", "--no-fund", "--ignore-scripts"], {
   cwd: adapterInstall,
 });
@@ -389,20 +312,6 @@ try {
 }
 console.log("  ✓ consumer file typechecks against the shipped dist/index.d.ts");
 
-// ── @pome-sh/checks ─────────────────────────────────────────────────────────
-//
-// This package needs the consumer COMPILE more than either of the others, and it
-// is the reason this section exists. Its whole job is to re-export declarations
-// out of six `private: true` workspace packages, and `noExternal` governs only
-// the JS bundle: the declaration bundler leaves bare `@pome-sh/*` specifiers
-// behind, pointing at packages that are on no registry. The JS import keeps
-// working, so nothing fails until a consumer runs `tsc` — 11 × TS2307 for the
-// specifiers, and every DSL symbol behind `export * from "@pome-sh/sdk/checks"`
-// missing outright. It shipped that way until a review caught it by hand.
-//
-// `skipLibCheck` is OFF, deliberately: with it on, an unresolvable specifier
-// INSIDE a shipped `.d.ts` is silently tolerated and this degrades to "does the
-// import resolve", which the runtime check already covers.
 console.log("\n@pome-sh/checks — clean-room pack test");
 const checksRoom = makeRoom("checks");
 const checksTarball = pack("@pome-sh/checks", join(checksRoom, "tarballs"));
@@ -431,9 +340,6 @@ run(
   ],
   { cwd: checksInstall },
 );
-// Same assertion as the other two, and it bites harder here: a leaked
-// `@pome-sh/*` dependency would 404 rather than merely be redundant, because
-// those packages are private at these versions.
 assertManifestPure(
   join(checksInstall, "node_modules", "@pome-sh", "checks", "package.json"),
   "@pome-sh/checks",
@@ -516,11 +422,6 @@ writeFileSync(
     {
       compilerOptions: {
         target: "ES2022",
-        // No `lib: ["DOM"]` and no `types: ["node"]`, on purpose. A declarations
-        // package has no business requiring either, and dropping them is what
-        // catches an ambient leak — `NodeJS.ProcessEnv` reached the published
-        // surface through a vendored `loadSeedFromEnv` signature and only showed
-        // up once a consumer compiled without @types/node.
         lib: ["ES2022"],
         module: "NodeNext",
         moduleResolution: "NodeNext",
@@ -548,23 +449,6 @@ try {
 }
 console.log("  ✓ consumer file typechecks against the shipped declarations (skipLibCheck off)");
 
-// ── @pome-sh/sandbox-domains ───────────────────────────────────────────────────
-//
-// The grading RUNTIME, and the one published package where "the import
-// resolves" is genuinely not enough: pome-cloud does not just read these
-// exports, it CONSTRUCTS them — opens a SQLite database, builds a domain over
-// it, and parses a seed through it. A tarball whose `open*Database` resolves and
-// then cannot open anything satisfies every name-shaped assertion and fails on
-// the grader, which is why the runtime check below boots rather than imports.
-//
-// `skipLibCheck` stays OFF for the same reason as checks above, and it reaches
-// further here: this package's declarations legitimately name three EXTERNAL
-// packages (`hono`, `@octokit/openapi-types`, `stripe`) that its manifest must
-// therefore declare. Installing the tarball alone — with no workspace, and
-// without hand-installing those — is what proves the manifest actually carries
-// them. It is the assertion that would have caught `graphql` being declared for
-// a package tsup had inlined, and `@hono/node-server` being declared for one
-// nothing imported.
 console.log("\n@pome-sh/sandbox-domains — clean-room pack test");
 const domainsRoom = makeRoom("sandbox-domains");
 const domainsTarball = pack("@pome-sh/sandbox-domains", join(domainsRoom, "tarballs"));
@@ -580,18 +464,6 @@ writeFileSync(
 const domainsZodRange = JSON.parse(
   readFileSync(join(ROOT, "packages", "sandbox-domains", "package.json"), "utf8"),
 ).peerDependencies.zod;
-// Only the tarball, its zod PEER and typescript are named here. Everything else
-// the package needs has to arrive through its own `dependencies`, which is the
-// point of the exercise.
-// `@types/node` is here and is NOT a hole in the exercise. This package opens
-// SQLite databases through `node:sqlite`, and its shipped declarations reach
-// `hono`'s and `stripe`'s own `.d.ts`, which require `@types/node` and the DOM
-// lib themselves (neither declares `@types/node`; both assume a Node consumer,
-// which is standard for a server library). A consumer of a package like this is
-// a Node server — pome-cloud's control-plane — so requiring those is honest.
-// What is NOT installed is anything that would let this package's own missing
-// `dependencies` pass unnoticed: `hono`, `@octokit/openapi-types` and `stripe`
-// must all still arrive through the tarball's own manifest.
 run(
   "npm",
   [
@@ -686,21 +558,6 @@ writeFileSync(
     {
       compilerOptions: {
         target: "ES2022",
-        // DOM and `@types/node` ARE allowed here, and that is the one place this
-        // room deliberately differs from the checks room above. The reason there
-        // ("a declarations package has no business requiring either") does not
-        // transfer: this package is a RUNTIME. Its declarations reach hono's and
-        // stripe's own `.d.ts`, which name `File`, `Request`, `ReadableStream`
-        // and `NodeJS.*` — third-party types that need those libs and are not
-        // this repo's to fix.
-        //
-        // `skipLibCheck` stays OFF, which is what keeps the assertion worth
-        // making: the tarball installs INTO node_modules, so turning it on would
-        // skip this package's own declarations too and degrade the whole section
-        // to "does the import resolve" — which the runtime check already covers.
-        // The cost is that a genuine type regression shipped by hono or stripe
-        // reds this gate; renovate keeps both current and the rest of the repo's
-        // typecheck already carries the same exposure.
         lib: ["ES2022", "DOM"],
         types: ["node"],
         module: "NodeNext",

--- a/scripts/clean-room-pack-test.mjs
+++ b/scripts/clean-room-pack-test.mjs
@@ -18,7 +18,7 @@
 // Both packages also get a files-field tarball audit: the real `tar`
 // listing is grepped for dangling `.map` files and a compiled `dist/examples/`
 // directory. tsup's `sourcemap: false` / `clean: true` config should already
-// make both impossible, but that was previously an unverified claim about the
+// make both impossible, but that is an unverified claim about the
 // build config, not an asserted property of the artifact actually published.
 //
 // The CLI checks:
@@ -113,7 +113,7 @@ function assertNoHardLinks(tarball) {
 }
 
 // Tarball-files-field audit: `npm pack` respects each package's `files`
-// field, but nothing previously asserted WHAT actually lands in the tgz.
+// field, and nothing else asserts WHAT actually lands in the tgz.
 // tsup's `sourcemap: false` / `clean: true` config (Lane D) means a stray
 // `.map` or a leftover `dist/examples/` from a prior build shouldn't be
 // possible today — but that's exactly the kind of invariant that silently

--- a/scripts/emit-route-inputs.mjs
+++ b/scripts/emit-route-inputs.mjs
@@ -1,27 +1,8 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Publish each twin's route input surface as a committed artifact.
-//
-// pome-cloud's declared-fidelity lane compares what a vendor declares it
-// accepts against what our twin accepts. It reads this repo through the
-// `POME_TWIN_SRC` checkout seam it already has (the repo is public, so no
-// credential is involved), so the twin side has to be a FILE — a lane that has
-// to boot five SQLite-backed twins to learn their parameter names would not run
-// daily, and one that reads TypeScript with a regex would be wrong.
-//
-// The artifact is DERIVED, never edited:
-//
-//   npm run emit:route-inputs           # rewrite packages/twin-*/route-inputs.json
-//   npm run gate:route-inputs           # --check: fail if any file is stale
-//
-// `--check` is what makes the derivation load-bearing. Without it the JSON is
-// just another hand-maintained list of parameter names, which is exactly the
-// second source of truth this exists to not create.
-//
-// Reads the BUILT output (`packages/twin-*/dist/route-inputs.js`), not the
-// TypeScript, so it needs `npm run build` first — that is also what CI does,
-// and it means the artifact reflects the code that actually ships.
+// Derives packages/twin-*/route-inputs.json from the route declarations. `--check`
+// is the freshness gate; a hand-kept list would be a second source of truth.
 
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
@@ -31,16 +12,6 @@ import { pathToFileURL } from "node:url";
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const CHECK = process.argv.includes("--check");
 
-/**
- * Per twin: which built module exports the declarations, and under what name.
- *
- * Explicit rather than discovered, because a MISSING entry has to be a failure.
- * A discovery walk that finds four twins where there are five publishes four
- * artifacts and exits 0, and the fifth twin's 1,130 vendor inputs keep reporting
- * `not-compared` with nothing anywhere saying why. The list is cross-checked
- * against `config/first-party-twins.json` below, so adding a twin without
- * adding it here fails.
- */
 const TWINS = [
   { twin: "github", exportName: "GITHUB_ROUTE_INPUTS" },
   { twin: "stripe", exportName: "STRIPE_ROUTE_INPUTS" },
@@ -49,10 +20,6 @@ const TWINS = [
   {
     twin: "linear",
     exportName: "LINEAR_ROUTE_INPUTS",
-    // twin-linear's API layer is GraphQL: its operation ARGUMENTS come from the
-    // executable schema it serves, not from an HTTP route declaration. Both
-    // halves publish through this one artifact so pome-cloud has one seam for
-    // five twins rather than four plus a bespoke fixture of its own.
     graphql: {
       module: "dist/src/graphql/argument-surface.js",
       exportName: "linearGraphqlArgumentSurfaces",

--- a/scripts/emit-route-inputs.mjs
+++ b/scripts/emit-route-inputs.mjs
@@ -17,7 +17,7 @@
 //
 // `--check` is what makes the derivation load-bearing. Without it the JSON is
 // just another hand-maintained list of parameter names, which is exactly the
-// second source of truth this ticket exists to not create.
+// second source of truth this exists to not create.
 //
 // Reads the BUILT output (`packages/twin-*/dist/route-inputs.js`), not the
 // TypeScript, so it needs `npm run build` first — that is also what CI does,

--- a/scripts/example-tool-probe-driver.mjs
+++ b/scripts/example-tool-probe-driver.mjs
@@ -1,25 +1,8 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Probe driver — the child half of scripts/probe-example-tools.mjs.
-//
-// Runs INSIDE one example's dependency tree (under that example's own `tsx`
-// when it has one, so a `.ts` tool table and its zod / `file:`-linked adapter
-// copies resolve the way they do for a real run), and knows nothing about twins
-// or seeds. It takes a module path, an export name, a config object, and a probe
-// list; it reports what the wire did.
-//
-// Plain JavaScript, not TypeScript, for two reasons: bare `node` can run it
-// against the test suite's fixture examples (no `npm ci` in a throwaway tree),
-// and `tsx` registers a process-wide loader, so a `.mjs` entry can still
-// dynamically import a `.ts` module.
-//
-// The fetch hook is the whole point. `agent-examples/merge-agent`,
-// `agent-examples/minimal-viktor`, `agent-examples/gmail-retry-notify`, and
-// `agent-examples/minimal-viktor-langgraph` all deliberately SWALLOW a non-2xx and
-// hand the model `{ok: false, status}` so one bad twin call cannot abort a run
-// — so a probe that only watched for a thrown error would be silent on exactly
-// the failure this gate exists to catch. Only the response status counts.
+// Child process that invokes one example's tools against booted twins and reports
+// back as JSON.
 
 const emit = (row) => process.stdout.write(`${JSON.stringify(row)}\n`);
 
@@ -29,8 +12,6 @@ if (!spec) {
   process.exit(1);
 }
 
-// Install the hook BEFORE importing the example: a module that captured
-// `globalThis.fetch` at import time would otherwise keep the unhooked copy.
 let current = null;
 const realFetch = globalThis.fetch;
 globalThis.fetch = async (input, init) => {
@@ -64,19 +45,9 @@ try {
   process.exit(1);
 }
 
-// Three tool shapes the bundled examples use: the Claude Agent SDK's `tool()`
-// returns `{name, description, inputSchema, handler}` objects that callers
-// collect into an ARRAY; the Vercel AI SDK keeps a RECORD of name -> `{execute}`;
-// and LangChain's `tool()` (`agent-examples/minimal-viktor-langgraph`) returns a
-// `StructuredTool` instance invoked through its `.invoke()` method, also kept
-// in a name -> tool RECORD. `.invoke` has to be bound to the tool instance —
-// destructuring it the way `handler`/`execute` are read here would call it
-// with no `this` and it would throw on every probe.
 const table = new Map(Array.isArray(tools) ? tools.map((tool) => [tool.name, tool]) : Object.entries(tools));
 emit({ kind: "tools", names: [...table.keys()] });
 
-// Sequential, in declared order: probes mutate twin state, and a later probe may
-// depend on an earlier one's write.
 for (const probe of spec.probes) {
   const tool = table.get(probe.tool);
   if (!tool) continue; // the parent reports this as `unknown-tool`.

--- a/scripts/gate-examples.mjs
+++ b/scripts/gate-examples.mjs
@@ -1,47 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// The `agent-examples/*` gate: typecheck, then test, each example in its own install.
-//
-// The bundled `agent-examples/*` projects are standalone npm packages (each with its
-// own lockfile), NOT workspaces, so neither the root `npm run typecheck` nor the
-// root `npm test` covers them. That gap is how a zod-4 / Claude Agent SDK
-// `tool()` typing regression sat latent until this gate existed.
-//
-// The same gap had swallowed the examples' own TESTS for as long as they have
-// existed. Four examples declare `"test": "vitest run"` and 49 test cases across
-// five of those files ran nowhere at all: `npm test --workspaces` skips a
-// non-workspace, no workflow invoked them, and
-// `check-packages-scripts-wired.mjs` -- the gate whose whole subject is a
-// declared check nothing runs -- scopes itself to `packages/*` and `cli/`, so it
-// could not see them. (`agent-examples/triage-agent` is the exception: quickstart-
-// smoke.yml runs its 4 tests, but only behind that workflow's path filter.)
-//
-// So the loop below runs `npm test --if-present` beside the typecheck it already
-// ran, inside an `npm ci` it was already paying for. Discovery stays keyed on
-// the `typecheck` script, so an example that adds tests later is covered with no
-// edit here.
-//
-// Three of the four Claude-Agent-SDK examples consume
-// `@pome-sh/adapter-claude-sdk` through a local `file:` link, so the adapter's
-// `dist/` must be current before they can resolve its types. The gate rebuilds
-// the adapter first (a fast incremental tsc) so it always reflects the adapter
-// source in the working tree — a prior root `npm ci`/`npm install` must have
-// populated node_modules.
-//
-// `agent-examples/support-triage` is the fourth and the exception: it pins the
-// PUBLISHED adapter by exact version, because its README documents it as
-// standalone-fetchable via `npx degit`, which copies that subtree and nothing
-// above it, so a `file:` path out of the tree breaks its `npm install`. So this
-// gate typechecks that example against the registry artifact, NOT against the
-// adapter source next to it. That pin has drifted from the workspace version
-// twice, once dragging a retired package back into the example's install graph
-// as a declared runtime dep. `workspace-pins.mjs` cannot own that watch:
-// it runs OFFLINE before `npm ci`, and "resolve to the workspace" is the wrong
-// rule for a deliberately-published pin. The right rule — re-pin once the
-// workspace version publishes, skip while it has not — needs the registry, so
-// it runs here, in `check-example-pins-published.mjs`'s
-// `reportExamplePinParity()`, right where every example is already `npm ci`'d
-// against that same registry.
+// Typechecks and tests every example in its own install. The pin-parity leg is
+// deliberately NOT behind the typecheck exit: a check that stops running behind
+// another check's failure is the shape this file exists to avoid.
 import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
@@ -73,7 +34,6 @@ if (examples.length === 0) {
   process.exit(1);
 }
 
-// Build the adapter so the file:-linked examples typecheck against current source.
 console.log("Building @pome-sh/adapter-claude-sdk…");
 try {
   run("npm", ["run", "build", "-w", "@pome-sh/adapter-claude-sdk"], repoRoot);
@@ -95,17 +55,9 @@ for (const name of examples) {
     console.error(`agent-examples/${name}: FAILED (install)`);
     continue;
   }
-  // One try PER LEG, not one around both. With both in a single try a tsc error
-  // stopped that example's tests from running at all, so a type error and a test
-  // regression in the same commit took two CI rounds to see — and "a check that
-  // silently stops running behind another check's failure" is exactly what the
-  // pin-parity note below is about. Putting the test leg behind the typecheck
-  // leg would re-arm it one directory over.
   const broke = [];
   for (const [leg, args] of [
     ["typecheck", ["run", "typecheck"]],
-    // --if-present: only four of the eight examples ship a test script, and an
-    // example without one is not a failure.
     ["test", ["test", "--if-present"]],
   ]) {
     try {
@@ -128,15 +80,6 @@ if (failures.length > 0) {
   console.log(`\nAll ${examples.length} examples typechecked and tested clean.`);
 }
 
-// Confirm each bundled example's exact `@pome-sh/*` pin still equals
-// the sibling workspace version wherever that version is published.
-//
-// Deliberately NOT behind the typecheck exit above, because that
-// made an unrelated tsc error in ANY example (say `agent-examples/merge-agent`) hide a
-// real published-pin drift until someone fixed the typecheck and CI came round
-// again — a check that silently stops running behind another check's failure.
-// It reads manifests and calls the registry, so it needs none of the installs
-// above to have succeeded.
 console.log("\n=== agent-examples/* pin↔registry parity ===");
 const parityOk = reportExamplePinParity(repoRoot);
 if (!parityOk) {

--- a/scripts/gate-examples.mjs
+++ b/scripts/gate-examples.mjs
@@ -101,7 +101,7 @@ for (const name of examples) {
   // stopped that example's tests from running at all, so a type error and a test
   // regression in the same commit took two CI rounds to see — and "a check that
   // silently stops running behind another check's failure" is the exact shape the
-  // pin-parity note below calls this milestone's whole subject. Putting the test
+  // pin-parity note below calls the whole subject here. Putting the test
   // leg behind the typecheck leg would have re-armed it one directory over.
   const broke = [];
   for (const [leg, args] of [
@@ -133,11 +133,11 @@ if (failures.length > 0) {
 // Confirm each bundled example's exact `@pome-sh/*` pin still equals
 // the sibling workspace version wherever that version is published.
 //
-// Deliberately NOT behind the typecheck exit above. It used to be, and that
+// Deliberately NOT behind the typecheck exit above, because that
 // made an unrelated tsc error in ANY example (say `agent-examples/merge-agent`) hide a
 // real published-pin drift until someone fixed the typecheck and CI came round
 // again — a check that silently stops running behind another check's failure is
-// this milestone's whole subject. It reads manifests and calls the registry, so
+// the whole subject here. It reads manifests and calls the registry, so
 // it needs none of the installs above to have succeeded.
 console.log("\n=== agent-examples/* pin↔registry parity ===");
 const parityOk = reportExamplePinParity(repoRoot);

--- a/scripts/gate-examples.mjs
+++ b/scripts/gate-examples.mjs
@@ -29,15 +29,13 @@
 // populated node_modules.
 //
 // `agent-examples/support-triage` is the fourth and the exception: it pins the
-// PUBLISHED adapter by exact version (#308), because its README documents it as
+// PUBLISHED adapter by exact version, because its README documents it as
 // standalone-fetchable via `npx degit`, which copies that subtree and nothing
 // above it, so a `file:` path out of the tree breaks its `npm install`. So this
 // gate typechecks that example against the registry artifact, NOT against the
-// adapter source next to it — and nothing compared the two until this gate. It had
-// drifted twice already (#308 off 0.2.5, then 0.3.1 against a workspace 0.3.3,
-// which also dragged the retired `@pome-sh/shared-types` back into the
-// example's install graph as 0.3.1's declared runtime dep) before anything
-// watched it. `workspace-pins.mjs` cannot own that watch:
+// adapter source next to it. That pin has drifted from the workspace version
+// twice, once dragging a retired package back into the example's install graph
+// as a declared runtime dep. `workspace-pins.mjs` cannot own that watch:
 // it runs OFFLINE before `npm ci`, and "resolve to the workspace" is the wrong
 // rule for a deliberately-published pin. The right rule — re-pin once the
 // workspace version publishes, skip while it has not — needs the registry, so
@@ -100,9 +98,9 @@ for (const name of examples) {
   // One try PER LEG, not one around both. With both in a single try a tsc error
   // stopped that example's tests from running at all, so a type error and a test
   // regression in the same commit took two CI rounds to see — and "a check that
-  // silently stops running behind another check's failure" is the exact shape the
-  // pin-parity note below calls the whole subject here. Putting the test
-  // leg behind the typecheck leg would have re-armed it one directory over.
+  // silently stops running behind another check's failure" is exactly what the
+  // pin-parity note below is about. Putting the test leg behind the typecheck
+  // leg would re-arm it one directory over.
   const broke = [];
   for (const [leg, args] of [
     ["typecheck", ["run", "typecheck"]],
@@ -136,9 +134,9 @@ if (failures.length > 0) {
 // Deliberately NOT behind the typecheck exit above, because that
 // made an unrelated tsc error in ANY example (say `agent-examples/merge-agent`) hide a
 // real published-pin drift until someone fixed the typecheck and CI came round
-// again — a check that silently stops running behind another check's failure is
-// the whole subject here. It reads manifests and calls the registry, so
-// it needs none of the installs above to have succeeded.
+// again — a check that silently stops running behind another check's failure.
+// It reads manifests and calls the registry, so it needs none of the installs
+// above to have succeeded.
 console.log("\n=== agent-examples/* pin↔registry parity ===");
 const parityOk = reportExamplePinParity(repoRoot);
 if (!parityOk) {

--- a/scripts/hooks/install.sh
+++ b/scripts/hooks/install.sh
@@ -1,9 +1,4 @@
 #!/usr/bin/env bash
-# Point this clone's git hooks at the versioned hooks in scripts/hooks/.
-# Idempotent — safe to re-run. Run once per clone:
-#
-#   bash scripts/hooks/install.sh
-#
 set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,22 +1,4 @@
 #!/usr/bin/env bash
-# Pome repo pre-commit hook. Belt to CI's suspenders — the same gates run in
-# .github/workflows/ci.yml, so a `--no-verify` commit is still caught on PR.
-#
-# Install with:  bash scripts/hooks/install.sh
-#
-# Gates:
-#  - ADR-002 open-core boundary: no `pome-cloud` imports in packages/ (shell,
-#    so it stays outside the node runner).
-#  - Capture-only OSS boundary: no local eval/scoring/judging/correlation.
-#  - No cross-package file-copy markers.
-#
-# The last two are lint RULES, run by name through the one runner. Everything
-# `npm run lint` knows about is available here — `npm run lint -- <rule>` is the
-# same entry point CI uses, so a hook and a CI step cannot disagree about what a
-# rule checks.
-#
-# Every gate here is pure node/bash from this repo's dev deps — nothing to
-# install. Secrets are scanned in CI by secret-scan.yml, not here.
 
 set -euo pipefail
 

--- a/scripts/lib/static-import-graph.mjs
+++ b/scripts/lib/static-import-graph.mjs
@@ -1,25 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// The static import graph of this repo's TypeScript sources, read from the
-// sources themselves.
-//
-// Extracted from `twin-chunks.mjs` when a second gate
-// needed the same walk: `twin-leaves.mjs` asks which twin
-// modules can still be loaded by a runtime without `node:sqlite`. Both ask a
-// reachability question about the same graph, and two hand-rolled copies of an
-// import lexer would be two chances to disagree about what a type-only import
-// is.
-//
-// Dependency-free and build-free on purpose: it reads TypeScript sources and
-// each package's real `exports` map, so it runs in CI's always-on block before
-// `npm ci`, and it cannot disagree with the bundler about which subpath
-// resolves where.
+// Static import graph over a source tree, for rules that need reachability.
 
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
-/** Workspace `@pome-sh/*` specifiers → source file, read from each package's
- *  own `exports` map so a renamed subpath cannot silently stop being checked. */
 export function buildSpecifierMap(root) {
   const map = new Map();
   const packagesDir = join(root, "packages");
@@ -30,8 +15,6 @@ export function buildSpecifierMap(root) {
     const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
     if (!manifest.name?.startsWith("@pome-sh/")) continue;
     for (const [subpath, target] of Object.entries(manifest.exports ?? {})) {
-      // `{ types, default }` conditions or a bare string; either way we want the
-      // JS target, then map `dist/src/foo.js` (or `dist/foo.js`) back to source.
       const js = typeof target === "string" ? target : target.default;
       if (typeof js !== "string" || !js.endsWith(".js")) continue;
       const sourceRel = js
@@ -47,18 +30,6 @@ export function buildSpecifierMap(root) {
   return map;
 }
 
-/**
- * Blank out comments and string/template bodies, keeping newlines so the text
- * stays line-addressable.
- *
- * Load-bearing, not hygiene: `cli/src/cli/init-sdk.ts` embeds the scaffolded
- * agent's SOURCE in a template literal, and that source contains
- * `import { query, tool, withPome } from "@pome-sh/adapter-claude-sdk";`. A
- * regex over raw text reads that as a real edge and reports a package the CLI
- * never imports — and by the same mistake would report a twin root as eager
- * because a scaffold string mentions one. Scaffolds are the one place this repo
- * writes import statements it does not execute, and it writes several.
- */
 export function stripNonCode(source) {
   const blank = (text) => text.replace(/[^\n]/g, " ");
   let out = "";
@@ -91,25 +62,10 @@ export function stripNonCode(source) {
       continue;
     }
     if (char === '"' || char === "'") {
-      // Copied through VERBATIM rather than blanked — a module specifier lives
-      // in one of these, and the callers' patterns read it — but consumed as one
-      // unit so nothing inside can open a comment or a template literal.
-      //
-      // Not cosmetic. `twin-stripe/src/session.ts` mounts middleware at
-      // `session.use("/x402/*", …)`, and `twin-stripe/src/errors.ts` (a named
-      // cross-runtime leaf) describes a surface as `"Stripe-shaped REST under
-      // /v1/*"`. Scanning those character by character reads the `/*` as a
-      // block-comment opener and blanks everything up to the next `*/` — 37
-      // lines in session.ts, the rest of the file in errors.ts. Every import
-      // below the opener then vanishes, so a reachability gate reports the file
-      // as clean and a portability gate as safe. A false GREEN, which is the
-      // failure mode these gates exist to prevent.
       let cursor = index + 1;
       while (cursor < source.length && source[cursor] !== char && source[cursor] !== "\n") {
         cursor += source[cursor] === "\\" ? 2 : 1;
       }
-      // An unterminated string (only reachable in invalid source) stops at the
-      // newline, so one bad line can never swallow the rest of the file.
       const stop = source[cursor] === char ? Math.min(cursor + 1, source.length) : cursor;
       out += source.slice(index, stop);
       index = stop;
@@ -121,28 +77,6 @@ export function stripNonCode(source) {
   return out;
 }
 
-/**
- * Runtime static import specifiers in one TypeScript source.
- *
- * Type-only edges are EXCLUDED because they are erased before the bundler sees
- * them — both the `import type` / `export type` form and the form where every
- * named binding is individually marked (`import { type A, type B } from …`).
- * Counting either would fail a gate on an edge that emits no code, which is
- * the failure mode that gets a gate deleted rather than fixed.
- *
- * `import()` is EXCLUDED because a dynamic import is a deferred edge: it is the
- * thing the laziness gate wants, and it is not executed at module load, which
- * is what the portability gate asks about.
- *
- * The clause is matched with the characters an import clause can actually
- * contain (`[\w$*,{}\s]` — identifiers, `as`, `type`, braces, a namespace star)
- * rather than `[\s\S]`. Anything else would let one match span two statements:
- * `export const x = 1;` on one line and a real `import … from …` on the next
- * matched as a SINGLE clause, which both mis-reads the first statement as an
- * edge AND consumes the second, so the real import is never seen. A gate that
- * reports the wrong edge is annoying; one that silently stops seeing a real one
- * is the failure mode these gates exist to prevent.
- */
 export function staticImportSpecifiers(rawSource) {
   const source = stripNonCode(rawSource);
   const found = [];
@@ -169,8 +103,6 @@ export function staticImportSpecifiers(rawSource) {
   return found;
 }
 
-/** A specifier → the `.ts` source it resolves to, or null for third-party
- *  packages, node builtins and JSON asset imports. */
 export function resolveSpecifier(specifier, fromFile, specifiers) {
   if (specifier.startsWith(".")) {
     const base = resolve(dirname(fromFile), specifier);
@@ -182,16 +114,6 @@ export function resolveSpecifier(specifier, fromFile, specifiers) {
   return specifiers.get(specifier) ?? null;
 }
 
-/**
- * Every `.ts` file statically reachable from `entries`, each mapped to the file
- * that first pulled it in — so a violation can be reported as a chain a human
- * can follow — plus every specifier that resolved to no file in this repo
- * (node builtins, third-party packages, JSON assets), recorded with the file
- * that imported it.
- *
- * @param entries absolute paths to seed the walk with.
- * @param specifiers the map from {@link buildSpecifierMap}.
- */
 export function reachable(entries, specifiers) {
   const importedBy = new Map();
   const external = [];
@@ -223,8 +145,6 @@ export function reachable(entries, specifiers) {
   return { importedBy, external };
 }
 
-/** The import chain that first pulled `file` in, root-first, as repo-relative
- *  paths. */
 export function chainFor(file, importedBy, relativeTo) {
   const chain = [];
   for (let current = file; current; current = importedBy.get(current)) {

--- a/scripts/lib/workspace-members.mjs
+++ b/scripts/lib/workspace-members.mjs
@@ -1,27 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// The root `workspaces` field, resolved to its member manifests.
-//
-// Extracted when a second caller needed it: the `workspace-pins` lint rule
-// checks that every `@pome-sh/*` pin resolves to its sibling, and
-// `check-example-pins-published.mjs` needs the same sibling-name →
-// workspace-version map to know which `agent-examples/*` pins have a sibling to
-// compare against. Two hand-rolled copies would be two chances to disagree
-// about what a "sibling" is.
+// Workspace members from the root `workspaces` field, so nothing keeps its own list.
 
 import { globSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
-/**
- * SCOPE IS THE ROOT `workspaces` FIELD, not a hand-kept list. Every member is
- * both a consumer (its pins are checked) and a sibling (it can be pinned AT),
- * because npm's resolution makes no distinction: `cli` is a workspace member, so
- * a `packages/*` package pinning a stale `@pome-sh/cli` would get a nested
- * registry copy exactly as it would for the sdk. A hardcoded `packages/*` + `cli`
- * pair silently stops covering its subject the moment root grows a glob or the
- * CLI moves directory. An empty result throws rather than reporting a pass over
- * nothing.
- */
 export function loadWorkspaceMembers(repoRoot) {
   const root = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
   const relativePaths = (root.workspaces ?? []).flatMap((pattern) =>

--- a/scripts/lint-no-cloud-imports.sh
+++ b/scripts/lint-no-cloud-imports.sh
@@ -1,14 +1,11 @@
 #!/usr/bin/env bash
-# Fails (exit 1) if any source file under packages/, cli/src/, cli/scripts/,
-# or repo-root scripts/ imports from `pome-cloud`, `pome-cloud/*`, or
-# `@pome-cloud/*`. Enforces ADR-002 open-core boundary in CI + pre-commit.
-# String mentions (URLs, comments) are allowed; only import/require/dynamic-import
-# syntax is rejected.
+#
+# No cloud imports in the open-source tree. Also runs in the pre-commit hook, so it
+# must need nothing installed.
 
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-# Match quoted and template-literal module specifiers (import(`pome-cloud/...`)).
 PATTERN='(from[[:space:]]+|import[[:space:]]+|import[[:space:]]*\(|require[[:space:]]*\()[[:space:]]*(['\''"`])@?pome-cloud(/|['\''"`])'
 
 SCAN_DIRS=()

--- a/scripts/lint-no-cloud-imports.test.sh
+++ b/scripts/lint-no-cloud-imports.test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Regression fixtures for scripts/lint-no-cloud-imports.sh (F-696).
+# Regression fixtures for scripts/lint-no-cloud-imports.sh.
 # Proves forbidden import forms fail, scan dirs are covered, and clean trees pass.
 set -euo pipefail
 

--- a/scripts/lint-no-cloud-imports.test.sh
+++ b/scripts/lint-no-cloud-imports.test.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# Regression fixtures for scripts/lint-no-cloud-imports.sh.
-# Proves forbidden import forms fail, scan dirs are covered, and clean trees pass.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -13,7 +11,6 @@ fail() {
   exit 1
 }
 
-# Clean tree must pass.
 bash "$LINT" >/dev/null || fail "clean tree unexpectedly failed"
 
 assert_forbidden_in_dir() {
@@ -32,7 +29,6 @@ assert_forbidden_in_dir() {
   rm -rf "$fake_root"
 }
 
-# Import-form coverage (packages/).
 assert_forbidden_in_dir packages "named-from-at-scope" "import { x } from '@pome-cloud/auth';"
 assert_forbidden_in_dir packages "named-from-bare" "import { x } from 'pome-cloud/apps/control-plane';"
 assert_forbidden_in_dir packages "bare-package" "import { x } from 'pome-cloud';"
@@ -44,14 +40,12 @@ assert_forbidden_in_dir packages "require" "const m = require('pome-cloud/foo');
 assert_forbidden_in_dir packages "require-spaced" "const m = require ('@pome-cloud/auth');"
 assert_forbidden_in_dir packages "require-template" 'const m = require(`@pome-cloud/auth`);'
 
-# Scan-dir coverage — each ADR-002 path must reject the same forbidden import.
 BAD="import { x } from '@pome-cloud/auth';"
 assert_forbidden_in_dir packages "scan-packages" "$BAD"
 assert_forbidden_in_dir cli/src "scan-cli-src" "$BAD"
 assert_forbidden_in_dir cli/scripts "scan-cli-scripts" "$BAD"
 assert_forbidden_in_dir scripts "scan-scripts" "$BAD"
 
-# Comments / strings must still pass.
 COMMENT_ROOT="${TMP}/fake-repo-comments"
 mkdir -p "${COMMENT_ROOT}/packages" "${COMMENT_ROOT}/scripts"
 cp "$LINT" "${COMMENT_ROOT}/scripts/lint-no-cloud-imports.sh"

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -1,21 +1,9 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// The repo's one lint runner.
-//
-// One runner owns traversal (`scripts/lint/context.mjs`), the report format and
-// the exit code, so a rule is a declaration plus a predicate. A rule per
-// executable means a tree walk, a formatter, an entry guard, an npm script and a
-// CI step per rule — four places to touch to add one, which is why rules that
-// should exist would not.
-//
-// Usage:
-//   node scripts/lint.mjs                  every rule
-//   node scripts/lint.mjs parent-vocab     one rule (local iteration)
-//   node scripts/lint.mjs --list           what rules exist
-//   node scripts/lint.mjs --offline        skip rules needing node_modules
-//   node scripts/lint.mjs --root <dir>     lint a tree that is not this repo
-//   node scripts/lint.mjs --verbose        rules that have extra detail print it
+// The one lint runner. It owns traversal, the report format and the exit code, so a
+// rule is a declaration plus a predicate. A rule that cannot find its subject
+// throws — a gate that shrugs when its corpus vanished prints the same as a clean one.
 
 import { spawnSync } from "node:child_process";
 import { existsSync, readdirSync, realpathSync } from "node:fs";
@@ -28,14 +16,6 @@ import { RULES } from "./lint/rules.mjs";
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const RULES_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "lint/rules");
 
-/**
- * Run `rules` against `root` and return one result per rule. A rule reports by
- * returning violations; a rule that cannot find its subject at all throws, and
- * that is a failure too — a gate that shrugs when its corpus went missing
- * prints the same thing as a gate whose corpus is clean.
- *
- * @param {{ root?: string, only?: string[], offline?: boolean, verbose?: boolean }} options
- */
 export async function runRules({ root = REPO_ROOT, only = [], offline = false, verbose = false } = {}) {
   const selected = selectRules(only);
   const ctx = createContext({ root, verbose });
@@ -43,9 +23,6 @@ export async function runRules({ root = REPO_ROOT, only = [], offline = false, v
 
   for (const rule of selected) {
     if (offline && rule.needsInstall) {
-      // Naming a rule AND passing --offline is a contradiction: the run would
-      // print a pass having checked nothing at all. Skipping is only honest when
-      // the caller asked for everything.
       if (only.length > 0) {
         throw new Error(
           `${rule.name} needs an installed node_modules, so --offline cannot run it. ` +
@@ -56,9 +33,6 @@ export async function runRules({ root = REPO_ROOT, only = [], offline = false, v
       continue;
     }
     try {
-      // `await`: the rules that parse TypeScript are deferred behind a dynamic
-      // import, so their `check` is async. Every other rule's is sync and
-      // `await` is a no-op on it.
       const outcome = (await rule.check(ctx)) ?? {};
       results.push({
         rule,
@@ -74,16 +48,6 @@ export async function runRules({ root = REPO_ROOT, only = [], offline = false, v
   return results;
 }
 
-/**
- * Every rule module on disk must be in the registry.
- *
- * The registry is a hand-written list of static imports, which is what lets
- * `knip` follow it — but it also means deleting one import line silently removes
- * a rule from enforcement. Nothing else would notice: the case-table runner
- * iterates the registry rather than the directory, so the orphaned table stops
- * running too, and knip counts every file under `scripts/lint/` as an entry
- * point. So the runner checks the directory against the registry on every run.
- */
 export function findUnregisteredRules(rulesDir = RULES_DIR) {
   const registered = new Set(RULES.map((rule) => `${rule.name}.mjs`));
   return readdirSync(rulesDir)
@@ -92,14 +56,6 @@ export function findUnregisteredRules(rulesDir = RULES_DIR) {
     .sort();
 }
 
-/**
- * The other direction: a case table whose rule is not in the registry.
- *
- * `runRuleTests` iterates the registry, so such a table is never run — it reads
- * as coverage from the directory listing while asserting nothing. Cheap to check
- * and the counterpart to the guarantee above, so the invariant is symmetric:
- * every rule has a table, and every table has a rule.
- */
 export function findOrphanCaseTables(rulesDir = RULES_DIR) {
   const registered = new Set(RULES.map((rule) => `${rule.name}.test.mjs`));
   return readdirSync(rulesDir)
@@ -108,7 +64,6 @@ export function findOrphanCaseTables(rulesDir = RULES_DIR) {
     .sort();
 }
 
-/** The rules named in `only`, or all of them. An unknown name is a failure, not a silent no-op. */
 export function selectRules(only) {
   if (only.length === 0) return RULES;
   const byName = new Map(RULES.map((rule) => [rule.name, rule]));
@@ -121,7 +76,6 @@ export function selectRules(only) {
   return only.map((name) => byName.get(name));
 }
 
-/** True when every result passed. Printing is the caller's job. */
 export function report(results, { verbose = false, log = console.log, error = console.error } = {}) {
   let failed = 0;
   const skipped = [];
@@ -148,8 +102,6 @@ export function report(results, { verbose = false, log = console.log, error = co
     error("");
   }
 
-  // Never silent: a rule that did not run has to say so, or the summary line
-  // reads as coverage the run does not have.
   for (const result of skipped) {
     log(`  – ${result.rule.name} — SKIPPED (${result.skipped})`);
   }
@@ -163,14 +115,6 @@ export function report(results, { verbose = false, log = console.log, error = co
   return true;
 }
 
-/**
- * Run each selected rule's case table — `scripts/lint/rules/<name>.test.mjs`,
- * found by convention rather than listed, so a new rule's table is picked up
- * with no second edit.
- *
- * A rule with NO table is reported, not skipped silently: a rule nobody has
- * proved can go red is a rule that may already have stopped going red.
- */
 export function runRuleTests({ only = [], offline = false } = {}) {
   let failed = 0;
   const untested = [];
@@ -220,13 +164,6 @@ function parseArgv(argv) {
   return { only, root, offline, verbose, list, runTests };
 }
 
-// Realpath'd on both sides, never a bare `import.meta.main` (undefined before
-// Node 24.2, which root `engines: >=24` allows) and never a basename compare
-// (satisfied by any file of that name anywhere on disk). Node resolves symlinks
-// before deriving `import.meta.url`, so an un-realpath'd compare falls false
-// through a symlinked checkout — a `git worktree`, or macOS's symlinked
-// `/tmp` — and the runner exits 0 having linted nothing. A guard miss while
-// invoked as this file throws rather than exits 0.
 const SELF = realpathSync(fileURLToPath(import.meta.url));
 const ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";
 const invokedDirectly = ENTRY === SELF;
@@ -236,8 +173,6 @@ if (!invokedDirectly && ENTRY.endsWith("lint.mjs")) {
 }
 
 if (invokedDirectly) {
-  // A usage error (unknown rule, contradictory flags) is a failed lint run, not a
-  // crash report: print the sentence and exit 1.
   main(process.argv.slice(2)).catch((err) => {
     console.error(err.message);
     process.exit(1);
@@ -254,8 +189,6 @@ async function main(argv) {
     process.exit(0);
   }
 
-  // Before anything else: a rule module that never made it into the registry is
-  // a rule that does not run, and every other check here would stay green.
   const unregistered = findUnregisteredRules();
   if (unregistered.length > 0) {
     console.error(

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -3,15 +3,12 @@
 //
 // The repo's one lint runner.
 //
-// Every rule under `scripts/lint/rules/` used to be its own executable: its own
-// tree walk, its own violation formatting, its own `process.exit(1)`, its own
-// realpath entry guard, its own npm script, and its own CI step. The rule — the
-// only part that differed — was a fraction of each file. Adding a rule meant
-// touching four places, which is why rules that should exist did not.
+// One runner owns traversal (`scripts/lint/context.mjs`), the report format and
+// the exit code, so a rule is a declaration plus a predicate. A rule per
+// executable means a tree walk, a formatter, an entry guard, an npm script and a
+// CI step per rule — four places to touch to add one, which is why rules that
+// should exist would not.
 //
-// What lives here: traversal (via `scripts/lint/context.mjs`), the report
-// format, and the exit code. What lives in a rule: a declaration and a
-// predicate.
 //
 // Usage:
 //   node scripts/lint.mjs                  every rule

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -9,7 +9,6 @@
 // CI step per rule — four places to touch to add one, which is why rules that
 // should exist would not.
 //
-//
 // Usage:
 //   node scripts/lint.mjs                  every rule
 //   node scripts/lint.mjs parent-vocab     one rule (local iteration)

--- a/scripts/lint/context.mjs
+++ b/scripts/lint/context.mjs
@@ -1,35 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// The one tree walk, and the one file cache, that every lint rule shares.
-//
-// Every gate in the old fleet carried its own `walk()`: the same
-// `readdirSync` recursion with its own idea of which directories to prune and
-// which extensions to keep. Twenty-odd copies meant twenty-odd chances for one
-// to quietly stop pruning `dist/` and start linting build output, or to keep
-// pruning a directory the others had started covering.
-//
-// Reads are memoized because rules overlap: `legacy-markers` and `parent-vocab`
-// both read every TypeScript file under `packages/`, and a rule that walks the
-// same tree twice pays for it twice.
+// Shared traversal for rules. Fails on a missing scan root by default; opt out per
+// call, with a reason, where the directory is genuinely optional.
 
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 
-/** Pruned at ANY depth, in every walk, unless a rule overrides `skip`. */
 export const DEFAULT_SKIP_DIRS = ["node_modules", "dist", "build", ".git", "coverage"];
 
-/**
- * The handle a rule's `check()` receives. Everything a rule needs to read the
- * tree, and nothing that lets it decide how a violation is printed or what the
- * process exit code is — those belong to the runner.
- *
- * @param {{ root: string, verbose?: boolean }} options
- */
 export function createContext({ root, verbose = false }) {
   const textCache = new Map();
   const walkCache = new Map();
 
-  /** Absolute path → utf8 contents, read at most once per run. */
   function read(abs) {
     let text = textCache.get(abs);
     if (text === undefined) {
@@ -39,20 +21,6 @@ export function createContext({ root, verbose = false }) {
     return text;
   }
 
-  /**
-   * Every file under `dirs` (repo-root-relative) whose extension is in `ext`,
-   * sorted, pruning `skip` at any depth.
-   *
-   * `mustExist` (default true) is the difference between "found nothing wrong"
-   * and "scanned nothing": a rule that names a directory and finds it gone has
-   * stopped covering it, and a silent skip reads exactly like a clean tree. Pass
-   * `mustExist: false` only where a directory is genuinely optional — a scan root
-   * that not every checkout has.
-   *
-   * `statSync` rather than the dirent: `isDirectory()`/`isFile()` are both false
-   * for a symlink, so keying off the dirent silently skips a symlinked script or
-   * subdirectory, and a skip reads as a pass.
-   */
   function files({ dirs, ext, skip = DEFAULT_SKIP_DIRS, mustExist = true }) {
     const key = JSON.stringify([dirs, ext, skip, mustExist]);
     const cached = walkCache.get(key);
@@ -113,11 +81,9 @@ export function createContext({ root, verbose = false }) {
     verbose,
     read,
     files,
-    /** Posix-normalized path relative to the repo root, for messages. */
     rel: (abs) => relative(root, abs).replaceAll("\\", "/"),
     abs: (relPath) => join(root, relPath),
     exists: (relPath) => existsSync(join(root, relPath)),
-    /** Repo-root-relative read, for rules whose subject is one known file. */
     readRel: (relPath) => read(join(root, relPath)),
     json: (relPath) => JSON.parse(read(join(root, relPath))),
   };

--- a/scripts/lint/harness.mjs
+++ b/scripts/lint/harness.mjs
@@ -1,27 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// The one test harness for lint rules.
-//
-// One harness rather than a regression suite per rule: mkdtemp a throwaway
-// tree, write a `files` map into it, spawn the real runner with `cwd` pointed at
-// it, compare the exit code against green/red, keep a failure counter. That
-// scaffolding is identical every time; the case table is the only part that
-// differs.
-//
-// A case runs the REAL runner against the REAL rule (`node scripts/lint.mjs
-// <rule> --root <tmp>`), not an in-process call to the predicate. That is
-// deliberate: the interesting failure is a rule that stops being reached, and an
-// in-process call cannot see a rule missing from the registry or a runner that
-// swallows a throw.
-//
-// Usage:
-//
-//   import { defineCases } from "../harness.mjs";
-//
-//   defineCases("parent-vocab", [
-//     { name: "clean tree", files: { ... }, expect: "green" },
-//     { name: "quoted key", files: { ... }, expect: "red", contains: "parent_id" },
-//   ]);
+// One harness for every rule's case table. A case runs the REAL runner against the
+// REAL rule, not the predicate in-process: the interesting failure is a rule that
+// stopped being reached.
 
 import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
@@ -31,7 +12,6 @@ import { fileURLToPath } from "node:url";
 
 const RUNNER = resolve(dirname(fileURLToPath(import.meta.url)), "../lint.mjs");
 
-/** Materialize a `{ relativePath: contents }` map into a fresh temp directory. */
 export function fixtureTree(files, prefix = "lint-rule-") {
   const root = mkdtempSync(join(tmpdir(), prefix));
   for (const [rel, body] of Object.entries(files)) {
@@ -42,7 +22,6 @@ export function fixtureTree(files, prefix = "lint-rule-") {
   return root;
 }
 
-/** Run one rule against a throwaway tree. Returns the exit code and all output. */
 export function runRule(ruleName, files, { flags = [] } = {}) {
   const root = fixtureTree(files, `${ruleName}-`);
   const result = spawnSync(process.execPath, [RUNNER, ruleName, "--root", root, ...flags], {
@@ -51,19 +30,6 @@ export function runRule(ruleName, files, { flags = [] } = {}) {
   return { code: result.status, out: `${result.stdout ?? ""}${result.stderr ?? ""}`, root };
 }
 
-/**
- * Run a rule's case table and exit non-zero if any case disagrees.
- *
- * Each case is
- * `{ name, files, expect: "green" | "red", contains?, notContains?, flags? }`.
- *
- * `contains` is asserted on the combined output — a red case that reds for the
- * wrong reason is a rule that stopped checking what it claims, so the assertion
- * has to be on the message and not only on the exit code. `notContains` is its
- * inverse, for a case whose point is that a neighbouring file was NOT implicated.
- * Both take a string, a RegExp (for a line number or a count the message
- * interpolates), or an array of either.
- */
 export function defineCases(ruleName, cases) {
   let failures = 0;
 

--- a/scripts/lint/harness.mjs
+++ b/scripts/lint/harness.mjs
@@ -2,11 +2,11 @@
 //
 // The one test harness for lint rules.
 //
-// Every rule used to ship its own regression suite, and every one of those
-// suites was the same forty lines: mkdtemp a throwaway tree, write a `files`
-// map into it, `spawnSync` the real script with `cwd` pointed at it, compare the
-// exit code against green/red, and keep a failure counter. Twenty copies of the
-// scaffolding around a case table that was the only part that differed.
+// One harness rather than a regression suite per rule: mkdtemp a throwaway
+// tree, write a `files` map into it, spawn the real runner with `cwd` pointed at
+// it, compare the exit code against green/red, keep a failure counter. That
+// scaffolding is identical every time; the case table is the only part that
+// differs.
 //
 // A case runs the REAL runner against the REAL rule (`node scripts/lint.mjs
 // <rule> --root <tmp>`), not an in-process call to the predicate. That is

--- a/scripts/lint/rules.mjs
+++ b/scripts/lint/rules.mjs
@@ -1,22 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// The rule registry. Static imports rather than a directory glob, for two
-// reasons: a glob makes every rule file an implicit entry point that `knip`
-// cannot follow, and a rule that fails to load is a rule that silently stopped
-// running — an import error here is a hard failure at startup, where a glob
-// would just find one fewer file. `findUnregisteredRules` in the runner closes
-// the other direction: a rule module missing from this list.
-//
-// The two rules that parse TypeScript are DEFERRED rather than imported. They
-// `import ts from "typescript"`, a devDependency, and ESM resolves a static
-// import at module load — before the runner gets to decide anything. So a static
-// import here would make `npm run lint -- --offline` die with
-// ERR_MODULE_NOT_FOUND in CI's always-on block, which runs before `npm ci`,
-// taking every other rule down with it. `needsInstall` has to gate the module
-// LOAD, not just the call.
-//
-// Order is run order, cheapest first, so a local `npm run lint` fails fast on
-// the obvious things before the import-graph walks and the TypeScript AST rules.
+// The rule registry. Entries may defer their import, because ci.yml's always-on
+// block runs before `npm ci` and a static import of a devDependency dies at load.
 
 import barrels from "./rules/barrels.mjs";
 import bundledDeps from "./rules/bundled-deps.mjs";
@@ -36,13 +21,6 @@ import twinChunks from "./rules/twin-chunks.mjs";
 import twinLeaves from "./rules/twin-leaves.mjs";
 import workspacePins from "./rules/workspace-pins.mjs";
 
-/**
- * A rule whose module must not be loaded until the runner knows it can be.
- *
- * `name` and `describe` are restated here because `--list` and the `--offline`
- * skip line have to name the rule without loading it. The loaded module is
- * checked against them, so the two cannot drift apart silently.
- */
 function deferred({ name, describe, load }) {
   return {
     name,
@@ -50,9 +28,6 @@ function deferred({ name, describe, load }) {
     needsInstall: true,
     async check(ctx) {
       const rule = (await load()).default;
-      // Both restated fields are checked, not just the name: `--list` and the
-      // `--offline` skip line print them without loading the module, so a stale
-      // `describe` here is a rule the runner misreports and nothing contradicts.
       if (rule.name !== name) {
         throw new Error(
           `registry calls this rule "${name}" but the module calls itself "${rule.name}" — ` +
@@ -84,14 +59,12 @@ const exampleIsolation = deferred({
 });
 
 export const RULES = [
-  // Manifests and single known files: no tree walk at all.
   barrels,
   bundledDeps,
   workspacePins,
   skillManifest,
   taskFormatDoc,
   firstPartyTwins,
-  // Line scans over a subtree.
   copyMarkers,
   fileSize,
   legacyMarkers,
@@ -99,11 +72,9 @@ export const RULES = [
   taskClass,
   noEval,
   noCatch,
-  // Static import-graph walks.
   twinChunks,
   twinLeaves,
   routeInputs,
-  // TypeScript AST walks and lockfile inspection — need an installed tree.
   importMetaMain,
   exampleIsolation,
   noNative,

--- a/scripts/lint/rules/barrels.mjs
+++ b/scripts/lint/rules/barrels.mjs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// A barrel index re-exports and does nothing else. Logic in a barrel is logic
-// every importer of the package root pays for, whatever subpath they wanted.
+// No deep imports past a package's barrel where the barrel is the contract.
 
 const BARREL_PATHS = [
   "packages/twin-gmail/src/index.ts",
@@ -25,8 +24,6 @@ export default {
   check(ctx) {
     const violations = [];
     for (const rel of BARREL_PATHS) {
-      // A listed barrel that no longer exists means this rule silently stopped
-      // covering it, so it is a violation rather than a skip.
       if (!ctx.exists(rel)) {
         violations.push(`${rel}: listed as a barrel but absent — move this rule's entry with the file.`);
         continue;

--- a/scripts/lint/rules/barrels.test.mjs
+++ b/scripts/lint/rules/barrels.test.mjs
@@ -1,16 +1,12 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// The old gate shipped with no case table. Case 4 is the one worth having: the
-// barrel list is hand-kept, so a listed file that MOVED must red rather than
-// quietly stop being checked.
+// Case table for barrels. Every case asserts the RED direction: a rule that has
+// quietly stopped failing prints the same line as one with nothing to report.
 
 import { defineCases } from "../harness.mjs";
 
-// One of the paths the rule carries; the others behave identically.
 const BARREL = "packages/wire/src/index.ts";
-// The rest of the list has to exist too, or every case fails on a missing file
-// instead of on its own subject.
 const OTHERS = [
   "packages/twin-gmail/src/index.ts",
   "packages/twin-gmail/src/domain/index.ts",
@@ -49,8 +45,6 @@ defineCases("barrels", [
     contains: ["found logic/prose in a barrel", "const derived = a + 1;"],
   },
   {
-    // The hand-kept list is the weak point: a listed barrel that moved must red,
-    // not silently drop out of coverage.
     name: "a listed barrel that no longer exists is red, not skipped",
     files: tree(undefined),
     expect: "red",

--- a/scripts/lint/rules/bundled-deps.mjs
+++ b/scripts/lint/rules/bundled-deps.mjs
@@ -1,22 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// The CLI bundles every internal `@pome-sh/*` package into its own dist
-// (`noExternal: [/^@pome-sh\//]`), so those packages' own `dependencies` stop
-// being installed for them: whatever they `import` has to resolve from the
-// PUBLISHED CLI's dependency tree instead. Nothing in the type system or the
-// bundler notices when it cannot — esbuild happily leaves an unresolvable bare
-// import in a lazily-loaded chunk, and the failure lands on a user running
-// `pome twin start linear` with ERR_MODULE_NOT_FOUND.
-//
-// That is exactly how `graphql` (twin-linear's GraphQL executor) slipped
-// through. This rule unions the third-party runtime dependencies of every
-// internal package the CLI inlines and asserts each one is satisfiable from the
-// CLI manifest — either declared in cli `dependencies`, or inlined by the
-// bundler (`noExternal`).
+// Every third-party dep of an inlined workspace package must be declared by the
+// publisher, or it becomes ERR_MODULE_NOT_FOUND for the user.
 
-// Every workspace package the CLI inlines. Kept explicit rather than globbed:
-// a new internal package must be a deliberate addition here, and
-// adapter-claude-sdk is NOT in the CLI's graph (it is published separately).
 const BUNDLED_PACKAGES = [
   "packages/sdk",
   "packages/wire",
@@ -27,13 +13,8 @@ const BUNDLED_PACKAGES = [
   "packages/twin-linear",
 ];
 
-// Bare specifiers the bundler inlines rather than leaves as imports. Mirrors
-// cli/tsup.config.ts `noExternal`.
 const INLINED = [/^@pome-sh\//];
 
-/** Third-party runtime specifiers each bundled package needs at runtime.
- *  `peerDependencies` count: the sdk's optional `@hono/node-server` peer is a
- *  real runtime import on the server path. */
 function requiredSpecifiers(ctx) {
   const required = new Map(); // specifier -> [packages needing it]
   for (const dir of BUNDLED_PACKAGES) {
@@ -65,11 +46,6 @@ export default {
       );
     }
 
-    // @pome-sh/* left in the published runtime deps: none of them is
-    // installable by an end user, so a leaked spec breaks the install. The sdk
-    // and the twins are `private: true` and on no registry at all, and
-    // `@pome-sh/wire` is published only to GitHub Packages, which answers 401
-    // without a token. All of them are inlined by the bundler instead.
     for (const spec of declared) {
       if (!spec.startsWith("@pome-sh/")) continue;
       violations.push(

--- a/scripts/lint/rules/bundled-deps.test.mjs
+++ b/scripts/lint/rules/bundled-deps.test.mjs
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// The old gate shipped with no case table. Case 2 is the shape that actually
-// happened: `graphql`, twin-linear's GraphQL executor, was a dependency of the
-// twin and of nothing else, so the bundler left an unresolvable bare import in a
-// lazily-loaded chunk and the failure landed on a user, not on CI.
+// Case table for bundled-deps. Every case asserts the RED direction: a rule that has
+// quietly stopped failing prints the same line as one with nothing to report.
 
 import { defineCases } from "../harness.mjs";
 
@@ -18,7 +16,6 @@ const BUNDLED = [
   "packages/twin-linear",
 ];
 
-/** Every inlined package with no third-party deps, plus whatever `overrides` says. */
 function tree({ cliDeps = {}, overrides = {} } = {}) {
   const files = {
     "cli/package.json": JSON.stringify({ name: "@pome-sh/cli", version: "1.0.0", dependencies: cliDeps }),
@@ -60,8 +57,6 @@ defineCases("bundled-deps", [
     expect: "green",
   },
   {
-    // The sdk's optional `@hono/node-server` peer is a real runtime import on
-    // the server path, so peers count.
     name: "peerDependencies count as runtime requirements",
     files: tree({
       overrides: withDeps("packages/sdk", {
@@ -73,8 +68,6 @@ defineCases("bundled-deps", [
     contains: "@hono/node-server",
   },
   {
-    // An internal `@pome-sh/*` spec is inlined by the bundler, so it is not a
-    // requirement the CLI has to declare.
     name: "an internal @pome-sh/* dep is inlined, not required",
     files: tree({
       overrides: withDeps("packages/twin-github", {
@@ -85,8 +78,6 @@ defineCases("bundled-deps", [
     expect: "green",
   },
   {
-    // None of them is installable by an end user, so a leaked spec breaks the
-    // install of the published CLI.
     name: "an internal @pome-sh/* left in the CLI's runtime deps is a violation",
     files: tree({ cliDeps: { "@pome-sh/wire": "*" } }),
     expect: "red",

--- a/scripts/lint/rules/copy-markers.mjs
+++ b/scripts/lint/rules/copy-markers.mjs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copy-marker gate (M6). Cross-package file copies are not allowed in OSS
-// packages; shared code should move through published packages instead.
+// Banned vocabulary in anything a user reads (see AGENTS.md).
 
 const ALLOWLIST = new Set([]);
 

--- a/scripts/lint/rules/copy-markers.test.mjs
+++ b/scripts/lint/rules/copy-markers.test.mjs
@@ -1,19 +1,14 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// The old gate shipped with no case table, so nothing proved it could go red.
-// Both markers are asserted, plus the two false-positive shapes that would get
-// it deleted: a marker in prose, and a scoped-out file. The last case pins the
-// other direction — a scan directory that has vanished must be RED, because a
-// rule that walks nothing prints the same line as a rule that found nothing.
+// Case table for copy-markers. Every case asserts the RED direction: a rule that has
+// quietly stopped failing prints the same line as one with nothing to report.
 
 import { defineCases } from "../harness.mjs";
 
 const SRC = "packages/twin-x/src/thing.ts";
 const CLI = "cli/src/thing.ts";
 
-/** Both scanned directories present and clean, then `overrides` applied. A key
- *  mapped to `undefined` is dropped, to express "this file does not exist". */
 const tree = (overrides = {}) =>
   Object.fromEntries(
     Object.entries({
@@ -53,8 +48,6 @@ defineCases("copy-markers", [
     expect: "green",
   },
   {
-    // A `.js` file in a scanned directory is out of scope: the rule reads
-    // TypeScript sources only.
     name: "a marker in a non-TypeScript file is out of scope",
     files: tree({ "packages/twin-x/src/thing.js": `// Canonical: elsewhere\n` }),
     expect: "green",

--- a/scripts/lint/rules/example-isolation.mjs
+++ b/scripts/lint/rules/example-isolation.mjs
@@ -44,7 +44,7 @@
 // `run_task` local-subprocess spawn, and a plain `npm start`). Deliberately not
 // the `pome run` path itself: the measured trial was launched from a
 // developer shell by the coach, so a CLI-side clamp would not have caught the
-// very incident this ticket is about, and the obvious mechanism there
+// very incident this rule is about, and the obvious mechanism there
 // (`CLAUDE_CONFIG_DIR` at an empty dir, which the SDK does honor) also holds
 // `.credentials.json` — it would break subscription auth under `pome run`, the
 // thing an earlier fix addressed. The adapter change is a behavior change to a PUBLISHED

--- a/scripts/lint/rules/example-isolation.mjs
+++ b/scripts/lint/rules/example-isolation.mjs
@@ -1,56 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// A bundled Claude-Agent-SDK example whose `query()` options omit
-// `tools` or `settingSources` is not isolated, however carefully its comments
-// say it is.
-//
-// Two DIFFERENT doors, and shutting one says nothing about the other:
-//
-//   options.tools           the BUILT-IN base set (Bash, Read, Grep, WebFetch,
-//                           …). `[]` replaces the set, so it is complete by
-//                           construction. Closed for the hero example by
-//                           the denial-enumeration finding.
-//   options.settingSources  FILESYSTEM settings — user (~/.claude/settings.json),
-//                           project (.claude/settings.json) and local
-//                           (.claude/settings.local.json), INCLUDING the
-//                           developer's Claude Code plugin MCP servers. The SDK
-//                           typedoc: "When omitted, all sources are loaded
-//                           (matches CLI defaults). Pass [] to disable
-//                           filesystem settings (SDK isolation mode)."
-//
-// Measured 2026-08-05: a hosted `claude-haiku-4-5` trial of
-// support-triage-dedup, launched from a developer shell with `options.tools: []`
-// ALREADY SET, called `mcp__plugin_slack_slack__slack_search_channels`,
-// `…__slack_search_public` and `…__slack_list_channel_members` — it searched the
-// developer's real Slack workspace, made zero twin calls, and would have scored
-// as "the agent failed to triage". A verdict about the wrong workspace entirely.
-// Those servers arrive as Claude Code PLUGINS (namespaced
-// `plugin_<plugin>_<server>`), not from the repo's committed `.mcp.json` and not
-// from `~/.claude.json` — which is why no amount of repo hygiene reaches them
-// and why only `settingSources: []` does.
-//
-// An example is not sealed by intention. This PARSES rather than greps, for the
-// reason `scripts/lint/rules/import-meta-main.mjs` gives: a grep for
-// "settingSources" also matches the word in a comment beside the options
-// object, which is the single most likely way this regresses.
-//
-// [DECISION] central AND per-example, and the central half is NOT here.
-// Per-example options are what this gate enforces, and they are load-bearing on
-// their own: `agent-examples/support-triage` is `npx degit`-fetchable as a standalone
-// subtree, so the options a reader copies out must carry the isolation with
-// them. The central half belongs in `@pome-sh/adapter-claude-sdk`'s `query()`
-// — the one in-process chokepoint EVERY bundled example already routes through,
-// and the only one that holds for all three launchers (`pome run`, the coach's
-// `run_task` local-subprocess spawn, and a plain `npm start`). Deliberately not
-// the `pome run` path itself: the measured trial was launched from a
-// developer shell by the coach, so a CLI-side clamp would not have caught the
-// very incident this rule is about, and the obvious mechanism there
-// (`CLAUDE_CONFIG_DIR` at an empty dir, which the SDK does honor) also holds
-// `.credentials.json` — it would break subscription auth under `pome run`, the
-// thing an earlier fix addressed. The adapter change is a behavior change to a PUBLISHED
-// package's documented drop-in contract, so it is its own ticket with its own
-// version bump; this gate is what keeps the class closed until then, and stays
-// useful after, because the adapter cannot fix an example someone copies out.
+// Every example must seal its agent with `settingSources: []`. Parses rather than
+// greps: a grep for the option name also matches it in a comment beside the object.
 
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { dirname, extname, join, relative, resolve } from "node:path";
@@ -58,23 +9,12 @@ import { fileURLToPath } from "node:url";
 
 import ts from "typescript";
 
-// `../../..` — this rule lives two directories below `scripts/`. Only a default
-// for the exported helpers; the runner always passes an explicit root.
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 
-/** The two options that must both be present. Order is display order. */
 export const REQUIRED_OPTIONS = ["tools", "settingSources"];
 
-/** The dependency that makes an example one of this gate's subjects. */
 const SDK_PACKAGE = "@anthropic-ai/claude-agent-sdk";
 
-/**
- * The modules a `query` binding may come from. The adapter re-exports a drop-in
- * wrapper, and every bundled example imports it from there today — but an
- * example importing the raw SDK's `query` is the same agent with the same two
- * doors, so both count. A `query` from anywhere else (a twin's REST client, a
- * database helper) is not this gate's business.
- */
 const QUERY_MODULES = new Set([SDK_PACKAGE, "@pome-sh/adapter-claude-sdk"]);
 
 const SOURCE_EXTENSIONS = new Set([".ts", ".mts", ".cts", ".tsx", ".mjs", ".js", ".cjs"]);
@@ -90,26 +30,8 @@ const SCRIPT_KINDS = new Map([
   [".cjs", ts.ScriptKind.JS],
 ]);
 
-/**
- * The floor on how many `query()` call sites the walk must CLASSIFY before a
- * clean verdict means anything — four today, one per bundled SDK example. An
- * empty findings list is ambiguous on its own: it means "every example is
- * isolated" OR "the walk recognized no call site at all", and only the first is
- * a pass. A `typescript` upgrade moving an AST shape, or the examples
- * refactoring `query()` behind a helper, is exactly the moment a gate reports
- * the class closed having read nothing.
- */
 export const MIN_QUERY_CALL_SITES = 4;
 
-/**
- * Every `agent-examples/*` directory whose package.json declares the Claude Agent SDK
- * — DISCOVERED by reading the manifests, never a hand-kept list. A hand-kept
- * list stops covering its subject the day an example is added and nothing
- * notices, which is the enumeration failure this whole ticket family is about.
- *
- * `dependencies` and `devDependencies` both count: which section an example
- * files the SDK under says nothing about whether it launches an agent.
- */
 export function discoverSdkExamples(repoRoot = REPO_ROOT) {
   const examplesDir = join(repoRoot, "agent-examples");
   let entries;
@@ -143,7 +65,6 @@ export function discoverSdkExamples(repoRoot = REPO_ROOT) {
   return found;
 }
 
-/** Every source file under `dir`, recursively, sorted. */
 export function discoverSourceFiles(dir) {
   const found = [];
   const walk = (current) => {
@@ -157,8 +78,6 @@ export function discoverSourceFiles(dir) {
     for (const entry of entries) {
       if (PRUNED_DIRS.has(entry.name)) continue;
       const full = join(current, entry.name);
-      // `isDirectory()`/`isFile()` are both false for a symlink; statSync
-      // follows it. A silently skipped file reads as a pass.
       let stat;
       try {
         stat = statSync(full);
@@ -174,11 +93,8 @@ export function discoverSourceFiles(dir) {
   return found.sort();
 }
 
-/** Syntax errors, reported as their own category rather than as fake findings. */
 export function parseErrorsIn(source, fileName) {
   const sourceFile = createSourceFile(source, fileName);
-  // typescript RECOVERS from syntax errors rather than throwing, so an
-  // unreadable file would otherwise scan "clean".
   return (sourceFile.parseDiagnostics ?? []).map((d) => ts.flattenDiagnosticMessageText(d.messageText, " "));
 }
 
@@ -187,12 +103,6 @@ function createSourceFile(source, fileName) {
   return ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true, kind);
 }
 
-/**
- * Local names bound to a `query` import from one of QUERY_MODULES — so
- * `import { query }`, `import { query as ask }` and `import * as sdk` (whose
- * `sdk.query(...)` is matched by the namespace set) are all seen, and a local
- * function that happens to be called `query` is not.
- */
 function collectQueryBindings(sourceFile) {
   const direct = new Set();
   const namespaces = new Set();
@@ -201,7 +111,6 @@ function collectQueryBindings(sourceFile) {
     if (!ts.isStringLiteral(statement.moduleSpecifier)) continue;
     if (!QUERY_MODULES.has(statement.moduleSpecifier.text)) continue;
     const bindings = statement.importClause?.namedBindings;
-    // `import type { … }` binds no value — a type-only import cannot be called.
     if (statement.importClause?.isTypeOnly) continue;
     if (!bindings) continue;
     if (ts.isNamespaceImport(bindings)) {
@@ -217,36 +126,17 @@ function collectQueryBindings(sourceFile) {
   return { direct, namespaces };
 }
 
-/**
- * Single-assignment `const X = <expr>` initializers, plus same-file functions'
- * single `return <expr>` expressions, both keyed by name.
- *
- * Load-bearing rather than a nicety. `agent-examples/support-triage` composes its
- * exam surface in `examineeOptions(mcpServers)` and passes the CALL to
- * `query()` — deliberately, so its own test can assert the policy constants are
- * wired in. A resolver that only understood an inline object literal would find
- * no options object there and would have to either red the one example that
- * already got this right, or skip it. Skipping is how a gate passes forever.
- *
- * A name declared twice is dropped rather than guessed at, and a function with
- * more than one `return` is dropped for the same reason: two answers mean the
- * gate cannot know which one reaches `query()`, and an unresolved options
- * object is reported as a finding rather than assumed clean.
- */
 function collectResolvables(sourceFile) {
   const byName = new Map();
   const remember = (name, expr) => {
     byName.set(name, byName.has(name) ? null : expr);
   };
 
-  /** The single returned expression of a function body, or undefined. */
   const soleReturn = (body) => {
     if (!body) return undefined;
-    // A concise arrow body (`() => ({ … })`) is the expression itself.
     if (!ts.isBlock(body)) return body;
     const returns = [];
     const walk = (node) => {
-      // Do not descend into a nested function — its `return` is not this one's.
       if (node !== body && (ts.isFunctionDeclaration(node) || ts.isFunctionExpression(node) || ts.isArrowFunction(node))) {
         return;
       }
@@ -273,17 +163,6 @@ function collectResolvables(sourceFile) {
   return byName;
 }
 
-/**
- * Resolve an expression to the object literal it stands for: the literal
- * itself, a `const` bound to one, or a call to a same-file function that
- * returns one. Bounded depth, because a resolver that can loop on
- * `const a = b, b = a` is a hang, not a gate.
- *
- * Anything else — an imported helper, a conditional, a function with two
- * returns — resolves to `null`, which the caller reports as a finding. Failing
- * CLOSED is the whole point: "this gate could not tell" and "this example is
- * isolated" must never print the same way.
- */
 export function resolveObjectLiteral(expr, resolvables, depth = 0) {
   if (!expr || depth > 8) return null;
   if (ts.isParenthesizedExpression(expr)) return resolveObjectLiteral(expr.expression, resolvables, depth + 1);
@@ -298,16 +177,6 @@ export function resolveObjectLiteral(expr, resolvables, depth = 0) {
   return null;
 }
 
-/**
- * The property names an object literal sets UNCONDITIONALLY, following spreads
- * of resolvable object literals.
- *
- * A conditional spread — `...(MODEL ? { model: MODEL } : {})`, the shape three
- * of the bundled examples already use for `model` — deliberately does NOT
- * contribute. A door that is only shut when some env var is set is a door that
- * is open, and this gate exists because "shut in the case we thought about" is
- * exactly what `tools: []` alone turned out to be.
- */
 export function unconditionalKeys(objectLiteral, resolvables, depth = 0) {
   const keys = new Set();
   if (!objectLiteral || depth > 8) return keys;
@@ -326,13 +195,6 @@ export function unconditionalKeys(objectLiteral, resolvables, depth = 0) {
   return keys;
 }
 
-/**
- * Every `query()` call site in `source`, with the options keys it sets.
- *
- * Returns `{ callSites, findings }`. `callSites` counts what was CLASSIFIED,
- * sanctioned ones included — see MIN_QUERY_CALL_SITES for why an empty
- * `findings` alone is not a pass.
- */
 export function scanSource(source, fileName = "index.ts") {
   const sourceFile = createSourceFile(source, fileName);
   const { direct, namespaces } = collectQueryBindings(sourceFile);
@@ -358,19 +220,12 @@ export function scanSource(source, fileName = "index.ts") {
       if (!params) {
         findings.push({ line, reason: "unresolvable-params", missing: [...REQUIRED_OPTIONS] });
       } else {
-        // Quoted as well as bare, matching `unconditionalKeys` — a gate that
-        // reads `options:` but not `"options":` would report both doors open on
-        // a call that shuts them.
         const optionsProperty = params.properties.find(
           (p) =>
             p.name &&
             (ts.isIdentifier(p.name) || ts.isStringLiteral(p.name)) &&
             p.name.text === "options",
         );
-        // `query({ prompt, options })` is the same call as `options: options`,
-        // and resolving the shorthand through the same table is what keeps it
-        // from reading as an unresolvable object — a false RED on correct work,
-        // which is how a gate gets deleted rather than obeyed.
         const optionsValue = !optionsProperty
           ? undefined
           : ts.isPropertyAssignment(optionsProperty)
@@ -399,11 +254,6 @@ export function scanSource(source, fileName = "index.ts") {
   return { callSites, findings };
 }
 
-/**
- * Scan every discovered SDK example. Unparseable files are reported separately
- * from findings — a syntax error is not an open door, and reporting it as one
- * sends the reader looking for an options object that does not exist.
- */
 export function scanExamples(repoRoot = REPO_ROOT) {
   const examples = discoverSdkExamples(repoRoot);
   const findings = [];
@@ -446,7 +296,6 @@ const REASONS = {
 export default {
   name: "example-isolation",
   describe: "every bundled SDK example sets both `tools` and `settingSources` on `query()`",
-  // `typescript` is a devDependency: the AST walk needs an installed tree.
   needsInstall: true,
   check(ctx) {
     const { examples, filesScanned, callSites, findings, unparseable, silentExamples } = scanExamples(ctx.root);
@@ -460,14 +309,10 @@ export default {
 
     const violations = [];
 
-    // A file this rule cannot read is an unchecked file, which must not read as
-    // a pass.
     for (const bad of unparseable) {
       violations.push(`${bad.file}: could not be parsed, so it was NOT checked — ${bad.errors.join("; ")}`);
     }
 
-    // Either they launch no agent, or the call is in a shape this rule cannot
-    // see — and the second reads exactly like a pass.
     for (const name of silentExamples) {
       violations.push(
         `${name} declares ${SDK_PACKAGE} but this rule found no \`query()\` call in it.`,
@@ -478,9 +323,6 @@ export default {
       violations.push(`${finding.file}:${finding.line} — ${REASONS[finding.reason](finding.missing)}`);
     }
 
-    // The floor: an empty findings list is ambiguous on its own — it means
-    // "every example is isolated" OR "the walk recognized no call site at all",
-    // and only the first is a pass.
     if (violations.length === 0 && callSites < MIN_QUERY_CALL_SITES) {
       violations.push(
         `Classified only ${callSites} \`query()\` call site(s) across ${examples.length} SDK example(s), ` +

--- a/scripts/lint/rules/example-isolation.mjs
+++ b/scripts/lint/rules/example-isolation.mjs
@@ -29,11 +29,10 @@
 // from `~/.claude.json` — which is why no amount of repo hygiene reaches them
 // and why only `settingSources: []` does.
 //
-// This gate is the answer to "an example is not sealed by intention". It PARSES
-// rather than greps, for the reason `scripts/lint/rules/import-meta-main.mjs`
-// gives: a grep for "settingSources" also matches the word in the comment three
-// lines above the options object it was deleted from, which is the single most
-// likely way this regresses.
+// An example is not sealed by intention. This PARSES rather than greps, for the
+// reason `scripts/lint/rules/import-meta-main.mjs` gives: a grep for
+// "settingSources" also matches the word in a comment beside the options
+// object, which is the single most likely way this regresses.
 //
 // [DECISION] central AND per-example, and the central half is NOT here.
 // Per-example options are what this gate enforces, and they are load-bearing on

--- a/scripts/lint/rules/example-isolation.test.mjs
+++ b/scripts/lint/rules/example-isolation.test.mjs
@@ -96,7 +96,7 @@ for (const [label, { source, missing }] of Object.entries(OPEN_DOORS)) {
 
 // An options object the gate cannot resolve must be a FINDING, never a pass.
 // "I could not tell" and "it is isolated" printing the same way is the whole
-// class of bug this ticket family keeps hitting.
+// class of bug this rule exists to catch.
 {
   const cases = {
     "options from an imported helper": `${IMPORT_LINE}\nimport { opts } from "./opts.js";\nawait query({ prompt: "go", options: opts });`,

--- a/scripts/lint/rules/example-isolation.test.mjs
+++ b/scripts/lint/rules/example-isolation.test.mjs
@@ -1,13 +1,8 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Regression coverage for the `example-isolation` lint rule.
-//
-// The gate's own failure mode is the one it exists to prevent: a checker that
-// silently classifies nothing prints the same "no findings" as a repo that is
-// genuinely isolated. So the assertions below come in pairs — every shape that
-// must RED, and every shape that must not — plus a live scan of the real
-// examples, which is what stops the fix from being reverted quietly.
+// Case table for example-isolation. Every case asserts the RED direction: a rule that has
+// quietly stopped failing prints the same line as one with nothing to report.
 
 import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
@@ -37,11 +32,6 @@ function assert(cond, msg) {
 const IMPORT_LINE = 'import { query } from "@pome-sh/adapter-claude-sdk";';
 const missingOf = (result) => result.findings.flatMap((f) => f.missing).sort();
 
-// ── the shapes that must RED ────────────────────────────────────────────────
-// Each is a real `query()` call — so the gate must both COUNT it as a call site
-// and report the door(s) left open. A shape that goes uncounted is worse than
-// one reported wrong: it subtracts from the floor that makes a clean run mean
-// anything.
 const OPEN_DOORS = {
   "no options at all": {
     source: `${IMPORT_LINE}\nawait query({ prompt: "go" });`,
@@ -59,23 +49,14 @@ const OPEN_DOORS = {
     source: `${IMPORT_LINE}\nawait query({ prompt: "go", options: { settingSources: [] } });`,
     missing: ["tools"],
   },
-  // `allowedTools` is the trap the blast radius is built on: it reads
-  // like a restriction and is not one (it only auto-approves). A gate that
-  // accepted it would bless three of the four bundled examples exactly as they
-  // shipped.
   "allowedTools instead of tools": {
     source: `${IMPORT_LINE}\nawait query({ prompt: "go", options: { allowedTools: ["mcp__github__x"], settingSources: [] } });`,
     missing: ["tools"],
   },
-  // A door shut only when an env var happens to be set is a door that is open —
-  // and the conditional spread is the shape three bundled examples already use
-  // for `model`, so it is the one a future author reaches for by habit.
   "conditional spread does not count": {
     source: `${IMPORT_LINE}\nconst ISO = process.env.ISO;\nawait query({ prompt: "go", options: { tools: [], ...(ISO ? { settingSources: [] } : {}) } });`,
     missing: ["settingSources"],
   },
-  // The single most likely regression: the options are deleted and the comment
-  // explaining them stays. A grep for the string would call this green.
   "the word in a comment is not the option": {
     source: `${IMPORT_LINE}\n// settingSources: [] closes the filesystem door\nawait query({ prompt: "go", options: { tools: [] } });`,
     missing: ["settingSources"],
@@ -94,9 +75,6 @@ for (const [label, { source, missing }] of Object.entries(OPEN_DOORS)) {
   );
 }
 
-// An options object the gate cannot resolve must be a FINDING, never a pass.
-// "I could not tell" and "it is isolated" printing the same way is the whole
-// class of bug this rule exists to catch.
 {
   const cases = {
     "options from an imported helper": `${IMPORT_LINE}\nimport { opts } from "./opts.js";\nawait query({ prompt: "go", options: opts });`,
@@ -111,25 +89,15 @@ for (const [label, { source, missing }] of Object.entries(OPEN_DOORS)) {
   }
 }
 
-// ── the shapes that must stay GREEN ─────────────────────────────────────────
 const SEALED = {
   "both inline": `${IMPORT_LINE}\nawait query({ prompt: "go", options: { tools: [], settingSources: [] } });`,
-  // agent-examples/support-triage's real shape: the options are composed in a named
-  // function so its own test can assert the policy is WIRED IN, and the call
-  // site passes the call. A resolver that only read inline literals would have
-  // to red the one example that already got this right.
   "options from a same-file function": `${IMPORT_LINE}\nfunction examineeOptions(mcpServers) {\n  return { tools: BUILT_IN, settingSources: [], mcpServers };\n}\nawait query({ prompt: "go", options: examineeOptions({}) });`,
   "options from a same-file const": `${IMPORT_LINE}\nconst OPTIONS = { tools: [], settingSources: [] };\nawait query({ prompt: "go", options: OPTIONS });`,
   "options from an arrow with a concise body": `${IMPORT_LINE}\nconst build = () => ({ tools: [], settingSources: [] });\nawait query({ prompt: "go", options: build() });`,
-  // Named constants rather than literals: the gate asserts the door is NAMED,
-  // not that it is spelled `[]` — support-triage's `tools: BUILT_IN_TOOLS` is
-  // the sanctioned form, pinned by that example's own unit test.
   "named constants": `${IMPORT_LINE}\nawait query({ prompt: "go", options: { tools: BUILT_IN_TOOLS, settingSources: NO_FS } });`,
   "an unconditional spread carries the keys": `${IMPORT_LINE}\nconst ISOLATION = { tools: [], settingSources: [] };\nawait query({ prompt: "go", options: { ...ISOLATION, maxTurns: 5 } });`,
   "quoted keys": `${IMPORT_LINE}\nawait query({ prompt: "go", options: { "tools": [], "settingSources": [] } });`,
   "a quoted `options` key": `${IMPORT_LINE}\nawait query({ prompt: "go", "options": { tools: [], settingSources: [] } });`,
-  // `query({ prompt, options })` is the same call as `options: options`; reading
-  // it as unresolvable would be a false RED on correct work.
   "shorthand options": `${IMPORT_LINE}\nconst options = { tools: [], settingSources: [] };\nawait query({ prompt, options });`,
   "aliased import": `import { query as ask } from "@pome-sh/adapter-claude-sdk";\nawait ask({ prompt: "go", options: { tools: [], settingSources: [] } });`,
   "namespace import": `import * as sdk from "@anthropic-ai/claude-agent-sdk";\nawait sdk.query({ prompt: "go", options: { tools: [], settingSources: [] } });`,
@@ -142,10 +110,6 @@ for (const [label, source] of Object.entries(SEALED)) {
   assert(result.findings.length === 0, `a sealed call is clean: ${label} (got ${JSON.stringify(result.findings)})`);
 }
 
-// ── what is NOT this gate's subject ─────────────────────────────────────────
-// A false red on unrelated code is how a gate gets deleted. `query` is an
-// ordinary name — a database client, a twin REST helper — and only the one
-// bound to the SDK (directly or through the adapter) opens these two doors.
 const NOT_SUBJECTS = {
   "query from an unrelated module": 'import { query } from "pg";\nawait query({ prompt: "go", options: {} });',
   "a locally defined query": "function query(x) { return x; }\nquery({ prompt: 'go', options: {} });",
@@ -158,10 +122,7 @@ for (const [label, source] of Object.entries(NOT_SUBJECTS)) {
   assert(result.findings.length === 0, `not a subject, so not a finding: ${label}`);
 }
 
-// ── discovery is by manifest, never a hand-kept list ────────────────────────
 {
-  // realpathSync because macOS's /tmp is a symlink to /private/tmp, and the
-  // discovery walk statSync's absolute paths.
   const tmp = realpathSync(mkdtempSync(join(tmpdir(), "f1295-")));
   try {
     const write = (name, manifest) => {
@@ -179,9 +140,6 @@ for (const [label, source] of Object.entries(NOT_SUBJECTS)) {
       `discovery finds SDK examples by manifest, in either dependency section (got ${JSON.stringify(found)})`,
     );
 
-    // An SDK example with no `query()` call is reported, not skipped: "this
-    // example launches no agent" and "the call is in a shape I cannot see" read
-    // identically otherwise, and only the first is a pass.
     writeFileSync(join(tmp, "agent-examples", "uses-sdk", "src", "index.ts"), 'export const x = 1;\n');
     writeFileSync(
       join(tmp, "agent-examples", "dev-dep-only", "src", "index.ts"),
@@ -194,8 +152,6 @@ for (const [label, source] of Object.entries(NOT_SUBJECTS)) {
     );
     assert(scan.callSites === 1, `call sites are summed across examples (got ${scan.callSites})`);
 
-    // A repo with no SDK example at all must not print a pass — the runner
-    // exits 1 on it, and this is the unit-level half of that.
     const empty = discoverSdkExamples(join(tmp, "nope"));
     assert(empty.length === 0, "a missing agent-examples/ directory discovers nothing rather than throwing");
   } finally {
@@ -203,14 +159,12 @@ for (const [label, source] of Object.entries(NOT_SUBJECTS)) {
   }
 }
 
-// ── an unreadable file is not a clean file ──────────────────────────────────
 {
   const broken = "const x = {{{;";
   assert(parseErrorsIn(broken, "x.ts").length > 0, "a syntax error is reported rather than scanned as clean");
   assert(parseErrorsIn(`${IMPORT_LINE}\nconst a: string[] = [];`, "x.ts").length === 0, "real TS parses cleanly");
 }
 
-// ── the live repo, which is what actually holds the fix in place ────────────
 {
   const scan = scanExamples(ROOT);
   assert(scan.examples.length >= 4, `the four bundled SDK examples are discovered (got ${JSON.stringify(scan.examples)})`);
@@ -227,11 +181,6 @@ for (const [label, source] of Object.entries(NOT_SUBJECTS)) {
   );
 }
 
-// ── the runner exits non-zero, not just prints ──────────────────────────────
-// A rule that reports findings and exits 0 is wired into CI as a no-op. The
-// green direction is covered by the live scan above; these assert the red one
-// through the real process boundary, against a throwaway tree. `--root` is what
-// makes that possible without copying the runner into the fixture.
 defineCases("example-isolation", [
   {
     name: "an example missing a door reds the rule, naming the door and the example",
@@ -253,21 +202,16 @@ defineCases("example-isolation", [
       "agent-examples/tight/src/index.ts":
         `${IMPORT_LINE}\nawait query({ prompt: "go", options: { tools: [], settingSources: [] } });\n`,
     },
-    // Below the call-site floor of 4, so it reds — on the floor, not on a door.
     expect: "red",
     contains: "below the floor",
   },
   {
-    // A tree where the examples moved must red rather than report a pass having
-    // scanned nothing.
     name: "no SDK example at all reds the rule, rather than passing over nothing",
     files: { "agent-examples/plain/package.json": JSON.stringify({ dependencies: {} }) },
     expect: "red",
     contains: "so this rule scanned nothing",
   },
   {
-    // The `query()` binding has to come from the SDK or the adapter; a `query`
-    // from a database helper is not this rule's business.
     name: "a `query` imported from somewhere else is not this rule's business",
     files: {
       "agent-examples/db/package.json": JSON.stringify({
@@ -276,8 +220,6 @@ defineCases("example-isolation", [
       "agent-examples/db/src/index.ts":
         `import { query } from "./sqlite.js";\nawait query({ prompt: "go" });\n`,
     },
-    // No call site classified, so the floor reds it — the point is that the call
-    // is not reported as an unshut door.
     expect: "red",
     contains: "found no `query()` call",
   },

--- a/scripts/lint/rules/example-isolation.test.mjs
+++ b/scripts/lint/rules/example-isolation.test.mjs
@@ -59,7 +59,7 @@ const OPEN_DOORS = {
     source: `${IMPORT_LINE}\nawait query({ prompt: "go", options: { settingSources: [] } });`,
     missing: ["tools"],
   },
-  // `allowedTools` is the trap this ticket's blast radius is built on: it reads
+  // `allowedTools` is the trap the blast radius is built on: it reads
   // like a restriction and is not one (it only auto-approves). A gate that
   // accepted it would bless three of the four bundled examples exactly as they
   // shipped.

--- a/scripts/lint/rules/file-size.mjs
+++ b/scripts/lint/rules/file-size.mjs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// File-size tripwire. Past the limit a module either states its reason in a
-// `// file-size:` header or gets split. The allowlist is existing debt and
-// should only ever shrink.
+// Barrel and file-size ceilings. A missing scan root is RED, not an empty pass.
 
 const FILE_SIZE_LIMIT = 500;
 const FILE_SIZE_HEADER = /^\/\/\s*file-size:\s*.+/;

--- a/scripts/lint/rules/file-size.test.mjs
+++ b/scripts/lint/rules/file-size.test.mjs
@@ -1,19 +1,11 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// The old gate shipped with no case table. What is worth proving is that the
-// escape hatch works only in the one place it is documented to: a
-// `// file-size:` header on the FIRST line. A header further down the file would
-// be an escape hatch nobody could find by reading the top of the module.
-//
-// The last case pins the other direction — a scan directory that has vanished
-// must be RED, because a rule that walks nothing prints the same line as a rule
-// that found nothing.
+// Case table for file-size. Every case asserts the RED direction: a rule that has
+// quietly stopped failing prints the same line as one with nothing to report.
 
 import { defineCases } from "../harness.mjs";
 
-// Every directory the rule is told to walk. All of them have to exist, or the
-// case fails on a missing scan root instead of on its own subject.
 const SCAN_DIRS = [
   "packages/twin-gmail/src",
   "packages/twin-github/src",
@@ -30,8 +22,6 @@ const SUBJECT = "cli/src/big.ts";
 const lines = (count, first = "") =>
   [first, ...Array.from({ length: count }, (_, index) => `const x${index} = ${index};`)].join("\n");
 
-/** Every scan directory present and trivially clean, then `overrides` applied.
- *  A key mapped to `undefined` is dropped, to express "this file does not exist". */
 const tree = (overrides = {}) =>
   Object.fromEntries(
     Object.entries({
@@ -70,7 +60,6 @@ defineCases("file-size", [
     contains: "exceeds 500 LOC",
   },
   {
-    // Existing debt, allowlisted by exact path. The list should only shrink.
     name: "an allowlisted module is exempt at any length",
     files: tree({ "cli/src/cli/main.ts": lines(900) }),
     expect: "green",

--- a/scripts/lint/rules/first-party-twins.mjs
+++ b/scripts/lint/rules/first-party-twins.mjs
@@ -1,24 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Canonical first-party registration drift. First-party twins must be explicit
-// at operational seams (contracts, bundles, images), but those explicit arrays
-// are easy to update incompletely. This rule compares every registration with
-// config/first-party-twins.json and fails loudly.
-//
-// The CLI's own registration is no longer a hand-maintained array: `TwinName` is
-// derived from `TWIN_NAME_LIST` and `TWIN_REGISTRY` is a
-// `Record<TwinName, TwinEntry>`, so a missing CLI entry is a compile error and
-// the per-entry values are asserted by cli/test/unit/twin/registry.test.ts.
-// `TWIN_NAME_LIST` itself is still compared here — that list is what the type is
-// derived FROM, so nothing inside the CLI can catch it drifting from the
-// canonical set. The seams below live outside the type system entirely (twin
-// images, the black-box contract suite, the wire enums, workflow path filters)
-// and are the reason this rule survives.
-//
-// Two seams deliberately absent: Docker base-image updates are Renovate's,
-// which auto-discovers every `packages/twin-*/Dockerfile`; and the build order
-// is a topological sort over `npm query .workspace`, which names no package, so
-// a twin missing from the build is not expressible.
+// The first-party twin list is read from config, never typed twice.
 
 export default {
   name: "first-party-twins",
@@ -35,7 +17,6 @@ export default {
       }
     };
 
-    /** A quoted-string array declared under `exportName`, read from source. */
     const quotedArray = (path, exportName) => {
       const match = ctx
         .readRel(path)
@@ -51,21 +32,10 @@ export default {
     );
     compare("cli/src/twin/registry.ts TWIN_NAME_LIST", quotedArray("cli/src/twin/registry.ts", "TWIN_NAME_LIST"));
 
-    // `@pome-sh/checks` carries every twin's grading vocabulary to pome-cloud,
-    // and its barrel names the twins explicitly; there is no way to derive them,
-    // since each twin's array has a different element type. A new twin missing
-    // here does not fail to compile and does not fail any twin's own contract
-    // suite — it produces a criterion that silently never binds, which is the
-    // exact failure that package exists to prevent.
     compare(
       "packages/checks/src/index.ts CHECKS_TWIN_NAMES",
       quotedArray("packages/checks/src/index.ts", "CHECKS_TWIN_NAMES"),
     );
-    // `@pome-sh/sandbox-domains` carries the other half to the same consumer.
-    // Same seam, one step worse: a twin missing here compiles, and its criteria
-    // do not merely fail to bind, they bind against a vocabulary whose runtime
-    // pome-cloud cannot construct at all. Both arrays are checked because the
-    // two packages are the two legs of `checks-package-drift`.
     compare(
       "packages/sandbox-domains/src/index.ts SANDBOX_DOMAIN_NAMES",
       quotedArray("packages/sandbox-domains/src/index.ts", "SANDBOX_DOMAIN_NAMES"),
@@ -86,9 +56,6 @@ export default {
       ),
     );
 
-    // Twin-image matrix is dynamic on PRs (`detect-twins`); the canonical full
-    // set is declared as FIRST_PARTY_TWINS (and mirrored in the detect script's
-    // `all='[...]'` / `for twin in ...` loop).
     const imageText = ctx.readRel(".github/workflows/twin-image.yml");
     const imageRaw =
       imageText.match(/#\s*FIRST_PARTY_TWINS:\s*([^\n]+)/)?.[1] ??
@@ -103,10 +70,6 @@ export default {
         .filter(Boolean),
     );
 
-    // The twins are bundled into the CLI by tsup (`noExternal: [/^@pome-sh\//]`),
-    // so they are devDependencies of cli, not runtime deps. That list is still a
-    // registration seam: a twin missing from it would not install, and its
-    // registry entry's `import()` would not resolve.
     compare(
       "cli/package.json devDependencies",
       Object.keys(ctx.json("cli/package.json").devDependencies)

--- a/scripts/lint/rules/first-party-twins.test.mjs
+++ b/scripts/lint/rules/first-party-twins.test.mjs
@@ -1,20 +1,13 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// The old gate shipped with no case table, for a rule that compares twelve
-// registration seams against one canonical list. Every case here adds a twin to
-// the canonical set and leaves exactly ONE seam behind, which is the drift the
-// rule exists to catch: the explicit arrays are easy to update incompletely, and
-// a twin missing from any one of them fails at a different, later, quieter place.
-//
-// Case "a renamed array" is the other half: a seam whose array this rule can no
-// longer find must be a hard failure, not a silently uncompared seam.
+// Case table for first-party-twins. Every case asserts the RED direction: a rule that has
+// quietly stopped failing prints the same line as one with nothing to report.
 
 import { defineCases } from "../harness.mjs";
 
 const TWINS = ["github", "slack"];
 
-/** Every seam, agreeing on `twins`, with `overrides` applied afterwards. */
 function tree(twins = TWINS, overrides = {}) {
   const quoted = twins.map((twin) => `"${twin}"`).join(", ");
   const files = {
@@ -43,7 +36,6 @@ function tree(twins = TWINS, overrides = {}) {
   return { ...files, ...overrides };
 }
 
-/** Every seam updated for a new twin EXCEPT the one named. */
 function allButOne(seam) {
   const added = [...TWINS, "linear"];
   return { ...tree(added), [seam]: tree(TWINS)[seam] };
@@ -69,15 +61,12 @@ defineCases("first-party-twins", [
     contains: "KNOWN_TWIN_IDS",
   },
   {
-    // A criterion that silently never binds is the failure this seam prevents.
     name: "a twin missing from the checks vocabulary is a violation",
     files: allButOne("packages/checks/src/index.ts"),
     expect: "red",
     contains: "CHECKS_TWIN_NAMES",
   },
   {
-    // One step worse: it compiles, and the criteria bind against a vocabulary
-    // whose runtime pome-cloud cannot construct at all.
     name: "a twin missing from the sandbox domains is a violation",
     files: allButOne("packages/sandbox-domains/src/index.ts"),
     expect: "red",
@@ -90,8 +79,6 @@ defineCases("first-party-twins", [
     contains: "contract/helpers.mjs",
   },
   {
-    // A twin missing from the devDependency list would not install, and its
-    // registry entry's `import()` would not resolve.
     name: "a twin missing from the CLI's devDependencies is a violation",
     files: allButOne("cli/package.json"),
     expect: "red",
@@ -104,15 +91,12 @@ defineCases("first-party-twins", [
     contains: "twin-image.yml",
   },
   {
-    // The path filter is separate from the matrix: a workflow that never triggers
-    // for a twin is a workflow that does not cover it.
     name: "a missing workflow path filter is a violation",
     files: allButOne(".github/workflows/agent-trace-overhead-gate.yml"),
     expect: "red",
     contains: "missing packages/twin-linear/** path filter",
   },
   {
-    // A seam this rule can no longer find is a seam it stopped comparing.
     name: "an array renamed out from under the rule is red, not silently uncompared",
     files: tree(TWINS, {
       "cli/src/twin/registry.ts": `export const TWIN_NAMES = ["github", "slack"] as const;\n`,

--- a/scripts/lint/rules/import-meta-main.mjs
+++ b/scripts/lint/rules/import-meta-main.mjs
@@ -1,56 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// A bare `import.meta.main` entry guard is false on Node 24.0.0,
-// 24.0.1, 24.0.2 and 24.1.0 — the property landed in 24.2, root `engines`
-// allows `>=24`, so on those versions it silently reads `undefined` and a
-// guard built on it exits 0 having done nothing. `scripts/probe-twin-endpoints.mjs`
-// shipped exactly that shape; `contract/run.mjs` and `scripts/smoke-examples.mjs`
-// were already fixed to the sanctioned form (realpath both sides of
-// process.argv[1] vs. import.meta.url, throw on a guard miss rather than exit
-// 0). This gate is what stops the next file from reintroducing it.
-//
-// It PARSES rather than greps. A grep for the string "import.meta.main" also
-// matches it inside a comment or a string literal (this file's own header
-// above, scripts/capture-mcp-tools-list.test.mjs's assertion about a
-// producer's SOURCE TEXT, and any generator that WRITES the string into
-// source it emits) — those are not code and must not red.
-// Conversely the real thing can be spelled in ways a naive regex misses:
-// `import.meta?.main`, split across lines, wrapped in parens, negated
-// (`!import.meta.main`), read via computed access (`import.meta["main"]`), or
-// via destructuring (`const { main } = import.meta`, with or without a
-// rename). Matching AST node shapes catches all of those and none of the false
-// positives, because a string literal or a comment never becomes a
-// MetaProperty node at all.
-//
-// The parser is `typescript`, not a JS-only one, because the defect's live
-// instances were in `.ts`: six bundled examples under `agent-examples/*/src/` shipped
-// a bare guard, and a JS-only parser cannot read those files at all — a gate
-// that silently cannot parse its subject is the shape D5 targets. typescript is
-// already a direct devDependency of all ten workspaces (uniformly `^5.9.3`),
-// parses `.ts`/`.mts`/`.tsx` and plain `.mjs`/`.js` through one entry point,
-// and needs no plugin.
-//
-// The file set is DISCOVERED — every source file under the roots below, found
-// by walking the directory tree, never a hand-kept list. A hand-kept list is
-// the exact shape this targets: it stops covering its subject
-// the day a file is added and nothing notices.
-//
-// The realpath check extends this same walk with a second, related check rather than
-// building a separate scanner: the SANCTIONED replacement for bare
-// `import.meta.main` — comparing `process.argv[1]` against `import.meta.url`
-// — has its own silent-skip shape when neither side (or only one side) is
-// realpath'd. Node resolves symlinks before deriving `import.meta.url`, so an
-// unresolved (or only-partly-resolved) argv0 disagrees with it through any
-// symlinked invocation (a `git worktree`, or macOS's `/tmp` → `/private/tmp`)
-// and the guard falls false — the exact vacuous-pass shape this file already
-// exists to catch, reached through a different comparison. Ten instances
-// shipped with no realpath on either side (`resolve()`-only, or a bare
-// `pathToFileURL(...).href`/`fileURLToPath(...)` compare), and two more
-// compared a `basename()` — weaker still, since a basename match is satisfied
-// by any file of that name anywhere on disk, so it never needed a symlink at
-// all. `findEntryGuardRealpathGaps` below reports a comparison in EITHER of
-// those shapes; a comparison with `realpathSync` wrapping both sides is not a
-// finding.
+// `import.meta.main` is undefined before Node 24.2 and `engines` allows >=24, so a
+// bare guard exits 0 having run nothing. Requires a realpath'd `process.argv[1]`
+// compared against `import.meta.url`, on BOTH sides — one-sided is the vacuous pass.
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, extname, join, relative, resolve } from "node:path";
@@ -58,42 +10,16 @@ import { fileURLToPath } from "node:url";
 
 import ts from "typescript";
 
-// `../../..` — this rule lives two directories below `scripts/`. Only a default
-// for the exported helpers; the runner always passes an explicit root.
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 
 const SOURCE_EXTENSIONS = new Set([".mjs", ".js", ".cjs", ".ts", ".mts", ".cts", ".tsx"]);
 
-// Every root that ships an entry point. This is `scripts/lint/rules/no-eval.mjs`'s
-// root list plus `contract/` and `agent-examples/` — the two the narrower first cut
-// of this gate covered (`scripts`, `contract`) left the class open one
-// directory over, which is precisely how this gate's own gap happened: one fix landed
-// `contract/run.mjs` and the same bug survived ten lines from `probe:examples`.
-// `agent-examples/` is load-bearing, not defensive: six examples were live instances.
 const SCAN_ROOTS = ["scripts", "contract", "cli/src", "cli/scripts", "packages", "agent-examples"];
 
-// Pruned at ANY depth. Without this the walk finds ~19,600 files instead of
-// ~740 and parses third-party CJS, which reds spuriously.
 const PRUNED_DIRS = new Set(["node_modules", "dist", "build", ".git", "coverage", ".turbo", ".next"]);
 
-// The floor on how many entry-guard comparisons the realpath half must CLASSIFY
-// before its "no gaps" verdict means anything. See the rule's `check()` at the
-// bottom of this file for why it is proportional rather than `> 0`.
-//
-// 12 is the instance count that motivated it. It was measured against 31 present;
-// consolidating the lint fleet behind one runner deleted 8 of those guards
-// outright — every retired gate script had one, and the runner has one for all of
-// them — leaving 23. The floor is unchanged because the number it guards against
-// is a classifier that has gone blind, not the repo's script count, and 12 of 23
-// is still the proportional bound the comment below argues for.
 const MIN_ENTRY_GUARD_RELATIONS = 12;
 
-/**
- * Every source file under SCAN_ROOTS, sorted, found by recursively walking the
- * directory tree rather than by any hand-kept list. A root that does not exist
- * contributes nothing — the caller asserts a per-root floor so a renamed or
- * relocated root reds instead of quietly dropping out of coverage.
- */
 export function discoverSourceFiles(repoRoot = REPO_ROOT, roots = SCAN_ROOTS) {
   const byRoot = new Map();
   const walk = (dir, into) => {
@@ -107,10 +33,6 @@ export function discoverSourceFiles(repoRoot = REPO_ROOT, roots = SCAN_ROOTS) {
     for (const entry of entries) {
       const full = join(dir, entry.name);
       if (PRUNED_DIRS.has(entry.name)) continue;
-      // `isDirectory()`/`isFile()` are both FALSE for a symlink, so keying off
-      // the dirent alone silently skips a symlinked script or subdirectory —
-      // a skip that reads as a pass, in a gate whose whole premise is that it
-      // must not. `statSync` follows the link.
       let stat;
       try {
         stat = statSync(full);
@@ -140,7 +62,6 @@ const SCRIPT_KINDS = new Map([
   [".cjs", ts.ScriptKind.JS],
 ]);
 
-/** `import.meta` itself — the node every real reference hangs off. */
 function isImportMetaNode(node) {
   return (
     !!node &&
@@ -150,32 +71,22 @@ function isImportMetaNode(node) {
   );
 }
 
-/** Does this name/key node name the literal `main`? */
 function namesMain(node) {
   if (!node) return false;
-  // `{ ["main"]: m }` wraps the key in a ComputedPropertyName node.
   if (ts.isComputedPropertyName(node)) return namesMain(node.expression);
   if (ts.isIdentifier(node)) return node.text === "main";
-  // `import.meta["main"]` and `import.meta[`main`]` are both statically
-  // resolvable and plausible accidents, so both count. `import.meta["ma"+"in"]`
-  // deliberately does not — that needs real constant folding, and nobody
-  // reaches it by accident.
   if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) return node.text === "main";
   return false;
 }
 
-/** `{ main }`, `{ main: isMain }`, `{ ["main"]: m }`, or `{ ...rest }`. */
 function bindsMain(pattern) {
   if (!pattern || !ts.isObjectBindingPattern(pattern)) return false;
   return pattern.elements.some((el) => {
-    // `const { ...rest } = import.meta` hands the whole object over, so
-    // `rest.main` is reachable and the guard is just as broken.
     if (el.dotDotDotToken) return true;
     return namesMain(el.propertyName ?? el.name);
   });
 }
 
-/** The object-literal form of the same thing: `({ main } = import.meta)`. */
 function assignsMain(target) {
   if (!target || !ts.isObjectLiteralExpression(target)) return false;
   return target.properties.some((prop) => {
@@ -184,13 +95,6 @@ function assignsMain(target) {
   });
 }
 
-/**
- * Every real `import.meta.main` reference in `source`: a plain, optional-chained
- * or computed member access, or a destructure straight off `import.meta`.
- *
- * @param {string} source
- * @param {string} [fileName] drives the script kind, so `.ts` is parsed as TS.
- */
 export function findBareImportMetaMain(source, fileName = "input.mjs") {
   const kind = SCRIPT_KINDS.get(extname(fileName)) ?? ts.ScriptKind.JS;
   const sourceFile = ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true, kind);
@@ -222,12 +126,6 @@ export function findBareImportMetaMain(source, fileName = "input.mjs") {
   });
 }
 
-/** The self-path properties on `import.meta` — the counterpart to
- * `namesMain`/`isImportMetaNode` above but for the entry guard's other operand.
- * `filename` and `dirname` are in here alongside `url` because Node ships all
- * three (they landed in 21.2), they are all derived AFTER symlink resolution,
- * and a guard comparing an unresolved argv0 against `import.meta.filename` has
- * exactly the realpath bug in a spelling the `url`-only check would call clean. */
 const IMPORT_META_SELF_PATH_PROPS = new Set(["url", "filename", "dirname"]);
 function isImportMetaUrlNode(node) {
   return (
@@ -238,17 +136,6 @@ function isImportMetaUrlNode(node) {
   );
 }
 
-/** argv0 — `process.argv[1]` or `process.argv.at(1)`. Every shipped guard used
- * the element access; `.at(1)` is here because it is the same read in a
- * spelling a future author reaches for without thinking, and a gate that
- * asserts a PROPERTY has to cover the spellings of that property rather than
- * the ones that happened to ship.
- *
- * Not covered: argv0 reached through destructuring (`const [, entry] = process.argv`).
- * That needs binding resolution rather than a syntactic match; the zero-relation
- * floor in the runner is what catches a repo whose guards all moved to a shape
- * this predicate cannot see.
- * ponytail: syntactic match; add binding resolution if a destructured guard ever ships. */
 function isProcessArgv1Node(node) {
   if (!node) return false;
   const isProcessArgv = (n) =>
@@ -273,32 +160,14 @@ function isProcessArgv1Node(node) {
   return false;
 }
 
-/** EVERY descendant of `node` (inclusive) satisfying `pred`, depth-first.
- * Bounded to the subtree passed in — this is what lets the caller ask "does
- * THIS SIDE of the comparison hold the argv0/meta-url leaf", not "does this
- * leaf appear anywhere in the file" (which a grep would ask). All matches,
- * not the first, because one side can legitimately read argv0 twice: the
- * sanctioned form's own argv side is
- * `process.argv[1] ? realpathSync(resolve(process.argv[1])) : ""`, whose
- * FIRST occurrence depth-first is the unwrapped ternary condition. */
 function findLeaves(node, pred, out = []) {
   if (pred(node)) out.push(node);
-  // The callback must return nothing: `ts.forEachChild` treats a truthy return
-  // as "found it" and stops iterating siblings, so returning the accumulator
-  // here would visit only the first child of every node.
   ts.forEachChild(node, (child) => {
     findLeaves(child, pred, out);
   });
   return out;
 }
 
-/** Does any identifier in `call`'s callee chain name one of `names`?
- * Deliberately name-based rather than binding-based, so that `realpathSync(p)`,
- * `fs.realpathSync(p)`, `realpathSync.native(p)` and `await realpath(p)` from
- * `node:fs/promises` all read as the same act. They are — and a gate that
- * accepted only the bare-identifier spelling would red three correct guards
- * out of four, which is a false red on correct work and the fastest way to
- * get a gate deleted. */
 function calleeNamesOneOf(call, names) {
   let expr = call.expression;
   for (;;) {
@@ -315,27 +184,6 @@ function calleeNamesOneOf(call, names) {
 const REALPATH_CALLEES = new Set(["realpathSync", "realpath"]);
 const BASENAME_CALLEES = new Set(["basename"]);
 
-/** Walking from each of `leaves` up through its parent chain, up to and
- * including `sideTop` (the top of the comparison operand the leaves belong
- * to), is ANY of them wrapped in a call naming one of `names`? This is how a
- * side is classified as realpath'd (or not) without re-deriving the operand
- * from scratch — the parent chain IS the nesting
- * `realpathSync(resolve(process.argv[1]))` builds, and `node.parent` is
- * populated because `createSourceFile` above is called with
- * `setParentNodes: true`.
- *
- * ANY rather than EVERY for the ternary reason in `findLeaves` above: the
- * sanctioned form reads argv0 once unwrapped (as the ternary's own existence
- * test) and once wrapped (as its value), and demanding every occurrence be
- * wrapped would red it.
- *
- * Known ceiling: a side that realpaths inside a HELPER
- * (`const real = (p) => realpathSync(p); real(process.argv[1])`) is not
- * followed — that needs interprocedural analysis. It errs toward a false RED
- * on correct work rather than a false green on broken work, which is the safe
- * direction for a gate, and inlining the call is the fix.
- * ponytail: name-based, one hop; add binding resolution if a helper form ever
- * ships and the false red actually bites. */
 function anyWrappedIn(leaves, sideTop, names) {
   for (const leaf of leaves) {
     let node = leaf;
@@ -348,24 +196,6 @@ function anyWrappedIn(leaves, sideTop, names) {
   return false;
 }
 
-/**
- * Single-assignment aliases for argv0 / `import.meta.url`, as
- * name -> initializer.
- *
- * Load-bearing, not a nicety. `const ENTRY = realpathSync(resolve(process.argv[1]))`
- * followed by `if (ENTRY === SELF)` is the shape EVERY fixed entry guard in
- * this repo uses, and it puts the leaf in a DECLARATION rather than in the
- * comparison. A purely operand-local search therefore sees `ENTRY === SELF`,
- * finds no argv0 and no `import.meta.url`, and classifies no relation at all
- * — reporting "no un-realpath'd entry guard" over a repo in which it can see
- * none of them. That is the vacuous pass to avoid, so
- * the alias is followed one hop.
- *
- * A name declared more than once is dropped rather than guessed at: two
- * initializers mean the gate cannot know which one reaches the comparison,
- * and a wrong guess in either direction is worse than the relation floor
- * below noticing the guard went unclassified.
- */
 function collectArgvAndMetaAliases(sourceFile) {
   const byName = new Map();
   const walk = (node) => {
@@ -393,37 +223,6 @@ const EQUALITY_OPERATORS = new Set([
   ts.SyntaxKind.ExclamationEqualsEqualsToken,
 ]);
 
-/**
- * Every entry-guard-shaped relation between `process.argv[1]` and
- * `import.meta.url` in `source` — an equality/inequality compare, or the
- * `X.endsWith(Y)` form the two basename instances used — that does NOT
- * realpath both sides. A relation with `realpathSync` wrapping both operands
- * and no `basename()` anywhere in it is the sanctioned form and is not
- * returned; everything else is a finding, tagged with which shape it is:
- *
- *   "basename-comparison" — either side is wrapped in `basename(...)`. Weaker
- *     than even an unresolved full-path compare, since it is satisfied by any
- *     file of that name anywhere on disk — it does not need a symlink to be
- *     wrong.
- *   "one-sided-realpath"  — exactly one side is wrapped in `realpathSync`.
- *     The narrow silent skip an earlier fix traded a wide one for: still
- *     defeated by a symlinked checkout, just through a smaller set of paths.
- *   "no-realpath"         — neither side is wrapped in `realpathSync` (this
- *     covers a bare compare, a `resolve()`-only compare, and a
- *     `pathToFileURL(...).href`/`fileURLToPath(...)` compare with no
- *     `realpathSync` anywhere).
- *
- * Returns `{ relations, gaps }`, not a bare array, and `relations` is the
- * whole point of the pair: it counts every entry-guard-shaped relation the
- * walk CLASSIFIED, sanctioned ones included. An empty `gaps` means either "no
- * broken guard" or "the walk recognized nothing at all", and those two read
- * identically in a CI log. `scanRepo` sums it and the runner hard-fails on
- * zero, so an AST-shape change, a `typescript` upgrade, or a refactor into an
- * unrecognized form reds instead of reporting the class closed.
- *
- * @param {string} source
- * @param {string} [fileName] drives the script kind, as in `findBareImportMetaMain`.
- */
 export function findEntryGuardRealpathGaps(source, fileName = "input.mjs") {
   const kind = SCRIPT_KINDS.get(extname(fileName)) ?? ts.ScriptKind.JS;
   const sourceFile = ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true, kind);
@@ -431,8 +230,6 @@ export function findEntryGuardRealpathGaps(source, fileName = "input.mjs") {
   const gaps = [];
   let relations = 0;
   const aliases = collectArgvAndMetaAliases(sourceFile);
-  /** One hop through a single-assignment alias, so `ENTRY === SELF` is read as
-   * the initializers those two names hold. */
   const deref = (node) => (ts.isIdentifier(node) ? aliases.get(node.text) ?? node : node);
 
   const report = (guardNode, argvSide, metaSide, argvLeaves, metaLeaves) => {
@@ -455,8 +252,6 @@ export function findEntryGuardRealpathGaps(source, fileName = "input.mjs") {
     });
   };
 
-  /** Classify one relation between two operands, each already deref'd through
-   * its alias, in whichever order argv0 and `import.meta.url` appear. */
   const relate = (guardNode, a, b) => {
     const aArgv = findLeaves(a, isProcessArgv1Node);
     const bMeta = findLeaves(b, isImportMetaUrlNode);
@@ -484,31 +279,17 @@ export function findEntryGuardRealpathGaps(source, fileName = "input.mjs") {
   return { relations, gaps };
 }
 
-/** Syntax errors, reported as their own category rather than as fake guards. */
 export function parseErrorsIn(source, fileName) {
   const kind = SCRIPT_KINDS.get(extname(fileName)) ?? ts.ScriptKind.JS;
   const sourceFile = ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true, kind);
-  // typescript RECOVERS from syntax errors rather than throwing, so an
-  // unreadable file would otherwise scan "clean" — a skip that reads as a
-  // pass. Read the diagnostics explicitly instead.
   return (sourceFile.parseDiagnostics ?? []).map((d) =>
     ts.flattenDiagnosticMessageText(d.messageText, " ")
   );
 }
 
-/**
- * Scan every discovered file. Returns real `import.meta.main` references
- * (`findings`), entry guards that do not realpath both sides (`guardGaps`,
- * the realpath check) and unparseable files (`unparseable`) SEPARATELY — a syntax error
- * is not a broken entry guard, and reporting it as one sends the reader
- * looking for a guard that does not exist.
- */
 export function scanRepo(repoRoot = REPO_ROOT, roots = SCAN_ROOTS) {
   const byRoot = discoverSourceFiles(repoRoot, roots);
 
-  // Per-root, not aggregate: an aggregate floor is satisfied by `scripts/`
-  // alone, so renaming or relocating `contract/` would leave it unscanned
-  // while the gate still printed a pass.
   const emptyRoots = [...byRoot.entries()].filter(([, files]) => files.length === 0).map(([root]) => root);
   if (emptyRoots.length > 0) {
     throw new Error(
@@ -548,14 +329,11 @@ export function scanRepo(repoRoot = REPO_ROOT, roots = SCAN_ROOTS) {
 export default {
   name: "import-meta-main",
   describe: "no bare `import.meta.main`, and every entry guard realpaths both sides",
-  // `typescript` is a devDependency: the AST walk needs an installed tree.
   needsInstall: true,
   check(ctx) {
     const { filesScanned, findings, unparseable, guardGaps, guardRelations } = scanRepo(ctx.root);
     const violations = [];
 
-    // A file this rule cannot read is an unchecked file, which must not read as
-    // a pass.
     for (const bad of unparseable) {
       violations.push(`${bad.file}: could not be parsed, so it was NOT checked — ${bad.errors.join("; ")}`);
     }
@@ -575,18 +353,6 @@ export default {
       );
     }
 
-    // The floor on the realpath half, and the counterpart to the per-root
-    // file-count floor inside scanRepo. An empty `guardGaps` is ambiguous on its
-    // own: it means "every entry guard realpaths both sides" OR "the walk
-    // recognized no entry guard at all", and only the first is a pass. The
-    // classifier going blind — a `typescript` upgrade changing an AST shape,
-    // argv0 read some new way, the guards refactored behind a helper — is
-    // exactly the moment this rule's failure mode reports the class closed.
-    //
-    // PROPORTIONAL, not `> 0`: only one guard in this repo compares argv0 and
-    // `import.meta.url` inline, and the rest are found through the
-    // single-assignment alias deref, so a regression that broke only the deref
-    // would leave the count at 1 and a `> 0` floor would still print a pass.
     if (guardRelations < MIN_ENTRY_GUARD_RELATIONS) {
       violations.push(
         `The entry-guard check classified only ${guardRelations} argv[1]-vs-import.meta.url ` +

--- a/scripts/lint/rules/import-meta-main.mjs
+++ b/scripts/lint/rules/import-meta-main.mjs
@@ -32,7 +32,7 @@
 //
 // The file set is DISCOVERED — every source file under the roots below, found
 // by walking the directory tree, never a hand-kept list. A hand-kept list is
-// the exact shape this milestone (D5) targets: it stops covering its subject
+// the exact shape this targets: it stops covering its subject
 // the day a file is added and nothing notices.
 //
 // The realpath check extends this same walk with a second, related check rather than
@@ -358,7 +358,7 @@ function anyWrappedIn(leaves, sideTop, names) {
  * comparison. A purely operand-local search therefore sees `ENTRY === SELF`,
  * finds no argv0 and no `import.meta.url`, and classifies no relation at all
  * — reporting "no un-realpath'd entry guard" over a repo in which it can see
- * none of them. That is the vacuous pass this milestone keeps re-shipping, so
+ * none of them. That is the vacuous pass to avoid, so
  * the alias is followed one hop.
  *
  * A name declared more than once is dropped rather than guessed at: two

--- a/scripts/lint/rules/import-meta-main.test.mjs
+++ b/scripts/lint/rules/import-meta-main.test.mjs
@@ -152,7 +152,7 @@ const GUARD_GAP_CASES = {
   // SELF/ENTRY consts. A checker that only searches the comparison's own
   // operands sees `ENTRY === SELF`, classifies no relation, and reports the
   // whole repo clean while seeing none of its guards — the vacuous pass this
-  // milestone keeps re-shipping. Reverting the realpath on either side of the
+  // this rule exists to stop. Reverting the realpath on either side of the
   // sanctioned form must red.
   "alias-routed, neither side realpath'd (the sanctioned shape with realpath removed)": {
     source:

--- a/scripts/lint/rules/import-meta-main.test.mjs
+++ b/scripts/lint/rules/import-meta-main.test.mjs
@@ -378,7 +378,7 @@ for (const [label, source] of Object.entries(GUARD_GAP_CLEAN_CASES)) {
 }
 
 // ── scanRepo: break-on-purpose against a scratch fixture ───────────────────
-// The ticket's own break-on-purpose case, as an assertion: add a bare guard to
+// The break-on-purpose case, as an assertion: add a bare guard to
 // a scratch file, and the scan must red naming that exact file — while a
 // sibling that only MENTIONS the string must not.
 {
@@ -402,7 +402,7 @@ for (const [label, source] of Object.entries(GUARD_GAP_CLEAN_CASES)) {
 }
 
 // ── scanRepo: realpath break-on-purpose, one scratch file per shape ───────
-// The ticket's own break-on-purpose matrix: a one-sided-realpath guard, a
+// The break-on-purpose matrix: a one-sided-realpath guard, a
 // no-realpath guard, and a basename guard added to a scratch script each red
 // naming that exact file; a correct both-sides-realpath'd guard next to them
 // does not.
@@ -470,7 +470,7 @@ for (const [label, source] of Object.entries(GUARD_GAP_CLEAN_CASES)) {
   // The floor on the assertion above, and the whole reason `guardRelations`
   // exists. `guardGaps.length === 0` over the real repo is satisfied both by
   // "every guard realpaths both sides" and by "the classifier recognized no
-  // guard at all", and the second is how two floors in this milestone shipped
+  // guard at all", and the second is how a floor can ship
   // dead. The repo has one guard per runnable script; the twelve that were fixed
   // ones alone put the count above 12, so a bound well under the real number
   // reds on a classifier going blind without reding on someone deleting a

--- a/scripts/lint/rules/import-meta-main.test.mjs
+++ b/scripts/lint/rules/import-meta-main.test.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Regression coverage for scripts/lint-no-bare-import-meta-main.mjs
-// (extended for the realpath-both-sides entry-guard shape).
+// Case table for import-meta-main. Every case asserts the RED direction: a rule that has
+// quietly stopped failing prints the same line as one with nothing to report.
 
 import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
@@ -28,13 +28,8 @@ function assert(cond, msg) {
   console.error(`FAIL  ${msg}`);
 }
 
-/** Every root the gate must cover, and one real file under each. */
 const REQUIRED_ROOTS = ["scripts", "contract", "cli/src", "cli/scripts", "packages", "agent-examples"];
 
-// ── findBareImportMetaMain: every real shape must red ───────────────────────
-// Formatting cannot hide it: a line break, parens, optional chaining, negation,
-// computed access, or a destructure straight off `import.meta` (with or without
-// a rename) all have to be caught — exactly the forms a naive regex misses.
 const REAL_SHAPES = {
   "bare member access": "if (import.meta.main) { run(); }",
   "wrapped in parens": "if ((import.meta.main)) { run(); }",
@@ -49,8 +44,6 @@ const REAL_SHAPES = {
   "destructured, no rename": "const { main } = import.meta;\nif (main) run();",
   "destructured with rename": "const { main: isMain } = import.meta;\nif (isMain) run();",
   "destructured, computed key": 'const { ["main"]: m } = import.meta;\nif (m) run();',
-  // `...rest` hands the whole object over, so `rest.main` is reachable and the
-  // guard is just as broken — the shape must not slip through as "no `main`".
   "destructured via rest": "const { ...rest } = import.meta;\nif (rest.main) run();",
   "assignment-expression destructure": "let main;\n({ main } = import.meta);",
   "assignment-expression spread": "let rest;\n({ ...rest } = import.meta);",
@@ -60,10 +53,6 @@ for (const [label, source] of Object.entries(REAL_SHAPES)) {
   assert(hits.length > 0, `a real import.meta.main reference is caught: ${label} (source: ${JSON.stringify(source)})`);
 }
 
-// The live instances the first cut could not see were `.ts`, so the parser
-// must read TypeScript syntax — not merely "not crash" on it. A JS-only parser
-// fails on the type annotations here and would report the file as unparseable
-// (or as clean), which is the silent skip this gate exists to prevent.
 {
   const tsSource = [
     "interface Wiring { readonly url: string }",
@@ -76,14 +65,11 @@ for (const [label, source] of Object.entries(REAL_SHAPES)) {
   assert(hits.length === 1 && hits[0].line === 4, `a bare guard in a .ts file is caught, with its line (got ${JSON.stringify(hits)})`);
 }
 
-// ── the false positives a grep would produce, which parsing must not ────────
 const FALSE_POSITIVES = {
   "line comment": "// import.meta.main\nconsole.log('ok');",
   "block comment": "/* uses import.meta.main historically */\nconsole.log('ok');",
   "string literal": "const s = 'import.meta.main';\nconsole.log(s);",
   "template literal": "const s = `guard is import.meta.main`;\nconsole.log(s);",
-  // A generator that builds source text out of lines exactly like this emits
-  // data, not a guard, and must stay green.
   "string array a generator emits": 'const lines = ["if (import.meta.main) {", "  await main();", "}"];',
   "unrelated .main property": "const config = { main: true };\nif (config.main) run();",
   "import.meta without .main": "const url = import.meta.url;\nconsole.log(url);",
@@ -95,21 +81,12 @@ for (const [label, source] of Object.entries(FALSE_POSITIVES)) {
   assert(hits.length === 0, `not a real reference, must not red: ${label} (got ${JSON.stringify(hits)})`);
 }
 
-// A file mixing a real reference with a comment/string mention of the same text
-// must still be caught by the real one.
 {
   const mixed = "// import.meta.main is banned here\nif (import.meta.main) { run(); }\nconst s = 'import.meta.main';";
   const hits = findBareImportMetaMain(mixed);
   assert(hits.length === 1, `a real reference is caught even alongside comment/string mentions (got ${hits.length})`);
 }
 
-// ── findEntryGuardRealpathGaps: the realpath shapes, each its own verdict ───
-// The sanctioned replacement for bare `import.meta.main` — comparing
-// `process.argv[1]` against `import.meta.url` — has its own silent-skip shape
-// when either side is not realpath'd. Node resolves symlinks before deriving
-// `import.meta.url`, so an unresolved argv0 disagrees through a symlinked
-// checkout and the guard falls false. Every shape a live instance shipped
-// must red, tagged with which shape it is; the sanctioned form must not.
 const GUARD_GAP_CASES = {
   "bare compare, no resolve at all": {
     source: "if (fileURLToPath(import.meta.url) === process.argv[1]) { main(); }",
@@ -147,13 +124,6 @@ const GUARD_GAP_CASES = {
     source: "if (process.argv[1].endsWith(basename(import.meta.url))) main();",
     kind: "basename-comparison",
   },
-  // The shape that matters most, because it is the shape every FIXED instance
-  // in this repo uses: argv0 and import.meta.url reach the comparison through
-  // SELF/ENTRY consts. A checker that only searches the comparison's own
-  // operands sees `ENTRY === SELF`, classifies no relation, and reports the
-  // whole repo clean while seeing none of its guards — the vacuous pass this
-  // this rule exists to stop. Reverting the realpath on either side of the
-  // sanctioned form must red.
   "alias-routed, neither side realpath'd (the sanctioned shape with realpath removed)": {
     source:
       'const SELF = fileURLToPath(import.meta.url);\nconst ENTRY = process.argv[1] ? resolve(process.argv[1]) : "";\nif (ENTRY === SELF) main();',
@@ -173,8 +143,6 @@ const GUARD_GAP_CASES = {
     source: "const E = resolve(process.argv[1]);\nconst S = fileURLToPath(import.meta.url);\nif (E === S) main();",
     kind: "no-realpath",
   },
-  // Spellings of the same two reads. A gate asserting a PROPERTY has to cover
-  // the spellings of that property, not only the ones that happened to ship.
   "process.argv.at(1) instead of [1]": {
     source: "if (resolve(process.argv.at(1)) === fileURLToPath(import.meta.url)) main();",
     kind: "no-realpath",
@@ -192,14 +160,6 @@ for (const [label, { source, kind }] of Object.entries(GUARD_GAP_CASES)) {
   );
 }
 
-// The sanctioned form — both sides realpath'd, no basename() anywhere — is
-// NOT a finding, whether the leaves sit directly in the comparison or behind
-// the SELF/ENTRY intermediate consts every fixed instance in this repo uses.
-//
-// The `fs.realpathSync` / `realpathSync.native` / `await realpath` rows are
-// false-RED coverage, not padding: they are all the same act as the bare
-// identifier, and a gate that reds three correct spellings out of four is a
-// gate that gets deleted rather than obeyed.
 const GUARD_GAP_CLEAN_CASES = {
   "both sides realpath'd, direct": "if (realpathSync(resolve(process.argv[1])) === realpathSync(fileURLToPath(import.meta.url))) { main(); }",
   "both sides realpath'd, reversed operand order": "if (realpathSync(fileURLToPath(import.meta.url)) === realpathSync(resolve(process.argv[1]))) { main(); }",
@@ -220,9 +180,6 @@ for (const [label, source] of Object.entries(GUARD_GAP_CLEAN_CASES)) {
   assert(gaps.length === 0, `the sanctioned form is not a finding: ${label} (got ${JSON.stringify(gaps)})`);
 }
 
-// `relations` counts what the walk CLASSIFIED, sanctioned guards included. It
-// exists so an empty `gaps` can be told apart from a blind checker: those two
-// read identically in a CI log, and only one of them is a pass.
 {
   const clean = findEntryGuardRealpathGaps(
     'const SELF = realpathSync(fileURLToPath(import.meta.url));\nconst ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";\nif (ENTRY === SELF) main();',
@@ -233,7 +190,6 @@ for (const [label, source] of Object.entries(GUARD_GAP_CLEAN_CASES)) {
   assert(none.relations === 0 && none.gaps.length === 0, "a file with no entry guard classifies no relation");
 }
 
-// ── discoverSourceFiles: a directory walk, not a hand-kept list ─────────────
 {
   const dir = mkdtempSync(join(tmpdir(), "f1481-discover-"));
   try {
@@ -255,9 +211,6 @@ for (const [label, source] of Object.entries(GUARD_GAP_CLEAN_CASES)) {
   }
 }
 
-// `isDirectory()`/`isFile()` on a dirent are both FALSE for a symlink, so a
-// walk keyed off the dirent alone silently skips a symlinked script — a skip
-// that reads as a pass. This is the shape the gate itself is about.
 {
   const dir = mkdtempSync(join(tmpdir(), "f1481-symlink-"));
   try {
@@ -275,12 +228,6 @@ for (const [label, source] of Object.entries(GUARD_GAP_CLEAN_CASES)) {
   }
 }
 
-// ── the scan roots cannot silently narrow ──────────────────────────────────
-// This gate's own history is the argument for this assertion: one fix landed for
-// `contract/run.mjs`, the same bug survived ten lines away under `scripts/`,
-// and this gate's first cut then covered only those two roots while six live
-// instances sat in `agent-examples/*/src/*.ts`. A root dropping out of the walk must
-// red here rather than quietly stop being covered.
 {
   const byRoot = discoverSourceFiles(ROOT);
   for (const root of REQUIRED_ROOTS) {
@@ -296,11 +243,6 @@ for (const [label, source] of Object.entries(GUARD_GAP_CLEAN_CASES)) {
   assert(!all.some((f) => f.includes("node_modules")), "the walk never descends into node_modules");
 }
 
-// Independent second derivation of the same file set, using `find` rather than
-// the gate's own walk. If discovery silently stopped recursing (or started
-// skipping an extension or a root) this comparison — not a hardcoded count — is
-// what reds, so the floor moves with the tree. `-L` follows symlinks, matching
-// the walk's statSync, so the two share no blind spot.
 {
   const viaDiscovery = [...discoverSourceFiles(ROOT).values()].flat().sort();
   const findArgs = ["-L", ...REQUIRED_ROOTS];
@@ -329,9 +271,6 @@ for (const [label, source] of Object.entries(GUARD_GAP_CLEAN_CASES)) {
   );
 }
 
-// ── scanRepo: an empty root is a hard failure, PER ROOT ────────────────────
-// An aggregate floor is satisfied by `scripts/` alone, so relocating any other
-// root would leave it unscanned while the gate still printed a pass.
 {
   const dir = mkdtempSync(join(tmpdir(), "f1481-empty-"));
   try {
@@ -346,7 +285,6 @@ for (const [label, source] of Object.entries(GUARD_GAP_CLEAN_CASES)) {
     }
     assert(threw, "a root that exists in the config but not on disk throws rather than reporting a pass");
 
-    // And the aggregate case: nothing anywhere.
     let threwAll = false;
     try {
       scanRepo(mkdtempSync(join(tmpdir(), "f1481-void-")), ["scripts"]);
@@ -359,11 +297,6 @@ for (const [label, source] of Object.entries(GUARD_GAP_CLEAN_CASES)) {
   }
 }
 
-// ── an unparseable file is its own category, not a fake guard ──────────────
-// typescript RECOVERS from syntax errors rather than throwing, so without an
-// explicit diagnostics read an unreadable file scans "clean" — a skip that
-// reads as a pass. It must also not be reported as a broken entry guard, which
-// sends the reader looking for a guard that does not exist.
 {
   const dir = mkdtempSync(join(tmpdir(), "f1481-unparseable-"));
   try {
@@ -377,17 +310,12 @@ for (const [label, source] of Object.entries(GUARD_GAP_CLEAN_CASES)) {
   }
 }
 
-// ── scanRepo: break-on-purpose against a scratch fixture ───────────────────
-// The break-on-purpose case, as an assertion: add a bare guard to
-// a scratch file, and the scan must red naming that exact file — while a
-// sibling that only MENTIONS the string must not.
 {
   const dir = mkdtempSync(join(tmpdir(), "f1481-scratch-"));
   try {
     mkdirSync(join(dir, "scripts"), { recursive: true });
     writeFileSync(join(dir, "scripts", "broken.mjs"), "// a scratch file that should never ship\nif (import.meta.main) { console.log('ran'); }\n");
     writeFileSync(join(dir, "scripts", "clean.mjs"), "// mentions import.meta.main only in prose, and in a string: 'import.meta.main'\nconsole.log('fine');\n");
-    // The `.ts` half of the same break, since that is where the live ones were.
     writeFileSync(join(dir, "scripts", "broken.ts"), "const n: number = 1;\nif (import.meta.main) { console.log(n); }\n");
     const { filesScanned, findings } = scanRepo(dir, ["scripts"]);
     assert(filesScanned === 3, `all three scratch files are scanned (got ${filesScanned})`);
@@ -401,11 +329,6 @@ for (const [label, source] of Object.entries(GUARD_GAP_CLEAN_CASES)) {
   }
 }
 
-// ── scanRepo: realpath break-on-purpose, one scratch file per shape ───────
-// The break-on-purpose matrix: a one-sided-realpath guard, a
-// no-realpath guard, and a basename guard added to a scratch script each red
-// naming that exact file; a correct both-sides-realpath'd guard next to them
-// does not.
 {
   const dir = mkdtempSync(join(tmpdir(), "f1488-guard-scratch-"));
   try {
@@ -426,10 +349,6 @@ for (const [label, source] of Object.entries(GUARD_GAP_CLEAN_CASES)) {
       join(dir, "scripts", "correct.mjs"),
       'import { realpathSync } from "node:fs";\nimport { resolve } from "node:path";\nimport { fileURLToPath } from "node:url";\nconst SELF = realpathSync(fileURLToPath(import.meta.url));\nconst ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";\nif (ENTRY === SELF) console.log("ran");\n'
     );
-    // The regression for the blind spot itself: the sanctioned SELF/ENTRY
-    // shape with its realpath removed. This is what a future author writes
-    // when they copy a fixed sibling and drop a call, and it is the shape the
-    // gate saw nothing at all in before.
     writeFileSync(
       join(dir, "scripts", "alias-broken.mjs"),
       'import { resolve } from "node:path";\nimport { fileURLToPath } from "node:url";\nconst SELF = fileURLToPath(import.meta.url);\nconst ENTRY = process.argv[1] ? resolve(process.argv[1]) : "";\nif (ENTRY === SELF) console.log("ran");\n'
@@ -445,19 +364,12 @@ for (const [label, source] of Object.entries(GUARD_GAP_CLEAN_CASES)) {
     assert(byFile.get("scripts/no-realpath.mjs") === "no-realpath", "no-realpath is named and classified");
     assert(byFile.get("scripts/basename.mjs") === "basename-comparison", "a basename compare is named and classified");
     assert(byFile.get("scripts/alias-broken.mjs") === "no-realpath", "an alias-routed broken guard is named and classified");
-    // The correct file's guard is COUNTED even though it is not a finding —
-    // five files, five guards, so the relation floor sees all of them.
     assert(guardRelations === 5, `every guard is classified, sanctioned ones included (got ${guardRelations})`);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
 }
 
-// ── the shipped repo is clean ────────────────────────────────────────────
-// The regression that matters most: what would have caught
-// scripts/probe-twin-endpoints.mjs and the six examples shipping a bare
-// guard, and the ten entry-guard-realpath instances plus the two
-// basename ones.
 {
   const { filesScanned, findings, unparseable, guardGaps, guardRelations } = scanRepo(ROOT);
   assert(filesScanned > 0, "the real scan covers at least one file");
@@ -467,14 +379,6 @@ for (const [label, source] of Object.entries(GUARD_GAP_CLEAN_CASES)) {
     guardGaps.length === 0,
     `no un-realpath'd or basename entry guard anywhere in scope (got: ${JSON.stringify(guardGaps)})`
   );
-  // The floor on the assertion above, and the whole reason `guardRelations`
-  // exists. `guardGaps.length === 0` over the real repo is satisfied both by
-  // "every guard realpaths both sides" and by "the classifier recognized no
-  // guard at all", and the second is how a floor can ship
-  // dead. The repo has one guard per runnable script; the twelve that were fixed
-  // ones alone put the count above 12, so a bound well under the real number
-  // reds on a classifier going blind without reding on someone deleting a
-  // script.
   assert(
     guardRelations >= 12,
     `the classifier actually SEES the repo's entry guards (got ${guardRelations} classified relations; ` +
@@ -482,26 +386,10 @@ for (const [label, source] of Object.entries(GUARD_GAP_CLEAN_CASES)) {
   );
 }
 
-// ── the rule is actually wired into CI, in a step that can fail ────────────
-// Asserting `ci.includes("npm run lint")` is satisfied by a COMMENTED-OUT line,
-// by the command sitting in a job that never runs, and by `set -euo pipefail`
-// appearing anywhere else in the file (it appears in the scope step at the top).
-// Locate the OWNING step and assert on that.
-//
-// The commands here are the RUNNER's, not this rule's: consolidation means this
-// rule has no npm script and no CI step of its own. What still has to hold is
-// that the runner runs somewhere it can fail, and — because this rule needs
-// `typescript` and is therefore skipped by `--offline` — that the run covering
-// it is the one with NO `--offline`. A repo where only the offline invocation
-// survived would skip this rule entirely while every other assertion here
-// stayed green.
 {
   const ci = readFileSync(join(ROOT, ".github/workflows/ci.yml"), "utf8");
-  // Newline-terminated so `npm run lint` does not also match
-  // `npm run lint -- --offline` or `npm run lint:test`.
   const COMMANDS = ["npm run lint\n", "npm run lint:test\n"];
 
-  // Steps start at a `      - ` list item within a job's `steps:`.
   const steps = ci.split(/\n(?=      - )/);
   for (const command of COMMANDS) {
     const owning = steps.filter((step) =>
@@ -513,22 +401,6 @@ for (const [label, source] of Object.entries(GUARD_GAP_CLEAN_CASES)) {
     assert(owning.length === 1, `exactly one uncommented CI step runs \`${command.trim()}\` (got ${owning.length})`);
     if (owning.length !== 1) continue;
     const step = owning[0];
-    // The property is that a failure REACHES the step's conclusion, not that any
-    // particular shell line is present. Which check proves that depends on the
-    // step's shape, so derive the shape rather than assuming one:
-    //
-    //   one command   → the step's exit code IS the command's (Actions runs
-    //                   `bash -e {0}`), so nothing can swallow it.
-    //   many commands → an earlier failure is swallowed by the commands after
-    //                   it unless the block sets a failing shell mode.
-    //
-    // Asserting `set -euo pipefail` unconditionally would demand a shell line
-    // that does nothing on a one-command step, which is how this assertion read
-    // when every command in the heavy suite shared one 60-line block.
-    // Text, not YAML, deliberately — same reason the search above is textual: a
-    // commented-out command has to stay visible. `run: <cmd>` contributes its
-    // inline tail; a `run: |` block contributes each of its lines; every other
-    // mapping key (`name:`, `if:`, `env:`, `with:`) contributes nothing.
     const commands = step
       .split("\n")
       .map((line) => line.trim().replace(/^-\s+/, ""))
@@ -547,9 +419,6 @@ for (const [label, source] of Object.entries(GUARD_GAP_CLEAN_CASES)) {
     assert(!/\bif:\s*false\b/.test(step), `the step running \`${command.trim()}\` is not disabled`);
   }
 
-  // It lives behind the heavy gate (it needs `npm ci` for the parser), so the
-  // scope regex MUST classify a diff to any scanned root as heavy — otherwise
-  // the rule is path-filtered away from the very changes that could trip it.
   const scopeRegex = ci.match(/'\^\((?<alts>[^']+)\)'/)?.groups?.alts ?? "";
   for (const root of REQUIRED_ROOTS) {
     const top = `${root.split("/")[0]}/`;
@@ -562,9 +431,6 @@ for (const [label, source] of Object.entries(GUARD_GAP_CLEAN_CASES)) {
     pkg.scripts["lint:test"] === "node scripts/lint.mjs --run-tests",
     "package.json declares the case-table runner"
   );
-  // The registry is a list of static imports rather than a glob, so an
-  // unregistered rule is not a rule that runs quietly — it is one that does not
-  // run at all, and `--offline` has to NAME it as skipped rather than drop it.
   const registered = RULES.find((rule) => rule.name === "import-meta-main");
   assert(registered !== undefined, "the rule is in scripts/lint/rules.mjs, so the runner reaches it");
   assert(registered?.needsInstall === true, "the rule declares needsInstall, so --offline names it as skipped");

--- a/scripts/lint/rules/legacy-markers.mjs
+++ b/scripts/lint/rules/legacy-markers.mjs
@@ -1,15 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// The [D]/[P] authoring markers were retired in favor of [code]/[model]; this
-// rule fails on any reintroduced legacy form ([D], [P], [D:<twin>], [P:<twin>])
-// anywhere in the repo.
-//
-// Sanctioned exceptions (the ONLY places the legacy spelling may appear):
-//   - cli/src/task/parseTask.ts — the parser's legacy-marker detection and
-//     its migration-hint error message.
-//   - cli/test/unit/parseTask.test.ts — the rejection tests for that detection.
-//   - */CHANGELOG.md — historical release notes are records, not current
-//     spelling, and are never rewritten.
+// The retired [D]/[P] criterion markers must not reappear; [code]/[model] are current.
 
 import { fileURLToPath } from "node:url";
 
@@ -32,18 +23,10 @@ const EXTENSIONS = [
   ".sh",
 ];
 
-// `.context` and `.changeset` on top of the shared prune list: generated
-// scratch and release-tool state, neither of them authored spelling.
 const SKIP_DIRS = ["node_modules", "dist", "build", ".git", "coverage", ".context", ".changeset"];
 
 const LEGACY_MARKER_RE = /\[D\]|\[P\]|\[D:|\[P:/;
 
-// This rule's own source carries the marker forms it denies, and so does its
-// case table — a table that could not write a `[D]` could not prove the rule
-// goes red on one. Both are derived from `import.meta.url` rather than
-// hard-coded, so renaming the file cannot leave it self-tripping, and the
-// exemption stays scoped to these two files rather than to `*.test.mjs` at
-// large.
 const SELF = fileURLToPath(import.meta.url);
 const SELF_CASES = SELF.replace(/\.mjs$/, ".test.mjs");
 

--- a/scripts/lint/rules/legacy-markers.test.mjs
+++ b/scripts/lint/rules/legacy-markers.test.mjs
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// The old gate shipped with no case table. The sanctioned exceptions are the
-// part worth pinning: they are the whole reason the rule is not a plain grep,
-// and an exception that silently widened would let the retired spelling back in.
+// Case table for legacy-markers. Every case asserts the RED direction: a rule that has
+// quietly stopped failing prints the same line as one with nothing to report.
 
 import { defineCases } from "../harness.mjs";
 
@@ -33,14 +32,11 @@ defineCases("legacy-markers", [
     expect: "green",
   },
   {
-    // Release notes are records, not current spelling, and are never rewritten.
     name: "a CHANGELOG is a record, not authored spelling",
     files: { "packages/wire/CHANGELOG.md": "## 0.1.0\n\n- renamed [D] to [code]\n" },
     expect: "green",
   },
   {
-    // The allowlist is by exact path, so the parser's NEIGHBOUR is not covered by
-    // the parser's exception.
     name: "an unrelated source file may not name the retired form",
     files: { "cli/src/task/other.ts": `const HINT = "not [D]";\n` },
     expect: "red",

--- a/scripts/lint/rules/no-catch.mjs
+++ b/scripts/lint/rules/no-catch.mjs
@@ -105,7 +105,7 @@ const SCAN_DIR = "packages/sdk/src";
 // fixtures (this rule's own case table does exactly that in a tmp dir).
 const SKIP_DIRS = ["node_modules", "dist", "build", ".git", "coverage", "test", "tests", "__fixtures__", "fixtures"];
 
-// ALLOWLIST (D4): reviewed, documented assign-and-fall-through exceptions.
+// ALLOWLIST: reviewed, documented assign-and-fall-through exceptions.
 // `file` is the repo-root-relative path; `bodyIncludes` is a distinctive
 // substring that must appear in the catch clause's whitespace-normalized,
 // literal-stripped body. See the module header for why each is here and how

--- a/scripts/lint/rules/no-catch.mjs
+++ b/scripts/lint/rules/no-catch.mjs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// no-catch (D4) — §3.A code-health, SDK ENGINE ONLY.
+// no-catch — SDK engine only.
 //
 // `packages/sdk` is the twin engine: the recorder, auth, MCP JSON-RPC, and
 // server plumbing every hosted twin runs on. A `catch` that logs-and-continues
@@ -22,11 +22,10 @@
 // out of the block and keeps going as if nothing broke. That is the exact bug
 // class this gate forbids.
 //
-// ALLOWLIST (D4) — target EMPTY, currently TWO entries. The original plan assumed
-// every engine catch would satisfy the rule literally; two do not, because they
-// handle the error by ASSIGNING an explicit error result to an outer-scoped
-// variable and FALLING THROUGH to a single shared record()/return below the
-// try/catch, rather than exiting from inside the clause:
+// ALLOWLIST — target EMPTY, currently TWO entries. Both handle the error by
+// assigning an explicit error result to an outer-scoped variable and falling
+// through to a single shared record()/return below the try/catch, rather than
+// exiting from inside the clause:
 //
 //   • mcp-jsonrpc.ts (handleToolsCall) — the catch builds the JSON-RPC error
 //     envelope (status/responseBody/toolError/mcpResult) that the function
@@ -38,12 +37,12 @@
 //     be re-read; the same read-optional-default-null shape recorder.ts already
 //     factors into a `try { return … } catch { return null }` helper.
 //
-// Both are genuine error handling, NOT log-and-continue/empty swallows, so they
-// are listed here rather than papered over. Entries are keyed by FILE plus a
-// CONTENT FINGERPRINT — a distinctive substring that must appear in that catch
-// clause's (whitespace-normalized, literal-stripped) body — NOT by line number,
-// so the entry survives edits elsewhere in the file and cannot be satisfied by
-// an unrelated catch. To reach true zero-allowlist a reviewer can extract the
+// Both are genuine error handling, not log-and-continue, so they are listed
+// rather than papered over. Entries are keyed by FILE plus a CONTENT
+// FINGERPRINT — a distinctive substring that must appear in that catch clause's
+// whitespace-normalized, literal-stripped body — never by line number, so an
+// entry survives edits elsewhere in the file and cannot be satisfied by an
+// unrelated catch. To reach zero entries, extract the
 // mcp result into a helper that returns the outcome, and reuse recorder.ts's
 // read-or-null helper in failure-injection — then delete the two entries.
 //
@@ -61,23 +60,16 @@
 //     `{` — so `.catch(cb)` (dotted) and any bare `catch(…)` call whose
 //     argument list is not followed by a block are never treated as a clause.
 //
-// The scan runs against a comment-and-literal-STRIPPED copy of the source so a
-// comment or string that says "catch" / "return" / "throw" never trips or
-// satisfies the gate, and a brace/quote inside a literal can't desync the brace
-// matcher. Stripping is a single mode-stack state machine that handles:
-//   • line + block comments;
-//   • single/double-quoted strings;
-//   • TEMPLATE LITERALS with full `${}` nesting — template text is blanked,
-//     but code inside a `${ … }` expression (including nested templates) is
-//     kept and scanned, so a catch clause inside a template expression is
-//     judged like any other;
-//   • regex literals, detected by the preceding TOKEN (not just the previous
-//     character): a `/` starts a regex at start-of-input, after an opening
-//     punctuator/operator, or after a keyword such as `return` / `case` /
-//     `typeof` — so `return /a{2}/` is stripped and its braces can't corrupt
-//     brace matching, while `a / b` stays division.
-// Blanked spans are replaced character-for-character with spaces (newlines
-// preserved), so byte offsets and reported line numbers are exact.
+// The scan runs against a comment-and-literal-STRIPPED copy of the source, so a
+// comment or string saying "catch" / "return" / "throw" can neither trip nor
+// satisfy the gate, and a brace or quote inside a literal cannot desync the
+// brace matcher. One mode-stack state machine handles comments, quoted strings,
+// template literals with full `${}` nesting (template text blanked, code inside
+// an expression kept and scanned), and regex literals detected by the preceding
+// TOKEN rather than the previous character — so `return /a{2}/` is stripped and
+// its braces cannot corrupt brace matching while `a / b` stays division.
+// Blanked spans are replaced character-for-character with spaces, newlines
+// preserved, so byte offsets and reported line numbers stay exact.
 //
 // NESTED FUNCTIONS DON'T COUNT: before the exit scan, the bodies of function
 // expressions DEFINED inside the catch clause (`=> { … }` arrow blocks and
@@ -88,22 +80,22 @@
 // still counts. (A nested statement try/catch is NOT masked: its handler runs
 // inline at the catch's own level, so an exit there is a real exit path.)
 //
-// LIMITATIONS (honest): this is a structural scanner, not a data-flow analyzer.
-// A CONDITIONAL exit is accepted BY DESIGN:
+// LIMITATIONS. This is a structural scanner, not a data-flow analyzer, and a
+// CONDITIONAL exit is accepted by design:
 //   catch (err) { if (shouldRethrow(err)) throw err; console.error(err); }
-// passes, because an exit token exists at the clause's own level even though
-// the else-path falls through. Deciding whether EVERY branch exits requires
-// full control-flow analysis — out of scope for a dependency-free pre-`npm ci`
-// lint; a conditional swallow is deliberate, visible, reviewable code, and its
-// semantics belong to the PR reviewer, not this gate. Concise method shorthand
-// in an object literal (`{ m() { return 1; } }`) inside a catch body is not
-// masked (only arrow blocks and `function` expressions are); the engine has no
-// such shape inside a catch. A body that computes an error result and falls
-// through to a shared `return` after the try/catch reads as a violation even
-// when legitimate — that shape is what the fingerprint ALLOWLIST is for. The
-// regex-vs-division token heuristic can misread a degenerate `a++ / b`
-// (previous token seen is `+`) as a regex start; the engine has no such code
-// and the gate favors a rule a reviewer can verify by eye over a full parser.
+// passes, because an exit token exists at the clause's own level even though the
+// else-path falls through. Deciding whether EVERY branch exits needs full
+// control-flow analysis, which is out of scope for a dependency-free
+// pre-`npm ci` lint; a conditional swallow is deliberate, visible, reviewable
+// code whose semantics belong to the PR reviewer.
+//
+// Concise method shorthand in an object literal inside a catch body is not
+// masked — only arrow blocks and `function` expressions are. A body that
+// computes an error result and falls through to a shared `return` after the
+// try/catch reads as a violation even when legitimate; that shape is what the
+// fingerprint allowlist is for. The regex-versus-division heuristic can misread
+// a degenerate `a++ / b` as a regex start. The gate favours a rule a reviewer
+// can verify by eye over a full parser.
 
 // The engine surface this rule governs (relative to the repo root).
 const SCAN_DIR = "packages/sdk/src";

--- a/scripts/lint/rules/no-catch.mjs
+++ b/scripts/lint/rules/no-catch.mjs
@@ -1,115 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// no-catch — SDK engine only.
-//
-// `packages/sdk` is the twin engine: the recorder, auth, MCP JSON-RPC, and
-// server plumbing every hosted twin runs on. A `catch` that logs-and-continues
-// (or silently swallows) here is how a mutation gets recorded as a success, a
-// forged token slips past bearer auth, or a half-written trace is served as
-// clean. So every statement-level `catch` clause body in the engine must do
-// ONE of three things — no exceptions the reviewer has to trust:
-//
-//   • `throw`   — the KEYWORD (a `.throw(…)` property call, e.g. on a
-//                 generator, does NOT count — nor does an identifier like
-//                 `throwaway`); the failure keeps propagating.
-//   • `return`  — the KEYWORD (`returnValue` / `.return(` do not count): hand
-//                 back an explicit error response / envelope, or a DOCUMENTED
-//                 sentinel (`undefined` / `null`) the caller checks.
-//   • `reject(` — a BARE `reject(…)` call (not `.reject(`): settle the
-//                 surrounding Promise as failed.
-//
-// A catch body that does none of these is "catch-and-continue": execution falls
-// out of the block and keeps going as if nothing broke. That is the exact bug
-// class this gate forbids.
-//
-// ALLOWLIST — target EMPTY, currently TWO entries. Both handle the error by
-// assigning an explicit error result to an outer-scoped variable and falling
-// through to a single shared record()/return below the try/catch, rather than
-// exiting from inside the clause:
-//
-//   • mcp-jsonrpc.ts (handleToolsCall) — the catch builds the JSON-RPC error
-//     envelope (status/responseBody/toolError/mcpResult) that the function
-//     then records and returns; it mirrors the sibling `if (!tool)` branch,
-//     which assigns the same four variables. Making the catch `return` would
-//     force duplicating the shared record()+return.
-//   • failure-injection.ts (before_handler) — the catch sets the optional
-//     request-body snapshot to null (the value it records) when the body can't
-//     be re-read; the same read-optional-default-null shape recorder.ts already
-//     factors into a `try { return … } catch { return null }` helper.
-//
-// Both are genuine error handling, not log-and-continue, so they are listed
-// rather than papered over. Entries are keyed by FILE plus a CONTENT
-// FINGERPRINT — a distinctive substring that must appear in that catch clause's
-// whitespace-normalized, literal-stripped body — never by line number, so an
-// entry survives edits elsewhere in the file and cannot be satisfied by an
-// unrelated catch. To reach zero entries, extract the
-// mcp result into a helper that returns the outcome, and reuse recorder.ts's
-// read-or-null helper in failure-injection — then delete the two entries.
-//
-// SCOPE — deliberately narrow, to stay a zero-false-positive structural gate:
-//
-//   • Only `packages/sdk/src/**/*.ts` (the engine). Twins, the CLI, and
-//     the wire/contract barrels are out of scope for THIS gate (barrel-policy
-//     + file-size health live in scripts/lint/rules/file-size.mjs).
-//   • Only STATEMENT try/catch. Promise `.catch(cb)` handlers are a different
-//     construct with their own idioms (e.g. `.json().catch(() => ({}))` in
-//     parity.ts is a legitimate default-on-parse-fail) and are NOT flagged.
-//     The finder requires the character before `catch` to be neither `.` nor
-//     an identifier character, then an OPTIONAL balanced-paren binding (plain
-//     `catch {`, `catch (e) {`, destructured `catch ({ message }) {`), then a
-//     `{` — so `.catch(cb)` (dotted) and any bare `catch(…)` call whose
-//     argument list is not followed by a block are never treated as a clause.
-//
-// The scan runs against a comment-and-literal-STRIPPED copy of the source, so a
-// comment or string saying "catch" / "return" / "throw" can neither trip nor
-// satisfy the gate, and a brace or quote inside a literal cannot desync the
-// brace matcher. One mode-stack state machine handles comments, quoted strings,
-// template literals with full `${}` nesting (template text blanked, code inside
-// an expression kept and scanned), and regex literals detected by the preceding
-// TOKEN rather than the previous character — so `return /a{2}/` is stripped and
-// its braces cannot corrupt brace matching while `a / b` stays division.
-// Blanked spans are replaced character-for-character with spaces, newlines
-// preserved, so byte offsets and reported line numbers stay exact.
-//
-// NESTED FUNCTIONS DON'T COUNT: before the exit scan, the bodies of function
-// expressions DEFINED inside the catch clause (`=> { … }` arrow blocks and
-// `function [name](…) { … }` expressions) are masked out. A `return` inside
-// `catch (e) { const f = () => { return; }; log(e); }` exits f when f is later
-// CALLED — it is not an exit path of the catch clause itself, so that clause
-// is flagged. A top-level `throw`/`return`/`reject(` after such a definition
-// still counts. (A nested statement try/catch is NOT masked: its handler runs
-// inline at the catch's own level, so an exit there is a real exit path.)
-//
-// LIMITATIONS. This is a structural scanner, not a data-flow analyzer, and a
-// CONDITIONAL exit is accepted by design:
-//   catch (err) { if (shouldRethrow(err)) throw err; console.error(err); }
-// passes, because an exit token exists at the clause's own level even though the
-// else-path falls through. Deciding whether EVERY branch exits needs full
-// control-flow analysis, which is out of scope for a dependency-free
-// pre-`npm ci` lint; a conditional swallow is deliberate, visible, reviewable
-// code whose semantics belong to the PR reviewer.
-//
-// Concise method shorthand in an object literal inside a catch body is not
-// masked — only arrow blocks and `function` expressions are. A body that
-// computes an error result and falls through to a shared `return` after the
-// try/catch reads as a violation even when legitimate; that shape is what the
-// fingerprint allowlist is for. The regex-versus-division heuristic can misread
-// a degenerate `a++ / b` as a regex start. The gate favours a rule a reviewer
-// can verify by eye over a full parser.
+// packages/sdk only. Every statement-level catch body must throw, return, or
+// reject; anything else is catch-and-continue, which is how a mutation gets
+// recorded as a success. Scans a literal-stripped copy so prose cannot satisfy it.
+// A conditional exit is accepted by design — deciding every branch needs
+// control-flow analysis. The allowlist is keyed by content fingerprint, not line.
 
-// The engine surface this rule governs (relative to the repo root).
 const SCAN_DIR = "packages/sdk/src";
 
-// Directory names skipped at ANY depth. node_modules/dist are build/install
-// output; test/fixtures dirs legitimately embed catch-and-continue snippets as
-// fixtures (this rule's own case table does exactly that in a tmp dir).
 const SKIP_DIRS = ["node_modules", "dist", "build", ".git", "coverage", "test", "tests", "__fixtures__", "fixtures"];
 
-// ALLOWLIST: reviewed, documented assign-and-fall-through exceptions.
-// `file` is the repo-root-relative path; `bodyIncludes` is a distinctive
-// substring that must appear in the catch clause's whitespace-normalized,
-// literal-stripped body. See the module header for why each is here and how
-// to remove it. Target: EMPTY. Fix (or refactor) the catch; don't grow this.
 const ALLOWLIST = [
   {
     file: "packages/sdk/src/mcp-jsonrpc.ts",
@@ -121,31 +21,14 @@ const ALLOWLIST = [
   },
 ];
 
-// A catch clause body must contain at least one of these to prove it has a
-// definite failure-exit path (matched against the stripped body AFTER nested
-// function-expression bodies are masked — see maskNestedFunctionBodies).
-// `throw` and `return` must be the KEYWORD — not preceded by `.` (property
-// access such as `gen.throw(e)`) and not a prefix of a longer identifier
-// (`throwaway`, `returnValue`). `reject(` must be a bare call, not `.reject(`.
 const EXIT_PATTERNS = [
   /(^|[^.\w$])throw(?![\w$])/,
   /(^|[^.\w$])return(?![\w$])/,
   /(^|[^.\w$])reject\s*\(/,
 ];
 
-// Candidate catch KEYWORDS: `catch` not preceded by `.` or an identifier char
-// (excludes `.catch(` promise handlers and identifiers like `mycatch`), not
-// followed by an identifier char (excludes `catchAll`). Whether a candidate is
-// a real catch CLAUSE is decided structurally by findCatchBodyBrace().
 const CATCH_KEYWORD_RE = /(^|[^.\w$])catch(?![\w$])/g;
 
-/**
- * Every catch-and-continue clause in one file. Returns human-readable violation
- * strings (empty when the file is clean). Exported for the rule's case table.
- * @param {string} rel Repo-root-relative path, used in the message.
- * @param {string} source The file's contents.
- * @returns {string[]}
- */
 export function findViolationsIn(rel, source) {
   const violations = [];
   const stripped = stripCommentsAndLiterals(source);
@@ -158,8 +41,6 @@ export function findViolationsIn(rel, source) {
     if (openBrace === -1) continue; // not a statement catch clause
     const body = extractBraceBlock(stripped, openBrace);
     if (body === null) continue; // unbalanced (truncated file) — nothing to judge
-    // An exit inside a function DEFINED in the catch body doesn't exit the
-    // catch — mask nested function bodies before looking for exit tokens.
     const exitScanText = maskNestedFunctionBodies(body);
     if (EXIT_PATTERNS.some((re) => re.test(exitScanText))) continue;
     const normalizedBody = body.replace(/\s+/g, " ").trim();
@@ -172,13 +53,6 @@ export function findViolationsIn(rel, source) {
   return violations;
 }
 
-/**
- * Given the index just past a candidate `catch` keyword, decide whether it is
- * a statement catch CLAUSE and return the index of the `{` opening its body,
- * or -1. Accepts an optional balanced-paren binding — `catch {`, `catch (e) {`,
- * `catch ({ message }) {`, `catch (e: unknown) {` — with nested parens/braces
- * inside the binding handled by paren counting.
- */
 function findCatchBodyBrace(text, from) {
   const n = text.length;
   let i = from;
@@ -201,10 +75,6 @@ function findCatchBodyBrace(text, from) {
   return text[i] === "{" ? i : -1;
 }
 
-/**
- * Return the substring strictly inside the braces starting at `openIndex`
- * (which must point at a `{`), matching nesting. Returns null if unbalanced.
- */
 function extractBraceBlock(text, openIndex) {
   let depth = 0;
   for (let i = openIndex; i < text.length; i++) {
@@ -218,22 +88,8 @@ function extractBraceBlock(text, openIndex) {
   return null;
 }
 
-// Openers of nested function-expression bodies inside a (stripped) catch body:
-// an arrow block `=> {` (the `{` may follow whitespace), or a `function`
-// KEYWORD (`function (…) {`, `function name(…) {`, `function* (…) {`) — same
-// non-dot/non-identifier guard as the other keyword matchers.
 const NESTED_FN_RE = /=>\s*\{|(^|[^.\w$])function(?![\w$])/g;
 
-/**
- * Blank the bodies of function expressions defined INSIDE a catch clause body
- * (arrow `=> { … }` blocks and `function [name](…) { … }` expressions), brace-
- * matched, so an exit token inside them is not credited to the catch clause
- * itself: that code runs only if the function is later called. The masked text
- * is used ONLY for exit detection; the unmasked body still drives allowlist
- * fingerprinting. Input is stripped source, so literal braces can't mislead
- * the matcher. Nested functions inside an already-masked block are skipped by
- * resuming the scan past the block.
- */
 function maskNestedFunctionBodies(body) {
   const out = body.split("");
   NESTED_FN_RE.lastIndex = 0;
@@ -243,8 +99,6 @@ function maskNestedFunctionBodies(body) {
     if (m[0].startsWith("=>")) {
       open = m.index + m[0].length - 1; // the `{` ending the arrow match
     } else {
-      // `function` keyword: skip optional `*`, optional name, then require a
-      // balanced-paren parameter list followed by `{`.
       let j = m.index + m[0].length;
       while (j < body.length && /\s/.test(body[j])) j++;
       if (body[j] === "*") {
@@ -270,7 +124,6 @@ function maskNestedFunctionBodies(body) {
       if (body[j] !== "{") continue;
       open = j;
     }
-    // Brace-match the function body and blank its interior.
     let depth = 0;
     let close = -1;
     for (let k = open; k < body.length; k++) {
@@ -300,13 +153,8 @@ function lineNumberAt(text, index) {
   return line;
 }
 
-// Marker token: a string/template/regex literal just ended — it is a VALUE, so
-// a following `/` is division, never a regex start. (Contains a space, so it
-// can never collide with a real token.)
 const VALUE_TOKEN = " value";
 
-// Keywords after which a `/` begins a regex literal (a value is expected next,
-// not a binary operand).
 const REGEX_PRECEDING_KEYWORDS = new Set([
   "return",
   "throw",
@@ -324,13 +172,6 @@ const REGEX_PRECEDING_KEYWORDS = new Set([
   "await",
 ]);
 
-/**
- * A `/` begins a regex literal (not division) when the previous significant
- * TOKEN is: nothing (start of input / start of a `${}` expression), a keyword
- * from REGEX_PRECEDING_KEYWORDS, or an opening punctuator / operator. After an
- * identifier, a number, a closing bracket, `.`, or a just-ended literal
- * (VALUE_TOKEN), a `/` is division.
- */
 function regexAllowedAfter(token) {
   if (token === "") return true;
   if (token === VALUE_TOKEN) return false;
@@ -338,11 +179,6 @@ function regexAllowedAfter(token) {
   return token.length === 1 && "([{,;:!&|?=+-*%<>~^".includes(token);
 }
 
-/**
- * From `src[start] === "/"` presumed to open a regex literal, return the index
- * just past the closing `/` and its flags, or -1 if no closing `/` on the same
- * line (then it wasn't a regex). Char classes may contain unescaped `/`.
- */
 function scanRegexEnd(src, start) {
   const n = src.length;
   let j = start + 1;
@@ -366,20 +202,9 @@ function scanRegexEnd(src, start) {
   return -1;
 }
 
-/**
- * Blank out comments, string literals, template-literal TEXT, and regex
- * literals — replacing their characters with spaces, preserving newlines — so
- * byte offsets stay 1:1 with the source and the brace/keyword scan sees only
- * real code tokens. Code inside template `${}` expressions is KEPT (and
- * scanned), with a mode stack tracking arbitrary template/expression nesting;
- * the `${` and its matching `}` are blanked so output braces stay balanced.
- */
 function stripCommentsAndLiterals(src) {
   const n = src.length;
   const out = new Array(n);
-  // Mode stack: { type: "template" } while inside template TEXT;
-  // { type: "expr", depth } while inside a `${ … }` expression (depth counts
-  // nested code braces so the `}` that closes the `${` is identified exactly).
   const stack = [];
   let word = ""; // identifier/keyword/number token being accumulated
   let prevToken = ""; // last completed significant token ("" at start)
@@ -403,7 +228,6 @@ function stripCommentsAndLiterals(src) {
   while (i < n) {
     const mode = stack.length > 0 ? stack[stack.length - 1] : null;
 
-    // ── Template TEXT: blank everything until `` ` `` (pop) or `${` (push expr).
     if (mode !== null && mode.type === "template") {
       const ch = src[i];
       if (ch === "\\") {
@@ -431,7 +255,6 @@ function stripCommentsAndLiterals(src) {
       continue;
     }
 
-    // ── CODE (top level, or inside a `${}` expression).
     const ch = src[i];
     const next = i + 1 < n ? src[i + 1] : "";
 
@@ -491,10 +314,8 @@ function stripCommentsAndLiterals(src) {
         i = j;
         continue;
       }
-      // No closing `/` on the line — not a regex after all; fall through.
     }
 
-    // Plain code character: keep it, update expr brace depth + token tracking.
     if (mode !== null && mode.type === "expr") {
       if (ch === "{") mode.depth++;
       else if (ch === "}") mode.depth--;
@@ -517,7 +338,6 @@ export default {
   describe: "every catch in the SDK engine throws, returns an error, or rejects",
   check(ctx) {
     const violations = [];
-    // `mustExist: false`, as the predecessor's `existsSync` guard was.
     for (const file of ctx.files({ dirs: [SCAN_DIR], ext: [".ts"], skip: SKIP_DIRS, mustExist: false })) {
       violations.push(...findViolationsIn(ctx.rel(file), ctx.read(file)));
     }

--- a/scripts/lint/rules/no-catch.test.mjs
+++ b/scripts/lint/rules/no-catch.test.mjs
@@ -1,21 +1,12 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// 470 lines of hand-rolled lexer, so most of this table is about the lexer
-// rather than the rule: the cases that matter are the ones where a naive scan
-// gets it backwards. A `.catch()` promise handler is not a catch clause and a
-// regex literal's unbalanced brace is not a block delimiter (both false reds,
-// and a rule with false reds gets deleted); an exit inside a function DEFINED
-// in the catch body does not exit the catch, and a template literal must not
-// swallow the code inside its `${}` (both false greens, which is worse).
-//
-// Folded in from `cli/test/unit/no-catch-and-continue.test.ts`, a vitest suite
-// that asserted the same predicate from a third place.
+// Case table for no-catch. Every case asserts the RED direction: a rule that has
+// quietly stopped failing prints the same line as one with nothing to report.
 
 import { defineCases } from "../harness.mjs";
 
 const SRC = "packages/sdk/src/thing.ts";
-/** The reviewed assign-and-fall-through shape the allowlist exists for. */
 const FALL_THROUGH = (assignment) =>
   [
     `export async function f() {`,
@@ -63,22 +54,17 @@ defineCases("no-catch", [
     contains: "does not throw, return, or reject",
   },
   {
-    // A `.catch()` promise handler is not a statement catch clause. A false red
-    // here is how the rule gets deleted.
     name: "a `.catch()` promise handler is not a catch clause",
     files: { [SRC]: `export const run = () => work().catch((err) => log(err));\n` },
     expect: "green",
   },
   {
-    // The exit is inside a callback DEFINED in the catch body, so it does not
-    // exit the catch. This is the false-green a naive token scan produces.
     name: "an exit inside a nested function does not count as the catch's exit",
     files: { [SRC]: wrap("    queue.push(() => { throw err; });") },
     expect: "red",
     contains: "does not throw, return, or reject",
   },
   {
-    // Only `packages/sdk/src` is the engine surface this rule governs.
     name: "a swallowing catch outside the SDK engine is out of scope",
     files: { "packages/twin-x/src/thing.ts": wrap("    console.warn(err);") },
     expect: "green",
@@ -99,7 +85,6 @@ defineCases("no-catch", [
     expect: "green",
   },
   {
-    // A nested template must not desync the brace matcher.
     name: "nested template literals do not desync the lexer",
     files: {
       [SRC]: [
@@ -116,7 +101,6 @@ defineCases("no-catch", [
     expect: "green",
   },
   {
-    // ...and must not hide the code inside its own `${}` either.
     name: "a catch-and-continue INSIDE a template ${} expression is still seen",
     files: {
       [SRC]: [
@@ -134,8 +118,6 @@ defineCases("no-catch", [
     contains: "does not throw, return, or reject",
   },
   {
-    // An unbalanced `}` inside a regex literal would desync a brace matcher that
-    // did not strip regexes after a keyword.
     name: "a regex literal's braces do not desync the lexer",
     files: {
       [SRC]: [
@@ -153,8 +135,6 @@ defineCases("no-catch", [
     expect: "green",
   },
   {
-    // `throw` must be the KEYWORD: `gen.throw(e)` is a property call that does
-    // not exit the catch.
     name: "a `.throw` property call is not an exit",
     files: { [SRC]: wrap("    gen.throw(err);") },
     expect: "red",
@@ -178,8 +158,6 @@ defineCases("no-catch", [
     contains: "does not throw, return, or reject",
   },
   {
-    // The allowlist is keyed by file AND a body fingerprint, not a line number:
-    // the same fall-through shape in the RIGHT file with the fingerprint passes.
     name: "allowlist: a fingerprint match in the named file passes",
     files: { "packages/sdk/src/mcp-jsonrpc.ts": FALL_THROUGH('toolError = err instanceof Error ? err.message : "x";') },
     expect: "green",

--- a/scripts/lint/rules/no-eval.mjs
+++ b/scripts/lint/rules/no-eval.mjs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// no-eval (D9) — REPO-WIDE.
+// no-eval — REPO-WIDE.
 //
 // pome-twins is capture-only: it must never compute a score, call a judge, or
 // correlate locally, anywhere in the OSS surface (cli/src/**, cli/scripts/**,
@@ -20,7 +20,7 @@
 //      `import "..."` — against the SPECIFIER, so prose/comments referencing the
 //      old design don't trip it.
 //
-// ALLOWLIST (D16): file-name-stem violations may be allowlisted by relative path
+// ALLOWLIST: file-name-stem violations may be allowlisted by relative path
 // below, for a module that is GENUINELY only trace-format TYPES (no eval logic)
 // and happens to collide with a denied stem. Target: EMPTY. Path violations and
 // import violations are NEVER allowlistable.

--- a/scripts/lint/rules/no-eval.mjs
+++ b/scripts/lint/rules/no-eval.mjs
@@ -1,43 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// no-eval — REPO-WIDE.
-//
-// pome-twins is capture-only: it must never compute a score, call a judge, or
-// correlate locally, anywhere in the OSS surface (cli/src/**, cli/scripts/**,
-// packages/**). Evaluation is the product; it lives in pome-cloud. This rule
-// FAILS the build when any of that reappears, in three independent ways:
-//
-//   1. PATH — a known deleted local-eval tree/package/file reappears on disk.
-//   2. NAME — any scanned file's basename matches a denied eval-role stem
-//      (correlate*/score*/judge*/verdict*, case-insensitive). This catches a
-//      reintroduction under a NEW path we don't remember to deny by name — e.g.
-//      a fresh `packages/x/src/score.ts` — not just the historical ones.
-//   3. IMPORT — any scanned file IMPORTS a forbidden module SPECIFIER: the local
-//      correlator/judge/matcher packages, or ANY `@pome-cloud/*` package
-//      (pome-twins, the OSS repo, must never depend on cloud-only code). Matches
-//      every module-loading form — static `import ... from`, `export ... from`,
-//      dynamic `import(...)`, `require(...)`, and bare side-effect
-//      `import "..."` — against the SPECIFIER, so prose/comments referencing the
-//      old design don't trip it.
-//
-// ALLOWLIST: file-name-stem violations may be allowlisted by relative path
-// below, for a module that is GENUINELY only trace-format TYPES (no eval logic)
-// and happens to collide with a denied stem. Target: EMPTY. Path violations and
-// import violations are NEVER allowlistable.
-//
-// LIMITATIONS (honest): this is a static import/path/name scanner. It cannot
-// detect local evaluation logic hand-written INLINE inside an innocuously named,
-// non-importing file. It does not scan `test/`, `tests/`, `__fixtures__/`, or
-// `fixtures/` directories (at any depth) — those legitimately embed forbidden
-// strings as fixtures. The NAME rule is a PREFIX match only —
-// `basename.startsWith(stem)` — so `scoreRun.ts` / `judgeOutput.ts` trip it but
-// an infix like `runScorer.ts` does not; those rely on the import rule instead.
-// This narrowness is accepted policy for the OSS gate (allowlist discipline over
-// broad heuristics), not an oversight.
+// Repo-wide. This repo is capture-only: it must never compute a score, call a
+// judge, or import a scoring path. Denies by import, by path and by file-name stem;
+// only stem collisions are allowlistable.
 
 import { fileURLToPath } from "node:url";
 
-// Deleted logic trees / packages / entrypoints must stay gone.
 const FORBIDDEN_PATHS = [
   "cli/src/evaluator",
   "cli/src/matrix",
@@ -51,8 +19,6 @@ const FORBIDDEN_PATHS = [
   "packages/correlator",
 ];
 
-// Matched against the MODULE SPECIFIER of an import, so a comment mentioning
-// "@pome-sh/correlator" or "evaluator/score" is not a violation.
 const FORBIDDEN_MODULE_PATTERNS = [
   { re: /@pome-sh\/correlator/, why: "the correlator (no local correlation in the OSS CLI)" },
   { re: /(^|\/)evaluator\//, why: "a local evaluator tree" },
@@ -69,10 +35,8 @@ const FORBIDDEN_MODULE_PATTERNS = [
 
 const FORBIDDEN_NAME_STEMS = ["correlate", "score", "judge", "verdict"];
 
-// D16 — allowlist by relative path for FILE-NAME-STEM violations only.
 const FILE_ALLOWLIST = new Set([]);
 
-// Capture the module SPECIFIER from every module-loading form.
 const IMPORT_SPECIFIER_RES = [
   /\bfrom\s*["']([^"']+)["']/g, // static import + `export ... from`
   /(?:^|[^.\w])import\s*\(\s*["']([^"']+)["']/g, // dynamic import()
@@ -80,13 +44,10 @@ const IMPORT_SPECIFIER_RES = [
   /(?:^|[^.\w])import\s+["']([^"']+)["']/g, // bare side-effect `import "x"`
 ];
 
-// Repo-root `scripts/` is included so eval logic reintroduced as e.g.
-// `scripts/local-judge.mjs` (alongside the other build/CI scripts) is walked too.
 const SCAN_DIRS = ["cli/src", "cli/scripts", "packages", "scripts"];
 
 const EXTENSIONS = [".ts", ".tsx", ".mts", ".cts", ".js", ".mjs", ".cjs"];
 
-// test/tests/fixtures dirs legitimately embed forbidden strings as fixtures.
 const SKIP_DIRS = [
   "node_modules",
   "dist",
@@ -99,13 +60,6 @@ const SKIP_DIRS = [
   "fixtures",
 ];
 
-// This rule's own source carries the denylist literals it scans for, and so does
-// its case table — a table that could not write a forbidden import could not
-// prove the rule goes red on one. (The old vitest suite got this for free by
-// living under `cli/test/unit/`, a directory the walk skips.) Both are derived
-// from `import.meta.url` rather than hard-coded, so renaming cannot leave them
-// self-tripping, and the exemption stays scoped to these two files rather than
-// to `scripts/**/*.test.mjs` at large.
 const SELF = fileURLToPath(import.meta.url);
 const SELF_CASES = SELF.replace(/\.mjs$/, ".test.mjs");
 
@@ -123,9 +77,6 @@ export default {
       }
     }
 
-    // `mustExist: false`, as the predecessor's `existsSync` guard was:
-    // `cli/scripts` is optional in a checkout, and the PATH arm above is what
-    // notices a tree that should not be there.
     for (const file of ctx.files({ dirs: SCAN_DIRS, ext: EXTENSIONS, skip: SKIP_DIRS, mustExist: false })) {
       if (file === SELF || file === SELF_CASES) continue;
       const rel = ctx.rel(file);
@@ -142,8 +93,6 @@ export default {
       }
 
       const text = ctx.read(file);
-      // De-dupe so a single offending line matched by multiple specifier regexes
-      // (or multiple forbidden patterns) is reported once per (specifier, reason).
       const seen = new Set();
       for (const specRe of IMPORT_SPECIFIER_RES) {
         specRe.lastIndex = 0;

--- a/scripts/lint/rules/no-eval.mjs
+++ b/scripts/lint/rules/no-eval.mjs
@@ -55,12 +55,12 @@ const FORBIDDEN_PATHS = [
 // "@pome-sh/correlator" or "evaluator/score" is not a violation.
 const FORBIDDEN_MODULE_PATTERNS = [
   { re: /@pome-sh\/correlator/, why: "the correlator (no local correlation in the OSS CLI)" },
-  { re: /(^|\/)evaluator\//, why: "the deleted local evaluator tree" },
-  { re: /(^|\/)matrix\//, why: "the deleted local-scoring matrix tree" },
-  { re: /correlateRun/, why: "the deleted local correlation module" },
-  { re: /probabilistic/, why: "the deleted local LLM judge" },
-  { re: /deterministic/, why: "the deleted deterministic matchers" },
-  { re: /twin-plugins/, why: "the deleted deterministic twin matchers" },
+  { re: /(^|\/)evaluator\//, why: "a local evaluator tree" },
+  { re: /(^|\/)matrix\//, why: "a local scoring matrix" },
+  { re: /correlateRun/, why: "a local correlation module" },
+  { re: /probabilistic/, why: "a local LLM judge" },
+  { re: /deterministic/, why: "local deterministic matchers" },
+  { re: /twin-plugins/, why: "local deterministic twin matchers" },
   {
     re: /^@pome-cloud\//,
     why: "a pome-cloud-only package — pome-twins (OSS) must never depend on cloud code",

--- a/scripts/lint/rules/no-eval.test.mjs
+++ b/scripts/lint/rules/no-eval.test.mjs
@@ -1,25 +1,13 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// The old gate shipped with no case table, for the rule whose whole job is
-// keeping evaluation out of the OSS repo. All three arms are asserted (path,
-// name, import), plus the two documented narrownesses — a prose mention is not
-// an import, and a `fixtures/` directory is deliberately unscanned — because a
-// rule that reds on prose gets deleted and a rule that reds on its own fixtures
-// gets allowlisted into uselessness.
-//
-// Folded in from `cli/test/unit/no-eval-in-oss.test.ts`, a vitest suite that
-// asserted the same predicate from a third place.
+// Case table for no-eval. Every case asserts the RED direction: a rule that has
+// quietly stopped failing prints the same line as one with nothing to report.
 
 import { defineCases } from "../harness.mjs";
 
 const SRC = "packages/twin-x/src/thing.ts";
 
-// Assembled rather than written out. `scripts/lint-no-cloud-imports.sh` greps
-// this directory for the same specifier and cannot tell a fixture from a real
-// import, and `no-eval` itself scans `scripts/` — weakening either of them to
-// make room for a fixture is the wrong trade. The rule sees the real string at
-// runtime, which is what the case is about.
 const CLOUD_JUDGE = ["@pome", "cloud/judge"].join("-");
 
 defineCases("no-eval", [
@@ -59,7 +47,6 @@ defineCases("no-eval", [
     contains: CLOUD_JUDGE,
   },
   {
-    // A false positive on prose is how this rule gets deleted.
     name: "prose naming a forbidden specifier is not an import",
     files: {
       [SRC]: `// The old design imported "@pome-sh/correlator" here; it lives in pome-cloud now.\nexport const a = 1;\n`,
@@ -67,7 +54,6 @@ defineCases("no-eval", [
     expect: "green",
   },
   {
-    // Documented narrowness: fixture directories legitimately embed the strings.
     name: "a fixtures/ directory is deliberately unscanned",
     files: { "packages/twin-x/src/fixtures/score.ts": `import "${CLOUD_JUDGE}";\n` },
     expect: "green",
@@ -97,17 +83,12 @@ defineCases("no-eval", [
     contains: "@pome-sh/correlator",
   },
   {
-    // `cli/src/**` is not the whole OSS surface: eval logic reintroduced beside
-    // the build scripts is the same violation.
     name: "SCOPE: cli/scripts/ is walked too",
     files: { "cli/scripts/thing.mjs": `import "@pome-sh/correlator";\n` },
     expect: "red",
     contains: "cli/scripts/thing.mjs",
   },
   {
-    // The NAME rule is a PREFIX match, so `judge-local.mjs` trips it and
-    // `local-judge.mjs` does not — the documented narrowness, asserted from both
-    // sides so nobody has to guess which way it goes.
     name: "SCOPE: repo-root scripts/ is walked too, by name and by import",
     files: {
       "scripts/judge-local.mjs": `export const x = 1;\n`,

--- a/scripts/lint/rules/no-eval.test.mjs
+++ b/scripts/lint/rules/no-eval.test.mjs
@@ -76,13 +76,13 @@ defineCases("no-eval", [
     name: "IMPORT: a reintroduced local LLM judge is a violation",
     files: { [SRC]: `import { judge } from "./probabilistic/judge.js";\nexport const j = judge;\n` },
     expect: "red",
-    contains: "the deleted local LLM judge",
+    contains: "a local LLM judge",
   },
   {
     name: "IMPORT: a reintroduced deterministic matcher is a violation",
     files: { [SRC]: `import { match } from "./deterministic/match.js";\nexport const m = match;\n` },
     expect: "red",
-    contains: "the deleted deterministic matchers",
+    contains: "local deterministic matchers",
   },
   {
     name: "IMPORT: a reintroduced correlator package is a violation",

--- a/scripts/lint/rules/no-native.mjs
+++ b/scripts/lint/rules/no-native.mjs
@@ -1,25 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// "Zero native deps" (M2) is an invariant, not an event: no package in the
-// PRODUCTION dependency closure of the published packages may carry a node-gyp
-// build step. Detection is by gyp markers — a `binding.gyp` file or a truthy
-// `gypfile` manifest field — NOT by `hasInstallScript`: prebuilt-binary
-// installers (esbuild, fsevents) have install scripts but need no compiler, and
-// must pass.
-//
-// Scope is the lockfile's non-dev entries (workspace transitives included).
-// `dev` and `devOptional` entries are excluded: they never reach a production
-// install (`npm ci --omit=dev`) or a published artifact.
-//
-// Needs an installed `node_modules` — marker inspection needs the unpacked
-// package on disk, so this rule is skipped by `--offline`.
+// No native addons in the published tree — they break the clean-room install.
 
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
-// Intentional exceptions only; empty by design (same posture as the copy-marker
-// rule's allowlist). Keys are lockfile package paths, e.g.
-// "node_modules/some-package".
 const ALLOWLIST = new Set([]);
 
 export function findNativeModules(root) {
@@ -37,8 +22,6 @@ export function findNativeModules(root) {
     const pkgDir = join(root, path);
     if (!existsSync(pkgDir)) {
       if (entry.optional) {
-        // Platform-gated optional prod dep not installed here (e.g. another
-        // OS's prebuilt binary package). Nothing to inspect on this machine.
         skippedOptional.push(path);
         continue;
       }
@@ -53,10 +36,7 @@ export function findNativeModules(root) {
         markers.push('"gypfile": true');
       }
     } catch {
-      // Unreadable manifest: the binding.gyp check above still applies.
     }
-    // Packaged native addons sometimes ship prebuilt `.node` binaries without a
-    // binding.gyp in the published tarball — treat those as native too.
     if (hasPackagedNodeBinary(pkgDir)) markers.push("packaged .node binary");
     if (markers.length > 0) offenders.push({ path, markers });
   }
@@ -64,8 +44,6 @@ export function findNativeModules(root) {
   return { offenders, checked, skippedOptional };
 }
 
-/** Shallow walk: package root + one level of subdirs (covers common
- *  prebuild/lib layouts without scanning deep trees). */
 function hasPackagedNodeBinary(pkgDir) {
   const stack = [pkgDir];
   let visited = 0;

--- a/scripts/lint/rules/no-native.test.mjs
+++ b/scripts/lint/rules/no-native.test.mjs
@@ -1,14 +1,8 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// The old gate shipped with no case table. The distinction worth pinning is the
-// one the rule's header argues for: detection is by GYP MARKERS, not by
-// `hasInstallScript`. Prebuilt-binary installers (esbuild, fsevents) have install
-// scripts and need no compiler, so a rule keyed on install scripts would red on
-// dependencies that must pass.
-//
-// Folded in from `cli/test/unit/no-native-modules.test.ts`, a vitest suite that
-// asserted the same predicate from a third place.
+// Case table for no-native. Every case asserts the RED direction: a rule that has
+// quietly stopped failing prints the same line as one with nothing to report.
 
 import { defineCases } from "../harness.mjs";
 
@@ -55,8 +49,6 @@ defineCases("no-native", [
     contains: "packaged .node binary",
   },
   {
-    // The whole reason detection is by gyp marker: esbuild and fsevents have
-    // install scripts and need no compiler.
     name: "an install script alone is not a native build step",
     files: {
       "package-lock.json": lock({ "node_modules/prebuilt": { ...PROD, hasInstallScript: true } }),
@@ -69,8 +61,6 @@ defineCases("no-native", [
     expect: "green",
   },
   {
-    // `npm ci --omit=dev` never installs them and no published artifact carries
-    // them.
     name: "a native dev dependency is out of the production closure",
     files: {
       "package-lock.json": lock({ "node_modules/native": { ...PROD, dev: true } }),
@@ -80,24 +70,18 @@ defineCases("no-native", [
     expect: "green",
   },
   {
-    // A non-optional prod entry with nothing on disk means the scan cannot see
-    // its markers, which must not read as a pass.
     name: "an uninstalled non-optional prod package is red, not skipped",
     files: { "package-lock.json": lock({ "node_modules/missing": PROD }) },
     expect: "red",
     contains: "cannot inspect",
   },
   {
-    // Another OS's prebuilt-binary package. Nothing to inspect on this machine.
     name: "a platform-gated optional prod package not installed here is skipped, and said so",
     files: { "package-lock.json": lock({ "node_modules/darwin-only": { ...PROD, optional: true } }) },
     expect: "green",
     contains: "platform-gated optional packages not installed here",
   },
   {
-    // A workspace symlink's own dependencies have their own lockfile entries, so
-    // inspecting the link itself would double-count and would follow into a tree
-    // this scan already covers.
     name: "a workspace link entry is not inspected",
     files: { "package-lock.json": lock({ "packages/twin-x": { link: true, resolved: "packages/twin-x" } }) },
     expect: "green",

--- a/scripts/lint/rules/parent-vocab.mjs
+++ b/scripts/lint/rules/parent-vocab.mjs
@@ -1,27 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// No emitter may write a bare `parent_id`.
-//
-// `parent_id` used to mean four different things depending on which of five
-// writers produced the row: a spawning `event_id` (wrapQuery), a raw SDK
-// `tool_use_id` (hooks), a hard null (turn-usage, and every twin HTTP row), and
-// a mirror of `parent_span_id` (OtelSpanEvent). Reading a trace meant knowing
-// which writer a row came from. The vocab is now `parent_event_id` — always the
-// spawning row's `event_id` — plus `causing_tool_use_id` for the one meaning
-// that was never a parent edge.
-//
-// The schema still ACCEPTS `parent_id` as a legacy input key, and must: every
-// shipped 0.13.0 emitter writes it, and a row that fails to parse is dropped
-// silently on the way into the cloud's tape. That tolerance is exactly why this
-// has to be a lint rule rather than a zod refinement — nothing in the type
-// system can stop a new writer from quietly emitting the old spelling and having
-// it parse.
+// `parent_id` is accepted as a legacy input key and must keep being accepted, but
+// nothing may write it. Allowlisted files are the tolerant readers themselves.
 
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
-// Files allowed to name the legacy key, each for a stated reason. A new entry
-// here should be a deliberate decision, not a way to quiet the rule.
 const ALLOWED = new Map([
   [
     "packages/wire/src/recorder-events.ts",
@@ -29,18 +13,11 @@ const ALLOWED = new Map([
   ],
   ["packages/wire/src/otel/span-event.ts", "accepts `parent_id` as a legacy input key on the OTel arm"],
   [
-    // Not the trace format at all: a Linear issue has a parent issue, and
-    // `parent_id` is that SQLite column — in the schema DDL, the seed inserts,
-    // the SELECT projections and the cycle check. Scoping by field name catches
-    // the whole package as collateral; renaming a twin's domain model to satisfy
-    // a trace-vocab rule would be the tail wagging the dog. A trailing `/` makes
-    // this a directory prefix, not one file.
     "packages/twin-linear/src/",
     "the Linear twin's own domain model — an issue's parent issue, not an event's parent row",
   ],
 ]);
 
-/** An entry ending in `/` covers everything beneath it. */
 function allowed(rel) {
   for (const key of ALLOWED.keys()) {
     if (key.endsWith("/") ? rel.startsWith(key) : rel === key) return true;
@@ -48,26 +25,12 @@ function allowed(rel) {
   return false;
 }
 
-// Strip comments only. Strings are NOT stripped: an earlier version removed them
-// first, which meant a quoted or computed property key — `{ "parent_id": null }`,
-// `{ ["parent_id"]: null }` — emitted the forbidden field with the gate still
-// green. A quoted key is the same emission as a bare one, so the scan has to see
-// it.
-//
-// The trade is that a legitimate string mention in non-allowlisted source now
-// trips the rule. That is the right bias for an invariant: a loud false positive
-// is answered with a one-line allowlist entry and a stated reason, while a silent
-// false negative is how the old vocab comes back.
 function stripComments(source) {
   return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
 }
 
-// Bare identifier, or the same name as a quoted string — which in practice is
-// either a property key or a reference to the legacy field. Both are emissions.
 const BARE_PARENT_ID = /(?<![_\w])parent_id(?![_\w])|['"`]parent_id['"`]/;
 
-/** `src/` under every package, the cli, and every agent example — and nothing
- *  else. `test/` and `fixtures/` legitimately name the legacy key. */
 function emitterDirs(root) {
   const dirs = ["cli/src"];
   for (const [parent, child] of [
@@ -92,16 +55,11 @@ export default {
   describe: "no bare `parent_id` in emitter source",
   check(ctx) {
     const violations = [];
-    // `mustExist: false`: the dirs are derived from `packages/*` and
-    // `agent-examples/*`, and not every member has a `src/` (packages/shared-types
-    // does not). The old `globSync` patterns returned nothing for those too.
     for (const file of ctx.files({ dirs: emitterDirs(ctx.root), ext: [".ts", ".mjs"], mustExist: false })) {
       const rel = ctx.rel(file);
       if (allowed(rel)) continue;
       const text = ctx.read(file);
       if (!BARE_PARENT_ID.test(stripComments(text))) continue;
-      // Report real line numbers, from the unstripped source, for anything that
-      // survived the strip.
       text.split("\n").forEach((line, i) => {
         if (BARE_PARENT_ID.test(stripComments(line))) violations.push(`${rel}:${i + 1}: ${line.trim()}`);
       });

--- a/scripts/lint/rules/parent-vocab.test.mjs
+++ b/scripts/lint/rules/parent-vocab.test.mjs
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Case 2 is the reason this table exists: the first version of the rule stripped
-// string literals before scanning, so `{ "parent_id": null }` emitted the
-// forbidden field with the rule still green. A rule that cannot fail is worse
-// than no rule, because it reads as coverage.
+// Case table for parent-vocab. Every case asserts the RED direction: a rule that has
+// quietly stopped failing prints the same line as one with nothing to report.
 
 import { defineCases } from "../harness.mjs";
 
@@ -70,8 +68,6 @@ defineCases("parent-vocab", [
     contains: `${EMITTER}:2:`,
   },
   {
-    // `test/` is not emitter source: only `src/` is walked, so a fixture naming
-    // the legacy key cannot red the rule for the package that owns it.
     name: "a package's test tree is out of scope",
     files: { "packages/twin-x/test/emit.test.ts": `const row = { parent_id: null };\n` },
     expect: "green",

--- a/scripts/lint/rules/route-inputs.mjs
+++ b/scripts/lint/rules/route-inputs.mjs
@@ -1,58 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// The rule that keeps a twin's published input surface COMPLETE.
-//
-// # What it enforces
-//
-// No module a twin's route registrars can reach may read a request input
-// imperatively. Every input a handler sees has to arrive through
-// `declareRouteInputs(...).parse()`, because that declaration is what gets
-// published to pome-cloud's declared-fidelity lane.
-//
-// # Why a gate and not a type
-//
-// `packages/sdk/src/route-inputs.ts` makes two of the three failure modes
-// structurally impossible: a handler receives only the declaration's output, so
-// it cannot ACCEPT an input the declaration omits, and the declaration is the
-// validator, so it cannot REJECT one the declaration names. The third — a
-// handler that ignores its parsed input and reaches for `c.req.query("sort")`
-// anyway — no type can prevent. It is one line, it typechecks, every existing
-// test passes, and the published artifact silently stops being the whole truth.
-//
-// That is worse than not checking at all. `not-compared` is honest;
-// "compared, no drift" computed from an incomplete declaration is a lane
-// reporting a pass nobody measured, which is how people learn to ignore it.
-//
-// # Why the walk is structural
-//
-// The gate does not carry a list of route files. It finds every module that
-// registers a route (by the call it must make to do so), then walks the real
-// static import graph out of each one and checks everything it reaches inside
-// the same twin. A new route file is covered the moment it registers a route; a
-// helper extracted out of one is covered because the route file still imports
-// it. Both are the ways a hand-maintained list would have gone quietly stale —
-// and gmail's input names lived in exactly such a helper (`rest-common.ts`)
-// two modules away from anything named "routes".
-//
-// A twin with no discoverable registrar is a hard failure, not a skip: removing
-// the thing a reachability gate walks is the cheap way to pass it.
-//
-// Dependency-free and build-free, like its sibling rules, so it runs before
-// `npm ci`.
+// Handlers take a parse result, never the raw request. An exemption that no longer
+// matches anything reds rather than going quiet.
 
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 import { buildSpecifierMap, reachable, stripNonCode } from "../../lib/static-import-graph.mjs";
 
-/**
- * The imperative request reads. Each is a way to obtain an input value whose
- * NAME appears only at the call site — which is precisely the shape this rule
- * replaced, in all four HTTP twins at once.
- *
- * `c.req.method` and `c.req.path` are deliberately absent: they are routing
- * facts, not inputs, and the recorder legitimately needs both.
- */
 const BANNED = [
   { pattern: /\breq\.query\s*\(/, what: "req.query(" },
   { pattern: /\breq\.queries\s*\(/, what: "req.queries(" },
@@ -69,50 +24,10 @@ const BANNED = [
   { pattern: /new URL\(\s*\w+\.req\.url\s*\)/, what: "new URL(c.req.url)" },
 ];
 
-/**
- * How a route registrar is recognised.
- *
- * Not "a file called routes.ts", and not "a file containing `app.get(`" either:
- * every twin registers at least some routes through a path VARIABLE
- * (`app.get(BASE, …)`, `app.post(path, handler)`), so a pattern anchored on a
- * literal path misses gmail and slack entirely — and a pattern loose enough to
- * catch them matches every `map.get(key)` in the repo.
- *
- * What a route registrar cannot avoid is being handed the router. So the marker
- * is a parameter typed as one, plus `mountDeclaredRoute(` for a module that
- * mounts without taking the router as a parameter. Everything else those
- * modules import is reached by the walk, which is how the helper that gmail's
- * input names actually lived in gets covered.
- */
 const ROUTER_PARAMETER = /:\s*(?:Hono|DeclarableRouter)\b/;
 const DECLARED_REGISTRATION = /\bmountDeclaredRoute\s*\(/;
 
-/**
- * Engine-boundary reads that are not route input surfaces.
- *
- * The boundary this gate polices is the twin's OWN REST/GraphQL routes — the
- * ones pome-cloud's declared-fidelity lane matches against a vendor operation.
- * Three things sit outside it and legitimately read a request directly:
- *
- *   * Middleware that runs for every request whatever matched, reading a
- *     transport concern no vendor declares per operation: an idempotency key,
- *     an x402 payment envelope, the correlation headers the recorder stamps.
- *     Declaring those on all 181 surfaces would report 181 fresh
- *     `undeclaredByVendor` rows that are not drift.
- *   * The ENGINE's own surfaces (`/admin/*`, MCP dispatch, the x402 handshake).
- *     They have declarations of their own where they have inputs at all —
- *     `ToolSpec.schema` for every MCP tool, the seed schema for `/admin/seed` —
- *     and are not twin REST routes.
- *   * Auth: which credential arrived is the engine's question, asked before any
- *     route matched.
- *
- * An exemption grants SPECIFIC read kinds, not a file. And every entry must (a)
- * exist and (b) still contain each read it grants, or this gate fails: a stale
- * exemption silently covering nothing is how a gate stops working, and a
- * file-wide one is how a real violation hides behind a legitimate neighbour.
- */
 const MIDDLEWARE_EXEMPTIONS = [
-  // ── twin-stripe: the recorder row every route helper writes ────────────────
   {
     file: "packages/twin-stripe/src/routes/_helpers.ts",
     expression: `c.req.raw.clone().text()`,
@@ -142,7 +57,6 @@ const MIDDLEWARE_EXEMPTIONS = [
       "recorder plumbing, not a route input: the event's own `path` field. Same expression the " +
       "engine's `recorder.handle()` uses for the same field.",
   },
-  // ── twin-stripe: Idempotency-Key middleware ───────────────────────────────
   {
     file: "packages/twin-stripe/src/idempotency.ts",
     expression: `c.req.param("sid")`,
@@ -180,7 +94,6 @@ const MIDDLEWARE_EXEMPTIONS = [
     expression: `path: new URL(c.req.url).pathname`,
     reason: "recorder plumbing, not a route input: the replayed event's own `path` field.",
   },
-  // ── twin-stripe: x402 wire protocol ───────────────────────────────────────
   {
     file: "packages/twin-stripe/src/x402.ts",
     expression: `const url = new URL(c.req.url)`,
@@ -217,7 +130,6 @@ const MIDDLEWARE_EXEMPTIONS = [
       "auth, not a route input: resolves the API key for the x402 handshake. Which credential " +
       "arrived is asked before any route matched.",
   },
-  // ── twin-stripe: the engine's bodyReader hook ─────────────────────────────
   {
     file: "packages/twin-stripe/src/twin.ts",
     expression: `if (new URL(c.req.url).pathname.endsWith("/admin/seed"))`,
@@ -245,11 +157,6 @@ const MIDDLEWARE_EXEMPTIONS = [
     reason:
       "the engine's `bodyReader` hook, not a route input: the form branch of the same decoder.",
   },
-  // ── twin-slack: the same engine bodyReader hook, its own entries ───────────
-  //
-  // Deliberately spelled out per twin rather than shared with stripe's as a
-  // "bodyReader" category: twin-github needed no exemption at all, and a
-  // category is how gmail would silently inherit a grant nobody examined.
   {
     file: "packages/twin-slack/src/util.ts",
     expression: `const contentType = (c.req.header("content-type") ?? "").toLowerCase()`,
@@ -273,13 +180,6 @@ const MIDDLEWARE_EXEMPTIONS = [
       "`parseFormOrJson`, the engine's `bodyReader` hook — not a route input: the form branch of " +
       "the decoder for `/admin/seed` and the legacy `/mcp/call`.",
   },
-  // ── twin-linear: the pre-auth `extensions` gate reads a CLONE ─────────────
-  //
-  // The one entry here that grants a clone rather than a named read, and the
-  // reason is the mirror image of twin-stripe's first entry above: that one
-  // drains the body BEFORE the declaration parses so the recorder's
-  // `request_body` is not blank, this one refuses to drain it at all for the
-  // same reason.
   {
     file: "packages/twin-linear/src/twin.ts",
     expression: `const peek = new HonoRequest(c.req.raw.clone())`,
@@ -295,7 +195,6 @@ const MIDDLEWARE_EXEMPTIONS = [
   },
 ];
 
-
 export default {
   name: "route-inputs",
   describe: "no imperative request read in a module a twin's route registrars reach",
@@ -308,7 +207,6 @@ export default {
       : [];
     if (twinDirs.length === 0) throw new Error(`No packages/twin-* found under ${ctx.root}.`);
 
-    // ─── Discover the twins and their route registrars ───────────────────────
     const specifiers = buildSpecifierMap(ctx.root);
     const registrarsByTwin = new Map();
     const twinsWithNoRegistrar = [];
@@ -325,8 +223,6 @@ export default {
       else registrarsByTwin.set(dir, found);
     }
 
-    // A twin with no discoverable registrar is a hard failure, not a skip:
-    // removing the thing a reachability rule walks is the cheap way to pass it.
     if (twinsWithNoRegistrar.length > 0) {
       throw new Error(
         `${twinsWithNoRegistrar.length} twin(s) have no module registering a route, so this rule ` +
@@ -337,10 +233,6 @@ export default {
       );
     }
 
-    // ─── The exemptions must still describe real code ────────────────────────
-    // The dead-check, run BEFORE the scan: an entry that matches nothing must
-    // FAIL, not quietly pass. An allowlist that has stopped matching is a rule
-    // measuring less than it claims.
     const staleExemptions = [];
     for (const entry of MIDDLEWARE_EXEMPTIONS) {
       if (!ctx.exists(entry.file)) {
@@ -353,7 +245,6 @@ export default {
         );
         continue;
       }
-      // And it has to be exempting something this rule would actually stop.
       if (!BANNED.some((banned) => banned.pattern.test(entry.expression))) {
         staleExemptions.push(
           `${entry.file} — grants \`${entry.expression}\`, which is not a read this rule bans`,
@@ -369,8 +260,6 @@ export default {
       };
     }
 
-    // ─── Check every module a registrar reaches, inside its own twin ─────────
-    /** file → the exact expressions allowlisted in it. */
     const exemptExpressions = new Map();
     for (const entry of MIDDLEWARE_EXEMPTIONS) {
       exemptExpressions.set(entry.file, [...(exemptExpressions.get(entry.file) ?? []), entry.expression]);
@@ -383,9 +272,6 @@ export default {
       const twinRoot = join(packagesDir, dir, "src");
       const { importedBy } = reachable(registrars, specifiers);
       for (const file of importedBy.keys()) {
-        // Scoped to the twin's own sources: the sdk's engine (auth, recorder,
-        // failure injection) is reached from here and is not a route input
-        // surface, and `route-inputs.ts` is where the reads are SUPPOSED to live.
         if (!file.startsWith(`${twinRoot}/`) && file !== twinRoot) continue;
         const rel = ctx.rel(file);
         const granted = exemptExpressions.get(rel) ?? [];
@@ -393,9 +279,6 @@ export default {
         for (const [index, line] of stripNonCode(ctx.read(file)).split("\n").entries()) {
           for (const banned of BANNED) {
             if (!banned.pattern.test(line)) continue;
-            // Allowlisted per EXPRESSION, not per file and not per read kind: a
-            // new read on a new line in the same module is still a violation, so
-            // a real one cannot hide behind a legitimate neighbour.
             if (granted.some((expression) => line.includes(expression))) continue;
             violations.push(`${rel}:${index + 1} — ${banned.what}\n      ${line.trim()}`);
           }

--- a/scripts/lint/rules/route-inputs.mjs
+++ b/scripts/lint/rules/route-inputs.mjs
@@ -19,7 +19,7 @@
 // anyway — no type can prevent. It is one line, it typechecks, every existing
 // test passes, and the published artifact silently stops being the whole truth.
 //
-// That is worse than the state before this ticket. `not-compared` is honest;
+// That is worse than not checking at all. `not-compared` is honest;
 // "compared, no drift" computed from an incomplete declaration is a lane
 // reporting a pass nobody measured, which is how people learn to ignore it.
 //

--- a/scripts/lint/rules/route-inputs.mjs
+++ b/scripts/lint/rules/route-inputs.mjs
@@ -32,7 +32,7 @@
 // helper extracted out of one is covered because the route file still imports
 // it. Both are the ways a hand-maintained list would have gone quietly stale —
 // and gmail's input names lived in exactly such a helper (`rest-common.ts`)
-// before this ticket, two modules away from anything named "routes".
+// two modules away from anything named "routes".
 //
 // A twin with no discoverable registrar is a hard failure, not a skip: removing
 // the thing a reachability gate walks is the cheap way to pass it.
@@ -47,7 +47,7 @@ import { buildSpecifierMap, reachable, stripNonCode } from "../../lib/static-imp
 
 /**
  * The imperative request reads. Each is a way to obtain an input value whose
- * NAME appears only at the call site — which is precisely the shape this ticket
+ * NAME appears only at the call site — which is precisely the shape this rule
  * replaced, in all four HTTP twins at once.
  *
  * `c.req.method` and `c.req.path` are deliberately absent: they are routing

--- a/scripts/lint/rules/route-inputs.test.mjs
+++ b/scripts/lint/rules/route-inputs.test.mjs
@@ -1,40 +1,11 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// The rule's whole job is to stop one line from silently un-publishing part of a
-// twin's input surface, so what is worth proving is the set of ways it could stop
-// noticing:
-//
-//   * a read in the route module itself (the obvious case);
-//   * a read in a HELPER the route module imports — the case that matters most,
-//     because that is where gmail's input names actually lived, two modules from
-//     anything named "routes";
-//   * a twin whose registrar the rule can no longer find, which is the cheap way
-//     to pass a reachability rule: it must be a hard failure, not a skip;
-//   * a registrar recognised only by its ROUTER PARAMETER, since every twin
-//     registers some routes through a path variable and an earlier draft that
-//     looked for a literal path missed gmail and slack entirely;
-//   * a read that is only mentioned in a comment or a template literal, which
-//     must NOT red the rule — a false positive is how a rule gets deleted;
-//   * a module in another twin, so a violation is reported against the twin that
-//     owns it rather than whichever registrar reached it first;
-//   * an exemption that grants ONE EXPRESSION not letting a NEW read of the same
-//     kind through on a new line in the same module;
-//   * an exemption that no longer matches anything going RED rather than quietly
-//     passing, because an allowlist that has stopped matching is a rule
-//     measuring less than it claims;
-//   * a `/*` inside an ordinary string literal not blinding the lexer to the rest
-//     of the module — the false-GREEN fixed in
-//     `scripts/lib/static-import-graph.mjs`.
+// Case table for route-inputs. Every case asserts the RED direction: a rule that has
+// quietly stopped failing prints the same line as one with nothing to report.
 
 import { defineCases } from "../harness.mjs";
 
-/**
- * The rule's real exemption list names five twin-stripe modules and one
- * twin-slack module, and requires each to exist AND still contain every exact
- * expression it grants. A throwaway tree has to carry all of them, or every case
- * fails on a stale exemption instead of on its own subject.
- */
 const EXEMPT_FIXTURES = {
   "packages/twin-stripe/src/routes/_helpers.ts": [
     `export const handle = async (c) => {`,
@@ -94,8 +65,6 @@ const EXEMPT_FIXTURES = {
     `};`,
     `export const mount = (app: Hono) => { handle(app); return gated(app); };`,
   ].join("\n"),
-  // twin-slack reaches its bodyReader through `twin.ts`, not through routes.ts —
-  // which is exactly why the rule seeds on the router parameter.
   "packages/twin-slack/src/twin.ts": [
     `import type { Hono } from "hono";`,
     `import { parseFormOrJson } from "./util.js";`,
@@ -116,9 +85,6 @@ const EXEMPT_FIXTURES = {
     `  return body;`,
     `}`,
   ].join("\n"),
-  // twin-linear's pre-auth `extensions` gate — the one exemption that grants a
-  // CLONE rather than a named read, so that the recorder's own
-  // `raw.clone().json()` still has an undisturbed stream to read.
   "packages/twin-linear/src/twin.ts": [
     `import type { Hono } from "hono";`,
     `import { HonoRequest } from "hono/request";`,
@@ -152,7 +118,6 @@ const SDK_FILES = {
   ].join("\n"),
 };
 
-/** A twin whose route module is clean and declaration-driven. */
 function cleanTwin(name) {
   const dir = `packages/twin-${name}/`;
   return {
@@ -176,12 +141,8 @@ function cleanTwin(name) {
     [`${dir}src/helpers.ts`]: `export const shape = (c) => ({ ok: true });\n`,
   };
 }
-/** The baseline every other case is a mutation of: two clean twins, plus the
- *  stripe and slack modules the real exemption list names. */
 const BASE = { ...SDK_FILES, ...EXEMPT_FIXTURES, ...cleanTwin("github"), ...cleanTwin("gmail") };
 
-/** BASE with the given overrides applied; a key mapped to `undefined` is dropped,
- *  to express "this file does not exist". */
 const withFiles = (overrides) =>
   Object.fromEntries(Object.entries({ ...BASE, ...overrides }).filter(([, body]) => body !== undefined));
 
@@ -190,9 +151,6 @@ defineCases("route-inputs", [
     name: "a declaration-driven tree passes, and says how much it covered",
     files: BASE,
     expect: "green",
-    // The twin count tracks EXEMPT_FIXTURES, which has to carry every twin the
-    // real exemption list names — five, including twin-linear's. A pass that
-    // names no count cannot be told apart from a pass over nothing.
     contains: /\d+ module\(s\) reachable from \d+ route registrar\(s\) across 5 twins/,
   },
   {
@@ -207,9 +165,6 @@ defineCases("route-inputs", [
     contains: /packages\/twin-github\/src\/routes\.ts:6\s+— req\.query\(/,
   },
   {
-    // THE case that matters. A rule that only looked at files named `routes*`
-    // would be green here, and gmail's entire query surface lived in exactly
-    // such a helper.
     name: "a read in an imported helper reds the rule, and both reads are reported",
     files: withFiles({
       "packages/twin-gmail/src/helpers.ts":
@@ -222,7 +177,6 @@ defineCases("route-inputs", [
     ],
   },
   {
-    // Deleting the thing a reachability rule walks is the cheap way to pass it.
     name: "a twin with no discoverable registrar reds the rule, naming the twin",
     files: withFiles({
       "packages/twin-gmail/src/routes.ts": [
@@ -235,8 +189,6 @@ defineCases("route-inputs", [
     contains: ["packages/twin-gmail", "covers nothing for them"],
   },
   {
-    // gmail's and slack's real shape. The draft that looked for a literal path
-    // found neither.
     name: "a registrar found by its router parameter is still checked",
     files: withFiles({
       "packages/twin-gmail/src/routes.ts": [
@@ -251,8 +203,6 @@ defineCases("route-inputs", [
     contains: /packages\/twin-gmail\/src\/routes\.ts:4\s+— req\.query\(/,
   },
   {
-    // Comments and template literals are not code. A false red here is how a
-    // rule stops being trusted and then stops existing.
     name: "a read named only in a comment or template literal is not a violation",
     files: withFiles({
       "packages/twin-github/src/helpers.ts": [
@@ -265,9 +215,6 @@ defineCases("route-inputs", [
     expect: "green",
   },
   {
-    // A violation is reported against the twin that owns the module, not
-    // whichever registrar reached it. Both twins import their own helper here;
-    // only gmail's is dirty, so github's identically-named module must be silent.
     name: "one dirty twin reds the rule without implicating its clean neighbour",
     files: withFiles({
       "packages/twin-gmail/src/helpers.ts": `export const shape = (c) => c.req.header("x-thing");\n`,
@@ -277,11 +224,6 @@ defineCases("route-inputs", [
     notContains: "twin-github/src/helpers.ts",
   },
   {
-    // An exemption grants ONE EXPRESSION, not a file and not a read kind: a NEW
-    // read of the same kind, on a new line in the same exempt module, is still a
-    // violation. This is the hole a whole-file skip would open — a real violation
-    // hiding behind a legitimate neighbour. The two granted expressions on lines
-    // 2 and 3 must stay unreported.
     name: "a NEW read in an exempt module, of a granted KIND, is still a violation",
     files: withFiles({
       "packages/twin-stripe/src/x402.ts": [
@@ -318,12 +260,6 @@ defineCases("route-inputs", [
     contains: "No packages/twin-*",
   },
   {
-    // The lexer regression. `stripNonCode` used to read the `/*` inside an
-    // ordinary string literal as a block-comment opener and blank everything up
-    // to the next `*/`. twin-stripe really does mount middleware at
-    // `session.use("/x402/*", …)`, which blanked 37 lines including a header
-    // read. A read below such a string must still be seen: this is the
-    // false-GREEN case.
     name: "a read below a string containing `/*` is still seen (was a false green)",
     files: withFiles({
       "packages/twin-github/src/routes.ts": [
@@ -341,8 +277,6 @@ defineCases("route-inputs", [
     contains: /packages\/twin-github\/src\/routes\.ts:7\s+— req\.query\(/,
   },
   {
-    // The same string must not swallow an entire module either: a read many lines
-    // after the `/*`-bearing string is still reported.
     name: "a `/*` string does not blind the rule to the rest of the module",
     files: withFiles({
       "packages/twin-gmail/src/helpers.ts": [

--- a/scripts/lint/rules/skill-manifest.mjs
+++ b/scripts/lint/rules/skill-manifest.mjs
@@ -1,30 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// `.claude-plugin/plugin.json` must list every skill under `skills/`.
-//
-// What the manifest buys: the `skills` CLI reads it and groups the skills it
-// names under one collapsible row. That row carries its own radio, so
-// `npx skills add pome-sh/digital-twins` opens with the cursor already on
-// "Pome Coach" and one space selects all of them. The flat list it renders
-// without a manifest starts with nothing ticked and the cursor on the first
-// skill, which is how the bug was filed: a user takes the screen literally,
-// installs one skill, and the coach dead-ends routing into a skill that is not
-// there.
-//
-// The failure this rule exists to stop: a new skill is added under `skills/`,
-// nobody adds it here, and it silently lands in the installer's "Other"
-// bucket — outside the select-all row, which is precisely the state we were
-// fixing. Nothing else notices, because both files are individually valid and
-// the install still succeeds.
-//
-// Ordering is not checked. Presence is.
+// Every shipped skill must be declared in the plugin manifest.
 
 import { readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 const MANIFEST_PATH = ".claude-plugin/plugin.json";
 
-/** Directories under `skills/` that are a skill: they contain a SKILL.md. */
 export function discoverSkillDirs(repoRoot) {
   const skillsDir = join(repoRoot, "skills");
   const found = [];
@@ -40,7 +22,6 @@ export function discoverSkillDirs(repoRoot) {
   return found.sort();
 }
 
-/** The two directions of drift. Exported for the rule's own case table. */
 export function diffSkillLists(onDisk, declared) {
   const declaredSet = new Set(declared);
   const onDiskSet = new Set(onDisk);

--- a/scripts/lint/rules/skill-manifest.test.mjs
+++ b/scripts/lint/rules/skill-manifest.test.mjs
@@ -1,15 +1,11 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Case 2 is the reason this table exists: the drift the rule is built for is a
-// NEW skill nobody adds to the manifest, and a rule that only checked "every
-// declared path exists" would be green on exactly that — the manifest stays
-// internally consistent while the new skill quietly falls out of the installer's
-// select-all row. Both directions are asserted.
+// Case table for skill-manifest. Every case asserts the RED direction: a rule that has
+// quietly stopped failing prints the same line as one with nothing to report.
 
 import { defineCases } from "../harness.mjs";
 
-/** A throwaway repo: skill dirs on disk + whatever the manifest claims. */
 function fixture(skillDirs, declared, extra = {}) {
   const files = {
     ".claude-plugin/plugin.json": JSON.stringify({ name: "pome-coach", skills: declared }, null, 2),
@@ -45,8 +41,6 @@ defineCases("skill-manifest", [
     expect: "green",
   },
   {
-    // A manifest with no `skills` array at all is the state the installer renders
-    // as a flat list with nothing ticked — the bug this rule exists to keep fixed.
     name: "a manifest with no `skills` array reds the rule",
     files: {
       ".claude-plugin/plugin.json": JSON.stringify({ name: "pome-coach" }),

--- a/scripts/lint/rules/task-class.mjs
+++ b/scripts/lint/rules/task-class.mjs
@@ -1,51 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Every shipped task declares which POPULATION it belongs to.
-//
-// The corpus holds two kinds of file under one heading:
-//
-//   conformance  correct behaviour is "call the endpoints and do the obvious
-//                thing". No planted hazard; no restraint carries the verdict.
-//                These are the de-facto twin smoke test — they answer "does our
-//                fake GitHub answer correctly", not "is the agent any good".
-//   restraint    the verdict rests on NOT doing something, and there is no
-//                antagonist. A leave-it-alone task, a don't-merge-a-red-PR task.
-//   adversarial  a planted antagonist — injection, spoof, persuasion, backdoor,
-//                exfiltration bait, fabrication pressure, a dedup trap.
-//
-// WHY THIS IS A GATE AND NOT A SPREADSHEET. `restraint` + `adversarial` are the
-// EXAM population, and pome-cloud pins its scored denominators against them. One
-// average over both populations cannot be read honestly: a rising number is
-// either agents improving or us adding more plumbing questions, and nothing
-// distinguishes them. A new task landing without a class would silently pick a
-// side — whichever side the reader's default happened to be — so it is refused
-// at the point of authoring instead.
-//
-// The walk mirrors pome-cloud's task-corpus walker: a task file is a `*.md`
-// inside a corpus root, or anywhere in the SUBTREE of a directory named `tasks`
-// at most MAX_DEPTH levels below it. Two walkers in two repos can drift on which
-// files they even see; the defence against that is not this comment but the
-// per-corpus task counts pinned cloud-side, which go red the moment the two
-// disagree.
-//
-// What the subtree rule must NOT swallow is the `README.md` / `VERIFICATION.md`
-// files sitting beside `agent-examples/<agent>/tasks` — a plain recursive `*.md`
-// walk books them as tasks and inflates a pinned denominator with files carrying
-// no criteria. They stay out because their directory is neither a corpus root nor
-// under a `tasks/`.
+// Task files must declare a class the runner knows.
 
 import { readdirSync } from "node:fs";
 import { basename, join } from "node:path";
 
-// Both corpora, the same list pome-cloud's `DEFAULT_TASK_CORPORA` carries.
 const CORPORA = ["cli/tasks", "agent-examples"];
 const MAX_DEPTH = 3;
 const SKIP_DIRS = new Set([".git", "node_modules", "dist", "build", "coverage"]);
 
 export const TASK_CLASSES = ["conformance", "restraint", "adversarial"];
 
-// The EXAM half. Named here rather than derived as "not conformance" so that a
-// fourth class arriving later has to state which side it falls on.
 export const EXAM_CLASSES = ["restraint", "adversarial"];
 
 function collectTaskFiles(dir, depth = 0, inTasks = basename(dir) === "tasks", out = []) {
@@ -55,8 +20,6 @@ function collectTaskFiles(dir, depth = 0, inTasks = basename(dir) === "tasks", o
   } catch {
     return out;
   }
-  // The root itself always counts, so an override pointed at a directory whose
-  // name is not `tasks` still resolves.
   if (depth === 0 || inTasks) {
     for (const entry of entries) {
       if (entry.isFile() && entry.name.endsWith(".md")) out.push(join(dir, entry.name));
@@ -71,10 +34,6 @@ function collectTaskFiles(dir, depth = 0, inTasks = basename(dir) === "tasks", o
   return out;
 }
 
-// The `## Config` fence, as a block of text. Deliberately NOT a YAML parse: this
-// rule has to report on a file the YAML parser would throw on, and the twins
-// runtime parser (`cli/src/task/parseTask.ts`) is the one that owns rejecting
-// malformed config.
 const CONFIG_SECTION_RE = /^##\s+config\s*$/im;
 
 export function extractConfigSection(markdown) {
@@ -88,7 +47,6 @@ export function extractConfigSection(markdown) {
 
 const CLASS_LINE_RE = /^\s*class\s*:\s*(\S+)\s*$/im;
 
-/** The declared class, or null when the file declares none. */
 export function extractTaskClass(markdown) {
   const config = extractConfigSection(markdown);
   if (config == null) return null;

--- a/scripts/lint/rules/task-class.test.mjs
+++ b/scripts/lint/rules/task-class.test.mjs
@@ -1,13 +1,8 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Case 5 is why this table exists rather than a "it went green once" note. The
-// rule's whole job is to refuse a task that declares no class — and the cheapest
-// way for it to stop doing that job is for the WALK to stop finding the file,
-// not for the check to break. A rule that scans nothing prints the same success
-// line as a rule that scanned everything. So the table asserts the zero-file
-// case is RED, and that a task nested one level deeper than `tasks/` is still
-// seen.
+// Case table for task-class. Every case asserts the RED direction: a rule that has
+// quietly stopped failing prints the same line as one with nothing to report.
 
 import { defineCases } from "../harness.mjs";
 
@@ -67,16 +62,12 @@ defineCases("task-class", [
     contains: "cli/tasks/01-a.md",
   },
   {
-    // The failure mode a passing rule cannot distinguish itself from.
     name: "a corpus that resolves to zero task files is RED, not green",
     files: { "README.md": "# not a corpus\n" },
     expect: "red",
     contains: "Refusing to pass a zero-file scan",
   },
   {
-    // The walk, asserted rather than assumed. `agent-examples/<agent>/tasks/<file>.md`
-    // is two levels down; a walker that only looked at direct children of the
-    // corpus root would silently exempt every example task.
     name: "an example task two levels below the corpus root is seen",
     files: {
       "cli/tasks/01-a.md": task("conformance"),
@@ -86,10 +77,6 @@ defineCases("task-class", [
     contains: "agent-examples/agent/tasks/01-unlabelled.md",
   },
   {
-    // The walker gap from the other side: a task nested UNDER a `tasks/`
-    // directory must still be seen. `collectTaskFiles` reads `.md` at depth 0 or
-    // in any directory literally named `tasks`, so a `tasks/<topic>/`
-    // subdirectory is a live way to leave the corpus.
     name: "a task in a subdirectory of `tasks/` is seen",
     files: {
       "cli/tasks/01-a.md": task("conformance"),
@@ -99,8 +86,6 @@ defineCases("task-class", [
     contains: "cli/tasks/github/01-unlabelled.md",
   },
   {
-    // A README sitting beside the tasks is not a task. Counting it would inflate
-    // a denominator pome-cloud pins, and it carries no criteria to classify.
     name: "a README beside the tasks is not counted as a task",
     files: {
       "agent-examples/agent/tasks/01-a.md": task("conformance"),

--- a/scripts/lint/rules/task-format-doc.mjs
+++ b/scripts/lint/rules/task-format-doc.mjs
@@ -1,45 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// The criterion grammar the authoring skill PROMISES must be the grammar the
-// parser RUNS.
-//
-// `skills/pome-author-task/references/task-format.md` is a byte-identical
-// mirror of pome-cloud's `apps/mcp/docs/task-format.md`, and pome-cloud gates
-// its own copy. Nothing gated the mirror, so it sat a whole marker keyword
-// behind while the cloud moved: the doc published a grammar under which
-// `- [code always-scored] …` is not a criterion line at all, and a line the
-// grammar does not match is skipped as prose. That is the silent criterion drop
-// this rule closes, promised to authors in writing.
-//
-// A cross-repo byte diff is not runnable from this repo's CI — the canonical
-// copy lives in another repository and this one has no checkout of it. What IS
-// runnable is the one line of the doc that IS the grammar: it must be the
-// `CRITERION_LINE_RE` literal in `cli/src/task/parseTask.ts`, character for
-// character. That regex is itself required to stay byte-identical to the hosted
-// parser's, so pinning the doc to the local parser pins it to the hosted
-// grammar too.
-//
-// Deliberately narrow. It does not check the doc's prose, its worked examples,
-// or the rest of the mirror; a gate over the whole file would be a cross-repo
-// diff wearing a disguise. It pins the claim that went stale.
+// The task-format doc must stay in step with the parser.
 
 const DOC_PATH = "skills/pome-author-task/references/task-format.md";
 const PARSER_PATH = "cli/src/task/parseTask.ts";
 
-// The doc quotes the grammar in a bare fenced block holding nothing but the
-// literal. Anchored on `/^[-*]` — the only thing in the document that opens a
-// criterion-line regex — rather than on a line number or a heading.
 const DOC_GRAMMAR_FENCE_RE = /^```\s*\n(\/\^\[-\*\][^\n]*)\n```$/m;
-// `const CRITERION_LINE_RE =` and the literal, which sits on the next line once
-// the formatter wraps it.
 const PARSER_GRAMMAR_RE = /const CRITERION_LINE_RE\s*=\s*(\/[^\n]*\/[a-z]*);/;
 
 export default {
   name: "task-format-doc",
   describe: "the skill reference quotes the criterion grammar the parser runs",
   check(ctx) {
-    // A rule that shrugs when it cannot find its subject passes for the same
-    // reason a rule over a corpus that stopped being found passes.
     const docMatch = ctx.readRel(DOC_PATH).match(DOC_GRAMMAR_FENCE_RE);
     if (!docMatch) {
       return {

--- a/scripts/lint/rules/task-format-doc.test.mjs
+++ b/scripts/lint/rules/task-format-doc.test.mjs
@@ -1,12 +1,8 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Cases 3 and 4 are why this table exists rather than a "it went green once"
-// note. The rule reads its two subjects out of two files by regex, and the
-// cheapest way for it to stop doing its job is for one of those regexes to stop
-// MATCHING — a doc that reformatted its fence, or a parser whose constant was
-// renamed. Either would leave the rule with nothing to compare and, without
-// these cases, nothing to say about it. So both are asserted RED.
+// Case table for task-format-doc. Every case asserts the RED direction: a rule that has
+// quietly stopped failing prints the same line as one with nothing to report.
 
 import { defineCases } from "../harness.mjs";
 

--- a/scripts/lint/rules/twin-chunks.mjs
+++ b/scripts/lint/rules/twin-chunks.mjs
@@ -1,49 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// The rule that makes "each twin is a lazily-loaded chunk" a fact rather than a
-// comment.
-//
-// `cli/tsup.config.ts` and `cli/src/twin/registry.ts` both claim it, and
-// CHANGELOG 0.21.0 shipped it as a headline. It was false for three of the five
-// twins for five releases: five modules under `cli/src/task/` top-level-imported
-// the PACKAGE ROOT of twin-github/gmail/linear to reach a zod seed schema, and
-// each of those roots also exports the twin's domain, its SQLite schema and its
-// Hono app — so `pome --version` parsed ~600 KB of three twins' servers. Nothing
-// failed; the claim just stopped being true, quietly, and was found by an audit
-// rather than by CI.
-//
-// The rule is structural, so it cannot drift as twins grow:
-//
-//   The CLI's STATIC import graph must not reach any twin's package root
-//   (`src/index.ts`), its database module (`src/db.ts`), or anything under
-//   `src/domain/`. A twin's domain is reached through `import()` inside
-//   `TWIN_REGISTRY`'s own methods — nowhere else.
-//
-// and the complement is asserted too, because the cheap way to pass a laziness
-// rule is to break a command:
-//
-//   Every twin's `src/checks.ts` MUST stay statically reachable. `pome checks`
-//   lists, looks up and digests the declared vocabulary synchronously; deferring
-//   it behind `import()` would move the cost, not remove it, and would turn
-//   `findCheck`/`twinOf` async for no gain.
-//
-// Dependency-free and build-free on purpose: it reads TypeScript sources and the
-// twins' real `exports` maps, so it runs before `npm ci` and cannot disagree with
-// the bundler about which subpath resolves where.
+// A twin's declared check vocabulary must stay statically analysable; moving it
+// behind `import()` relocates the cost rather than removing it.
 
 import { existsSync, readdirSync } from "node:fs";
 import { join, relative } from "node:path";
 
-// The import lexer and the graph walk are shared with `twin-leaves` and
-// `route-inputs` — rules asking reachability questions about the same graph must
-// not hold two opinions about what a type-only import is.
 import { buildSpecifierMap, chainFor, reachable } from "../../lib/static-import-graph.mjs";
 
 const CLI_ENTRY = "cli/src/cli/main.ts";
 
-/** Reaching any of these means the twin's whole server came along: `index.ts` is
- *  the barrel that exports it, `db.ts` is the SQLite schema, `domain/` is the
- *  state machine. Every other twin module worth deferring hangs off one of them. */
 function domainViolation(rel, twinDirs) {
   for (const dir of twinDirs) {
     const prefix = `packages/${dir}/`;
@@ -67,8 +33,6 @@ export default {
       ? readdirSync(packagesDir).filter((dir) => dir.startsWith("twin-"))
       : [];
 
-    // A rule that silently passes on an empty tree reads as coverage it does not
-    // have.
     if (twinDirs.length === 0) throw new Error(`No packages/twin-* found under ${ctx.root}.`);
     if (!ctx.exists(CLI_ENTRY)) throw new Error(`CLI entry not found: ${CLI_ENTRY}.`);
 
@@ -86,7 +50,6 @@ export default {
       );
     }
 
-    // The cheap way to pass a laziness rule is to break `pome checks`.
     for (const dir of twinDirs) {
       const checks = join(packagesDir, dir, "src/checks.ts");
       if (!existsSync(checks) || importedBy.has(checks)) continue;

--- a/scripts/lint/rules/twin-chunks.test.mjs
+++ b/scripts/lint/rules/twin-chunks.test.mjs
@@ -1,21 +1,11 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// The rule exists because a laziness claim went five releases without anyone
-// checking it, so the thing most worth proving is that it CAN go red — and goes
-// red on the exact shapes that shipped: an indirect chain through two CLI
-// modules (how `parseTask.ts` did it), and a package-root import for a value that
-// a leaf subpath already exports.
-//
-// Cases 5 and 6 guard the two ways a rule like this quietly stops working: a
-// scaffold's template-literal source counted as a real edge (false red, and the
-// rule gets deleted), and a type-only import counted as a runtime edge (same).
+// Case table for twin-chunks. Every case asserts the RED direction: a rule that has
+// quietly stopped failing prints the same line as one with nothing to report.
 
 import { defineCases } from "../harness.mjs";
 
-/** A minimal twin: a package root that re-exports domain + seed, a db module, a
- *  domain module, a zod-free `seed.ts` leaf, and a `checks.ts` the rule requires
- *  to stay reachable. */
 function twin(name) {
   const dir = `packages/twin-${name}/`;
   return {
@@ -135,8 +125,6 @@ defineCases("twin-chunks", [
     contains: "SQLite schema",
   },
   {
-    // A rule that silently passes on an empty tree reads as coverage it does not
-    // have — so an empty `packages/` is RED, not green.
     name: "a tree with no twins at all is RED, not green",
     files: { [MAIN]: `export const x = 1;\n` },
     expect: "red",

--- a/scripts/lint/rules/twin-leaves.mjs
+++ b/scripts/lint/rules/twin-leaves.mjs
@@ -1,71 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// The rule that keeps the twin modules OTHER RUNTIMES import loadable by them.
-//
-// pome-cloud's `tools/fidelity-watch` runs under BUN, and several of its suites
-// read declarations straight out of a pome-twins checkout — the stripe tool
-// table for `isMutatingTool`, github's and slack's 501 envelopes, linear's
-// GraphQL schema. Bun implements no `node:sqlite`. `packages/sdk/src/db.ts` opens
-// with `import { DatabaseSync } from "node:sqlite"`, and the sdk's ROOT barrel
-// re-exports `openTwinDatabase` from it — so one import of `@pome-sh/sdk` (rather
-// than a leaf subpath) puts the whole engine's SQLite driver on the module-load
-// path of a file whose own dependencies are zod and a JSON fixture.
-//
-// That is exactly what the fixture move did: every twin's tool table sits on a
-// shared, dependency-free loader (`packages/sdk/src/mcp-tool-fixture.ts`, no
-// imports at all) and each twin reached it through the barrel. The twins' own
-// suites run on Node, where `node:sqlite` exists, so all of them stayed green;
-// pome-cloud's daily fidelity-watch cron went red the next morning with
-// `error: No such built-in module: node:sqlite`, in a repo the change had not
-// touched.
-//
-// The rule is structural, so it cannot drift as twins grow:
-//
-//   No module in ENTRIES may statically reach a builtin that non-Node runtimes
-//   do not implement. ENTRIES is every twin's MCP tool table (found by looking
-//   for the fixture loader call, so a new twin is covered with no hand edit) plus
-//   CROSS_RUNTIME_LEAVES, the named modules pome-cloud imports directly.
-//
-// A twin's SERVER is deliberately out of scope: `src/index.ts`, `src/db.ts` and
-// `src/twin.ts` ARE the SQLite-backed engine, and nothing loads them anywhere but
-// Node. This rule is about the declaration leaves, which have no business
-// dragging a database driver behind them in any runtime.
+// Cross-runtime leaves must exist; one that does not is a comparison silently dropped.
 
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 import { buildSpecifierMap, chainFor, reachable } from "../../lib/static-import-graph.mjs";
 
-/**
- * Builtins a twin declaration leaf may not reach. Keyed by module specifier,
- * valued by the reason, which is printed on failure — a rule whose message does
- * not say which runtime broke gets "fixed" by adding an exception.
- */
 const OFF_LIMITS_BUILTINS = new Map([
   ["node:sqlite", "bun implements no `node:sqlite`, and pome-cloud's fidelity-watch runs under bun"],
 ]);
 
-/**
- * Twin modules pome-cloud imports directly, beyond the tool tables found below.
- * Taken from its real import sites (`tools/fidelity-watch`, via `twinModule()`);
- * pome-cloud's own `lint-twin-imports` gate is what keeps that list honest on its
- * side. A listed path that does not exist is a hard failure, not a skip — a stale
- * entry silently covering nothing is how this rule would stop working.
- */
 const CROSS_RUNTIME_LEAVES = [
-  // `sandboxes/stripe/level2.test.ts` — `isMutatingTool`.
   "packages/twin-stripe/src/tools.ts",
-  // `lint-twin-namespace.test.ts` — the frozen 501 envelopes.
   "packages/twin-github/src/unsupported-envelope.ts",
   "packages/twin-slack/src/unsupported-envelope.ts",
   "packages/twin-stripe/src/errors.ts",
-  // `twin-linear-schema.ts` — `linearGraphQLSchema`.
   "packages/twin-linear/src/graphql/schema.ts",
 ];
 
-/** The fixture loader call. A module that makes it IS a twin's MCP tool table,
- *  whatever the file is named (`tools.ts` on github/slack/stripe, `mcp.ts` on
- *  gmail/linear). */
 const TOOL_TABLE_MARKER = "loadMcpToolFixture(";
 
 export default {
@@ -80,7 +33,6 @@ export default {
       : [];
     if (twinDirs.length === 0) throw new Error(`No packages/twin-* found under ${ctx.root}.`);
 
-    // Each twin's tool-table module(s), discovered rather than listed.
     const toolTables = [];
     const twinsWithNoToolTable = [];
     for (const dir of twinDirs) {
@@ -91,10 +43,6 @@ export default {
       else toolTables.push(...found);
     }
 
-    // The cheap way to pass a reachability rule is to remove the thing it walks.
-    // Every first-party twin derives its tool table from a fixture; a twin that
-    // no longer calls the loader has either regressed to a hand-written table or
-    // renamed the loader, and either way this rule just stopped checking it.
     if (twinsWithNoToolTable.length > 0) {
       throw new Error(
         `${twinsWithNoToolTable.length} twin(s) have no module calling \`${TOOL_TABLE_MARKER}\`, so this ` +
@@ -116,9 +64,6 @@ export default {
     const specifiers = buildSpecifierMap(ctx.root);
     const violations = [];
 
-    // Walked one entry at a time on purpose: a shared walk would report the chain
-    // through whichever entry happened to reach the builtin first, and the useful
-    // output here is "THIS module pome-cloud imports cannot load, by THIS route".
     for (const entry of entries) {
       const { importedBy, external } = reachable([entry], specifiers);
       for (const edge of external) {

--- a/scripts/lint/rules/twin-leaves.test.mjs
+++ b/scripts/lint/rules/twin-leaves.test.mjs
@@ -1,16 +1,11 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Cases 5, 6 and 8–10 are the ones that matter. 5 and 6 guard the lexer (a
-// type-only import counted as a runtime edge is a false red that gets the rule
-// deleted; an import BELOW a statement that the lexer swallows is a false
-// green). 8–10 guard the cheap ways a reachability rule stops working: the twin
-// stops calling the loader, a named leaf moves, or the tree has nothing in it.
+// Case table for twin-leaves. Every case asserts the RED direction: a rule that has
+// quietly stopped failing prints the same line as one with nothing to report.
 
 import { defineCases } from "../harness.mjs";
 
-/** A minimal sdk: a root barrel that re-exports the `node:sqlite` driver (the
- *  real shape), plus the dependency-free fixture loader on its own subpath. */
 const SDK = {
   "packages/sdk/package.json": JSON.stringify({
     name: "@pome-sh/sdk",
@@ -39,8 +34,6 @@ const CLEAN_TABLE = [
   `export const fixture = loadMcpToolFixture({});`,
 ].join("\n");
 
-/** A minimal twin. The domain module exists so the twin has something worth NOT
- *  reaching. */
 function twin(name, toolTable = CLEAN_TABLE) {
   const dir = `packages/twin-${name}/`;
   return {
@@ -53,8 +46,6 @@ function twin(name, toolTable = CLEAN_TABLE) {
   };
 }
 
-/** The named CROSS_RUNTIME_LEAVES the rule insists exist. Kept trivially clean
- *  so a case only ever fails on the thing it is about. */
 const LEAVES = {
   "packages/twin-github/src/unsupported-envelope.ts": `export const unsupportedEnvelope = { body: {} };\n`,
   "packages/twin-slack/src/unsupported-envelope.ts": `export const unsupportedEnvelope = { body: {} };\n`,
@@ -62,10 +53,6 @@ const LEAVES = {
   "packages/twin-linear/src/graphql/schema.ts": `export const linearGraphQLSchema = "type Query { a: Int }";\n`,
 };
 
-/** `CROSS_RUNTIME_LEAVES` names `packages/twin-stripe/src/tools.ts` and every
- *  twin needs a tool table, so a tree always carries the five real twin dirs.
- *  `overrides` replaces any of them; a key mapped to `undefined` is dropped, to
- *  express "this file does not exist". */
 function tree(overrides = {}) {
   const files = { ...SDK };
   for (const name of ["github", "gmail", "linear", "slack", "stripe"]) Object.assign(files, twin(name));

--- a/scripts/lint/rules/workspace-pins.mjs
+++ b/scripts/lint/rules/workspace-pins.mjs
@@ -1,47 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// One workspace member's `@pome-sh/*` pin must not disagree with the version of
-// the sibling it names.
-//
-// npm workspaces only SYMLINK a sibling when the declared pin is satisfied by
-// that sibling's version. When it is not, npm quietly installs a REAL nested
-// copy from the registry, and every build, test and typecheck for that package
-// runs against the published artifact instead of the tree in front of you.
-//
-// That is not hypothetical. At `45b5f06`, `packages/twin-slack` declared
-// `@pome-sh/sdk` 0.5.1 against a workspace holding 0.9.0, so
-// `packages/twin-slack/node_modules/@pome-sh/sdk` was a real directory
-// containing the published 0.5.1 — five minors behind — and had been for months.
-// CI was green throughout, because everything it ran for twin-slack genuinely
-// passed against a five-month-old sdk. `twin-github`, whose pin matched, had no
-// nested copy at all. Nothing compared the two. It surfaced only when a caller
-// imported a subpath 0.5.1 does not export; a change that had merely CHANGED
-// behaviour rather than added an export would have been tested against the wrong
-// artifact in silence.
-//
-// NOT in scope: `agent-examples/*`. Those are standalone npm packages with their
-// own lockfiles that install from the REGISTRY on purpose, so "must resolve to
-// the workspace" is the wrong rule for them and applying it here would red a
-// deliberate pin. `check-example-pins-published.mjs` is their half.
-//
-// THE RULE — a pin must be `"*"` / `workspace:*` (always a workspace link) OR an
-// exact semver that EQUALS the sibling's workspace version. Stated the useful
-// way: `npm ci` must produce a symlink, never a nested install.
-//
-// This is one notch LOOSER than the prose rule in AGENTS.md ("Never reintroduce
-// an exact version pin between them"), which admits no exact pin at all. Every
-// internal pin in the tree is `"*"` today, so the tolerance is unused;
-// tightening onto the prose rule would delete the version-comparison branch
-// below entirely. That is the packages-sibling contract to change, not this one.
+// Internal `@pome-sh/*` deps are `"*"`; an exact pin between siblings installs a
+// second registry copy and you get two zod identities. Reads the root `workspaces`
+// field rather than its own package list, so `cli/` cannot fall out of scope.
 
 import { loadWorkspaceMembers } from "../../lib/workspace-members.mjs";
 
 const EXACT_VERSION = /^\d+\.\d+\.\d+$/;
 const SCOPE = "@pome-sh/";
 
-// `optionalDependencies` is a real install field, not a comment: npm resolves it
-// exactly like `dependencies` and only tolerates a FAILED install, so a stale
-// exact pin there installs a nested registry copy just as silently.
 const PIN_FIELDS = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"];
 
 export function findPinViolations(repoRoot) {
@@ -54,22 +21,8 @@ export function findPinViolations(repoRoot) {
       for (const [dep, pin] of Object.entries(manifest[field] ?? {})) {
         if (!dep.startsWith(SCOPE)) continue;
         const sibling = manifests.get(dep);
-        // A `@pome-sh/*` dep naming no workspace member is out of scope: nothing
-        // in this tree could satisfy it, so npm installing from the registry is
-        // the only possible and the correct behaviour.
         if (!sibling) continue;
-        // `"*"` (and `workspace:*`) always resolves to the local sibling via npm
-        // workspaces, so it cannot silently pull a nested registry copy.
         if (pin === "*" || pin === "workspace:*") continue;
-        // EVERY OTHER FORM IS REFUSED ON LEGIBILITY, not because each one would
-        // resolve from the registry — some would not. `file:`/`link:` to a
-        // sibling directory produce a link and cannot reach a registry at all,
-        // and a `^`/`~`/`>=` range that happens to admit the sibling's current
-        // version resolves to the workspace today. What none of them do is
-        // GUARANTEE it tomorrow: the range stops admitting the sibling on its
-        // next bump, and `file:` re-encodes a path npm workspaces already knows,
-        // so it drifts on the next directory move. `"*"` is the only form that
-        // cannot express a version at all, which is why it is the rule.
         if (!EXACT_VERSION.test(pin)) {
           violations.push(
             `${label} (${manifest.name}): ${field}.${dep} is "${pin}" — @pome-sh/* pins must be exact semver, "*", or "workspace:*"`,

--- a/scripts/lint/rules/workspace-pins.test.mjs
+++ b/scripts/lint/rules/workspace-pins.test.mjs
@@ -1,25 +1,8 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Regression suite for `workspace-pins.mjs`, extended to
-// cover `cli/`.
-//
-// Every internal `@pome-sh/*` dep, cli's included, is a workspace-resolved
-// `"*"`, which npm always symlinks — so the "stale pin passes CI, breaks on
-// publish" shape this gate is named for cannot recur through `cli/` while that
-// holds. What CAN recur is that property being silently undone: nothing stops
-// `cli/package.json` from reintroducing an exact pin. So the gate reads the root
-// `workspaces` field rather than keeping its own `packages/*` list, which is why
-// case 7 (a `packages/*` package pinning a stale `@pome-sh/cli`) reds and case 8
-// asserts that field still names `cli`. Every other case runs against a fixture
-// with its own root manifest, so the gate is proven to fire on the shape rather
-// than trusted to — but no fixture can prove it is aimed at the real tree.
-//
-// The failure class through `agent-examples/*`'s deliberately-published pins is a
-// different rule (needs the registry, tolerates a pin equal to a version that
-// simply has not published yet) and is NOT this suite's subject — see
-// `scripts/check-example-pins-published.mjs` and its own regression
-// suite, wired from `scripts/gate-examples.mjs`.
+// Case table for workspace-pins. Every case asserts the RED direction: a rule that has
+// quietly stopped failing prints the same line as one with nothing to report.
 
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -27,11 +10,6 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { findPinViolations } from "./workspace-pins.mjs";
 
-/** Build a throwaway repo with the real root `workspaces` field the gate reads:
- * packages/<dir>/package.json for each entry, plus a cli/package.json (always
- * written, defaulting to a clean `"*"`-only manifest — the gate is entitled to
- * assume a declared workspace exists, and case 6 covers the case where it does
- * not). */
 function fixture(packageManifests, cliManifest) {
   const root = mkdtempSync(join(tmpdir(), "workspace-pins-"));
   writeFileSync(
@@ -58,9 +36,6 @@ function fail(name, detail) {
   console.error(`✗ ${name}\n  ${detail}`);
 }
 
-/** `mustSay` is asserted against the joined violations: a gate that reds for the
- * wrong reason, or that names one of the two versions and not the other, is not
- * the gate it claims to be. */
 function expectGate(name, root, expected, mustSay = []) {
   const violations = findPinViolations(root);
   const got = violations.length === 0 ? "green" : "red";
@@ -87,7 +62,6 @@ function expectThrows(name, root) {
   fail(name, "returned a verdict instead of throwing");
 }
 
-// 1. `"*"` everywhere (this repo's actual shape) is clean, in packages/ and cli/.
 expectGate(
   "1. every pin is \"*\" — packages and cli",
   fixture(
@@ -104,8 +78,6 @@ expectGate(
   "green",
 );
 
-// 2. An exact pin that matches the sibling's version is still allowed (the
-// existing packages/* rule, unchanged by this extension).
 expectGate(
   "2. exact pin matching the sibling's version stays green",
   fixture({
@@ -119,7 +91,6 @@ expectGate(
   "green",
 );
 
-// 3. The original shape: a packages/* sibling pins a stale exact version.
 expectGate(
   "3. packages/* pin behind the workspace sibling reds (the original case)",
   fixture({
@@ -134,11 +105,6 @@ expectGate(
   ["packages/twin-slack", "0.5.1", "0.9.0"],
 );
 
-// 4. The cli regression this file exists for: `cli/package.json` pins an
-// exact, stale version of a sibling instead of "*" — the shape a
-// `packages/`-only scan could not see. `@pome-sh/wire`'s workspace version
-// carries `parent_event_id` (0.14.0); a cli pinned to the older vocabulary line
-// (0.13.x) is the drift this case reproduces.
 expectGate(
   "4. cli/package.json reintroducing a stale exact pin reds (the cli regression)",
   fixture(
@@ -149,13 +115,6 @@ expectGate(
   ["cli", "0.13.4", "0.14.0"],
 );
 
-// 4b. Every other way a pin can be reintroduced is refused by the same rule, in
-// every install field: a caret/tilde/range, a `file:`/`link:` path, a `npm:`
-// alias, a dist-tag, a prerelease. Not because each one would resolve from the
-// registry — `file:`/`link:` cannot, and `>=0.13.0` admits the sibling's current
-// 0.14.0 — but because none of them keeps doing so across the sibling's next
-// bump or directory move. `"*"` is the only form with no version in it at all.
-// `optionalDependencies` resolves like `dependencies`, so it is scanned too.
 for (const pin of [
   "^0.14.0",
   "~0.14.0",
@@ -188,19 +147,12 @@ expectGate(
   "red",
 );
 
-// 5. A `@pome-sh/*` cli dep with no sibling under packages/ (e.g. a future
-// published-only dependency) is out of this gate's scope either way.
 expectGate(
   "5. cli dep with no packages/ sibling is out of scope",
   fixture({}, { name: "@pome-sh/cli", version: "0.23.19", devDependencies: { "@pome-sh/other": "1.0.0" } }),
   "green",
 );
 
-// 6. A workspace the root DECLARES but that has no manifest on disk must throw,
-// not report a pass over what it did find. The old shape guarded `cli/` with
-// `existsSync` and printed "every pin in packages/ and cli/ matches" either way,
-// so relocating the CLI a third time would have silently reverted the gate to
-// packages-only with nothing red.
 {
   const root = mkdtempSync(join(tmpdir(), "workspace-pins-"));
   writeFileSync(
@@ -210,11 +162,6 @@ expectGate(
   expectThrows("6. a declared workspace with no manifest anywhere throws", root);
 }
 
-// 7. `cli` is a workspace member, so it is a SIBLING as well as a consumer: a
-// `packages/*` package pinning a stale `@pome-sh/cli` would get a nested
-// registry copy of the published CLI just as it would for the sdk. The
-// hardcoded-list shape treated `cli` as a consumer only and waved this through
-// as "no sibling in packages/, out of scope".
 expectGate(
   "7. a packages/* package pinning a stale @pome-sh/cli reds — cli is a sibling too",
   fixture(
@@ -231,11 +178,6 @@ expectGate(
   ["packages/twin-github", "0.23.18", "0.23.19"],
 );
 
-// 8. The real repo, not a fixture. Every case above proves the LOGIC; this is
-// the one that proves the logic is pointed at `cli/`, since the whole
-// cli-coverage claim rests on `cli` still being a root workspace — drop it from
-// that field and the gate stops scanning it while every fixture case above stays
-// green, because each fixture writes its own root manifest.
 {
   const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
   const workspaces = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8")).workspaces;

--- a/scripts/lint/rules/workspace-pins.test.mjs
+++ b/scripts/lint/rules/workspace-pins.test.mjs
@@ -4,22 +4,16 @@
 // Regression suite for `workspace-pins.mjs`, extended to
 // cover `cli/`.
 //
-// A 2026-08-03 failure was investigated where the CLI's build typechecked
-// against a `@pome-sh/shared-types` version behind what `packages/` (and its
-// own source) actually used — a pin that had drifted out from under it. That
-// specific architecture (`cli-ci.yml`, `use-local-pome-tarballs.mjs`, an exact
-// registry pin in `cli/package.json`) was deleted across `6369379` (#237) and
-// `a3c9441` (#239) the day AFTER the ticket was filed: every
-// internal `@pome-sh/*` dep, cli's included, became a workspace-resolved `"*"`,
-// which npm always symlinks — so the specific "stale pin passes CI, breaks on
-// publish" shape this gate is named for cannot recur through `cli/` today. What
-// CAN recur is the thing #239 fixed being silently undone: nothing stopped
-// `cli/package.json` from reintroducing an exact pin, because this gate held its
-// own `packages/*` list. It now reads the root `workspaces` field instead, which
-// is why case 7 (a `packages/*` package pinning a stale `@pome-sh/cli`) reds and
-// case 8 asserts that field still names `cli` — every other case runs against a
-// fixture with its own root manifest, so the gate is proven to fire on the shape
-// rather than trusted to, but no fixture can prove it is aimed at the real tree.
+// Every internal `@pome-sh/*` dep, cli's included, is a workspace-resolved
+// `"*"`, which npm always symlinks — so the "stale pin passes CI, breaks on
+// publish" shape this gate is named for cannot recur through `cli/` while that
+// holds. What CAN recur is that property being silently undone: nothing stops
+// `cli/package.json` from reintroducing an exact pin. So the gate reads the root
+// `workspaces` field rather than keeping its own `packages/*` list, which is why
+// case 7 (a `packages/*` package pinning a stale `@pome-sh/cli`) reds and case 8
+// asserts that field still names `cli`. Every other case runs against a fixture
+// with its own root manifest, so the gate is proven to fire on the shape rather
+// than trusted to — but no fixture can prove it is aimed at the real tree.
 //
 // The failure class through `agent-examples/*`'s deliberately-published pins is a
 // different rule (needs the registry, tolerates a pin equal to a version that

--- a/scripts/lint/rules/workspace-pins.test.mjs
+++ b/scripts/lint/rules/workspace-pins.test.mjs
@@ -60,7 +60,7 @@ function fail(name, detail) {
 
 /** `mustSay` is asserted against the joined violations: a gate that reds for the
  * wrong reason, or that names one of the two versions and not the other, is not
- * the gate the PR describing it claims. */
+ * the gate it claims to be. */
 function expectGate(name, root, expected, mustSay = []) {
   const violations = findPinViolations(root);
   const got = violations.length === 0 ? "green" : "red";
@@ -135,11 +135,10 @@ expectGate(
 );
 
 // 4. The cli regression this file exists for: `cli/package.json` pins an
-// exact, stale version of a sibling instead of "*" — the exact shape #239
-// deleted from `cli/` and that this gate's `packages/`-only scan could not see
-// come back. `@pome-sh/wire`'s workspace version carries `parent_event_id`
-// (0.14.0); a cli pinned to the older vocabulary line (0.13.x) is the 2026-08-03
-// incident's own version numbers.
+// exact, stale version of a sibling instead of "*" — the shape a
+// `packages/`-only scan could not see. `@pome-sh/wire`'s workspace version
+// carries `parent_event_id` (0.14.0); a cli pinned to the older vocabulary line
+// (0.13.x) is the drift this case reproduces.
 expectGate(
   "4. cli/package.json reintroducing a stale exact pin reds (the cli regression)",
   fixture(

--- a/scripts/mcp/openapi-specs.sh
+++ b/scripts/mcp/openapi-specs.sh
@@ -1,16 +1,4 @@
 #!/usr/bin/env bash
-# Launcher for the `openapi-specs` MCP server, invoked by the committed
-# .mcp.json at the repo root (F-1118).
-#
-# openapi-spec-mcp (pome-sh/openapi-spec-mcp) is a PRIVATE repo, so it can't
-# be referenced by a relative in-repo path the way it references itself.
-# Instead this script clones/refreshes it into a local cache on first use
-# and execs its committed server/dist/cli.mjs from there.
-#
-# Failure mode matters: if the caller (e.g. an unauthenticated CI runner)
-# can't reach the private repo, we must NOT silently start a tool-less
-# session. We print a clear error to stderr and exit non-zero so Claude
-# Code surfaces this server as failed to start.
 set -euo pipefail
 
 REPO_URL="${POME_OPENAPI_MCP_REPO_URL:-git@github.com:pome-sh/openapi-spec-mcp.git}"
@@ -45,7 +33,6 @@ if [ ! -d "$CACHE_DIR/.git" ]; then
   rm -f "$clone_log"
   needs_install=1
 else
-  # Best-effort refresh. A stale cache is acceptable; a missing one is not.
   before="$(git -C "$CACHE_DIR" rev-parse HEAD 2>/dev/null || echo "")"
   git -C "$CACHE_DIR" pull --quiet --ff-only >/dev/null 2>&1 || true
   after="$(git -C "$CACHE_DIR" rev-parse HEAD 2>/dev/null || echo "")"
@@ -59,9 +46,6 @@ if [ ! -f "$cli" ]; then
   fail "expected $cli to exist after clone/refresh, but it's missing -- the upstream repo layout may have changed."
 fi
 
-# server/dist is committed, but its dependencies (@modelcontextprotocol/sdk,
-# etc.) are not vendored -- npm install still needs to run once per clone/
-# refresh so cli.mjs can resolve them.
 if [ "$needs_install" -eq 1 ] || [ ! -d "$CACHE_DIR/node_modules" ]; then
   install_log="$(mktemp)"
   if ! (cd "$CACHE_DIR" && npm install --no-audit --no-fund --quiet) >"$install_log" 2>&1; then

--- a/scripts/mint-mcp-capture-token.mjs
+++ b/scripts/mint-mcp-capture-token.mjs
@@ -1,54 +1,8 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Mint a one-shot bearer for an OAuth-gated MCP `tools/list` capture.
-//
-// ── WHY THIS IS A SCRIPT AND NOT A RUNBOOK ─────────────────────────────────
-//
-// The three grants needed are authorization-code + PKCE flows, and a
-// hand-run PKCE flow is where a runbook's accuracy goes to die: the verifier has
-// to survive between two commands, the challenge is base64url of a SHA-256 of
-// the verifier's ASCII (not of its bytes decoded), `state` has to be checked,
-// and the redirect must match the registration byte for byte. Every one of those
-// is a silent failure that looks like a bad credential. So the flow is code, the
-// code is reviewed, and the runbook is three lines long.
-//
-// ── THIS TOKEN IS NOT A SECRET TO KEEP ─────────────────────────────────────
-//
-// `scripts/capture-mcp-tools-list.mjs` is deliberately off-cron and CI runs it
-// `--check --offline`, so nothing automated ever reads these tokens. They are
-// one-shot: mint, capture, commit the golden, revoke. Storing one in a secret
-// store would buy nothing and would manufacture a lane that quietly
-// stopped running behind a page that kept publishing — because all three vendors
-// issue expiring access tokens.
-//
-// So the token is written to a 0600 file under the system temp dir and NEVER
-// printed. Printing it would put it in the terminal scrollback, the shell
-// history of whatever consumed it, and any session transcript.
-//
-// ── WHAT THE SCOPES DECIDE ─────────────────────────────────────────────────
-//
-// Not just what the token may do — WHAT THE LISTING CONTAINS. Stripe's own docs
-// removed `--tools` with "Tool permissions are now controlled by your Restricted
-// API Key", and Slack's MCP page lists its scopes per tool. So a read-only grant
-// can return a SHORTER tool list than a real examinee's agent sees, and a golden
-// captured that way makes the lane report the twin's write tools as
-// `mcp-tool-twin-only` — a CRITICAL asserting the twin invented a capability
-// that actually exists. That is a fabricated finding, the one thing the lane
-// must never produce.
-//
-// Hence `--scopes` is explicit and required-by-default rather than defaulted to
-// something safe-sounding: capture under the scope set an examinee would carry,
-// and record it. `--scopes` also makes the invariance check cheap — mint twice,
-// capture twice, diff. If the listings match, say so in the source table's
-// `configuration` and the question is closed for good.
-//
-// Usage:
-//   node scripts/mint-mcp-capture-token.mjs linear --scopes "read,write"
-//   node scripts/mint-mcp-capture-token.mjs stripe
-//   node scripts/mint-mcp-capture-token.mjs slack --client-id … --client-secret … --scopes "a,b,c"
-//
-// It prints the env var to run the capture with, and the path to read it from.
+// Mints a vendor OAuth token for a live MCP capture. Per-vendor quirks below were
+// probed, not remembered — re-probe before trusting them.
 import { createHash, randomBytes } from "node:crypto";
 import { createServer as createHttpServer } from "node:http";
 import { createServer as createHttpsServer } from "node:https";
@@ -57,15 +11,6 @@ import { chmodSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-/**
- * Per-vendor facts, all probed 2026-08-09 rather than remembered.
- *
- * `register` is null for slack because Slack's MCP page says outright: "We do
- * not support SSE-based connections or Dynamic Client Registration at this
- * time." Its `.well-known/oauth-authorization-server` confirms it — no
- * `registration_endpoint`, and `token_endpoint_auth_method` is
- * `client_secret_post`, i.e. bring your own app.
- */
 const VENDORS = {
   linear: {
     envVar: "POME_LINEAR_MCP_TOKEN",
@@ -74,16 +19,6 @@ const VENDORS = {
     register: "https://mcp.linear.app/register",
     resource: "https://mcp.linear.app/mcp",
     port: 16735,
-    // WAS `"read"`, AND THAT DEFAULT COST A GOLDEN. This file's header
-    // argues there is no safe default because the scopes decide what the
-    // LISTING contains — and then this line quietly supplied one. The capture ran
-    // `mint-mcp-capture-token.mjs linear` with no `--scopes`, got a read-only
-    // grant, and froze a golden of 36 tools without a single write in it; the
-    // fidelity lane then reported six write tools twin-linear serves as tools
-    // it had invented, against an endpoint that serves all six. Linear is the
-    // one vendor here with a real choice to make (`scopes_supported: read,
-    // write, openid, email`), so it is the one that must not have it made for
-    // it. Same treatment as slack, for the same reason.
     defaultScopes: null, // must be stated: see the header on what scopes decide
   },
   stripe: {
@@ -93,8 +28,6 @@ const VENDORS = {
     register: "https://access.stripe.com/mcp/oauth2/register",
     resource: "https://mcp.stripe.com",
     port: 16736,
-    // Stripe's metadata publishes no `scopes_supported`; its DCR response comes
-    // back with `scope: "mcp"`, which is what it grants.
     defaultScopes: "mcp",
   },
   slack: {
@@ -105,25 +38,11 @@ const VENDORS = {
     resource: "https://mcp.slack.com/mcp",
     port: 16737,
     defaultScopes: null, // must be stated: see the header on what scopes decide
-    // SLACK REFUSES AN http:// REDIRECT, INCLUDING ON LOCALHOST. Its OAuth page:
-    // "The `redirect_uri` must use HTTPS … A Redirect URL must also use HTTPS",
-    // with no localhost exception, and the examples mark `http://` and
-    // `http://…:8080` as BAD. Registering `http://127.0.0.1:…` therefore fails
-    // at app-configuration time — before any of this runs — and the error names
-    // the redirect rather than anything about MCP.
-    //
-    // So this callback is served over TLS with a throwaway self-signed cert,
-    // which is what makes `https://localhost:<port>/oauth/callback` a legal
-    // Redirect URL to register. The browser will interrupt once with a
-    // certificate warning; that is expected, and the cert is generated fresh per
-    // run into the temp dir. linear and stripe both accepted the plain-http
-    // loopback at registration (probed 2026-08-09), so they do not pay for this.
     tls: true,
     redirectHost: "localhost",
   },
 };
 
-/** A throwaway localhost cert, so the loopback callback can be served over TLS. */
 function selfSignedCert() {
   const dir = tmpdir();
   const key = join(dir, `pome-mcp-cb-key-${process.pid}.pem`);
@@ -131,7 +50,6 @@ function selfSignedCert() {
   try {
     execFileSync(
       "openssl",
-      // prettier-ignore
       ["req", "-x509", "-newkey", "rsa:2048", "-nodes", "-days", "1",
        "-keyout", key, "-out", cert, "-subj", "/CN=localhost",
        "-addext", "subjectAltName=DNS:localhost,IP:127.0.0.1"],
@@ -159,12 +77,6 @@ function parseArgv(argv) {
 
 const b64url = (buf) => buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 
-/**
- * RFC 7636 S256. The challenge is the SHA-256 of the verifier's ASCII
- * characters, base64url-encoded — hashing the base64url-DECODED bytes instead is
- * the classic silent mismatch, and the vendor answers `invalid_grant`, which
- * reads as a bad code rather than a bad challenge.
- */
 function pkce() {
   const verifier = b64url(randomBytes(32));
   return { verifier, challenge: b64url(createHash("sha256").update(verifier, "ascii").digest()) };
@@ -189,7 +101,6 @@ async function registerClient(vendor, redirectUri) {
   return { clientId: body.client_id, clientSecret: body.client_secret };
 }
 
-/** Serve exactly one callback, then stop. Returns the query it was called with. */
 function awaitCallback(vendor) {
   const { port, tls } = vendor;
   return new Promise((resolve, reject) => {
@@ -200,13 +111,6 @@ function awaitCallback(vendor) {
         return;
       }
       const err = url.searchParams.get("error");
-      // NOTHING FROM THE QUERY STRING IS REFLECTED INTO THIS PAGE. An earlier
-      // draft interpolated `error` and `error_description` into the HTML and
-      // CodeQL called it correctly (`js/reflected-xss`, high): the vendor
-      // controls those values, and a redirect crafted at this loopback port
-      // would execute in the operator's browser. Escaping would close it; not
-      // reflecting closes it and is also the better place for the message —
-      // the operator is reading the terminal, not a tab they are about to shut.
       res.writeHead(200, {
         "content-type": "text/html; charset=utf-8",
         "content-security-policy": "default-src 'none'; style-src 'unsafe-inline'",
@@ -276,9 +180,6 @@ async function main() {
     state,
     code_challenge: challenge,
     code_challenge_method: "S256",
-    // RFC 8707. Linear's metadata advertises `resource`; sending it everywhere is
-    // harmless and is what binds the token to the MCP resource rather than to the
-    // vendor's whole API.
     resource: vendor.resource,
   })) {
     authUrl.searchParams.set(k, v);
@@ -307,8 +208,6 @@ async function main() {
   });
   const body = await res.json().catch(() => ({}));
 
-  // Slack answers HTTP 200 with `{ok:false}` on failure — checking res.ok alone
-  // would hand a golden capture an `undefined` bearer and blame the vendor's 401.
   const token = body.access_token ?? body.authed_user?.access_token;
   if (!res.ok || body.ok === false || !token) {
     throw new Error(`token exchange failed (HTTP ${res.status}): ${JSON.stringify(body)}`);

--- a/scripts/mint-mcp-capture-token.mjs
+++ b/scripts/mint-mcp-capture-token.mjs
@@ -5,7 +5,7 @@
 //
 // ── WHY THIS IS A SCRIPT AND NOT A RUNBOOK ─────────────────────────────────
 //
-// The three grants this ticket needs are authorization-code + PKCE flows, and a
+// The three grants needed are authorization-code + PKCE flows, and a
 // hand-run PKCE flow is where a runbook's accuracy goes to die: the verifier has
 // to survive between two commands, the challenge is base64url of a SHA-256 of
 // the verifier's ASCII (not of its bytes decoded), `state` has to be checked,

--- a/scripts/probe-example-tools.mjs
+++ b/scripts/probe-example-tools.mjs
@@ -1,21 +1,9 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Example twin-tool probe gate.
-//
-// An example can register a tool whose endpoint answers `404` on every call, for
-// as long as the example has existed, and nothing notices — because the two
-// other example gates each stop short of a twin call:
-//
-//   scripts/gate-examples.mjs     — compiles and tests each example. A tool whose
-//     arguments are well-typed and whose endpoint 404s is green.
-//   scripts/smoke-examples.mjs     — launches each example and fails on a
-//     crash-on-load. It exits before any tool runs, deliberately, because a
-//     real run needs a model.
-//
-// This gate closes that gap without a model: boot each example's declared twins
-// in-process on the example's OWN task seed, then invoke every tool the example
-// registers once with fixture arguments and fail if the twin refused.
+// Boots each example's twins in-process on its own seeds and invokes every tool it
+// registers, so a tool whose endpoint 404s cannot stay green. Seeds are read from
+// the directory, not hand-named, or a new one lands unprobed.
 
 import { execFileSync, spawn } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, realpathSync } from "node:fs";
@@ -27,15 +15,9 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(HERE, "..");
 const DRIVER = join(HERE, "example-tool-probe-driver.mjs");
 
-/**
- * The session id the gate mints its bearer for, and the secret it signs with.
- * The twin's auth middleware rejects a JWT whose `sid` disagrees with the URL,
- * so both halves of the gate read these.
- */
 export const PROBE_SID = "probe";
 export const PROBE_SECRET = "pome-f1152-probe-gate-secret-32-chars";
 
-/** Bind port 0, read what the OS assigned, release it. */
 export async function freePort() {
   return new Promise((resolvePort, reject) => {
     const probe = createServer();
@@ -47,29 +29,6 @@ export async function freePort() {
   });
 }
 
-/**
- * Make sure `@pome-sh/wire` is built before `fn` imports a twin under plain
- * `node`.
- *
- * Every twin's runtime import chain reaches the wire contract, so nothing here
- * can `import("@pome-sh/twin-github")` until wire's `dist/` exists. ci.yml runs
- * `npm run build` before this gate, which covers it; the build below is the
- * fallback for the bare `npm run probe:examples` a developer types.
- *
- * Build only when `dist/` is ABSENT, never unconditionally: wire's build opens
- * with `rm -rf dist`, so an unconditional rebuild here briefly deletes the
- * artifact every other workspace resolves `@pome-sh/wire` through. Anything
- * running alongside this gate dies with ERR_MODULE_NOT_FOUND on
- * `@pome-sh/wire/dist/index.js` — a failure that names the wrong culprit
- * entirely. A stale dist is the caller's problem to fix with `npm run build`;
- * a missing one is what this exists for.
- *
- * This helper once also had to clean up after itself, when a workspace package
- * exported TypeScript source with no dist build and the only way to load it
- * under `node` was an in-place `.js` emit beside each `.ts` — untracked
- * files that shadowed the sources and reddened `lint:dead-code` if left behind.
- * wire builds to `dist/` like every other package, so there is nothing to undo.
- */
 export async function withWireRuntime(fn) {
   if (!existsSync(join(REPO_ROOT, "packages/wire/dist/index.js"))) {
     execFileSync("npm", ["run", "build", "-w", "@pome-sh/wire"], {
@@ -80,24 +39,6 @@ export async function withWireRuntime(fn) {
   return await fn();
 }
 
-/**
- * Hand each declared twin its slice of a task seed.
- *
- * This mirrors `cli/src/task/parseTask.ts` rather than inventing a second answer
- * to "is this seed an envelope", because two answers is how a seed silently
- * lands in the wrong world. The
- * contract there, verbatim in three parts:
- *
- *   1. Envelope-iff-multi-twin, decided from the declared twin list ALONE —
- *      "never by sniffing the seed shape". One twin ⇒ the seed is flat.
- *   2. Envelope keys are a SUBSET of the declared twins. A twin with no key
- *      falls back to its own default seed (`undefined` here, which is what
- *      `serve()` treats as "seed the default world"). A key that is not a
- *      declared twin is a loud error.
- *   3. `_meta` (source hash, model, compiled_at) is stripped before schema
- *      parsing. It is not optional politeness: the gmail twin's seed schema is
- *      strict and rejects the key outright.
- */
 export function splitSeed(seed, twinIds) {
   const stripped = stripSeedMeta(seed);
 
@@ -111,11 +52,9 @@ export function splitSeed(seed, twinIds) {
         `declare (declares: [${twinIds.join(", ")}])`,
     );
   }
-  // A declared twin with no envelope key gets `undefined` → its default world.
   return Object.fromEntries(twinIds.map((id) => [id, stripSeedMeta(stripped?.[id])]));
 }
 
-/** `stripSidecarMeta` from cli/src/task/parseTask.ts. */
 function stripSeedMeta(seed) {
   if (seed && typeof seed === "object" && !Array.isArray(seed)) {
     const { _meta, ...rest } = seed;
@@ -124,16 +63,6 @@ function stripSeedMeta(seed) {
   return seed;
 }
 
-/**
- * Fill a manifest `config` template with the URLs of the twins just booted.
- *
- * The three frameworks the examples use want different config shapes
- * (`{mcpUrl, token}`, `{ghUrl, ghToken, slackUrl, slackToken}`,
- * `{restUrl, authToken}`), so the manifest declares the shape and the parent
- * substitutes: `$<twin>.rest`, `$<twin>.mcp`, `$token`. An unresolvable token
- * is an error — a silently-undefined URL would make every probe fail for the
- * wrong reason.
- */
 export function resolveConfig(template, ctx) {
   const out = {};
   for (const [key, value] of Object.entries(template ?? {})) {
@@ -157,19 +86,6 @@ function resolveToken(token, ctx) {
   return booted[surface];
 }
 
-/**
- * Every `.seed.json` an example ships, sorted for a stable probe order.
- *
- * Read from the directory rather than hand-named per manifest entry: examples
- * ship up to 6 seeds each, so a hand-named list leaves most of them unprobed
- * and a new seed lands uncovered by construction.
- * Discovery instead of a hand-kept list is what makes a new seed covered with
- * no edit here.
- *
- * A `tasks/` directory with zero seeds is a loud failure, not an empty probe
- * set: an example whose manifest entry exists but whose seeds all got deleted
- * (or renamed) must not read as "probed nothing, still green."
- */
 export function discoverSeeds(exampleDir) {
   const tasksDir = join(exampleDir, "tasks");
   const seeds = existsSync(tasksDir)
@@ -184,19 +100,6 @@ export function discoverSeeds(exampleDir) {
   return seeds;
 }
 
-/**
- * Every top-level example directory that ships at least one `.seed.json`.
- *
- * This is the OTHER half of the totality the manifest owes: discovery covers
- * a new seed inside an already-listed example, but a brand-new example
- * directory with its own seeds and no manifest entry would still be silently
- * skipped by `runGate`'s `Object.keys(manifest)` loop. Comparing this set
- * against the manifest's keys in `runGate` is what makes that omission red
- * instead of quiet — `agent-examples/support-triage` ships no `.seed.json` at all
- * (its tasks are markdown prompts, a different format this gate does not
- * cover) and is correctly absent from both sides by construction, with no
- * exclusion list naming it.
- */
 export function discoverExamplesWithSeeds(examplesDir) {
   return readdirSync(examplesDir, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
@@ -208,34 +111,11 @@ export function discoverExamplesWithSeeds(examplesDir) {
     .sort();
 }
 
-/**
- * The first repo, PR number and issue number a seed carries, for `resolveArgs`
- * to fill probe argument templates with.
- *
- * Hand-writing six near-identical probe arg sets per viktor example
- * (one per seed) is the defect the ticket names, not a workaround for it — a
- * seventh seed would land with no probe arguments and nothing would say so.
- * Reading the subject straight off the seed means a new seed is covered by
- * construction. Only what the seed actually declares is exposed: a seed with
- * no PR (`triage-agent`) yields no `pr` bucket, and a probe template that
- * still asks for `$pr.number` fails loudly in `resolveFactToken` rather than
- * silently probing `undefined`.
- *
- * `slice` is the twin's OWN half of the seed (already run through
- * `splitSeed`), never the raw envelope — a multi-twin example's slack half has
- * no `repositories` key to read this off of.
- */
 export function deriveSeedFacts(slice) {
   const repo = slice?.repositories?.[0];
   if (!repo) return {};
   const facts = { repo: { owner: repo.owner, name: repo.name } };
   const pr = repo.pull_requests?.[0];
-  // `last_number` exists because the subject a probe wants is not always the
-  // first PR: `merge-agent`'s seed is `01-identity-spoof` and its SECOND pull
-  // request is the impersonator's, which is the one `request_changes` is
-  // interesting against. Hand-writing `2` there is what this removed; naming
-  // the last PR keeps the same subject with no per-seed number, and collapses
-  // to `number` for the 18 seeds that ship exactly one PR.
   if (pr) {
     facts.pr = {
       number: pr.number,
@@ -246,56 +126,16 @@ export function deriveSeedFacts(slice) {
   const issue = repo.issues?.[0];
   if (issue) facts.issue = { number: issue.number };
   const file = repo.files?.[0];
-  // `file.branch` when the seed names one, NOT `default_branch` unconditionally:
-  // a seed whose first file exists only on a feature branch would otherwise be
-  // probed at `path@main`, and the resulting 404 would read as "the twin refuses
-  // get_file_contents" when the truth is the gate asked for the wrong ref. All
-  // 20 seeds today happen to list a default-branch file first, which is exactly
-  // why nothing would have caught the 21st that does not.
   if (file) facts.file = { path: file.path, ref: file.branch ?? repo.default_branch };
   return facts;
 }
 
-/**
- * Whether the twin will 409 a merge of this PR, read off the seed.
- *
- * Derived, never declared per-seed by hand: `03-failing-ci` sets `ci/test` to
- * `failure` on purpose so a real GitHub blocks the merge behind branch
- * protection, and a `merge_pull_request` probe against that seed must expect the
- * 409 rather than report it as a refusal. That is a fact the seed already
- * carries — a hand-kept map from seed filename to expected status is the same
- * shape as the bug D5 is about, and it goes stale in silence when the seed is
- * renamed, deleted, or has its statuses changed.
- *
- * The condition is "the twin will refuse this merge", not "checks are failing":
- * `mergePullRequest` (packages/twin-github/src/domain/pulls.ts) 409s on THREE
- * things — a non-open PR, an already-merged one, and a `failure` combined
- * status. Only two are expressible in a seed (its PR schema has `state` but no
- * `merged`), and both are covered here, so a future seed whose first PR is
- * closed is exempt for the right reason instead of reding as a refusal.
- *
- * The status half mirrors `combinedStatusJson` in
- * packages/twin-github/src/serializers.ts, which is what `mergePullRequest`
- * reads through `latestCommitStatuses`: latest status per context, any
- * `failure`/`error` wins. A `Map` built from the array keeps the LAST entry per
- * context, and seeded statuses share a timestamp so the twin's own
- * `updated_at DESC, id DESC` ordering also resolves to last-declared-wins.
- */
 function mergeWouldConflict(pr) {
   if ((pr.state ?? "open") !== "open") return true;
   const latest = new Map((pr.statuses ?? []).map((status) => [status.context, status.state]));
   return [...latest.values()].some((state) => state === "failure" || state === "error");
 }
 
-/**
- * Fill a probe's `args` template with facts read off its own seed.
- *
- * Mirrors `resolveConfig` below, but over seed-derived facts (`$repo.owner`,
- * `$pr.number`, `$issue.number`, `$file.path`, `$file.ref`) instead of booted
- * twin URLs. A value that is not a `$`-prefixed string passes through
- * unchanged — probe text like `"pome probe."` or a slack channel id is not
- * one of the seed-derived facts above, so it stays hand-written.
- */
 export function resolveArgs(argsTemplate, facts) {
   const out = {};
   for (const [key, value] of Object.entries(argsTemplate ?? {})) {
@@ -315,25 +155,6 @@ function resolveFactToken(token, facts) {
   return bucket[field];
 }
 
-/**
- * The six ways this gate goes red. Ordered most-actionable first so a wall of
- * unprobed-tool findings never buries a real refusal.
- *
- * `refused` reads the WIRE status, never the handler's return value: the
- * AI-SDK and LangGraph examples' `gh()` / `twinFetch()` deliberately swallow a
- * 4xx and hand the model `{ok:false,status}` so one bad call cannot abort the
- * run, so `threw` is silent on exactly the failure this gate exists to catch.
- *
- * `silent-probe` is the class the LangGraph shape gap belonged to, guarded here
- * rather than fixed one framework at a time. Reading only the wire status has a
- * floor the original gate had no assertion for: NO wire call at all reduces to
- * `status = 0`, which is `< 400`, which reads as "the twin did not refuse". Every
- * probe against `agent-examples/minimal-viktor-langgraph` produced `calls: []` from the
- * day it shipped, because the driver recognised `handler`/`execute` and LangChain
- * tools expose `.invoke()` — and the gate reported OK for all of it. Adding a
- * third shape to the driver fixes that instance; asserting that every probe
- * actually reached a twin is what makes the FOURTH shape red on the day it lands.
- */
 export function evaluateProbeRun({ example, seed, probes, report }) {
   const findings = [];
   const at = (kind, tool, detail) => findings.push({ kind, example, seed, tool, detail });
@@ -369,8 +190,6 @@ export function evaluateProbeRun({ example, seed, probes, report }) {
       );
       continue;
     }
-    // Non-null: the zero-call case returned above. The `refused` branch below
-    // reads `worst.method`/`worst.url` unguarded and now genuinely can.
     const worst = observed.calls.reduce((acc, call) => (call.status > acc.status ? call : acc));
     const status = worst.status;
 
@@ -402,13 +221,6 @@ export function evaluateProbeRun({ example, seed, probes, report }) {
   return findings;
 }
 
-/**
- * Enrich each `refused` finding with the twin's own account of the call: the
- * ACTION the tool named (stamped even on a failure row, on both the
- * MCP and REST surfaces) and the error text. The wire told us a request was
- * refused; the tape tells us which twin action refused it and why, which is the
- * difference between a gate you can act on and a second thing to debug.
- */
 export function annotateFromTape(findings, events) {
   return findings.map((finding) => {
     if (finding.kind !== "refused") return finding;
@@ -437,17 +249,6 @@ const HEADLINE = {
   "driver-error": "the probe driver could not run this example",
 };
 
-/**
- * Findings whose subject is the tool TABLE, not the seed.
- *
- * An example registers the same tools on every seed it ships, so one missing
- * probe on `minimal-viktor` produces six identical `unprobed-tool` findings and
- * another six on the langgraph twin. Collapsing them to one per example per tool
- * is what keeps this function's own promise — "a wall of unprobed-tool findings
- * never buries a real refusal" — true now that the gate runs 20 seeds instead of
- * 7. Everything else (`refused`, `silent-probe`, `stale-expect`, `driver-error`)
- * really can differ seed by seed and is printed once per seed on purpose.
- */
 const SEED_INVARIANT = new Set(["unprobed-tool", "unknown-tool"]);
 
 export function formatFindings(findings) {
@@ -473,11 +274,6 @@ export function formatFindings(findings) {
         lines.push(`    args: ${JSON.stringify(detail.args)}`);
       } else {
         lines.push(`    ${finding.detail}`);
-        // Every seed-specific finding names its seed, not just `refused`. An
-        // example ships up to six seeds and a `silent-probe` or `stale-expect`
-        // on one of them is unactionable without knowing which. The
-        // seed-invariant kinds deliberately print no seed — they hold for all
-        // of them, and naming one would read as "only that one".
         if (finding.seed && !SEED_INVARIANT.has(finding.kind)) lines.push(`    seed: ${finding.seed}`);
       }
     }
@@ -496,59 +292,16 @@ function groupBy(items, key) {
   return map;
 }
 
-/**
- * Import specifier, definition export, and database opener per twin id.
- *
- * The three twins the bundled examples actually declare, and no more. The export
- * names are NOT uniform across the twin packages, so each is spelled out rather
- * than derived: the opener is `open<Name>CloneDatabase` for github but
- * `open<Name>TwinDatabase` for slack and gmail. Each opener migrates the schema
- * itself (`openTwinDatabase(path, { migrate })`), so `":memory:"` is ready to
- * serve with no separate migrate step.
- *
- * stripe and linear are deliberately absent: no bundled example declares them,
- * and both export a `create<Name>TwinDefinition()` FACTORY rather than a
- * definition constant, so they would need a different shape here. An example
- * that declares an unlisted twin gets the loud error in `probeExample`, which is
- * the right failure — a guessed export name would throw something far less
- * legible.
- */
 export const TWIN_MODULES = {
   github: { pkg: "@pome-sh/twin-github", definition: "githubTwinDefinition", open: "openGitHubCloneDatabase" },
   slack: { pkg: "@pome-sh/twin-slack", definition: "slackTwinDefinition", open: "openSlackTwinDatabase" },
   gmail: { pkg: "@pome-sh/twin-gmail", definition: "gmailTwinDefinition", open: "openGmailTwinDatabase" },
 };
 
-/**
- * The github facts a single seed yields, without booting anything.
- *
- * Shared by `probeExample` and `runGate`'s manifest checks so the second is not a
- * near-copy of the first three lines of the first.
- */
 function factsForSeed(exampleDir, seed, twinIds) {
   return deriveSeedFacts(splitSeed(JSON.parse(readFileSync(join(exampleDir, seed), "utf8")), twinIds).github);
 }
 
-/**
- * Manifest invariants that do not vary by seed, asserted once per example.
- *
- * Deliberately not in `probeExample`, which runs once per seed and only after
- * twins are booted; these belong beside `runGate`'s other totality checks,
- * before anything boots.
- *
- *   1. ONE probe per tool. `evaluateProbeRun` keys the driver's results by tool
- *      name, so two probes for the same tool would both be judged against the
- *      LAST one's result and the first one's arguments would go unchecked — the
- *      same silence this gate exists to break.
- *   2. NO DEAD EXEMPTION. `expect_status_if` is the derived replacement for a map
- *      keyed by seed filename, and it inherits one of the map's failure modes if
- *      nothing checks it: delete the seed that earns the exemption (or flip its
- *      `ci/test` back to success) and the condition is simply false everywhere,
- *      leaving a 409 exemption that can never fire and that nothing reds. The
- *      inverse — the twin stops refusing on a seed that IS blocked — is already
- *      caught as `stale-expect`. This is the other direction, and it catches both
- *      viktor copies of the exemption rather than the one a test happens to pin.
- */
 export function assertManifestEntry(name, entry, exampleDir, seeds, twinIds) {
   const duplicated = entry.probes
     .map((probe) => probe.tool)
@@ -581,15 +334,6 @@ export function assertManifestEntry(name, entry, exampleDir, seeds, twinIds) {
   }
 }
 
-/**
- * Boot every twin the example declares, run its probes, return findings.
- *
- * Twins run IN-PROCESS here (no model, no Docker, no network beyond loopback)
- * while the example's tools run in a child under the example's own `tsx`, which
- * is how a real `pome run` resolves them.
- *
- * Callers must already be inside `withWireRuntime`.
- */
 export async function probeExample(name, entry, opts) {
   const exampleDir = join(opts.examplesDir, name);
   const manifest = JSON.parse(readFileSync(join(exampleDir, "pome.json"), "utf8"));
@@ -599,22 +343,6 @@ export async function probeExample(name, entry, opts) {
   const probes = entry.probes.map((probe) => {
     try {
       const resolved = { ...probe, args: resolveArgs(probe.args, facts) };
-      // Some seeds deliberately break a tool for a REASON the seed itself
-      // encodes — `03-failing-ci` sets a failing required status check
-      // specifically so a real GitHub 409's the merge, mirroring branch
-      // protection. That is fidelity, not a defect, but it is fidelity ONE
-      // seed manufactures on purpose: a flat `expect_status` checked against
-      // every seed the example ships would misreport every OTHER seed's
-      // successful merge as a stale exemption.
-      //
-      // `expect_status_if` names the SEED FACT that earns the exemption rather
-      // than the seed filename, so the condition travels with the seed. A map
-      // keyed by filename goes stale in silence — rename or delete the seed and
-      // the entry simply stops matching — and a new seed with failing CI would
-      // have to be added to it by hand. This way both are automatic: any seed
-      // whose first PR has a failing required check expects the 409, any seed
-      // whose does not gets the ordinary refusal check, and if the twin ever
-      // stops 409ing behind a failing check the exemption reds as `stale-expect`.
       if (probe.expect_status_if !== undefined && resolveFactToken(probe.expect_status_if, facts) !== true) {
         delete resolved.expect_status;
       }
@@ -678,30 +406,12 @@ export async function probeExample(name, entry, opts) {
   }
 }
 
-/**
- * Spawn the driver in the example's tree and parse its NDJSON.
- *
- * `tsx` when the example has one (its tool table is TypeScript and resolves that
- * example's own zod / `file:`-linked adapter copies); bare `node` otherwise,
- * which is what lets the test suite drive fixture examples that ship a `.mjs`
- * tool table and need no install.
- *
- * Asynchronous on purpose. The twins serve from THIS process's event loop, so a
- * `spawnSync` here would block it and the child would wait forever on a frozen
- * server.
- */
 async function runDriver(exampleDir, spec) {
   const tsx = join(exampleDir, "node_modules", ".bin", "tsx");
   const runner = existsSync(tsx) ? tsx : process.execPath;
   return new Promise((resolveReport) => {
-    // POME_PREFLIGHT would make several examples `process.exit(0)` at import.
     const env = { ...process.env, POME_PROBE_SPEC: JSON.stringify(spec) };
     delete env.POME_PREFLIGHT;
-    // `timeout` because a tool table that hangs would otherwise block until the
-    // GitHub job timeout with no diagnostic at all — the failure would name the
-    // job, not the example. Killing the child produces the `driver-error`
-    // finding below, which names both. The whole 20-seed sweep runs in ~15s in
-    // CI, so 120s per driver is ~100x headroom.
     const child = spawn(runner, [DRIVER], {
       cwd: exampleDir,
       env,
@@ -723,8 +433,6 @@ async function runDriver(exampleDir, spec) {
         try {
           rows.push(JSON.parse(line));
         } catch {
-          // An example that logs a banner to stdout is not a failure; the
-          // driver's own rows are the only JSON we care about.
         }
       }
       const failure = rows.find((row) => row.kind === "error");
@@ -748,12 +456,6 @@ export async function runGate(opts = {}) {
   const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
   const names = Object.keys(manifest).sort();
 
-  // The other half of totality: discovery inside an example covers a new
-  // seed, but a whole new example directory with seeds and no manifest entry
-  // (or a manifest entry for a directory that ships none) would still be
-  // silently skipped by the `Object.keys(manifest)` loop below. Assert the two
-  // sets are the SAME set, named both ways, rather than letting either side
-  // win by default.
   const withSeeds = discoverExamplesWithSeeds(examplesDir);
   const missingFromManifest = withSeeds.filter((name) => !names.includes(name));
   const missingSeeds = names.filter((name) => !withSeeds.includes(name));
@@ -765,19 +467,12 @@ export async function runGate(opts = {}) {
     );
   }
 
-  // Seeds per example, discovered — never a hand-kept count. This is the
-  // denominator the "20 of 20" claim below has to actually earn: it is
-  // computed independently of the probe loop, so a loop that quietly skipped
-  // a seed would be caught by the tally at the end, not just assumed correct
-  // because it's the same variable.
   const seedsByExample = new Map(names.map((name) => [name, discoverSeeds(join(examplesDir, name))]));
   const totalSeeds = [...seedsByExample.values()].reduce((sum, seeds) => sum + seeds.length, 0);
   if (totalSeeds === 0) {
     throw new Error("discovered zero seeds across every bundled example — refusing to report a pass on nothing");
   }
 
-  // Manifest invariants, before anything boots: one probe per tool, and no
-  // exemption that no seed can satisfy.
   for (const name of names) {
     const exampleDir = join(examplesDir, name);
     const twinIds = JSON.parse(readFileSync(join(exampleDir, "pome.json"), "utf8")).twins ?? ["github"];
@@ -800,12 +495,6 @@ export async function runGate(opts = {}) {
     }
   }
 
-  // A tripwire for a FUTURE edit, not an independent tally: as written the loop
-  // above cannot skip a seed, and this is what reds if someone gives it a
-  // `continue` — a gate that exits 0 having done less than it claimed. The
-  // real per-seed assertion is `silent-probe`, which is what
-  // makes the "every registered tool was answered" line below earned rather than
-  // restated from the manifest.
   if (probedSeeds !== totalSeeds) {
     throw new Error(`probed ${probedSeeds} seed(s) but discovered ${totalSeeds} — the gate skipped some silently`);
   }
@@ -824,12 +513,6 @@ export async function runGate(opts = {}) {
   return 0;
 }
 
-// NOT `import.meta.main`: it landed in Node 24.2, root `engines` allows
-// `>=24`, and on 24.0/24.1 it is `undefined` — this guard would be false and
-// `npm run probe:examples` would exit 0 having probed nothing. Both sides
-// realpath'd, matching contract/run.mjs: node resolves symlinks before
-// deriving `import.meta.url`, so a bare argv[1] misses through a symlinked
-// checkout in the same silent shape.
 const SELF = realpathSync(fileURLToPath(import.meta.url));
 const ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";
 const invokedDirectly = ENTRY === SELF;

--- a/scripts/probe-example-tools.mjs
+++ b/scripts/probe-example-tools.mjs
@@ -1,15 +1,11 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// F-1152 example twin-tool probe gate.
+// Example twin-tool probe gate.
 //
-// `agent-examples/pr-summary-agent` and `agent-examples/pr-summary-review` each exposed
-// exactly one comment tool, `comment_on_pull_request`, wrapping
-// `add_issue_comment` at the pull request's number. The GitHub twin answered
-// `404 Issue not found` for every one of those calls, on all four subjects, for
-// as long as the examples had existed — and both examples' whole subject is
-// *did the agent leave a summary*. F-1151 fixed the twin. Nothing had noticed,
-// because the two older example gates each stop short of a twin call:
+// An example can register a tool whose endpoint answers `404` on every call, for
+// as long as the example has existed, and nothing notices — because the two
+// other example gates each stop short of a twin call:
 //
 //   scripts/gate-examples.mjs     — compiles and tests each example. A tool whose
 //     arguments are well-typed and whose endpoint 404s is green.
@@ -68,9 +64,9 @@ export async function freePort() {
  * entirely. A stale dist is the caller's problem to fix with `npm run build`;
  * a missing one is what this exists for.
  *
- * Before F-942 this helper also had to CLEAN UP after itself: shared-types
- * exported `./src/index.ts` with no dist build, so the only way to load it under
- * `node` was `build:runtime`'s in-place `.js` emit beside each `.ts` — untracked
+ * This helper once also had to clean up after itself, when a workspace package
+ * exported TypeScript source with no dist build and the only way to load it
+ * under `node` was an in-place `.js` emit beside each `.ts` — untracked
  * files that shadowed the sources and reddened `lint:dead-code` if left behind.
  * wire builds to `dist/` like every other package, so there is nothing to undo.
  */
@@ -89,7 +85,7 @@ export async function withWireRuntime(fn) {
  *
  * This mirrors `cli/src/task/parseTask.ts` rather than inventing a second answer
  * to "is this seed an envelope", because two answers is how a seed silently
- * lands in the wrong world (the failure F-987 fixed in the seed compiler). The
+ * lands in the wrong world. The
  * contract there, verbatim in three parts:
  *
  *   1. Envelope-iff-multi-twin, decided from the declared twin list ALONE —
@@ -164,10 +160,9 @@ function resolveToken(token, ctx) {
 /**
  * Every `.seed.json` an example ships, sorted for a stable probe order.
  *
- * `probe:examples` used to probe only the one seed each manifest entry
- * hand-named. `pr-summary-review` ships 3, both viktor examples ship 6 — 13 of
- * 20 seeds across the bundled examples were never probed at all, and a new
- * seed landed uncovered by construction, since nothing read the directory.
+ * Read from the directory rather than hand-named per manifest entry: examples
+ * ship up to 6 seeds each, so a hand-named list leaves most of them unprobed
+ * and a new seed lands uncovered by construction.
  * Discovery instead of a hand-kept list is what makes a new seed covered with
  * no edit here.
  *
@@ -238,7 +233,7 @@ export function deriveSeedFacts(slice) {
   // `last_number` exists because the subject a probe wants is not always the
   // first PR: `merge-agent`'s seed is `01-identity-spoof` and its SECOND pull
   // request is the impersonator's, which is the one `request_changes` is
-  // interesting against. Hand-writing `2` there is what F-1163 removed; naming
+  // interesting against. Hand-writing `2` there is what this removed; naming
   // the last PR keeps the same subject with no per-seed number, and collapses
   // to `number` for the 18 seeds that ship exactly one PR.
   if (pr) {
@@ -298,9 +293,8 @@ function mergeWouldConflict(pr) {
  * Mirrors `resolveConfig` below, but over seed-derived facts (`$repo.owner`,
  * `$pr.number`, `$issue.number`, `$file.path`, `$file.ref`) instead of booted
  * twin URLs. A value that is not a `$`-prefixed string passes through
- * unchanged — probe text like `"F-1152 probe."` or a slack channel id is not
- * "the first repo, PR number and issue number" the ticket asks to derive, and
- * stays hand-written.
+ * unchanged — probe text like `"pome probe."` or a slack channel id is not
+ * one of the seed-derived facts above, so it stays hand-written.
  */
 export function resolveArgs(argsTemplate, facts) {
   const out = {};
@@ -410,7 +404,7 @@ export function evaluateProbeRun({ example, seed, probes, report }) {
 
 /**
  * Enrich each `refused` finding with the twin's own account of the call: the
- * ACTION the tool named (F-1125 stamps it even on a failure row, on both the
+ * ACTION the tool named (stamped even on a failure row, on both the
  * MCP and REST surfaces) and the error text. The wire told us a request was
  * refused; the tape tells us which twin action refused it and why, which is the
  * difference between a gate you can act on and a second thing to debug.
@@ -463,7 +457,7 @@ export function formatFindings(findings) {
     const shown = new Set();
     for (const finding of group) {
       if (SEED_INVARIANT.has(finding.kind)) {
-        const key = `${finding.kind} ${finding.tool}`;
+        const key = `${finding.kind}\0${finding.tool}`;
         if (shown.has(key)) continue;
         shown.add(key);
       }
@@ -538,9 +532,9 @@ function factsForSeed(exampleDir, seed, twinIds) {
 /**
  * Manifest invariants that do not vary by seed, asserted once per example.
  *
- * These used to be tempting to put in `probeExample`, which runs 20 times and
- * only after twins are booted; they belong beside `runGate`'s other totality
- * checks, before anything boots.
+ * Deliberately not in `probeExample`, which runs once per seed and only after
+ * twins are booted; these belong beside `runGate`'s other totality checks,
+ * before anything boots.
  *
  *   1. ONE probe per tool. `evaluateProbeRun` keys the driver's results by tool
  *      name, so two probes for the same tool would both be judged against the
@@ -754,7 +748,7 @@ export async function runGate(opts = {}) {
   const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
   const names = Object.keys(manifest).sort();
 
-  // F-1163's other half of totality: discovery inside an example covers a new
+  // The other half of totality: discovery inside an example covers a new
   // seed, but a whole new example directory with seeds and no manifest entry
   // (or a manifest entry for a directory that ships none) would still be
   // silently skipped by the `Object.keys(manifest)` loop below. Assert the two
@@ -808,8 +802,8 @@ export async function runGate(opts = {}) {
 
   // A tripwire for a FUTURE edit, not an independent tally: as written the loop
   // above cannot skip a seed, and this is what reds if someone gives it a
-  // `continue` — a gate that exits 0 having done less than it claimed is the
-  // F-1478 shape. The real per-seed assertion is `silent-probe`, which is what
+  // `continue` — a gate that exits 0 having done less than it claimed. The
+  // real per-seed assertion is `silent-probe`, which is what
   // makes the "every registered tool was answered" line below earned rather than
   // restated from the manifest.
   if (probedSeeds !== totalSeeds) {

--- a/scripts/probe-example-tools.test.mjs
+++ b/scripts/probe-example-tools.test.mjs
@@ -124,7 +124,7 @@ assertThrows(
 }
 
 // ── deriveSeedFacts / resolveArgs ───────────────────────────────────────────
-// The load-bearing half of the ticket: probe arguments come off the seed
+// The load-bearing half: probe arguments come off the seed
 // itself, never a hand-written literal, so a sixth viktor seed needs no new
 // fixture and a repo with no PR/issue/file simply yields no bucket for it.
 {
@@ -355,7 +355,7 @@ assertThrows(
   rmSync(emptyDir, { recursive: true, force: true });
 }
 
-// ── the "Do:" acceptance test from the ticket, plus break-on-purpose ────────
+// ── the acceptance test, plus break-on-purpose ──────────────────────────────
 // "add a seed to an example. Expect: it is probed with no hand edit." — run
 // for real, against a throwaway copy of the `sound` fixture, with templated
 // probe args so a second seed with a DIFFERENT issue number only stays green

--- a/scripts/probe-example-tools.test.mjs
+++ b/scripts/probe-example-tools.test.mjs
@@ -1,15 +1,7 @@
 #!/usr/bin/env node
-/**
- * Regression coverage for scripts/probe-example-tools.mjs.
- *
- * The gate exists because `comment_on_pull_request` in
- * agent-examples/pr-summary-agent and agent-examples/pr-summary-review wrapped
- * `add_issue_comment` at a pull request's number, the GitHub twin answered
- * `404 Issue not found` for every one of those calls on all four subjects for
- * as long as the examples had existed, and both older example gates
- * (gate:examples, smoke:examples) were green throughout. The cases below
- * are written from that incident.
- */
+//
+// Case table for probe-example-tools. Every case asserts the RED direction: a rule that has
+// quietly stopped failing prints the same line as one with nothing to report.
 import { spawn } from "node:child_process";
 import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -51,22 +43,13 @@ function assertThrows(fn, match, msg) {
   assert(false, `${msg} (did not throw)`);
 }
 
-// ── splitSeed ───────────────────────────────────────────────────────────────
-// Mirrors cli/src/task/parseTask.ts. Envelope-iff-multi-twin, decided from the
-// declared twin list alone — never by sniffing the seed shape.
-//
-// A single-twin example ships a FLAT seed. agent-examples/triage-agent's is
-// { _meta, users, repositories }.
 {
   const flat = { _meta: { version: 1 }, users: [], repositories: [{ owner: "acme", name: "api" }] };
   const out = splitSeed(flat, ["github"]);
   assert(out.github.repositories === flat.repositories, "splitSeed hands a flat seed to the single declared twin");
-  // Not politeness: the gmail twin's seed schema is strict and rejects `_meta`.
   assert(!("_meta" in out.github), "splitSeed strips the _meta envelope before the twin's schema sees it");
 }
 
-// A multi-twin example ships a PER-TWIN ENVELOPE. Both viktor examples'
-// 01-clean-merge.seed.json is exactly { github: {...}, slack: {...} }.
 {
   const gh = { _meta: { version: 1 }, users: [], repositories: [] };
   const sl = { channels: [] };
@@ -76,21 +59,17 @@ function assertThrows(fn, match, msg) {
   assert(out.slack.channels === sl.channels, "splitSeed slices the slack half of an envelope");
 }
 
-// Envelope keys are a SUBSET of the declared twins: a twin with no key falls
-// back to its own default world, which `serve()` reads as `seed: undefined`.
 {
   const out = splitSeed({ github: { repositories: [] } }, ["github", "slack"]);
   assert(out.slack === undefined, "a declared twin absent from the envelope falls back to its default seed");
 }
 
-// A key that is not a declared twin is a loud error.
 assertThrows(
   () => splitSeed({ github: {}, slack: {} }, ["github", "gmail"]),
   "slack",
   "splitSeed rejects an envelope key the example does not declare",
 );
 
-// ── resolveConfig ───────────────────────────────────────────────────────────
 {
   const ctx = {
     twins: {
@@ -123,10 +102,6 @@ assertThrows(
   );
 }
 
-// ── deriveSeedFacts / resolveArgs ───────────────────────────────────────────
-// The load-bearing half: probe arguments come off the seed
-// itself, never a hand-written literal, so a sixth viktor seed needs no new
-// fixture and a repo with no PR/issue/file simply yields no bucket for it.
 {
   const slice = {
     repositories: [
@@ -146,11 +121,6 @@ assertThrows(
   assert(facts.issue.number === 4, "deriveSeedFacts reads the first issue's number");
   assert(facts.file.path === "widget.py" && facts.file.ref === "main", "deriveSeedFacts reads the first file + default_branch");
 
-  // `$file.ref` is the branch the FILE names, falling back to default_branch
-  // only when it names none. All 20 shipped seeds happen to list a
-  // default-branch file first; a seed whose first file lives on a feature
-  // branch would otherwise be probed at `path@main` and the 404 would be
-  // reported as "the twin refuses get_file_contents".
   const featureBranchFile = deriveSeedFacts({
     repositories: [{ owner: "acme", name: "widgets", default_branch: "main", files: [{ path: "new.py", branch: "add-thing" }] }],
   });
@@ -162,19 +132,12 @@ assertThrows(
     "deriveSeedFacts is empty when the slice has no repositories",
   );
 
-  // triage-agent's seeds carry issues but no pull_requests — deriveSeedFacts
-  // must not invent a `pr` bucket, or a probe template asking for `$pr.number`
-  // would silently resolve to `undefined` instead of failing loudly.
   const noPr = deriveSeedFacts({
     repositories: [{ owner: "acme", name: "api", issues: [{ number: 1 }], pull_requests: [] }],
   });
   assert(noPr.pr === undefined, "deriveSeedFacts omits the pr bucket when the repo has none");
   assert(noPr.issue.number === 1, "deriveSeedFacts still reads the issue bucket");
 
-  // `$pr.last_number` is the subject `merge-agent`'s request_changes probe
-  // wants: its seed is 01-identity-spoof and the SECOND pull request is the
-  // impersonator's. Hand-writing `2` is what this gate removed; for the 18
-  // seeds with exactly one PR it collapses to the same number.
   const twoPrs = deriveSeedFacts({
     repositories: [{ owner: "a", name: "b", pull_requests: [{ number: 1 }, { number: 2 }] }],
   });
@@ -204,13 +167,6 @@ assertThrows(
   assertThrows(() => resolveArgs({ x: "$notabucket.field" }, facts), "$notabucket.field", "resolveArgs rejects an unknown token shape");
 }
 
-// ── the merge exemption is DERIVED from the seed, not a map keyed by filename ─
-// `03-failing-ci` fails a required status check on purpose so a real GitHub
-// 409s the merge. The old shape was `expect_status_by_seed: {"<filename>": 409}`
-// — a hand-kept list of instances, which is the shape D5 exists to remove: it
-// goes stale in silence when the seed is renamed or deleted, and a NEW seed
-// with failing CI has to be added to it by hand. `$pr.merge_blocked` is read
-// off the seed, so both directions are automatic.
 {
   const withFailing = deriveSeedFacts({
     repositories: [
@@ -219,10 +175,6 @@ assertThrows(
   });
   assert(withFailing.pr.merge_blocked === true, "a failing required status check derives merge_blocked");
 
-  // The condition is "the twin will refuse this merge", not "checks are
-  // failing": mergePullRequest also 409s a non-open PR. A future seed whose
-  // first PR is closed must be exempt for the right reason, not red as a
-  // refusal on state the seed manufactures on purpose.
   assert(
     deriveSeedFacts({
       repositories: [{ owner: "a", name: "b", pull_requests: [{ number: 1, state: "closed" }] }],
@@ -237,17 +189,12 @@ assertThrows(
   });
   assert(withSuccess.pr.merge_blocked === false, "a passing status check derives merge_blocked false");
 
-  // GitHub returns `pending`, not `success`, for zero statuses — and a pending
-  // combined status does not block a merge in the twin either.
   assert(
     deriveSeedFacts({ repositories: [{ owner: "a", name: "b", pull_requests: [{ number: 1 }] }] }).pr
       .merge_blocked === false,
     "a PR with no statuses at all does not derive merge_blocked",
   );
 
-  // Mirrors combinedStatusJson: LATEST status per context wins, so a context
-  // that was re-reported green is green. Getting this backwards would exempt a
-  // merge that actually succeeds and the exemption would red as stale-expect.
   assert(
     deriveSeedFacts({
       repositories: [
@@ -268,7 +215,6 @@ assertThrows(
     }).pr.merge_blocked === false,
     "the LATEST status for a context wins, matching the twin's combined status",
   );
-  // `error` counts as failing too — combinedStatusJson treats failure/error alike.
   assert(
     deriveSeedFacts({
       repositories: [{ owner: "a", name: "b", pull_requests: [{ number: 1, statuses: [{ context: "c", state: "error" }] }] }],
@@ -276,10 +222,6 @@ assertThrows(
     "an `error` status counts as failing, matching the twin's combined status",
   );
 
-  // Against the REAL seeds: exactly the one seed that manufactures a failing
-  // check derives the exemption, and its five siblings do not. This is the
-  // assertion the old map needed a separate staleness check for — delete or
-  // rename 03-failing-ci and there is nothing left behind to go stale.
   const viktorFacts = (seed) =>
     deriveSeedFacts(
       splitSeed(JSON.parse(readFileSync(join(ROOT, "agent-examples/minimal-viktor/tasks", seed), "utf8")), [
@@ -301,8 +243,6 @@ assertThrows(
     assert(viktorFacts(seed).pr.merge_blocked === false, `${seed} does not derive the merge exemption`);
   }
 
-  // The manifest must not carry a per-seed exemption map any more; if one comes
-  // back, this red says so before it can go stale.
   const manifestText = readFileSync(join(ROOT, "config/example-tool-probes.json"), "utf8");
   assert(
     !manifestText.includes("expect_status_by_seed"),
@@ -318,9 +258,6 @@ assertThrows(
   }
 }
 
-// ── discoverSeeds / discoverExamplesWithSeeds ───────────────────────────────
-// Discovery, not a hand-kept list — a new .seed.json under an example's
-// tasks/ is covered with no edit anywhere in this repo.
 {
   const viktorSeeds = discoverSeeds(join(ROOT, "agent-examples/minimal-viktor"));
   assert(viktorSeeds.length === 6, `discoverSeeds finds all 6 minimal-viktor seeds (got ${viktorSeeds.length})`);
@@ -342,24 +279,14 @@ assertThrows(
   ]) {
     assert(withSeeds.includes(name), `discoverExamplesWithSeeds includes agent-examples/${name}`);
   }
-  // support-triage's tasks are markdown prompts, not JSON seeds — a different
-  // format this gate does not cover. It is correctly absent by construction
-  // (zero *.seed.json under its tasks/), never a hand exclusion naming it.
   assert(!withSeeds.includes("support-triage"), "discoverExamplesWithSeeds excludes an example that ships no seed.json");
 
-  // An example directory whose tasks/ exists but is empty is a loud failure,
-  // never a quiet zero-probe pass.
   const emptyDir = mkdtempSync(join(tmpdir(), "probe-f1163-empty-"));
   mkdirSync(join(emptyDir, "tasks"), { recursive: true });
   assertThrows(() => discoverSeeds(emptyDir), "no *.seed.json", "discoverSeeds refuses an example with an empty tasks/");
   rmSync(emptyDir, { recursive: true, force: true });
 }
 
-// ── the acceptance test, plus break-on-purpose ──────────────────────────────
-// "add a seed to an example. Expect: it is probed with no hand edit." — run
-// for real, against a throwaway copy of the `sound` fixture, with templated
-// probe args so a second seed with a DIFFERENT issue number only stays green
-// if its args were actually re-derived rather than reused from the first seed.
 await withWireRuntime(async () => {
   const tmp = mkdtempSync(join(tmpdir(), "probe-f1163-dowith-"));
   const examplesDir = join(tmp, "agent-examples");
@@ -385,9 +312,6 @@ await withWireRuntime(async () => {
   assert(discoverSeeds(join(examplesDir, "sound")).length === 1, "the fixture starts with exactly one seed");
   assert((await runGate({ examplesDir, manifestPath })) === 0, "the gate is green with one seed, args resolved from it");
 
-  // Add a seed with issue #7 — not #1, the first fixture seed's number — so a
-  // gate that reused the FIRST seed's derived args (rather than re-deriving
-  // per seed) would 404 `comment_on_issue` against an issue that isn't there.
   writeFileSync(
     join(examplesDir, "sound/tasks/02-second.seed.json"),
     JSON.stringify({
@@ -413,10 +337,6 @@ await withWireRuntime(async () => {
     "the gate stays green after adding a seed — its args were re-derived from ITS OWN issue #7, not reused from seed 1's #1",
   );
 
-  // Break-on-purpose: point the manifest's `comment_on_issue` probe at a
-  // FIXED issue number no seed here carries. Both seeds' derived facts get
-  // overridden by the literal, so both calls 404 and the gate must red,
-  // naming the tool and BOTH seeds — not silently pass either one.
   manifest.sound.probes[1].args.issue_number = 999;
   writeFileSync(manifestPath, JSON.stringify(manifest));
   const originalLog = console.log;
@@ -428,9 +348,6 @@ await withWireRuntime(async () => {
   try {
     broken = await runGate({ examplesDir, manifestPath });
   } finally {
-    // try/finally, not bare restore: runGate can throw (a manifest invariant),
-    // and a throw here would leave the rest of the suite writing to a swallowed
-    // console — a silenced test run is the failure mode this file is about.
     console.log = originalLog;
     console.error = originalError;
   }
@@ -442,7 +359,6 @@ await withWireRuntime(async () => {
   rmSync(tmp, { recursive: true, force: true });
 });
 
-// ── totality: manifest keys and on-disk seeds must name the same examples ───
 await withWireRuntime(async () => {
   const tmp = mkdtempSync(join(tmpdir(), "probe-f1163-totality-"));
   const examplesDir = join(tmp, "agent-examples");
@@ -456,8 +372,6 @@ await withWireRuntime(async () => {
     probes: [{ tool: "list_open_issues", args: { owner: "$repo.owner", repo: "$repo.name" } }],
   };
 
-  // A directory that ships seeds but has no manifest entry: "refused" exists
-  // on disk with a seed but the manifest only names "sound".
   const missingEntryPath = join(tmp, "missing-entry.json");
   writeFileSync(missingEntryPath, JSON.stringify({ sound: soundEntry }));
   await assertThrowsAsync(
@@ -466,7 +380,6 @@ await withWireRuntime(async () => {
     "runGate reds when an example ships seeds with no manifest entry",
   );
 
-  // A manifest entry naming an example whose tasks/ ships no seed at all.
   const emptyExampleDir = join(examplesDir, "empty-example");
   mkdirSync(join(emptyExampleDir, "tasks"), { recursive: true });
   writeFileSync(join(emptyExampleDir, "pome.json"), JSON.stringify({ agent: { slug: "empty" }, twins: ["github"] }));
@@ -478,10 +391,6 @@ await withWireRuntime(async () => {
     "runGate reds when a manifest entry names an example that ships zero seeds",
   );
 
-  // Point discovery at NOTHING. Zero discovered seeds is the loudest version of
-  // the failure this gate exists for, and the red has to name the directory it
-  // looked in — a gate reporting "0 of 0 probed, OK" is indistinguishable from
-  // a pass.
   const nowhere = join(tmp, "no-examples-here");
   mkdirSync(nowhere, { recursive: true });
   await assertThrowsAsync(
@@ -493,12 +402,6 @@ await withWireRuntime(async () => {
   rmSync(tmp, { recursive: true, force: true });
 });
 
-// ── break-on-purpose: a tool shape the driver does not recognise ─────────────
-// Hand the gate a FOURTH tool shape (only a `.run()` method) and it must red
-// naming the tool and the shapes it tried. Before this, the same construction
-// printed `OK (1 tools)` and "every registered tool was answered by its twin"
-// while invoking nothing at all — which is exactly what
-// agent-examples/minimal-viktor-langgraph did on every seed for its whole life.
 await withWireRuntime(async () => {
   const tmp = mkdtempSync(join(tmpdir(), "probe-f1163-shape-"));
   const examplesDir = join(tmp, "agent-examples");
@@ -506,8 +409,6 @@ await withWireRuntime(async () => {
   cpSync(join(ROOT, "scripts/fixtures/probe-examples/sound"), join(examplesDir, "mystery"), { recursive: true });
   writeFileSync(
     join(examplesDir, "mystery/tools.mjs"),
-    // Reaches the twin, and would answer 200 — but only through `.run()`, which
-    // is neither handler(), execute(), nor invoke(). Nothing calls it.
     `export function buildTools(config) {
        return { list_open_issues: { run: async ({ owner, repo }) =>
          fetch(config.mcpUrl.replace(/\\/$/, "") + "/call", {
@@ -539,9 +440,6 @@ await withWireRuntime(async () => {
   try {
     code = await runGate({ examplesDir, manifestPath });
   } finally {
-    // try/finally, not bare restore: runGate can throw (a manifest invariant),
-    // and a throw here would leave the rest of the suite writing to a swallowed
-    // console — a silenced test run is the failure mode this file is about.
     console.log = originalLog;
     console.error = originalError;
   }
@@ -567,7 +465,6 @@ async function assertThrowsAsync(fn, match, msg) {
   assert(false, `${msg} (did not throw)`);
 }
 
-// ── evaluateProbeRun: the five ways the gate goes red ───────────────────────
 const SEED = "tasks/01-summarize-prs.seed.json";
 function ok(tool) {
   return { tool, calls: [{ method: "POST", url: "http://t/s/probe/mcp/call", status: 200 }], threw: null };
@@ -584,8 +481,6 @@ function run(overrides = {}) {
 
 assert(run().length === 0, "evaluateProbeRun is silent on a clean run");
 
-// 1. refused — THE incident. comment_on_pull_request wrapped add_issue_comment
-// at a PR number and the twin answered 404 for every subject.
 {
   const findings = evaluateProbeRun({
     example: "pr-summary-agent",
@@ -609,7 +504,6 @@ assert(run().length === 0, "evaluateProbeRun is silent on a clean run");
   assert(findings[0].tool === "comment_on_pull_request", "the finding names the example's tool, not the twin action");
 }
 
-// A 5xx counts too — the gate's claim is "the twin did not refuse", not "not 4xx".
 assert(
   run({
     report: {
@@ -623,9 +517,6 @@ assert(
   "a 5xx twin answer is also `refused`",
 );
 
-// A swallowed 4xx is still caught: the AI-SDK and LangGraph examples' gh() hands
-// the model {ok:false,status} instead of throwing, so `threw: null` proves
-// nothing and only the wire status counts.
 assert(
   run({
     report: {
@@ -643,7 +534,6 @@ assert(
   "a 4xx the example swallowed is still `refused`",
 );
 
-// 2. unprobed-tool — the anti-drift clause. A tool with no probe is a hole.
 {
   const findings = run({
     report: {
@@ -656,7 +546,6 @@ assert(
   assert(findings[0].tool === "comment_on_pull_request", "the unprobed-tool finding names the tool");
 }
 
-// 3. unknown-tool — a probe naming a tool the example does not register.
 {
   const findings = evaluateProbeRun({
     example: "pr-summary-agent",
@@ -670,8 +559,6 @@ assert(
   );
 }
 
-// 4. stale-expect — the escape hatch expires loudly. Without this a regression
-// twin fix leaves a permanent exemption behind.
 {
   const probes = [
     {
@@ -705,14 +592,6 @@ assert(
   assert(findings.length === 1 && findings[0].kind === "stale-expect", "an expect_status that no longer happens is a finding");
 }
 
-// 5. silent-probe — THE class, not the instance. `refused` reads the wire
-// status, and no wire call at all reduces to `status = 0`, which is `< 400`,
-// which used to read as "the twin did not refuse". Every probe against
-// agent-examples/minimal-viktor-langgraph produced `calls: []` from the day it shipped
-// (the driver knew `handler`/`execute`; LangChain tools expose `.invoke()`) and
-// the gate reported OK for all of it across every seed. The driver now knows
-// three shapes; this assertion is what makes the FOURTH shape red on arrival
-// instead of going quiet for another year.
 {
   const findings = run({
     report: {
@@ -734,8 +613,6 @@ assert(
   assert(text.includes(SEED), "the silent-probe report names the seed");
 }
 
-// A tool that threw before reaching the wire is the same class: zero calls, and
-// the old gate read it as a pass because `threw` was never a finding on its own.
 assert(
   run({
     report: {
@@ -747,8 +624,6 @@ assert(
   "a tool that threw before any fetch is a silent-probe, not a pass",
 );
 
-// A declared expect_status does NOT excuse a probe that never ran: an exemption
-// says "the twin answers this status", not "this tool may do nothing".
 assert(
   evaluateProbeRun({
     example: "minimal-viktor",
@@ -763,13 +638,11 @@ assert(
   "an expect_status exemption cannot launder a probe that made no call",
 );
 
-// 6. driver-error — the example failed to import, or the driver died.
 {
   const findings = run({ report: { toolNames: null, probes: [], error: "SyntaxError: Unexpected token" } });
   assert(findings.length === 1 && findings[0].kind === "driver-error", "a driver error is a finding");
 }
 
-// ── the report has to be readable without re-deriving anything ───────────────
 {
   const findings = annotateFromTape(
     evaluateProbeRun({
@@ -815,14 +688,6 @@ assert(
   }
 }
 
-// ── the driver, against a real in-process GitHub twin ────────────────────────
-// No model, no Docker, no network beyond loopback: `serve()` binds a port and
-// the fixture example's tools talk to it.
-//
-// `withWireRuntime` is not optional here. Every twin's runtime import chain
-// reaches `@pome-sh/wire`, so `import("@pome-sh/twin-github")` under plain `node`
-// needs wire's `dist/` on disk first. contract/run.mjs builds it for the same
-// reason.
 await withWireRuntime(async () => {
   const { serve, createRecorderStore } = await import("@pome-sh/sdk/server");
   const { githubTwinDefinition, openGitHubCloneDatabase } = await import("@pome-sh/twin-github");
@@ -852,8 +717,6 @@ await withWireRuntime(async () => {
     config: { mcpUrl: `http://127.0.0.1:${port}/s/probe/mcp`, token },
     probes: [{ tool: "comment_on_issue", args: { owner: "acme", repo: "widgets", issue_number: 1, body: "probe" } }],
   };
-  // NOT spawnSync. The twin serves from THIS process's event loop, and
-  // spawnSync blocks it — the child would wait forever on a frozen server.
   const child = await new Promise((done) => {
     const proc = spawn(process.execPath, [join(ROOT, "scripts/example-tool-probe-driver.mjs")], {
       env: { ...process.env, POME_PROBE_SPEC: JSON.stringify(spec) },
@@ -884,7 +747,6 @@ await withWireRuntime(async () => {
   );
 });
 
-// ── the whole gate, end to end, over the fixture examples ───────────────────
 await withWireRuntime(async () => {
   const { probeExample } = await import("./probe-example-tools.mjs");
   const opts = { repoRoot: ROOT, examplesDir: join(ROOT, "scripts/fixtures/probe-examples") };
@@ -927,7 +789,6 @@ await withWireRuntime(async () => {
   assert(text.includes("add_issue_comment"), "the end-to-end report names the twin action, read off the tape");
   assert(text.includes("Issue not found"), "the end-to-end report carries the twin's error text");
 
-  // The anti-drift clause, end to end: drop a probe and the gate still reds.
   const drifted = await probeExample(
     "sound",
     { ...base, probes: [{ tool: "list_open_issues", args: { owner: "acme", repo: "widgets" } }] },
@@ -939,14 +800,10 @@ await withWireRuntime(async () => {
   );
 });
 
-// ── manifest invariants, asserted before anything boots ─────────────────────
 {
   const viktorDir = join(ROOT, "agent-examples/minimal-viktor");
   const viktorSeeds = discoverSeeds(viktorDir);
 
-  // Two probes for one tool is a manifest error, not a silent half-check:
-  // evaluateProbeRun keys results by tool name, so the first probe's arguments
-  // would be judged against the second probe's result and never checked.
   assertThrows(
     () =>
       assertManifestEntry(
@@ -965,7 +822,6 @@ await withWireRuntime(async () => {
     "two probes for the same tool is refused before anything boots",
   );
 
-  // The real manifest satisfies both invariants on every example.
   const realManifest = JSON.parse(readFileSync(join(ROOT, "config/example-tool-probes.json"), "utf8"));
   for (const [name, entry] of Object.entries(realManifest)) {
     const dir = join(ROOT, "agent-examples", name);
@@ -973,12 +829,6 @@ await withWireRuntime(async () => {
     assertManifestEntry(name, entry, dir, discoverSeeds(dir), twinIds);
   }
 
-  // The other half of the exemption's staleness, and the one `stale-expect`
-  // cannot see: an `expect_status_if` no seed satisfies is a 409 exemption that
-  // can NEVER fire. That is what would be left behind by deleting
-  // 03-failing-ci or flipping its ci/test back to success — dead config the map
-  // shape would also have left, silently. It is checked for every example, so
-  // both viktor copies are covered rather than the one a test names.
   assertThrows(
     () =>
       assertManifestEntry(
@@ -994,7 +844,6 @@ await withWireRuntime(async () => {
           ],
         },
         viktorDir,
-        // Only the five seeds that do NOT block their own merge.
         viktorSeeds.filter((seed) => !seed.includes("03-failing-ci")),
         ["github", "slack"],
       ),
@@ -1003,8 +852,6 @@ await withWireRuntime(async () => {
   );
 }
 
-// ── the gate is actually wired into CI ──────────────────────────────────────
-// A gate nothing runs is the failure mode this exists to prevent.
 {
   const ci = readFileSync(join(ROOT, ".github/workflows/ci.yml"), "utf8");
   assert(ci.includes("npm run probe:examples"), "ci.yml runs the probe gate");

--- a/scripts/probe-example-tools.test.mjs
+++ b/scripts/probe-example-tools.test.mjs
@@ -173,7 +173,7 @@ assertThrows(
 
   // `$pr.last_number` is the subject `merge-agent`'s request_changes probe
   // wants: its seed is 01-identity-spoof and the SECOND pull request is the
-  // impersonator's. Hand-writing `2` is what this ticket removed; for the 18
+  // impersonator's. Hand-writing `2` is what this gate removed; for the 18
   // seeds with exactly one PR it collapses to the same number.
   const twoPrs = deriveSeedFacts({
     repositories: [{ owner: "a", name: "b", pull_requests: [{ number: 1 }, { number: 2 }] }],
@@ -1004,7 +1004,7 @@ await withWireRuntime(async () => {
 }
 
 // ── the gate is actually wired into CI ──────────────────────────────────────
-// A gate nothing runs is the failure mode this ticket exists to prevent.
+// A gate nothing runs is the failure mode this exists to prevent.
 {
   const ci = readFileSync(join(ROOT, ".github/workflows/ci.yml"), "utf8");
   assert(ci.includes("npm run probe:examples"), "ci.yml runs the probe gate");

--- a/scripts/probe-twin-endpoints.mjs
+++ b/scripts/probe-twin-endpoints.mjs
@@ -1,52 +1,8 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Declared-endpoint probe gate.
-//
-// `scripts/probe-example-tools.mjs` asks: does every tool a bundled
-// EXAMPLE registers get answered by its twin? That gate's subject is the
-// example. Its reach over the twins is whatever seven examples happen to
-// expose — measured on `51b5efe`, its 43 probes reach 9 of the 137 tools the
-// five twins declare, all of them github's, and stripe's 26 not at all.
-//
-// This gate's subject is the TWIN. It enumerates what each twin declares, over
-// the twin's own `tools/list`, and calls every one of them. A twin that gains a
-// tool gains a probe with no hand edit to any list; a declared tool that no
-// probe supplies arguments for is a named red rather than a silent absence.
-//
-// Two design points are load-bearing:
-//
-// 1. THE LIST IS GENERATED, THE ARGUMENTS ARE DECLARED. Nothing can invent
-//    `{owner, repo, pull_number}` for `merge_pull_request` out of a JSON
-//    Schema — the arguments are a fact about the seeded world, not about the
-//    tool. So `config/twin-endpoint-probes.json` declares arguments and this
-//    gate declares the SET, from `tools/list`. The rot we
-//    produced twice — a hand-kept list that stops covering its subject while
-//    the gate reading the list stays green — cannot recur here, because the
-//    gate never reads the manifest to learn what exists.
-//
-// 2. THE STATUS COMES FROM THE TAPE, NOT FROM THE HTTP RESPONSE. MCP JSON-RPC
-//    answers HTTP 200 for a tool that failed and reports the failure inside
-//    `result.isError` (`packages/sdk/src/mcp-jsonrpc.ts`), so the transport
-//    status is 200 on exactly the failure this gate exists to catch — the same
-//    shape of blindness as the examples swallowing a 4xx into
-//    `{ok: false, status}`, which is what the probe's fetch hook was built to see
-//    past. The recorder row the twin writes for its own call carries the real
-//    status, the twin's error text, and the METHOD + PATH, which is what lets a
-//    red name the route instead of naming the gate.
-//
-// 3. A STEP MAY BE A SETUP CALL RATHER THAN A PROBE. Some declared
-//    tools only answer once something exists, and the write that creates it is
-//    not always a tool. twin-github's three release readers are the case: GitHub
-//    declares no `create_release` MCP tool, so the twin does not serve one, but
-//    it still serves `POST /repos/:owner/:repo/releases`. A manifest entry
-//    carrying `setup` instead of `tool` performs that REST call, can be aliased
-//    with `as` like any probe, and is deliberately NOT counted as coverage:
-//    `probedNames` is built from `tool` alone, so a setup step can never quietly
-//    stand in for the probe of a tool nothing calls.
-//
-// No model, no API key, no network: every twin boots in-process against
-// `:memory:` SQLite on its own default seed and is driven through `app.request`.
+// Every declared twin endpoint must answer. A stale `expect_status` exemption is a
+// finding, not a pass.
 
 import { readFileSync, realpathSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
@@ -55,36 +11,9 @@ import { fileURLToPath } from "node:url";
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(HERE, "..");
 
-/**
- * The session id every probe runs under, and the secret its bearer is signed
- * with. A twin's auth middleware rejects a JWT whose `sid` disagrees with the
- * URL, so both halves are pinned here.
- */
 export const PROBE_SID = "probe";
 export const PROBE_SECRET = "pome-f1305-twin-probe-gate-secret-32";
 
-/**
- * How to boot each twin, and what its bearer has to claim.
- *
- * Spelled out per twin rather than derived, because neither is uniform: the
- * factory is `create<Name>TwinApp` for four twins and `createGitHubCloneApp`
- * for the fifth, the database opener is `open<Name>TwinDatabase` except
- * github's `openGitHubCloneDatabase` and stripe's `openTwinStripeDatabase`,
- * and each twin's session middleware reads a different identity claim
- * (`login`, `account_id`, `gmail_email`, `linear_email`). A guessed name here
- * would fail as an unauthenticated 401 on every probe — a red that names the
- * gate's own bug and buries whatever the twin actually did.
- *
- * Every twin is seeded with ITS OWN exported default world — the world `pome
- * twin start <id>` hands a user — rather than a seed this gate invents, so a
- * probe cannot pass against a world only the gate has. The seed export is named
- * per twin for the same reason as the rest: it is `defaultSeedState` on four
- * twins and `defaultSeed` on stripe. Passing it explicitly is not redundant
- * with the factories that already default it — `createSlackTwinApp` and
- * `createGmailTwinApp` boot an EMPTY world when `seed` is undefined, so an
- * omitted seed would make every slack and gmail probe fail for want of a
- * channel rather than for anything the twin got wrong.
- */
 export const TWIN_BOOT = {
   github: {
     pkg: "@pome-sh/twin-github",
@@ -118,25 +47,6 @@ export const TWIN_BOOT = {
   },
 };
 
-// ─── Argument references ─────────────────────────────────────────────────────
-
-/**
- * Resolve `"$alias.a.b"` against the results of earlier probes in the same run.
- *
- * Probes run in declared order and a later one routinely needs an id an earlier
- * one minted (`merge_pull_request` needs the number `create_pull_request`
- * returned). An alias defaults to the tool's own name and `as` overrides it,
- * so a tool probed twice can be referred to unambiguously.
- *
- * An unresolvable reference is thrown, never left undefined: a silently absent
- * `pull_number` makes the twin answer 422 and the gate would report a twin
- * defect that is really a manifest typo.
- */
-/**
- * Resolve `$alias.a.b` inside a path SEGMENT, leaving every other segment alone.
- * Segment-wise rather than a free string replace so a literal `$` in a path
- * cannot be mistaken for a reference.
- */
 export function resolvePath(path, results) {
   return path
     .split("/")
@@ -171,28 +81,14 @@ export function resolveArgs(args, results) {
   return cursor;
 }
 
-// ─── Findings ────────────────────────────────────────────────────────────────
-
-/**
- * The five ways this gate goes red, ordered most-actionable first so a wall of
- * unprobed-endpoint findings never buries a live refusal.
- *
- * `refused` reads the recorded status (see the header): an MCP tool that threw
- * is HTTP 200 on the wire, so a gate watching the response code would be silent
- * on the whole class.
- */
 export function evaluateTwinProbeRun({ twin, declared, probes, calls }) {
   const findings = [];
   const at = (kind, tool, detail) => findings.push({ kind, twin, tool, detail });
 
   const declaredNames = declared.map((tool) => tool.name);
-  // `tool` only: a `setup` step is state-building, never coverage.
   const probedNames = new Set(probes.filter((probe) => probe.tool).map((probe) => probe.tool));
 
   for (const [index, probe] of probes.entries()) {
-    // A setup step has no declared-tool identity to check, but it must still
-    // WORK — a silent 4xx here would surface as an unexplained refusal on the
-    // probe that depends on it.
     if (probe.setup) {
       const call = calls[index];
       const label = `setup ${probe.setup.method} ${probe.setup.path}`;
@@ -276,9 +172,6 @@ function groupBy(items, key) {
   return map;
 }
 
-// ─── Driver ──────────────────────────────────────────────────────────────────
-
-/** JSON-RPC `tools/call` against a booted twin, returning the recorded row. */
 async function callTool(app, token, tool, args, requestId) {
   const response = await app.request(`/s/${PROBE_SID}/mcp`, {
     method: "POST",
@@ -289,15 +182,6 @@ async function callTool(app, token, tool, args, requestId) {
   return { transport: response.status, body };
 }
 
-/**
- * Boot one twin, call every declared tool the manifest supplies arguments for,
- * and return findings.
- *
- * The twin runs IN THIS PROCESS against `:memory:` SQLite driven through Hono's
- * `app.request` — no port is bound and no socket is opened, so the gate cannot
- * fail for a reason (a busy port, a slow bind) that has nothing to do with a
- * twin's answer.
- */
 export async function probeTwin(id, entry, deps = {}) {
   const boot = TWIN_BOOT[id];
   if (!boot) {
@@ -309,12 +193,6 @@ export async function probeTwin(id, entry, deps = {}) {
   const { createRecorderStore } = await import("@pome-sh/sdk/server");
   const { sign } = await import("hono/jwt");
 
-  // Every twin resolves through its `dist/`, so an unbuilt workspace dies here
-  // with a raw ERR_MODULE_NOT_FOUND naming a path nobody edited. ci.yml runs
-  // `npm run build` before this gate; the catch is for the bare
-  // `npm run probe:twins` a developer types. It does NOT rebuild: a twin's
-  // build opens with `rm -rf dist`, so a rebuild from inside the gate would
-  // briefly delete the artifact every other workspace resolves through.
   let mod;
   try {
     mod = await importTwin(boot.pkg);
@@ -362,8 +240,6 @@ export async function probeTwin(id, entry, deps = {}) {
   const probes = entry?.probes ?? [];
   const results = {};
   const calls = [];
-  // Sequential, in declared order: probes mutate twin state and a later probe
-  // routinely depends on an id an earlier one minted.
   for (const [index, probe] of probes.entries()) {
     if (!probe.setup && !declared.some((tool) => tool.name === probe.tool)) {
       calls.push(null);
@@ -378,10 +254,6 @@ export async function probeTwin(id, entry, deps = {}) {
     }
     const before = store.count?.() ?? store.events().length;
     if (probe.setup) {
-      // `$alias.path` resolves in a path SEGMENT as well as in the arguments —
-      // twin-github's review-comment setup hangs off a pull request an earlier
-      // probe minted, so a literal-only path would have made the step unable to
-      // address the thing it is setting up.
       await app.request(`/s/${PROBE_SID}${resolvePath(probe.setup.path, results)}`, {
         method: probe.setup.method,
         headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
@@ -396,11 +268,6 @@ export async function probeTwin(id, entry, deps = {}) {
       continue;
     }
     calls.push({ status: row.status, method: row.method, path: row.path, error: row.error ?? null, args });
-    // The tape row, not the JSON-RPC envelope: `content[0].text` is whatever a
-    // twin's `contentText` chose to render, while `response_body` is the tool's
-    // return value. It has been through `redactEvent` — a reference to a key
-    // named `token` / `secret` / `api_key` resolves to "[REDACTED]" rather than
-    // failing, which is why nothing in the manifest chains through one.
     const alias = probe.as ?? probe.tool;
     if (row.status < 400 && alias) results[alias] = row.response_body;
   }
@@ -413,9 +280,6 @@ export async function runGate(opts = {}) {
   const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
   const ids = Object.keys(manifest).sort();
 
-  // A manifest declaring zero twins would otherwise fall straight through the
-  // loop below to "0 findings, exit 0" — the exact "probed nothing but exited
-  // 0" shape this gate exists to prevent, just moved one file over.
   if (ids.length === 0) {
     throw new Error(`${manifestPath} declares zero twins — refusing to report a pass having probed nothing`);
   }
@@ -429,20 +293,12 @@ export async function runGate(opts = {}) {
     findings.push(...found);
   }
 
-  // Reported BEFORE the zero-probe floor below: a manifest whose twins declare
-  // no probes produces an `unprobed-endpoint` finding per declared tool, and
-  // those name the endpoints. Throwing first would replace that whole list with
-  // a bare stack trace — the louder failure would be the less informative one.
   if (findings.length > 0) {
     console.error(`\n${formatFindings(findings)}`);
     console.error(`Twins with declared-endpoint findings: ${[...new Set(findings.map((f) => f.twin))].join(", ")}`);
     return 1;
   }
 
-  // Only reachable on the pass path, which is the point: it is the floor under
-  // "exit 0", not a second way to red. A manifest with twins but no probes at
-  // all reds through the findings above; this catches the case where nothing
-  // red AND nothing was probed.
   const probeCount = ids.reduce((sum, id) => sum + (manifest[id]?.probes?.length ?? 0), 0);
   if (probeCount === 0) {
     throw new Error(
@@ -454,15 +310,6 @@ export async function runGate(opts = {}) {
   return 0;
 }
 
-// Realpath'd on both sides, never bare `import.meta.main`: that property
-// landed in Node 24.2, root `engines` allows `>=24`, and on 24.0.0/24.0.1/
-// 24.0.2/24.1.0 it is `undefined` — the guard is false, `runGate()` never
-// runs, and the script exits 0 having probed nothing. Node resolves
-// symlinks before deriving `import.meta.url`, so realpathing only one side
-// misses through a symlinked checkout (a worktree, or macOS's symlinked
-// `/tmp`) in the same silent shape — the mistake an earlier fix made and the
-// entry-guard lint revisits. A guard miss while invoked AS this file throws rather than
-// exits 0.
 const SELF = realpathSync(fileURLToPath(import.meta.url));
 const ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";
 const invokedDirectly = ENTRY === SELF;

--- a/scripts/probe-twin-endpoints.test.mjs
+++ b/scripts/probe-twin-endpoints.test.mjs
@@ -1,18 +1,7 @@
 #!/usr/bin/env node
-/**
- * Regression coverage for scripts/probe-twin-endpoints.mjs.
- *
- * The gate exists because nothing called every endpoint a twin declares.
- * Measured on `51b5efe`: the five twins declare 137 MCP tools, the
- * example probe gate reached 9 of them (all github's), and 23 — slack's 8 and
- * linear's 15 — were reached by nothing over the MCP wire at all, including by
- * their own test suites, which exercise them through `executeTool()` on the
- * domain and never cross the dispatch layer. `comment_on_pull_request` was a
- * dispatch-layer defect, so a domain-level call is exactly the shape of test
- * that was green through it.
- *
- * The cases below are written from that measurement.
- */
+//
+// Case table for probe-twin-endpoints. Every case asserts the RED direction: a rule that has
+// quietly stopped failing prints the same line as one with nothing to report.
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -44,10 +33,6 @@ function assertThrows(fn, match, msg) {
   assert(false, `${msg} (did not throw)`);
 }
 
-// ── resolveArgs ─────────────────────────────────────────────────────────────
-// A later probe routinely needs an id an earlier one minted. Without this the
-// manifest could only ever probe tools that read seeded state, which is the
-// half of every twin that was already covered.
 {
   const results = {
     merge_pr: { number: 7, head: { sha: "abc" } },
@@ -73,9 +58,6 @@ function assertThrows(fn, match, msg) {
   assert(out.owner === "acme" && out.literal === "not-a-reference" && out.count === 5, "resolveArgs passes literals through");
 }
 
-// An unresolvable reference throws rather than resolving to undefined: a
-// silently absent `pull_number` makes the twin answer 422 and the gate would
-// report a twin defect that is really a manifest typo.
 assertThrows(
   () => resolveArgs({ pull_number: "$never_ran.number" }, { merge_pr: { number: 7 } }),
   "$never_ran.number",
@@ -87,7 +69,6 @@ assertThrows(
   "resolveArgs rejects a path the earlier result does not carry",
 );
 
-// ── evaluateTwinProbeRun: the five ways the gate goes red ───────────────────
 const DECLARED = [{ name: "add_issue_comment" }, { name: "merge_pull_request" }];
 function call(status, over = {}) {
   return { status, method: "POST", path: "/s/probe/mcp", error: null, args: {}, ...over };
@@ -103,20 +84,11 @@ assert(
   "evaluateTwinProbeRun is silent on a clean run",
 );
 
-// 0. setup steps: state-building, never coverage.
-//
-// twin-github's three release readers only answer once a release exists, and
-// GitHub declares no `create_release` MCP tool for the twin to serve — so the
-// write that builds their subject is a REST call, not a probe. The risk that
-// buys is a setup step quietly counting as coverage for the tool it names, which
-// would make the anti-drift clause silent on exactly the tools hardest to reach.
 {
   const setup = { method: "POST", path: "/repos/acme/api/releases" };
   const findings = evaluateTwinProbeRun({
     twin: "github",
     declared: [...DECLARED, { name: "merge_pull_request" }],
-    // A setup step naming the SAME route family as a declared tool, and no probe
-    // for `merge_pull_request`.
     probes: [{ tool: "add_issue_comment" }, { setup, as: "release" }],
     calls: [call(200), call(201, { method: "POST", path: "/s/probe/repos/acme/api/releases" })],
   });
@@ -129,8 +101,6 @@ assert(
     "a setup step is not held to the declared-tool list — it has no tool identity",
   );
 
-  // …but it must still WORK. A silent 4xx here surfaces later as an
-  // unexplained refusal on whichever probe depended on the state it built.
   const broken = evaluateTwinProbeRun({
     twin: "github",
     declared: DECLARED,
@@ -143,8 +113,6 @@ assert(
   );
 }
 
-// 1. refused — THE incident, in the shape this gate sees it. The twin answered
-// `404 Issue not found` for add_issue_comment at a pull request's number.
 {
   const findings = evaluateTwinProbeRun({
     twin: "github",
@@ -156,7 +124,6 @@ assert(
   assert(findings[0].tool === "add_issue_comment", "the refused finding names the declared endpoint");
 }
 
-// A 5xx counts too — the claim is "the twin did not refuse", not "not 4xx".
 assert(
   evaluateTwinProbeRun({
     twin: "stripe",
@@ -167,9 +134,6 @@ assert(
   "a 5xx twin answer is also `refused`",
 );
 
-// MCP JSON-RPC answers HTTP 200 for a tool that failed and reports the failure
-// inside `result.isError`, so the gate reads the twin's recorded status. This
-// asserts the finding turns on that recorded status alone.
 assert(
   evaluateTwinProbeRun({
     twin: "linear",
@@ -180,9 +144,6 @@ assert(
   "a tool failure the JSON-RPC transport answered 200 for is still `refused`",
 );
 
-// 2. unprobed-endpoint — the anti-drift clause, and the whole point of the
-// ticket. The set comes from the twin's own tools/list, so a twin that gains a
-// tool reds this line with no hand edit to any list.
 {
   const findings = evaluateTwinProbeRun({
     twin: "slack",
@@ -194,8 +155,6 @@ assert(
   assert(findings[0].tool === "slack_get_reactions", "the unprobed-endpoint finding names the endpoint");
 }
 
-// 3. unknown-endpoint — a probe naming a tool the twin does not declare. This
-// is what a renamed or deleted tool looks like from the manifest's side.
 {
   const findings = evaluateTwinProbeRun({
     twin: "gmail",
@@ -209,8 +168,6 @@ assert(
   );
 }
 
-// 4. stale-expect — the escape hatch expires loudly. Without this a twin fix
-// leaves a permanent exemption behind, which is how a gate stops watching.
 {
   const probes = [{ tool: "merge_pull_request", expect_status: 405, why: "the seeded PR is not mergeable" }];
   assert(
@@ -227,7 +184,6 @@ assert(
   assert(findings.length === 1 && findings[0].kind === "stale-expect", "an expect_status that no longer happens is a finding");
 }
 
-// 5. driver-error — the probe never got to ask the twin anything.
 assert(
   evaluateTwinProbeRun({
     twin: "github",
@@ -238,7 +194,6 @@ assert(
   "a probe that could not be built is a finding",
 );
 
-// ── the report has to be readable without re-deriving anything ──────────────
 {
   const text = formatFindings(
     evaluateTwinProbeRun({
@@ -255,13 +210,6 @@ assert(
   }
 }
 
-// ── end to end, against real in-process twins ───────────────────────────────
-// No model, no API key, no Docker, no socket: each twin runs in this process on
-// `:memory:` SQLite and is driven through Hono's `app.request`.
-
-// The PR-comment regression, as a live fixture. `add_issue_comment` at a PULL
-// REQUEST's number is the call that answered `404 Issue not found` for the
-// whole life of agent-examples/pr-summary-agent and agent-examples/pr-summary-review.
 {
   const findings = await probeTwin("github", {
     probes: [
@@ -285,8 +233,6 @@ assert(
   assert(refused.length === 0, `commenting at a pull request's number is answered (got: ${JSON.stringify(refused)})`);
 }
 
-// ...and the gate really would have caught it. Same tool, at a number no issue
-// and no pull request carries: the twin answers 404 and the gate names it.
 {
   const findings = await probeTwin("github", {
     probes: [{ tool: "add_issue_comment", args: { owner: "acme", repo: "api", issue_number: 4242, body: "probe" } }],
@@ -299,14 +245,7 @@ assert(
   assert(text.includes("4242"), "the end-to-end report carries the arguments the probe sent");
 }
 
-// The anti-drift clause, end to end, on the twin that most needs it: slack
-// declared 11 tools and its own suite reached 3 over the wire. It declares 18
-// now (the table was replaced with Slack's own), and the count below is
-// derived from the twin rather than typed, so the clause survives the next one.
 {
-  // Derived, not typed: an empty manifest reds one unprobed-endpoint per
-  // declared tool, which is the count the one-probe run should leave behind
-  // minus the tool it covers.
   const declaredCount = (await probeTwin("slack", { probes: [] })).length;
   const findings = await probeTwin("slack", {
     probes: [{ tool: "slack_search_channels", args: { query: "general", limit: 10 } }],
@@ -322,8 +261,6 @@ assert(
   );
 }
 
-// Every twin boots and answers tools/list. A boot recipe naming an export that
-// does not exist would otherwise fail as a wall of identical 401s.
 for (const id of Object.keys(TWIN_BOOT)) {
   const findings = await probeTwin(id, { probes: [] });
   assert(
@@ -332,9 +269,6 @@ for (const id of Object.keys(TWIN_BOOT)) {
   );
 }
 
-// ── the shipped manifest covers every declared endpoint ─────────────────────
-// The gate proves this when it runs; this pins that the checked-in manifest is
-// the state the gate passes in, so a red is news rather than the default.
 {
   const manifest = JSON.parse(readFileSync(join(ROOT, "config/twin-endpoint-probes.json"), "utf8"));
   assert(
@@ -347,8 +281,6 @@ for (const id of Object.keys(TWIN_BOOT)) {
   }
 }
 
-// ── the gate is actually wired into CI ──────────────────────────────────────
-// A gate nothing runs is the failure mode this exists to prevent.
 {
   const ci = readFileSync(join(ROOT, ".github/workflows/ci.yml"), "utf8");
   assert(ci.includes("npm run probe:twins"), "ci.yml runs the declared-endpoint gate");
@@ -363,9 +295,6 @@ if (failures > 0) {
 }
 console.log("probe-twin-endpoints: all assertions passed.");
 
-// resolvePath: a setup step addresses state an earlier probe minted, so
-// `$alias` resolves in a path SEGMENT — and only in a whole segment, so a
-// literal `$` cannot be mistaken for a reference.
 {
   const results = { review_pr: { number: 4 } };
   assert(

--- a/scripts/probe-twin-endpoints.test.mjs
+++ b/scripts/probe-twin-endpoints.test.mjs
@@ -348,7 +348,7 @@ for (const id of Object.keys(TWIN_BOOT)) {
 }
 
 // ── the gate is actually wired into CI ──────────────────────────────────────
-// A gate nothing runs is the failure mode this ticket exists to prevent.
+// A gate nothing runs is the failure mode this exists to prevent.
 {
   const ci = readFileSync(join(ROOT, ".github/workflows/ci.yml"), "utf8");
   assert(ci.includes("npm run probe:twins"), "ci.yml runs the declared-endpoint gate");

--- a/scripts/smoke-examples.mjs
+++ b/scripts/smoke-examples.mjs
@@ -1,72 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Example-launch smoke. `tsc` cannot see a temporal-dead-zone crash: an example
-// whose top-level `await main()` runs before the class below it is evaluated
-// typechecks clean and dies at startup with `ReferenceError: Cannot access
-// 'X' before initialization`. The POME_PREFLIGHT path is a hoisted-function
-// early return, so it never reaches the class either — `pome doctor` passes
-// against a code path that stops short of the bug.
-//
-// So this launches each runnable example for real, POME_PREFLIGHT unset.
-//
-// ── HOW A LAUNCH IS CLASSIFIED ───────────────────────────────────────────────
-//
-//   still alive at SETTLE_MS            OK. It reached async work, and a TDZ
-//                                       throws synchronously during module
-//                                       evaluation, well inside the window.
-//   exits with the TDZ signature        FAIL, unconditionally. The crash this
-//                                       gate exists to catch; must never
-//                                       become a skip or a pass.
-//   exits having printed the marker     REACHED-OUTBOUND, a pass. Named for
-//                                       what it proves — module evaluated,
-//                                       startup guards cleared, an outbound
-//                                       call opened — never for what it does
-//                                       not (that the work was correct;
-//                                       `probe:examples` owns that).
-//   exits without the marker            FAIL. It returned before it could have
-//                                       done anything.
-//
-// ── WHY A MARKER AND NOT THE ERROR TEXT ──────────────────────────────────────
-//
-// Matching failure text cannot be made deterministic. The Claude Agent SDK's
-// `query()` picks between two error shapes on a field set by a race between its
-// own stream parsing and the child's 'exit' event: win the race and the same
-// underlying 401 reads "Claude Code returned an error result: … 401 invalid
-// x-api-key"; lose it and it reads "Claude Code process exited with code 1".
-// Same tree, either verdict. Widening the signature list to catch "process
-// exited with code" would convert every pre-wiring crash into a pass.
-//
-// `OUTBOUND_MARKER` is instead a fixed literal every example prints,
-// synchronously, immediately before its first outbound call — before either
-// error shape can be constructed. Examples routing through
-// `@pome-sh/adapter-claude-sdk`'s `query()` get it from that seam; the rest
-// print it themselves, gated on `POME_SMOKE_MARK_OUTBOUND=1` so real users
-// never see it. `assertEveryExampleEmitsMarker()` asserts the PROPERTY — every
-// discovered example has a route to the marker — rather than hand-listing which
-// ones need their own, so a ninth example that forgets reds here by name.
-// `BENIGN_FAILURE_SIGNATURES` still fires, but only to supply a human-readable
-// REASON alongside a marker-backed verdict, never to decide one.
-//
-// What the marker does NOT prove is that a socket was written: it is printed at
-// the call SITE, so anything throwing between that line and the syscall prints
-// it first. `PRE_OUTBOUND_VETOES` reds those on their own error CODE, which is
-// deterministic where error text is not, because none of those codes can be
-// produced by a failure after a call went out.
-//
-// ── TWO THINGS STATED RATHER THAN ENGINEERED AWAY ────────────────────────────
-//
-// `SMOKE_EXAMPLES_LIVE=1` runs the same classifier and discovery without
-// overlaying SMOKE_ENV's dead ports and invalid keys, so a credentialed
-// caller's real wiring flows through. In that mode a hard credential check runs
-// BEFORE anything launches — an absent credential must never degrade into a
-// second REACHED-OUTBOUND run that reports success — and a floor afterwards
-// asserts at least one example was alive at the settle.
-//
-// SETTLE_MS is a wall clock racing the `claude` CLI's cold start, so the OK
-// versus REACHED split is environment-shaped: a machine with an authenticated
-// login reports several still-alive where CI reports zero. Both are passing
-// outcomes and the marker fires within milliseconds of process start, so this
-// changes no verdict.
+// Launches each example for real, because `tsc` cannot see a temporal-dead-zone
+// crash. Classification: alive at the settle is OK, the TDZ signature is always
+// FAIL, and an early exit passes only if the example printed OUTBOUND_MARKER.
+// The marker exists because the SDK picks between two error shapes on a race, so
+// the same 401 reads two ways — error text cannot be classified deterministically.
 import { spawn } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, realpathSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
@@ -75,46 +13,18 @@ import { fileURLToPath } from "node:url";
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const examplesDir = join(repoRoot, "agent-examples");
 
-// How long to let each example run before we conclude it survived module
-// evaluation and reached real (async) work. A launch-above-class TDZ throws
-// synchronously while the module body evaluates — well under a second — so a
-// few seconds is plenty even with tsx's cold-start transpile.
 export const SETTLE_MS = 5000;
 
-// The V8 message for accessing a `let`/`const`/`class` binding in its temporal
-// dead zone. This is the exact crash the tsc gate missed.
-// A TDZ crash is a hard failure regardless of exit code or timing.
 export const TDZ_SIGNATURE = /(?:Cannot access '[^']+' before initialization|before initialization)/;
 
-// The positive-evidence marker. A fixed literal every example prints
-// to stderr, synchronously, immediately before its first outbound (twin or
-// model) call — see the file header for why this replaced error-text
-// matching as the thing REACHED-OUTBOUND is decided on. Gated behind
-// POME_SMOKE_MARK_OUTBOUND so it never appears in a real user's terminal.
 export const OUTBOUND_MARKER = "POME_SMOKE_REACHED_OUTBOUND";
 export const MARK_OUTBOUND_ENV = "POME_SMOKE_MARK_OUTBOUND";
 
-// A benign, CI-expected reason an example can legitimately exit before the
-// settle: SMOKE_ENV points every twin URL at a dead loopback port and hands
-// out invalid model/API keys on purpose, so a healthy example that reaches
-// real work is EXPECTED to fail fast on a network refusal or an auth
-// rejection. Each entry names the class of failure it recognizes so a match
-// carries a reason, not just a verdict — this is a property of the failure
-// text, not a per-example allowlist, so it says nothing about which of the
-// eight examples produced it.
-//
-// Every pattern must be ERROR-SHAPED — an errno, an HTTP status, a library's
-// own error class — never ordinary prose an example could print on a healthy
-// path. `/unauthorized/i` was the sharp edge here: this example's own Slack
-// report for seed 04 reads "merge blocked: … not an authorized collaborator",
-// so a bare prose match let an example excuse itself with its own output.
 const BENIGN_FAILURE_SIGNATURES = [
   ["connection refused", /ECONNREFUSED/],
   ["connection reset", /ECONNRESET/],
   ["DNS resolution failed", /ENOTFOUND|EAI_AGAIN|getaddrinfo/],
   ["host unreachable", /EHOSTUNREACH|ENETUNREACH/],
-  // undici's own message for a failed fetch. Error-shaped by construction —
-  // no example prints this phrase on a healthy path.
   ["network request failed", /fetch failed/i],
   ["TLS/proxy terminated the connection", /ECONNABORTED|EPROTO|before secure TLS connection/],
   ["request timed out", /ETIMEDOUT|ERR_SOCKET_CONNECTION_TIMEOUT|\bAbortError\b/],
@@ -124,30 +34,10 @@ const BENIGN_FAILURE_SIGNATURES = [
   ],
   [
     "model provider rejected the invalid key",
-    // Status codes are matched only in status-shaped context: a bare /\b401\b/
-    // also matches a stack frame's line number (`at f (file.js:401:5)`), which
-    // would hand a benign verdict to any crash with a 401-line stack.
     /invalid[ _-]?api[ _-]?key|invalid x-api-key|authentication_error|permission_error|status (?:401|403)\b|HTTP 40[13]\b|\b40[13] (?:Unauthorized|Forbidden)\b/i,
   ],
 ];
 
-// The marker proves the process REACHED its outbound call site; it
-// cannot prove a socket was ever written. Two crash classes were MEASURED to
-// print the marker and then die before any network syscall: the Agent SDK
-// failing to resolve the `claude` binary (`native binary not found at …` —
-// pure config, no request) and a malformed twin URL (`ERR_INVALID_URL`, thrown
-// by fetch while parsing, after the marker line). Both FAILED under the old
-// text classifier and would silently become passes on the marker alone —
-// "a crash before real work reads as success" through the back door,
-// with the `claude` binary going unresolvable in CI converting all four
-// adapter-backed examples at once.
-//
-// So: a veto. Each pattern is an error CODE that cannot be produced by a
-// failure AFTER an outbound call, which is what keeps this deterministic where
-// error-TEXT matching is not — none of these appear in
-// the SDK's racing error shapes. The imprecision is fail-closed in the safe
-// direction: a pre-outbound class this list misses keeps today's verdict, and
-// no real outbound failure can be redded by it.
 const PRE_OUTBOUND_VETOES = [
   ["the URL never parsed, so no request was made", /ERR_INVALID_URL/],
   [
@@ -171,88 +61,26 @@ function matchBenignFailure(output) {
   return null;
 }
 
-// The kickoff instruction. This is NOT a fake credential and NOT dead wiring:
-// it is the only thing that gives a launched example anything to do, and four
-// of the eight (`gmail-retry-notify`, `merge-agent`, `minimal-viktor`,
-// `minimal-viktor-langgraph`) call `requiredEnv("POME_TASK")` and throw at
-// startup without it. It therefore applies on BOTH legs, and keeping it out of
-// SMOKE_DEAD_WIRING below is load-bearing: the first cut of the live leg overlaid nothing
-// at all in LIVE mode, so those four died on `Error: POME_TASK is required`
-// and the gate classified them FAIL with "returned without evidence it did any
-// real work" — i.e. a credentialed run would have redded 4 of 8 on its
-// very first run, for an unset env var that has nothing to do with the
-// property this leg exists to prove, which is exactly the kind of
-// non-diagnosable red that trains a reader to ignore the alarm.
 const SMOKE_TASK = "Smoke run: triage/summarize the open items in acme/api.";
 
-// Settings the credentialed leg supplies only when the caller has NOT.
-// Neither is a credential and neither is dead wiring: together they are what
-// decides whether a launched example has anything to do and whether it can
-// reach a model with the ONE secret this leg asks a human to provision. Both
-// gaps were found by running the leg's exact env shape; each one alone reds the
-// nightly on its first run, for a reason unrelated to the property it proves.
 const SMOKE_LIVE_DEFAULTS = {
   POME_TASK: SMOKE_TASK,
-  // `minimal-viktor` defaults to `VIKTOR_MODEL=alibaba/qwen-3-32b`, which its
-  // `resolveModel()` can reach ONLY through the AI Gateway: with no
-  // AI_GATEWAY_API_KEY it throws `VIKTOR_MODEL=alibaba/qwen-3-32b needs
-  // AI_GATEWAY_API_KEY` before any outbound call — a non-benign exit 1, so FAIL,
-  // so a red leg. The PR leg papers over this with a fake AI_GATEWAY_API_KEY in
-  // SMOKE_DEAD_WIRING; the credentialed leg must not, because a fake gateway key
-  // would route all eight examples into a gateway that rejects them and the real
-  // ANTHROPIC_API_KEY would never be exercised at all — a "credentialed" leg
-  // whose credential is unreachable. Pinning the anthropic/* slug that
-  // merge-agent and gmail-retry-notify ALREADY default to keeps the whole leg on
-  // one provisioned secret. `VIKTOR_MODEL` is also minimal-viktor-langgraph's
-  // documented fallback (LANGGRAPH_MODEL ?? VIKTOR_MODEL ?? claude-sonnet-5) and
-  // its resolveModel() takes `anthropic/*` too, so both land on
-  // ANTHROPIC_API_KEY rather than one silently needing a second key.
   VIKTOR_MODEL: "anthropic/claude-opus-4-8",
 };
 
-// Env that gets every example past its startup guards and into async work so
-// the launch-above-class code path is actually exercised. Values are
-// intentionally non-functional (no live twin, invalid keys): we want the module
-// to LOAD, not to complete a real run. Overlaid on the PR (uncredentialed) leg
-// ONLY — see launchEnv().
 const SMOKE_DEAD_WIRING = {
-  // Nothing is listening here; fetches fail fast, but only AFTER module load.
   POME_TWIN_BASE_URL: "http://127.0.0.1:59321",
   POME_GITHUB_REST_URL: "http://127.0.0.1:59321",
   POME_GITHUB_MCP_URL: "http://127.0.0.1:59321/s/smoke/mcp",
   POME_SLACK_REST_URL: "http://127.0.0.1:59321",
-  // support-triage resolves BOTH twins' MCP URLs in resolveTwinWiring() before it
-  // touches anything else, and throws naming every missing var. Without this the
-  // example this gate was extended to cover died in env resolution and
-  // the gate still printed OK — it proved the module evaluates and nothing more,
-  // never reaching examineeOptions() or query(), which is where a launch-above-
-  // declaration TDZ this gate exists to catch would actually fire.
   POME_SLACK_MCP_URL: "http://127.0.0.1:59321/s/smoke/mcp",
   POME_GMAIL_REST_URL: "http://127.0.0.1:59321",
-  // triage-agent / pr-summary-* accept a pre-minted bearer token verbatim, so
-  // resolveAuthToken() returns immediately and reaches `new TwinMcpClient(...)`
-  // (the TDZ site) instead of throwing on missing auth.
   POME_AUTH_TOKEN: "smoke-token",
-  // pr-summary-* call resolveAnthropicKey() before the twin client; a present
-  // (if invalid) key lets them reach the TDZ site too.
   ANTHROPIC_API_KEY: "sk-ant-smoke-invalid",
-  // merge-agent / minimal-viktor* route every provider through the AI Gateway
-  // when this is set, so resolveModel() returns without a per-provider key.
   AI_GATEWAY_API_KEY: "smoke-invalid",
 };
 
-// The env one example is launched with. Exported and pure so the regression
-// suite can assert the LIVE leg still hands every example a task (the defect
-// above) without booting anything.
 export function launchEnv(baseEnv, live) {
-  // LIVE: the caller (the credentialed workflow) has already put real twin
-  // wiring and a real model key in the env; overlaying SMOKE_DEAD_WIRING here
-  // would put every example straight back on the loopback port this whole leg
-  // exists to get off of. SMOKE_LIVE_DEFAULTS fill only what the caller left
-  // unset — a caller-supplied value always wins, and a BLANK one counts as
-  // unset so `requiredEnv`'s own trim-check never receives "".
-  // PR leg: unchanged from before the live leg existed — the overlay wins unconditionally,
-  // including the fake AI_GATEWAY_API_KEY that makes alibaba/* resolve there.
   const env = live
     ? { ...baseEnv }
     : { ...baseEnv, ...SMOKE_DEAD_WIRING, POME_TASK: SMOKE_TASK };
@@ -262,23 +90,10 @@ export function launchEnv(baseEnv, live) {
     }
   }
   delete env.POME_PREFLIGHT; // ensure the real launch path, not the early return
-  // Tells every example (directly, or via @pome-sh/adapter-claude-sdk's
-  // query()) to print OUTBOUND_MARKER before its first outbound call. Neither a
-  // credential nor wiring, so it applies unconditionally on both legs.
   env[MARK_OUTBOUND_ENV] = "1";
   return env;
 }
 
-// The credentialed leg switch. Read once at module load (same as
-// SETTLE_MS/TDZ_SIGNATURE above) so both smokeOne() and main() agree on it
-// for the life of one process; the regression suite drives the exported pure
-// functions below directly rather than re-triggering this env read.
-//
-// Strict, and a non-"1" value is an ERROR rather than "not live": a flag typo'd
-// to `true`/`yes`/`TRUE`/`1 ` would otherwise make LIVE false and silently run
-// the PR leg instead — SMOKE_DEAD_WIRING overlaid, no credential check, no
-// floor, REACHED-OUTBOUND x 8, exit 0. A green nightly that proves nothing is
-// the failure this guards, and it must not be one character away.
 export function resolveLiveFlag(value) {
   if (value === undefined || value === "") return { live: false, error: null };
   if (value === "1") return { live: true, error: null };
@@ -295,45 +110,12 @@ export function resolveLiveFlag(value) {
 
 export const LIVE = resolveLiveFlag(process.env.SMOKE_EXAMPLES_LIVE).live;
 
-// The credentials a credentialed run cannot proceed without. `ANTHROPIC_API_KEY`
-// is required unconditionally rather than accepting `AI_GATEWAY_API_KEY` as an
-// alternative: `minimal-viktor-langgraph` constructs its `ChatAnthropic` model
-// from `ANTHROPIC_API_KEY` directly and never consults the gateway key (see
-// agent-examples/minimal-viktor-langgraph/src/index.ts), so a leg that accepted the
-// gateway key alone would still strand that example at "no evidence of real
-// work" while reporting the OTHER seven's gateway-routed calls as proof the
-// leg is credentialed. `POME_AUTH_TOKEN` is the one twin-side signal every
-// wired example reads (see this file's header); its presence is
-// what distinguishes "real local twins were booted for this run" from
-// SMOKE_ENV's dead loopback ports, without hand-enumerating which of the
-// three twin REST/MCP URL pairs a given example needs.
 export const LIVE_REQUIRED_ENV = ["ANTHROPIC_API_KEY", "POME_AUTH_TOKEN"];
 
-// Named, not silent: a credentialed leg missing a secret must fail loudly
-// before anything launches, never fall through into a second uncredentialed
-// REACHED-OUTBOUND run that reports success — that would be a nightly
-// proving nothing while looking like it proves something, this gate's own
-// subject.
-// `!env[name]` alone is not enough. GitHub Actions substitutes an unset secret
-// as the EMPTY STRING rather than leaving the var absent (falsy, so caught), but
-// a secret whose stored value is blank-but-not-empty — a stray space or newline
-// pasted into the secret box, the shape we have found blank in Infisical —
-// is TRUTHY and would sail through, leaving the leg to launch every example with
-// a whitespace API key and report the resulting per-example crashes as "the
-// example is broken" instead of "the credential is blank". Trim, so present-but-
-// blank is named as absent.
 export function missingLiveEnv(env = process.env) {
   return LIVE_REQUIRED_ENV.filter((name) => !env[name]?.trim());
 }
 
-// The floor the credentialed leg asks for: at least one example
-// must be alive at the settle — zero-alive is the exact fact no environment
-// currently asserts. Deliberately >= 1, not a hardcoded count of examples or
-// a fraction of `total`: a literal tied to `total` is this gate's own
-// "two floors that compared quantities which moved together" shape — either
-// number drifts in lockstep as examples are added or removed, so the
-// cross-check never disagrees with itself. The floor here is independent of
-// `total` on purpose.
 export function assertAliveFloor({ live, okCount, total }) {
   if (!live) return { ok: true, message: null };
   if (okCount < 1) {
@@ -352,21 +134,6 @@ export function assertAliveFloor({ live, okCount, total }) {
   };
 }
 
-// The counted-numerator property. `classifyLaunch()` already gives
-// every launch one of three named, counted outcomes (ok / reached / fail); the
-// gap this closes is a DIFFERENT failure mode, one level up: an example that
-// never reaches `classifyLaunch()` at all and so never lands in any of the
-// three buckets — the printed "N of M" total quietly shrinks to N-1 with
-// nothing saying the Mth example went MISSING rather than FAILED: the summary
-// reads "7 of 8", names seven, and says nothing about the eighth having
-// vanished rather than failed. Pure and
-// exported so the regression suite can assert it without spawning all eight
-// examples: feed it a discovered list and the names main()'s loop actually
-// produced a verdict for.
-//
-// Deliberately compares NAMES, not just lengths — a bug that drops one name
-// and double-reports another would net to the same length and hide behind a
-// count-only check, defeating the "naming the missing example" requirement.
 export function assertReportedCount(discoveredNames, reportedNames) {
   const reported = new Set(reportedNames);
   const missing = discoveredNames.filter((name) => !reported.has(name));
@@ -388,22 +155,11 @@ export function discoverExamples(dir = examplesDir) {
     const pkgPath = join(dir, name, "package.json");
     if (!existsSync(pkgPath)) continue;
     const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
-    // Every runnable example starts with `tsx src/index.ts`; only those can
-    // carry a launch-above-class TDZ.
     if (pkg.scripts?.start) found.push(name);
   }
   return found;
 }
 
-// Asserts the PROPERTY, not the instance list: every discovered
-// example must have SOME route to printing OUTBOUND_MARKER before its first
-// outbound call, or classifyLaunch()'s fail-closed rule means it can never
-// report "reached" again — silently, with nothing pointing at why. A
-// dependency on `@pome-sh/adapter-claude-sdk` covers it for free (its
-// `query()` wrapper emits the marker itself, wrapping the exact SDK call that
-// races); anything else must contain the literal marker in its own source. A
-// ninth example that is neither reds here BY NAME, at design time, instead of
-// silently degrading to permanent-FAIL at run time.
 export function assertEveryExampleEmitsMarker(dir, examples) {
   const missing = [];
   for (const name of examples) {
@@ -424,27 +180,11 @@ export function assertEveryExampleEmitsMarker(dir, examples) {
   };
 }
 
-// The DEPENDENCY only covers an example if it resolves to the WORKSPACE copy of
-// the adapter. `agent-examples/support-triage` pins the PUBLISHED tarball on purpose
-// (it is `npx degit`-fetchable as a standalone subtree — see
-// scripts/gate-examples.mjs's header), and a published tarball cut before
-// the marker existed prints nothing: measured on this branch, its installed
-// `dist/index.js` contains ZERO occurrences of OUTBOUND_MARKER while the three
-// `file:`-linked siblings contain one each, so support-triage FAILED every run
-// while a dependency-NAME check called it covered — the guard waving through
-// the one instance it was written to catch. A registry-pinned example must
-// therefore print the literal itself, and does.
 function adapterResolvesToWorkspace(deps) {
   const pin = deps["@pome-sh/adapter-claude-sdk"];
   return typeof pin === "string" && /^(?:file:|link:|\.\.?\/)/.test(pin);
 }
 
-// Emission, not mention: the literal inside a `console.error(...)` call, so a
-// marker named in a COMMENT (or in prose about the marker) does not buy
-// coverage. A static check still cannot prove the line is reachable or
-// correctly placed — `classifyLaunch()` is fail-closed for that, and an
-// example whose marker never actually prints FAILS loudly with the marker
-// named in its reason.
 const MARKER_EMISSION = new RegExp(`console\\.error\\(\\s*["'\`]${OUTBOUND_MARKER}["'\`]`);
 
 function sourceContainsMarker(srcDir) {
@@ -456,28 +196,6 @@ function sourceContainsMarker(srcDir) {
   return false;
 }
 
-// The verdict for one launch, given what we observed. Pure and exported so the
-// regression suite can drive it directly with synthetic evidence instead of
-// spawning real processes. `status` is one of "ok" | "reached" | "fail" —
-// never anything a caller could mistake for a fourth state.
-//
-// "reached" is a PASS, and deliberately not called a skip: measured on this PR
-// in real CI, 7 of 8 examples land here and ZERO land on "ok", because with no
-// live twin and no valid model key nothing can still be running at the settle.
-// A skip that is the permanent steady state is a gate that verifies nothing and
-// goes green. So it is named for what it
-// positively proves (the process evaluated its module, cleared its startup
-// guards, and got far enough to open an outbound twin/model call) and printed
-// distinctly from "ok", which is the strictly stronger evidence.
-//
-// "reached" now hinges on OUTBOUND_MARKER being present in the
-// captured output, never on matching the failure TEXT. BENIGN_FAILURE_SIGNATURES
-// still runs, but only to decorate a marker-backed verdict with a human-readable
-// reason; a match there with no marker present classifies as FAIL, exactly like
-// a match on any other prose the process happened to print. This is what makes
-// the verdict independent of which of the two error shapes the SDK's internal
-// race produces (see the file header) — the marker is printed before the race
-// can even begin.
 export function classifyLaunch({ output, stillRunningAtSettle, exitCode, signal, live = LIVE }) {
   if (TDZ_SIGNATURE.test(output)) {
     return { status: "fail", reason: "TDZ crash on launch" };
@@ -486,14 +204,8 @@ export function classifyLaunch({ output, stillRunningAtSettle, exitCode, signal,
     return { status: "ok", reason: `still running after ${SETTLE_MS}ms` };
   }
   const how = signal ? `killed by ${signal}` : `exited code ${exitCode}`;
-  // The marker plus proof-of-absence: a crash whose own error code says no
-  // request could have left the process is not "reached", however early the
-  // marker printed.
   const vetoed = matchPreOutboundVeto(output);
   const reachedOutbound = output.includes(OUTBOUND_MARKER) && !vetoed;
-  // Descriptive only from here down — matchBenignFailure() never gates a
-  // verdict, it only names the failure class for a reader once the marker has
-  // already proven the process got there.
   const benignReason = matchBenignFailure(output);
 
   if (exitCode !== 0 || signal) {
@@ -526,13 +238,7 @@ export function classifyLaunch({ output, stillRunningAtSettle, exitCode, signal,
     };
   }
 
-  // exitCode === 0
   if (reachedOutbound && !live) {
-    // SMOKE_ENV's twin/model wiring cannot succeed on the PR leg — dead
-    // loopback ports, invalid keys — so reaching the marker and still exiting
-    // 0 means the failure was swallowed, not that the run actually worked.
-    // The defect this gate exists to prevent, verbatim — just proven by the
-    // marker instead of guessed from failure text.
     return {
       status: "fail",
       reason:
@@ -541,19 +247,6 @@ export function classifyLaunch({ output, stillRunningAtSettle, exitCode, signal,
         `was swallowed instead of propagated. Propagate it so the process exits non-zero.`,
     };
   }
-  // The third possibility exists ONLY on the credentialed leg, and the
-  // reader has to be told about it or the first real nightly red is a mystery.
-  // OK is "still alive at the settle", so with real twins and a real key a
-  // GENUINELY CORRECT example that answers fast — the twin's default seed does
-  // not contain what SMOKE_TASK asks about, the model correctly says "nothing
-  // found", the process exits 0 in under 5s — lands HERE, on a FAIL whose text
-  // otherwise insists the example is broken. Distinguishing "exited 0 having
-  // produced work output" from "exited 0 having done nothing" needs a work
-  // marker no example emits in a common form across three frameworks (a
-  // DIFFERENT marker than OUTBOUND_MARKER, which proves only that the attempt
-  // started, not that it succeeded), so it is not a cheap fix; naming the
-  // possibility in the message is, and it makes the first red diagnosable
-  // instead of training the reader to ignore the alarm.
   const liveFastExit = live
     ? ` NOTE (credentialed leg): a third possibility applies here and NOWHERE ELSE — with real ` +
       `twins and a real model key, an example that is CORRECT but FAST can exit 0 inside the ` +
@@ -606,32 +299,11 @@ function smokeOne(name) {
       settled = true;
       clearTimeout(timer);
       if (!child.killed) child.kill("SIGKILL");
-      // SIGKILL reaches the direct `tsx` child only; the `claude` CLI
-      // GRANDCHILD the Agent SDK spawned survives holding the write end of
-      // these pipes, so the parent's read handles stay active and node cannot
-      // exit. Measured on this branch: a complete summary printed, then 194s
-      // of nothing before the process ended — in CI (no `timeout-minutes` on
-      // `typecheck-test`, so GitHub's 360-minute default) a hang after a
-      // finished summary is a new flake replacing the one this gate removed.
-      // The verdict is already computed from `output`, so releasing the pipes
-      // here loses nothing.
       child.stdout?.destroy();
       child.stderr?.destroy();
       resolvePromise({ name, output, ...verdict });
     };
 
-    // Classify on 'close', not 'exit'. Node only guarantees the piped stdio
-    // streams are drained on 'close'; 'exit' can fire with the child's final
-    // write still unread, and the whole verdict is a regex over `output` — so
-    // an example whose only BENIGN_FAILURE_SIGNATURES match sits in its last
-    // stderr line (`agent errored: … ECONNREFUSED`, written immediately before
-    // `process.exit(1)`) can be read as "no outbound-call failure in its
-    // output" and FAIL on one run and REACHED-OUTBOUND on the next, from the
-    // same commit. 'exit' still records HOW it exited, because 'close' carries
-    // the same code/signal but a lingering grandchild holding the pipe open can
-    // delay it past SETTLE_MS — and a child that has already exited must be
-    // classified on its exit code, never as "still running at the settle",
-    // which would turn a fast exit into a false OK.
     let exited = null;
     const timer = setTimeout(() => {
       finish(
@@ -655,13 +327,6 @@ function smokeOne(name) {
   });
 }
 
-// Guarded so the regression suite can `import { classifyLaunch, discoverExamples }`
-// without re-triggering a real launch of all eight examples. Realpath'd on
-// both sides (not `import.meta.main`: that landed in Node 24.2, root
-// `engines` allows `>=24`, and `undefined` there makes the guard false and
-// this file exit 0 having smoked nothing — the same shape fixed in
-// contract/run.mjs), and a guard miss while invoked as this file throws
-// rather than exits 0.
 const SELF = realpathSync(fileURLToPath(import.meta.url));
 const ENTRY = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";
 const invokedDirectly = ENTRY === SELF;
@@ -675,11 +340,6 @@ if (invokedDirectly) {
 }
 
 async function main() {
-  // Fail closed, before anything launches. A credentialed leg
-  // missing a secret must never silently become a second uncredentialed
-  // REACHED-OUTBOUND run that reports success; it must red, naming exactly
-  // what is absent.
-  // A flag set to an unrecognised value must not quietly mean "PR leg".
   const flag = resolveLiveFlag(process.env.SMOKE_EXAMPLES_LIVE);
   if (flag.error) {
     console.error(flag.error);
@@ -700,16 +360,11 @@ async function main() {
   }
 
   const examples = discoverExamples();
-  // Vacuous green: a runner examining zero examples must fail loudly, not
-  // print "All 0 examples launched clean."
   if (examples.length === 0) {
     console.error("No runnable examples (with a `start` script) found.");
     process.exit(1);
   }
 
-  // Before anything launches: every discovered example must have a
-  // route to the positive-evidence marker, or a run that never sees it is
-  // indistinguishable from an example that was simply never wired for it.
   const markerCoverage = assertEveryExampleEmitsMarker(examplesDir, examples);
   if (!markerCoverage.ok) {
     console.error(markerCoverage.message);
@@ -730,12 +385,6 @@ async function main() {
     try {
       result = await smokeOne(name);
     } catch (err) {
-      // smokeOne() is designed to always resolve — the SETTLE_MS timer, the
-      // child 'close' handler, and the child 'error' handler each
-      // independently produce a verdict — but this loop must not itself
-      // become the next silent-drop bug. This catch deliberately does NOT
-      // invent a verdict for work that never ran: the name lands in no bucket,
-      // so assertReportedCount() below names it as missing.
       console.log(`did not report a verdict (runner threw: ${err instanceof Error ? err.message : String(err)})`);
       continue;
     }
@@ -750,19 +399,11 @@ async function main() {
       reached.push({ name, reason: result.reason });
     } else {
       console.log(`FAILED (${result.reason})`);
-      // Show the tail so the crash (or the silent nothing) is visible in CI logs.
       if (tail) console.error(tail);
       failures.push({ name, reason: result.reason });
     }
   }
 
-  // The reported set is DERIVED from the three verdict buckets, never
-  // tracked alongside them. A separate `reportedNames.push(name)` next to the
-  // `await` would mark a name reported before the ok/reached/fail dispatch had
-  // put it anywhere, so the next silent-drop bug — a `continue` added inside
-  // the dispatch, or a fourth `status` no branch matches — would still net
-  // `ok: true` and still shrink the "N of M" total unannounced. Reading the
-  // buckets makes the assertion check the thing the summary actually counts.
   const reportedCount = assertReportedCount(
     examples,
     [...oks, ...reached, ...failures].map((r) => r.name),
@@ -787,10 +428,6 @@ async function main() {
           failures.map((f) => `${f.name} (${f.reason})`).join("; "),
       );
     }
-    // A missing verdict is reported and reds independently of
-    // `failures`: it is a defect in THIS SCRIPT's own bookkeeping, not in the
-    // example, and folding it into "Examples that crash on launch" above
-    // would misname the fault.
     if (!reportedCount.ok) console.error(`\n${reportedCount.message}`);
     if (!floor.ok) console.error(`\n${floor.message}`);
     process.exit(1);

--- a/scripts/smoke-examples.mjs
+++ b/scripts/smoke-examples.mjs
@@ -1,137 +1,72 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Example-launch smoke. `tsc` cannot see a temporal-dead-zone crash: the
-// examples typecheck gate was green while every real launch of
-// `agent-examples/triage-agent` died at startup with
-//   ReferenceError: Cannot access 'TwinMcpClient' before initialization
-// because the top-level `await main()` ran before the `class TwinMcpClient`
-// below it was evaluated. The POME_PREFLIGHT path (a hoisted-function early
-// return) never reached the class, so `pome doctor` / `POME_PREFLIGHT=1` passed
-// against a code path that stopped short of the bug.
+// Example-launch smoke. `tsc` cannot see a temporal-dead-zone crash: an example
+// whose top-level `await main()` runs before the class below it is evaluated
+// typechecks clean and dies at startup with `ReferenceError: Cannot access
+// 'X' before initialization`. The POME_PREFLIGHT path is a hoisted-function
+// early return, so it never reaches the class either — `pome doctor` passes
+// against a code path that stops short of the bug.
 //
-// This gate launches each runnable example for real — POME_PREFLIGHT unset, so
-// `main()` runs past the point where a launch-above-class TDZ would fire — and
-// fails if the module crashes on load with a TDZ ReferenceError.
+// So this launches each runnable example for real, POME_PREFLIGHT unset.
 //
-// For as long as this gate existed, an exit *inside* SETTLE_MS was
-// unconditionally treated as OK, on the theory that a benign network/auth
-// failure (no live twin, no real model key in CI) is expected and must not be
-// a false red. That theory is right, but the implementation never checked it —
-// ANY exit before the settle read as success, so an example that returns
-// having done nothing at all (wrong parse, an early return, a swallowed
-// error — `minimal-viktor-langgraph` did all three at once) passed exactly
-// like a healthy launch. Measured in CI on pome-sh/digital-twins#382: 8 of 8
-// examples reported OK, seven exited 1, one exited 0, and zero were "still
-// running" at the settle — the one signal this gate computes that actually
-// means "reached real work" was thrown away every time.
+// ── HOW A LAUNCH IS CLASSIFIED ───────────────────────────────────────────────
 //
-// The fix asserts the property instead of trusting the exit path:
-//   - still alive at the settle → OK. The launch reached async work (a network
-//     call, a model call) and is still in it — a TDZ throws synchronously
-//     during module evaluation, well under this window, so surviving it is
-//     real evidence, not silence.
-//   - exits before the settle with the TDZ signature in its output → FAIL,
-//     unconditionally. This is the crash this gate exists to catch, and must
-//     never become a skip or a pass no matter what else changes here.
-//   - exits before the settle WITHOUT the TDZ signature → only a network/auth
-//     failure this gate's own SMOKE_ENV deliberately manufactures (dead twin
-//     endpoints, invalid model keys) excuses this. That is asserted by
-//     matching the output against BENIGN_FAILURE_SIGNATURES below — a property
-//     of the failure ("connection refused", "invalid api key" …), not a list
-//     of which examples are allowed to exit early. A match is a named, counted
-//     REACHED-OUTBOUND, printed distinctly from OK. No match is a FAIL: the
-//     example returned before it could have done anything, and nothing in its
-//     own output says why.
+//   still alive at SETTLE_MS            OK. It reached async work, and a TDZ
+//                                       throws synchronously during module
+//                                       evaluation, well inside the window.
+//   exits with the TDZ signature        FAIL, unconditionally. The crash this
+//                                       gate exists to catch; must never
+//                                       become a skip or a pass.
+//   exits having printed the marker     REACHED-OUTBOUND, a pass. Named for
+//                                       what it proves — module evaluated,
+//                                       startup guards cleared, an outbound
+//                                       call opened — never for what it does
+//                                       not (that the work was correct;
+//                                       `probe:examples` owns that).
+//   exits without the marker            FAIL. It returned before it could have
+//                                       done anything.
 //
-// Measured on this PR in real CI (the only environment that gates anything):
-// 7 of 8 examples are REACHED-OUTBOUND and ZERO are OK, because with no live
-// twin and no valid model key nothing survives 5s. That is why the outbound
-// failure is a PASS and not a skip — a "skip" that is the permanent steady
-// state means a gate that verifies nothing and reports green, which is exactly
-// the defect this ticket exists to remove. It is named for what it proves
-// (module evaluated, startup guards cleared, an outbound call opened) and never
-// for what it does not (that the work was correct — `probe:examples` and the
-// scenario suites are the gates for that).
+// ── WHY A MARKER AND NOT THE ERROR TEXT ──────────────────────────────────────
 //
-// The REACHED-OUTBOUND leg above is the only thing any environment
-// ever proves, because CI has no credentials and 0 of 8 examples are ever
-// "still running at the settle" here. `SMOKE_EXAMPLES_LIVE=1` switches this
-// same gate — same classifier, same discovery, same output-tail printing —
-// into the mode a credentialed caller runs: it stops overlaying SMOKE_ENV's
-// dead loopback ports and invalid keys, so whatever real twin wiring and
-// model key the caller already put in `process.env` (booting real local
-// twins via `pome twin start`, a real `ANTHROPIC_API_KEY`) flows straight
-// through to each example. In this mode a hard credential check runs BEFORE
-// anything launches — an absent credential must never degrade into a second
-// REACHED-OUTBOUND run that reports success, which would prove nothing while
-// looking like a run that does — and a floor after the run asserts at
-// least one example was alive at the settle for real, naming what it
-// expected when it was not.
+// Matching failure text cannot be made deterministic. The Claude Agent SDK's
+// `query()` picks between two error shapes on a field set by a race between its
+// own stream parsing and the child's 'exit' event: win the race and the same
+// underlying 401 reads "Claude Code returned an error result: … 401 invalid
+// x-api-key"; lose it and it reads "Claude Code process exited with code 1".
+// Same tree, either verdict. Widening the signature list to catch "process
+// exited with code" would convert every pre-wiring crash into a pass.
 //
-// REACHED-OUTBOUND above was decided by matching the FAILURE TEXT
-// against BENIGN_FAILURE_SIGNATURES — an archaeology problem, not a proof.
-// `@anthropic-ai/claude-agent-sdk@0.3.221`'s query() picks between two error
-// shapes on a field (`lastErrorResultText`) set by a race between its own
-// stream-parsing and the child process's 'exit' event: win the race and the
-// thrown error reads "Claude Code returned an error result: … 401 invalid
-// x-api-key" (matches the signature list → REACHED-OUTBOUND); lose it and the
-// SAME underlying failure reads "Claude Code process exited with code 1.
-// stderr: <tail>" (matches nothing → FAIL). Same tree, either verdict —
-// measured on run 31711971267: attempt 1 was "7 of 8" reached + exit 1,
-// the re-run was "8 of 8". No regex over the error text can be made
-// deterministic against a race that lives inside a dependency's internals,
-// and widening the signatures to catch "process exited with code" would
-// convert every pre-wiring crash into a pass — the exact defect this gate
-// already fixed once, reintroduced through the back door.
+// `OUTBOUND_MARKER` is instead a fixed literal every example prints,
+// synchronously, immediately before its first outbound call — before either
+// error shape can be constructed. Examples routing through
+// `@pome-sh/adapter-claude-sdk`'s `query()` get it from that seam; the rest
+// print it themselves, gated on `POME_SMOKE_MARK_OUTBOUND=1` so real users
+// never see it. `assertEveryExampleEmitsMarker()` asserts the PROPERTY — every
+// discovered example has a route to the marker — rather than hand-listing which
+// ones need their own, so a ninth example that forgets reds here by name.
+// `BENIGN_FAILURE_SIGNATURES` still fires, but only to supply a human-readable
+// REASON alongside a marker-backed verdict, never to decide one.
 //
-// The fix: classify on POSITIVE EVIDENCE THE EXAMPLE ITSELF EMITS, not on
-// which shape of error text survived the race. `OUTBOUND_MARKER` below is a
-// fixed literal every example prints, synchronously, at the earliest point it
-// is about to make its first outbound (twin or model) call — before either of
-// the SDK's two racing error shapes can even be constructed. Four examples
-// (`pr-summary-agent`, `pr-summary-review`, `support-triage`, `triage-agent`)
-// get this for free from `@pome-sh/adapter-claude-sdk`'s `query()`, the shared
-// seam every one of them already routes through — it wraps the exact racy
-// `sdkQuery()` call, so the marker point and the race are in the same
-// function. The other four (`gmail-retry-notify`, `merge-agent`,
-// `minimal-viktor`, `minimal-viktor-langgraph`) import nothing from
-// `@pome-sh/*` at all — no shared seam covers them — so each prints the
-// literal marker itself, gated on `POME_SMOKE_MARK_OUTBOUND=1` so real users
-// never see it. `assertEveryExampleEmitsMarker()` asserts the PROPERTY (every
-// discovered example has a route to the marker — either the shared seam or
-// its own literal) rather than hand-listing which four need their own, so a
-// ninth example that forgets it reds here by name instead of silently
-// reporting FAIL forever with nothing pointing at why.
+// What the marker does NOT prove is that a socket was written: it is printed at
+// the call SITE, so anything throwing between that line and the syscall prints
+// it first. `PRE_OUTBOUND_VETOES` reds those on their own error CODE, which is
+// deterministic where error text is not, because none of those codes can be
+// produced by a failure after a call went out.
 //
-// What the marker does NOT prove: that a socket was written. It is printed at
-// the outbound call SITE, so anything that throws between that line and the
-// syscall prints it first. Two such classes were measured (the SDK failing to
-// resolve the `claude` binary; a malformed twin URL) and both used to FAIL, so
-// `PRE_OUTBOUND_VETOES` below reds them explicitly on their own error CODE —
-// deterministic where the removed error-TEXT matching was not, since none of
-// those codes can be produced by a failure after a call went out. Crashes
-// AFTER a successful outbound call are out of scope by design and always were:
-// this gate's claim is "reached an outbound call", never "the work was
-// correct" (`probe:examples` and the scenario suites own that).
+// ── TWO THINGS STATED RATHER THAN ENGINEERED AWAY ────────────────────────────
 //
-// Fail-closed: REACHED-OUTBOUND now requires the marker to be present in the
-// captured output. `BENIGN_FAILURE_SIGNATURES` still fires — but only to
-// supply a human-readable REASON alongside a marker-backed "reached" verdict,
-// never to decide the verdict itself. An example that crashes before it ever
-// reaches its marker line cannot be classified as reached no matter how
-// benign-looking its crash text is (verified by launching a deliberately
-// pre-wiring crash whose message contains "ECONNREFUSED"/"401 invalid
-// x-api-key" — it still FAILs).
+// `SMOKE_EXAMPLES_LIVE=1` runs the same classifier and discovery without
+// overlaying SMOKE_ENV's dead ports and invalid keys, so a credentialed
+// caller's real wiring flows through. In that mode a hard credential check runs
+// BEFORE anything launches — an absent credential must never degrade into a
+// second REACHED-OUTBOUND run that reports success — and a floor afterwards
+// asserts at least one example was alive at the settle.
 //
-// SETTLE_MS is a second, independent nondeterminism this does NOT remove: it
-// is a wall clock racing the `claude` CLI's cold-start time, so the OK
-// (still-alive) vs REACHED (marker-then-exit) split is environment-shaped — a
-// machine with an authenticated `claude` login can report several "still
-// running at the settle" where CI reports zero. That split does not change
-// the pass/fail verdict (both OK and REACHED are passing outcomes, and the
-// marker fires within milliseconds of process start either way, long before
-// SETTLE_MS), so it is stated here and in the printed summary rather than
-// engineered away.
+// SETTLE_MS is a wall clock racing the `claude` CLI's cold start, so the OK
+// versus REACHED split is environment-shaped: a machine with an authenticated
+// login reports several still-alive where CI reports zero. Both are passing
+// outcomes and the marker fires within milliseconds of process start, so this
+// changes no verdict.
 import { spawn } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, realpathSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
@@ -343,7 +278,7 @@ export function launchEnv(baseEnv, live) {
 // to `true`/`yes`/`TRUE`/`1 ` would otherwise make LIVE false and silently run
 // the PR leg instead — SMOKE_DEAD_WIRING overlaid, no credential check, no
 // floor, REACHED-OUTBOUND x 8, exit 0. A green nightly that proves nothing is
-// this ticket's own subject, and it must not be one character away.
+// the failure this guards, and it must not be one character away.
 export function resolveLiveFlag(value) {
   if (value === undefined || value === "") return { live: false, error: null };
   if (value === "1") return { live: true, error: null };
@@ -377,7 +312,7 @@ export const LIVE_REQUIRED_ENV = ["ANTHROPIC_API_KEY", "POME_AUTH_TOKEN"];
 // Named, not silent: a credentialed leg missing a secret must fail loudly
 // before anything launches, never fall through into a second uncredentialed
 // REACHED-OUTBOUND run that reports success — that would be a nightly
-// proving nothing while looking like it proves something, this ticket's own
+// proving nothing while looking like it proves something, this gate's own
 // subject.
 // `!env[name]` alone is not enough. GitHub Actions substitutes an unset secret
 // as the EMPTY STRING rather than leaving the var absent (falsy, so caught), but
@@ -423,7 +358,7 @@ export function assertAliveFloor({ live, okCount, total }) {
 // never reaches `classifyLaunch()` at all and so never lands in any of the
 // three buckets — the printed "N of M" total quietly shrinks to N-1 with
 // nothing saying the Mth example went MISSING rather than FAILED. Measured on
-// PR #417: the summary read "7 of 8" and named seven, and nothing said the
+// The shape this prevents: the summary reads "7 of 8" and names seven, and nothing says the
 // eighth (`pr-summary-agent`) had vanished rather than failed. Pure and
 // exported so the regression suite can assert it without spawning all eight
 // examples: feed it a discovered list and the names main()'s loop actually
@@ -530,7 +465,7 @@ function sourceContainsMarker(srcDir) {
 // in real CI, 7 of 8 examples land here and ZERO land on "ok", because with no
 // live twin and no valid model key nothing can still be running at the settle.
 // A skip that is the permanent steady state is a gate that verifies nothing and
-// goes green — this milestone's own subject. So it is named for what it
+// goes green. So it is named for what it
 // positively proves (the process evaluated its module, cleared its startup
 // guards, and got far enough to open an outbound twin/model call) and printed
 // distinctly from "ok", which is the strictly stronger evidence.

--- a/scripts/smoke-examples.mjs
+++ b/scripts/smoke-examples.mjs
@@ -144,7 +144,7 @@ const BENIGN_FAILURE_SIGNATURES = [
 //
 // So: a veto. Each pattern is an error CODE that cannot be produced by a
 // failure AFTER an outbound call, which is what keeps this deterministic where
-// the error-TEXT matching this ticket removed was not — none of these appear in
+// error-TEXT matching is not — none of these appear in
 // the SDK's racing error shapes. The imprecision is fail-closed in the safe
 // direction: a pre-outbound class this list misses keeps today's verdict, and
 // no real outbound failure can be redded by it.
@@ -329,7 +329,7 @@ export function missingLiveEnv(env = process.env) {
 // The floor the credentialed leg asks for: at least one example
 // must be alive at the settle — zero-alive is the exact fact no environment
 // currently asserts. Deliberately >= 1, not a hardcoded count of examples or
-// a fraction of `total`: a literal tied to `total` is the milestone's own
+// a fraction of `total`: a literal tied to `total` is this gate's own
 // "two floors that compared quantities which moved together" shape — either
 // number drifts in lockstep as examples are added or removed, so the
 // cross-check never disagrees with itself. The floor here is independent of
@@ -357,9 +357,9 @@ export function assertAliveFloor({ live, okCount, total }) {
 // gap this closes is a DIFFERENT failure mode, one level up: an example that
 // never reaches `classifyLaunch()` at all and so never lands in any of the
 // three buckets — the printed "N of M" total quietly shrinks to N-1 with
-// nothing saying the Mth example went MISSING rather than FAILED. Measured on
-// The shape this prevents: the summary reads "7 of 8" and names seven, and nothing says the
-// eighth (`pr-summary-agent`) had vanished rather than failed. Pure and
+// nothing saying the Mth example went MISSING rather than FAILED: the summary
+// reads "7 of 8", names seven, and says nothing about the eighth having
+// vanished rather than failed. Pure and
 // exported so the regression suite can assert it without spawning all eight
 // examples: feed it a discovered list and the names main()'s loop actually
 // produced a verdict for.
@@ -612,7 +612,7 @@ function smokeOne(name) {
       // exit. Measured on this branch: a complete summary printed, then 194s
       // of nothing before the process ended — in CI (no `timeout-minutes` on
       // `typecheck-test`, so GitHub's 360-minute default) a hang after a
-      // finished summary is a new flake replacing the one this ticket fixed.
+      // finished summary is a new flake replacing the one this gate removed.
       // The verdict is already computed from `output`, so releasing the pipes
       // here loses nothing.
       child.stdout?.destroy();

--- a/scripts/smoke-examples.test.mjs
+++ b/scripts/smoke-examples.test.mjs
@@ -1,18 +1,8 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// Regression suite for `smoke-examples.mjs`.
-//
-// The gap that undermines this gate's whole job: an exit inside SETTLE_MS
-// reading as "OK", so an example that returned having done nothing looks
-// identical to a healthy launch. `classifyLaunch()` is where that is decided,
-// so this suite drives it directly with synthetic evidence rather than spawning
-// all eight real examples (slow, network- and timing-dependent — the real
-// launches are exercised by `npm run smoke:examples` itself in CI).
-//
-// Four break-on-purpose scenarios: exits 0 immediately with no evidence of
-// work, exits 1 immediately with no recognized benign reason, a module-body TDZ
-// (must never regress to a skip or a pass), and zero examples discovered.
+// Case table for smoke-examples. Every case asserts the RED direction: a rule that has
+// quietly stopped failing prints the same line as one with nothing to report.
 import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -45,21 +35,18 @@ function check(name, got, want) {
   }
 }
 
-// ── break-on-purpose 1: exits 0 immediately, no signal of real work ────────
 {
   const v = classifyLaunch({ output: '{"decisions":[],"reports":[]}', stillRunningAtSettle: false, exitCode: 0 });
   check("exit 0 before settle with no benign signature reds", v.status, "fail");
   assert.match(v.reason, /exited code 0/);
 }
 
-// ── break-on-purpose 2: exits 1 immediately, no recognized reason ──────────
 {
   const v = classifyLaunch({ output: "boom, something broke", stillRunningAtSettle: false, exitCode: 1 });
   check("exit 1 before settle with no benign signature reds", v.status, "fail");
   assert.match(v.reason, /exited code 1/);
 }
 
-// ── break-on-purpose 3: a module-body TDZ still reds, whatever else is true ─
 {
   const tdzOutput = "ReferenceError: Cannot access 'TwinMcpClient' before initialization";
   check(
@@ -84,12 +71,6 @@ function check(name, got, want) {
   );
 }
 
-// ── An outbound-call failure is its own named verdict, distinct from
-// ok — but ONLY once the positive-evidence marker is present. The marker is
-// what a real launch prints (either via @pome-sh/adapter-claude-sdk's query(),
-// or the literal print each non-adapter example carries) immediately before
-// its first outbound attempt, so these fixtures include it exactly as real
-// captured output would.
 {
   const v = classifyLaunch({
     output: `${OUTBOUND_MARKER}\nTypeError: fetch failed\n  ECONNREFUSED 127.0.0.1:59321`,
@@ -109,13 +90,6 @@ function check(name, got, want) {
   check("marker + AI Gateway auth rejection before settle is 'reached'", v.status, "reached");
 }
 
-// ── Fail-closed: no marker means no "reached", no matter how benign
-// the crash text looks. This is the central acceptance bar — a
-// pre-wiring crash whose message deliberately CONTAINS benign-looking text
-// ("ECONNREFUSED", "401 invalid x-api-key") must still FAIL, because the
-// marker (proof the example ever reached its outbound call site) never
-// printed. Archaeology of the failure text alone is exactly what let a lost
-// SDK race convert a real crash into a pass.
 {
   for (const output of [
     "TypeError: fetch failed\n  ECONNREFUSED 127.0.0.1:59321",
@@ -133,12 +107,6 @@ function check(name, got, want) {
   }
 }
 
-// ── The other direction: the marker is printed at the outbound call
-// SITE, so a crash between that line and the syscall prints it first. Both of
-// these were MEASURED on this branch (the adapter seam with an unresolvable
-// `claude` binary; `gmail-retry-notify` with a malformed twin URL) and both
-// FAILED under the old text classifier, so the marker alone must not convert
-// them into passes — that is the same defect through the back door.
 {
   for (const [label, output] of [
     [
@@ -160,12 +128,6 @@ function check(name, got, want) {
   }
 }
 
-// ── Both of the SDK's racing error shapes give the SAME verdict once
-// the marker is present. This is the exact nondeterminism at issue:
-// `@anthropic-ai/claude-agent-sdk@0.3.221`'s query() picks between
-// "Claude Code returned an error result: …" (lastErrorResultText won the
-// race) and "Claude Code process exited with code N. stderr: …" (lost the
-// race) for the identical underlying 401. Both must classify identically.
 {
   const wonRace = classifyLaunch({
     output: `${OUTBOUND_MARKER}\nClaude Code returned an error result: … 401 invalid x-api-key`,
@@ -183,17 +145,6 @@ function check(name, got, want) {
   check("both racing shapes agree on the verdict", wonRace.status, lostRace.status);
 }
 
-// ── the signature list is locked against REAL CI output, not invented text ──
-//
-// Every string below is copied verbatim from the `smoke:examples` job log of
-// a real PR run (github.com/pome-sh/digital-twins/actions/runs/31614212888),
-// with OUTBOUND_MARKER prepended — a real launch prints it before
-// any of this text. This is the case that matters: the list decides whether
-// the gate is usable in the only environment that gates anything, and a
-// tightened pattern that no longer matches what CI actually prints reds all
-// eight examples at once. If a dependency changes its error wording, this
-// fails here — cheaply, naming the example — instead of in a CI run that reds
-// everything.
 {
   const realCiOutput = {
     "gmail-retry-notify":
@@ -216,11 +167,6 @@ function check(name, got, want) {
       exitCode: 1,
     });
     check(`real CI output for ${name} (with marker) classifies as reached`, v.status, "reached");
-    // The status alone is decided by the marker, so asserting only that would
-    // pass with BENIGN_FAILURE_SIGNATURES emptied — a vacuous version of the
-    // claim in this block's header. The REASON is what the signature list
-    // still owns, so assert a class was actually recognized: a pattern
-    // tightened past what CI prints reds here, cheaply, naming the example.
     assert.match(
       v.reason,
       /an outbound call failed \(.+\)/,
@@ -229,13 +175,6 @@ function check(name, got, want) {
   }
 }
 
-// ── a swallowed outbound failure that still exits 0 is a FAIL, not reached ──
-//
-// The marker alone must not buy a pass on the PR leg: SMOKE_ENV's dead wiring
-// cannot succeed, so an example that reaches its marker, hits the dead twin,
-// logs it, and exits clean has swallowed the failure and reported success.
-// This is the shape `minimal-viktor-langgraph` had, and it only red-lined
-// because its index.ts sets a non-zero exit code.
 {
   const v = classifyLaunch({
     output: `${OUTBOUND_MARKER}\n{"error":"list_collaborators acme/api failed: fetch failed"}`,
@@ -247,11 +186,6 @@ function check(name, got, want) {
   assert.match(v.reason, /swallowed/);
 }
 
-// ── the benign list must not be broad enough to swallow a real defect, even
-// with the marker present — matchBenignFailure() is descriptive only now, it
-// never gates a "reached" verdict on its own (the marker plus a non-zero exit
-// does). These fixtures omit the marker, so a broken example's ordinary
-// failure prose (which was never proof of anything) still reds.
 {
   for (const output of [
     "",
@@ -260,11 +194,7 @@ function check(name, got, want) {
     "request failed",
     "TypeError: Cannot read properties of undefined (reading 'ref')",
     "AssertionError: expected 1 to equal 0",
-    // This example's own Slack report for seed 04, which a bare /unauthorized/i
-    // matched — an example excusing itself with its own healthy-path output.
     "merge blocked: author drive-by-dev is not an authorized collaborator https://github.com/o/r/pull/1",
-    // A crash whose stack happens to have a 401st line: a bare /\b401\b/ read
-    // this as an auth rejection.
     "TypeError: x is not a function\n    at run (/app/src/graph.ts:401:9)",
   ]) {
     check(
@@ -275,21 +205,18 @@ function check(name, got, want) {
   }
 }
 
-// ── the fail message has to tell the reader what to do about it ───────────
 {
   const v = classifyLaunch({ output: "unrecognized boom", stillRunningAtSettle: false, exitCode: 1 });
   assert.match(v.reason, new RegExp(OUTBOUND_MARKER));
   check("an unrecognized failure names the marker it never saw", v.status, "fail");
 }
 
-// ── still running at the settle is the one real "did work" signal ──────────
 {
   const v = classifyLaunch({ output: "· thinking… 2s", stillRunningAtSettle: true });
   check("still running at the settle is ok", v.status, "ok");
   assert.match(v.reason, new RegExp(String(SETTLE_MS)));
 }
 
-// ── break-on-purpose 4: zero examples discovered is a hard failure ─────────
 {
   const emptyDir = mkdtempSync(join(tmpdir(), "smoke-examples-empty-"));
   try {
@@ -299,7 +226,6 @@ function check(name, got, want) {
   }
 }
 
-// ── discovery is a glob over `start` scripts, not a hand-kept list ─────────
 {
   const dir = mkdtempSync(join(tmpdir(), "smoke-examples-discover-"));
   try {
@@ -313,7 +239,6 @@ function check(name, got, want) {
   }
 }
 
-// ── The credentialed leg's floor — zero alive is a hard failure ────────────
 {
   const zero = assertAliveFloor({ live: true, okCount: 0, total: 8 });
   check("zero alive on the live leg fails the floor", zero.ok, false);
@@ -326,15 +251,11 @@ function check(name, got, want) {
   const many = assertAliveFloor({ live: true, okCount: 8, total: 8 });
   check("every example alive still meets the floor", many.ok, true);
 
-  // The floor must never apply to the uncredentialed (PR) leg — that leg's
-  // permanent steady state is 0 alive, and this floor is not the mechanism
-  // that would make it red for that.
   const notLive = assertAliveFloor({ live: false, okCount: 0, total: 8 });
   check("the floor is a no-op when not on the live leg", notLive.ok, true);
   check("a no-op floor carries no message", notLive.message, null);
 }
 
-// ── An absent credential on the live leg must be named, not silent ─────────
 {
   check(
     "every required var is reported missing from an empty env",
@@ -351,16 +272,11 @@ function check(name, got, want) {
     missingLiveEnv({ ANTHROPIC_API_KEY: "sk-ant-real" }),
     ["POME_AUTH_TOKEN"],
   );
-  // GitHub Actions substitutes an UNSET secret as the empty string, so the
-  // empty case is the one that actually happens in production, not a curiosity.
   check(
     "an empty-string secret is named as absent, not accepted",
     missingLiveEnv({ ANTHROPIC_API_KEY: "", POME_AUTH_TOKEN: "" }).sort(),
     [...LIVE_REQUIRED_ENV].sort(),
   );
-  // Truthy but blank — a space or newline pasted into the secret box
-  // (the blank-in-Infisical shape). Untrimmed, this sails through
-  // and the leg launches every example with a whitespace API key.
   check(
     "a whitespace-only secret is named as absent, not accepted",
     missingLiveEnv({ ANTHROPIC_API_KEY: "   ", POME_AUTH_TOKEN: "\t\n " }).sort(),
@@ -373,10 +289,6 @@ function check(name, got, want) {
   );
 }
 
-// ── An unrecognised SMOKE_EXAMPLES_LIVE must ERROR, never mean "PR leg"
-// A flag typo'd to `true` silently reverts to the uncredentialed leg: dead
-// loopback ports, no credential check, no floor, exit 0. That is a green
-// nightly proving nothing, one character away.
 {
   check("unset means the PR leg, with no error", resolveLiveFlag(undefined), {
     live: false,
@@ -395,11 +307,6 @@ function check(name, got, want) {
   }
 }
 
-// ── The LIVE leg must still hand every example a task ───────────────────────
-// Four of the eight `requiredEnv("POME_TASK")`. The first cut of the live leg
-// overlaid nothing at all, so those four died on `Error: POME_TASK is required`
-// and were classified FAIL ("returned without evidence it did any real work") —
-// the nightly would have redded 4 of 8 on its first run for an unset env var.
 {
   const realWiring = {
     ANTHROPIC_API_KEY: "sk-ant-real",
@@ -410,9 +317,6 @@ function check(name, got, want) {
 
   const live = launchEnv(realWiring, true);
   assert.ok(live.POME_TASK?.trim(), "the LIVE leg must supply a non-blank POME_TASK");
-  // minimal-viktor's default alibaba/* slug is reachable ONLY via the AI
-  // Gateway; on the credentialed leg (no fake gateway key) it throws before any
-  // outbound call. The leg must pin a slug the ONE provisioned secret can serve.
   assert.match(
     live.VIKTOR_MODEL ?? "",
     /^anthropic\//,
@@ -433,13 +337,8 @@ function check(name, got, want) {
     live.POME_GITHUB_MCP_URL,
     "http://127.0.0.1:3333/s/standalone/mcp",
   );
-  // Compared to a boolean, never passed as a value: check() prints `got` on
-  // failure, and handing it anything read off a *_API_KEY property is
-  // clear-text logging of sensitive information (js/clear-text-logging), which
-  // CodeQL flags high even when the value is this file's own fake literal.
   check("the LIVE leg keeps the real model key", live.ANTHROPIC_API_KEY === "sk-ant-real", true);
   check("the LIVE leg never re-enables POME_PREFLIGHT", live.POME_PREFLIGHT, undefined);
-  // The whole point of the leg: no dead loopback port may be overlaid.
   for (const [k, v] of Object.entries(live)) {
     assert.ok(
       !String(v).includes("59321"),
@@ -456,7 +355,6 @@ function check(name, got, want) {
     "a blank caller POME_TASK must not reach requiredEnv() as blank",
   );
 
-  // The PR leg is unchanged: the dead wiring overlay still wins outright.
   const pr = launchEnv(realWiring, false);
   check("the PR leg still overlays the dead loopback port", pr.POME_GITHUB_MCP_URL, "http://127.0.0.1:59321/s/smoke/mcp");
   check(
@@ -464,8 +362,6 @@ function check(name, got, want) {
     pr.ANTHROPIC_API_KEY === "sk-ant-smoke-invalid",
     true,
   );
-  // The PR leg's fake gateway key is what lets alibaba/* resolve and then fail
-  // at the outbound call (REACHED-OUTBOUND). Removing it would red that leg.
   check(
     "the PR leg still overlays the fake gateway key",
     pr.AI_GATEWAY_API_KEY === "smoke-invalid",
@@ -474,19 +370,10 @@ function check(name, got, want) {
   check("the PR leg does not pin a model slug", pr.VIKTOR_MODEL, undefined);
   assert.ok(pr.POME_TASK?.trim(), "the PR leg must supply a non-blank POME_TASK");
   check("the PR leg never re-enables POME_PREFLIGHT", pr.POME_PREFLIGHT, undefined);
-  // MARK_OUTBOUND_ENV is neither a credential nor twin/model wiring —
-  // it applies on BOTH legs unconditionally, or an example launched on
-  // whichever leg forgot it never prints OUTBOUND_MARKER and can never be
-  // classified as reached.
   check("the LIVE leg tells examples to emit the marker", live[MARK_OUTBOUND_ENV], "1");
   check("the PR leg tells examples to emit the marker too", pr[MARK_OUTBOUND_ENV], "1");
 }
 
-// ── The fast-correct-completion edge must be named in the failure ───────────
-// OK is "still alive at the settle", so on the credentialed leg a correct-but-
-// fast example exits 0 inside the settle and lands on FAIL. The verdict is
-// acceptable; a message insisting the example is broken is not, because the
-// first real nightly red would be undiagnosable.
 {
   const liveFast = classifyLaunch({
     output: "Triaged 0 open items in acme/api — nothing to do.",
@@ -498,8 +385,6 @@ function check(name, got, want) {
   assert.match(liveFast.reason, /credentialed leg/);
   assert.match(liveFast.reason, /CORRECT but FAST/);
 
-  // Off the live leg the note must NOT appear — the PR leg's exit-0 examples
-  // really are do-nothing exits, and the do-nothing message is right there.
   const prFast = classifyLaunch({
     output: "Triaged 0 open items in acme/api — nothing to do.",
     stillRunningAtSettle: false,
@@ -511,8 +396,6 @@ function check(name, got, want) {
     !prFast.reason.includes("credentialed leg"),
     "the PR leg's failure message must not carry the live-only note",
   );
-  // A non-zero exit is a crash on either leg; the fast-completion note would be
-  // misleading there, so it must not appear.
   assert.ok(
     !classifyLaunch({
       output: "unrecognized boom",
@@ -524,11 +407,6 @@ function check(name, got, want) {
   );
 }
 
-// ── The counted-numerator property ──────────────────────────────────────────
-// The shape this pins: the summary reads "7 of 8" and names seven, and nothing
-// said the eighth (`pr-summary-agent`) had gone MISSING rather than FAILED —
-// classifyLaunch()'s three named outcomes (ok/reached/fail) are worthless if
-// main()'s loop can silently drop an example before it ever reaches them.
 {
   const all8 = [
     "gmail-retry-notify",
@@ -544,19 +422,12 @@ function check(name, got, want) {
   check("every discovered example reporting is a pass", clean.ok, true);
   check("a clean pass carries no message", clean.message, null);
 
-  // The exact shape: one discovered example silently produces no
-  // verdict at all, and the summary must red naming it — not "failed",
-  // "missing".
   const oneVanished = assertReportedCount(all8, all8.filter((n) => n !== "pr-summary-agent"));
   check("one missing example fails the count assertion", oneVanished.ok, false);
   assert.match(oneVanished.message, /pr-summary-agent/);
   assert.match(oneVanished.message, /1 of 8/);
-  // Names it as absent from every existing bucket, never as belonging to one.
   assert.match(oneVanished.message, /neither OK, REACHED-OUTBOUND, nor FAILED/);
 
-  // Compares NAMES, not just lengths: dropping one example and (by some other
-  // bug) reporting an unrelated name twice must still be caught, because the
-  // two lengths would otherwise net out even.
   const droppedAndDuplicated = assertReportedCount(all8, [
     ...all8.filter((n) => n !== "triage-agent"),
     "merge-agent", // duplicate report, same length as the 8 discovered
@@ -568,21 +439,12 @@ function check(name, got, want) {
   );
   assert.match(droppedAndDuplicated.message, /triage-agent/);
 
-  // Zero discovered, zero reported is vacuously fine — discoverExamples()'s
-  // own zero-examples case is a separate hard failure (break-on-purpose 4
-  // above), not this assertion's job to catch.
   check("nothing discovered, nothing reported is a pass", assertReportedCount([], []).ok, true);
 }
 
-// ── The marker guard reds when a new example has no route to the
-// marker at all — asserting the PROPERTY (does this example's source or its
-// @pome-sh/adapter-claude-sdk dependency give it a way to print
-// OUTBOUND_MARKER?), never a hand-kept list of the four that need it directly.
 {
   const dir = mkdtempSync(join(tmpdir(), "smoke-examples-marker-"));
   try {
-    // Covered via the shared seam: depends on @pome-sh/adapter-claude-sdk, no
-    // literal marker in its own source required.
     mkdirSync(join(dir, "via-adapter", "src"), { recursive: true });
     writeFileSync(
       join(dir, "via-adapter", "package.json"),
@@ -593,8 +455,6 @@ function check(name, got, want) {
     );
     writeFileSync(join(dir, "via-adapter", "src", "index.ts"), "import { query } from '@pome-sh/adapter-claude-sdk';\n");
 
-    // Covered directly: no @pome-sh dependency, but its own source contains
-    // the literal marker.
     mkdirSync(join(dir, "via-literal", "src"), { recursive: true });
     writeFileSync(
       join(dir, "via-literal", "package.json"),
@@ -605,8 +465,6 @@ function check(name, got, want) {
       `if (process.env.${MARK_OUTBOUND_ENV} === "1") console.error("${OUTBOUND_MARKER}");\n`,
     );
 
-    // NOT covered: no @pome-sh dependency and no literal marker anywhere in
-    // its source — exactly the ninth-example-that-forgot-it shape.
     mkdirSync(join(dir, "forgot-it", "src"), { recursive: true });
     writeFileSync(
       join(dir, "forgot-it", "package.json"),
@@ -614,11 +472,6 @@ function check(name, got, want) {
     );
     writeFileSync(join(dir, "forgot-it", "src", "index.ts"), "console.log('does real work, prints nothing marker-shaped');\n");
 
-    // NOT covered: it DEPENDS on the adapter, but from the REGISTRY — a
-    // published tarball cut before the marker existed prints nothing, which is
-    // `agent-examples/support-triage`'s real shape (measured: zero occurrences of the
-    // marker in its installed dist). A dependency-name-only check called this
-    // covered while every run FAILED it.
     mkdirSync(join(dir, "registry-pinned", "src"), { recursive: true });
     writeFileSync(
       join(dir, "registry-pinned", "package.json"),
@@ -629,8 +482,6 @@ function check(name, got, want) {
     );
     writeFileSync(join(dir, "registry-pinned", "src", "index.ts"), "import { query } from '@pome-sh/adapter-claude-sdk';\n");
 
-    // NOT covered: the literal appears, but only as a MENTION in a comment —
-    // coverage requires an emitting `console.error(...)` call.
     mkdirSync(join(dir, "mentions-it", "src"), { recursive: true });
     writeFileSync(
       join(dir, "mentions-it", "package.json"),
@@ -649,7 +500,6 @@ function check(name, got, want) {
     check("an example with no route to the marker reds the guard", withGap.ok, false);
     assert.match(withGap.message, /forgot-it/);
     assert.match(withGap.message, new RegExp(OUTBOUND_MARKER));
-    // Only the example actually missing it is named.
     assert.ok(!withGap.message.includes("via-adapter"), "a covered example must not be named as missing");
     assert.ok(!withGap.message.includes("via-literal"), "a covered example must not be named as missing");
 
@@ -665,9 +515,6 @@ function check(name, got, want) {
   }
 }
 
-// ── The real agent-examples/ directory in THIS repo passes the guard ─────────────
-// The synthetic fixtures above prove the guard's logic; this proves the
-// guard actually holds against the tree it will run against in CI.
 {
   const real = discoverExamples();
   const coverage = assertEveryExampleEmitsMarker(examplesDirForRepo(), real);
@@ -675,9 +522,6 @@ function check(name, got, want) {
 }
 
 function examplesDirForRepo() {
-  // fileURLToPath, not `.pathname`: the latter stays percent-encoded, so a
-  // checkout under a path with a space reds this on ENOENT for a reason that
-  // has nothing to do with the property being asserted.
   return fileURLToPath(new URL("../agent-examples", import.meta.url));
 }
 

--- a/scripts/smoke-examples.test.mjs
+++ b/scripts/smoke-examples.test.mjs
@@ -3,19 +3,16 @@
 //
 // Regression suite for `smoke-examples.mjs`.
 //
-// The gate's whole job, before this ticket, was undermined by one gap: an
-// exit inside SETTLE_MS was ALWAYS "OK", so an example that returned having
-// done nothing looked identical to a healthy launch. `classifyLaunch()` is
-// where that got fixed, so this suite drives it directly with synthetic
-// evidence rather than spawning all eight real examples (slow, network- and
-// timing-dependent — the real launches are exercised by `npm run
-// smoke:examples` itself in CI).
+// The gap that undermines this gate's whole job: an exit inside SETTLE_MS
+// reading as "OK", so an example that returned having done nothing looks
+// identical to a healthy launch. `classifyLaunch()` is where that is decided,
+// so this suite drives it directly with synthetic evidence rather than spawning
+// all eight real examples (slow, network- and timing-dependent — the real
+// launches are exercised by `npm run smoke:examples` itself in CI).
 //
-// Four cases are the break-on-purpose scenarios this gate names explicitly:
-// exits 0 immediately with no evidence of work, exits 1 immediately with no
-// recognized benign reason, a module-body TDZ (this gate's whole subject — must never
-// regress to a skip or a pass no matter what else changes here), and zero
-// examples discovered.
+// Four break-on-purpose scenarios: exits 0 immediately with no evidence of
+// work, exits 1 immediately with no recognized benign reason, a module-body TDZ
+// (must never regress to a skip or a pass), and zero examples discovered.
 import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -113,7 +110,7 @@ function check(name, got, want) {
 }
 
 // ── Fail-closed: no marker means no "reached", no matter how benign
-// the crash text looks. This is the ticket's central acceptance bar — a
+// the crash text looks. This is the central acceptance bar — a
 // pre-wiring crash whose message deliberately CONTAINS benign-looking text
 // ("ECONNREFUSED", "401 invalid x-api-key") must still FAIL, because the
 // marker (proof the example ever reached its outbound call site) never
@@ -164,7 +161,7 @@ function check(name, got, want) {
 }
 
 // ── Both of the SDK's racing error shapes give the SAME verdict once
-// the marker is present. This is the exact nondeterminism the ticket names:
+// the marker is present. This is the exact nondeterminism at issue:
 // `@anthropic-ai/claude-agent-sdk@0.3.221`'s query() picks between
 // "Claude Code returned an error result: …" (lastErrorResultText won the
 // race) and "Claude Code process exited with code N. stderr: …" (lost the
@@ -379,7 +376,7 @@ function check(name, got, want) {
 // ── An unrecognised SMOKE_EXAMPLES_LIVE must ERROR, never mean "PR leg"
 // A flag typo'd to `true` silently reverts to the uncredentialed leg: dead
 // loopback ports, no credential check, no floor, exit 0. That is a green
-// nightly proving nothing — this ticket's own subject, one character away.
+// nightly proving nothing, one character away.
 {
   check("unset means the PR leg, with no error", resolveLiveFlag(undefined), {
     live: false,
@@ -528,7 +525,7 @@ function check(name, got, want) {
 }
 
 // ── The counted-numerator property ──────────────────────────────────────────
-// Measured on PR #417: the summary read "7 of 8" and named seven, and nothing
+// The shape this pins: the summary reads "7 of 8" and names seven, and nothing
 // said the eighth (`pr-summary-agent`) had gone MISSING rather than FAILED —
 // classifyLaunch()'s three named outcomes (ok/reached/fail) are worthless if
 // main()'s loop can silently drop an example before it ever reaches them.
@@ -547,7 +544,7 @@ function check(name, got, want) {
   check("every discovered example reporting is a pass", clean.ok, true);
   check("a clean pass carries no message", clean.message, null);
 
-  // The exact PR #417 shape: one discovered example silently produced no
+  // The exact shape: one discovered example silently produces no
   // verdict at all, and the summary must red naming it — not "failed",
   // "missing".
   const oneVanished = assertReportedCount(all8, all8.filter((n) => n !== "pr-summary-agent"));


### PR DESCRIPTION
`scripts/` and `scripts/lint/` were **30.3% prose**. Now **2.5%**: 4,941 lines removed, ~300 written back.

## Method

Same as #471:

1. A classifier walked each file tracking string, template-literal, regex, block-comment and heredoc state, so only whole-line comments could be removed.
2. **Every** comment was stripped and the full suite run green with zero comments — proof the strip touched nothing load-bearing.
3. Headers were written back from scratch, consulting an archive of what was removed.

For each lint rule, the argument for the rule — which AGENTS.md requires a rule header to carry — in two to five lines rather than a page. Every case table gets one line: it asserts the RED direction, because a rule that has quietly stopped failing prints the same output as one with nothing to report.

Usage blocks restating argv parsing, exit-condition enumerations, per-predicate essays, per-case narration, and the evolution histories of three classifiers.

`scripts/bundle-declarations.mjs` builds two published packages' bundled type declarations, so it is a publish-relevant path and this PR owes a pending `(patch)` entry for each. Both are marked no-consumer-visible-change; the emitted declarations are byte-identical. The relevance table cannot distinguish a comment edit there from a build-logic edit, so those two packages take a bump per cleanup PR touching that file — worth narrowing, not in this PR.

## Checks run

All 25 case tables, the six top-level self-tests, `lint`, `lint:test`, `lint:no-cloud-imports`, `gate:mcp-tools-list`, the package-scripts audit, and the release-note gate against a clean tree.