### PR TITLE
A seed file a stranger can write: one envelope shape, generated not typed (F-1691)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ Or start a standalone twin to point your own agent at it:
 npx @pome-sh/cli twin start github    # http://127.0.0.1:3333 — prints MCP URL + POME_AUTH_TOKEN
 ```
 
+To start it from your own world rather than the twin's, generate a seed file and
+edit it. It is generated from the twin, so it always parses:
+
+```bash
+npx @pome-sh/cli twin seed github --out seed.json   # the github twin's starting state
+npx @pome-sh/cli twin start --seed seed.json        # the file names the twin
+```
+
+A seed **replaces** the twin's default state; it does not merge into it. One file
+covers one twin or several — `{ "github": { … }, "slack": { … } }` — and the same
+file seeds a hosted sandbox: `pome sandbox create --seed seed.json`.
+
 For a persistent `pome` command: `npm install -g @pome-sh/cli`.
 
 <!-- One generic quickstart above; the per-twin walkthroughs live on the docs

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,6 +8,70 @@ allocates on `main` after the merge, in the same commit that moves
 write a version number here or in `package.json`. Released entries are insertions
 only: a correction is the next entry, naming the one it corrects.
 
+## Unreleased (minor)
+
+**A seed file a stranger can write.** One shape, generated rather than typed,
+and the same file at every door.
+
+`pome twin seed <name...>` prints a starter seed file for a twin, built from
+that twin's own starting state and normalised by its own `parseSeed`. Nobody
+types it, which is the point: every hand-written seed example we shipped was
+correct the day it merged, and three of the five on the docs site had since
+stopped parsing against their own twin's schema — `github` on
+`repositories.0.owner`, `gmail` on `primaryMailbox`, `linear` on
+`issues.0.assignee`. Copy one and the hosted path answers `503 Failed to spawn
+twin pod` twelve seconds later, so the first thing a new user does produces an
+error that blames us. A computed starter cannot reach a reader in that state.
+
+**The file shape is the per-twin envelope**, one twin or five:
+
+```json
+{ "github": { "repositories": [ … ] },
+  "slack":  { "channels":     [ … ] } }
+```
+
+`pome twin start --seed` and `pome sandbox create --seed` both take it, and both
+still take the flat single-twin shape 0.27.0 shipped. **The wire does not move**:
+`POME_SEED_JSON` stays flat, `POST /v1/sessions` keeps its envelope-iff-multi-twin
+rule, and `seed-envelope.ts` is untouched — the CLI unwraps, so a one-twin
+sandbox seeded from an envelope still sends the flat seed.
+
+Twelve of the twenty `<task>.seed.json` files in `agent-examples/` are already
+envelopes, and before this `twin start github --seed <one of them>` failed on
+`repositories: expected array, received undefined`. Worse: `twin start slack
+--seed <the same file>` **succeeded**. slack's and stripe's seed schemas are
+non-strict, so they accepted the envelope as their own flat seed, defaulted every
+field, and served an empty workspace while the boot line said the seed had
+landed. A file naming a twin the command was not asked for is now a loud error
+naming that twin, never a skipped key.
+
+**`pome sandbox create --seed`** is new, and it parses the seed with the twin's
+own parser before the round trip, so a bad seed is refused instantly with the
+field named instead of arriving as a 503 twelve seconds later. `--twin` becomes
+optional when the file's envelope names exactly one twin, as does `twin start`'s
+`<name>` argument.
+
+The boot line now reads `Seed:` rather than `World:`, and says what seeding does:
+
+```
+Seed: ./seed.json (replaces the github twin's default).
+```
+
+That sentence is the correction most worth having. A seed **replaces** the twin's
+default state; it does not merge into it. `vercel-labs/emulate` merges — its
+`api.ts` runs the plugin's own default seed and then layers your config on top —
+so a reader arriving from there will assume wrong.
+
+`pome twin seed --out <path>` refuses to overwrite an existing file. Generated
+output carries no `_meta`, and because it is `parseSeed`'s own output it declares
+only fields the schema declares, which is what will let it survive those schemas
+refusing unknown keys.
+
+`TWIN_REGISTRY` gains `seedFields()` and its `defaultSeed()` now answers for
+every twin, github included — that entry used to return `undefined` and let
+`boot` reach for `defaultSeedState()` itself, which left "what does this twin
+start with" unanswerable without booting one.
+
 ## 0.28.0 — 2026-08-26
 
 **A hosted run whose every `[code]` criterion was scored no longer prints

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -523,7 +523,7 @@ export function createProgram() {
   session
     .command("create")
     .description("Create a hosted sandbox session for one or more twins and print its connection info")
-    .requiredOption(
+    .option(
       "--twin <name>",
       // The enumeration is derived, never typed: this line is the public
       // discovery surface for which twins exist, and a hand-written copy of the
@@ -531,8 +531,18 @@ export function createProgram() {
       // stays editorial — github+gmail is the pairing bundled task 27 exercises —
       // and `session-twin-help.test.ts` runs the twins it names through the same
       // validator, so it cannot rot either.
-      `${SESSION_TWIN_NAMES.join(" | ")}. Repeat the flag for a multi-twin session (e.g. --twin github --twin gmail).`,
+      //
+      // No longer `requiredOption`: a `--seed` file whose envelope names exactly
+      // one twin already says which twin the sandbox is for. Commander would
+      // reject the invocation before the action runs, so the check moved into
+      // `runSessionCreate`, which fails with the same "No twin specified"
+      // sentence when neither source supplies one.
+      `${SESSION_TWIN_NAMES.join(" | ")}. Repeat the flag for a multi-twin session (e.g. --twin github --twin gmail). Optional when --seed names exactly one twin.`,
       (value: string, previous: string[] = []) => [...previous, value],
+    )
+    .option(
+      "--seed <path>",
+      "Start the sandbox from a JSON or YAML seed file instead of each twin's default. A seed REPLACES the default; it does not merge. Same file `pome twin start --seed` takes; write one with `pome twin seed <name>`.",
     )
     .option(
       "--api-url <url>",
@@ -551,11 +561,12 @@ export function createProgram() {
     )
     .action(
       async (opts: {
-        twin: string[];
+        twin?: string[];
         apiUrl: string;
         showSecrets: boolean;
         secretsFile?: string;
         format: string;
+        seed?: string;
       }) => {
         try {
           const format = opts.format.trim().toLowerCase();
@@ -566,10 +577,11 @@ export function createProgram() {
           }
           await runSessionCreate({
             apiBaseUrl: opts.apiUrl,
-            twins: opts.twin,
+            twins: opts.twin ?? [],
             showSecrets: opts.showSecrets,
             format: format as "text" | "json" | "env",
             secretsFile: opts.secretsFile,
+            seedPath: opts.seed,
           });
         } catch (err) {
           console.error(friendlyHostedError(err));
@@ -1335,21 +1347,36 @@ export function createProgram() {
   const twin = program.command("twin").description("Manage local twins");
   twin
     .command("start")
-    .argument("<name>", `Twin name (${TWIN_NAME_LIST.join(" | ")})`)
+    .argument(
+      "[name]",
+      `Twin name (${TWIN_NAME_LIST.join(" | ")}). Optional when --seed names exactly one twin.`,
+    )
     .option(
       "--port <port>",
       "Port to bind (default: $PORT, else GMAIL_TWIN_PORT/3336 for gmail, else 3333)",
     )
     .option(
       "--seed <path>",
-      "Boot this twin's world from a JSON or YAML file instead of its default. Overrides POME_SEED_JSON.",
+      "Boot this twin from a JSON or YAML seed file instead of its default. A seed REPLACES the default; it does not merge. Takes the per-twin envelope { <twin>: { … } } or one twin's flat seed. Overrides POME_SEED_JSON.",
     )
     .description(
       "Start a standalone twin as a long-lived foreground server (Ctrl-C to stop)",
     )
-    .action(async (name: string, options: { port?: string; seed?: string }) => {
+    .action(async (name: string | undefined, options: { port?: string; seed?: string }) => {
       const { runTwinStartCommand } = await import("../twin/twinStart.js");
       await runTwinStartCommand(name, options);
+    });
+
+  twin
+    .command("seed")
+    .argument("<name...>", `Twin name (${TWIN_NAME_LIST.join(" | ")}). Repeat for one file covering several.`)
+    .option("--out <path>", "Write to this file instead of stdout. Refuses to overwrite.")
+    .description(
+      "Print a starter seed file for a twin, generated from the twin's own starting state",
+    )
+    .action(async (names: string[], options: { out?: string }) => {
+      const { runTwinSeedCommand } = await import("../twin/twinSeed.js");
+      await runTwinSeedCommand(names, options);
     });
 
   twin

--- a/cli/src/cli/session.ts
+++ b/cli/src/cli/session.ts
@@ -3,8 +3,15 @@ import { randomUUID } from "node:crypto";
 import { chmod, mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
-import { MOUNTED_TWINS } from "../contract/index.js";
+import { isMultiTwinSeedEnvelope, MOUNTED_TWINS } from "../contract/index.js";
 import { createHostedClient, perTwinReturnedByCloud } from "../hosted/client.js";
+import type { TwinName } from "../twin/registry.js";
+import {
+  parseSeedFileText,
+  readSeedFileText,
+  seedsForTwins,
+  soleTwinOf,
+} from "../twin/seedFile.js";
 import type { CreateSessionResponse } from "../types/shared.js";
 import {
   HostedAuthError,
@@ -147,15 +154,62 @@ export function normalizeSessionTwins(raw: string[]): string[] {
   return deduped;
 }
 
+/**
+ * Resolve `--seed <path>` into the twin list and the `seed` the wire wants.
+ *
+ * THE RULE does not move (`cli/src/contract/seed-envelope.ts`): a create-session
+ * `seed` is a per-twin envelope IFF the session has more than one twin, decided
+ * from `twins` alone. So the file the user wrote and the body we POST are not
+ * the same shape, and this is the only place that translates between them — a
+ * one-twin sandbox seeded from an envelope sends the FLAT seed.
+ *
+ * The twin's own `parseSeed` runs HERE, before the round trip. That is the same
+ * parser the pod runs, and without it a seed the pod refuses comes back as
+ * `503 Failed to spawn twin pod` twelve seconds later (F-1688) with nothing
+ * naming the field.
+ */
+export async function resolveSessionSeed(
+  seedPath: string,
+  requestedTwins: string[],
+): Promise<{ twins: string[]; seed: unknown }> {
+  const raw = readSeedFileText(seedPath, "pome sandbox create --seed");
+  const origin = `--seed ${seedPath}`;
+  const file = parseSeedFileText(raw, origin);
+
+  // An envelope naming exactly one twin already says which twin the sandbox is
+  // for, so `--twin` becomes optional rather than a second place to say it.
+  const twins = normalizeSessionTwins(
+    requestedTwins.length > 0 ? requestedTwins : [soleTwinOf(file) ?? ""].filter(Boolean),
+  );
+
+  // `normalizeSessionTwins` has already rejected anything outside MOUNTED_TWINS,
+  // and `scripts/lint/rules/first-party-twins.mjs` is the standing gate that
+  // MOUNTED_TWINS and the registry's TWIN_NAME_LIST name the same five — so this
+  // narrowing is checked, just not by the type system.
+  const byTwin = await seedsForTwins(file, twins as TwinName[], origin);
+  return {
+    twins,
+    seed: isMultiTwinSeedEnvelope(twins) ? byTwin : byTwin[twins[0]!],
+  };
+}
+
 export async function runSessionCreate(opts: {
   apiBaseUrl: string;
-  /** One-or-more twins. Repeated `--twin` flags stand up a multi-twin session. */
+  /** One-or-more twins. Repeated `--twin` flags stand up a multi-twin session.
+   *  May be empty when `seedPath` names exactly one twin. */
   twins: string[];
   showSecrets: boolean;
   format: "text" | "json" | "env";
   secretsFile?: string;
+  /** `--seed <path>`: the sandbox starts from this seed instead of each twin's
+   *  default. Same file `pome twin start --seed` takes. */
+  seedPath?: string;
 }): Promise<void> {
-  const twins = normalizeSessionTwins(opts.twins);
+  const resolvedSeed =
+    opts.seedPath === undefined
+      ? undefined
+      : await resolveSessionSeed(opts.seedPath, opts.twins);
+  const twins = resolvedSeed?.twins ?? normalizeSessionTwins(opts.twins);
 
   const creds = await resolveCredentials({ apiBaseUrl: opts.apiBaseUrl });
   const client = createHostedClient({
@@ -173,6 +227,7 @@ export async function runSessionCreate(opts: {
     idempotencyKey: randomUUID(),
     agentId: identity.agentId,
     agentVersion: identity.agentVersion,
+    ...(resolvedSeed ? { seed: resolvedSeed.seed } : {}),
   });
 
   if (opts.secretsFile) {
@@ -199,6 +254,11 @@ export async function runSessionCreate(opts: {
 
   console.error(`Session: ${session.session_id}`);
   console.error(`Expires: ${session.expires_at}`);
+  // Same reason the standalone twin prints a Seed line: once it is running,
+  // every seeded twin looks seeded.
+  if (opts.seedPath !== undefined) {
+    console.error(`Seed: ${opts.seedPath} (replaces the default for ${twins.join(", ")}).`);
+  }
   // Multi-twin (M3): print one API/MCP line per twin so a github+slack session
   // shows both endpoints. Falls back to the legacy bare twin_url on an older
   // cloud that only ships it.

--- a/cli/src/twin/registry.ts
+++ b/cli/src/twin/registry.ts
@@ -97,9 +97,27 @@ export type TwinEntry = {
   readonly tokenEnvName?: string;
   /** The twin package's OWN version, inlined at build time. */
   readonly version: string;
-  /** Default world for `pome twin start` with no seed. `undefined` means the
-   *  twin seeds its own default during boot. */
+  /**
+   * The twin's own declared starting seed, reached through its `/seed` leaf.
+   *
+   * Always a value. github's entry used to return `undefined` and let `boot`
+   * reach for `defaultSeedState()` itself, which left "what does this twin start
+   * with" unanswerable without booting one — and that is the question
+   * `pome twin seed` exists to answer, so it is answered here for every twin.
+   * `boot` still applies its own default when handed `undefined`, so the boot
+   * path is unchanged either way.
+   */
   defaultSeed(): Promise<unknown>;
+  /**
+   * The top-level field names this twin's seed schema declares, read off the
+   * twin's own zod object rather than listed here.
+   *
+   * `seedFile.ts` tells a per-twin envelope from a flat seed by asking whether
+   * every top-level key is a twin id. That is only unambiguous while no twin
+   * declares a seed field named after a twin, and this is the accessor that
+   * lets `seedFile.test.ts` assert it for all five instead of assuming it.
+   */
+  seedFields(): Promise<readonly string[]>;
   /**
    * The twin's OWN seed parser, reached through its `/seed` leaf. This is the
    * arbiter for a user-authored world: it is the same function the twin runs
@@ -121,10 +139,10 @@ export const TWIN_REGISTRY: Record<TwinName, TwinEntry> = {
     envName: "GITHUB",
     defaultPort: 3333,
     version: githubManifest.version,
-    // The github twin's own `defaultSeedState()` is applied by `boot` below
-    // when no seed is supplied — the pre-existing standalone behavior.
-    defaultSeed: async () => undefined,
+    defaultSeed: async () => (await import("@pome-sh/twin-github/seed")).defaultSeedState(),
     parseSeed: async (input) => (await import("@pome-sh/twin-github/seed")).parseSeed(input),
+    seedFields: async () =>
+      Object.keys((await import("@pome-sh/twin-github/seed")).seedSchema.shape),
     async boot({ seedState, runId, recorder }) {
       const {
         createGitHubCloneApp,
@@ -152,8 +170,10 @@ export const TWIN_REGISTRY: Record<TwinName, TwinEntry> = {
     envName: "SLACK",
     defaultPort: 3333,
     version: slackManifest.version,
-    defaultSeed: async () => (await import("@pome-sh/twin-slack")).defaultSeedState(),
+    defaultSeed: async () => (await import("@pome-sh/twin-slack/seed")).defaultSeedState(),
     parseSeed: async (input) => (await import("@pome-sh/twin-slack/seed")).parseSeed(input),
+    seedFields: async () =>
+      Object.keys((await import("@pome-sh/twin-slack/seed")).seedSchema.shape),
     async boot({ seedState, runId, recorder }) {
       const { createSlackTwinApp, openSlackTwinDatabase, SlackDomain } =
         await import("@pome-sh/twin-slack");
@@ -183,8 +203,10 @@ export const TWIN_REGISTRY: Record<TwinName, TwinEntry> = {
     envName: "STRIPE",
     defaultPort: 3333,
     version: stripeManifest.version,
-    defaultSeed: async () => (await import("@pome-sh/twin-stripe")).defaultSeed(),
+    defaultSeed: async () => (await import("@pome-sh/twin-stripe/seed")).defaultSeed(),
     parseSeed: async (input) => (await import("@pome-sh/twin-stripe/seed")).parseSeed(input),
+    seedFields: async () =>
+      Object.keys((await import("@pome-sh/twin-stripe/seed")).seedSchema.shape),
     async boot({ seedState, runId, recorder, twinBaseUrl }) {
       // Engine-based twin: the factory owns middleware, MCP mount, and
       // the failure-injection store — seed rules ride in via `seed` and land in
@@ -249,8 +271,10 @@ export const TWIN_REGISTRY: Record<TwinName, TwinEntry> = {
     portEnvName: "GMAIL_TWIN_PORT",
     tokenEnvName: "POME_GMAIL_TOKEN",
     version: gmailManifest.version,
-    defaultSeed: async () => (await import("@pome-sh/twin-gmail")).defaultSeedState(),
+    defaultSeed: async () => (await import("@pome-sh/twin-gmail/seed")).defaultSeedState(),
     parseSeed: async (input) => (await import("@pome-sh/twin-gmail/seed")).parseSeed(input),
+    seedFields: async () =>
+      Object.keys((await import("@pome-sh/twin-gmail/seed")).gmailSeedSchema.shape),
     async boot({ seedState, runId, recorder }) {
       const { createGmailTwinApp, GmailDomain, openGmailTwinDatabase, parseSeed } =
         await import("@pome-sh/twin-gmail");
@@ -273,8 +297,10 @@ export const TWIN_REGISTRY: Record<TwinName, TwinEntry> = {
     portEnvName: "LINEAR_TWIN_PORT",
     tokenEnvName: "POME_LINEAR_TOKEN",
     version: linearManifest.version,
-    defaultSeed: async () => (await import("@pome-sh/twin-linear")).defaultSeedState(),
+    defaultSeed: async () => (await import("@pome-sh/twin-linear/seed")).defaultSeedState(),
     parseSeed: async (input) => (await import("@pome-sh/twin-linear/seed")).parseSeed(input),
+    seedFields: async () =>
+      Object.keys((await import("@pome-sh/twin-linear/seed")).linearSeedSchema.shape),
     async boot({ seedState, runId, recorder }) {
       const {
         createLinearTwinApp,

--- a/cli/src/twin/seedFile.ts
+++ b/cli/src/twin/seedFile.ts
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The one seed-file door. Every command that takes a user-authored world reads
+// it through here: `pome twin start --seed`, `pome sandbox create --seed`, and
+// `pome twin seed`'s own round-trip check.
+//
+// A seed file is JSON or YAML (JSON is a YAML subset, so one parser) in one of
+// two shapes:
+//
+//   flat      { "repositories": [ … ] }              one twin's seed
+//   envelope  { "github": { "repositories": [ … ] }} twin id → that twin's seed
+//
+// The envelope is the shape to write and the shape `pome twin seed` generates.
+// Flat is kept because F-1686 shipped it and eight of the twenty
+// `<task>.seed.json` files in agent-examples/ are one; the other twelve are
+// already envelopes, and before this module `twin start github --seed <one of
+// those>` failed on `repositories: expected array, received undefined`.
+//
+// THE SHAPE IS DECIDED FROM THE KEYS, AND ONLY THE KEYS: a file is an envelope
+// iff every top-level key is a twin id. That is safe because no twin's seed
+// schema declares a top-level field named after a twin, which is not an
+// assumption — `seedFields()` derives the field names from each twin's own zod
+// object and `seedFile.test.ts` asserts the disjointness for all five. A file
+// that mixes the two vocabularies is refused rather than guessed at.
+//
+// WHY THIS IS NOT A SECOND SEED PARSER: it decides which BYTES belong to which
+// twin and nothing else. The twin's own `parseSeed`, reached through
+// `TWIN_REGISTRY[twin]`, is still the only thing that says whether a seed is
+// valid — the same function the twin runs inside `loadSeedFromEnv`, so a seed
+// this accepts is a seed the twin boots.
+//
+// SILENCE IS THE FAILURE MODE THIS EXISTS TO PREVENT. slack's and stripe's seed
+// schemas are non-strict, so before the envelope was declared they ACCEPTED a
+// `{github, slack}` file as their own flat seed, defaulted every field, and
+// served an empty workspace while the boot line said the seed had landed. A file
+// naming a twin the command was not asked for is a loud error here, never a
+// skipped key.
+
+import { readFileSync } from "node:fs";
+import { parse as parseYaml } from "yaml";
+import { isTwinName, TWIN_NAMES, TWIN_REGISTRY, type TwinName } from "./registry.js";
+
+/** A seed file after `_meta` is dropped and its shape is decided. */
+export type SeedFile =
+  | { shape: "flat"; seed: unknown }
+  | { shape: "envelope"; byTwin: Record<string, unknown> };
+
+/** Read side of `--seed <path>`. Split from parsing so a caller that needs the
+ *  twin BEFORE it has one (`twin start` with the name omitted) reads the file
+ *  exactly once. */
+export function readSeedFileText(path: string, flag = "--seed"): string {
+  try {
+    return readFileSync(path, "utf8");
+  } catch (err) {
+    throw new Error(`${flag}: cannot read ${path}: ${(err as Error).message}`);
+  }
+}
+
+export function parseSeedFileText(raw: string, origin: string): SeedFile {
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(raw);
+  } catch (err) {
+    throw new Error(`${origin} is not valid JSON or YAML: ${(err as Error).message}`);
+  }
+  if (Array.isArray(parsed)) {
+    throw new Error(`${origin} is not a seed file: its top level is an array, not an object.`);
+  }
+  if (parsed === null || typeof parsed !== "object") {
+    throw new Error(
+      `${origin} is not a seed file: its top level is ${parsed === null ? "null" : typeof parsed}, not an object.`,
+    );
+  }
+
+  // Drop the sidecar provenance block, so a compiled `<task>.seed.json` is a
+  // seed file this door accepts as-is. DECLARED, not inherited: the twins' seed
+  // schemas are non-strict today so `_meta` would be stripped by `parseSeed`
+  // anyway, but only by accident, and the moment those schemas refuse unknown
+  // keys (F-1689) that accident becomes a refusal of every sidecar in the
+  // library. `parseTask` strips it on the task path for the same reason.
+  const { _meta, ...rest } = parsed as Record<string, unknown>;
+  void _meta;
+
+  const keys = Object.keys(rest);
+  const twinKeys = keys.filter((key) => isTwinName(key));
+  if (twinKeys.length === 0) return { shape: "flat", seed: rest };
+  if (twinKeys.length !== keys.length) {
+    const others = keys.filter((key) => !isTwinName(key));
+    throw new Error(
+      `${origin} mixes twin ids (${twinKeys.join(", ")}) with other keys (${others.join(", ")}). ` +
+        `A seed file is either one twin's flat seed or a per-twin envelope { <twin>: <seed> }, not both.`,
+    );
+  }
+  return { shape: "envelope", byTwin: rest };
+}
+
+/** The twins an envelope names, in file order. Empty for a flat file: a flat
+ *  seed names no twin, which is why `--twin` stays required for one. */
+export function twinsNamedBy(file: SeedFile): TwinName[] {
+  if (file.shape === "flat") return [];
+  return Object.keys(file.byTwin).filter((key): key is TwinName => isTwinName(key));
+}
+
+/** The single twin an envelope names, when it names exactly one — the case that
+ *  makes `--twin` / the `<name>` argument unnecessary. */
+export function soleTwinOf(file: SeedFile): TwinName | undefined {
+  const named = twinsNamedBy(file);
+  return named.length === 1 ? named[0] : undefined;
+}
+
+/** The top-level field names this twin's seed schema declares. Derived from the
+ *  twin's own zod object, never typed here. Two callers: the "your keys are not
+ *  seed fields" hint below, and the standing assertion that no twin field is
+ *  named after a twin — the property the shape rule rests on. */
+export async function seedFieldsFor(twin: TwinName): Promise<readonly string[]> {
+  return TWIN_REGISTRY[twin].seedFields();
+}
+
+/**
+ * The seed for one twin, parsed by that twin's own `parseSeed`.
+ *
+ * Flat: the whole file is that twin's seed. Envelope: the entry under its id —
+ * and a missing entry is an error, not a default, because the command was
+ * pointed at a file that turns out to say nothing about the twin it is booting.
+ *
+ * `asked` is the twin list the command was invoked for. Any twin the file names
+ * outside it is refused BY NAME.
+ */
+export async function seedForTwin(
+  file: SeedFile,
+  twin: TwinName,
+  origin: string,
+  opts: { asked?: readonly string[] } = {},
+): Promise<unknown> {
+  if (file.shape === "flat") return parseWith(twin, file.seed, origin, file);
+
+  assertOnlyAsked(file, opts.asked, origin);
+  const named = twinsNamedBy(file);
+  if (!(twin in file.byTwin)) {
+    throw new Error(
+      `${origin} declares no ${twin} seed (it names ${named.join(", ")}). ` +
+        `Add a "${twin}" key, or start the twin it names.`,
+    );
+  }
+  return parseWith(twin, file.byTwin[twin], `${origin} ("${twin}")`, file);
+}
+
+/**
+ * Every seed the file declares, restricted to `twins` and keyed by twin id.
+ *
+ * A twin in `twins` with no entry is ABSENT from the result rather than
+ * defaulted here — the receiving side applies its own default, which is the
+ * rule `parseTask`'s multi-twin envelope already follows. A twin the file names
+ * that is NOT in `twins` is a loud error.
+ */
+export async function seedsForTwins(
+  file: SeedFile,
+  twins: readonly TwinName[],
+  origin: string,
+): Promise<Record<string, unknown>> {
+  if (file.shape === "flat") {
+    if (twins.length !== 1) {
+      throw new Error(
+        `${origin} is a flat seed and this sandbox has ${twins.length} twins ` +
+          `(${twins.join(", ")}), so nothing says which one it is for. ` +
+          `Wrap it in a per-twin envelope: { "${twins[0] ?? "<twin>"}": { … } }.`,
+      );
+    }
+    return { [twins[0]!]: await parseWith(twins[0]!, file.seed, origin, file) };
+  }
+
+  assertOnlyAsked(file, twins, origin);
+  const out: Record<string, unknown> = {};
+  for (const twin of twins) {
+    if (twin in file.byTwin) {
+      out[twin] = await parseWith(twin, file.byTwin[twin], `${origin} ("${twin}")`, file);
+    }
+  }
+  return out;
+}
+
+function assertOnlyAsked(
+  file: SeedFile,
+  asked: readonly string[] | undefined,
+  origin: string,
+): void {
+  if (asked === undefined || file.shape !== "envelope") return;
+  const extras = twinsNamedBy(file).filter((twin) => !asked.includes(twin));
+  if (extras.length === 0) return;
+  // Emulate's `if (!owner) continue;` is the anti-pattern here: it drops a
+  // correctly-spelled repository over an undeclared owner and says nothing.
+  throw new Error(
+    `${origin} names ${extras.join(", ")}, which this command was not asked for ` +
+      `(asked: ${asked.length ? asked.join(", ") : "none"}). ` +
+      `Add --twin for each, or remove them from the file.`,
+  );
+}
+
+async function parseWith(
+  twin: TwinName,
+  seed: unknown,
+  where: string,
+  file: SeedFile,
+): Promise<unknown> {
+  try {
+    return await TWIN_REGISTRY[twin].parseSeed(seed);
+  } catch (err) {
+    const hint = file.shape === "flat" ? await notSeedFieldsHint(twin, file.seed) : "";
+    throw new Error(`${where} is not a seed this twin can boot: ${(err as Error).message}${hint}`);
+  }
+}
+
+/** A flat file whose keys are none of the twin's seed fields is usually an
+ *  envelope with a misspelled or unsupported twin id, and the zod error alone
+ *  ("primaryMailbox: expected object, received undefined") sends the reader
+ *  looking for the wrong mistake. */
+async function notSeedFieldsHint(twin: TwinName, seed: unknown): Promise<string> {
+  if (seed === null || typeof seed !== "object" || Array.isArray(seed)) return "";
+  const keys = Object.keys(seed as Record<string, unknown>);
+  if (keys.length === 0) return "";
+  const fields = new Set(await seedFieldsFor(twin));
+  if (keys.some((key) => fields.has(key))) return "";
+  return (
+    `\n  None of its top-level keys (${keys.join(", ")}) is a field of the ${twin} seed. ` +
+    `If this file is a per-twin envelope, its keys must be twin ids: ${TWIN_NAMES.join(", ")}.`
+  );
+}

--- a/cli/src/twin/twinSeed.ts
+++ b/cli/src/twin/twinSeed.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// `pome twin seed <name...>` — a starter seed file, generated from the twin.
+//
+// THE POINT IS THAT NOBODY TYPES IT. Every hand-written seed example we shipped
+// was correct the day it merged and three of the five stopped parsing against
+// their own twin's schema without anything noticing (F-1691). A starter that is
+// COMPUTED from `defaultSeed()` and normalised by the twin's own `parseSeed`
+// cannot reach a reader in that state: if the twin's schema moves, the generated
+// file moves with it, and if the twin cannot parse its own default the generator
+// itself fails.
+//
+// Two consequences worth stating, because they are the reason this is not just
+// `JSON.stringify(defaultSeed())`:
+//
+//   - The output is `parseSeed`'s, not the raw default. That fills every
+//     defaulted field in, so the file DECLARES the world rather than implying
+//     it, and it declares only fields the schema declares — which is what makes
+//     it survive those schemas refusing unknown keys (F-1689).
+//   - It carries no `_meta`. A generated starter is a seed file, not a compiled
+//     task sidecar.
+//
+// The shape is always the per-twin envelope, one twin or five. Flat is still
+// ACCEPTED at every door (`seedFile.ts`); it is no longer produced.
+
+import { writeFile } from "node:fs/promises";
+import { isTwinName, TWIN_NAMES, TWIN_REGISTRY, type TwinName } from "./registry.js";
+
+/**
+ * The starter seed file for `twins`, as the text to write.
+ *
+ * Deterministic: the same twins produce the same bytes, which is what lets a
+ * docs page and a CI gate hold the generated content to equality rather than to
+ * "looks about right".
+ */
+export async function generateSeedFile(twins: readonly TwinName[]): Promise<string> {
+  if (twins.length === 0) {
+    throw new Error(`No twin specified. Pass at least one of: ${TWIN_NAMES.join(", ")}.`);
+  }
+  for (const twin of twins) {
+    if (!isTwinName(twin)) {
+      throw new Error(`Unknown twin '${twin}'. Supported: ${TWIN_NAMES.join(", ")}.`);
+    }
+  }
+  const duplicates = twins.filter((twin, i) => twins.indexOf(twin) !== i);
+  if (duplicates.length > 0) {
+    // An envelope is a JSON object, so a repeated twin would not produce a
+    // duplicate key — it would silently produce one entry and look fine.
+    throw new Error(`A seed file has one entry per twin, and this one is named twice: ${[...new Set(duplicates)].join(", ")}.`);
+  }
+
+  const envelope: Record<string, unknown> = {};
+  for (const twin of twins) {
+    const entry = TWIN_REGISTRY[twin];
+    envelope[twin] = await entry.parseSeed(await entry.defaultSeed());
+  }
+  return `${JSON.stringify(envelope, null, 2)}\n`;
+}
+
+/** Write a generated seed file, refusing to overwrite. A file at this path is
+ *  authored content the moment it exists — `emulate init` takes the same line,
+ *  and the alternative is a command that silently discards a world someone
+ *  edited. */
+export async function writeSeedFile(path: string, text: string): Promise<void> {
+  try {
+    await writeFile(path, text, { flag: "wx" });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "EEXIST") {
+      throw new Error(
+        `${path} already exists — delete it or pass a different --out. ` +
+          `A seed file is authored content once it is on disk.`,
+      );
+    }
+    throw err;
+  }
+}
+
+export async function runTwinSeedCommand(
+  names: string[],
+  options: { out?: string } = {},
+): Promise<void> {
+  const text = await generateSeedFile(names as TwinName[]);
+  if (options.out === undefined) {
+    process.stdout.write(text);
+    return;
+  }
+  await writeSeedFile(options.out, text);
+  // stderr, so `pome twin seed github --out seed.json` says what it did without
+  // that line landing in a file when someone also redirects stdout.
+  console.error(`Wrote ${options.out} — the ${names.join(" + ")} starting seed.`);
+  console.error(`Boot it: pome twin start ${names[0]} --seed ${options.out}`);
+}

--- a/cli/src/twin/twinStart.ts
+++ b/cli/src/twin/twinStart.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // `pome twin start <twin>` — the docker-free front door. Boots any
-// of the three twins as a long-lived foreground server (Ctrl-C to stop) on
+// of the five twins as a long-lived foreground server (Ctrl-C to stop) on
 // the same in-process boot path `pome run --local` uses (`bootTwin`), so
 // `npx @pome-sh/cli twin start github` serves the identical control plane
 // the packaged twin entries serve, with zero installs beyond Node ≥ 24.
@@ -21,7 +21,6 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { serve } from "@hono/node-server";
 import { sign } from "hono/jwt";
-import { parse as parseYaml } from "yaml";
 import {
   defaultPortFor,
   isTwinName,
@@ -29,6 +28,13 @@ import {
   TWIN_REGISTRY,
   type TwinName,
 } from "./registry.js";
+import {
+  parseSeedFileText,
+  readSeedFileText,
+  seedForTwin,
+  soleTwinOf,
+  twinsNamedBy,
+} from "./seedFile.js";
 import { bootTwin } from "./twinHarness.js";
 
 /** The fixed session id a standalone twin serves under (`/s/standalone`). */
@@ -78,46 +84,44 @@ export function resolveStandaloneAuthSecret(
   return { secret: randomBytes(32).toString("hex"), source: "ephemeral" };
 }
 
-/** Where the world a standalone twin booted came from. Printed on boot so the
+/** Where the seed a standalone twin booted came from. Printed on boot so the
  *  answer to "did my seed land?" does not require reading `/_pome/state`. */
 export type StandaloneSeed = {
   seedState: unknown;
   source: "file" | "env" | "default";
-  /** Set when `source` is "file": the path the world was read from. */
+  /** Set when `source` is "file": the path the seed was read from. */
   path?: string;
 };
 
 /**
- * Read side of the world contract, mirroring `resolveStandaloneAuthSecret`:
+ * Read side of the seed contract, mirroring `resolveStandaloneAuthSecret`:
  *   1. `--seed <path>` (JSON or YAML — JSON is a YAML subset, one parser)
  *   2. env `POME_SEED_JSON` — the SAME channel the cloud sets on a pod, so a
- *      world that boots hosted boots here. Before this it was read by the twin
+ *      seed that boots hosted boots here. Before this it was read by the twin
  *      and silently discarded by this command, which boots through `bootTwin`
  *      rather than the twin's own `loadSeedFromEnv`.
- *   3. the twin's default world
+ *   3. the twin's default seed
  *
- * The twin's own `parseSeed` is the arbiter in both non-default cases: a
- * user-authored world is refused HERE, naming its own bad field, rather than
+ * Both authored cases go through `seedFile.ts`, so a flat file and a per-twin
+ * envelope are the same door, and the twin's own `parseSeed` is the arbiter: a
+ * user-authored seed is refused HERE, naming its own bad field, rather than
  * reaching SQLite (github) or throwing an un-attributed zod error mid-boot.
+ *
+ * `seedText` is the already-read contents of `seedPath`, for the caller that had
+ * to read the file BEFORE it knew which twin to start (`--seed` alone, with the
+ * `<name>` argument omitted). Passing it keeps that a single read.
  */
 export async function resolveStandaloneSeed(
   twin: TwinName,
   seedPath: string | undefined,
   env: NodeJS.ProcessEnv = process.env,
+  seedText?: string,
 ): Promise<StandaloneSeed> {
-  const entry = TWIN_REGISTRY[twin];
-
   if (seedPath !== undefined) {
-    let raw: string;
-    try {
-      raw = readFileSync(seedPath, "utf8");
-    } catch (err) {
-      throw new Error(
-        `pome twin start --seed: cannot read ${seedPath}: ${(err as Error).message}`,
-      );
-    }
+    const raw = seedText ?? readSeedFileText(seedPath, "pome twin start --seed");
+    const origin = `--seed ${seedPath}`;
     return {
-      seedState: await parseWorld(entry, raw, `--seed ${seedPath}`),
+      seedState: await seedForTwin(parseSeedFileText(raw, origin), twin, origin),
       source: "file",
       path: seedPath,
     };
@@ -125,55 +129,66 @@ export async function resolveStandaloneSeed(
 
   const fromEnv = env.POME_SEED_JSON;
   if (fromEnv !== undefined && fromEnv !== "") {
-    return { seedState: await parseWorld(entry, fromEnv, "POME_SEED_JSON"), source: "env" };
+    return {
+      seedState: await seedForTwin(
+        parseSeedFileText(fromEnv, "POME_SEED_JSON"),
+        twin,
+        "POME_SEED_JSON",
+      ),
+      source: "env",
+    };
   }
 
-  return { seedState: await entry.defaultSeed(), source: "default" };
+  return { seedState: await TWIN_REGISTRY[twin].defaultSeed(), source: "default" };
 }
 
 /**
- * Drop the sidecar provenance block, so a compiled `<task>.seed.json` is a
- * world file this door accepts as-is — `pome compile-seeds` has been emitting
- * exactly this shape all along, and every task in the library is already one.
+ * Which twin `pome twin start` is starting.
  *
- * DECLARED, not inherited. The twins' seed schemas are non-strict zod today, so
- * `_meta` would be stripped by `parseSeed` anyway — but only by accident, and
- * the moment those schemas refuse unknown keys that accident becomes a refusal
- * of every sidecar in the library. Stripping it here is what survives that.
+ * The `<name>` argument stays the plain answer. It is optional only when a seed
+ * file supplies one instead — an envelope naming exactly one twin already says
+ * which twin it is for, and making the reader repeat it is a second place to get
+ * it wrong. Anything less certain than that is an error naming what is missing.
  */
-function stripSidecarMeta(seed: unknown): unknown {
-  if (seed && typeof seed === "object" && !Array.isArray(seed)) {
-    const { _meta, ...rest } = seed as Record<string, unknown>;
-    return rest;
+export function resolveStandaloneTwin(
+  name: string | undefined,
+  seedPath: string | undefined,
+  seedText: string | undefined,
+): TwinName {
+  if (name !== undefined) {
+    if (!isTwinName(name)) {
+      throw new Error(`Unknown twin '${name}'. Supported: ${TWIN_NAMES.join(", ")}.`);
+    }
+    return name;
   }
-  return seed;
-}
-
-async function parseWorld(
-  entry: (typeof TWIN_REGISTRY)[TwinName],
-  raw: string,
-  origin: string,
-): Promise<unknown> {
-  let parsed: unknown;
-  try {
-    parsed = parseYaml(raw);
-  } catch (err) {
-    throw new Error(`${origin} is not valid JSON or YAML: ${(err as Error).message}`);
+  if (seedPath === undefined || seedText === undefined) {
+    throw new Error(
+      `pome twin start: name a twin (${TWIN_NAMES.join(", ")}), or pass a --seed file whose envelope names exactly one.`,
+    );
   }
-  try {
-    return await entry.parseSeed(stripSidecarMeta(parsed));
-  } catch (err) {
-    throw new Error(`${origin} is not a world this twin can boot: ${(err as Error).message}`);
-  }
+  const origin = `--seed ${seedPath}`;
+  const file = parseSeedFileText(seedText, origin);
+  const sole = soleTwinOf(file);
+  if (sole !== undefined) return sole;
+  const named = twinsNamedBy(file);
+  throw new Error(
+    named.length === 0
+      ? `${origin} is a flat seed, so it does not name a twin. Pass the name: pome twin start <${TWIN_NAMES.join("|")}> --seed ${seedPath}`
+      : `${origin} names ${named.length} twins (${named.join(", ")}), so it does not say which one to start. Pass the name: pome twin start ${named[0]} --seed ${seedPath}`,
+  );
 }
 
 export async function runTwinStartCommand(
-  name: string,
+  nameArg: string | undefined,
   options: { port?: string; seed?: string },
 ): Promise<void> {
-  if (!isTwinName(name)) {
-    throw new Error(`Unknown twin '${name}'. Supported: ${TWIN_NAMES.join(", ")}.`);
-  }
+  // Read the seed file BEFORE resolving the twin: with `<name>` omitted, the
+  // file is what names it. One read feeds both.
+  const seedText =
+    options.seed === undefined
+      ? undefined
+      : readSeedFileText(options.seed, "pome twin start --seed");
+  const name = resolveStandaloneTwin(nameArg, options.seed, seedText);
   // `PORT` wins when set (contract suite / packaged entries). Gmail defaults
   // to 3336 via GMAIL_TWIN_PORT; other twins keep 3333.
   const portRaw = options.port ?? defaultPortFor(name, process.env);
@@ -184,9 +199,9 @@ export async function runTwinStartCommand(
     throw new Error(`pome twin start: invalid --port "${portRaw}"`);
   }
 
-  // Resolve the world BEFORE the auth secret and the listener: a refused seed
+  // Resolve the seed BEFORE the auth secret and the listener: a refused seed
   // must not persist a secret file or leave a bound port behind.
-  const world = await resolveStandaloneSeed(name, options.seed);
+  const world = await resolveStandaloneSeed(name, options.seed, process.env, seedText);
 
   const resolved = resolveStandaloneAuthSecret(name);
   // The in-process twin's auth middleware (resolveAuthSecret) reads the env;
@@ -238,14 +253,18 @@ export async function runTwinStartCommand(
   }
 
   console.log(`Pome ${name} twin listening at ${restUrl}`);
-  // "Did my world land?" is the question a user-authored seed creates, and the
-  // twin cannot answer it after the fact — every world looks like a world.
+  // "Did my seed land?" is the question a user-authored seed creates, and the
+  // twin cannot answer it after the fact — every seeded twin looks seeded.
   if (world.source === "file") {
-    console.log(`World: seeded from ${world.path}.`);
+    console.log(`Seed: ${world.path} (replaces the ${name} twin's default).`);
   } else if (world.source === "env") {
-    console.log("World: seeded from POME_SEED_JSON (--seed <path> overrides it).");
+    console.log(
+      `Seed: POME_SEED_JSON (replaces the ${name} twin's default; --seed <path> overrides it).`,
+    );
   } else {
-    console.log(`World: the ${name} twin's default (pass --seed <path> for your own).`);
+    console.log(
+      `Seed: the ${name} twin's default (pass --seed <path>, or write one with \`pome twin seed ${name}\`).`,
+    );
   }
   if (resolved.source === "persisted") {
     console.log(

--- a/cli/test/e2e/twinSeedRoundTrip.test.ts
+++ b/cli/test/e2e/twinSeedRoundTrip.test.ts
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+// Acceptance for the generated starter, all five twins, as real child
+// processes: generate → `--seed` it → the twin SERVES what the file declares.
+//
+//     pome twin seed <twin> --out seed.json
+//     pome twin start --seed seed.json          <- name omitted on purpose
+//     GET /s/standalone/_pome/state             <- read back
+//
+// The `<name>` argument is left off deliberately: a generated file is a one-twin
+// envelope, so it already says which twin it is for, and that is the path a
+// reader who copied the two commands out of the docs actually takes.
+//
+// WHAT THE ASSERTION IS PULLED FROM. Every expected value is read out of the
+// GENERATED FILE, never typed here. A hard-coded `acme/api` would turn any
+// change to a twin's declared starting state into a red test in the CLI suite,
+// which is the wrong place to notice it — and it would let the generator and the
+// expectation drift apart in exactly the way the docs examples drifted.
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { once } from "node:events";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveTsxBin } from "../../scripts/lib/resolve-tsx.js";
+import { TWIN_NAME_LIST, type TwinName } from "../../src/twin/registry.js";
+
+const CLI_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+const TSX_BIN = resolveTsxBin(import.meta.url);
+const MAIN_TS = join(CLI_ROOT, "src", "cli", "main.ts");
+
+/** Distinctive strings the generated seed DECLARES, which the twin's own
+ *  `/_pome/state` must therefore report. Read from the file, per twin, because
+ *  each twin exports a different vocabulary.
+ *
+ *  stripe is the one twin whose default seed declares nothing `/_pome/state`
+ *  exports — it declares an API key, and the state export is deliberately
+ *  credential-free. Its arm returns no strings and the test falls through to the
+ *  credential probe below, which is the only observable form "the seed landed"
+ *  takes for that twin. */
+const DECLARED: Record<TwinName, (seed: never) => string[]> = {
+  github: (seed: { repositories: { owner: string; name: string }[] }) =>
+    seed.repositories.map((repo) => `${repo.owner}/${repo.name}`),
+  slack: (seed: { channels: { name: string }[] }) => seed.channels.map((c) => c.name),
+  stripe: () => [],
+  gmail: (seed: { primaryMailbox: { email: string } }) => [seed.primaryMailbox.email],
+  linear: (seed: { organization: { urlKey: string }; teams: { key: string }[] }) => [
+    seed.organization.urlKey,
+    ...seed.teams.map((team) => team.key),
+  ],
+};
+
+async function freePort(): Promise<number> {
+  const srv = createServer();
+  srv.listen(0, "127.0.0.1");
+  await once(srv, "listening");
+  const { port } = srv.address() as { port: number };
+  await new Promise((resolve) => srv.close(resolve));
+  return port;
+}
+
+function runCli(args: string[], cwd: string): Promise<{ code: number | null; output: string }> {
+  const proc = spawn(TSX_BIN, [MAIN_TS, ...args], { cwd, stdio: ["ignore", "pipe", "pipe"] });
+  let output = "";
+  proc.stdout?.on("data", (chunk) => { output += chunk; });
+  proc.stderr?.on("data", (chunk) => { output += chunk; });
+  return new Promise((resolve) =>
+    proc.once("exit", (code) => resolve({ code, output })),
+  );
+}
+
+let child: ChildProcess | undefined;
+
+afterEach(() => {
+  child?.kill("SIGKILL");
+  child = undefined;
+});
+
+describe("pome twin seed → pome twin start --seed (e2e)", () => {
+  it.each(TWIN_NAME_LIST)(
+    "%s: the generated seed boots, and the twin serves what it declares",
+    async (twin) => {
+      const cwd = await mkdtemp(join(tmpdir(), `pome-seed-roundtrip-${twin}-`));
+      const seedPath = join(cwd, "seed.json");
+
+      const generated = await runCli(["twin", "seed", twin, "--out", seedPath], cwd);
+      expect(generated.code, generated.output).toBe(0);
+
+      const file = JSON.parse(await readFile(seedPath, "utf8")) as Record<string, unknown>;
+      // One twin, one envelope key: the shape the reader is told to write.
+      expect(Object.keys(file)).toEqual([twin]);
+      const declared = DECLARED[twin](file[twin] as never);
+
+      const port = await freePort();
+      // No `<name>`: the envelope names exactly one twin, so the file supplies it.
+      child = spawn(
+        TSX_BIN,
+        [MAIN_TS, "twin", "start", "--port", String(port), "--seed", seedPath],
+        { cwd, env: { ...process.env }, stdio: ["ignore", "pipe", "pipe"] },
+      );
+      let output = "";
+      child.stdout?.on("data", (chunk) => { output += chunk; });
+      child.stderr?.on("data", (chunk) => { output += chunk; });
+
+      const base = `http://127.0.0.1:${port}`;
+      const deadline = Date.now() + 60_000;
+      for (;;) {
+        try {
+          if ((await fetch(`${base}/healthz`)).status === 200) break;
+        } catch {
+          // not listening yet
+        }
+        if (Date.now() > deadline) {
+          throw new Error(`twin start never answered /healthz 200\n--- output ---\n${output}`);
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+
+      const tokenDeadline = Date.now() + 5_000;
+      while (!/POME_AUTH_TOKEN=/.test(output) && Date.now() < tokenDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      const token = output.match(/POME_AUTH_TOKEN=(\S+)/)?.[1];
+      expect(token, output).toBeTruthy();
+
+      // The boot line names the file and says what seeding does to the default.
+      expect(output).toContain(`Seed: ${seedPath} (replaces the ${twin} twin's default).`);
+
+      const state = await fetch(`${base}/s/standalone/_pome/state`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      expect(state.status).toBe(200);
+      const served = JSON.stringify(await state.json());
+      for (const value of declared) expect(served).toContain(value);
+
+      if (twin === "stripe") {
+        // The credential the seed declares is recognised; one it does not
+        // declare is not. 401 is "no such credential" — the seeded key gets past
+        // that, an invented one does not, and that difference is the only place
+        // stripe's seeded `api_keys` is observable from outside the twin.
+        const declaredKey = (file.stripe as { api_keys: { key: string }[] }).api_keys[0]!.key;
+        const withSeeded = await fetch(`${base}/s/standalone/v1/customers`, {
+          headers: { Authorization: `Bearer ${declaredKey}` },
+        });
+        const withInvented = await fetch(`${base}/s/standalone/v1/customers`, {
+          headers: { Authorization: "Bearer sk_test_not_in_the_seed" },
+        });
+        expect(withInvented.status).toBe(401);
+        expect(withSeeded.status).not.toBe(401);
+      }
+    },
+    120_000,
+  );
+
+  it(
+    "refuses to overwrite a seed file that already exists",
+    async () => {
+      const cwd = await mkdtemp(join(tmpdir(), "pome-seed-overwrite-"));
+      const seedPath = join(cwd, "seed.json");
+      const first = await runCli(["twin", "seed", "stripe", "--out", seedPath], cwd);
+      expect(first.code).toBe(0);
+      const second = await runCli(["twin", "seed", "github", "--out", seedPath], cwd);
+      expect(second.code).not.toBe(0);
+      expect(second.output).toContain("already exists");
+      // The stripe seed is still there, unedited.
+      const kept = JSON.parse(await readFile(seedPath, "utf8")) as Record<string, unknown>;
+      expect(Object.keys(kept)).toEqual(["stripe"]);
+    },
+    120_000,
+  );
+});

--- a/cli/test/e2e/twinStart.test.ts
+++ b/cli/test/e2e/twinStart.test.ts
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Acceptance — `pome twin start` as a real child process: boots the twin as a
 // foreground server, reuses the secret persisted at the boot-secret contract,
-// and boots a USER-AUTHORED world from `--seed`, read back through the twin's
+// and boots a USER-AUTHORED seed from `--seed`, read back through the twin's
 // own REST surface.
+//
+// The generated-starter round trip (`pome twin seed` → `--seed` → read back, all
+// five twins) is `twinSeedRoundTrip.test.ts`.
 
 import { spawn, type ChildProcess } from "node:child_process";
 import { once } from "node:events";
@@ -111,10 +114,10 @@ describe("pome twin start (e2e)", () => {
   );
 
   it(
-    "boots a world from --seed and serves a repository the default world has never had",
+    "boots a seed from --seed and serves a repository the default has never had",
     async () => {
       const cwd = await mkdtemp(join(tmpdir(), "pome-twin-start-seed-e2e-"));
-      const seedPath = join(cwd, "world.json");
+      const seedPath = join(cwd, "seed.json");
       // `vakoi/billing` is not in the github twin's defaultSeedState(); the
       // default's `acme/api` is. Asserting BOTH is what separates "my seed
       // landed" from "the twin merged my seed into its default".
@@ -179,8 +182,9 @@ describe("pome twin start (e2e)", () => {
       const fromDefault = await fetch(`${base}/s/standalone/repos/acme/api`, { headers: auth });
       expect(fromDefault.status).toBe(404);
 
-      // The boot line answers "did my world land?" without reading state.
-      expect(output).toContain(`World: seeded from ${seedPath}`);
+      // The boot line answers "did my seed land?" without reading state, and
+      // says outright what seeding does to the default.
+      expect(output).toContain(`Seed: ${seedPath} (replaces the github twin's default).`);
     },
     90_000,
   );
@@ -189,7 +193,7 @@ describe("pome twin start (e2e)", () => {
     "refuses a schema-invalid --seed before binding a port, and exits non-zero",
     async () => {
       const cwd = await mkdtemp(join(tmpdir(), "pome-twin-start-badseed-e2e-"));
-      const seedPath = join(cwd, "world.json");
+      const seedPath = join(cwd, "seed.json");
       await writeFile(seedPath, JSON.stringify({ repositories: [{ owner: "acme" }] }));
 
       const port = await freePort();
@@ -206,7 +210,7 @@ describe("pome twin start (e2e)", () => {
       );
 
       expect(exitCode).not.toBe(0);
-      expect(output).toContain("is not a world this twin can boot");
+      expect(output).toContain("is not a seed this twin can boot");
       // Nothing is listening: the world is resolved before the server binds.
       await expect(fetch(`http://127.0.0.1:${port}/healthz`)).rejects.toThrow();
     },

--- a/cli/test/unit/session-seed.test.ts
+++ b/cli/test/unit/session-seed.test.ts
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: Apache-2.0
+// `pome sandbox create --seed <path>` — the hosted half of the seed door.
+//
+// One seed file, three doors. This asserts the part that is this command's own
+// business: which twins the session gets, and WHICH SHAPE reaches the wire.
+//
+// THE RULE does not move (`cli/src/contract/seed-envelope.ts`): the create-session
+// `seed` is a per-twin envelope iff the session has more than one twin, decided
+// from `twins` alone. So a one-twin session sends the FLAT seed even when the
+// file the user wrote was an envelope, and the CLI unwraps rather than forwards.
+
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CreateSessionResponse } from "../../src/types/shared.js";
+
+const mocks = vi.hoisted(() => ({
+  createSession: vi.fn(),
+  resolveCredentials: vi.fn(),
+}));
+
+vi.mock("../../src/cli/credentials.js", () => ({
+  resolveCredentials: mocks.resolveCredentials,
+}));
+
+vi.mock("../../src/cli/agent-identity.js", () => ({
+  resolveRunAgentIdentity: vi.fn(async () => ({})),
+}));
+
+vi.mock("../../src/hosted/client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/hosted/client.js")>();
+  return {
+    ...actual,
+    createHostedClient: vi.fn(() => ({ createSession: mocks.createSession })),
+  };
+});
+
+import { runSessionCreate } from "../../src/cli/session.js";
+
+const response: CreateSessionResponse = {
+  session_id: "ses_test",
+  session_token: "ses_test",
+  twin_url: "https://twin.example.com/s/ses_test",
+  expires_at: "2026-06-24T16:30:00.000Z",
+  openapi_url: "https://twin.example.com/s/ses_test/openapi.json",
+  agent_token: "agent_secret_token",
+  per_twin: {},
+  provider_credentials: {},
+};
+
+const GITHUB_SEED = {
+  users: [{ login: "vakoi", type: "Organization", name: "Vakoi" }],
+  repositories: [{ owner: "vakoi", name: "billing" }],
+};
+const SLACK_SEED = { channels: [{ id: "C_ENG", name: "eng-alerts" }] };
+
+async function seedFile(value: unknown, name = "seed.json"): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "pome-sandbox-seed-"));
+  const path = join(dir, name);
+  await writeFile(path, JSON.stringify(value));
+  return path;
+}
+
+/** The `seed` this invocation actually put on the wire. */
+function sentSeed(): unknown {
+  return mocks.createSession.mock.calls.at(-1)?.[0]?.seed;
+}
+function sentTwins(): string[] {
+  return mocks.createSession.mock.calls.at(-1)?.[0]?.twins as string[];
+}
+
+describe("pome sandbox create --seed", () => {
+  beforeEach(() => {
+    mocks.resolveCredentials.mockResolvedValue({
+      apiBaseUrl: "https://api.example.com",
+      apiKey: "control_plane_secret",
+    });
+    mocks.createSession.mockResolvedValue(response);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mocks.createSession.mockReset();
+    mocks.resolveCredentials.mockReset();
+  });
+
+  it("sends no `seed` at all when --seed is omitted", async () => {
+    await runSessionCreate({
+      apiBaseUrl: "https://api.example.com",
+      twins: ["github"],
+      showSecrets: false,
+      format: "text",
+    });
+    expect(sentSeed()).toBeUndefined();
+  });
+
+  it("unwraps a one-twin envelope to the FLAT wire shape", async () => {
+    await runSessionCreate({
+      apiBaseUrl: "https://api.example.com",
+      twins: ["github"],
+      showSecrets: false,
+      format: "text",
+      seedPath: await seedFile({ github: GITHUB_SEED }),
+    });
+    expect(sentTwins()).toEqual(["github"]);
+    expect(sentSeed()).toMatchObject({
+      repositories: [expect.objectContaining({ owner: "vakoi", name: "billing" })],
+    });
+    expect(sentSeed()).not.toHaveProperty("github");
+  });
+
+  it("still takes the flat file shape F-1686 shipped", async () => {
+    await runSessionCreate({
+      apiBaseUrl: "https://api.example.com",
+      twins: ["github"],
+      showSecrets: false,
+      format: "text",
+      seedPath: await seedFile(GITHUB_SEED),
+    });
+    expect(sentSeed()).toMatchObject({ repositories: [expect.objectContaining({ name: "billing" })] });
+  });
+
+  it("sends the ENVELOPE when the session has more than one twin", async () => {
+    await runSessionCreate({
+      apiBaseUrl: "https://api.example.com",
+      twins: ["github", "slack"],
+      showSecrets: false,
+      format: "text",
+      seedPath: await seedFile({ github: GITHUB_SEED, slack: SLACK_SEED }),
+    });
+    expect(sentTwins()).toEqual(["github", "slack"]);
+    const seed = sentSeed() as Record<string, { channels?: unknown[] }>;
+    expect(Object.keys(seed).sort()).toEqual(["github", "slack"]);
+    expect(seed.slack?.channels).toHaveLength(1);
+  });
+
+  it("an envelope naming exactly one twin makes --twin unnecessary", async () => {
+    await runSessionCreate({
+      apiBaseUrl: "https://api.example.com",
+      twins: [],
+      showSecrets: false,
+      format: "text",
+      seedPath: await seedFile({ linear: {} }),
+    });
+    expect(sentTwins()).toEqual(["linear"]);
+  });
+
+  it("refuses BY NAME a file naming a twin the sandbox was not asked for", async () => {
+    await expect(
+      runSessionCreate({
+        apiBaseUrl: "https://api.example.com",
+        twins: ["github"],
+        showSecrets: false,
+        format: "text",
+        seedPath: await seedFile({ github: GITHUB_SEED, slack: SLACK_SEED }),
+      }),
+    ).rejects.toThrow(/names slack, which this command was not asked for/);
+    expect(mocks.createSession).not.toHaveBeenCalled();
+  });
+
+  it("refuses a flat file when the sandbox has more than one twin — it names no twin", async () => {
+    await expect(
+      runSessionCreate({
+        apiBaseUrl: "https://api.example.com",
+        twins: ["github", "slack"],
+        showSecrets: false,
+        format: "text",
+        seedPath: await seedFile(GITHUB_SEED),
+      }),
+    ).rejects.toThrow(/is a flat seed and this sandbox has 2 twins/);
+    expect(mocks.createSession).not.toHaveBeenCalled();
+  });
+
+  it("still needs --twin when the file is flat and names nothing", async () => {
+    await expect(
+      runSessionCreate({
+        apiBaseUrl: "https://api.example.com",
+        twins: [],
+        showSecrets: false,
+        format: "text",
+        seedPath: await seedFile(GITHUB_SEED),
+      }),
+    ).rejects.toThrow(/No twin specified/);
+  });
+
+  // F-1688: a seed the pod refuses reports as `503 Failed to spawn twin pod`
+  // twelve seconds later. The same `parseSeed` the pod runs is right here, so
+  // the refusal is instant and names the field — no round trip, no session.
+  it("refuses a schema-invalid seed before the round trip, naming the twin's own field", async () => {
+    await expect(
+      runSessionCreate({
+        apiBaseUrl: "https://api.example.com",
+        twins: ["github"],
+        showSecrets: false,
+        format: "text",
+        seedPath: await seedFile({ github: { repositories: [{ owner: "acme" }] } }),
+      }),
+    ).rejects.toThrow(/is not a seed this twin can boot[\s\S]*name/);
+    expect(mocks.createSession).not.toHaveBeenCalled();
+  });
+
+  it("drops the `_meta` block, so a compiled sidecar is a hosted seed file too", async () => {
+    await runSessionCreate({
+      apiBaseUrl: "https://api.example.com",
+      twins: ["github"],
+      showSecrets: false,
+      format: "text",
+      seedPath: await seedFile({ _meta: { source_hash: "sha256:abc" }, ...GITHUB_SEED }),
+    });
+    expect(sentSeed()).not.toHaveProperty("_meta");
+  });
+});

--- a/cli/test/unit/twin/seedFile.test.ts
+++ b/cli/test/unit/twin/seedFile.test.ts
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+// The one seed-file door, in isolation: what shape a file is, which twin each
+// part belongs to, and what it says when the file names a twin the command was
+// not asked for.
+//
+// The rule under test is DECLARED, not sniffed at the value level: a file is a
+// per-twin envelope iff its top-level keys are twin ids. `noTwinFieldIsNamedAfterATwin`
+// below is what makes that rule safe, and it derives both sides from the twins.
+
+import { describe, expect, it } from "vitest";
+import {
+  parseSeedFileText,
+  seedFieldsFor,
+  seedForTwin,
+  soleTwinOf,
+  twinsNamedBy,
+} from "../../../src/twin/seedFile.js";
+import { TWIN_NAME_LIST } from "../../../src/twin/registry.js";
+
+const GITHUB_FLAT = {
+  users: [{ login: "vakoi", type: "Organization", name: "Vakoi" }],
+  repositories: [{ owner: "vakoi", name: "billing" }],
+};
+const SLACK_FLAT = {
+  channels: [{ id: "C_ENG", name: "eng-alerts", members: [] }],
+};
+
+describe("parseSeedFileText — which shape is this file", () => {
+  it("reads a flat single-twin seed as flat", () => {
+    const file = parseSeedFileText(JSON.stringify(GITHUB_FLAT), "--seed w.json");
+    expect(file.shape).toBe("flat");
+    expect(twinsNamedBy(file)).toEqual([]);
+  });
+
+  it("reads a per-twin envelope as an envelope, in file order", () => {
+    const file = parseSeedFileText(
+      JSON.stringify({ github: GITHUB_FLAT, slack: SLACK_FLAT }),
+      "--seed w.json",
+    );
+    expect(file.shape).toBe("envelope");
+    expect(twinsNamedBy(file)).toEqual(["github", "slack"]);
+  });
+
+  it("reads YAML, because JSON is a YAML subset and one parser is the contract", () => {
+    const file = parseSeedFileText(
+      ["github:", "  repositories:", "    - owner: vakoi", "      name: billing", ""].join("\n"),
+      "--seed w.yaml",
+    );
+    expect(file.shape).toBe("envelope");
+    expect(twinsNamedBy(file)).toEqual(["github"]);
+  });
+
+  it("strips the `_meta` provenance block a compiled sidecar carries, on BOTH shapes", () => {
+    const flat = parseSeedFileText(
+      JSON.stringify({ _meta: { source_hash: "abc" }, ...GITHUB_FLAT }),
+      "--seed w.json",
+    );
+    if (flat.shape !== "flat") throw new Error(`expected a flat file, got ${flat.shape}`);
+    expect(Object.keys(flat.seed as object)).not.toContain("_meta");
+
+    const enveloped = parseSeedFileText(
+      JSON.stringify({ _meta: { source_hash: "abc" }, github: GITHUB_FLAT }),
+      "--seed w.json",
+    );
+    expect(enveloped.shape).toBe("envelope");
+    expect(twinsNamedBy(enveloped)).toEqual(["github"]);
+  });
+
+  it("treats an empty object as flat — a slack or stripe seed may legitimately be `{}`", () => {
+    expect(parseSeedFileText("{}", "--seed w.json").shape).toBe("flat");
+  });
+
+  it("refuses a file that mixes twin ids with flat seed fields", () => {
+    expect(() =>
+      parseSeedFileText(
+        JSON.stringify({ github: GITHUB_FLAT, repositories: [] }),
+        "--seed w.json",
+      ),
+    ).toThrow(/mixes twin ids \(github\) with other keys \(repositories\)/);
+  });
+
+  it("names the file and the parser's own complaint when the text is not JSON or YAML", () => {
+    expect(() => parseSeedFileText("{ nope", "--seed w.json")).toThrow(
+      /--seed w\.json is not valid JSON or YAML/,
+    );
+  });
+
+  it("refuses a top-level array — a seed file declares a world, not a list", () => {
+    expect(() => parseSeedFileText("[]", "--seed w.json")).toThrow(
+      /--seed w\.json is not a seed file: its top level is an array/,
+    );
+  });
+});
+
+describe("seedForTwin — which part of the file belongs to this twin", () => {
+  it("hands a flat file straight to the named twin", async () => {
+    const file = parseSeedFileText(JSON.stringify(GITHUB_FLAT), "--seed w.json");
+    await expect(seedForTwin(file, "github", "--seed w.json")).resolves.toMatchObject({
+      repositories: [expect.objectContaining({ owner: "vakoi", name: "billing" })],
+    });
+  });
+
+  it("unwraps the envelope entry for the twin asked for", async () => {
+    const file = parseSeedFileText(
+      JSON.stringify({ github: GITHUB_FLAT, slack: SLACK_FLAT }),
+      "--seed w.json",
+    );
+    const seed = (await seedForTwin(file, "github", "--seed w.json")) as {
+      repositories: { name: string }[];
+    };
+    expect(seed.repositories.map((r) => r.name)).toEqual(["billing"]);
+  });
+
+  it("refuses BY NAME an envelope entry for a twin this command was not asked for", async () => {
+    const file = parseSeedFileText(
+      JSON.stringify({ github: GITHUB_FLAT, slack: SLACK_FLAT }),
+      "--seed w.json",
+    );
+    await expect(
+      seedForTwin(file, "github", "--seed w.json", { asked: ["github"] }),
+    ).rejects.toThrow(/names slack, which this command was not asked for/);
+  });
+
+  it("refuses BY NAME a key that is not a Pome twin at all", () => {
+    expect(() =>
+      parseSeedFileText(JSON.stringify({ github: GITHUB_FLAT, notion: {} }), "--seed w.json"),
+    ).toThrow(/mixes twin ids \(github\) with other keys \(notion\)/);
+  });
+
+  it("is a loud error, not a silent skip, when the envelope has no entry for the twin", async () => {
+    const file = parseSeedFileText(JSON.stringify({ slack: SLACK_FLAT }), "--seed w.json");
+    await expect(seedForTwin(file, "github", "--seed w.json")).rejects.toThrow(
+      /declares no github seed \(it names slack\)/,
+    );
+  });
+
+  it("refuses a flat file the twin's own parseSeed rejects, quoting the twin's field", async () => {
+    const file = parseSeedFileText(JSON.stringify({ repositories: [{ owner: "acme" }] }), "--seed w.json");
+    await expect(seedForTwin(file, "github", "--seed w.json")).rejects.toThrow(
+      /--seed w\.json is not a seed this twin can boot[\s\S]*name/,
+    );
+  });
+
+  // The regression this whole module exists for: slack's and stripe's seed
+  // schemas are non-strict, so before the envelope was declared they ACCEPTED a
+  // `{github, slack}` file and served an EMPTY world while the boot line said
+  // the seed had landed. Twelve of the twenty sidecars in agent-examples/ are
+  // that shape.
+  it("does not let a non-strict twin silently accept an envelope as its own flat seed", async () => {
+    const file = parseSeedFileText(
+      JSON.stringify({ github: GITHUB_FLAT, slack: SLACK_FLAT }),
+      "--seed w.json",
+    );
+    const seed = (await seedForTwin(file, "slack", "--seed w.json")) as {
+      channels: { name: string }[];
+    };
+    expect(seed.channels.map((c) => c.name)).toEqual(["eng-alerts"]);
+  });
+
+  it("tells a reader their keys are not seed fields when a flat parse fails on all of them", async () => {
+    const file = parseSeedFileText(JSON.stringify({ notion: { pages: [] } }), "--seed w.json");
+    await expect(seedForTwin(file, "github", "--seed w.json")).rejects.toThrow(
+      /None of its top-level keys \(notion\) is a field of the github seed/,
+    );
+  });
+});
+
+describe("soleTwinOf — when the file makes `--twin` unnecessary", () => {
+  it("returns the one twin an envelope names", () => {
+    const file = parseSeedFileText(JSON.stringify({ linear: {} }), "--seed w.json");
+    expect(soleTwinOf(file)).toBe("linear");
+  });
+
+  it("returns undefined for an envelope naming more than one", () => {
+    const file = parseSeedFileText(
+      JSON.stringify({ github: GITHUB_FLAT, slack: SLACK_FLAT }),
+      "--seed w.json",
+    );
+    expect(soleTwinOf(file)).toBeUndefined();
+  });
+
+  it("returns undefined for a flat file — a flat seed names no twin", () => {
+    const file = parseSeedFileText(JSON.stringify(GITHUB_FLAT), "--seed w.json");
+    expect(soleTwinOf(file)).toBeUndefined();
+  });
+});
+
+// The safety proof for the detection rule above. Both sides are derived: the
+// twin ids from the registry, the field names from each twin's own zod schema.
+// If a twin ever declares a top-level seed field named after a twin, "keys are
+// twin ids" stops telling an envelope from a flat seed, and this goes red before
+// anyone finds out from a silently-empty world.
+describe("no twin's seed field is named after a twin", () => {
+  it.each(TWIN_NAME_LIST)("%s", async (twin) => {
+    const fields = await seedFieldsFor(twin);
+    expect(fields.length).toBeGreaterThan(0);
+    expect(fields.filter((f) => (TWIN_NAME_LIST as readonly string[]).includes(f))).toEqual([]);
+  });
+});

--- a/cli/test/unit/twin/twinSeed.test.ts
+++ b/cli/test/unit/twin/twinSeed.test.ts
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// `pome twin seed <name...>` — the starter seed file, generated from the twin.
+//
+// The property that matters is the round trip, and it is asserted here rather
+// than described: what this command prints, `--seed` accepts, and the twin's own
+// `parseSeed` is the arbiter on both ends. A starter that cannot boot is the
+// defect this command exists to make impossible, so "it parses" is the test.
+
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { TWIN_NAME_LIST } from "../../../src/twin/registry.js";
+import { parseSeedFileText, seedForTwin } from "../../../src/twin/seedFile.js";
+import { generateSeedFile, writeSeedFile } from "../../../src/twin/twinSeed.js";
+
+describe("generateSeedFile", () => {
+  it.each(TWIN_NAME_LIST)("%s: what it prints is a seed file --seed accepts", async (twin) => {
+    const text = await generateSeedFile([twin]);
+    const file = parseSeedFileText(text, `pome twin seed ${twin}`);
+    expect(file.shape).toBe("envelope");
+    await expect(seedForTwin(file, twin, "generated")).resolves.toBeTypeOf("object");
+  });
+
+  it.each(TWIN_NAME_LIST)("%s: is the envelope shape, one twin or five", async (twin) => {
+    const parsed = JSON.parse(await generateSeedFile([twin])) as Record<string, unknown>;
+    expect(Object.keys(parsed)).toEqual([twin]);
+  });
+
+  it("writes one envelope for several twins, in the order they were asked for", async () => {
+    const parsed = JSON.parse(await generateSeedFile(["slack", "github"])) as Record<string, unknown>;
+    expect(Object.keys(parsed)).toEqual(["slack", "github"]);
+  });
+
+  it("carries no `_meta` — a generated starter is a seed file, not a compiled sidecar", async () => {
+    const parsed = JSON.parse(await generateSeedFile(["github"])) as Record<string, unknown>;
+    expect(parsed).not.toHaveProperty("_meta");
+    expect(parsed.github).not.toHaveProperty("_meta");
+  });
+
+  // F-1689 will make the twins' seed schemas refuse unknown keys. A starter
+  // built from `parseSeed`'s own output declares only fields that schema
+  // declares, so it survives that change by construction — asserted, because
+  // "by construction" is exactly the kind of claim that stops being true.
+  it.each(TWIN_NAME_LIST)("%s: re-parsing the generated seed is a fixed point", async (twin) => {
+    const once = await generateSeedFile([twin]);
+    const seed = await seedForTwin(parseSeedFileText(once, "generated"), twin, "generated");
+    const twice = JSON.stringify({ [twin]: seed }, null, 2);
+    expect(`${twice}\n`).toBe(once);
+  });
+
+  it.each(TWIN_NAME_LIST)("%s: is byte-identical across calls", async (twin) => {
+    expect(await generateSeedFile([twin])).toBe(await generateSeedFile([twin]));
+  });
+
+  it("ends with a newline, so `pome twin seed github > seed.json` is a well-formed file", async () => {
+    expect(await generateSeedFile(["stripe"])).toMatch(/\n$/);
+  });
+
+  it("refuses an unknown twin by name and lists the ones that exist", async () => {
+    await expect(generateSeedFile(["notion" as never])).rejects.toThrow(
+      /Unknown twin 'notion'\. Supported: github, slack, stripe, gmail, linear\./,
+    );
+  });
+
+  it("refuses the same twin twice rather than emitting a duplicate key", async () => {
+    await expect(generateSeedFile(["github", "github"])).rejects.toThrow(/named twice: github/);
+  });
+});
+
+describe("writeSeedFile", () => {
+  it("writes the file and reports the path", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pome-twin-seed-"));
+    const path = join(dir, "seed.json");
+    await writeSeedFile(path, await generateSeedFile(["stripe"]));
+    const parsed = JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
+    expect(Object.keys(parsed)).toEqual(["stripe"]);
+  });
+
+  it("refuses to overwrite — a seed file is authored content once it exists", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pome-twin-seed-"));
+    const path = join(dir, "seed.json");
+    await writeFile(path, "{}");
+    await expect(writeSeedFile(path, "{}\n")).rejects.toThrow(
+      /already exists.*delete it or pass a different --out/s,
+    );
+  });
+});

--- a/cli/test/unit/twinStartSeed.test.ts
+++ b/cli/test/unit/twinStartSeed.test.ts
@@ -1,8 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
-// Read side of the world contract in `pome twin start`: `--seed <path>` wins,
+// Read side of the seed contract in `pome twin start`: `--seed <path>` wins,
 // else `POME_SEED_JSON` (the same channel the cloud sets on a pod), else the
 // twin's default. The twin's own `parseSeed` is the arbiter in both authored
-// cases, so a bad world is refused here rather than at boot.
+// cases, so a bad seed is refused here rather than at boot.
+//
+// A file may be flat (one twin's seed, the F-1686 shape) or the per-twin
+// envelope `{ <twin>: <seed> }`. `cli/src/twin/seedFile.ts` owns that decision
+// and is unit-tested on its own; what this file holds is the resolution ORDER
+// and what the command does with the answer.
 
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -10,7 +15,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolveStandaloneSeed } from "../../src/twin/twinStart.js";
 
-const WORLD = {
+const FLAT = {
   users: [{ login: "vakoi", type: "Organization", name: "Vakoi" }],
   repositories: [{ owner: "vakoi", name: "billing" }],
 };
@@ -31,7 +36,7 @@ function repoNames(seedState: unknown): string[] {
 
 describe("resolveStandaloneSeed", () => {
   it("reads a JSON world from --seed and reports the path it came from", async () => {
-    const path = await seedFile(JSON.stringify(WORLD));
+    const path = await seedFile(JSON.stringify(FLAT));
     const resolved = await resolveStandaloneSeed("github", path, {});
     expect(resolved.source).toBe("file");
     expect(resolved.path).toBe(path);
@@ -49,7 +54,7 @@ describe("resolveStandaloneSeed", () => {
 
   it("honors POME_SEED_JSON when --seed is absent", async () => {
     const resolved = await resolveStandaloneSeed("github", undefined, {
-      POME_SEED_JSON: JSON.stringify(WORLD),
+      POME_SEED_JSON: JSON.stringify(FLAT),
     });
     expect(resolved.source).toBe("env");
     expect(resolved.path).toBeUndefined();
@@ -57,7 +62,7 @@ describe("resolveStandaloneSeed", () => {
   });
 
   it("--seed wins over POME_SEED_JSON", async () => {
-    const path = await seedFile(JSON.stringify(WORLD));
+    const path = await seedFile(JSON.stringify(FLAT));
     const resolved = await resolveStandaloneSeed("github", path, {
       POME_SEED_JSON: JSON.stringify({ repositories: [{ owner: "env", name: "loser" }] }),
     });
@@ -65,11 +70,14 @@ describe("resolveStandaloneSeed", () => {
     expect(repoNames(resolved.seedState)).toEqual(["vakoi/billing"]);
   });
 
-  it("falls back to the twin's default world when neither is set", async () => {
+  it("falls back to the twin's default seed when neither is set", async () => {
     const resolved = await resolveStandaloneSeed("github", undefined, {});
     expect(resolved.source).toBe("default");
-    // github's entry defers to the twin's own defaultSeedState() inside `boot`.
-    expect(resolved.seedState).toBeUndefined();
+    // The registry answers this for every twin now, github included: its entry
+    // used to return `undefined` and let `boot` reach for defaultSeedState(),
+    // which left "what does this twin start with" unanswerable without booting
+    // — the question `pome twin seed` has to answer.
+    expect(repoNames(resolved.seedState)).toContain("acme/api");
   });
 
   it("treats an empty POME_SEED_JSON as absent rather than as an empty world", async () => {
@@ -83,40 +91,40 @@ describe("resolveStandaloneSeed", () => {
     ).rejects.toThrow(/--seed: cannot read \/nope\/does-not-exist\.json/);
   });
 
-  it("refuses an unparseable world, naming the flag", async () => {
+  it("refuses an unparseable seed, naming the flag", async () => {
     const path = await seedFile("{ not json ::: and not yaml");
     await expect(resolveStandaloneSeed("github", path, {})).rejects.toThrow(
       /is not valid JSON or YAML/,
     );
   });
 
-  it("refuses a schema-invalid world through the twin's OWN parser", async () => {
+  it("refuses a schema-invalid seed through the twin's OWN parser", async () => {
     // A repository with no `name`. github's `boot` hands its seed to
     // `domain.seed()` unparsed, so without the registry's parseSeed entry this
     // reaches SQLite instead of the user.
     const path = await seedFile(JSON.stringify({ repositories: [{ owner: "acme" }] }));
     await expect(resolveStandaloneSeed("github", path, {})).rejects.toThrow(
-      /is not a world this twin can boot/,
+      /is not a seed this twin can boot/,
     );
   });
 
-  it("refuses a schema-invalid world from POME_SEED_JSON too, naming the env var", async () => {
+  it("refuses a schema-invalid seed from POME_SEED_JSON too, naming the env var", async () => {
     await expect(
       resolveStandaloneSeed("github", undefined, {
         POME_SEED_JSON: JSON.stringify({ repositories: [{ owner: "acme" }] }),
       }),
-    ).rejects.toThrow(/POME_SEED_JSON is not a world this twin can boot/);
+    ).rejects.toThrow(/POME_SEED_JSON is not a seed this twin can boot/);
   });
 
   it("accepts a compiled task sidecar as-is, provenance block and all", async () => {
     // `pome compile-seeds` emits `<task>.seed.json` with an `_meta` block, and
-    // that file IS a world — every task in the bundled library is already one.
+    // that file IS a seed file — every task in the bundled library is one.
     // The strip is declared here rather than left to non-strict zod, so a
     // later move to strict schemas does not refuse the whole library.
     const path = await seedFile(
       JSON.stringify({
         _meta: { version: 1, source_hash: "sha256:abc", compiled_at: "2026-05-22T14:30:00.154Z" },
-        ...WORLD,
+        ...FLAT,
       }),
     );
     const resolved = await resolveStandaloneSeed("github", path, {});
@@ -130,5 +138,52 @@ describe("resolveStandaloneSeed", () => {
       expect(resolved.source).toBe("default");
       expect(resolved.seedState).toBeTypeOf("object");
     }
+  });
+});
+
+describe("resolveStandaloneSeed — the per-twin envelope", () => {
+  it("unwraps the entry for the twin being started", async () => {
+    const path = await seedFile(JSON.stringify({ github: FLAT }));
+    const resolved = await resolveStandaloneSeed("github", path, {});
+    expect(repoNames(resolved.seedState)).toEqual(["vakoi/billing"]);
+  });
+
+  it("accepts an envelope through POME_SEED_JSON too", async () => {
+    const resolved = await resolveStandaloneSeed("github", undefined, {
+      POME_SEED_JSON: JSON.stringify({ github: FLAT }),
+    });
+    expect(resolved.source).toBe("env");
+    expect(repoNames(resolved.seedState)).toEqual(["vakoi/billing"]);
+  });
+
+  // The library's own multi-twin sidecars are this shape — twelve of the twenty
+  // `<task>.seed.json` files under agent-examples/ are `{github, slack}`. Before
+  // the envelope, `twin start github --seed <one of them>` failed on
+  // `repositories: expected array, received undefined`.
+  it("reads a multi-twin sidecar, taking only the twin being started", async () => {
+    const path = await seedFile(
+      JSON.stringify({ github: FLAT, slack: { channels: [{ id: "C1", name: "eng" }] } }),
+    );
+    const resolved = await resolveStandaloneSeed("github", path, {});
+    expect(repoNames(resolved.seedState)).toEqual(["vakoi/billing"]);
+  });
+
+  // The one that was silently wrong: slack's seed schema is non-strict, so it
+  // ACCEPTED the envelope above as its own flat seed, defaulted every field,
+  // and served an empty workspace while the boot line said the seed had landed.
+  it("gives slack the slack entry, not an empty workspace defaulted from the envelope", async () => {
+    const path = await seedFile(
+      JSON.stringify({ github: FLAT, slack: { channels: [{ id: "C1", name: "eng-alerts" }] } }),
+    );
+    const resolved = await resolveStandaloneSeed("slack", path, {});
+    const seed = resolved.seedState as { channels: { name: string }[] };
+    expect(seed.channels.map((c) => c.name)).toEqual(["eng-alerts"]);
+  });
+
+  it("refuses by name when the envelope has no entry for the twin being started", async () => {
+    const path = await seedFile(JSON.stringify({ slack: { channels: [] } }));
+    await expect(resolveStandaloneSeed("github", path, {})).rejects.toThrow(
+      /declares no github seed \(it names slack\)/,
+    );
   });
 });

--- a/llms.txt
+++ b/llms.txt
@@ -27,4 +27,5 @@
 
 - Run an agent task with no install: `npx @pome-sh/cli init && npx @pome-sh/cli run --local tasks/01-bug-happy-path.md`
 - Start a standalone twin: `npx @pome-sh/cli twin start github`
+- Start one from your own world: `npx @pome-sh/cli twin seed github --out seed.json` then `npx @pome-sh/cli twin start --seed seed.json`. The seed file is `{ "<twin>": { … } }`, one twin or several, and it REPLACES the twin's default state rather than merging into it. The same file seeds a hosted sandbox via `pome sandbox create --seed`.
 - The hosted platform (hosted twins, grading, observability): https://pome.sh


### PR DESCRIPTION
## What this fixes

Every documented seed example was correct the day it merged. Three of the five had since stopped parsing against their own twin's schema, measured against `main`:

```
github   REFUSED  ->  repositories.0.owner: expected string, received undefined
gmail    REFUSED  ->  primaryMailbox: expected object, received string
linear   REFUSED  ->  issues.0.assignee: expected string, received null
slack    parses
stripe   parses
```

Copy one and the hosted path answers `503 Failed to spawn twin pod` after twelve seconds (F-1688), so the first thing a new user does produces an error that blames us.

A CI gate that parses the examples is the second line and lands with the docs. **This PR is the first line: a starter nobody types.**

## Two defects found in our own library while measuring

Both are fixed here and both have a test.

1. **Twelve of the twenty `<task>.seed.json` files under `agent-examples/` are already envelopes** (`{ github: …, slack: … }` — the two `minimal-viktor` families). `pome twin start github --seed <one of them>` failed on `repositories: expected array, received undefined`. The ticket's premise that "every `<task>.seed.json` in the library is flat" was not right.

2. **`pome twin start slack --seed <the same file>` succeeded — and served an empty workspace.** slack's and stripe's seed schemas are non-strict, so they accepted the envelope as their own flat seed and defaulted every field, while the boot line printed `World: seeded from <path>.`

   ```
   declared in the file : channels = [eng-alerts]
   what the twin served : channels = []
   ```

   This is the `if (!owner) continue;` shape the ticket calls out in `vercel-labs/emulate`, happening in our own CLI. A file naming a twin the command was not asked for is now refused by name.

## What ships

| | |
|---|---|
| `pome twin seed <name...>` | **new.** Prints a starter seed file built from the twin's own `defaultSeed()` and normalised by its own `parseSeed`. `--out <path>` writes it and refuses to overwrite. |
| `pome sandbox create --seed <path>` | **new.** Same file. Parses with the twin's own parser *before* the round trip, so a bad seed is refused instantly with the field named rather than as a 503 twelve seconds later. |
| `pome twin start --seed <path>` | now takes the envelope as well as the flat shape. `<name>` is optional when the envelope names exactly one twin. |
| `cli/src/twin/seedFile.ts` | **new.** The one seed-file door: parse, strip `_meta`, decide the shape, hand each part to its twin. |

One file shape, one twin or five:

```json
{ "github": { "repositories": [ … ] },
  "slack":  { "channels":     [ … ] } }
```

**The wire does not move.** `POME_SEED_JSON` stays flat, `POST /v1/sessions` keeps its envelope-iff-multi-twin rule, and `cli/src/contract/seed-envelope.ts` is untouched — the CLI unwraps, so a one-twin sandbox seeded from an envelope still sends the flat seed. There is an explicit test for that.

## Naming: `seed`, not `world`

The ticket, and my first proposal, called this a *world file*. Measured against both reference points before committing to it:

- **`vercel-labs/emulate`** @ `d0219d0` — `seed` appears 36 times in the README, `world` 3 times and all three are `hello-world`, a repo name. Flag is `--seed`, option is `seed`, `reset()` is "wipe the store and replay seed data". File shape is the per-service envelope.
- **Arga Labs** (`argalabs.com`, direct competitor, same "digital twins" noun) — the API field for exactly this object is **`seed_config`**, shaped as the per-twin envelope alongside a `twins[]` array. `world` appears zero times across their docs index.

We already say `seed` in `POME_SEED_JSON`, `POST /v1/sessions`.seed, `--seed`, `compile-seeds`, `<task>.seed.json`, `parseSeed`, `defaultSeedState` and `/admin/seed`. A user-facing `world` would be a second name for one object — the `session`/`sandbox` split again. So the boot line moves from `World:` to `Seed:` and states the thing `world` was reaching for instead of implying it:

```
Seed: ./seed.json (replaces the github twin's default).
```

⚠️ **A seed replaces; it does not merge.** Emulate merges — `packages/emulate/src/api.ts:76-81` runs the plugin's own default seed unconditionally and then layers your config on top — so a reader arriving from there will assume wrong. Now said out loud in the boot line, in both `--help` strings, in the README and in `llms.txt`.

## One correction to the ticket

> `emulate init --service github` assembles its starter file from each service's `initConfig` held in the registry, so the starter cannot drift from the code — it *is* the code.

It is not. `initConfig` is a hand-written literal in `packages/emulate/src/registry.ts` typed `Record<string, unknown>`, with no schema binding, and `grep -rn initConfig` across their repo returns **no test**. It is also not their default world: `seedDefaults()` gives you `ghost` + `admin` and no repos, `initConfig` gives you `octocat/hello-world`. Two hand-written worlds.

Deriving from `defaultSeed()` and asserting the round trip, as this PR does, is strictly stronger than the thing it was modelled on.

## Reviewer notes

- **The shape rule is decided from the top-level keys and nothing else.** That is only unambiguous while no twin's seed schema declares a field named after a twin. `TWIN_REGISTRY` gains `seedFields()`, read off each twin's own zod object, and `seedFile.test.ts` asserts the disjointness for all five — so it goes red before anyone finds out from a silently-empty world.
- **`defaultSeed()` now answers for every twin.** github's entry returned `undefined` and left `boot` to reach for `defaultSeedState()` itself, which made "what does this twin start with" unanswerable without booting one. `boot` still applies its own default when handed `undefined`, so that path is unchanged. slack's and stripe's defaults also move from the package root to the `./seed` leaf, which is the lazy-chunk-safe path the registry header already prescribes.
- **`--twin` on `sandbox create` is no longer a `requiredOption`.** Commander rejects before the action runs, and a one-twin envelope makes the flag redundant. The check moved into `runSessionCreate` and fails with the same `No twin specified` sentence; verified by hand that `pome sandbox create` with no arguments still exits 2 before touching credentials.
- **No second seed parser.** `seedFile.ts` decides which *bytes* belong to which twin. Every validity question still goes to `TWIN_REGISTRY[twin].parseSeed`, the same function the twin runs inside `loadSeedFromEnv`.
- The generated output is `parseSeed`'s own, so it declares only fields the schema declares and carries no `_meta` — it survives F-1689 tightening those schemas by construction, and there is a fixed-point test saying so.

## Tests

TDD, red first. 78 new assertions across four files plus the e2e round trip:

- `cli/test/unit/twin/seedFile.test.ts` — shape detection, `_meta` on both shapes, mixed-vocabulary refusal, the not-asked-for refusal, the non-strict-twin regression, and the schema-derived no-collision proof.
- `cli/test/unit/twin/twinSeed.test.ts` — generate → `--seed` accepts it, for all five twins; envelope shape; determinism; fixed point; overwrite refusal.
- `cli/test/unit/session-seed.test.ts` — which shape reaches the wire, per THE RULE; `--twin` optional; refusals before the round trip.
- `cli/test/e2e/twinSeedRoundTrip.test.ts` — for each of the five twins, as real child processes: `twin seed --out` → `twin start --seed` with `<name>` omitted → `GET /_pome/state` reports what the file declares. Every expected value is read out of the generated file, never typed in the test.

## CI / gates run locally

| | |
|---|---|
| `npx vitest run` | 340 files, **3785 passed** |
| `npm run typecheck` | clean, all workspaces |
| `npm run lint` | 17 rules pass, incl. `twin-chunks` and `first-party-twins` |
| `npm run lint:dead-code` (knip) | clean |
| `npm run test:contract` | 115 tests, 0 fail |
| `npm run gate:golden` | 8 passed |
| `npm run build` | 11 packages |

## Not in this PR

The pome-cloud half, which is the other side of the ticket:

- the five `## Task seed shape` blocks on `apps/docs/docs/twins/*.mdx` replaced with `pome twin seed` output (github 84 lines, slack 91, stripe 16, gmail 138, linear 272);
- `apps/docs/docs/cli/twin.mdx`, which documents neither `--seed` (shipped in 0.27.0) nor `twin seed`;
- the always-on gate that parses every fenced seed example, and the marker that tells a seed block from the response bodies the quickstarts are full of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)