### PR TITLE
`sandbox create --help` lists every mounted twin, derived not typed (F-1665)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -32,6 +32,21 @@ provenance block `pome compile-seeds` writes is dropped before parse. That was
 already true by accident — the twins' seed schemas are non-strict zod — and is
 now declared, so it survives those schemas being tightened.
 
+## Unreleased (patch)
+
+**`sandbox create --help` lists every mounted twin.** The `--twin` line read
+`github | stripe | slack | gmail`, a hand-written copy of an allowlist that has
+accepted `linear` since that twin mounted. So `--twin linear` was taken, the twin
+booted and served its endpoints, and the one surface a reader consults to find
+out which twins exist said it was not there.
+
+The enumeration is now derived from the mounted-twin set — `SESSION_TWIN_NAMES`
+in `src/cli/session.ts`, the same set `normalizeSessionTwins` rejects a typo
+against — so a sixth twin cannot mount without appearing in help. The worked
+example is still hand-picked, and `test/unit/session-twin-help.test.ts` runs the
+twins it names back through that validator, so it cannot go stale either. No flag
+name, default, exit code, wire field or response shape moved.
+
 ## 0.26.13 — 2026-08-25
 
 **No consumer-visible change.** Deleted an orphaned changeset file and the empty

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -50,6 +50,7 @@ import {
   runSessionCreate,
   runSessionList,
   runSessionStop,
+  SESSION_TWIN_NAMES,
   type SessionListStateFilter,
 } from "./session.js";
 import { normalizeRegisterTwins, runRegisterAgent } from "./register.js";
@@ -524,7 +525,13 @@ export function createProgram() {
     .description("Create a hosted sandbox session for one or more twins and print its connection info")
     .requiredOption(
       "--twin <name>",
-      "github | stripe | slack | gmail. Repeat the flag for a multi-twin session (e.g. --twin github --twin gmail).",
+      // The enumeration is derived, never typed: this line is the public
+      // discovery surface for which twins exist, and a hand-written copy of the
+      // allowlist is what made it omit `linear` for a release. The worked example
+      // stays editorial — github+gmail is the pairing bundled task 27 exercises —
+      // and `session-twin-help.test.ts` runs the twins it names through the same
+      // validator, so it cannot rot either.
+      `${SESSION_TWIN_NAMES.join(" | ")}. Repeat the flag for a multi-twin session (e.g. --twin github --twin gmail).`,
       (value: string, previous: string[] = []) => [...previous, value],
     )
     .option(

--- a/cli/src/cli/session.ts
+++ b/cli/src/cli/session.ts
@@ -25,12 +25,27 @@ export function ensureMcpSuffix(url: string): string {
   return /\/mcp\/?$/.test(url) ? url : `${url.replace(/\/$/, "")}/mcp`;
 }
 
-// Multi-twin (M3): the CLI's ad-hoc session allowlist is the shared mounted-twin
-// set (github, stripe, slack, gmail, linear). Repeated `--twin` flags
-// stand up a multi-twin session in one call.
-// Keep newly-added twin ids explicit during contract publish windows: local
-// development may still resolve a previous installed package.
-const ALLOWED_TWINS = new Set<string>([...MOUNTED_TWINS, "gmail", "linear"]);
+// Multi-twin (M3): the CLI's ad-hoc session allowlist IS the shared mounted-twin
+// set. Repeated `--twin` flags stand up a multi-twin session in one call.
+//
+// The parenthetical roll-call that used to sit in this comment, and the
+// `"gmail", "linear"` that used to be appended below it "during contract publish
+// windows", were both inert: `MOUNTED_TWINS` arrives from `cli/src/contract/`,
+// which is source in this workspace and never a resolved package, so neither
+// could add a name the set lacked. What they did do is read as a second place
+// twins are named — the shape that let `sandbox create --help` spend a release
+// advertising four twins while this validator already accepted five.
+const ALLOWED_TWINS = new Set<string>(MOUNTED_TWINS);
+
+/** The twins `--twin` accepts, in mounted order.
+ *
+ *  `sandbox create` renders THIS as its `--twin` help (`cli/src/cli/main.ts`),
+ *  so the sentence a reader browses `--help` for and the code that rejects their
+ *  typo cannot name different sets. Before it did: help was a hand-written
+ *  `github | stripe | slack | gmail`, and `linear` mounted, booted and served its
+ *  whole surface without ever appearing there. Deriving is the fix rather than
+ *  adding the one missing word, because the sixth twin has the same problem. */
+export const SESSION_TWIN_NAMES: readonly string[] = [...ALLOWED_TWINS];
 
 function redactSession(res: CreateSessionResponse): Record<string, unknown> {
   const pcIn = res.provider_credentials;

--- a/cli/test/unit/session-twin-help.test.ts
+++ b/cli/test/unit/session-twin-help.test.ts
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// `sandbox create --twin`'s help is the public discovery surface for which twins
+// exist. It was hand-written, and it went stale the release linear mounted: the
+// flag accepted `linear`, the twin booted, and `--help` still said
+// `github | stripe | slack | gmail`. A reader browsing help concluded a working
+// twin was unavailable.
+//
+// So the assertions below are all one shape — the help text and the code that
+// validates the flag must never be able to name different sets. Nothing here
+// spells a twin id: the expectations are derived from `MOUNTED_TWINS`, which is
+// what makes them fail rather than pass the day a sixth twin mounts.
+
+import type { Command, Option } from "commander";
+import { describe, expect, it } from "vitest";
+
+import { MOUNTED_TWINS } from "../../src/contract/index.js";
+import { createProgram } from "../../src/cli/main.js";
+import { normalizeSessionTwins } from "../../src/cli/session.js";
+
+/** `--help` calls `process.exit()`, which takes the vitest worker down instead
+ *  of failing an assertion. `exitOverride()` only reaches the commands that
+ *  existed when it was called, so walk the tree the program already built. */
+function program(): Command {
+  const root = createProgram();
+  const walk = (cmd: Command) => {
+    cmd.exitOverride();
+    cmd.commands.forEach(walk);
+  };
+  walk(root);
+  return root;
+}
+
+/** The rendered text a user actually reads. Commander soft-wraps the option
+ *  column at word boundaries, so whitespace is collapsed: a twin name is never
+ *  split mid-word, but the list can straddle a line. */
+function renderedHelp(...argv: string[]): string {
+  const chunks: string[] = [];
+  const root = program();
+  const walk = (cmd: Command) => {
+    cmd.configureOutput({
+      writeOut: (s) => void chunks.push(s),
+      writeErr: (s) => void chunks.push(s),
+    });
+    cmd.commands.forEach(walk);
+  };
+  walk(root);
+  try {
+    root.parse(["node", "pome", ...argv]);
+  } catch (err) {
+    // `--help` exits through exitOverride once the text is already written.
+    if ((err as { code?: string }).code !== "commander.helpDisplayed") throw err;
+  }
+  return chunks.join("").replace(/\s+/g, " ");
+}
+
+/** The `--twin` option as declared, before help wrapping touches it. */
+function twinOption(): Option {
+  const create = program()
+    .commands.find((cmd) => cmd.name() === "session")
+    ?.commands.find((cmd) => cmd.name() === "create");
+  if (!create) throw new Error("`session create` is no longer in the command tree");
+  const option = create.options.find((opt) => opt.long === "--twin");
+  if (!option) throw new Error("`session create` no longer declares --twin");
+  return option;
+}
+
+describe("`sandbox create --twin` help agrees with the mounted-twin set", () => {
+  it("lists every mounted twin, in the mounted order", () => {
+    // Ordered and exact, not five `toContain`s: an enumeration derived from
+    // `MOUNTED_TWINS` reproduces its order, and a hand-written one that happens
+    // to hold the same five names does not stay that way.
+    expect(twinOption().description).toContain(MOUNTED_TWINS.join(" | "));
+  });
+
+  it("reaches the text `sandbox create --help` prints", () => {
+    const help = renderedHelp("sandbox", "create", "--help");
+
+    for (const twin of MOUNTED_TWINS) {
+      expect(help, `${twin} is mounted but absent from --help`).toContain(twin);
+    }
+  });
+
+  it("names only twins the flag's own validator accepts", () => {
+    // The help line and `normalizeSessionTwins` are the two halves that drifted.
+    // Feeding one to the other is the assertion the original defect fails.
+    const listed = twinOption()
+      .description.split(".")[0]!
+      .split("|")
+      .map((name) => name.trim())
+      .filter((name) => name.length > 0);
+
+    expect(listed).toEqual([...MOUNTED_TWINS]);
+    expect(normalizeSessionTwins(listed)).toEqual([...MOUNTED_TWINS]);
+  });
+
+  it("keeps its worked example runnable", () => {
+    // The prose example names twins too, and rots the same way the list did.
+    // Twin-id shape, not `\S+`: the last name in the example is followed by
+    // `).`, and swallowing that punctuation would make this assert on a string
+    // no twin was ever going to equal.
+    const exampled = [...twinOption().description.matchAll(/--twin ([a-z][a-z0-9-]*)/g)].map(
+      (match) => match[1]!,
+    );
+
+    expect(exampled.length).toBeGreaterThan(1);
+    expect(() => normalizeSessionTwins(exampled)).not.toThrow();
+  });
+
+  it("rejects a twin it does not list", () => {
+    expect(twinOption().description).not.toContain("notion");
+    expect(() => normalizeSessionTwins(["notion"])).toThrow(/Unknown twin "notion"/);
+  });
+});


### PR DESCRIPTION
## Summary

`pome sandbox create --help` advertised four twins while the flag accepted five. The `--twin` line read `github | stripe | slack | gmail` — a hand-written copy of an allowlist that has accepted `linear` since that twin mounted. `--twin linear` was taken, the twin booted and served its whole surface, and the one place a reader looks to find out which twins exist said it was not there.

The list is now derived from the mounted-twin set rather than typed, so a sixth twin cannot mount without appearing in help.

## What changed

**`cli/src/cli/session.ts`** — exports `SESSION_TWIN_NAMES`, the same set `normalizeSessionTwins` rejects a typo against:

```ts
const ALLOWED_TWINS = new Set<string>(MOUNTED_TWINS);
export const SESSION_TWIN_NAMES: readonly string[] = [...ALLOWED_TWINS];
```

`ALLOWED_TWINS` also stopped appending `"gmail", "linear"` to `MOUNTED_TWINS`. That append was **inert** — `MOUNTED_TWINS` arrives from `cli/src/contract/`, source in this workspace and never a resolved package, so the "contract publish window" the old comment described could not occur. What it did do is read as a second place twins are named, which is the shape of this defect.

**`cli/src/cli/main.ts`** — the `--twin` help renders that set. Shipped output:

```
--twin <name>          github | stripe | slack | gmail | linear. Repeat the
                       flag for a multi-twin session (e.g. --twin github
                       --twin gmail).
```

The worked example stays hand-picked — `github`+`gmail` is the pairing bundled task 27 (Gmail → GitHub support escalation) actually exercises — but the test runs the twins it names back through the validator, so it cannot rot either.

## Tests

New `cli/test/unit/session-twin-help.test.ts`, five cases, none of which spells a twin id — every expectation derives from `MOUNTED_TWINS`, which is what makes them fail rather than pass the day a sixth twin mounts:

1. help lists every mounted twin, in mounted order
2. the list reaches the text `sandbox create --help` actually prints
3. every name help lists, the flag's own validator accepts
4. the worked example is runnable through that validator
5. a twin help does not list is rejected

Both guards were mutation-checked: changing the example to `--twin notion` goes red, and reverting the list to the hand-written four goes red.

## Reviewer notes

Two claims from the originating report did **not** survive checking, and are not reproduced here:

- The report cited linear as serving "22 endpoints". In this repo that figure is **22 MCP tools / 45 GraphQL surfaces** (`packages/twin-linear/fidelity.inventory.json`). It is not load-bearing for the fix, so no count was written into a source comment where it would drift.
- The report drew an analogy to stale integration lists on the marketing site. That is a different repo; a sweep here found no second hand-written twin enumeration to fix alongside this one.

## Verification

`npm test` (335 files / 3699 tests), `typecheck`, `lint` (17 rules), `lint:test`, `lint:dead-code`, `test:contract` (110 pass / 5 skip), `gate:golden`, `gate:route-inputs`, `gate:mcp-tools-list`, `check:manifest-schema` — all green. `scripts/ci/check-release-note-required.mjs` run against the real diff: identifies `@pome-sh/cli` as moved, `## Unreleased (patch)` entry present. Help output verified from a built artifact under both the `sandbox` and `session` spellings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)