### PR TITLE
pome install's retirement message ends at a documented step (F-1683)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,6 +8,19 @@ allocates on `main` after the merge, in the same commit that moves
 write a version number here or in `package.json`. Released entries are insertions
 only: a correction is the next entry, naming the one it corrects.
 
+## Unreleased (patch)
+
+`pome install` is retired, and its redirect message no longer ends at a step you
+cannot look up. It used to close with "the pome-intake / REST-launch preflight" —
+internal vocabulary for something that lives inside an installed skill and
+appears on no published page, which left a reader two commands they could run
+and a third step they could not find. The docs are gated against documenting
+retired commands, so this message is the only surface there is. It now names the
+two wiring commands, the `pome` skill that routes from there, the `pome register
+agent` / `pome doctor` equivalent for a local repo, and the two docs.pome.sh URLs
+that walk the rest. Behavior is unchanged: still registered, still tolerates the
+old flags, still exits 0.
+
 ## 0.29.1 — 2026-08-26
 
 A task's `## Config` block now accepts `pass_threshold` as an alias for

--- a/cli/src/cli/install.ts
+++ b/cli/src/cli/install.ts
@@ -5,36 +5,50 @@
 // `pome-setup` skill, staging the edits in a shadow copy and gating them behind
 // a terminal diff. `pome-setup` then became a redirect
 // tombstone — so the wiring no longer actually ran, it just injected a pointer.
-// This command is now a thin redirect to the Gen-2 path; the shadow-diff engine
-// (`embedded-wiring.ts`) and the Agent SDK provisioning (`agent-sdk.ts`) were
-// deleted with it.
+// This command is now a thin redirect to the current path; the shadow-diff
+// engine (`embedded-wiring.ts`) and the Agent SDK provisioning (`agent-sdk.ts`)
+// were deleted with it.
 //
-// Wiring your own agent to pome is now: connect the pome control MCP, install
-// the Gen-2 coach skill set, then run `pome-intake` (managed agents) or the
-// coach's REST-launch preflight (self-hosted REST agents).
+// The message below is the only user-facing surface for the retirement:
+// `scripts/check-docs-retired-surface.ts` keeps docs.pome.sh from documenting
+// retired commands at all, so a reader who runs this one has nowhere else to
+// land. It therefore names only things they can then look up on docs.pome.sh.
+// It used to end at "the pome-intake / REST-launch preflight" — internal
+// vocabulary for a step that lives inside an installed skill
+// (`pome-run-task/references/launch-rest.md`) and appears on no published page,
+// which left the reader with two commands they could run and a third step they
+// could not find. "Gen-1"/"Gen-2" are ours too: the docs site never uses either.
 
-/** The Gen-2 wiring path `pome install` now points at. Printed to stderr,
- *  matching the rest of the CLI's informational output. */
-const GEN2_REDIRECT = [
-  "pome install (Gen-1 agent-driven wiring) is retired.",
+/** The wiring path `pome install` now points at. Printed to stderr, matching
+ *  the rest of the CLI's informational output.
+ *
+ *  Every step here is documented on docs.pome.sh, and
+ *  `install-command.test.ts` holds it that way: the skills it names are checked
+ *  against the `skills/` directory, and the internal terms it dropped are
+ *  asserted absent. */
+const RETIRED_REDIRECT = [
+  "pome install is retired. Wiring your agent to Pome is two commands:",
   "",
-  "Wire your own agent to pome the Gen-2 way:",
   "  1. claude mcp add --transport http pome https://mcp.pome.sh/mcp",
-  "                                           # connect the pome control MCP",
+  "                                           # connect the Pome MCP server",
   "  2. npx skills add pome-sh/digital-twins --skill '*'",
-  "                                           # install the Gen-2 coach skills",
+  "                                           # install the coach skills",
   "                                           # (--skill '*' takes all six; the",
   "                                           #  picker opens with none ticked)",
-  "  3. run the pome-intake skill to register the examinee and check twin",
-  "     coverage (self-hosted REST agent: use the coach's REST-launch preflight).",
   "",
-  "Already have pome.json? `pome register agent <name>` and `pome doctor` still apply.",
-  "See `pome docs getting-started`.",
+  "Then ask your agent to run the `pome` skill. It routes to `pome-intake`,",
+  "which registers the agent under test and checks twin coverage for it.",
+  "",
+  "Already have a repo with a pome.json? `pome register agent <name>` then",
+  "`pome doctor` is the same wiring from the CLI side.",
+  "",
+  "Walkthrough:      https://docs.pome.sh/quickstart/claude-code",
+  "Your own agent:   https://docs.pome.sh/existing-agent",
 ];
 
-/** Print the Gen-2 wiring path. Exported for the `pome install` command and its
- *  unit test. Never errors — a retired command should land the user on the
+/** Print the current wiring path. Exported for the `pome install` command and
+ *  its unit test. Never errors — a retired command should land the user on the
  *  right path, not exit non-zero. */
 export function runInstall(): void {
-  for (const line of GEN2_REDIRECT) console.error(line);
+  for (const line of RETIRED_REDIRECT) console.error(line);
 }

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -278,14 +278,14 @@ export function createProgram() {
 
   program
     .command("install")
-    // The Gen-1 agent-driven wiring is retired; this is a redirect to
-    // the Gen-2 path. allowUnknownOption + allowExcessArguments keep old
+    // The Gen-1 agent-driven wiring is retired; this is a redirect to the
+    // current path. allowUnknownOption + allowExcessArguments keep old
     // invocations (`pome install --interactive`, `--api-url …`) landing on the
     // redirect instead of erroring on a now-removed flag or stray operand.
     .allowUnknownOption()
     .allowExcessArguments()
     .description(
-      "Retired. Prints the Gen-2 wiring path: `claude mcp add … pome` + `npx skills add pome-sh/digital-twins --skill '*'`, then the pome-intake / REST-launch preflight.",
+      "Retired. Prints the wiring path it was replaced by: `claude mcp add … pome` + `npx skills add pome-sh/digital-twins --skill '*'`, then the `pome` skill, and the docs URL that walks the rest.",
     )
     .action(async () => {
       const { runInstall } = await import("./install.js");

--- a/cli/test/unit/install-command.test.ts
+++ b/cli/test/unit/install-command.test.ts
@@ -1,10 +1,32 @@
 // SPDX-License-Identifier: Apache-2.0
-// `pome install` is retired to a redirect.
+// `pome install` is retired to a redirect, and that redirect is the ONLY
+// user-facing account of the retirement — the docs gate in pome-cloud
+// (`scripts/check-docs-retired-surface.ts`) keeps docs.pome.sh from documenting
+// retired commands, so there is no page to fall back to. It used to end at "the
+// pome-intake / REST-launch preflight": two runnable commands, then a step named
+// in our vocabulary that no published page defines (F-1683).
+//
+// So the assertions below are about lookup-ability, not wording. Every skill the
+// message names is checked against the `skills/` directory rather than spelled
+// twice, and the internal terms are asserted absent by name.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { runInstall } from "../../src/cli/install.js";
 import { createProgram } from "../../src/cli/main.js";
+
+const REPO_ROOT = join(fileURLToPath(new URL(".", import.meta.url)), "../../..");
+
+/** The skills `npx skills add` actually installs, read from the source of truth
+ *  in this repo. Naming one that is not here is the defect this catches. */
+function installedSkills(): string[] {
+  return readdirSync(join(REPO_ROOT, "skills"), { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+}
 
 describe("pome install", () => {
   let errSpy: ReturnType<typeof vi.spyOn>;
@@ -23,28 +45,57 @@ describe("pome install", () => {
     return errSpy.mock.calls.map((c: unknown[]) => String(c[0])).join("\n");
   }
 
-  it("prints the Gen-2 wiring path and exits 0", () => {
+  it("prints the wiring path that replaced it, and exits 0", () => {
     runInstall();
 
     const out = captured();
     expect(out).toContain("retired");
-    // Both Gen-2 install steps are named.
+    // Both install steps are named.
     expect(out).toContain("claude mcp add --transport http pome https://mcp.pome.sh/mcp");
     // The bare form drops the reader on a picker with nothing ticked and
     // the coach only works as a set, so the install-all flag is part of the copy.
     expect(out).toContain("npx skills add pome-sh/digital-twins --skill '*'");
-    // Points at the intake / REST-launch preflight as the next step.
-    expect(out).toContain("pome-intake");
     // A retired command lands the user on the right path — never a non-zero exit.
     expect(process.exitCode).toBeUndefined();
   });
 
-  it("does not advertise the removed Gen-1 flow", () => {
+  it("names a step after the two commands, and only skills that exist", () => {
+    runInstall();
+
+    // A backticked token with no space in it is a skill name; `pome doctor` and
+    // `pome register agent <name>` are commands and are excluded by the space.
+    const named = [...captured().matchAll(/`(pome(?:-[a-z]+)*)`/g)].map((m) => m[1]!);
+    const skills = installedSkills();
+
+    expect(named.length).toBeGreaterThan(0);
+    for (const skill of new Set(named)) {
+      expect(skills, `${skill} is named but is not a skill in skills/`).toContain(skill);
+    }
+  });
+
+  it("ends somewhere the reader can look up", () => {
+    runInstall();
+
+    // The whole point of the rewrite: the last thing the message says is a URL
+    // that resolves, not a step only we have a name for.
+    const urls = [...captured().matchAll(/https:\/\/docs\.pome\.sh\/\S+/g)].map((m) => m[0]!);
+
+    expect(urls).toContain("https://docs.pome.sh/quickstart/claude-code");
+    expect(urls.length).toBeGreaterThan(0);
+  });
+
+  it("does not advertise the removed Gen-1 flow, or vocabulary the docs lack", () => {
     runInstall();
     const out = captured();
     expect(out).not.toContain("pome-setup");
     expect(out).not.toContain("headless");
     expect(out).not.toContain("approve the diff");
+    // Named, not a generic sweep: each of these was in the copy and is defined
+    // nowhere on docs.pome.sh. "Gen-1"/"Gen-2" included — the docs site has
+    // never used either, so a reader cannot place the generation they are in.
+    for (const internal of ["REST-launch", "preflight", "Gen-1", "Gen-2"]) {
+      expect(out, `${internal} is internal vocabulary`).not.toContain(internal);
+    }
   });
 
   it("runs from the CLI and tolerates the old flags", async () => {


### PR DESCRIPTION
- `pome install` is retired but still registered, and its message ended at "the pome-intake / REST-launch preflight" — our vocabulary for a step that lives inside an installed skill (`pome-run-task/references/launch-rest.md`) and appears on no published page. Since the docs are gated against documenting retired commands, this message is the only surface a reader gets, and it pointed into a gap.
- It now names the two wiring commands, the `pome` skill that routes onward, the `pome register agent` / `pome doctor` equivalent for a local repo, and two docs.pome.sh URLs (both verified 200). "Gen-1"/"Gen-2" dropped as well — the docs site has never used either. Behavior unchanged: still registered, still tolerates old flags, still exits 0.
- The test asserts lookup-ability, not wording: skill names in the copy are checked against the `skills/` directory, a `docs.pome.sh` URL must be present, and the internal terms are asserted absent. Each new assertion perturbed red and restored.