### PR TITLE
lint rule re-write + remove stale code

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -10,6 +10,12 @@ write a version number here or in `package.json`. Released
 entries are insertions only: a correction is the next entry, naming the one it
 corrects.
 
+## Unreleased (patch)
+
+**No consumer-visible change.** Added `// file-size:` header comments to four CLI
+modules that were previously exempted from the file-size lint by name. Prose only
+— no export, flag, schema, route, status code or response body moved.
+
 ## 0.26.11 — 2026-08-24
 
 **No consumer-visible change.** The repo's lint gates were consolidated behind

--- a/cli/src/cli/eval.ts
+++ b/cli/src/cli/eval.ts
@@ -1,3 +1,6 @@
+// file-size: the `pome eval` command with its server contract documented inline against
+// the calls that depend on it — the route shapes, the ADR-013 no-local-scoring rule and
+// the idempotent-re-run behaviour are the reason the code reads the way it does.
 // SPDX-License-Identifier: Apache-2.0
 //
 // `pome eval [run-dir]` — upload an EXISTING raw trace directory to Pome

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+// file-size: the whole CLI command surface — 31 `.command()` registrations plus their
+// options, in one file so `pome --help` and this module list the same commands in the
+// same order. Splitting per command moves a registration away from its siblings, which
+// is how two commands end up disagreeing about a shared flag's name or default.
 // SPDX-License-Identifier: Apache-2.0
 import { Command } from "commander";
 import { existsSync, readFileSync, realpathSync } from "node:fs";

--- a/cli/src/hosted/client.ts
+++ b/cli/src/hosted/client.ts
@@ -1,3 +1,7 @@
+// file-size: every control-plane call the CLI makes, each paired with the zod schema it
+// parses its response through. The pairing is the point: a call whose schema lives in
+// another module can be changed without the schema following it, and the schema is the
+// only thing standing between a changed server response and a silent misread.
 // SPDX-License-Identifier: Apache-2.0
 import {
   createEvalSessionResponseSchema,

--- a/cli/src/hosted/client.ts
+++ b/cli/src/hosted/client.ts
@@ -1,7 +1,10 @@
-// file-size: every control-plane call the CLI makes, each paired with the zod schema it
-// parses its response through. The pairing is the point: a call whose schema lives in
-// another module can be changed without the schema following it, and the schema is the
-// only thing standing between a changed server response and a silent misread.
+// file-size: every control-plane call lives inside one `createHostedClient` closure, so
+// they share the auth headers, the timeout and retry budgets, and the error mapping to
+// HostedAuthError / HostedOrchError. Splitting a call out means either re-deriving that
+// wiring or exporting it, and a second caller of the retry budget is how two commands
+// start disagreeing about how long to wait. The finalize accept/poll state machine below
+// is local because it is the only multi-step protocol here; the plain response schemas
+// are shared and imported from ../types/shared.js.
 // SPDX-License-Identifier: Apache-2.0
 import {
   createEvalSessionResponseSchema,

--- a/cli/src/runner/runTaskHosted.ts
+++ b/cli/src/runner/runTaskHosted.ts
@@ -1,3 +1,7 @@
+// file-size: one hosted run end to end — mint session, run the agent, upload the trace,
+// finalize, write the verdict artifact. The exit-code and `state` decisions at the tail
+// depend on nearly every step above them, and the long comments arguing those decisions
+// are worth more beside the code than in a module that has to re-derive the context.
 // SPDX-License-Identifier: Apache-2.0
 import { createHash, randomUUID } from "node:crypto";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";

--- a/packages/checks/CHANGELOG.md
+++ b/packages/checks/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pome-sh/checks
 
+## Unreleased (patch)
+
+**No consumer-visible change.** Added `// file-size:` header comments to twin
+modules that were previously exempted from the file-size lint by name, and removed
+four header comments that no longer applied. Prose only — no export, schema, tool,
+route, status code or response body moved.
+
 ## 0.3.7 — 2026-08-25
 
 **No consumer-visible change.** Comment cleanup in `scripts/bundle-declarations.mjs`,

--- a/packages/sandbox-domains/CHANGELOG.md
+++ b/packages/sandbox-domains/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pome-sh/sandbox-domains
 
+## Unreleased (patch)
+
+**No consumer-visible change.** Added `// file-size:` header comments to twin
+modules that were previously exempted from the file-size lint by name, and removed
+four header comments that no longer applied. Prose only — no export, schema, tool,
+route, status code or response body moved.
+
 ## 0.2.13 — 2026-08-25
 
 **No consumer-visible change.** Comment cleanup in `scripts/bundle-declarations.mjs`,

--- a/packages/twin-github/src/serializers.ts
+++ b/packages/twin-github/src/serializers.ts
@@ -1,3 +1,6 @@
+// file-size: one serializer per GitHub resource the twin emits, 39 of them — splitting
+// the anchored emitters would scatter the shape-anchor discipline across modules. Same
+// reason as twin-stripe's serializers.
 // SPDX-License-Identifier: Apache-2.0
 import type {
   BranchRow,

--- a/packages/twin-github/src/tools.ts
+++ b/packages/twin-github/src/tools.ts
@@ -1,3 +1,6 @@
+// file-size: the twin's whole MCP tool table in one registry, and the import discipline
+// documented directly below is what keeps it loadable under bun — a split would give a
+// second file the chance to reach the `@pome-sh/sdk` root and pull in `node:sqlite`.
 // SPDX-License-Identifier: Apache-2.0
 // `@pome-sh/sdk/mcp-tool-fixture` rather than the `@pome-sh/sdk` root: the root
 // barrel re-exports `openTwinDatabase`, so importing it EXECUTES `db.ts`'s

--- a/packages/twin-linear/src/domain/issues.ts
+++ b/packages/twin-linear/src/domain/issues.ts
@@ -1,4 +1,3 @@
-// file-size: Issue CRUD + label/relation patches share one transaction surface with webhook emit; further split would duplicate ActorContext/scope checks.
 // SPDX-License-Identifier: Apache-2.0
 import { badUserInput } from "../errors.js";
 import type { LinearIssue } from "../types.js";

--- a/packages/twin-linear/src/domain/linear-domain.ts
+++ b/packages/twin-linear/src/domain/linear-domain.ts
@@ -1,6 +1,5 @@
 // file-size: LinearDomain coordinator keeps lifecycle/identity helpers and thin delegations; area modules own issues/comments/catalog/etc.
 // SPDX-License-Identifier: Apache-2.0
-// file-size: Thin facade over domain modules; method surface mirrors LinearDomain API.
 import { resetDatabase } from "../db.js";
 import { badUserInput, notFound } from "../errors.js";
 import { linearIdFromCounter } from "../ids.js";

--- a/packages/twin-linear/src/graphql/schema.ts
+++ b/packages/twin-linear/src/graphql/schema.ts
@@ -1,6 +1,5 @@
 // file-size: Linear GraphQL schema SDL string — single source of truth for the twin schema surface.
 // SPDX-License-Identifier: Apache-2.0
-// file-size: GraphQL SDL floor; keep ops + input fields co-located for fidelity parity.
 import { buildSchema, type GraphQLSchema } from "graphql";
 
 /** Emulate Linear operation-floor schema (rewritten for twin-linear). */

--- a/packages/twin-linear/src/mcp.ts
+++ b/packages/twin-linear/src/mcp.ts
@@ -1,6 +1,5 @@
 // file-size: Linear MCP tool surface — one registry of tool defs + handlers pending further split.
 // SPDX-License-Identifier: Apache-2.0
-// file-size: MCP launch tool table co-located with canonical fixture mapping.
 // The two VALUES come from `@pome-sh/sdk/mcp-tool-fixture`, not the root barrel:
 // the barrel re-exports `openTwinDatabase`, so importing it EXECUTES `db.ts`'s
 // `import { DatabaseSync } from "node:sqlite"` and this module stops loading in

--- a/packages/twin-linear/src/seed.ts
+++ b/packages/twin-linear/src/seed.ts
@@ -1,3 +1,5 @@
+// file-size: the Linear seed schema and its defaults in one module, so the shape a task
+// author writes and the values it falls back to cannot drift apart.
 // SPDX-License-Identifier: Apache-2.0
 import { z } from "zod";
 import {

--- a/packages/twin-stripe/src/x402.ts
+++ b/packages/twin-stripe/src/x402.ts
@@ -1,3 +1,6 @@
+// file-size: the x402 seller-side middleware plus the fidelity caveat below it, which
+// bounds what any output from this module can be trusted to mean. The caveat is only
+// load-bearing while it sits in front of the flow it qualifies.
 // SPDX-License-Identifier: Apache-2.0
 //
 // =============================================================================

--- a/scripts/lint/rules/file-size.mjs
+++ b/scripts/lint/rules/file-size.mjs
@@ -1,23 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Barrel and file-size ceilings. A missing scan root is RED, not an empty pass.
+// File-size ceiling. A missing scan root is RED, not an empty pass.
+//
+// One escape hatch: a `// file-size: <reason>` header on the first line, or the
+// line after a shebang. The reason travels with the file, so it cannot go stale
+// by rename and it is visible to whoever opens the module rather than only to
+// whoever opens this rule.
+//
+// A header on a file that no longer exceeds the limit is RED, the same way
+// `barrels` reds on an absent barrel and `route-inputs` reds on an exemption
+// matching nothing. An exemption nobody has to re-justify is an exemption
+// forever, and this rule used to carry three that had stopped meaning anything.
+//
+// The count includes comment lines on purpose: the ceiling is about how much
+// one file asks a reader to hold at once, and prose is part of that.
 
 const FILE_SIZE_LIMIT = 500;
 const FILE_SIZE_HEADER = /^\/\/\s*file-size:\s*.+/;
-
-const ALLOWLIST = new Set([
-  "cli/src/cli/main.ts",
-  "cli/src/cli/eval.ts",
-  "cli/src/cli/embedded-wiring.ts",
-  "cli/src/cli/install.ts",
-  "cli/src/hosted/client.ts",
-  "cli/src/runner/runTaskHosted.ts",
-  "packages/wire/src/otel/fixtures/data.ts",
-  "packages/twin-github/src/serializers.ts",
-  "packages/twin-github/src/tools.ts",
-  "packages/twin-linear/src/seed.ts",
-  "packages/twin-stripe/src/x402.ts",
-]);
 
 const SCAN_DIRS = [
   "packages/twin-gmail/src",
@@ -31,21 +30,39 @@ const SCAN_DIRS = [
   "cli/src",
 ];
 
+/** The header sits on line 1, or on line 2 where a shebang owns line 1. */
+function declaredReason(lines) {
+  const at = lines[0]?.startsWith("#!") ? 1 : 0;
+  return FILE_SIZE_HEADER.test(lines[at] ?? "");
+}
+
 export default {
   name: "file-size",
   describe: `modules over ${FILE_SIZE_LIMIT} LOC state a reason or get split`,
   check(ctx) {
     const violations = [];
+    let exempt = 0;
     for (const file of ctx.files({ dirs: SCAN_DIRS, ext: [".ts", ".tsx"] })) {
       const rel = ctx.rel(file);
-      if (ALLOWLIST.has(rel)) continue;
       const lines = ctx.read(file).split("\n");
-      if (lines.length <= FILE_SIZE_LIMIT) continue;
-      if (FILE_SIZE_HEADER.test(lines[0] ?? "")) continue;
+      const stated = declaredReason(lines);
+      if (lines.length <= FILE_SIZE_LIMIT) {
+        if (stated) {
+          violations.push(
+            `${rel}: ${lines.length} lines is under the ${FILE_SIZE_LIMIT} LOC limit, so its ` +
+              `\`// file-size:\` header exempts nothing — drop the header.`,
+          );
+        }
+        continue;
+      }
+      if (stated) {
+        exempt += 1;
+        continue;
+      }
       violations.push(
         `${rel}: ${lines.length} lines exceeds ${FILE_SIZE_LIMIT} LOC — add a \`// file-size: <reason>\` header or split the module`,
       );
     }
-    return { violations, summary: `${ALLOWLIST.size} allowlisted large module(s)` };
+    return { violations, summary: `${exempt} module(s) state a reason` };
   },
 };

--- a/scripts/lint/rules/file-size.mjs
+++ b/scripts/lint/rules/file-size.mjs
@@ -2,9 +2,9 @@
 //
 // File-size ceiling. A missing scan root is RED, not an empty pass.
 //
-// One escape hatch: a `// file-size: <reason>` header on the first line, or the
-// line after a shebang. The reason travels with the file, so it cannot go stale
-// by rename and it is visible to whoever opens the module rather than only to
+// One escape hatch: a `// file-size: <reason>` header in the file's leading
+// comment block. The reason travels with the file, so it cannot go stale by
+// rename and it is visible to whoever opens the module rather than only to
 // whoever opens this rule.
 //
 // A header on a file that no longer exceeds the limit is RED, the same way
@@ -18,6 +18,10 @@
 const FILE_SIZE_LIMIT = 500;
 const FILE_SIZE_HEADER = /^\/\/\s*file-size:\s*.+/;
 
+// How far into the file the header may sit: shebang, SPDX, and the header itself
+// in either order, plus a blank line. Deliberately small.
+const LEADING_BLOCK_LINES = 4;
+
 const SCAN_DIRS = [
   "packages/twin-gmail/src",
   "packages/twin-github/src",
@@ -30,10 +34,26 @@ const SCAN_DIRS = [
   "cli/src",
 ];
 
-/** The header sits on line 1, or on line 2 where a shebang owns line 1. */
+/** The header sits in the file's leading comment block, so it can go above or
+ *  below the SPDX line and after a shebang — the twin entrypoints are
+ *  `#!` then SPDX, and demanding one exact index there reports a missing header
+ *  while the header is visibly two lines up. Bounded to the block so a
+ *  `// file-size:` written mid-file cannot exempt anything. */
 function declaredReason(lines) {
-  const at = lines[0]?.startsWith("#!") ? 1 : 0;
-  return FILE_SIZE_HEADER.test(lines[at] ?? "");
+  for (const raw of lines.slice(0, LEADING_BLOCK_LINES)) {
+    const line = raw.trim();
+    if (FILE_SIZE_HEADER.test(line)) return true;
+    if (line === "" || line.startsWith("#!") || line.startsWith("//")) continue;
+    return false;
+  }
+  return false;
+}
+
+/** Content lines, ignoring the trailing empty string a final newline leaves.
+ *  Counting it made the reported length one more than the file has, which read
+ *  as an off-by-one in every violation message. */
+function lineCount(lines) {
+  return lines.length > 0 && lines.at(-1) === "" ? lines.length - 1 : lines.length;
 }
 
 export default {
@@ -46,10 +66,11 @@ export default {
       const rel = ctx.rel(file);
       const lines = ctx.read(file).split("\n");
       const stated = declaredReason(lines);
-      if (lines.length <= FILE_SIZE_LIMIT) {
+      const count = lineCount(lines);
+      if (count <= FILE_SIZE_LIMIT) {
         if (stated) {
           violations.push(
-            `${rel}: ${lines.length} lines is under the ${FILE_SIZE_LIMIT} LOC limit, so its ` +
+            `${rel}: ${count} lines is under the ${FILE_SIZE_LIMIT} LOC limit, so its ` +
               `\`// file-size:\` header exempts nothing — drop the header.`,
           );
         }
@@ -60,7 +81,7 @@ export default {
         continue;
       }
       violations.push(
-        `${rel}: ${lines.length} lines exceeds ${FILE_SIZE_LIMIT} LOC — add a \`// file-size: <reason>\` header or split the module`,
+        `${rel}: ${count} lines exceeds ${FILE_SIZE_LIMIT} LOC — add a \`// file-size: <reason>\` header or split the module`,
       );
     }
     return { violations, summary: `${exempt} module(s) state a reason` };

--- a/scripts/lint/rules/file-size.test.mjs
+++ b/scripts/lint/rules/file-size.test.mjs
@@ -54,7 +54,7 @@ defineCases("file-size", [
     contains: "exceeds 500 LOC",
   },
   {
-    name: "a header that is not on the first line does not count",
+    name: "a header below the first statement does not count",
     files: tree({ [SUBJECT]: `const a = 1;\n// file-size: buried where nobody reads it\n${lines(600)}` }),
     expect: "red",
     contains: "exceeds 500 LOC",
@@ -64,6 +64,35 @@ defineCases("file-size", [
     files: tree({
       [SUBJECT]: `#!/usr/bin/env node\n// file-size: the whole command surface in one place\n${lines(600)}`,
     }),
+    expect: "green",
+  },
+  {
+    // The shape every twin entrypoint has. Demanding one exact index reported a
+    // missing header while the header sat two lines above the complaint.
+    name: "a header below a shebang AND an SPDX line still counts",
+    files: tree({
+      [SUBJECT]: `#!/usr/bin/env node\n// SPDX-License-Identifier: Apache-2.0\n// file-size: one boot path\n${lines(600)}`,
+    }),
+    expect: "green",
+  },
+  {
+    name: "a header below SPDX with no shebang counts",
+    files: tree({
+      [SUBJECT]: `// SPDX-License-Identifier: Apache-2.0\n// file-size: one boot path\n${lines(600)}`,
+    }),
+    expect: "green",
+  },
+  {
+    name: "a header under a shebang on a small file is RED too, not skipped",
+    files: tree({ [SUBJECT]: `#!/usr/bin/env node\n// file-size: stale\n${lines(10)}` }),
+    expect: "red",
+    contains: "exempts nothing",
+  },
+  {
+    // 500 content lines plus the trailing newline's empty string. Counting that
+    // string reported 501 and called a conforming file a violation.
+    name: "a file at exactly the limit passes, trailing newline not counted",
+    files: tree({ [SUBJECT]: `${lines(499)}\n` }),
     expect: "green",
   },
   {

--- a/scripts/lint/rules/file-size.test.mjs
+++ b/scripts/lint/rules/file-size.test.mjs
@@ -60,9 +60,29 @@ defineCases("file-size", [
     contains: "exceeds 500 LOC",
   },
   {
-    name: "an allowlisted module is exempt at any length",
-    files: tree({ "cli/src/cli/main.ts": lines(900) }),
+    name: "a header on the line after a shebang counts, because a shebang owns line 1",
+    files: tree({
+      [SUBJECT]: `#!/usr/bin/env node\n// file-size: the whole command surface in one place\n${lines(600)}`,
+    }),
     expect: "green",
+  },
+  {
+    name: "a shebang with no header on the line below it is still a violation",
+    files: tree({ [SUBJECT]: `#!/usr/bin/env node\n${lines(600)}` }),
+    expect: "red",
+    contains: "exceeds 500 LOC",
+  },
+  {
+    name: "a header on a module under the limit is RED — a stale exemption, not a free pass",
+    files: tree({ [SUBJECT]: lines(10, "// file-size: a reason that stopped applying") }),
+    expect: "red",
+    contains: [SUBJECT, "exempts nothing"],
+  },
+  {
+    name: "no module is exempt by name — the reason has to be in the file",
+    files: tree({ "cli/src/cli/main.ts": lines(900) }),
+    expect: "red",
+    contains: "exceeds 500 LOC",
   },
   {
     name: "a scan directory that no longer exists is RED, not an empty pass",


### PR DESCRIPTION
The `file-size` lint rule had two ways to exempt an oversized module: sit in a name
allowlist inside the rule, or carry a `// file-size: <reason>` header. This drops the
allowlist and keeps the header, which states a reason and travels with the file.

Three of the allowlist's 11 entries were dead — a file that no longer exists, a
41-line file, and a 321-line file against a 500-line limit. The rule had no
staleness check, unlike its siblings: `barrels` reds on an absent barrel,
`route-inputs` reds on an exemption matching nothing.

## Changes

- The 8 live exemptions now carry headers explaining why each module is one module.
- `ALLOWLIST` is gone.
- A header on a file under the limit is now a violation. This immediately caught a
  fourth dead exemption the audit missed.
- The header is recognized anywhere in the leading comment block, bounded to four
  lines. Needed because the CLI entry point has a shebang on line 1 and the twin
  entrypoints are shebang-then-license.
- Fixed an off-by-one: the trailing empty string from a final newline was counted,
  so a 500-line file reported as "501 lines exceeds 500 LOC".

## Notes

The count includes comment lines. Now stated in the rule as deliberate rather than
left as a surprise — the alternative is counting non-comment lines if you'd rather.

A byte-order mark before the header hides it. Nothing in the scanned trees has one
and it fails closed (spurious "add a header", never a silent exemption), so left
alone.

## Verification

`lint` and `lint:test` green offline and installed, `typecheck`, `npm test` at 334
files / 3694 tests. Case table 7 → 14 cases.

Checked by hand, since a size rule that stops binding looks like one with nothing to
report: deleting a real header reds its file, and a sweep of the scanned trees
confirms no file lost protection or gained an exemption.