### PR TITLE
Link the five per-twin quickstarts from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ npx @pome-sh/cli twin start github    # http://127.0.0.1:3333 — prints MCP URL
 
 For a persistent `pome` command: `npm install -g @pome-sh/cli`.
 
+<!-- One generic quickstart above; the per-twin walkthroughs live on the docs
+     site and are LINKED, never copied — one source per walkthrough. -->
+
+Per-twin walkthroughs — one twin end to end on a hosted sandbox, five
+minutes each: [GitHub](https://docs.pome.sh/quickstart/twins/github) ·
+[Stripe](https://docs.pome.sh/quickstart/twins/stripe) ·
+[Slack](https://docs.pome.sh/quickstart/twins/slack) ·
+[Gmail](https://docs.pome.sh/quickstart/twins/gmail) ·
+[Linear](https://docs.pome.sh/quickstart/twins/linear).
+
 ## Running an agent
 
 `pome run --local` records a run — the trace plus before/after state — for you to


### PR DESCRIPTION
Every twin now has its own quickstart page on docs.pome.sh, so the README can point
at that depth instead of carrying it. This adds the five links and nothing else.

The rule this follows: the README keeps ONE generic quickstart and LINKS the per-twin
walkthroughs, never copies them. A copied walkthrough is exactly what goes stale — the
last page we kept a second copy of sat three releases behind what it described, and it
was only wrong because it was a copy.

## Changes

- A one-paragraph block at the tail of `## Quickstart` linking the five pages, in the
  order the README already uses everywhere else: github, stripe, slack, gmail, linear.
- An HTML comment above it recording the link-never-copy rule, so the next editor sees
  the constraint at the place where a walkthrough would otherwise get pasted in.

That's the whole diff: 10 insertions, 0 deletions, one hunk.

## Notes

**The two halves do not overlap.** The README's quickstart is the local path (`init`,
`run --local`, `twin start`). Each linked page is one twin end to end on a hosted
sandbox (`login`, `sandbox create --twin <name>`, read, act, verify, tape, stop). The
new paragraph says which is which and stops there — no commands, no steps, nothing
that can drift out of sync with the pages.

**Placement is deliberate, not incidental.** Showcase additions are queued against the
agent-examples paragraph in `## Running an agent`. Keeping this hunk inside
`## Quickstart` leaves those as one-line additions rather than conflicts, which is also
why there is no restructure here even where one might be tempting — the twins table
could carry a quickstart column, but that would rewrite six lines to place links that
already have a home.

**Ordering.** github, stripe, slack, gmail, linear matches the twins table, both prose
enumerations, `KNOWN_TWIN_IDS`, `MOUNTED_TWINS` and the `--twin` help text. Note that
the `first-party-twins` lint rule prints registration order (github, slack, stripe,
...), which is a different thing and not user-facing.

## Verification

Every link checked against the live site, resolved from the committed text rather than
from what I meant to type:

- All five return HTTP 200, each with its own `<twin> twin in 5 minutes` title.
- A nonexistent sibling under the same prefix returns 404 — so the 200s are real pages,
  not a catch-all that would make this check vacuous.
- No redirects on any of the five, so the URLs are canonical.

`npm run lint` green, 18 rules. Wording checked against the banned-vocabulary list in
AGENTS.md and against the `digital twin` first-use rule.

`quickstart-smoke` runs on this PR — `README.md` is in its path filter. It hardcodes
the commands it boots rather than parsing the README, so a prose-only change cannot
alter what it tests.