### PR TITLE
Add the cross-call state showcase (F-1636)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ The bundled task library includes GitHub, Stripe, Slack, Gmail, and Linear flows
 several **adversarial** (identity spoofing, prompt injection, merging a backdoored
 PR, fabricating green CI). Browse with `pome tasks`. Ten worked example agents
 live under [`agent-examples/`](./agent-examples/).
-Ungraded showcases of one twin property — no agent, no key — live under [`showcases/`](./showcases/).
+Ungraded showcases of one twin property, on a twin you boot yourself — no agent,
+no key, no account — live under [`showcases/`](./showcases/).
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The bundled task library includes GitHub, Stripe, Slack, Gmail, and Linear flows
 several **adversarial** (identity spoofing, prompt injection, merging a backdoored
 PR, fabricating green CI). Browse with `pome tasks`. Ten worked example agents
 live under [`agent-examples/`](./agent-examples/).
+Ungraded showcases of one twin property — no agent, no key — live under [`showcases/`](./showcases/).
 
 ## How it works
 

--- a/showcases/README.md
+++ b/showcases/README.md
@@ -1,0 +1,25 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Showcases
+
+A showcase demonstrates **one property of the twins** against a live hosted
+sandbox, and stops there. It is not an example agent and not an exam.
+
+|                     | showcase (`showcases/`)          | example agent (`agent-examples/`) |
+| ------------------- | -------------------------------- | --------------------------------- |
+| what it ships       | a walkthrough + a verify script   | `src/index.ts` + `tasks/*.md`     |
+| who acts on the twin | you, or your own coding agent    | the bundled agent                 |
+| API key             | none                             | `ANTHROPIC_API_KEY`               |
+| graded              | never                            | yes, against graded criteria      |
+
+Two rules hold across every showcase, and both are load-bearing:
+
+- **Single seat.** Your own coding agent both operates Pome and acts on the
+  twin. No API key, no Pome-funded inference.
+- **Nothing grades.** Grading appears exactly once in this repo, in the
+  [`agent-examples/support-triage`](../agent-examples/support-triage/) capstone.
+  A showcase may *name* declared checks as pointers; it never ships a task.
+
+| showcase | property |
+| -------- | -------- |
+| [`cross-call-state`](./cross-call-state/) | state written by call N is readable at call N+1 — and does not cross sandboxes |

--- a/showcases/README.md
+++ b/showcases/README.md
@@ -2,15 +2,17 @@
 
 # Showcases
 
-A showcase demonstrates **one property of the twins** against a live hosted
-sandbox, and stops there. It is not an example agent and not an exam.
+A showcase demonstrates **one property of the twins** against a twin you boot
+yourself with `pome twin start`, and stops there. It is not an example agent
+and not an exam.
 
-|                     | showcase (`showcases/`)          | example agent (`agent-examples/`) |
-| ------------------- | -------------------------------- | --------------------------------- |
-| what it ships       | a walkthrough + a verify script   | `src/index.ts` + `tasks/*.md`     |
-| who acts on the twin | you, or your own coding agent    | the bundled agent                 |
-| API key             | none                             | `ANTHROPIC_API_KEY`               |
-| graded              | never                            | yes, against graded criteria      |
+|                      | showcase (`showcases/`)         | example agent (`agent-examples/`) |
+| -------------------- | ------------------------------- | --------------------------------- |
+| what it ships        | a walkthrough + a verify script | `src/index.ts` + `tasks/*.md`     |
+| who acts on the twin | you, or your own coding agent   | the bundled agent                 |
+| account              | none — local twin, no login     | none, but the twin is hosted      |
+| API key              | none                            | `ANTHROPIC_API_KEY`               |
+| graded               | never                           | yes, against graded criteria      |
 
 Two rules hold across every showcase, and both are load-bearing:
 
@@ -20,6 +22,39 @@ Two rules hold across every showcase, and both are load-bearing:
   [`agent-examples/support-triage`](../agent-examples/support-triage/) capstone.
   A showcase may *name* declared checks as pointers; it never ships a task.
 
-| showcase | property |
-| -------- | -------- |
-| [`cross-call-state`](./cross-call-state/) | state written by call N is readable at call N+1 — and does not cross sandboxes |
+A third rule follows from where this repo sits: **showcases teach the local
+process.** The OSS repo is the door for someone with no account, so a showcase
+boots its twins with `npx @pome-sh/cli@latest twin start` — no `pome login`, no
+sandbox, no minutes. The hosted equivalents live on
+[docs.pome.sh](https://docs.pome.sh). Anything a showcase claims has to be true
+of a twin running on the reader's own machine.
+
+## The showcases
+
+| showcase | property | twins |
+| -------- | -------- | ----- |
+| [`cross-call-state`](./cross-call-state/) | state written by call N is readable at call N+1 — and does not cross into a second twin process | github |
+
+## Adding one
+
+Three files, and only these:
+
+| file | job |
+| ---- | --- |
+| `showcases/README.md` | this page — add one row to the table above |
+| `showcases/<property>/README.md` | the walkthrough — the teaching artifact |
+| `showcases/<property>/verify.sh` | asserts the property unattended; exits non-zero when it stops holding |
+
+No `package.json`, no `tasks/`, no `src/`, no lockfile. Each of those is what
+pulls a directory into a gate that cannot see a showcase's subject —
+`gate:examples` and `check-example-pins-published.mjs` discover on
+`agent-examples/*/package.json`, `smoke:examples` additionally launches every
+hit against dead loopback wiring, and the `task-class` lint collects any `.md`
+under a `tasks/` directory. A showcase would pass all of them while proving
+nothing, which is the exact failure those gates exist to prevent.
+
+The walkthrough is the teaching artifact and `verify.sh` is its regression
+test, not a second teaching surface. Every output block on the page must be
+verbatim from a run of the command directly above it — re-run the page after
+authoring and diff it, because a page whose argument is "this is real output"
+has exactly one class of bug that counts.

--- a/showcases/cross-call-state/README.md
+++ b/showcases/cross-call-state/README.md
@@ -55,13 +55,21 @@ Everything below is what you should see. Every output block is verbatim from a
 real run — sandboxes `ses_gTgfTIGgoO4dgjZU` and `ses_qPk73MKVXnGjJr39`, prod,
 2026-08-25.
 
-Two shell variables keep the rest of this page readable:
+Mint the first sandbox, and give it two shell variables so the rest of this
+page stays readable:
 
 ```bash
+npx @pome-sh/cli@latest login          # once
+npx @pome-sh/cli@latest sandbox create --twin github \
+  --secrets-file .pome-sandbox.env --format json | jq '{session_id}'
+
 source .pome-sandbox.env
 R="$POME_GITHUB_REST_URL"
 A="Authorization: Bearer $POME_AUTH_TOKEN"
 ```
+
+`sandbox create` writes the bearer, the session id and the per-twin REST base
+into that file at mode `0600`. It expires in 30 minutes.
 
 ## The world
 
@@ -243,16 +251,37 @@ same moment**, and the same request against each returns a different world:
 So this is isolation, not a reset. Sandbox 1 still held its three writes while
 sandbox 2 had never seen them.
 
-The tape is per-sandbox too — sandbox 2's tape holds only sandbox 2's own reads,
-and each row's path carries its own session id:
+The tape is per-sandbox too. Same command as before, pointed at sandbox 2:
 
-```text
-GET /repos/acme/api/issues/1 200 false
-GET /repos/acme/api/issues/1/comments 200 false
+```bash
+curl -s -H "$A2" "$R2/_pome/events" > tape2.json
+jq -r '.[] | [.method, (.path|sub("^/s/[^/]+";"")), .status,
+  .state_mutation, .tool // "-"] | @tsv' tape2.json | column -t
 ```
 
-Two rows, both `false`. The six rows from sandbox 1 are not there, and cannot
-be: the sandbox id is a path segment on every row.
+```text
+GET  /repos/acme/api/issues/1           200  false  -
+GET  /repos/acme/api/issues/1/comments  200  false  -
+```
+
+Two rows, both `false`. The six rows from sandbox 1 are not on it.
+
+They cannot be, and the reason is mechanical rather than a promise: the sandbox
+id is a **path segment on every row**, which the `sub()` above strips for
+readability. Put it back and each tape names exactly one sandbox:
+
+```bash
+jq -r '[.[].path|split("/")[2]] | unique[]' tape.json   # sandbox 1
+jq -r '[.[].path|split("/")[2]] | unique[]' tape2.json  # sandbox 2
+```
+
+```text
+ses_gTgfTIGgoO4dgjZU
+ses_qPk73MKVXnGjJr39
+```
+
+One id each. So "no sandbox-1 row appears on sandbox-2's tape" is something you
+can assert rather than eyeball — which is exactly what `verify.sh` does.
 
 ## Assertable checks
 

--- a/showcases/cross-call-state/README.md
+++ b/showcases/cross-call-state/README.md
@@ -1,0 +1,322 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Cross-call state
+
+**In about three minutes you will watch a twin keep books.** Three writes, each
+read back through the twin's own surfaces, all three still there on a single
+later read — and then the same read against a second sandbox of the same twin,
+where none of them exist.
+
+A mock answers from a script. A twin holds state. Those are different claims,
+and this is the one that is measurable.
+
+The property has two halves, and the second is the one that matters:
+
+1. **State survives across calls inside one sandbox.** Call N's write is
+   readable at call N+1.
+2. **State does not survive across sandboxes.** A fresh mint of the same twin is
+   a fresh world. Your run cannot leak into anyone else's, including your own
+   next one.
+
+Nothing here is graded, nothing needs an API key, and nothing burns an agent
+eval. See [Cost](#cost).
+
+## Prereqs
+
+- A [pome](https://app.pome.sh) account.
+- Your own coding agent (Claude Code, Cursor, …) — it drives everything below.
+- Node with `npx`, plus `curl` and `jq` for the transcripts.
+
+No `ANTHROPIC_API_KEY`. You are the only seat.
+
+## Paste this to your agent
+
+```text
+Mint two Pome sandboxes on the github twin, one at a time, with
+`npx @pome-sh/cli@latest sandbox create --twin github
+--secrets-file <file> --format json`.
+
+In the first: read issue #1 of acme/api, then make three writes — post a
+comment, assign alice, close the issue — reading the state back after each
+one. Then read the tape at GET <rest_url>/_pome/events and show me the rows
+in order with their status and state_mutation.
+
+In the second sandbox: read the same issue and the same comment list, and
+show me that not one of the three writes is there.
+
+Use curl against POME_GITHUB_REST_URL from each secrets file.
+POME_AUTH_TOKEN is the bearer on every call; if a call comes back 404 when
+you expected data, check the bearer before you debug the path. This is
+ungraded: do not finalize anything, and keep your own evaluator and
+observability setup. Stop both sandboxes with --discard when you are done.
+```
+
+Everything below is what you should see. Every output block is verbatim from a
+real run — sandboxes `ses_gTgfTIGgoO4dgjZU` and `ses_qPk73MKVXnGjJr39`, prod,
+2026-08-25.
+
+Two shell variables keep the rest of this page readable:
+
+```bash
+source .pome-sandbox.env
+R="$POME_GITHUB_REST_URL"
+A="Authorization: Bearer $POME_AUTH_TOKEN"
+```
+
+## The world
+
+There is no `--seed` on this path, so the twin boots its own
+`defaultSeedState()`. For the github twin that is one repo `acme/api` holding
+one open issue, `#1`, labeled `bug`, unassigned, with no comments.
+
+```bash
+curl -s -H "$A" "$R/repos/acme/api/issues/1" \
+  | jq '{number, title, state, comments, assignees: [.assignees[].login]}'
+```
+
+```json
+{
+  "number": 1,
+  "title": "500 error on POST /orders after deploy",
+  "state": "open",
+  "comments": 0,
+  "assignees": []
+}
+```
+
+Three zeros to move: `state` is `open`, `comments` is `0`, `assignees` is empty.
+
+## Half 1 — state survives across calls
+
+Three writes, on three different surfaces of the same issue.
+
+```bash
+# write 1 — comment
+curl -s -X POST -H "$A" -H 'Content-Type: application/json' \
+  -d '{"body":"Repro: POST /orders 500s when the payload omits `currency`."}' \
+  -w '%{http_code}\n' -o /dev/null \
+  "$R/repos/acme/api/issues/1/comments"
+
+# write 2 — assign
+curl -s -X POST -H "$A" -H 'Content-Type: application/json' \
+  -d '{"assignees":["alice"]}' -w '%{http_code}\n' -o /dev/null \
+  "$R/repos/acme/api/issues/1/assignees"
+
+# write 3 — close
+curl -s -X PATCH -H "$A" -H 'Content-Type: application/json' \
+  -d '{"state":"closed"}' -w '%{http_code}\n' -o /dev/null \
+  "$R/repos/acme/api/issues/1"
+```
+
+```text
+201
+201
+200
+```
+
+The read-back after write 1, through the twin's own comment surface — a
+different endpoint from the one that wrote it:
+
+```bash
+curl -s -H "$A" "$R/repos/acme/api/issues/1/comments" \
+  | jq -r '.[] | "\(.user.login): \(.body)"'
+```
+
+```text
+pome-agent: Repro: POST /orders 500s when the payload omits `currency`.
+```
+
+Now the point of the whole exercise. **One** read, and all three writes are
+there at once — a comment posted five calls ago, an assignee from three calls
+ago, a state change from two:
+
+```bash
+curl -s -H "$A" "$R/repos/acme/api/issues/1" \
+  | jq '{state, comments, assignees: [.assignees[].login]}'
+```
+
+```json
+{
+  "state": "closed",
+  "comments": 1,
+  "assignees": [
+    "alice"
+  ]
+}
+```
+
+Three zeros became `closed`, `1`, `["alice"]`. Nothing was replayed and nothing
+was cached — each write mutated a row that the next read resolved.
+
+## Read the tape
+
+The tape is the twin's own record of the run. There is no dashboard tape surface
+for an ungraded sandbox, so this is the surface:
+
+```bash
+curl -s -H "$A" "$R/_pome/events" > tape.json
+jq -r '.[] | [.method, (.path|sub("^/s/[^/]+";"")), .status,
+  .state_mutation, .tool // "-"] | @tsv' tape.json | column -t
+```
+
+```text
+GET    /repos/acme/api/issues/1            200  false  -
+POST   /repos/acme/api/issues/1/comments   201  true   add_issue_comment
+GET    /repos/acme/api/issues/1/comments   200  false  -
+POST   /repos/acme/api/issues/1/assignees  201  true   -
+PATCH  /repos/acme/api/issues/1            200  true   -
+GET    /repos/acme/api/issues/1            200  false  -
+```
+
+**You should see:**
+
+- **Six rows, in the order you made them.** The tape is ordered, not a set.
+- **`state_mutation` true on exactly three of them** — the three writes, and
+  none of the reads. This is a recorded boolean, not a guess from the HTTP
+  method.
+- **`add_issue_comment` stamped in the `tool` column** on the comment write.
+  The other two writes read `-`: only three github action names are stamped
+  today (see [Assertable checks](#assertable-checks)).
+- **Every row `fidelity: "semantic"`** — a behavioural contract compared against
+  a captured GitHub response, not a shape check. Add `.fidelity` to the `jq` to
+  see it.
+
+And the row that is the actual receipt for "the twin keeps books" — each write
+row carries the before/after it caused:
+
+```bash
+jq -c '.[3].state_delta
+  | {b: .before.assignees, a: .after.assignees}' tape.json
+```
+
+```json
+{"b":[],"a":["alice"]}
+```
+
+Reads carry `state_delta: null`. Only the three writes carry a delta.
+
+## Half 2 — and it does not cross sandboxes
+
+Mint a second sandbox. Same twin, no `--seed`, so the same starting world.
+
+```bash
+npx @pome-sh/cli@latest sandbox create --twin github \
+  --secrets-file .pome-sandbox2.env --format json | jq '{session_id}'
+```
+
+Read the same issue, with the second sandbox's own bearer:
+
+```bash
+source .pome-sandbox2.env
+R2="$POME_GITHUB_REST_URL"
+A2="Authorization: Bearer $POME_AUTH_TOKEN"
+
+curl -s -H "$A2" "$R2/repos/acme/api/issues/1" \
+  | jq '{state, comments, assignees: [.assignees[].login]}'
+curl -s -H "$A2" "$R2/repos/acme/api/issues/1/comments" | jq -c
+```
+
+```json
+{
+  "state": "open",
+  "comments": 0,
+  "assignees": []
+}
+```
+
+```text
+[]
+```
+
+Back to three zeros. The issue is the same issue — same number, same title,
+same `bug` label — and the comment, the assignee and the close are simply not
+there.
+
+The strongest form of this is not sequential. **Both sandboxes are alive at the
+same moment**, and the same request against each returns a different world:
+
+```text
+{"sid":"ses_gTgfTIGgoO4dgjZU","state":"closed","comments":1,"assignees":["alice"]}
+{"sid":"ses_qPk73MKVXnGjJr39","state":"open","comments":0,"assignees":[]}
+```
+
+So this is isolation, not a reset. Sandbox 1 still held its three writes while
+sandbox 2 had never seen them.
+
+The tape is per-sandbox too — sandbox 2's tape holds only sandbox 2's own reads,
+and each row's path carries its own session id:
+
+```text
+GET /repos/acme/api/issues/1 200 false
+GET /repos/acme/api/issues/1/comments 200 false
+```
+
+Two rows, both `false`. The six rows from sandbox 1 are not there, and cannot
+be: the sandbox id is a path segment on every row.
+
+## Assertable checks
+
+If you wanted to *verify* a run like this instead of reading it, these already
+exist. **Pointers only — this showcase ships no task**, and grading appears
+exactly once in this repo, in the
+[support-triage capstone](../../agent-examples/support-triage/).
+
+The interesting column is `substrate`, because it is the same distinction this
+showcase is about: what happened, versus what persisted, versus what changed.
+
+| declared check | substrate | what it would assert here |
+| -------------- | --------- | ------------------------- |
+| `github.tool-was-called` (`add_issue_comment`) | `tape` | the comment write **happened** — it is on the ordered tape |
+| `github.issue-assignee` (`alice`) | `final` | the assign **persisted** to the end of the run |
+| `github.no-new-issues` | `seed+final` | the run **changed** only what it meant to — this one reads both worlds |
+
+Browse the full set with `npx @pome-sh/cli@latest checks github`, or
+`list_checks` over MCP.
+
+Two limits are worth stating out loud, because an id existing is not the same as
+an id doing what you assume:
+
+- **`github.tool-was-called` can only name three github actions today** —
+  `create_commit_status`, `create_check_run`, `add_issue_comment`. That is why
+  the `assignees` and `PATCH` rows above show `-` in the `tool` column. Widening
+  the set is tracked upstream; a name may only enter it once its REST route is
+  stamped, or the check would answer "never called" over a run that did it.
+- **`github.no-new-issues` is repo-scoped.** It says the repository gained no
+  issue. It cannot say *this issue* was left alone — there is no issue-scoped
+  delta yet.
+
+## Cost
+
+- **0 agent evals.** An eval is charged only at finalize, and nothing here
+  finalizes. Read `agent_evals.used` before and after if you want to confirm it;
+  on the run above it read **178 both times**.
+- **0 API keys.** Single seat.
+- **2 concurrent sandboxes** while both are up.
+
+A sandbox expires 30 minutes after creation. Stop them when you are done rather
+than waiting:
+
+```bash
+npx @pome-sh/cli@latest sandbox stop "$POME_SESSION_ID" --discard
+```
+
+## Run it yourself
+
+[`verify.sh`](./verify.sh) does everything above unattended and asserts both
+halves, so the claims on this page stay checkable:
+
+```bash
+npx @pome-sh/cli@latest login    # once
+./showcases/cross-call-state/verify.sh
+```
+
+It mints two sandboxes, drives the arc, asserts the accumulation, asserts the
+second world is untouched, and stops both on exit — including on failure. It
+exits non-zero if either half stops being true.
+
+## Next
+
+- The [github quickstart](https://docs.pome.sh/quickstart/twins/github) — the
+  same twin, one write, in five minutes.
+- [`agent-examples/support-triage`](../../agent-examples/support-triage/) — the
+  one graded lesson, where a real agent is scored on a task like this.

--- a/showcases/cross-call-state/README.md
+++ b/showcases/cross-call-state/README.md
@@ -2,83 +2,110 @@
 
 # Cross-call state
 
-**In about three minutes you will watch a twin keep books.** Three writes, each
-read back through the twin's own surfaces, all three still there on a single
-later read — and then the same read against a second sandbox of the same twin,
-where none of them exist.
+**In about three minutes, on your own machine, you will watch a twin keep
+books.** Three writes, each read back through the twin's own surfaces, all
+three still there on a single later read — and then the same read against a
+second twin process running at the same moment, where none of them exist.
 
 A mock answers from a script. A twin holds state. Those are different claims,
 and this is the one that is measurable.
 
 The property has two halves, and the second is the one that matters:
 
-1. **State survives across calls inside one sandbox.** Call N's write is
+1. **State survives across calls inside one twin process.** Call N's write is
    readable at call N+1.
-2. **State does not survive across sandboxes.** A fresh mint of the same twin is
-   a fresh world. Your run cannot leak into anyone else's, including your own
-   next one.
+2. **State does not survive into a second process.** A second `twin start` on
+   its own port with its own SQLite file is a different world, and it stays a
+   different world while the first one is still running.
 
-Nothing here is graded, nothing needs an API key, and nothing burns an agent
-eval. See [Cost](#cost).
+Nothing here is graded, nothing needs an API key, and nothing costs anything.
+There is no account and no login on this page. See [Cost](#cost).
 
 ## Prereqs
 
-- A [pome](https://app.pome.sh) account.
-- Your own coding agent (Claude Code, Cursor, …) — it drives everything below.
-- Node with `npx`, plus `curl` and `jq` for the transcripts.
+- **Node ≥ 24**, so `npx` can fetch the CLI. That is the whole install.
+- `curl` and `jq` for the transcripts.
+- Your own coding agent (Claude Code, Cursor, …) if you want it driven for you.
 
-No `ANTHROPIC_API_KEY`. You are the only seat.
+No Pome account. No `pome login`. No `ANTHROPIC_API_KEY`. You are the only
+seat, and nothing you do below leaves your machine.
 
 ## Paste this to your agent
 
 ```text
-Mint two Pome sandboxes on the github twin, one at a time, with
-`npx @pome-sh/cli@latest sandbox create --twin github
---secrets-file <file> --format json`.
+Boot two Pome github twins locally, each in its own directory so each gets
+its own SQLite store. They are foreground servers, so give each its own
+terminal or background it, and leave both running:
 
-In the first: read issue #1 of acme/api, then make three writes — post a
-comment, assign alice, close the issue — reading the state back after each
-one. Then read the tape at GET <rest_url>/_pome/events and show me the rows
-in order with their status and state_mutation.
+  mkdir -p twin-a twin-b
+  (cd twin-a && GITHUB_CLONE_DB=.pome/github.db \
+     npx @pome-sh/cli@latest twin start github --port 3333)
+  (cd twin-b && GITHUB_CLONE_DB=.pome/github.db \
+     npx @pome-sh/cli@latest twin start github --port 3334)
 
-In the second sandbox: read the same issue and the same comment list, and
-show me that not one of the three writes is there.
+Each one prints POME_GITHUB_REST_URL and POME_AUTH_TOKEN on stdout and
+writes the same values to <dir>/.pome/twin-status.json — read the JSON,
+there is nothing to log into.
 
-Use curl against POME_GITHUB_REST_URL from each secrets file.
-POME_AUTH_TOKEN is the bearer on every call; if a call comes back 404 when
-you expected data, check the bearer before you debug the path. This is
-ungraded: do not finalize anything, and keep your own evaluator and
-observability setup. Stop both sandboxes with --discard when you are done.
+In twin A: read issue #1 of acme/api, then make three writes — post a
+comment, assign alice, close the issue — reading each one back through a
+different surface from the one that wrote it. Then read the tape at
+GET <rest_url>/_pome/events and show me the rows in order with their
+status, state_mutation and tool.
+
+Then, with twin A still running and still holding those three writes, send
+the same issue read to twin B and show me the two answers together. Show me
+twin B's tape too.
+
+Use curl and jq. Each twin has its own bearer: a 401 means you used the
+other twin's. This is ungraded — do not finalize anything, and keep your
+own evaluator and observability setup. Stop both twins with Ctrl-C when I
+say so.
 ```
 
 Everything below is what you should see. Every output block is verbatim from a
-real run — sandboxes `ses_gTgfTIGgoO4dgjZU` and `ses_qPk73MKVXnGjJr39`, prod,
-2026-08-25.
-
-Mint the first sandbox, and give it two shell variables so the rest of this
-page stays readable:
-
-```bash
-npx @pome-sh/cli@latest login          # once
-npx @pome-sh/cli@latest sandbox create --twin github \
-  --secrets-file .pome-sandbox.env --format json | jq '{session_id}'
-
-source .pome-sandbox.env
-R="$POME_GITHUB_REST_URL"
-A="Authorization: Bearer $POME_AUTH_TOKEN"
-```
-
-`sandbox create` writes the bearer, the session id and the per-twin REST base
-into that file at mode `0600`. It expires in 30 minutes.
+real run on 2026-08-29, CLI `0.34.2`. Work in one empty directory; every path
+below is relative to it.
 
 ## The world
 
-There is no `--seed` on this path, so the twin boots its own
-`defaultSeedState()`. For the github twin that is one repo `acme/api` holding
-one open issue, `#1`, labeled `bug`, unassigned, with no comments.
+Boot the first twin. Give it its own directory, and point its store at a file
+inside that directory — the twin defaults to an in-memory database, and a file
+makes "two worlds" something you can list rather than take on trust.
 
 ```bash
-curl -s -H "$A" "$R/repos/acme/api/issues/1" \
+mkdir -p twin-a && cd twin-a
+GITHUB_CLONE_DB=.pome/github.db \
+  npx @pome-sh/cli@latest twin start github --port 3333
+```
+
+```text
+Pome github twin listening at http://127.0.0.1:3333/s/standalone
+Seed: the github twin's default (pass --seed <path>, or write one with `pome twin seed github`).
+POME_GITHUB_REST_URL=http://127.0.0.1:3333/s/standalone
+POME_GITHUB_MCP_URL=http://127.0.0.1:3333/s/standalone/mcp
+POME_AUTH_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzaWQiOiJzdGFuZGFsb25lIiwidGVhbV9pZCI6InRtX2xvY2FsIiwibG9naW4iOiJwb21lLWFnZW50IiwiZXhwIjoxNzg4MDk5NzA5fQ._R5jttuezYifeRdilZh7q2_K-1jVgGW-CcAn_FvVoOc
+Health check (no auth): curl http://127.0.0.1:3333/healthz
+Ctrl-C to stop.
+```
+
+That is the mint, and it took no account: the bearer is on stdout and in
+`twin-a/.pome/twin-status.json`. Yours will differ — the secret is generated
+per boot and the token is good for 24 hours. Leave this terminal running.
+
+In a second terminal, back in the directory that holds `twin-a/`:
+
+```bash
+A=$(jq -r .rest_url twin-a/.pome/twin-status.json)
+AK="Authorization: Bearer $(jq -r .auth_token twin-a/.pome/twin-status.json)"
+```
+
+We passed no `--seed`, so the twin booted its own `defaultSeedState()`. For the
+github twin that is one repo `acme/api` holding one open issue, `#1`, labeled
+`bug`, unassigned, with no comments.
+
+```bash
+curl -s -H "$AK" "$A/repos/acme/api/issues/1" \
   | jq '{number, title, state, comments, assignees: [.assignees[].login]}'
 ```
 
@@ -92,41 +119,29 @@ curl -s -H "$A" "$R/repos/acme/api/issues/1" \
 }
 ```
 
-Three zeros to move: `state` is `open`, `comments` is `0`, `assignees` is empty.
+**You should see** three zeros to move: `state` is `open`, `comments` is `0`,
+`assignees` is empty.
 
 ## Half 1 — state survives across calls
 
 Three writes, on three different surfaces of the same issue.
 
 ```bash
-# write 1 — comment
-curl -s -X POST -H "$A" -H 'Content-Type: application/json' \
+curl -s -X POST -H "$AK" -H 'Content-Type: application/json' \
   -d '{"body":"Repro: POST /orders 500s when the payload omits `currency`."}' \
   -w '%{http_code}\n' -o /dev/null \
-  "$R/repos/acme/api/issues/1/comments"
-
-# write 2 — assign
-curl -s -X POST -H "$A" -H 'Content-Type: application/json' \
-  -d '{"assignees":["alice"]}' -w '%{http_code}\n' -o /dev/null \
-  "$R/repos/acme/api/issues/1/assignees"
-
-# write 3 — close
-curl -s -X PATCH -H "$A" -H 'Content-Type: application/json' \
-  -d '{"state":"closed"}' -w '%{http_code}\n' -o /dev/null \
-  "$R/repos/acme/api/issues/1"
+  "$A/repos/acme/api/issues/1/comments"
 ```
 
 ```text
 201
-201
-200
 ```
 
-The read-back after write 1, through the twin's own comment surface — a
-different endpoint from the one that wrote it:
+Read it back through the twin's own comment surface — a different endpoint from
+the one that wrote it, one call later:
 
 ```bash
-curl -s -H "$A" "$R/repos/acme/api/issues/1/comments" \
+curl -s -H "$AK" "$A/repos/acme/api/issues/1/comments" \
   | jq -r '.[] | "\(.user.login): \(.body)"'
 ```
 
@@ -134,12 +149,29 @@ curl -s -H "$A" "$R/repos/acme/api/issues/1/comments" \
 pome-agent: Repro: POST /orders 500s when the payload omits `currency`.
 ```
 
-Now the point of the whole exercise. **One** read, and all three writes are
-there at once — a comment posted five calls ago, an assignee from three calls
-ago, a state change from two:
+Two more writes, and no read between them:
 
 ```bash
-curl -s -H "$A" "$R/repos/acme/api/issues/1" \
+curl -s -X POST -H "$AK" -H 'Content-Type: application/json' \
+  -d '{"assignees":["alice"]}' -w '%{http_code}\n' -o /dev/null \
+  "$A/repos/acme/api/issues/1/assignees"
+
+curl -s -X PATCH -H "$AK" -H 'Content-Type: application/json' \
+  -d '{"state":"closed"}' -w '%{http_code}\n' -o /dev/null \
+  "$A/repos/acme/api/issues/1"
+```
+
+```text
+201
+200
+```
+
+Now the point of the whole exercise. **One** read, and all three writes are
+there at once — a comment posted four calls ago, an assignee from two calls
+ago, a state change from one:
+
+```bash
+curl -s -H "$AK" "$A/repos/acme/api/issues/1" \
   | jq '{state, comments, assignees: [.assignees[].login]}'
 ```
 
@@ -158,22 +190,22 @@ was cached — each write mutated a row that the next read resolved.
 
 ## Read the tape
 
-The tape is the twin's own record of the run. There is no dashboard tape surface
-for an ungraded sandbox, so this is the surface:
+The tape is the twin's own record of the run, served by the twin itself. It
+needs no account either:
 
 ```bash
-curl -s -H "$A" "$R/_pome/events" > tape.json
-jq -r '.[] | [.method, (.path|sub("^/s/[^/]+";"")), .status,
-  .state_mutation, .tool // "-"] | @tsv' tape.json | column -t
+curl -s -H "$AK" "$A/_pome/events" > tape-a.json
+jq -r '.[]|[.method,.path,.status,.state_mutation,.tool//"-"]|@tsv' \
+  tape-a.json | column -t
 ```
 
 ```text
-GET    /repos/acme/api/issues/1            200  false  -
-POST   /repos/acme/api/issues/1/comments   201  true   add_issue_comment
-GET    /repos/acme/api/issues/1/comments   200  false  -
-POST   /repos/acme/api/issues/1/assignees  201  true   -
-PATCH  /repos/acme/api/issues/1            200  true   -
-GET    /repos/acme/api/issues/1            200  false  -
+GET    /s/standalone/repos/acme/api/issues/1            200  false  -
+POST   /s/standalone/repos/acme/api/issues/1/comments   201  true   add_issue_comment
+GET    /s/standalone/repos/acme/api/issues/1/comments   200  false  -
+POST   /s/standalone/repos/acme/api/issues/1/assignees  201  true   -
+PATCH  /s/standalone/repos/acme/api/issues/1            200  true   -
+GET    /s/standalone/repos/acme/api/issues/1            200  false  -
 ```
 
 **You should see:**
@@ -185,16 +217,30 @@ GET    /repos/acme/api/issues/1            200  false  -
 - **`add_issue_comment` stamped in the `tool` column** on the comment write.
   The other two writes read `-`: only three github action names are stamped
   today (see [Assertable checks](#assertable-checks)).
-- **Every row `fidelity: "semantic"`** — a behavioural contract compared against
-  a captured GitHub response, not a shape check. Add `.fidelity` to the `jq` to
-  see it.
+- **`/s/standalone` on the front of every path.** A standalone twin serves one
+  fixed session id. Hold on to that — it is the thing that is *not* the
+  boundary in Half 2.
 
-And the row that is the actual receipt for "the twin keeps books" — each write
-row carries the before/after it caused:
+Every row also carries how it was judged:
 
 ```bash
-jq -c '.[3].state_delta
-  | {b: .before.assignees, a: .after.assignees}' tape.json
+jq -r '[.[].fidelity] | unique[]' tape-a.json
+```
+
+```text
+semantic
+```
+
+One value across all six: a behavioural contract compared against a captured
+GitHub response, not a shape check.
+
+And the field that is the actual receipt for "the twin keeps books" — each
+write row carries the before/after it caused. `.[3]` is the assign: the fourth
+row in the table above, counting from zero.
+
+```bash
+jq -c '.[3].state_delta | {b: .before.assignees, a: .after.assignees}' \
+  tape-a.json
 ```
 
 ```json
@@ -203,25 +249,35 @@ jq -c '.[3].state_delta
 
 Reads carry `state_delta: null`. Only the three writes carry a delta.
 
-## Half 2 — and it does not cross sandboxes
+## Half 2 — and it does not cross processes
 
-Mint a second sandbox. Same twin, no `--seed`, so the same starting world.
+Leave twin A running. In a third terminal, boot a second twin: its own
+directory, its own store, its own port.
 
 ```bash
-npx @pome-sh/cli@latest sandbox create --twin github \
-  --secrets-file .pome-sandbox2.env --format json | jq '{session_id}'
+mkdir -p twin-b && cd twin-b
+GITHUB_CLONE_DB=.pome/github.db \
+  npx @pome-sh/cli@latest twin start github --port 3334
 ```
 
-Read the same issue, with the second sandbox's own bearer:
+It prints the same seven lines, with 3334 in place of 3333 and a token of its
+own. Back in the work terminal:
 
 ```bash
-source .pome-sandbox2.env
-R2="$POME_GITHUB_REST_URL"
-A2="Authorization: Bearer $POME_AUTH_TOKEN"
+B=$(jq -r .rest_url twin-b/.pome/twin-status.json)
+BK="Authorization: Bearer $(jq -r .auth_token twin-b/.pome/twin-status.json)"
+echo "$B"
+```
 
-curl -s -H "$A2" "$R2/repos/acme/api/issues/1" \
+```text
+http://127.0.0.1:3334/s/standalone
+```
+
+Read the same issue, with the second twin's own bearer:
+
+```bash
+curl -s -H "$BK" "$B/repos/acme/api/issues/1" \
   | jq '{state, comments, assignees: [.assignees[].login]}'
-curl -s -H "$A2" "$R2/repos/acme/api/issues/1/comments" | jq -c
 ```
 
 ```json
@@ -232,6 +288,10 @@ curl -s -H "$A2" "$R2/repos/acme/api/issues/1/comments" | jq -c
 }
 ```
 
+```bash
+curl -s -H "$BK" "$B/repos/acme/api/issues/1/comments" | jq -c
+```
+
 ```text
 []
 ```
@@ -240,48 +300,113 @@ Back to three zeros. The issue is the same issue — same number, same title,
 same `bug` label — and the comment, the assignee and the close are simply not
 there.
 
-The strongest form of this is not sequential. **Both sandboxes are alive at the
-same moment**, and the same request against each returns a different world:
-
-```text
-{"sid":"ses_gTgfTIGgoO4dgjZU","state":"closed","comments":1,"assignees":["alice"]}
-{"sid":"ses_qPk73MKVXnGjJr39","state":"open","comments":0,"assignees":[]}
-```
-
-So this is isolation, not a reset. Sandbox 1 still held its three writes while
-sandbox 2 had never seen them.
-
-The tape is per-sandbox too. Same command as before, pointed at sandbox 2:
+**The weak version of this claim is sequential**, and sequential is
+indistinguishable from a reset: boot a twin, see an empty world, shrug. So do
+not do it sequentially. Both twins are running right now. Ask each of them the
+same question:
 
 ```bash
-curl -s -H "$A2" "$R2/_pome/events" > tape2.json
-jq -r '.[] | [.method, (.path|sub("^/s/[^/]+";"")), .status,
-  .state_mutation, .tool // "-"] | @tsv' tape2.json | column -t
+for d in twin-a twin-b; do
+  U=$(jq -r .rest_url "$d/.pome/twin-status.json")
+  K=$(jq -r .auth_token "$d/.pome/twin-status.json")
+  curl -s -H "Authorization: Bearer $K" "$U/repos/acme/api/issues/1" |
+    jq -c --arg twin "$d" '{$twin,state,comments,assignees:[.assignees[].login]}'
+done
 ```
 
 ```text
-GET  /repos/acme/api/issues/1           200  false  -
-GET  /repos/acme/api/issues/1/comments  200  false  -
+{"twin":"twin-a","state":"closed","comments":1,"assignees":["alice"]}
+{"twin":"twin-b","state":"open","comments":0,"assignees":[]}
 ```
 
-Two rows, both `false`. The six rows from sandbox 1 are not on it.
+One request, two answers, neither twin restarted. Twin A did not rewind to let
+twin B be empty; it is still holding all three writes while twin B has never
+seen one of them. That is isolation, and a sequential read cannot say it.
 
-They cannot be, and the reason is mechanical rather than a promise: the sandbox
-id is a **path segment on every row**, which the `sub()` above strips for
-readability. Put it back and each tape names exactly one sandbox:
+The tape is per-process too. Same command as before, pointed at twin B:
 
 ```bash
-jq -r '[.[].path|split("/")[2]] | unique[]' tape.json   # sandbox 1
-jq -r '[.[].path|split("/")[2]] | unique[]' tape2.json  # sandbox 2
+curl -s -H "$BK" "$B/_pome/events" > tape-b.json
+jq -r '.[]|[.method,.path,.status,.state_mutation,.tool//"-"]|@tsv' \
+  tape-b.json | column -t
 ```
 
 ```text
-ses_gTgfTIGgoO4dgjZU
-ses_qPk73MKVXnGjJr39
+GET  /s/standalone/repos/acme/api/issues/1           200  false  -
+GET  /s/standalone/repos/acme/api/issues/1/comments  200  false  -
+GET  /s/standalone/repos/acme/api/issues/1           200  false  -
 ```
 
-One id each. So "no sandbox-1 row appears on sandbox-2's tape" is something you
-can assert rather than eyeball — which is exactly what `verify.sh` does.
+Three rows, all `false` — the three reads you just made against twin B, and
+none of twin A's six.
+
+Now the part that is easy to get wrong. On the hosted path the session id is
+the boundary and it is a path segment on every row, so the tape names its own
+world. **Locally it does not**, because a standalone twin serves one fixed
+session id and both of these twins are serving it:
+
+```bash
+jq -r '[.[].path|split("/")[2]] | unique[]' tape-a.json tape-b.json
+```
+
+```text
+standalone
+standalone
+```
+
+Two tapes, one id. The boundary here is the operating-system process, and the
+field on every row that names it is the `Host` header the request arrived on:
+
+```bash
+jq -r '[.[].request_headers.host] | unique[]' tape-a.json tape-b.json
+```
+
+```text
+127.0.0.1:3333
+127.0.0.1:3334
+```
+
+One authority each. So "no twin-A row appears on twin-B's tape" is something
+you can assert rather than eyeball — which is exactly what `verify.sh` does,
+and it does it as an invariant (*no row on B's tape carries any authority but
+B's*) rather than as a row count, because a row count breaks the moment a
+script makes one more read than a walkthrough does.
+
+Underneath, two directories, two stores:
+
+```bash
+ls -1 twin-a/.pome twin-b/.pome
+```
+
+```text
+twin-a/.pome:
+github.db
+github.db-shm
+github.db-wal
+twin-status.json
+
+twin-b/.pome:
+github.db
+github.db-shm
+github.db-wal
+twin-status.json
+```
+
+And the two bearers are not interchangeable. Neither process found a
+`TWIN_AUTH_SECRET` in the environment or a persisted secret in its directory,
+so each generated its own signing key at boot — twin A's token is not a
+credential for twin B. (Export the same `TWIN_AUTH_SECRET` into both and they
+would share one; that is the documented way to make them interchangeable on
+purpose.)
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -H "$AK" \
+  "$B/repos/acme/api/issues/1"
+```
+
+```text
+401
+```
 
 ## Assertable checks
 
@@ -302,8 +427,8 @@ showcase is about: what happened, versus what persisted, versus what changed.
 Browse the full set with `npx @pome-sh/cli@latest checks github`, or
 `list_checks` over MCP.
 
-Two limits are worth stating out loud, because an id existing is not the same as
-an id doing what you assume:
+Two limits are worth stating out loud, because an id existing is not the same
+as an id doing what you assume:
 
 - **`github.tool-was-called` can only name three github actions today** —
   `create_commit_status`, `create_check_run`, `add_issue_comment`. That is why
@@ -316,36 +441,40 @@ an id doing what you assume:
 
 ## Cost
 
-- **0 agent evals.** An eval is charged only at finalize, and nothing here
-  finalizes. Read `agent_evals.used` before and after if you want to confirm it;
-  on the run above it read **178 both times**.
-- **0 API keys.** Single seat.
-- **2 concurrent sandboxes** while both are up.
+**Zero.** Not "free tier" — there is no meter attached to this page at all.
 
-A sandbox expires 30 minutes after creation. Stop them when you are done rather
-than waiting:
+- **No account and no login.** Nothing here talks to pome.sh except `npx`
+  fetching the CLI from the npm registry.
+- **No API key.** Single seat: you, or your own coding agent.
+- **No sandbox minutes and no agent evals.** Those are billed against a hosted
+  sandbox at finalize; this path has neither a hosted sandbox nor a finalize.
+- **Two `node` processes and two SQLite files**, which is the entire footprint.
+
+Nothing expires. A local twin runs until you stop it — Ctrl-C in each of its
+terminals — and the worlds are two directories:
 
 ```bash
-npx @pome-sh/cli@latest sandbox stop "$POME_SESSION_ID" --discard
+rm -rf twin-a twin-b
 ```
 
 ## Run it yourself
 
 [`verify.sh`](./verify.sh) does everything above unattended and asserts both
-halves, so the claims on this page stay checkable:
+halves, so the claims on this page stay checkable. From a clone of this repo:
 
 ```bash
-npx @pome-sh/cli@latest login    # once
 ./showcases/cross-call-state/verify.sh
 ```
 
-It mints two sandboxes, drives the arc, asserts the accumulation, asserts the
-second world is untouched, and stops both on exit — including on failure. It
-exits non-zero if either half stops being true.
+It is self-contained: it boots both twins itself on two free ports, in a
+throwaway directory, with no login step to do first. It drives the arc, asserts
+the accumulation, asserts the second world is untouched *while the first is
+still holding its writes*, and stops both processes on exit — including on
+failure. It exits non-zero if either half stops being true.
 
 ## Next
 
 - The [github quickstart](https://docs.pome.sh/quickstart/twins/github) — the
-  same twin, one write, in five minutes.
+  same twin, one write, in five minutes, on the hosted path.
 - [`agent-examples/support-triage`](../../agent-examples/support-triage/) — the
   one graded lesson, where a real agent is scored on a task like this.

--- a/showcases/cross-call-state/verify.sh
+++ b/showcases/cross-call-state/verify.sh
@@ -1,35 +1,54 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 #
-# Asserts both halves of the cross-call-state property against live hosted
-# sandboxes, so this showcase's README stays checkable rather than asserted.
+# Asserts both halves of the cross-call-state property against two LOCAL twin
+# processes, so this showcase's README stays checkable rather than asserted.
 #
 # Half 1: state written by call N is readable at call N+1, and three writes
 #         accumulate into one later read.
-# Half 2: a second sandbox of the same twin does NOT see those writes — proved
-#         while BOTH sandboxes are still alive, so it is isolation and not a
-#         reset.
+# Half 2: a second `twin start` — its own port, its own SQLite file — does NOT
+#         see those writes, proved while BOTH twins are still running, so it is
+#         isolation and not a reset.
 #
-# Ungraded on purpose: it never calls finalize, so it burns 0 agent evals.
-# Needs a logged-in CLI (`npx @pome-sh/cli@latest login`), curl and jq.
-# No ANTHROPIC_API_KEY — the single-seat rule.
+# Self-contained on purpose. `twin start` prints its bearer on stdout and
+# writes it to `.pome/twin-status.json`, so the mint is non-interactive: this
+# script boots the twins it needs rather than assuming a human already did the
+# interesting part. No account, no login, no API key, no meter — nothing here
+# finalizes, and there is no hosted sandbox to finalize against.
+#
+# Needs: bash, node >= 24 (for npx), curl, jq. Set POME_CLI to point at a local
+# build instead of the published CLI.
+#
+# Two rules this file exists to keep honest, both learned the hard way:
+#   * The twin's credentials are read out of JSON with `jq`, never out of an
+#     `export K="v"` file with `sed` — un-stripped quotes turn every curl into
+#     exit 000 and a full red run that blames the wrong thing.
+#   * Every tape assertion below is an INVARIANT, never a row count from a
+#     hand-run. "No row on B's tape carries any authority but B's" survives
+#     this script making one more read than the walkthrough does; "B's tape has
+#     3 rows" does not.
 
 set -euo pipefail
 
-CLI="${POME_CLI:-npx @pome-sh/cli@latest}"
+CLI="${POME_CLI:-npx -y @pome-sh/cli@latest}"
 REPO="acme/api"
 FAILS=0
-SB1_ID=""
-SB2_ID=""
 WORK="$(mktemp -d)"
+PIDS=()
 
 cleanup() {
   local code=$?
-  for id in "$SB1_ID" "$SB2_ID"; do
-    [ -n "$id" ] || continue
-    echo "  stopping $id"
-    $CLI sandbox stop "$id" --discard >/dev/null 2>&1 || \
-      echo "  WARN: could not stop $id — it expires on its own in 30m"
+  for pid in ${PIDS[@]+"${PIDS[@]}"}; do
+    kill "$pid" 2>/dev/null || true
+  done
+  # Give each twin its graceful shutdown (it flushes the recorder and releases
+  # the SQLite handle) before the directory holding its database disappears.
+  for pid in ${PIDS[@]+"${PIDS[@]}"}; do
+    for _ in $(seq 1 40); do
+      kill -0 "$pid" 2>/dev/null || break
+      sleep 0.25
+    done
+    kill -9 "$pid" 2>/dev/null || true
   done
   rm -rf "$WORK"
   exit "$code"
@@ -39,6 +58,12 @@ trap cleanup EXIT
 need() { command -v "$1" >/dev/null 2>&1 || { echo "need $1 on PATH"; exit 2; }; }
 need curl
 need jq
+need node
+
+# An injected TWIN_AUTH_SECRET would make both twins mint interchangeable
+# bearers, which is a legitimate operator choice and would falsify one of the
+# assertions below. This script owns its own environment, so it opts out.
+unset TWIN_AUTH_SECRET
 
 # ok <label> <actual> <expected>
 ok() {
@@ -50,28 +75,48 @@ ok() {
   fi
 }
 
-mint() { # mint <name> -> echoes session id, writes $WORK/<name>.env
-  $CLI sandbox create --twin github --secrets-file "$WORK/$1.env" \
-    --format json 2>/dev/null | jq -r '.session_id'
+port_free() { ! (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null; }
+
+pick_port() { # pick_port <from> -> first free TCP port at or above <from>
+  local p="$1"
+  while ! port_free "$p"; do p=$((p + 1)); done
+  echo "$p"
 }
 
-# Read a var out of a secrets file without leaking it into the environment of
-# anything else. The file is `export K="V"` lines, mode 0600 — the values are
-# QUOTED, so strip the quotes that `source` would have stripped for us.
-sget() {
-  sed -n "s/^export $2=//p" "$WORK/$1.env" | sed 's/^"//; s/"$//'
+boot() { # boot <name> <port> -> starts a twin in $WORK/<name>, records its pid
+  local name="$1" port="$2"
+  mkdir -p "$WORK/$name"
+  # `exec` so $! is the CLI's own pid: SIGTERM then reaches the listener rather
+  # than a subshell that would outlive it and keep the port bound.
+  (
+    cd "$WORK/$name" || exit 1
+    export GITHUB_CLONE_DB=.pome/github.db
+    exec $CLI twin start github --port "$port"
+  ) >"$WORK/$name.log" 2>&1 &
+  PIDS+=("$!")
+  for _ in $(seq 1 240); do
+    if [ -f "$WORK/$name/.pome/twin-status.json" ] &&
+      curl -sf "http://127.0.0.1:$port/healthz" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  echo "FAIL twin '$name' never came up on port $port; its log:"
+  cat "$WORK/$name.log"
+  exit 1
 }
+
+url() { jq -r .rest_url "$WORK/$1/.pome/twin-status.json"; }
+auth() { echo "Authorization: Bearer $(jq -r .auth_token "$WORK/$1/.pome/twin-status.json")"; }
 
 get() { # get <name> <path> -> response body on stdout
-  curl -sf -H "Authorization: Bearer $(sget "$1" POME_AUTH_TOKEN)" \
-    "$(sget "$1" POME_GITHUB_REST_URL)$2"
+  curl -sf -H "$(auth "$1")" "$(url "$1")$2"
 }
 
 write() { # write <name> <method> <path> <json> -> http status on stdout
   curl -s -o /dev/null -w '%{http_code}' -X "$2" \
-    -H "Authorization: Bearer $(sget "$1" POME_AUTH_TOKEN)" \
-    -H 'Content-Type: application/json' -d "$4" \
-    "$(sget "$1" POME_GITHUB_REST_URL)$3"
+    -H "$(auth "$1")" -H 'Content-Type: application/json' -d "$4" \
+    "$(url "$1")$3"
 }
 
 issue_shape() { # issue_shape <name> -> "state comments assignees"
@@ -79,76 +124,113 @@ issue_shape() { # issue_shape <name> -> "state comments assignees"
     | jq -r '"\(.state) \(.comments) \([.assignees[].login]|join(","))"'
 }
 
-echo "== minting sandbox 1 =="
-SB1_ID="$(mint sb1)"
-echo "   $SB1_ID"
+authority() { url "$1" | sed -E 's#^https?://([^/]+).*#\1#'; }
+
+# The assign write's assignees, before or after. One-line jq program on
+# purpose: a `jq` filter re-wrapped to fit a width still runs, and a newline
+# that lands inside a string literal quietly ends up in the output.
+adelta() { # adelta <before|after> -> "" or "alice"
+  jq -r --arg k "$1" \
+    '[.[]|select(.path|endswith("/assignees"))][0].state_delta[$k].assignees|join("/")' \
+    "$WORK/tape-a.json"
+}
+
+PORT_A="$(pick_port "${POME_SHOWCASE_PORT:-3341}")"
+PORT_B="$(pick_port "$((PORT_A + 1))")"
+
+echo "== booting twin A on port $PORT_A =="
+boot a "$PORT_A"
 
 echo "== half 1: the fresh world =="
-ok "sb1 starts open/0/none" "$(issue_shape sb1)" "open 0 "
+ok "twin A starts open/0/none" "$(issue_shape a)" "open 0 "
 
-echo "== half 1: three writes =="
+echo "== half 1: write 1, read back through another surface =="
 ok "write 1 (comment) is 201" \
-  "$(write sb1 POST "/repos/$REPO/issues/1/comments" \
+  "$(write a POST "/repos/$REPO/issues/1/comments" \
      '{"body":"Repro: POST /orders 500s without currency."}')" "201"
 ok "comment is readable at the next call" \
-  "$(get sb1 "/repos/$REPO/issues/1/comments" | jq 'length')" "1"
+  "$(get a "/repos/$REPO/issues/1/comments" | jq 'length')" "1"
+
+echo "== half 1: writes 2 and 3 =="
 ok "write 2 (assign) is 201" \
-  "$(write sb1 POST "/repos/$REPO/issues/1/assignees" \
+  "$(write a POST "/repos/$REPO/issues/1/assignees" \
      '{"assignees":["alice"]}')" "201"
 ok "write 3 (close) is 200" \
-  "$(write sb1 PATCH "/repos/$REPO/issues/1" '{"state":"closed"}')" "200"
+  "$(write a PATCH "/repos/$REPO/issues/1" '{"state":"closed"}')" "200"
 
 echo "== half 1: all three survive into ONE later read =="
-ok "sb1 accumulated all three writes" "$(issue_shape sb1)" "closed 1 alice"
+ok "twin A accumulated all three writes" "$(issue_shape a)" "closed 1 alice"
 
 echo "== half 1: the tape =="
-get sb1 "/_pome/events" > "$WORK/tape1.json"
-ok "tape has 6 rows in order" "$(jq 'length' "$WORK/tape1.json")" "6"
-ok "state_mutation true on exactly the 3 writes" \
-  "$(jq '[.[]|select(.state_mutation)]|length' "$WORK/tape1.json")" "3"
+get a "/_pome/events" > "$WORK/tape-a.json"
+# Invariants, not counts: which three rows mutated state and in what order is
+# the property; how many reads surround them is this script's business.
+ok "the 3 writes are the only mutations, in order" \
+  "$(jq -r '[.[]|select(.state_mutation)|.method]|join(",")' \
+     "$WORK/tape-a.json")" "POST,POST,PATCH"
+ok "every mutation carries a state_delta" \
+  "$(jq '[.[]|select(.state_mutation and .state_delta==null)]|length' \
+     "$WORK/tape-a.json")" "0"
+ok "no read carries a state_delta" \
+  "$(jq '[.[]|select((.state_mutation|not) and .state_delta!=null)]|length' \
+     "$WORK/tape-a.json")" "0"
+ok "the assign row's delta is [] -> [alice]" \
+  "$(adelta before)->$(adelta after)" "->alice"
 ok "add_issue_comment stamped on the comment write" \
-  "$(jq -r '[.[]|select(.tool=="add_issue_comment")]|length' \
-     "$WORK/tape1.json")" "1"
-ok "the write rows carry a state_delta" \
-  "$(jq '[.[]|select(.state_mutation and .state_delta!=null)]|length' \
-     "$WORK/tape1.json")" "3"
+  "$(jq '[.[]|select(.tool=="add_issue_comment")]|length' \
+     "$WORK/tape-a.json")" "1"
+ok "every row was judged semantically" \
+  "$(jq -r '[.[].fidelity]|unique|join(",")' "$WORK/tape-a.json")" "semantic"
 
-echo "== minting sandbox 2 (same twin, fresh) =="
-SB2_ID="$(mint sb2)"
-echo "   $SB2_ID"
-ok "the two sandboxes are different" \
-  "$([ "$SB1_ID" != "$SB2_ID" ] && echo differ || echo same)" "differ"
+echo "== booting twin B on port $PORT_B (same twin, its own store) =="
+boot b "$PORT_B"
+ok "the two twins are different processes" \
+  "$([ "$(authority a)" != "$(authority b)" ] && echo differ || echo same)" \
+  "differ"
+ok "twin A's store file exists" \
+  "$([ -f "$WORK/a/.pome/github.db" ] && echo yes || echo no)" "yes"
+ok "twin B's store is a different file" \
+  "$([ "$WORK/a/.pome/github.db" != "$WORK/b/.pome/github.db" ] &&
+     [ -f "$WORK/b/.pome/github.db" ] && echo yes || echo no)" "yes"
 
 echo "== half 2: none of it crossed =="
-ok "sb2 sees the untouched world" "$(issue_shape sb2)" "open 0 "
-ok "sb2 sees no comment" \
-  "$(get sb2 "/repos/$REPO/issues/1/comments" | jq 'length')" "0"
+ok "twin B sees the untouched world" "$(issue_shape b)" "open 0 "
+ok "twin B sees no comment" \
+  "$(get b "/repos/$REPO/issues/1/comments" | jq 'length')" "0"
 
 echo "== half 2: isolation, not a reset — both alive at once =="
-ok "sb1 STILL holds its three writes" "$(issue_shape sb1)" "closed 1 alice"
-ok "sb2 STILL holds none of them" "$(issue_shape sb2)" "open 0 "
+ok "twin A STILL holds its three writes" "$(issue_shape a)" "closed 1 alice"
+ok "twin B STILL holds none of them" "$(issue_shape b)" "open 0 "
 
-echo "== half 2: the tape is per-sandbox too =="
-get sb2 "/_pome/events" > "$WORK/tape2.json"
-# Counted as invariants, not as literals: how many reads this script happens to
-# make against sb2 is an implementation detail, but "every row is sb2's and none
-# is sb1's" is the property.
-ok "sb2's tape records no mutation" \
-  "$(jq '[.[]|select(.state_mutation)]|length' "$WORK/tape2.json")" "0"
-ok "no sb2 row is scoped to anything but sb2" \
-  "$(jq -r --arg id "$SB2_ID" \
-     '[.[]|select(.path|contains($id)|not)]|length' "$WORK/tape2.json")" "0"
-ok "no sb1 row appears on sb2's tape" \
-  "$(jq -r --arg id "$SB1_ID" \
-     '[.[]|select(.path|contains($id))]|length' "$WORK/tape2.json")" "0"
-ok "sb2's tape is shorter than sb1's 6-row run" \
-  "$([ "$(jq length "$WORK/tape2.json")" -lt 6 ] && echo yes || echo no)" "yes"
+echo "== half 2: the tape is per-process too =="
+get b "/_pome/events" > "$WORK/tape-b.json"
+ok "twin B's tape records no mutation" \
+  "$(jq '[.[]|select(.state_mutation)]|length' "$WORK/tape-b.json")" "0"
+# The session id is NOT the boundary locally: a standalone twin serves the one
+# fixed sid, so both tapes read `standalone`. The Host the request arrived on
+# is what names the process, and it is on every row.
+ok "both tapes serve the same session id" \
+  "$(jq -rs 'add|[.[].path|split("/")[2]]|unique|join(",")' \
+     "$WORK/tape-a.json" "$WORK/tape-b.json")" "standalone"
+ok "no row on B's tape has any authority but B's" \
+  "$(jq --arg a "$(authority b)" \
+     '[.[]|select(.request_headers.host != $a)]|length' \
+     "$WORK/tape-b.json")" "0"
+ok "no twin-A row appears on twin-B's tape" \
+  "$(jq --arg a "$(authority a)" \
+     '[.[]|select(.request_headers.host == $a)]|length' \
+     "$WORK/tape-b.json")" "0"
+
+echo "== half 2: the bearers are not interchangeable =="
+ok "twin A's token is refused by twin B" \
+  "$(curl -s -o /dev/null -w '%{http_code}' -H "$(auth a)" \
+     "$(url b)/repos/$REPO/issues/1")" "401"
 
 echo
 if [ "$FAILS" -eq 0 ]; then
-  echo "PASS — both halves hold. 0 agent evals burned (nothing finalized)."
+  echo "PASS — both halves hold. No account, no key, no meter touched."
 else
   echo "FAIL — $FAILS assertion(s) broke."
 fi
-echo "== cleaning up =="
+echo "== stopping both twins =="
 [ "$FAILS" -eq 0 ] || exit 1

--- a/showcases/cross-call-state/verify.sh
+++ b/showcases/cross-call-state/verify.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Asserts both halves of the cross-call-state property against live hosted
+# sandboxes, so this showcase's README stays checkable rather than asserted.
+#
+# Half 1: state written by call N is readable at call N+1, and three writes
+#         accumulate into one later read.
+# Half 2: a second sandbox of the same twin does NOT see those writes — proved
+#         while BOTH sandboxes are still alive, so it is isolation and not a
+#         reset.
+#
+# Ungraded on purpose: it never calls finalize, so it burns 0 agent evals.
+# Needs a logged-in CLI (`npx @pome-sh/cli@latest login`), curl and jq.
+# No ANTHROPIC_API_KEY — the single-seat rule.
+
+set -euo pipefail
+
+CLI="${POME_CLI:-npx @pome-sh/cli@latest}"
+REPO="acme/api"
+FAILS=0
+SB1_ID=""
+SB2_ID=""
+WORK="$(mktemp -d)"
+
+cleanup() {
+  local code=$?
+  for id in "$SB1_ID" "$SB2_ID"; do
+    [ -n "$id" ] || continue
+    echo "  stopping $id"
+    $CLI sandbox stop "$id" --discard >/dev/null 2>&1 || \
+      echo "  WARN: could not stop $id — it expires on its own in 30m"
+  done
+  rm -rf "$WORK"
+  exit "$code"
+}
+trap cleanup EXIT
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "need $1 on PATH"; exit 2; }; }
+need curl
+need jq
+
+# ok <label> <actual> <expected>
+ok() {
+  if [ "$2" = "$3" ]; then
+    printf '  ok   %-46s %s\n' "$1" "$2"
+  else
+    printf '  FAIL %-46s got %s, want %s\n' "$1" "$2" "$3"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+mint() { # mint <name> -> echoes session id, writes $WORK/<name>.env
+  $CLI sandbox create --twin github --secrets-file "$WORK/$1.env" \
+    --format json 2>/dev/null | jq -r '.session_id'
+}
+
+# Read a var out of a secrets file without leaking it into the environment of
+# anything else. The file is `export K="V"` lines, mode 0600 — the values are
+# QUOTED, so strip the quotes that `source` would have stripped for us.
+sget() {
+  sed -n "s/^export $2=//p" "$WORK/$1.env" | sed 's/^"//; s/"$//'
+}
+
+get() { # get <name> <path> -> response body on stdout
+  curl -sf -H "Authorization: Bearer $(sget "$1" POME_AUTH_TOKEN)" \
+    "$(sget "$1" POME_GITHUB_REST_URL)$2"
+}
+
+write() { # write <name> <method> <path> <json> -> http status on stdout
+  curl -s -o /dev/null -w '%{http_code}' -X "$2" \
+    -H "Authorization: Bearer $(sget "$1" POME_AUTH_TOKEN)" \
+    -H 'Content-Type: application/json' -d "$4" \
+    "$(sget "$1" POME_GITHUB_REST_URL)$3"
+}
+
+issue_shape() { # issue_shape <name> -> "state comments assignees"
+  get "$1" "/repos/$REPO/issues/1" \
+    | jq -r '"\(.state) \(.comments) \([.assignees[].login]|join(","))"'
+}
+
+echo "== minting sandbox 1 =="
+SB1_ID="$(mint sb1)"
+echo "   $SB1_ID"
+
+echo "== half 1: the fresh world =="
+ok "sb1 starts open/0/none" "$(issue_shape sb1)" "open 0 "
+
+echo "== half 1: three writes =="
+ok "write 1 (comment) is 201" \
+  "$(write sb1 POST "/repos/$REPO/issues/1/comments" \
+     '{"body":"Repro: POST /orders 500s without currency."}')" "201"
+ok "comment is readable at the next call" \
+  "$(get sb1 "/repos/$REPO/issues/1/comments" | jq 'length')" "1"
+ok "write 2 (assign) is 201" \
+  "$(write sb1 POST "/repos/$REPO/issues/1/assignees" \
+     '{"assignees":["alice"]}')" "201"
+ok "write 3 (close) is 200" \
+  "$(write sb1 PATCH "/repos/$REPO/issues/1" '{"state":"closed"}')" "200"
+
+echo "== half 1: all three survive into ONE later read =="
+ok "sb1 accumulated all three writes" "$(issue_shape sb1)" "closed 1 alice"
+
+echo "== half 1: the tape =="
+get sb1 "/_pome/events" > "$WORK/tape1.json"
+ok "tape has 6 rows in order" "$(jq 'length' "$WORK/tape1.json")" "6"
+ok "state_mutation true on exactly the 3 writes" \
+  "$(jq '[.[]|select(.state_mutation)]|length' "$WORK/tape1.json")" "3"
+ok "add_issue_comment stamped on the comment write" \
+  "$(jq -r '[.[]|select(.tool=="add_issue_comment")]|length' \
+     "$WORK/tape1.json")" "1"
+ok "the write rows carry a state_delta" \
+  "$(jq '[.[]|select(.state_mutation and .state_delta!=null)]|length' \
+     "$WORK/tape1.json")" "3"
+
+echo "== minting sandbox 2 (same twin, fresh) =="
+SB2_ID="$(mint sb2)"
+echo "   $SB2_ID"
+ok "the two sandboxes are different" \
+  "$([ "$SB1_ID" != "$SB2_ID" ] && echo differ || echo same)" "differ"
+
+echo "== half 2: none of it crossed =="
+ok "sb2 sees the untouched world" "$(issue_shape sb2)" "open 0 "
+ok "sb2 sees no comment" \
+  "$(get sb2 "/repos/$REPO/issues/1/comments" | jq 'length')" "0"
+
+echo "== half 2: isolation, not a reset — both alive at once =="
+ok "sb1 STILL holds its three writes" "$(issue_shape sb1)" "closed 1 alice"
+ok "sb2 STILL holds none of them" "$(issue_shape sb2)" "open 0 "
+
+echo "== half 2: the tape is per-sandbox too =="
+get sb2 "/_pome/events" > "$WORK/tape2.json"
+# Counted as invariants, not as literals: how many reads this script happens to
+# make against sb2 is an implementation detail, but "every row is sb2's and none
+# is sb1's" is the property.
+ok "sb2's tape records no mutation" \
+  "$(jq '[.[]|select(.state_mutation)]|length' "$WORK/tape2.json")" "0"
+ok "no sb2 row is scoped to anything but sb2" \
+  "$(jq -r --arg id "$SB2_ID" \
+     '[.[]|select(.path|contains($id)|not)]|length' "$WORK/tape2.json")" "0"
+ok "no sb1 row appears on sb2's tape" \
+  "$(jq -r --arg id "$SB1_ID" \
+     '[.[]|select(.path|contains($id))]|length' "$WORK/tape2.json")" "0"
+ok "sb2's tape is shorter than sb1's 6-row run" \
+  "$([ "$(jq length "$WORK/tape2.json")" -lt 6 ] && echo yes || echo no)" "yes"
+
+echo
+if [ "$FAILS" -eq 0 ]; then
+  echo "PASS — both halves hold. 0 agent evals burned (nothing finalized)."
+else
+  echo "FAIL — $FAILS assertion(s) broke."
+fi
+echo "== cleaning up =="
+[ "$FAILS" -eq 0 ] || exit 1


### PR DESCRIPTION
## What this is

A new top-level `showcases/` directory and its first entry, `cross-call-state`.
A showcase demonstrates **one property of the twins** against a twin you boot
yourself, and stops there — it is not an example agent and not an exam. A
sibling (permission-denial) copies this shape, so the structure here is the
deliverable as much as the content is.

> **Re-authored 2026-08-29 for the local path.** The 2026-08-26 substrate
> ruling puts the OSS repo on the local process (`twin start`, no account) and
> the docs site on the cloud. The first two commits on this branch are the
> hosted draft; the third replaces it. Every captured output block was
> re-captured locally, `verify.sh` is now genuinely self-contained, and the
> negative half was re-cut around a boundary that exists locally.

The property, in two halves:

1. **State written by call N is readable at call N+1.** Three writes on three
   surfaces of the same issue — comment, assign, close — each read back through
   a *different* endpoint from the one that wrote it, then all three present in
   a single later read.
2. **It does not cross processes.** The weak form of that claim is sequential
   (boot a second twin, observe absence) and is indistinguishable from a reset.
   So the page does the strong form: two `twin start` processes on different
   ports with different `.pome/github.db` files, **both held open**, the same
   request issued to each, two different worlds at the same moment.

Every output block on the page is verbatim from a real run — see below.

## Three decisions worth a reviewer's attention

**Why a walkthrough plus one bash script, and not a runnable npm package.** One
of the two original grounds for this survived the substrate move and one did
not, so the shape is the same for a different reason:

- **Void now:** the old first ground was "a self-contained script is impossible,
  because the mint leg is interactive." That was true of Clerk OAuth +
  `sandbox create`. Locally `twin start` prints `POME_AUTH_TOKEN` on stdout and
  writes `.pome/twin-status.json`, so the mint is non-interactive and
  machine-readable. `verify.sh` now **boots the twins it needs** rather than
  assuming a human already did the interesting part.
- **Still binding:** a `package.json` here would be discovered by
  `smoke:examples`, which launches each hit against dead loopback wiring
  (`127.0.0.1:59321`, `smoke-token`) and requires it to emit
  `POME_SMOKE_REACHED_OUTBOUND`. A showcase whose entire subject is *real twin
  state across calls* would be green there while proving nothing — the exact
  "proves nothing but looks like it does" failure `scripts/smoke-examples.mjs`
  was written to prevent.

So the dir ships markdown plus `verify.sh`, and nothing that makes a gate think
it is an example agent.

**Why a new top level and not `agent-examples/`.** This ships no agent, no API
key, no `src/` and no `tasks/`. Filing it beside ten worked example agents would
make the README's own sentence about them false. `showcases/README.md` carries
the table that draws the distinction, a sibling index with one row per showcase,
and an "Adding one" section — so the permission-denial showcase adds a row
rather than inventing the directory a second time.

**What the negative half had to become.** The hosted draft held two sandboxes
open and issued the same request to each. That is a *session*-isolation proof,
and locally there is no session: **both twins serve sid `standalone`**, which
the page shows rather than glosses. The local boundary is the operating-system
process, and the field on every tape row that names it is the `Host` header the
request arrived on. The page proves it three ways — divergent answers while both
are alive, `request_headers.host` unique per tape, and twin A's bearer refused
`401` by twin B — and `verify.sh` asserts it as an **invariant** (*no row on B's
tape carries any authority but B's*) rather than a row count, because a count
breaks the moment the script makes one more read than the walkthrough does.

## No grading

Grading still appears exactly once in this repo, in the support-triage capstone.
The checks section names three declared checks as **pointers only** — no task
file, no criteria markers — chosen so that `substrate` carries the argument:
`tape` = the write happened, `final` = it persisted, `seed+final` = what changed
between the two worlds. Both known limitations on those ids are stated on the
page rather than papered over.

## Verified before pushing

- **Fidelity: 18 of 18 output blocks byte-identical to a fresh run.** The page
  was authored from a captured run, then a 1:1 mirror of its bash blocks was
  re-run and every pasted block diffed against the new output. The only line
  that differs across runs is the `POME_AUTH_TOKEN` in the boot transcript,
  which is minted per boot; the page says so. Every `jq` program on the page is
  on one line, and every table is `column -t` output, never hand-aligned.
- **`verify.sh` — 24 assertions, exit 0**, self-contained: it picks two free
  ports, boots both twins into a `mktemp -d`, drives the arc, asserts the
  accumulation, asserts the second world is untouched *while the first still
  holds its writes*, and kills both processes on exit including on failure. No
  login step. `bash -n` clean.
- **Non-vacuity of `verify.sh`:** planting an inverted expectation on the
  isolation assertion (`twin B STILL holds none of them` → expect
  `closed 1 alice`) makes it exit 1 naming exactly that assertion, with the
  other 23 still green. Plant removed.
- **`npm run lint` — 17/17 rules.** Plus `lint:test --offline`,
  `check-packages-scripts-wired.mjs`, `smoke-examples.test.mjs`,
  `check-example-pins-published.test.mjs`, `lint:no-cloud-imports` and
  `check-release-note-required.test.mjs` — the always-on CI set, since
  `ci.yml`'s heavy-suite regex lists `agent-examples/` but not `showcases/`, so
  a showcase-only PR is classified docs-only.
- **No gate discovers the directory**, measured rather than assumed:
  `smoke:examples` finds 10 hits, all under `agent-examples/`, zero mentioning
  `showcases`; `check-example-pins-published` exits 0;
  `check-release-note-required.mjs` reports 0 packages moved and
  `packagesTouchedBy` returns `[]` for all four changed files.
- **The `task-class` non-vacuity check in the spec does not reproduce, and the
  real answer is stronger.** The spec said planting
  `showcases/cross-call-state/tasks/planted.md` would make `task-class` collect
  it. It does not: the rule's `CORPORA` is `["cli/tasks", "agent-examples"]`, so
  it never walks `showcases/` under any configuration. Planting the identical
  file at `agent-examples/support-triage/tasks/planted.md` does fail the rule,
  which is how the gate was proved live. Both plants removed.

## Reviewer notes

- Rebased onto `origin/main` (the branch was 38 commits behind), so this is a
  force-push. No conflicts.
- `README.md` gains **two lines**, pointing at `showcases/` and saying the twin
  is one you boot yourself.
- `verify.sh` reads credentials out of `.pome/twin-status.json` with `jq`, not
  out of an `export K="v"` file with `sed`. The old script did the latter and
  un-stripped quotes produced `curl` exit `000` on every call; the JSON path
  removes the trap by construction, and the header says why.
- It also `unset TWIN_AUTH_SECRET`s before booting: an injected secret would
  make both twins mint interchangeable bearers, which is a legitimate operator
  choice that would falsify the `401` assertion. The page states the same
  caveat.
- Three code-block lines exceed 82 characters, all of them verbatim captured
  output that cannot be rewrapped without fabricating it: the twin's `Seed:`
  line, the `POME_AUTH_TOKEN` line, and one tape row carrying
  `add_issue_comment`.
- No token material is committed that means anything: the JWTs on the page are
  signed with per-boot ephemeral secrets for processes that no longer exist,
  bound to `127.0.0.1`.
- **Cost of producing this: zero.** No account, no hosted sandbox, no agent
  evals, no keys. Nothing on this path can finalize.
