### PR TITLE
fix(contract): accept pass_threshold in a task ## Config block

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,6 +8,19 @@ allocates on `main` after the merge, in the same commit that moves
 write a version number here or in `package.json`. Released entries are insertions
 only: a correction is the next entry, naming the one it corrects.
 
+## Unreleased (patch)
+
+A task's `## Config` block now accepts `pass_threshold` as an alias for
+`passThreshold`. The manifest spells the same setting in snake_case, and
+`taskConfigSchema` is a non-strict object, so an authored `pass_threshold: 80`
+was silently stripped and the threshold fell back to the default `100` — the run
+then passed on evidence the author had ruled out. `passThreshold` remains
+canonical and wins when both spellings are present. Additive: no existing task
+changes meaning, and every consumer keeps reading `config.passThreshold`.
+
+New contract exports: `TASK_CONFIG_SNAKE_CASE_KEY_MAP` and
+`normalizeTaskConfigKeys`.
+
 ## 0.29.0 — 2026-08-26
 
 **A seed file a stranger can write.** One shape, generated rather than typed,

--- a/cli/src/contract/task.ts
+++ b/cli/src/contract/task.ts
@@ -48,14 +48,66 @@ import { seedStateSchema } from "./seed-state.js";
 export const taskClassSchema = z.enum(["conformance", "restraint", "adversarial"]);
 export type TaskClass = z.infer<typeof taskClassSchema>;
 
-export const taskConfigSchema = z.object({
-  twins: z.array(z.string()).default(["github"]),
-  class: taskClassSchema.optional(),                        // conformance vs the exam half
-  timeout: z.number().int().positive().default(60),         // seconds
-  runs: z.number().int().positive().default(1),
-  passThreshold: z.number().min(0).max(100).default(100),
-  judge: judgeModelSchema.default("claude-haiku-4-5"),       // CLI's BYOK config decides which endpoint serves this
-});
+/**
+ * snake_case spelling → canonical `## Config` key, for the keys a user hand-authors.
+ *
+ * The manifest (`./manifest.ts`) is snake_case — `pass_threshold`, `artifacts_dir` —
+ * and snake_case is what the published JSON Schema at `pome.sh/schemas/v1/pome.json`
+ * teaches. A task's `## Config` block is camelCase. Both files are written by hand,
+ * often in the same sitting, so the same word arriving in the other casing is not a
+ * typo to punish: `taskConfigSchema` is a non-strict `z.object`, so before this map
+ * existed an authored `pass_threshold: 80` was silently STRIPPED and the threshold
+ * fell back to the default 100 — the run then passed on evidence the author had
+ * explicitly said was not enough.
+ *
+ * Additive and permanent, the same shape `sandbox`/`session` took: camelCase stays
+ * canonical, and every consumer keeps reading `config.passThreshold`.
+ *
+ * Only keys with more than one word can disagree about casing, which today is
+ * exactly one. `twins`, `class`, `timeout`, `runs` and `judge` have nothing to
+ * alias.
+ */
+export const TASK_CONFIG_SNAKE_CASE_KEY_MAP = {
+  pass_threshold: "passThreshold",
+} as const;
+
+/**
+ * Rename a snake_case `## Config` key to its canonical camelCase name on a raw
+ * config object. Non-objects pass through untouched, so the wrapped schema still
+ * reports the real type error.
+ *
+ * When BOTH spellings are present the canonical one wins and the alias is dropped
+ * — the same precedence `normalizeTaskVocabKeys` uses, and for the same reason: a
+ * writer that knows the canonical key is the more authoritative of the two.
+ */
+export function normalizeTaskConfigKeys(value: unknown): unknown {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return value;
+  }
+  const record = value as Record<string, unknown>;
+  let out: Record<string, unknown> | null = null;
+  for (const [aliasKey, canonicalKey] of Object.entries(TASK_CONFIG_SNAKE_CASE_KEY_MAP)) {
+    if (!(aliasKey in record)) continue;
+    out ??= { ...record };
+    if (!(canonicalKey in record)) {
+      out[canonicalKey] = record[aliasKey];
+    }
+    delete out[aliasKey];
+  }
+  return out ?? value;
+}
+
+export const taskConfigSchema = z.preprocess(
+  normalizeTaskConfigKeys,
+  z.object({
+    twins: z.array(z.string()).default(["github"]),
+    class: taskClassSchema.optional(),                        // conformance vs the exam half
+    timeout: z.number().int().positive().default(60),         // seconds
+    runs: z.number().int().positive().default(1),
+    passThreshold: z.number().min(0).max(100).default(100),
+    judge: judgeModelSchema.default("claude-haiku-4-5"),       // CLI's BYOK config decides which endpoint serves this
+  }),
+);
 export type TaskConfig = z.infer<typeof taskConfigSchema>;
 
 /** @deprecated Use `taskConfigSchema`. Removed after the 0.3.0 window. */

--- a/cli/src/task/taskSchema.ts
+++ b/cli/src/task/taskSchema.ts
@@ -9,7 +9,7 @@ import { linearSeedSchema as linearSeedStateSchema } from "@pome-sh/twin-linear/
 // (legacy `D`/`P` enum values) exists only for 0.3.0-era persisted artifacts,
 // never for scenario markdown. The former local criterion-kind fork is
 // retired here (M6 — one published contract).
-import { criterionSchema } from "../contract/index.js";
+import { criterionSchema, normalizeTaskConfigKeys } from "../contract/index.js";
 import { z } from "zod";
 
 export { criterionSchema };
@@ -42,13 +42,22 @@ export const taskCriterionSchema = criterionSchema.extend({
 // optional here but mandatory for the tasks THIS repo ships.
 export const taskClassSchema = z.enum(["conformance", "restraint", "adversarial"]);
 
-export const taskConfigSchema = z.object({
-  twins: z.array(z.string()).default(["github"]),
-  class: taskClassSchema.optional(),
-  timeout: z.number().int().positive().default(60),
-  runs: z.number().int().positive().default(1),
-  passThreshold: z.number().min(0).max(100).default(100)
-});
+// The snake_case alias for `passThreshold` comes from the published contract
+// (`normalizeTaskConfigKeys`, ../contract/task.ts) rather than being re-declared
+// here. This parser's config schema and the contract's are two schemas — the
+// contract carries `judge`, this one does not — but which spellings a hand-authored
+// `## Config` block may use is one fact, and a parser that knew fewer of them than
+// the contract would silently strip the key the contract accepts.
+export const taskConfigSchema = z.preprocess(
+  normalizeTaskConfigKeys,
+  z.object({
+    twins: z.array(z.string()).default(["github"]),
+    class: taskClassSchema.optional(),
+    timeout: z.number().int().positive().default(60),
+    runs: z.number().int().positive().default(1),
+    passThreshold: z.number().min(0).max(100).default(100)
+  })
+);
 
 // Scenario-level failure injection. Mirrors the packaged
 // twin-stripe `failureInjectionRuleSchema` without importing it into the

--- a/cli/test/unit/parseTask.test.ts
+++ b/cli/test/unit/parseTask.test.ts
@@ -63,6 +63,28 @@ passThreshold: 75
     expect(asGithub(scenario.seedState).repositories[0]?.labels?.[0]?.name).toBe("bug");
   });
 
+  // F-1681 — the manifest spells this key `pass_threshold`; a `## Config` block
+  // spells it `passThreshold`. `taskConfigSchema` is non-strict, so before the
+  // alias an authored `pass_threshold: 80` was stripped and the threshold fell
+  // back to 100 — the run then passed on evidence the author had ruled out.
+  it("honours a snake_case pass_threshold in the config block", () => {
+    const scenario = parseTask(`# Demo
+
+## Prompt
+Triage issue #1.
+
+## Success Criteria
+- [code] Issue #1 has the \`bug\` label applied
+
+## Config
+\`\`\`yaml
+pass_threshold: 80
+\`\`\`
+`);
+
+    expect(scenario.config.passThreshold).toBe(80);
+  });
+
   it("rejects scenarios without a prompt", () => {
     expect(() =>
       parseTask(`# Demo

--- a/cli/test/unit/wire/export-surface.test.ts
+++ b/cli/test/unit/wire/export-surface.test.ts
@@ -140,6 +140,8 @@ const EXPECTED_EXPORTS = [
   "MOUNTED_TWINS",
   "SLUG_MAX_LENGTH",
   "SLUG_RE",
+  // snake_case aliases accepted in a task `## Config` block (F-1681).
+  "TASK_CONFIG_SNAKE_CASE_KEY_MAP",
   "acceptInviteRequestSchema",
   "acceptInviteResponseSchema",
   "agentResponseSchema",
@@ -182,6 +184,7 @@ const EXPECTED_EXPORTS = [
   "manifestAgentSchema",
   "manifestSchema",
   "meResponseSchema",
+  "normalizeTaskConfigKeys",
   "normalizeTaskVocabKeys",
   "perTwinStateKeysSchema",
   "persistedScenarioSchema",

--- a/cli/test/unit/wire/task-vocab.test.ts
+++ b/cli/test/unit/wire/task-vocab.test.ts
@@ -7,6 +7,10 @@ import {
   normalizeTaskVocabKeys,
 } from "../../../src/contract/task-vocab.js";
 import {
+  TASK_CONFIG_SNAKE_CASE_KEY_MAP,
+  normalizeTaskConfigKeys,
+} from "../../../src/contract/task.js";
+import {
   CRITERION_KINDS,
   criterionKindSchema,
   criterionResultSchema,
@@ -369,5 +373,55 @@ describe("task*/scenario* export aliases", () => {
     });
     expect(parsed.criteria.map((c) => c.type)).toEqual(["code", "model"]);
     expect(parsed.config.judge).toBe("claude-haiku-4-5");
+  });
+});
+
+// ─── snake_case aliases in a task `## Config` block (F-1681) ─────────────────
+
+describe("normalizeTaskConfigKeys", () => {
+  it("renames every aliased key to its canonical spelling", () => {
+    for (const [alias, canonical] of Object.entries(TASK_CONFIG_SNAKE_CASE_KEY_MAP)) {
+      const out = normalizeTaskConfigKeys({ [alias]: 42 }) as Record<string, unknown>;
+      expect(out[canonical]).toBe(42);
+      expect(alias in out).toBe(false);
+    }
+  });
+
+  it("lets the canonical key win when both spellings are present", () => {
+    const out = normalizeTaskConfigKeys({
+      passThreshold: 80,
+      pass_threshold: 30,
+    }) as Record<string, unknown>;
+    expect(out.passThreshold).toBe(80);
+    expect("pass_threshold" in out).toBe(false);
+  });
+
+  it("passes non-objects through so the wrapped schema reports the type error", () => {
+    expect(normalizeTaskConfigKeys("nope")).toBe("nope");
+    expect(normalizeTaskConfigKeys(null)).toBe(null);
+    expect(normalizeTaskConfigKeys([1, 2])).toEqual([1, 2]);
+  });
+
+  it("returns the input untouched when it carries no alias", () => {
+    const input = { passThreshold: 55 };
+    expect(normalizeTaskConfigKeys(input)).toBe(input);
+  });
+});
+
+describe("taskConfigSchema snake_case alias", () => {
+  it("honours an authored pass_threshold instead of silently defaulting to 100", () => {
+    expect(taskConfigSchema.parse({ pass_threshold: 80 }).passThreshold).toBe(80);
+  });
+
+  it("still validates the aliased value — 101 is out of range under either spelling", () => {
+    expect(() => taskConfigSchema.parse({ pass_threshold: 101 })).toThrow();
+    expect(() => taskConfigSchema.parse({ passThreshold: 101 })).toThrow();
+  });
+
+  it("leaves the camelCase spelling and the other config keys working", () => {
+    const config = taskConfigSchema.parse({ passThreshold: 75, timeout: 12, runs: 3 });
+    expect(config.passThreshold).toBe(75);
+    expect(config.timeout).toBe(12);
+    expect(config.runs).toBe(3);
   });
 });

--- a/skills/pome-author-task/references/task-format.md
+++ b/skills/pome-author-task/references/task-format.md
@@ -162,9 +162,14 @@ YAML). Keys and defaults:
 | `twins` | array of twin ids | *(required)* | The twins mounted for the session. Available twins today: `github`, `slack`, `stripe`, `gmail`, `linear`. Must list at least one — there is no default, because the seed schema is chosen from this key alone. Order matters: `twins[0]` is the primary twin. |
 | `timeout` | integer | `60` | Seconds; must be a positive integer. |
 | `runs` | integer | `1` | Trials per run-set; must be a positive integer. |
-| `passThreshold` | number | `100` | Percent of runs that must pass; `0`–`100`. |
+| `passThreshold` | number | `100` | Percent of runs that must pass; `0`–`100`. Also accepted as `pass_threshold`, the spelling `pome.json` uses. |
 
-Unknown config keys are silently stripped, not rejected. `## Config` is
+Unknown config keys are silently stripped, not rejected. That is why
+`pass_threshold` is accepted here as an alias for `passThreshold`: the manifest
+spells the same setting in snake_case, so an author moving between the two files
+used to have `pass_threshold: 80` stripped and the threshold fall back to `100`
+— the run then passed on evidence they had explicitly ruled out. Write either
+spelling; when both appear, `passThreshold` wins. `## Config` is
 therefore mandatory: `twins` has no default, so a task with no config section
 fails validation with `config.twins must list at least one twin`.
 


### PR DESCRIPTION
## Summary 

- `pass_threshold` in a task `## Config` block is now honoured instead of silently stripped, which used to reset the threshold to the default 100.
- camelCase stays canonical and wins when both spellings appear; one alias map in the contract feeds both config schemas.
- Tests perturbed red-then-green; `task-format.md` documents the alias.
