### PR TITLE
`pome twin start --seed`: the local twin takes a world

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -27,6 +27,11 @@ registry as `TWIN_REGISTRY[twin].parseSeed`, alongside `defaultSeed`.
 The boot output gains one line naming where the world came from, because every
 world looks like a world once it is running.
 
+A compiled `<task>.seed.json` is accepted as a world file unchanged: the `_meta`
+provenance block `pome compile-seeds` writes is dropped before parse. That was
+already true by accident — the twins' seed schemas are non-strict zod — and is
+now declared, so it survives those schemas being tightened.
+
 ## 0.26.13 — 2026-08-25
 
 **No consumer-visible change.** Deleted an orphaned changeset file and the empty

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,6 +8,25 @@ allocates on `main` after the merge, in the same commit that moves
 write a version number here or in `package.json`. Released entries are insertions
 only: a correction is the next entry, naming the one it corrects.
 
+## Unreleased (minor)
+
+`pome twin start` takes a world. `--seed <path>` boots the twin from a JSON or
+YAML file instead of its built-in default, and `POME_SEED_JSON` — the same env
+the cloud sets on a hosted pod — is now honored here too. `--seed` wins over the
+env; neither set keeps the twin's default world. Before this, `twin start` boots
+through the registry's `defaultSeed()` and the env never reaches the twin's
+`loadSeedFromEnv`, so a world set that way was read by the twin and silently
+discarded: the only way to seed a twin was to write a Pome task file.
+
+The twin's own `parseSeed` is the arbiter. A world it refuses is refused before
+the port binds, naming the file (or the env var) and the field, and the command
+exits non-zero — including for the github twin, whose `boot` handed its seed
+straight to `domain.seed()` unparsed. Each twin's parser is reachable from the
+registry as `TWIN_REGISTRY[twin].parseSeed`, alongside `defaultSeed`.
+
+The boot output gains one line naming where the world came from, because every
+world looks like a world once it is running.
+
 ## 0.26.13 — 2026-08-25
 
 **No consumer-visible change.** Deleted an orphaned changeset file and the empty

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -1333,10 +1333,14 @@ export function createProgram() {
       "--port <port>",
       "Port to bind (default: $PORT, else GMAIL_TWIN_PORT/3336 for gmail, else 3333)",
     )
+    .option(
+      "--seed <path>",
+      "Boot this twin's world from a JSON or YAML file instead of its default. Overrides POME_SEED_JSON.",
+    )
     .description(
       "Start a standalone twin as a long-lived foreground server (Ctrl-C to stop)",
     )
-    .action(async (name: string, options: { port?: string }) => {
+    .action(async (name: string, options: { port?: string; seed?: string }) => {
       const { runTwinStartCommand } = await import("../twin/twinStart.js");
       await runTwinStartCommand(name, options);
     });

--- a/cli/src/twin/registry.ts
+++ b/cli/src/twin/registry.ts
@@ -100,6 +100,19 @@ export type TwinEntry = {
   /** Default world for `pome twin start` with no seed. `undefined` means the
    *  twin seeds its own default during boot. */
   defaultSeed(): Promise<unknown>;
+  /**
+   * The twin's OWN seed parser, reached through its `/seed` leaf. This is the
+   * arbiter for a user-authored world: it is the same function the twin runs
+   * inside `loadSeedFromEnv`, so a seed this accepts is a seed the twin boots
+   * and a seed this rejects names its own bad field.
+   *
+   * `boot` re-parses for the twins whose factories take a parsed seed; that
+   * duplication is deliberate. `boot` is reached with an ALREADY-shaped seed
+   * from the task path, whereas this runs on raw user input BEFORE a port is
+   * bound — and github's `boot` hands its seed to `domain.seed()` unparsed, so
+   * without this entry a `--seed` typo would reach SQLite instead of an error.
+   */
+  parseSeed(input: unknown): Promise<unknown>;
   boot(ctx: TwinBootContext): Promise<TwinBoot>;
 };
 
@@ -111,6 +124,7 @@ export const TWIN_REGISTRY: Record<TwinName, TwinEntry> = {
     // The github twin's own `defaultSeedState()` is applied by `boot` below
     // when no seed is supplied — the pre-existing standalone behavior.
     defaultSeed: async () => undefined,
+    parseSeed: async (input) => (await import("@pome-sh/twin-github/seed")).parseSeed(input),
     async boot({ seedState, runId, recorder }) {
       const {
         createGitHubCloneApp,
@@ -139,6 +153,7 @@ export const TWIN_REGISTRY: Record<TwinName, TwinEntry> = {
     defaultPort: 3333,
     version: slackManifest.version,
     defaultSeed: async () => (await import("@pome-sh/twin-slack")).defaultSeedState(),
+    parseSeed: async (input) => (await import("@pome-sh/twin-slack/seed")).parseSeed(input),
     async boot({ seedState, runId, recorder }) {
       const { createSlackTwinApp, openSlackTwinDatabase, SlackDomain } =
         await import("@pome-sh/twin-slack");
@@ -169,6 +184,7 @@ export const TWIN_REGISTRY: Record<TwinName, TwinEntry> = {
     defaultPort: 3333,
     version: stripeManifest.version,
     defaultSeed: async () => (await import("@pome-sh/twin-stripe")).defaultSeed(),
+    parseSeed: async (input) => (await import("@pome-sh/twin-stripe/seed")).parseSeed(input),
     async boot({ seedState, runId, recorder, twinBaseUrl }) {
       // Engine-based twin: the factory owns middleware, MCP mount, and
       // the failure-injection store — seed rules ride in via `seed` and land in
@@ -234,6 +250,7 @@ export const TWIN_REGISTRY: Record<TwinName, TwinEntry> = {
     tokenEnvName: "POME_GMAIL_TOKEN",
     version: gmailManifest.version,
     defaultSeed: async () => (await import("@pome-sh/twin-gmail")).defaultSeedState(),
+    parseSeed: async (input) => (await import("@pome-sh/twin-gmail/seed")).parseSeed(input),
     async boot({ seedState, runId, recorder }) {
       const { createGmailTwinApp, GmailDomain, openGmailTwinDatabase, parseSeed } =
         await import("@pome-sh/twin-gmail");
@@ -257,6 +274,7 @@ export const TWIN_REGISTRY: Record<TwinName, TwinEntry> = {
     tokenEnvName: "POME_LINEAR_TOKEN",
     version: linearManifest.version,
     defaultSeed: async () => (await import("@pome-sh/twin-linear")).defaultSeedState(),
+    parseSeed: async (input) => (await import("@pome-sh/twin-linear/seed")).parseSeed(input),
     async boot({ seedState, runId, recorder }) {
       const {
         createLinearTwinApp,

--- a/cli/src/twin/twinStart.ts
+++ b/cli/src/twin/twinStart.ts
@@ -21,7 +21,14 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { serve } from "@hono/node-server";
 import { sign } from "hono/jwt";
-import { defaultPortFor, isTwinName, TWIN_NAMES, TWIN_REGISTRY } from "./registry.js";
+import { parse as parseYaml } from "yaml";
+import {
+  defaultPortFor,
+  isTwinName,
+  TWIN_NAMES,
+  TWIN_REGISTRY,
+  type TwinName,
+} from "./registry.js";
 import { bootTwin } from "./twinHarness.js";
 
 /** The fixed session id a standalone twin serves under (`/s/standalone`). */
@@ -71,9 +78,80 @@ export function resolveStandaloneAuthSecret(
   return { secret: randomBytes(32).toString("hex"), source: "ephemeral" };
 }
 
+/** Where the world a standalone twin booted came from. Printed on boot so the
+ *  answer to "did my seed land?" does not require reading `/_pome/state`. */
+export type StandaloneSeed = {
+  seedState: unknown;
+  source: "file" | "env" | "default";
+  /** Set when `source` is "file": the path the world was read from. */
+  path?: string;
+};
+
+/**
+ * Read side of the world contract, mirroring `resolveStandaloneAuthSecret`:
+ *   1. `--seed <path>` (JSON or YAML — JSON is a YAML subset, one parser)
+ *   2. env `POME_SEED_JSON` — the SAME channel the cloud sets on a pod, so a
+ *      world that boots hosted boots here. Before this it was read by the twin
+ *      and silently discarded by this command, which boots through `bootTwin`
+ *      rather than the twin's own `loadSeedFromEnv`.
+ *   3. the twin's default world
+ *
+ * The twin's own `parseSeed` is the arbiter in both non-default cases: a
+ * user-authored world is refused HERE, naming its own bad field, rather than
+ * reaching SQLite (github) or throwing an un-attributed zod error mid-boot.
+ */
+export async function resolveStandaloneSeed(
+  twin: TwinName,
+  seedPath: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<StandaloneSeed> {
+  const entry = TWIN_REGISTRY[twin];
+
+  if (seedPath !== undefined) {
+    let raw: string;
+    try {
+      raw = readFileSync(seedPath, "utf8");
+    } catch (err) {
+      throw new Error(
+        `pome twin start --seed: cannot read ${seedPath}: ${(err as Error).message}`,
+      );
+    }
+    return {
+      seedState: await parseWorld(entry, raw, `--seed ${seedPath}`),
+      source: "file",
+      path: seedPath,
+    };
+  }
+
+  const fromEnv = env.POME_SEED_JSON;
+  if (fromEnv !== undefined && fromEnv !== "") {
+    return { seedState: await parseWorld(entry, fromEnv, "POME_SEED_JSON"), source: "env" };
+  }
+
+  return { seedState: await entry.defaultSeed(), source: "default" };
+}
+
+async function parseWorld(
+  entry: (typeof TWIN_REGISTRY)[TwinName],
+  raw: string,
+  origin: string,
+): Promise<unknown> {
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(raw);
+  } catch (err) {
+    throw new Error(`${origin} is not valid JSON or YAML: ${(err as Error).message}`);
+  }
+  try {
+    return await entry.parseSeed(parsed);
+  } catch (err) {
+    throw new Error(`${origin} is not a world this twin can boot: ${(err as Error).message}`);
+  }
+}
+
 export async function runTwinStartCommand(
   name: string,
-  options: { port?: string },
+  options: { port?: string; seed?: string },
 ): Promise<void> {
   if (!isTwinName(name)) {
     throw new Error(`Unknown twin '${name}'. Supported: ${TWIN_NAMES.join(", ")}.`);
@@ -88,6 +166,10 @@ export async function runTwinStartCommand(
     throw new Error(`pome twin start: invalid --port "${portRaw}"`);
   }
 
+  // Resolve the world BEFORE the auth secret and the listener: a refused seed
+  // must not persist a secret file or leave a bound port behind.
+  const world = await resolveStandaloneSeed(name, options.seed);
+
   const resolved = resolveStandaloneAuthSecret(name);
   // The in-process twin's auth middleware (resolveAuthSecret) reads the env;
   // pinning the resolved secret here is what makes the minted JWT and the
@@ -97,7 +179,7 @@ export async function runTwinStartCommand(
   const baseUrl = `http://127.0.0.1:${port}`;
   const harness = await bootTwin({
     twin: name,
-    seedState: await TWIN_REGISTRY[name].defaultSeed(),
+    seedState: world.seedState,
     runId: STANDALONE_SID,
     twinBaseUrl: baseUrl,
   });
@@ -138,6 +220,15 @@ export async function runTwinStartCommand(
   }
 
   console.log(`Pome ${name} twin listening at ${restUrl}`);
+  // "Did my world land?" is the question a user-authored seed creates, and the
+  // twin cannot answer it after the fact — every world looks like a world.
+  if (world.source === "file") {
+    console.log(`World: seeded from ${world.path}.`);
+  } else if (world.source === "env") {
+    console.log("World: seeded from POME_SEED_JSON (--seed <path> overrides it).");
+  } else {
+    console.log(`World: the ${name} twin's default (pass --seed <path> for your own).`);
+  }
   if (resolved.source === "persisted") {
     console.log(
       `Auth: using the persisted secret from ${resolved.path} (an env-injected TWIN_AUTH_SECRET overrides it).`,

--- a/cli/src/twin/twinStart.ts
+++ b/cli/src/twin/twinStart.ts
@@ -131,6 +131,24 @@ export async function resolveStandaloneSeed(
   return { seedState: await entry.defaultSeed(), source: "default" };
 }
 
+/**
+ * Drop the sidecar provenance block, so a compiled `<task>.seed.json` is a
+ * world file this door accepts as-is — `pome compile-seeds` has been emitting
+ * exactly this shape all along, and every task in the library is already one.
+ *
+ * DECLARED, not inherited. The twins' seed schemas are non-strict zod today, so
+ * `_meta` would be stripped by `parseSeed` anyway — but only by accident, and
+ * the moment those schemas refuse unknown keys that accident becomes a refusal
+ * of every sidecar in the library. Stripping it here is what survives that.
+ */
+function stripSidecarMeta(seed: unknown): unknown {
+  if (seed && typeof seed === "object" && !Array.isArray(seed)) {
+    const { _meta, ...rest } = seed as Record<string, unknown>;
+    return rest;
+  }
+  return seed;
+}
+
 async function parseWorld(
   entry: (typeof TWIN_REGISTRY)[TwinName],
   raw: string,
@@ -143,7 +161,7 @@ async function parseWorld(
     throw new Error(`${origin} is not valid JSON or YAML: ${(err as Error).message}`);
   }
   try {
-    return await entry.parseSeed(parsed);
+    return await entry.parseSeed(stripSidecarMeta(parsed));
   } catch (err) {
     throw new Error(`${origin} is not a world this twin can boot: ${(err as Error).message}`);
   }

--- a/cli/test/e2e/twinStart.test.ts
+++ b/cli/test/e2e/twinStart.test.ts
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Acceptance — `pome twin start` as a real child process: boots the twin as a
-// foreground server, reuses the secret persisted at the boot-secret contract.
+// foreground server, reuses the secret persisted at the boot-secret contract,
+// and boots a USER-AUTHORED world from `--seed`, read back through the twin's
+// own REST surface.
 
 import { spawn, type ChildProcess } from "node:child_process";
 import { once } from "node:events";
@@ -104,6 +106,109 @@ describe("pome twin start (e2e)", () => {
       // Foreground contract: Ctrl-C stops the server and exits 0.
       child.kill("SIGINT");
       await expect(exited).resolves.toBe(0);
+    },
+    90_000,
+  );
+
+  it(
+    "boots a world from --seed and serves a repository the default world has never had",
+    async () => {
+      const cwd = await mkdtemp(join(tmpdir(), "pome-twin-start-seed-e2e-"));
+      const seedPath = join(cwd, "world.json");
+      // `vakoi/billing` is not in the github twin's defaultSeedState(); the
+      // default's `acme/api` is. Asserting BOTH is what separates "my seed
+      // landed" from "the twin merged my seed into its default".
+      await writeFile(
+        seedPath,
+        JSON.stringify({
+          users: [{ login: "vakoi", type: "Organization", name: "Vakoi" }],
+          repositories: [
+            {
+              owner: "vakoi",
+              name: "billing",
+              issues: [{ number: 1, title: "Invoice webhook drops retries" }],
+            },
+          ],
+        }),
+      );
+
+      const port = await freePort();
+      child = spawn(
+        TSX_BIN,
+        [MAIN_TS, "twin", "start", "github", "--port", String(port), "--seed", seedPath],
+        { cwd, env: { ...process.env }, stdio: ["ignore", "pipe", "pipe"] },
+      );
+      let output = "";
+      child.stdout?.on("data", (chunk) => { output += chunk; });
+      child.stderr?.on("data", (chunk) => { output += chunk; });
+
+      const base = `http://127.0.0.1:${port}`;
+      const deadline = Date.now() + 60_000;
+      for (;;) {
+        try {
+          if ((await fetch(`${base}/healthz`)).status === 200) break;
+        } catch {
+          // not listening yet
+        }
+        if (Date.now() > deadline) {
+          throw new Error(`twin start --seed never answered /healthz 200\n--- output ---\n${output}`);
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+
+      const tokenDeadline = Date.now() + 5_000;
+      while (!/POME_AUTH_TOKEN=/.test(output) && Date.now() < tokenDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      const token = output.match(/POME_AUTH_TOKEN=(\S+)/)?.[1];
+      expect(token).toBeTruthy();
+      const auth = { Authorization: `Bearer ${token}` };
+
+      const seeded = await fetch(`${base}/s/standalone/repos/vakoi/billing`, { headers: auth });
+      expect(seeded.status).toBe(200);
+      expect(((await seeded.json()) as { full_name: string }).full_name).toBe("vakoi/billing");
+
+      const issues = await fetch(`${base}/s/standalone/repos/vakoi/billing/issues`, {
+        headers: auth,
+      });
+      expect(((await issues.json()) as { title: string }[])[0]?.title).toBe(
+        "Invoice webhook drops retries",
+      );
+
+      // The default world is REPLACED, not merged into.
+      const fromDefault = await fetch(`${base}/s/standalone/repos/acme/api`, { headers: auth });
+      expect(fromDefault.status).toBe(404);
+
+      // The boot line answers "did my world land?" without reading state.
+      expect(output).toContain(`World: seeded from ${seedPath}`);
+    },
+    90_000,
+  );
+
+  it(
+    "refuses a schema-invalid --seed before binding a port, and exits non-zero",
+    async () => {
+      const cwd = await mkdtemp(join(tmpdir(), "pome-twin-start-badseed-e2e-"));
+      const seedPath = join(cwd, "world.json");
+      await writeFile(seedPath, JSON.stringify({ repositories: [{ owner: "acme" }] }));
+
+      const port = await freePort();
+      child = spawn(
+        TSX_BIN,
+        [MAIN_TS, "twin", "start", "github", "--port", String(port), "--seed", seedPath],
+        { cwd, env: { ...process.env }, stdio: ["ignore", "pipe", "pipe"] },
+      );
+      let output = "";
+      child.stdout?.on("data", (chunk) => { output += chunk; });
+      child.stderr?.on("data", (chunk) => { output += chunk; });
+      const exitCode = await new Promise<number | null>((resolve) =>
+        child?.once("exit", (code) => resolve(code)),
+      );
+
+      expect(exitCode).not.toBe(0);
+      expect(output).toContain("is not a world this twin can boot");
+      // Nothing is listening: the world is resolved before the server binds.
+      await expect(fetch(`http://127.0.0.1:${port}/healthz`)).rejects.toThrow();
     },
     90_000,
   );

--- a/cli/test/unit/twinStartSeed.test.ts
+++ b/cli/test/unit/twinStartSeed.test.ts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Read side of the world contract in `pome twin start`: `--seed <path>` wins,
+// else `POME_SEED_JSON` (the same channel the cloud sets on a pod), else the
+// twin's default. The twin's own `parseSeed` is the arbiter in both authored
+// cases, so a bad world is refused here rather than at boot.
+
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveStandaloneSeed } from "../../src/twin/twinStart.js";
+
+const WORLD = {
+  users: [{ login: "vakoi", type: "Organization", name: "Vakoi" }],
+  repositories: [{ owner: "vakoi", name: "billing" }],
+};
+
+async function seedFile(contents: string, name = "world.json"): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "pome-twin-start-seed-"));
+  const path = join(dir, name);
+  await writeFile(path, contents);
+  return path;
+}
+
+/** The one fact every case below turns on: `vakoi/billing` is not a repository
+ *  the github twin's own `defaultSeedState()` has, and `acme/api` is. */
+function repoNames(seedState: unknown): string[] {
+  const seed = seedState as { repositories: { owner: string; name: string }[] };
+  return seed.repositories.map((repo) => `${repo.owner}/${repo.name}`);
+}
+
+describe("resolveStandaloneSeed", () => {
+  it("reads a JSON world from --seed and reports the path it came from", async () => {
+    const path = await seedFile(JSON.stringify(WORLD));
+    const resolved = await resolveStandaloneSeed("github", path, {});
+    expect(resolved.source).toBe("file");
+    expect(resolved.path).toBe(path);
+    expect(repoNames(resolved.seedState)).toEqual(["vakoi/billing"]);
+  });
+
+  it("reads a YAML world from --seed (JSON is a YAML subset, so one parser)", async () => {
+    const path = await seedFile(
+      ["repositories:", "  - owner: vakoi", "    name: billing", ""].join("\n"),
+      "world.yaml",
+    );
+    const resolved = await resolveStandaloneSeed("github", path, {});
+    expect(repoNames(resolved.seedState)).toEqual(["vakoi/billing"]);
+  });
+
+  it("honors POME_SEED_JSON when --seed is absent", async () => {
+    const resolved = await resolveStandaloneSeed("github", undefined, {
+      POME_SEED_JSON: JSON.stringify(WORLD),
+    });
+    expect(resolved.source).toBe("env");
+    expect(resolved.path).toBeUndefined();
+    expect(repoNames(resolved.seedState)).toEqual(["vakoi/billing"]);
+  });
+
+  it("--seed wins over POME_SEED_JSON", async () => {
+    const path = await seedFile(JSON.stringify(WORLD));
+    const resolved = await resolveStandaloneSeed("github", path, {
+      POME_SEED_JSON: JSON.stringify({ repositories: [{ owner: "env", name: "loser" }] }),
+    });
+    expect(resolved.source).toBe("file");
+    expect(repoNames(resolved.seedState)).toEqual(["vakoi/billing"]);
+  });
+
+  it("falls back to the twin's default world when neither is set", async () => {
+    const resolved = await resolveStandaloneSeed("github", undefined, {});
+    expect(resolved.source).toBe("default");
+    // github's entry defers to the twin's own defaultSeedState() inside `boot`.
+    expect(resolved.seedState).toBeUndefined();
+  });
+
+  it("treats an empty POME_SEED_JSON as absent rather than as an empty world", async () => {
+    const resolved = await resolveStandaloneSeed("github", undefined, { POME_SEED_JSON: "" });
+    expect(resolved.source).toBe("default");
+  });
+
+  it("names the file when it cannot be read", async () => {
+    await expect(
+      resolveStandaloneSeed("github", "/nope/does-not-exist.json", {}),
+    ).rejects.toThrow(/--seed: cannot read \/nope\/does-not-exist\.json/);
+  });
+
+  it("refuses an unparseable world, naming the flag", async () => {
+    const path = await seedFile("{ not json ::: and not yaml");
+    await expect(resolveStandaloneSeed("github", path, {})).rejects.toThrow(
+      /is not valid JSON or YAML/,
+    );
+  });
+
+  it("refuses a schema-invalid world through the twin's OWN parser", async () => {
+    // A repository with no `name`. github's `boot` hands its seed to
+    // `domain.seed()` unparsed, so without the registry's parseSeed entry this
+    // reaches SQLite instead of the user.
+    const path = await seedFile(JSON.stringify({ repositories: [{ owner: "acme" }] }));
+    await expect(resolveStandaloneSeed("github", path, {})).rejects.toThrow(
+      /is not a world this twin can boot/,
+    );
+  });
+
+  it("refuses a schema-invalid world from POME_SEED_JSON too, naming the env var", async () => {
+    await expect(
+      resolveStandaloneSeed("github", undefined, {
+        POME_SEED_JSON: JSON.stringify({ repositories: [{ owner: "acme" }] }),
+      }),
+    ).rejects.toThrow(/POME_SEED_JSON is not a world this twin can boot/);
+  });
+
+  it("every twin resolves its own default without reaching for github's", async () => {
+    for (const twin of ["slack", "stripe", "gmail", "linear"] as const) {
+      const resolved = await resolveStandaloneSeed(twin, undefined, {});
+      expect(resolved.source).toBe("default");
+      expect(resolved.seedState).toBeTypeOf("object");
+    }
+  });
+});

--- a/cli/test/unit/twinStartSeed.test.ts
+++ b/cli/test/unit/twinStartSeed.test.ts
@@ -108,6 +108,22 @@ describe("resolveStandaloneSeed", () => {
     ).rejects.toThrow(/POME_SEED_JSON is not a world this twin can boot/);
   });
 
+  it("accepts a compiled task sidecar as-is, provenance block and all", async () => {
+    // `pome compile-seeds` emits `<task>.seed.json` with an `_meta` block, and
+    // that file IS a world — every task in the bundled library is already one.
+    // The strip is declared here rather than left to non-strict zod, so a
+    // later move to strict schemas does not refuse the whole library.
+    const path = await seedFile(
+      JSON.stringify({
+        _meta: { version: 1, source_hash: "sha256:abc", compiled_at: "2026-05-22T14:30:00.154Z" },
+        ...WORLD,
+      }),
+    );
+    const resolved = await resolveStandaloneSeed("github", path, {});
+    expect(repoNames(resolved.seedState)).toEqual(["vakoi/billing"]);
+    expect(resolved.seedState).not.toHaveProperty("_meta");
+  });
+
   it("every twin resolves its own default without reaching for github's", async () => {
     for (const twin of ["slack", "stripe", "gmail", "linear"] as const) {
       const resolved = await resolveStandaloneSeed(twin, undefined, {});


### PR DESCRIPTION
## What

`pome twin start` gains `--seed <path>` — a JSON or YAML file the twin boots from instead of its built-in default — and stops ignoring `POME_SEED_JSON`.

Resolution order: `--seed` → `POME_SEED_JSON` → the twin's default. The twin's own `parseSeed` is the arbiter for the two authored cases, and it now hangs off the registry beside `defaultSeed`.

## Why

There was no way to give a locally-started twin a world. `twin start` boots through `TWIN_REGISTRY[name].defaultSeed()`, unconditionally — so the only way to seed a twin was to write a Pome task file, and `POME_SEED_JSON` (the env a hosted pod is given) was read by the twin and never reached it.

Measured against published `0.26.13`:

```
$ POME_SEED_JSON='{"repositories":[{"owner":"vakoi","name":"billing"}]}' \
    npx @pome-sh/cli twin start github --port 3399

GET /s/standalone/repos/vakoi/billing   -> 404      # the world asked for
GET /s/standalone/repos/acme/api        -> 200      # the default, still there
```

After:

```
$ pome twin start github --port 3399 --seed world.json
Pome github twin listening at http://127.0.0.1:3399/s/standalone
World: seeded from world.json.

GET /s/standalone/repos/vakoi/billing   -> 200      # + its seeded issue
GET /s/standalone/repos/acme/api        -> 404      # replaced, not merged into
```

## Notes for reviewer

**`parseSeed` on the registry entry, and the deliberate double parse.** Four of five `boot()` entries already run their twin's `parseSeed`/`applySeed`. The new registry method is not a replacement for those — it runs on *raw user input, before a port is bound*, so the error names the file and the field instead of surfacing mid-boot. It reaches each twin through its zod-only `/seed` leaf, never the package root, so `twin-chunks` stays green.

**github was the one twin with no validation at all** on this path: its `boot` passes the seed to `domain.seed(… as never)` unparsed. A `--seed` typo would have reached SQLite. That is the main reason the parse lives at the door rather than being left to `boot`.

**JSON and YAML cost one parser.** JSON is a YAML subset and `yaml` is already a dependency (`## Config` blocks use it), so `--seed world.yaml` and `--seed world.json` go through the same `parse()`.

**Refusal happens before the listener binds** — asserted in the e2e, which checks that nothing is listening on the port after the process exits non-zero.

⚠️ **What this does not fix:** the seed schemas are non-strict zod, so a *misspelled* key is silently stripped rather than refused — `{"isuses": [...]}` parses clean and yields `issues: []`. That is a twin-package change on its own ticket; routing this door through `parseSeed` does not catch it, and the changelog does not claim it does.

## Tests

- `cli/test/unit/twinStartSeed.test.ts` — 11 cases over the resolution contract: precedence, YAML, empty-env-is-absent, unreadable file, unparseable file, schema-invalid from both sources, and every twin resolving its own default.
- `cli/test/e2e/twinStart.test.ts` — two new cases spawning the real command: a seeded repo served **and** the default world 404ing, and a schema-invalid seed exiting non-zero with nothing listening.

Mutation-checked: reverting the one-line `seedState:` change reds the seeded-world e2e.

Full suite: 335 files / 3707 tests green, `npm run lint` 17/17, `npm run typecheck` clean.

## Review required

Yes — public OSS API. `--seed` is a new user-facing flag, `POME_SEED_JSON` changes meaning on this command from "ignored" to "honored", and `TwinEntry` gains a required `parseSeed` method.