### PR TITLE
The task parser's slack and stripe seed mirrors name what the twin declares (F-1691)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,6 +8,57 @@ allocates on `main` after the merge, in the same commit that moves
 write a version number here or in `package.json`. Released entries are insertions
 only: a correction is the next entry, naming the one it corrects.
 
+## Unreleased (minor)
+
+**A slack task seed could not declare `emoji`, and a stripe one could not declare
+`refunds`.** Both are fields those twins' seed schemas have declared for
+releases. `cli/src/task/taskSchema.ts` keeps a LOCAL schema for slack and stripe
+— three of the five arms import the twin's own, but those two must be `.strict()`
+and the twins' schemas are not — and both local copies had drifted from the twin
+they mirror:
+
+```
+slack    mirror lacked `emoji`                          (in the twin since #190)
+stripe   mirror lacked `refunds`, `balance_transactions`
+         and carried five fields the twin's seed schema does not have:
+         `customers`, `products`, `prices`, `events`, `balances`
+```
+
+So `parseTask` refused a slack seed using `emoji` with `Unrecognized key`, and
+accepted a stripe seed declaring `customers` that the twin then silently
+dropped. This had already been fixed once, for `files` — that fixed the
+instance. The mirrors now name exactly the twin's fields, in the twin's order; the field
+types stay this module's own permissive ones, `.strict()` is unchanged, and
+`task-seed-mirror.test.ts` fails the next time either key set moves — field order
+included, because key order survives `parse()` and a mirror that lists the same
+fields in a different order makes a parsed seed and a generated one differ by
+nothing but that.
+
+⚠️ The comparison lives in the test rather than in `taskSchema.ts` because
+deriving it there is not available: `@pome-sh/twin-stripe/seed` statically
+imports `./domain/schema.js` for `applySeed`, so it is **not** the zod-only leaf
+`registry.ts`'s header and `twin-chunks.mjs`'s own advice both call it, and a
+static import from the task parser puts stripe's domain in the graph
+`pome --version` loads. The lint rule caught that attempt. A test file is not in
+that graph.
+
+The five removed stripe keys were used by no task in this repo. `.strict()` means
+a task that does declare one now fails to parse instead of losing it at boot.
+
+**`pome twin seed --for-task`** writes the same generated seed in the shape a
+`<task>.seed.json` sidecar takes: flat for a single-twin task, the per-twin
+envelope for a multi-twin one — the rule `parseTask` has followed since
+2026-05-12, read off the twin count rather than chosen. Without the flag you
+still get a seed file for `--seed`, which is always the envelope, because a file
+handed around on its own has to say which twin it is for. The two outputs are
+byte-identical from two twins up, and a test asserts that so the flag cannot
+become a second format.
+
+This closes a hole that predates the seed door: `pome compile-seeds` emits a
+sidecar only for a single-twin **github** task, so slack, stripe, gmail and
+linear task seeds have always been hand-written. That is the same standing
+invitation to drift that left three documented seed examples unable to boot.
+
 ## 0.31.0 — 2026-08-27
 
 **One spelling for the sandbox command** (F-1695). `pome sandbox` is the only

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -1330,10 +1330,14 @@ export function createProgram() {
     .command("seed")
     .argument("<name...>", `Twin name (${TWIN_NAME_LIST.join(" | ")}). Repeat for one file covering several.`)
     .option("--out <path>", "Write to this file instead of stdout. Refuses to overwrite.")
+    .option(
+      "--for-task",
+      "Emit the shape a `<task>.seed.json` sidecar takes — flat for one twin, the per-twin envelope for more, the rule the task's `## Config` twins already set. Without it you get a seed file for `--seed`, which is always the envelope.",
+    )
     .description(
       "Print a starter seed file for a twin, generated from the twin's own starting state",
     )
-    .action(async (names: string[], options: { out?: string }) => {
+    .action(async (names: string[], options: { out?: string; forTask?: boolean }) => {
       const { runTwinSeedCommand } = await import("../twin/twinSeed.js");
       await runTwinSeedCommand(names, options);
     });

--- a/cli/src/task/taskSchema.ts
+++ b/cli/src/task/taskSchema.ts
@@ -59,6 +59,32 @@ export const taskConfigSchema = z.preprocess(
   })
 );
 
+// ── THE SLACK AND STRIPE ARMS ARE HAND-WRITTEN MIRRORS, AND THEY DRIFT ──────
+//
+// Three of the five arms below import the twin's own schema and so cannot
+// drift. slack and stripe cannot: both must be `.strict()` and the twins'
+// schemas are not, and that strictness is load-bearing twice over — it makes the
+// legacy `{ <twin>: { seed: … } }` wrapper fail loudly instead of parsing to an
+// empty seed, and it stops the slack arm greedily matching a github or stripe
+// seed inside `seedStateSchema`'s union.
+//
+// Both had drifted, measured 2026-08-27. slack's had never carried `emoji` (in
+// the twin since #190), so a slack task seed using it was refused with
+// `Unrecognized key`. stripe's lacked `refunds` and `balance_transactions` while
+// carrying five fields the twin's seed schema does not have, so a task declaring
+// `customers` parsed clean here and was dropped at boot. It had been fixed once
+// before, for `files` (#432) — that fixed the instance.
+//
+// ⚠️ DERIVING THE KEY SET AT RUNTIME IS NOT AVAILABLE HERE. It was the first
+// fix, and `scripts/lint/rules/twin-chunks.mjs` refused it: `@pome-sh/twin-stripe/seed`
+// statically imports `./domain/schema.js` for `applySeed`, so it is NOT the
+// zod-only leaf `registry.ts`'s header and that rule's own advice both call it,
+// and a static import from this module puts stripe's domain in the graph
+// `pome --version` loads. So the field LISTS stay written out here, in the
+// TWIN's field order, and `cli/test/unit/task-seed-mirror.test.ts` is the gate:
+// it imports both twins and fails the moment either key set moves. Tests are not
+// in the CLI's runtime graph, so the derivation is free there.
+
 // Scenario-level failure injection. Mirrors the packaged
 // twin-stripe `failureInjectionRuleSchema` without importing it into the
 // parser, so scenario validation stays decoupled from twin boot/runtime code.
@@ -74,6 +100,11 @@ export const stripeFailureInjectionRuleSchema = z.object({
 // `.strict()` at the top level: unknown keys (notably the legacy
 // `stripe: { seed: ... }` wrapper) fail parsing loudly
 // instead of silently being stripped to an empty seed.
+//
+// `customers` / `products` / `prices` / `events` / `balances` used to be listed
+// here and are gone: the stripe twin's seed schema has never had them, so a task
+// declaring one parsed clean here and then reached a twin that dropped it. No
+// task in this repo used any of the five.
 export const stripeSeedStateSchema = z
   .object({
     api_keys: z
@@ -85,14 +116,11 @@ export const stripeSeedStateSchema = z
         })
       )
       .default([]),
-    customers: z.array(z.record(z.string(), z.unknown())).default([]),
-    products: z.array(z.record(z.string(), z.unknown())).default([]),
-    prices: z.array(z.record(z.string(), z.unknown())).default([]),
+    failure_injection: z.array(stripeFailureInjectionRuleSchema).default([]),
     payment_intents: z.array(z.record(z.string(), z.unknown())).default([]),
     charges: z.array(z.record(z.string(), z.unknown())).default([]),
-    events: z.array(z.record(z.string(), z.unknown())).default([]),
-    balances: z.array(z.record(z.string(), z.unknown())).default([]),
-    failure_injection: z.array(stripeFailureInjectionRuleSchema).default([])
+    refunds: z.array(z.record(z.string(), z.unknown())).default([]),
+    balance_transactions: z.array(z.record(z.string(), z.unknown())).default([])
   })
   .strict();
 
@@ -104,22 +132,21 @@ export const stripeSeedStateSchema = z
 // arm reject any object carrying a GitHub (`repositories`) or Stripe
 // (`api_keys`, `charges`, …) discriminator, so placing it FIRST in the union
 // (below) can't greedily mis-match a non-Slack seed.
+//
+// `files` and `emoji` are the reason the key set is derived. Both are fields the
+// twin declares; `files` was added by hand after a slack seed that used it
+// failed to parse (#432), and `emoji` never was — so it kept failing, for two
+// releases, with `Unrecognized key: "emoji"`.
 export const slackSeedStateSchema = z
   .object({
     team: z.record(z.string(), z.unknown()).optional(),
     users: z.array(z.record(z.string(), z.unknown())).default([]),
     channels: z.array(z.record(z.string(), z.unknown())).default([]),
-    // Permissive like its siblings — the vendored `parseSeed` does the
-    // regex-level validation. It has to be listed at all because `.strict()`
-    // REJECTS an unlisted key: without this line a slack seed declaring `files`
-    // fails to parse rather than being stripped.
-    files: z.array(z.record(z.string(), z.unknown())).default([])
+    files: z.array(z.record(z.string(), z.unknown())).default([]),
+    emoji: z.array(z.record(z.string(), z.unknown())).default([])
   })
   .strict();
 
-// [DECISION 2026-05-12]: scenario seeds are FLAT per twin.
-// GitHub scenarios use the GitHub seed shape (`{ repositories: [...] }`),
-// Stripe scenarios use the Stripe seed shape (`{ api_keys: [...], ... }`),
 // Slack scenarios use the Slack seed shape (`{ users, channels, ... }`).
 // Multi-twin scenarios are not a current requirement; the wrapped
 // `{ <twin>: { seed: ... } }` form was rejected here to keep one canonical

--- a/cli/src/twin/twinSeed.ts
+++ b/cli/src/twin/twinSeed.ts
@@ -20,8 +20,26 @@
 //   - It carries no `_meta`. A generated starter is a seed file, not a compiled
 //     task sidecar.
 //
-// The shape is always the per-twin envelope, one twin or five. Flat is still
-// ACCEPTED at every door (`seedFile.ts`); it is no longer produced.
+// TWO DESTINATIONS, ONE RULE EACH — and `--for-task` picks the destination, not
+// the shape.
+//
+//   a DOOR file (`twin start --seed`, `sandbox create --seed`) is always the
+//   per-twin envelope, one twin or five. It is handed around on its own, so it
+//   has to say which twin it is for, and it must not change shape the moment its
+//   author adds a second twin ([DECISION] on F-1685, 2026-08-26).
+//
+//   a SIDECAR (`<task>.seed.json`) is flat for one twin and the envelope for
+//   more, because the `<task>.md` beside it already names its twins in
+//   `## Config`. That is `parseTask`'s rule since 2026-05-12 and this does not
+//   change it — `--for-task` just emits what that rule asks for.
+//
+// So the two outputs are identical from two twins up, and `twinSeedForTask.test.ts`
+// asserts that convergence so `--for-task` cannot drift into a second format.
+//
+// The sidecar half closes a real hole: `pome compile-seeds` emits one only for a
+// single-twin GITHUB task, so slack, stripe, gmail and linear task seeds have
+// always been hand-written — the same standing invitation to drift that left
+// three documented examples unable to boot.
 
 import { writeFile } from "node:fs/promises";
 import { isTwinName, TWIN_NAMES, TWIN_REGISTRY, type TwinName } from "./registry.js";
@@ -33,7 +51,10 @@ import { isTwinName, TWIN_NAMES, TWIN_REGISTRY, type TwinName } from "./registry
  * docs page and a CI gate hold the generated content to equality rather than to
  * "looks about right".
  */
-export async function generateSeedFile(twins: readonly TwinName[]): Promise<string> {
+export async function generateSeedFile(
+  twins: readonly TwinName[],
+  opts: { forTask?: boolean } = {},
+): Promise<string> {
   if (twins.length === 0) {
     throw new Error(`No twin specified. Pass at least one of: ${TWIN_NAMES.join(", ")}.`);
   }
@@ -54,7 +75,10 @@ export async function generateSeedFile(twins: readonly TwinName[]): Promise<stri
     const entry = TWIN_REGISTRY[twin];
     envelope[twin] = await entry.parseSeed(await entry.defaultSeed());
   }
-  return `${JSON.stringify(envelope, null, 2)}\n`;
+  // The one place the two destinations differ. Everywhere else — two twins or
+  // five, door or sidecar — the bytes are the same.
+  const body = opts.forTask && twins.length === 1 ? envelope[twins[0]!] : envelope;
+  return `${JSON.stringify(body, null, 2)}\n`;
 }
 
 /** Write a generated seed file, refusing to overwrite. A file at this path is
@@ -77,9 +101,9 @@ export async function writeSeedFile(path: string, text: string): Promise<void> {
 
 export async function runTwinSeedCommand(
   names: string[],
-  options: { out?: string } = {},
+  options: { out?: string; forTask?: boolean } = {},
 ): Promise<void> {
-  const text = await generateSeedFile(names as TwinName[]);
+  const text = await generateSeedFile(names as TwinName[], { forTask: options.forTask });
   if (options.out === undefined) {
     process.stdout.write(text);
     return;
@@ -87,6 +111,11 @@ export async function runTwinSeedCommand(
   await writeSeedFile(options.out, text);
   // stderr, so `pome twin seed github --out seed.json` says what it did without
   // that line landing in a file when someone also redirects stdout.
-  console.error(`Wrote ${options.out} — the ${names.join(" + ")} starting seed.`);
-  console.error(`Boot it: pome twin start ${names[0]} --seed ${options.out}`);
+  const what = options.forTask ? "task seed" : "starting seed";
+  console.error(`Wrote ${options.out} — the ${names.join(" + ")} ${what}.`);
+  console.error(
+    options.forTask
+      ? `Put it next to a task whose \`## Config\` reads twins: [${names.join(", ")}], named <task>.seed.json.`
+      : `Boot it: pome twin start ${names[0]} --seed ${options.out}`,
+  );
 }

--- a/cli/test/unit/task-seed-mirror.test.ts
+++ b/cli/test/unit/task-seed-mirror.test.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// The task parser's slack and stripe seed schemas are LOCAL mirrors of the
+// twins', and this is the gate that stops them drifting.
+//
+// Three of the five arms in `taskSchema.ts` import the twin's own schema
+// (`githubSeedStateSchema`, `gmailSeedStateSchema`, `linearSeedStateSchema`) and
+// so cannot drift. slack and stripe are hand-written, because both are
+// `.strict()` and that strictness is load-bearing for the union below them: it
+// is what stops a github or stripe seed greedily matching the slack arm.
+//
+// Both had drifted, measured 2026-08-27:
+//
+//   slack   mirror lacked `emoji`                      (in the twin since #190)
+//   stripe  mirror lacked `refunds`, `balance_transactions`,
+//           and carried five keys the twin's seed schema does not have
+//           (`customers`, `products`, `prices`, `events`, `balances`)
+//
+// Which meant `pome twin seed slack` output was refused by `parseTask` on
+// `Unrecognized key: "emoji"`, and — the half that matters more — a HUMAN
+// writing a slack task seed with `emoji` had never been able to. This is the
+// same defect as the three broken doc examples: a copy with no gate. It had
+// already been fixed once, for `files` (#432), and the fix was that instance
+// rather than the class.
+//
+// ⚠️ THIS TEST IS THE DERIVATION. Deriving the key set inside `taskSchema.ts`
+// was the first fix and `scripts/lint/rules/twin-chunks.mjs` refused it:
+// `@pome-sh/twin-stripe/seed` statically imports `./domain/schema.js`, so it is
+// not the zod-only leaf it is documented as, and a static import there puts
+// stripe's domain in the graph `pome --version` loads. A test file is not in
+// that graph, so the comparison lives here instead — which means this file
+// failing IS the drift, not a symptom of it.
+//
+// Field ORDER is asserted too, not just membership: key order survives `parse()`
+// into the object `parseTask` returns, so a mirror listing the same fields in a
+// different order makes a parsed seed and a generated one differ by nothing but
+// key order — enough to fail a byte comparison between them.
+
+import { describe, expect, it } from "vitest";
+import { seedSchema as slackTwinSeedSchema } from "@pome-sh/twin-slack/seed";
+import { seedSchema as stripeTwinSeedSchema } from "@pome-sh/twin-stripe/seed";
+import { slackSeedStateSchema, stripeSeedStateSchema } from "../../src/task/taskSchema.js";
+
+const MIRRORS = [
+  { twin: "slack", mirror: slackSeedStateSchema, real: slackTwinSeedSchema },
+  { twin: "stripe", mirror: stripeSeedStateSchema, real: stripeTwinSeedSchema },
+] as const;
+
+function keysOf(schema: { shape: Record<string, unknown> }): string[] {
+  return Object.keys(schema.shape);
+}
+
+describe("the task parser's seed mirrors name exactly the twin's fields, in order", () => {
+  it.each(MIRRORS)("$twin", ({ mirror, real }) => {
+    expect(keysOf(mirror as never)).toEqual(keysOf(real as never));
+  });
+});
+
+describe("what the mirrors must keep doing", () => {
+  it.each(MIRRORS)("$twin: stays .strict(), so an unknown key is loud", ({ mirror }) => {
+    // The legacy `{ <twin>: { seed: … } }` wrapper is the case this was added
+    // for: without `.strict()` it parses to an empty seed instead of failing.
+    expect(() => (mirror as never as { parse(v: unknown): unknown }).parse({ seed: {} })).toThrow();
+  });
+
+  it("slack: an empty seed still fills its collections", () => {
+    const parsed = slackSeedStateSchema.parse({});
+    expect(parsed.users).toEqual([]);
+    expect(parsed.channels).toEqual([]);
+    expect(parsed.files).toEqual([]);
+  });
+
+  it("stripe: the default single-api-key seed still parses", () => {
+    const parsed = stripeSeedStateSchema.parse({
+      api_keys: [{ key: "sk_test_pome_default", sid: "default", account_id: "acct_default" }],
+    });
+    expect(parsed.api_keys).toHaveLength(1);
+  });
+
+  // The union in `taskSchema.ts` puts slack FIRST and relies on `.strict()` to
+  // stop it swallowing its neighbours. Widening the mirror by a key set is only
+  // safe while that still holds.
+  it("slack does not greedily match a github seed", () => {
+    expect(
+      slackSeedStateSchema.safeParse({
+        users: [{ login: "acme" }],
+        repositories: [{ owner: "acme", name: "api" }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("slack does not greedily match a stripe seed", () => {
+    expect(slackSeedStateSchema.safeParse({ api_keys: [], charges: [] }).success).toBe(false);
+  });
+
+  it("stripe does not greedily match a slack seed", () => {
+    expect(stripeSeedStateSchema.safeParse({ team: {}, channels: [] }).success).toBe(false);
+  });
+});

--- a/cli/test/unit/twin/twinSeedForTask.test.ts
+++ b/cli/test/unit/twin/twinSeedForTask.test.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// `pome twin seed <name...> --for-task` — the same generated seed, in the shape
+// a `<task>.seed.json` sidecar takes.
+//
+// WHY A SECOND SHAPE IS NOT A SECOND RULE. A seed file written for a DOOR
+// (`twin start --seed`, `sandbox create --seed`) is always the per-twin
+// envelope: it is handed around on its own, so it has to say which twin it is
+// for, and it must not change shape when its author adds a second twin
+// ([DECISION] on F-1685, 2026-08-26). A sidecar never travels alone — the
+// `<task>.md` beside it names its twins in `## Config` — so it follows the rule
+// `parseTask` has had since 2026-05-12: flat for one twin, envelope for more.
+//
+// `--for-task` therefore picks a DESTINATION, not a shape. The shape follows
+// from the destination plus the twin count, by the rule that already exists.
+//
+// THE HOLE THIS CLOSES. `pome compile-seeds` only emits a sidecar for a
+// single-twin GITHUB task (`compile-seeds.ts` skips everything else by design,
+// because compiling a multi-twin task would drop the other twin's half). So for
+// slack, stripe, gmail and linear there has been no sidecar generator at all,
+// and every task seed for those twins was hand-written — the same standing
+// invitation to drift that left three doc examples unable to boot.
+//
+// The assertion is the real consumer: `parseTaskFile`, on a real task file.
+
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseTaskFile } from "../../../src/task/parseTask.js";
+import { TWIN_NAME_LIST, type TwinName } from "../../../src/twin/registry.js";
+import { generateSeedFile } from "../../../src/twin/twinSeed.js";
+
+/** A minimal task whose `## Config` names `twins`, written next to a sidecar. */
+async function taskWith(twins: TwinName[], sidecar: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "pome-for-task-"));
+  const taskPath = join(dir, "probe.md");
+  await writeFile(
+    taskPath,
+    [
+      "# Probe",
+      "",
+      "## Prompt",
+      "",
+      "Do the thing.",
+      "",
+      "## Success Criteria",
+      "",
+      // A multi-twin task requires the twin tag on a `[code]` criterion —
+      // parseTask has to know which twin's state to check it against.
+      `- [code${twins.length > 1 ? `:${twins[0]}` : ""}] The thing was done`,
+      "",
+      "## Config",
+      "",
+      "```yaml",
+      `twins: [${twins.join(", ")}]`,
+      "class: conformance",
+      "timeout: 120",
+      "runs: 1",
+      "passThreshold: 100",
+      "```",
+      "",
+    ].join("\n"),
+  );
+  await writeFile(taskPath.replace(/\.md$/, ".seed.json"), sidecar);
+  return taskPath;
+}
+
+describe("generateSeedFile({ forTask: true }) — the sidecar shape", () => {
+  it.each(TWIN_NAME_LIST)("%s: one twin is FLAT, and parseTask accepts it", async (twin) => {
+    const text = await generateSeedFile([twin], { forTask: true });
+    const parsed = JSON.parse(text) as Record<string, unknown>;
+    // Flat: the twin's own fields at the top level, no envelope key.
+    expect(Object.keys(parsed)).not.toContain(twin);
+    expect(Object.keys(parsed).length).toBeGreaterThan(0);
+
+    const task = await parseTaskFile(await taskWith([twin], text));
+    expect(Object.keys(task.seedState as object)).toEqual(Object.keys(parsed));
+  });
+
+  it("two twins are the ENVELOPE, and parseTask accepts that too", async () => {
+    const text = await generateSeedFile(["github", "slack"], { forTask: true });
+    expect(Object.keys(JSON.parse(text) as object)).toEqual(["github", "slack"]);
+
+    const task = await parseTaskFile(await taskWith(["github", "slack"], text));
+    expect(Object.keys(task.seedState as object).sort()).toEqual(["github", "slack"]);
+  });
+
+  it("is byte-identical to the door file once there is more than one twin", async () => {
+    // The two shapes only differ for a single twin. Asserting the convergence
+    // keeps `--for-task` from quietly becoming a second format.
+    expect(await generateSeedFile(["github", "slack"], { forTask: true })).toBe(
+      await generateSeedFile(["github", "slack"]),
+    );
+  });
+
+  it("without the flag, one twin is still the envelope — the door shape", async () => {
+    expect(Object.keys(JSON.parse(await generateSeedFile(["github"])) as object)).toEqual([
+      "github",
+    ]);
+  });
+
+  it("carries no `_meta`, so `compile-seeds` treats it as authored and leaves it alone", async () => {
+    const parsed = JSON.parse(await generateSeedFile(["github"], { forTask: true })) as object;
+    expect(parsed).not.toHaveProperty("_meta");
+  });
+
+  // The regression that produced `--for-task` in the first place: the DOOR
+  // shape is not a sidecar, and a reader who drops one next to a single-twin
+  // task should find that out from the parser, not from an empty world.
+  it("the door shape is still refused as a single-twin sidecar", async () => {
+    const doorFile = await generateSeedFile(["github"]);
+    await expect(parseTaskFile(await taskWith(["github"], doorFile))).rejects.toThrow(
+      /repositories/,
+    );
+  });
+});


### PR DESCRIPTION
Second half of F-1691's CLI work, found while writing the docs half of `#483`.

## The defect

```
$ pome twin seed slack --out probe.seed.json   # generated from the twin itself
$ # ...next to a task whose ## Config reads twins: [slack]
parseTask -> REFUSED: Unrecognized key: "emoji"
```

`cli/src/task/taskSchema.ts` keeps a **local** seed schema for slack and stripe. The other three arms import the twin's own and so cannot drift; those two cannot, because both must be `.strict()` and the twins' schemas are not. Strictness is load-bearing twice over — it makes the legacy `{ <twin>: { seed: … } }` wrapper fail loudly instead of parsing to an empty seed, and it stops the slack arm greedily matching a github or stripe seed inside `seedStateSchema`'s union.

Both copies had drifted from the twin they mirror, measured at `179ee22`:

| | mirror lacked | mirror carried, twin has never had |
|---|---|---|
| slack | `emoji` (in the twin since `#190`) | — |
| stripe | `refunds`, `balance_transactions` | `customers`, `products`, `prices`, `events`, `balances` |

Two user-visible consequences, and the second is the one that matters:

1. `pome twin seed slack` / `stripe` output is refused by `parseTask`.
2. **A human writing a slack task seed with `emoji` has never been able to**, and a stripe one declaring `customers` parsed clean here and was then silently dropped by the twin.

This is the same defect as the three broken doc examples — a copy with no gate — and it had already been fixed once, for `files` (`#432`), with a comment in the file explaining why the field had to be listed. That fixed the instance.

## The fix

The mirrors now name exactly the twin's fields, in the twin's order, and `cli/test/unit/task-seed-mirror.test.ts` is the gate for the class: it imports both twins and fails the moment either key set moves.

Order is asserted, not just membership — key order survives `parse()` into the object `parseTask` returns, so a mirror that lists the same fields in a different order makes a parsed seed and a generated one differ by nothing but that. It caught a real ordering mismatch in stripe during the build.

⚠️ **The comparison lives in the test rather than in `taskSchema.ts`, and the reason is worth reading.** Deriving the key set at runtime was the first fix and `scripts/lint/rules/twin-chunks.mjs` refused it:

```
✗ twin-chunks
    packages/twin-stripe/src/domain/schema.ts — twin-stripe's domain; statically
    reachable from cli/src/cli/main.ts, so it loads on every `pome` invocation:
      cli/src/cli/main.ts -> cli/src/task/parseTask.ts -> cli/src/task/taskSchema.ts
      -> packages/twin-stripe/src/seed.ts -> packages/twin-stripe/src/domain/schema.ts
```

`@pome-sh/twin-stripe/seed` statically imports `./domain/schema.js` for `applySeed`, so **it is not the zod-only leaf that `registry.ts`'s header and that lint rule's own advice both call it.** A test file is not in the CLI's runtime graph, so the comparison is free there. Making that subpath a real leaf is its own change — see below.

## `pome twin seed --for-task`

Writes the same generated seed in the shape a `<task>.seed.json` sidecar takes:

| | door file (`--seed`) | sidecar (`--for-task`) |
|---|---|---|
| one twin | `{ "github": { … } }` | `{ "repositories": [ … ] }` |
| two or more | `{ "github": …, "slack": … }` | identical |

The flag picks a **destination, not a shape**. The shape then follows from the destination plus the twin count, by rules that already exist: a door file is always the envelope ([DECISION] on F-1685 — it is handed around on its own, so it has to say which twin it is for, and it must not change shape when its author adds a second twin), and a sidecar is flat-for-one because the `<task>.md` beside it names its twins in `## Config` (`parseTask`, 2026-05-12). The two outputs converge from two twins up and a test asserts that, so the flag cannot quietly become a second format.

**This closes a hole older than the seed door.** `pome compile-seeds` emits a sidecar only for a single-twin **github** task — it skips everything else by design, because compiling a multi-twin task would drop the other twin's half. So slack, stripe, gmail and linear task seeds have always been hand-written, with no generator at all. That is the same standing invitation to drift that left three documented examples unable to boot.

## Reviewer notes

- **Behaviour change worth a look:** the five removed stripe keys mean a task declaring `customers` now fails to parse instead of losing the field at boot. No task in this repo used any of the five (`grep`'d `agent-examples/**`), and `.strict()` was already the arm's contract.
- Every arm is now asserted against the **real consumer** — `parseTaskFile`, on a real task file written to a temp dir, for all five twins — rather than against the schema in isolation.
- `--for-task` output carries no `_meta`, so `compile-seeds` treats it as authored content and leaves it alone. That is the existing "hand-authored seed left untouched" branch, and it is the right answer for a starter you are meant to edit.

## Two findings NOT fixed here

Both are real, both are out of this ticket's scope, and I would rather they were tickets than quiet patches.

1. **`cli/src/contract/seed-state.ts` is a THIRD copy of the seed shapes, and its stripe arm has the same drift** — contract-only `customers, products, prices, events, balances`, twin-only `failure_injection, refunds, balance_transactions`. github and slack match there. It has no runtime consumer in this repo (`contract/task.ts`'s `taskSchema` is never `.parse()`d here), but it is the declared `/v1` surface mirrored with pome-cloud, and CONTRACT.md is the coordination point for changing it. Not a unilateral edit.
2. **`@pome-sh/twin-stripe/seed` is documented as a zod-only leaf and is not one.** Both `registry.ts`'s header and `twin-chunks.mjs`'s failure message tell you to reach for `/seed` when all you need is a schema; for stripe that advice is false, and only the dynamic `import()` in the registry entry keeps the lint green today.

## CI / gates run locally

| | |
|---|---|
| `npx vitest run` | 341 files, **3836 passed** |
| `npm run typecheck` | clean, all workspaces |
| `npm run lint` | **17/17** (`twin-chunks` is the rule that shaped this change) |
| `npm run lint:dead-code` (knip) | clean |
| `npm run test:contract` | 115 tests, 0 fail |

## Sequencing

The pome-cloud docs PR depends on this: `## Task seed shape` on the five twin pages becomes `pome twin seed <twin> --for-task` output, so it should land after this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)