### PR TITLE
merge sandbox cmd / remove redundancy. fix exit codes

### DIFF
--- a/agent-examples/minimal-viktor/README.md
+++ b/agent-examples/minimal-viktor/README.md
@@ -150,7 +150,7 @@ out-of-band `--probe`/`--verify` helpers in `run-trials.ts`.
 ## Cleaning up a leaked sandbox
 
 If a `--probe` run is hard-killed mid-flight, delete any orphaned Slack sandbox
-(they don't show up in `pome session list`):
+(they don't show up in `pome sandbox list`):
 
 ```bash
 npx tsx scripts/run-trials.ts --cleanup <session_id> [<session_id> ...]

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,6 +8,31 @@ allocates on `main` after the merge, in the same commit that moves
 write a version number here or in `package.json`. Released entries are insertions
 only: a correction is the next entry, naming the one it corrects.
 
+## Unreleased (minor)
+
+**One spelling for the sandbox command** (F-1695). `pome sandbox` is the only
+name for it, and `pome sandbox stop` the only name for its third subcommand. The
+`session` and `kill` spellings are gone, along with the "session" wording in
+every line this command prints: `Sandbox: ses_…`, `Stopped sandbox ses_…`, `No
+sandboxes returned`, and the `--discard` refusal, which now tells you to type the
+command you actually have.
+
+`session_id`, `/v1/sessions` and the `ses_` id prefix are the wire and are
+untouched. This is the command a human types.
+
+**Two exit codes move onto the documented contract.** A `pome run` the doctor
+refuses now exits `5`, not `1`, and a `pome sandbox stop` refused for want of
+`--discard` exits `5`, not `2`. `1` means "scored below its pass threshold" and
+`2` means "twin or runner error"; neither had happened. A CI job branching on
+`$?` was reading a hardcoded production host as an agent regression.
+
+**`pome checks` finishes its sentence.** The description read "the closed set
+[code] criteria come from", which has no object. It is "the closed set a `[code]`
+criterion is graded by".
+
+**Minor, not patch:** a script typing `pome session` or `pome sandbox kill` stops
+working, and one branching on those two exit codes reads a different number.
+
 ## 0.30.0 — 2026-08-27
 
 Back-compat surfaces are removed rather than documented. There is nothing in the

--- a/cli/src/cli/login.ts
+++ b/cli/src/cli/login.ts
@@ -61,7 +61,7 @@ export async function loginWithClerk(options: LoginOptions): Promise<void> {
   }
 
   console.error("Pome login complete.");
-  console.error("Next: `pome session create --twin github` or `pome run <task>.md`");
+  console.error("Next: `pome sandbox create --twin github` or `pome run <task>.md`");
 }
 
 async function exchangeCode(input: {

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -374,7 +374,7 @@ export function createProgram() {
     .argument("[twin]", "Twin id (e.g. github). Omit to list twins that declare checks.")
     .option("--json", "Emit the declaration as JSON (for skills and agents).", false)
     .description(
-      "Browse the typed checks a twin declares — the closed set [code] criteria come from",
+      "Browse the typed checks a twin declares — the closed set a [code] criterion is graded by",
     )
     .action(async (twin: string | undefined, opts: { json: boolean }) => {
       await runChecksCommand(twin, { json: opts.json });
@@ -488,20 +488,21 @@ export function createProgram() {
       },
     );
 
-  // `sandbox` is the product noun (VOCABULARY.md); `session` is the
-  // spelling the CLI shipped with and every existing script types. Commander
-  // resolves both to this one command, so every subcommand, flag and line of
-  // output below is reachable under either without a second tree to drift.
+  // One spelling, and it is the product noun (VOCABULARY.md bans user-facing
+  // `session` outright). The `session` alias existed so scripts written against
+  // the CLI's first spelling kept working; there are no such scripts, and an
+  // alias a reader can meet in `--help` is a second name for one thing.
+  //
+  // `session_id`, `/v1/sessions` and the `ses_` prefix are the WIRE and stay.
   const session = program
-    .command("session")
-    .alias("sandbox")
+    .command("sandbox")
     .description(
-      "Hosted sandbox sessions (same API as the dashboard Twins page — requires login)",
+      "Hosted sandboxes (same API as the dashboard Twins page — requires login)",
     );
 
   session
     .command("create")
-    .description("Create a hosted sandbox session for one or more twins and print its connection info")
+    .description("Create a hosted sandbox for one or more twins and print its connection info")
     .option(
       "--twin <name>",
       // The enumeration is derived, never typed: this line is the public
@@ -516,7 +517,7 @@ export function createProgram() {
       // reject the invocation before the action runs, so the check moved into
       // `runSessionCreate`, which fails with the same "No twin specified"
       // sentence when neither source supplies one.
-      `${SESSION_TWIN_NAMES.join(" | ")}. Repeat the flag for a multi-twin session (e.g. --twin github --twin gmail). Optional when --seed names exactly one twin.`,
+      `${SESSION_TWIN_NAMES.join(" | ")}. Repeat the flag for a multi-twin sandbox (e.g. --twin github --twin gmail). Optional when --seed names exactly one twin.`,
       (value: string, previous: string[] = []) => [...previous, value],
     )
     .option(
@@ -568,7 +569,7 @@ export function createProgram() {
 
   session
     .command("list")
-    .description("List hosted sessions (defaults to --state running, like the dashboard)")
+    .description("List hosted sandboxes (defaults to --state running, like the dashboard)")
     .option(
       "--api-url <url>",
       "Control-plane URL",
@@ -613,9 +614,8 @@ export function createProgram() {
 
   session
     .command("stop")
-    .alias("kill")
-    .description("Stop a hosted session (aliased as `kill`)")
-    .argument("<session-id>", "Session id (ses_…)")
+    .description("Stop a hosted sandbox")
+    .argument("<session-id>", "Sandbox id (ses_…)")
     .option(
       "--api-url <url>",
       "Control-plane URL",
@@ -643,7 +643,7 @@ export function createProgram() {
           // so we don't print a duplicate (or bare blank) line here.
           const friendly = friendlyHostedError(err);
           if (friendly) console.error(friendly);
-          process.exitCode = 2;
+          process.exitCode = exitCodeFor(err);
         }
       },
     );
@@ -840,7 +840,11 @@ export function createProgram() {
             console.error(
               "pome run: wiring check failed — refusing to spawn the agent. Fix the cause above and re-run (there is no --force).",
             );
-            process.exitCode = 1;
+            // 5 = usage error, per docs/05-api-spec.md §1. NOT 1: that code
+            // means "scored below its pass threshold", and nothing ran here —
+            // a CI job branching on $? would read a hardcoded production host
+            // as an agent regression.
+            process.exitCode = 5;
             return;
           }
         }

--- a/cli/src/cli/session.ts
+++ b/cli/src/cli/session.ts
@@ -80,7 +80,7 @@ function redactSession(res: CreateSessionResponse): Record<string, unknown> {
 
 function formatEnvExport(res: CreateSessionResponse, twins: string[]): string {
   const lines: string[] = [
-    `# Pome hosted session — treat as secret. Twins: ${twins.join(", ")}`,
+    `# Pome hosted sandbox — treat as secret. Twins: ${twins.join(", ")}`,
     `export POME_AUTH_TOKEN=${JSON.stringify(res.agent_token)}`,
     `export POME_SESSION_ID=${JSON.stringify(res.session_id)}`,
     // Legacy single-endpoint URL (= the primary twin's api_url). Kept for
@@ -231,7 +231,7 @@ export async function runSessionCreate(opts: {
 
   if (opts.secretsFile) {
     await writeSecretsFile(opts.secretsFile, formatEnvExport(session, twins));
-    console.error(`Wrote session secrets to ${opts.secretsFile} (mode 0600).`);
+    console.error(`Wrote sandbox secrets to ${opts.secretsFile} (mode 0600).`);
   }
 
   if (opts.format === "json") {
@@ -251,7 +251,7 @@ export async function runSessionCreate(opts: {
     return;
   }
 
-  console.error(`Session: ${session.session_id}`);
+  console.error(`Sandbox: ${session.session_id}`);
   console.error(`Expires: ${session.expires_at}`);
   // Same reason the standalone twin prints a Seed line: once it is running,
   // every seeded twin looks seeded.
@@ -345,7 +345,7 @@ export async function runSessionList(opts: {
   }
   if (rows.length === 0) {
     const scope = opts.state === "all" ? "any" : `state=${opts.state}`;
-    console.error(`No sessions returned (${scope}).`);
+    console.error(`No sandboxes returned (${scope}).`);
     return;
   }
   for (const r of rows) {
@@ -383,12 +383,12 @@ export async function runSessionStop(opts: {
       console.error(`  Open for ${err.openSeconds}s.`);
       console.error(
         `  To keep the run, finalize it instead. To discard it anyway: ` +
-          `pome session stop ${err.sessionId} --discard`,
+          `pome sandbox stop ${err.sessionId} --discard`,
       );
     }
     throw err;
   }
-  console.error(`Stopped session ${opts.sessionId}.`);
+  console.error(`Stopped sandbox ${opts.sessionId}.`);
 }
 
 /** Empty string means "already fully reported — print nothing more". Only

--- a/cli/src/hosted/errors.ts
+++ b/cli/src/hosted/errors.ts
@@ -111,5 +111,9 @@ export function exitCodeFor(err: unknown): number {
   if (err instanceof HostedAuthError) return 3;
   if (err instanceof HostedQuotaError) return 4;
   if (err instanceof HostedUsageError) return 5;
+  // A refused discard is a usage error, not a twin/orch failure: nothing is
+  // broken, the invocation was missing `--discard`. Mapped here rather than at
+  // the one call site so every caller of this mapper agrees on it.
+  if (err instanceof HostedDiscardRefusedError) return 5;
   return 2;
 }

--- a/cli/src/runner/runTaskHosted.ts
+++ b/cli/src/runner/runTaskHosted.ts
@@ -118,7 +118,7 @@ export interface RunTaskHostedResult {
  * host-rewrites api.pome.sh→mcp.pome.sh with NO `/mcp` suffix. Trusting it would
  * drift POME_*_MCP_URL off main's `${twin_url}/mcp`. So for a synthesized entry
  * we construct `${api_url}/mcp`; only a cloud-returned value gets ensureMcpSuffix
- * (the same normalization `pome session create` applies). */
+ * (the same normalization `pome sandbox create` applies). */
 export function buildAgentEnv(params: {
   session: CreateSessionResponse;
   twins: string[];

--- a/cli/test/unit/run-default-task.test.ts
+++ b/cli/test/unit/run-default-task.test.ts
@@ -297,7 +297,8 @@ describe("bare `pome run` glue", () => {
     process.chdir(dir);
     await run();
 
-    expect(process.exitCode).toBe(1);
+    // 5 = usage error, the code for an invocation that could not proceed.
+    expect(process.exitCode).toBe(5);
     const err = stderr.join("\n");
     expect(err).toContain("wiring check failed");
     expect(err).not.toContain(runYoursFrameLines()[0]);

--- a/cli/test/unit/run-doctor-gate.test.ts
+++ b/cli/test/unit/run-doctor-gate.test.ts
@@ -63,7 +63,10 @@ describe("pome run — doctor preflight gate", () => {
       "--no-capture",
     ]);
 
-    expect(process.exitCode).toBe(1);
+    // 5 = usage error. NOT 1: the documented table reserves 1 for "scored below
+    // its pass threshold", and nothing ran here — a CI job branching on $? would
+    // read a hardcoded production host as an agent regression.
+    expect(process.exitCode).toBe(5);
     const text = stderr.join("\n");
     expect(text).toContain("cause");
     expect(text).toContain("api.github.com");

--- a/cli/test/unit/sandbox-command.test.ts
+++ b/cli/test/unit/sandbox-command.test.ts
@@ -1,5 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
-// `pome sandbox` is an ALIAS of `pome session`, never a second command tree.
+// `pome sandbox` is the ONLY spelling of this command tree, and `stop` is the
+// only spelling of its third subcommand.
+//
+// Two halves, both load-bearing. The dispatch cases prove every subcommand still
+// reaches its runner with each flag intact. The absence cases pin that no command
+// anywhere answers to `session` or `kill`, because a command alias is the kind of
+// convenience that gets re-added by a reviewer being helpful, and
+// VOCABULARY.md bans user-facing `session` outright.
+//
+// `session_id`, `/v1/sessions` and the `ses_` prefix are the WIRE, and are a
+// different thing from a command name a human types.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Command } from "commander";
@@ -73,7 +83,7 @@ async function dispatch(
   return mocks[runner].mock.calls[0]!;
 }
 
-describe("`pome sandbox` aliases `pome session`", () => {
+describe("`pome sandbox` is the only spelling", () => {
   const originalExitCode = process.exitCode;
 
   beforeEach(() => {
@@ -91,10 +101,9 @@ describe("`pome sandbox` aliases `pome session`", () => {
     process.exitCode = originalExitCode;
   });
 
-  // Flags are carried on every case so a spelling that reached a *different*
-  // parser — its own command tree with drifted defaults — shows up as an
+  // Flags are carried on every case so a subcommand that lost one shows up as an
   // argument diff rather than passing on the bare form.
-  const CASES: Array<{ name: string; runner: Runner; argv: string[] }> = [
+  const CASES: Array<{ name: string; runner: Runner; argv: string[]; expect: unknown[] }> = [
     {
       name: "create",
       runner: "runSessionCreate",
@@ -109,61 +118,73 @@ describe("`pome sandbox` aliases `pome session`", () => {
         "--api-url",
         "https://api.example.test",
       ],
+      expect: [
+        expect.objectContaining({
+          twins: ["github", "gmail"],
+          format: "json",
+          apiBaseUrl: "https://api.example.test",
+        }),
+      ],
     },
     {
       name: "list",
       runner: "runSessionList",
       argv: ["list", "--state", "all", "--limit", "5", "--format", "json"],
+      expect: [expect.objectContaining({ state: "all", limit: 5, format: "json" })],
     },
     {
       name: "stop",
       runner: "runSessionStop",
       argv: ["stop", "ses_a", "--discard"],
-    },
-    // The `stop` → `kill` alias nests under the outer one; both spellings of
-    // both levels have to compose.
-    {
-      name: "stop's own `kill` alias",
-      runner: "runSessionStop",
-      argv: ["kill", "ses_a", "--discard"],
+      expect: [expect.objectContaining({ sessionId: "ses_a", discard: true })],
     },
   ];
 
-  for (const { name, runner, argv } of CASES) {
-    it(`sandbox ${name} calls the same runner with the same arguments as session ${name}`, async () => {
-      const viaSandbox = await dispatch("sandbox", runner, argv);
-      const viaSession = await dispatch("session", runner, argv);
-
-      expect(viaSandbox).toEqual(viaSession);
+  for (const { name, runner, argv, expect: expected } of CASES) {
+    it(`sandbox ${name} reaches its runner with every flag intact`, async () => {
+      const call = await dispatch("sandbox", runner, argv);
+      expect(call).toMatchObject(expected);
       expect(process.exitCode).toBeUndefined();
     });
   }
 
-  it("is one command object, not a second tree", () => {
-    const answering = program().commands.filter(
-      (cmd) =>
-        [cmd.name(), ...cmd.aliases()].includes("session") ||
-        [cmd.name(), ...cmd.aliases()].includes("sandbox"),
+  it("is one command, named for the product noun", () => {
+    const answering = program().commands.filter((cmd) =>
+      [cmd.name(), ...cmd.aliases()].includes("sandbox"),
     );
 
     expect(answering).toHaveLength(1);
-    expect(answering[0]!.name()).toBe("session");
-    expect(answering[0]!.aliases()).toContain("sandbox");
+    expect(answering[0]!.name()).toBe("sandbox");
+    expect(answering[0]!.aliases()).toEqual([]);
   });
 
-  it("`pome --help` lists the sandbox spelling", () => {
-    expect(helpFor("--help")).toContain("session|sandbox");
+  it("no command anywhere answers to `session` or `kill`", () => {
+    const spellings: string[] = [];
+    const walk = (cmd: Command): void => {
+      for (const sub of cmd.commands) {
+        spellings.push(sub.name(), ...sub.aliases());
+        walk(sub);
+      }
+    };
+    walk(program());
+
+    expect(spellings).not.toContain("session");
+    expect(spellings).not.toContain("kill");
   });
 
-  it("`pome sandbox --help` lists it, and is byte-identical to `pome session --help`", () => {
-    const viaSandbox = helpFor("sandbox", "--help");
+  it("`pome --help` shows one spelling, not two", () => {
+    const help = helpFor("--help");
 
-    expect(viaSandbox).toContain("session|sandbox");
-    expect(viaSandbox).toBe(helpFor("session", "--help"));
-    // Every subcommand is reachable under the alias, not just the ones the
-    // dispatch cases above happen to name.
+    expect(help).toContain("sandbox");
+    expect(help).not.toContain("session|sandbox");
+  });
+
+  it("`pome sandbox --help` reaches every subcommand", () => {
+    const help = helpFor("sandbox", "--help");
+
     for (const sub of ["create", "list", "stop"]) {
-      expect(viaSandbox).toContain(sub);
+      expect(help).toContain(sub);
     }
+    expect(help).not.toContain("kill");
   });
 });

--- a/cli/test/unit/sandbox-stop-flag.test.ts
+++ b/cli/test/unit/sandbox-stop-flag.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Pins `pome session stop`'s `--discard` flag wiring in cli/src/cli/main.ts.
+// Pins `pome sandbox stop`'s `--discard` flag wiring in cli/src/cli/main.ts.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -17,8 +17,9 @@ vi.mock("../../src/cli/session.js", async (importOriginal) => {
 });
 
 import { createProgram } from "../../src/cli/main.js";
+import { HostedDiscardRefusedError } from "../../src/hosted/errors.js";
 
-describe("pome session stop --discard wiring", () => {
+describe("pome sandbox stop --discard wiring", () => {
   const originalExitCode = process.exitCode;
 
   beforeEach(() => {
@@ -34,7 +35,7 @@ describe("pome session stop --discard wiring", () => {
   });
 
   async function run(...args: string[]): Promise<void> {
-    await createProgram().parseAsync(["node", "pome", "session", "stop", ...args]);
+    await createProgram().parseAsync(["node", "pome", "sandbox", "stop", ...args]);
   }
 
   it("defaults discard to false", async () => {
@@ -51,17 +52,16 @@ describe("pome session stop --discard wiring", () => {
     );
   });
 
-  it("the `kill` alias also wires --discard through", async () => {
-    await createProgram().parseAsync([
-      "node",
-      "pome",
-      "session",
-      "kill",
-      "ses_a",
-      "--discard",
-    ]);
-    expect(mocks.runSessionStop).toHaveBeenCalledWith(
-      expect.objectContaining({ sessionId: "ses_a", discard: true }),
+  it("a refused discard is a usage error, not a twin failure", async () => {
+    // Exit 5, not 2. Nothing is broken when the CLI refuses: the invocation was
+    // missing `--discard`. Exit 2 means "twin or runner error" in the documented
+    // table, and a CI job branching on $? would go looking for an outage.
+    mocks.runSessionStop.mockRejectedValueOnce(
+      new HostedDiscardRefusedError("refused", "ses_a", "running", "my-task", 42, "tok"),
     );
+
+    await run("ses_a");
+
+    expect(process.exitCode).toBe(5);
   });
 });

--- a/cli/test/unit/sandbox-twin-help.test.ts
+++ b/cli/test/unit/sandbox-twin-help.test.ts
@@ -56,11 +56,11 @@ function renderedHelp(...argv: string[]): string {
 /** The `--twin` option as declared, before help wrapping touches it. */
 function twinOption(): Option {
   const create = program()
-    .commands.find((cmd) => cmd.name() === "session")
+    .commands.find((cmd) => cmd.name() === "sandbox")
     ?.commands.find((cmd) => cmd.name() === "create");
-  if (!create) throw new Error("`session create` is no longer in the command tree");
+  if (!create) throw new Error("`sandbox create` is no longer in the command tree");
   const option = create.options.find((opt) => opt.long === "--twin");
-  if (!option) throw new Error("`session create` no longer declares --twin");
+  if (!option) throw new Error("`sandbox create` no longer declares --twin");
   return option;
 }
 

--- a/cli/test/unit/session.test.ts
+++ b/cli/test/unit/session.test.ts
@@ -305,7 +305,7 @@ describe("runSessionStop", () => {
     });
   });
 
-  it("prints 'Stopped session' when a confirmed discard succeeds", async () => {
+  it("prints 'Stopped sandbox' when a confirmed discard succeeds", async () => {
     // deleteSession resolving means the client already replayed the
     // discard_token and the second attempt landed a real 204/200 — the
     // ordinary success path, not a refusal.
@@ -322,7 +322,7 @@ describe("runSessionStop", () => {
       discard: true,
     });
     spy.mockRestore();
-    expect(errors.join("\n")).toContain("Stopped session ses_a");
+    expect(errors.join("\n")).toContain("Stopped sandbox ses_a");
   });
 
   it("prints the refusal naming the task and the keep-it path, and exits nonzero", async () => {


### PR DESCRIPTION
`pome --help` printed `session|sandbox`: Commander's primary name was `session`, the product noun was the alias. `VOCABULARY.md` bans user-facing `session` outright, and the 0.25.0 entry states why both existed — `session` is "what every existing script types", kept "working permanently". That is back-compat for scripts nobody has written, so it and `stop`'s `kill` alias are gone, along with the "session" wording in every line this command prints. The `--discard` refusal was the sharpest case: it told the reader to type a command `sandbox.mdx` is not allowed to print.

`session_id`, `/v1/sessions` and the `ses_` prefix are the wire and are untouched.

remove two hallucinated exit codes:
- A doctor-refused `pome run` exited `1` — reserved for "scored below its pass threshold" — so CI branching on `$?` read a hardcoded production host as an agent regression. 
- A `sandbox stop` refused for want of `--discard` exited `2`, "twin or runner error", with nothing broken. Both are usage errors and now exit `5`; the discard mapping went into `exitCodeFor` so every caller of the shared mapper agrees.

`pome checks` also advertised itself as "the closed set [code] criteria come from" — a sentence with no object.

Minor, not patch: a script typing `pome session` or `pome sandbox kill` stops working, and one branching on those two codes reads a different number.

The alias test inverts rather than being deleted — its dispatch half still proves every subcommand reaches its runner with each flag intact, its second half now pins the absence. Both absence cases were driven red by re-adding each alias in turn.