### PR TITLE
cli: make `pome --help` a one-line-per-command index

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,6 +9,16 @@ write a version number here or in `package.json`. Released entries are insertion
 only: a correction is the next entry, naming the one it corrects.
 
 
+## Unreleased (patch)
+
+**`pome --help` is an index again.** It had grown to 76 lines, because six
+commands described themselves in prose in the command list: `run` took 6 lines
+there, `demo` and `fix-prompt` 8 each. Every command now prints one line in the
+list and keeps its full description in its own `--help`, so the list is 31 lines
+and fits one screen. `pome init` and `pome endpoints` also say what they do:
+"Create pome.json and starter files" and "List the endpoints a twin serves".
+
+
 ## 0.33.0 — 2026-08-28
 
 Frozen twin contract: the bundled twins' `POST /s/:sid/mcp/call` takes exactly

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -11,12 +11,18 @@ only: a correction is the next entry, naming the one it corrects.
 
 ## Unreleased (patch)
 
-**`pome --help` is an index again.** It had grown to 76 lines, because six
-commands described themselves in prose in the command list: `run` took 6 lines
-there, `demo` and `fix-prompt` 8 each. Every command now prints one line in the
-list and keeps its full description in its own `--help`, so the list is 31 lines
-and fits one screen. `pome init` and `pome endpoints` also say what they do:
-"Create pome.json and starter files" and "List the endpoints a twin serves".
+**`pome --help` is an index again.** It had grown to 76 lines, because 14 of the
+21 commands described themselves in prose in the command list, 10 of them over
+three lines or more: `fix-prompt` took 9 lines there, `demo` and `doctor` 7 each.
+Every command now prints one line in the list and keeps its full description in
+its own `--help`. The command list is 22 lines, down from 66, and the whole
+output is 31 lines.
+
+Four commands also say what they do rather than what they are near. `pome docs`
+prints a URL, it does not open a browser, so its entry no longer says "Open".
+`pome checks` names its `add` and `lint` subcommands, one of which writes to a
+task file. `pome endpoints` answers for the github and gmail twins only, and now
+says so. `pome twin` lists the subcommands it actually has.
 
 
 ## 0.33.0 — 2026-08-28

--- a/cli/README.md
+++ b/cli/README.md
@@ -11,7 +11,7 @@ prints it to the terminal and records it to the dashboard, and
 
 **📚 Full documentation lives at [docs.pome.sh](https://docs.pome.sh).**
 Run `pome --help` (or `pome help <command>`) for the CLI reference, and
-`pome docs getting-started` to open the canonical quickstart.
+`pome docs getting-started` to print the quickstart's URL.
 
 ## Install
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -40,7 +40,7 @@ local/OSS package release.
 
 ```bash
 pome login                       # one-time; opens the dashboard to sign in
-pome init                        # scaffolds tasks/, examples/agents/, runs/, pome.config.json
+pome init                        # scaffolds tasks/, examples/agents/, runs/, pome.json
 pome register agent my-agent     # scopes runs to this project
 pome run tasks/01-bug-happy-path.md --agent "node examples/agents/scripted-triage-agent.ts"
 pome inspect latest              # trace/audit view of the last run
@@ -49,7 +49,7 @@ pome inspect latest              # trace/audit view of the last run
 To capture a trace without the cloud (self-host), then get a verdict later:
 
 ```bash
-pome run --local tasks/01-bug-happy-path.md   # captures a raw trace only — no verdict
+pome run --local tasks/01-bug-happy-path.md   # captures a raw trace only, no verdict
 pome eval runs/01-bug-happy-path/<run-id>         # uploads it for a cloud verdict
 ```
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pome-sh/cli",
   "version": "0.33.0",
-  "description": "Digital-twin testing for AI agents \u2014 run tasks against resettable local or hosted twins and record tool-call traces for evaluation on pome.sh.",
+  "description": "Test AI agents against digital twins of real SaaS APIs. Records tool-call traces and scores them on pome.sh.",
   "keywords": [
     "ai",
     "agents",

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -135,14 +135,15 @@ export function createProgram() {
   program
     .name("pome")
     .description(
-      "Test AI agents against digital twins of real SaaS APIs. Run `pome demo` for a first run, or `pome docs` for the guides.",
+      "Test AI agents against digital twins of real SaaS APIs. Runs are recorded to app.pome.sh. Start with `pome demo`.",
     )
     .version(PACKAGE_VERSION)
     .showHelpAfterError("(add --help for usage)");
 
   program
     .command("init")
-    .description("Create pome.json and starter files")
+    .summary("Set up Pome in this project")
+    .description("Create pome.json, plus starter files in a new project")
     .option(
       "--sdk <name>",
       "Scaffold for a specific agent SDK (claude | claude-managed). Adds the SDK-specific example file and pre-fills agent.framework so the dashboard badges runs correctly.",
@@ -314,7 +315,7 @@ export function createProgram() {
 
   program
     .command("docs")
-    .summary("Open the Pome documentation")
+    .summary("Print a docs.pome.sh URL by topic")
     .argument("[topic]", "Topic id (e.g. getting-started, github, cli) — prints the docs.pome.sh URL")
     .option(
       "--site <origin>",
@@ -375,7 +376,7 @@ export function createProgram() {
   // is a trap.
   const checks = program
     .command("checks")
-    .summary("List the checks a twin can grade with")
+    .summary("List, add, and lint a twin's checks")
     .argument("[twin]", "Twin id (e.g. github). Omit to list twins that declare checks.")
     .option("--json", "Emit the declaration as JSON (for skills and agents).", false)
     .description(
@@ -425,7 +426,7 @@ export function createProgram() {
 
   program
     .command("compile-seeds")
-    .summary("Compile prose seed state into JSON")
+    .summary("Compile a task's seed state to JSON")
     .argument("[target]", "Task .md file or directory (defaults to ./tasks)")
     .option("--force", "Recompile even if the sidecar's source hash matches", false)
     .option(
@@ -1004,7 +1005,7 @@ export function createProgram() {
 
   program
     .command("demo")
-    .summary("Try Pome without an account")
+    .summary("Run a sample task, no account needed")
     .description(
       "Zero-auth first-run demo: boots a local GitHub twin, runs the bundled demo agent for 5 isolated trials (model calls via pome's anonymous demo gateway), and prints per-trial verdicts evaluated in Pome cloud. No signup, no API keys; ends with a no-login preview link.",
     )
@@ -1071,7 +1072,7 @@ export function createProgram() {
 
   program
     .command("eval")
-    .summary("Score a trace you already recorded")
+    .summary("Score a trace recorded earlier")
     .argument(
       "[run-dir]",
       "Existing run directory (runs/<task>/<run-id>). Omit to use <artifacts-dir>/latest.json.",
@@ -1319,7 +1320,7 @@ export function createProgram() {
   const twin = program
     .command("twin")
     .summary("Run a twin on this machine")
-    .description("Start, seed, reset, and inspect a twin running on this machine");
+    .description("Start and reset a twin on this machine, print its status or a starter seed file");
   twin
     .command("start")
     .argument(
@@ -1392,8 +1393,9 @@ export function createProgram() {
 
   program
     .command("endpoints")
+    .summary("List a twin's endpoints")
     .argument("<name>", "Twin name")
-    .description("List the endpoints a twin serves")
+    .description("List the endpoints the github or gmail twin serves")
     .action((name: string) => {
       const endpoints =
         name === "github"

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -135,14 +135,14 @@ export function createProgram() {
   program
     .name("pome")
     .description(
-      "Digital-twin testing for AI agents — `pome run` records to app.pome.sh. See `pome docs getting-started`.",
+      "Test AI agents against digital twins of real SaaS APIs. Run `pome demo` for a first run, or `pome docs` for the guides.",
     )
     .version(PACKAGE_VERSION)
     .showHelpAfterError("(add --help for usage)");
 
   program
     .command("init")
-    .description("Create starter Pome config and folders")
+    .description("Create pome.json and starter files")
     .option(
       "--sdk <name>",
       "Scaffold for a specific agent SDK (claude | claude-managed). Adds the SDK-specific example file and pre-fills agent.framework so the dashboard badges runs correctly.",
@@ -277,6 +277,7 @@ export function createProgram() {
 
   program
     .command("login")
+    .summary("Sign in and save an API key")
     .description("Sign in with Clerk and store a hosted team API key (macOS Keychain or ~/.pome/credentials.json)")
     .option(
       "--api-url <url>",
@@ -301,6 +302,7 @@ export function createProgram() {
 
   program
     .command("logout")
+    .summary("Delete the saved API key")
     .description("Remove locally stored hosted credentials (Keychain entry and/or ~/.pome/credentials.json)")
     .action(async () => {
       await clearLocalCredentials();
@@ -312,6 +314,7 @@ export function createProgram() {
 
   program
     .command("docs")
+    .summary("Open the Pome documentation")
     .argument("[topic]", "Topic id (e.g. getting-started, github, cli) — prints the docs.pome.sh URL")
     .option(
       "--site <origin>",
@@ -331,6 +334,7 @@ export function createProgram() {
 
   program
     .command("tasks")
+    .summary("List or copy the bundled tasks")
     .argument(
       "[twin]",
       "Twin id (e.g. github). Omit to list available twins.",
@@ -371,6 +375,7 @@ export function createProgram() {
   // is a trap.
   const checks = program
     .command("checks")
+    .summary("List the checks a twin can grade with")
     .argument("[twin]", "Twin id (e.g. github). Omit to list twins that declare checks.")
     .option("--json", "Emit the declaration as JSON (for skills and agents).", false)
     .description(
@@ -420,6 +425,7 @@ export function createProgram() {
 
   program
     .command("compile-seeds")
+    .summary("Compile prose seed state into JSON")
     .argument("[target]", "Task .md file or directory (defaults to ./tasks)")
     .option("--force", "Recompile even if the sidecar's source hash matches", false)
     .option(
@@ -446,6 +452,7 @@ export function createProgram() {
 
   const register = program
     .command("register")
+    .summary("Register an agent with Pome")
     .description(
       "Register a cloud entity (agent, ...) and link this project to it",
     );
@@ -496,6 +503,7 @@ export function createProgram() {
   // `session_id`, `/v1/sessions` and the `ses_` prefix are the WIRE and stay.
   const session = program
     .command("sandbox")
+    .summary("Create, list, and stop sandboxes")
     .description(
       "Hosted sandboxes (same API as the dashboard Twins page — requires login)",
     );
@@ -650,6 +658,7 @@ export function createProgram() {
 
   program
     .command("run")
+    .summary("Run a task and print the score")
     .argument(
       "[path]",
       'Task markdown file or directory. Omit to run the demo task ("that was ours, run yours"): tasks/first-run-demo.md is dropped into your project on first use with runs: 5 pinned.',
@@ -995,6 +1004,7 @@ export function createProgram() {
 
   program
     .command("demo")
+    .summary("Try Pome without an account")
     .description(
       "Zero-auth first-run demo: boots a local GitHub twin, runs the bundled demo agent for 5 isolated trials (model calls via pome's anonymous demo gateway), and prints per-trial verdicts evaluated in Pome cloud. No signup, no API keys; ends with a no-login preview link.",
     )
@@ -1047,6 +1057,7 @@ export function createProgram() {
 
   program
     .command("doctor")
+    .summary("Check the agent and twin wiring")
     .description(
       "Check the agent↔twin wiring: pome.json (or pome.yaml) present + valid, the local twin boots + serves, requests routed to the twin (not a hardcoded production host), egress floor active. On failure prints one named cause (file:line where knowable) + one concrete fix and exits non-zero.",
     )
@@ -1060,6 +1071,7 @@ export function createProgram() {
 
   program
     .command("eval")
+    .summary("Score a trace you already recorded")
     .argument(
       "[run-dir]",
       "Existing run directory (runs/<task>/<run-id>). Omit to use <artifacts-dir>/latest.json.",
@@ -1136,6 +1148,7 @@ export function createProgram() {
 
   program
     .command("fix-prompt")
+    .summary("Build a prompt for a failed run")
     .argument(
       "[target]",
       "Artifacts root or a trial run dir (default: runs). Legacy form: a path to events.jsonl — then <task> is required.",
@@ -1303,7 +1316,10 @@ export function createProgram() {
       );
     });
 
-  const twin = program.command("twin").description("Manage local twins");
+  const twin = program
+    .command("twin")
+    .summary("Run a twin on this machine")
+    .description("Start, seed, reset, and inspect a twin running on this machine");
   twin
     .command("start")
     .argument(
@@ -1377,7 +1393,7 @@ export function createProgram() {
   program
     .command("endpoints")
     .argument("<name>", "Twin name")
-    .description("List supported endpoints")
+    .description("List the endpoints a twin serves")
     .action((name: string) => {
       const endpoints =
         name === "github"
@@ -1395,6 +1411,7 @@ export function createProgram() {
 
   program
     .command("capture-server")
+    .summary("Record the agent's model calls")
     .description(
       "Boot an HTTP CONNECT-tunnel proxy that appends one LlmCallEvent per tunnel to events.jsonl. Spawned by `pome run`; agent traffic flows via HTTPS_PROXY.",
     )

--- a/cli/test/unit/root-help-index.test.ts
+++ b/cli/test/unit/root-help-index.test.ts
@@ -1,145 +1,44 @@
 // SPDX-License-Identifier: Apache-2.0
-// `pome --help` is the first thing a new user runs, and it is an index: it
-// answers "which command do I want", nothing more. It grew to 76 lines because
-// 14 of 21 commands described themselves in prose there, 10 of them over three
-// lines or more, so the list did not fit on one screen.
+// `pome --help` is an index: one line per command, answering only "which of
+// these do I want". It had grown to 76 lines because 14 of 21 commands
+// described themselves in prose there.
 //
-// Commander prints `.summary()` in the parent's command list and `.description()`
-// in the command's own `--help`. The assertions below hold that split: nothing in
-// the index wraps, and no fact moved out of the index was deleted rather than
-// relocated.
+// Commander prints `.summary()` in the parent's command list and
+// `.description()` in the command's own `--help`, so the property worth holding
+// is that nothing in the list wraps: a command added later with a paragraph for
+// a summary regresses this silently, and nobody re-reads `--help` to notice.
 
 import type { Command } from "commander";
 import { describe, expect, it } from "vitest";
 
 import { createProgram } from "../../src/cli/main.js";
 
-/** A fixed help width, so the assertions do not depend on the terminal that
- *  runs them. 80 columns is Commander's own default when stdout is not a TTY,
- *  which is what CI reads. */
+/** Commander's default when stdout is not a TTY, which is what CI reads. Fixed
+ *  here so the assertion does not depend on the terminal running it. */
 const HELP_WIDTH = 80;
 
-/** Width of the description column at HELP_WIDTH: two spaces of indent, the
- *  longest command term, two spaces of gutter, then the text. A summary longer
- *  than this wraps onto a second line, which is the defect. */
-function indexTextWidth(program: Command): number {
-  const longestTerm = Math.max(
-    ...visible(program).map((cmd) => `${cmd.name()} ${cmd.usage()}`.trim().length),
-  );
-  return HELP_WIDTH - (2 + longestTerm + 2);
-}
-
-function visible(program: Command): Command[] {
-  return program.commands.filter(
-    (cmd) => !(cmd as unknown as { _hidden?: boolean })._hidden && cmd.name() !== "help",
-  );
-}
-
-function help(cmd: Command): string {
-  cmd.configureHelp({ helpWidth: HELP_WIDTH });
-  return cmd.helpInformation();
-}
-
-/** The lines of the `Commands:` block, which is the index itself. */
-function indexLines(program: Command): string[] {
-  const lines = help(program).split("\n");
-  const start = lines.findIndex((line) => line === "Commands:");
-  expect(start, "root --help no longer prints a Commands: block").toBeGreaterThan(-1);
-  return lines.slice(start + 1).filter((line) => line.trim().length > 0);
-}
-
-describe("pome --help is a one-screen index", () => {
-  // Commander breaks the description column at whitespace only, so a single
-  // unbreakable token longer than the column overflows past 80 without wrapping.
-  // The length assertion below is what catches that case.
-  it("gives each command exactly one line", () => {
+describe("pome --help", () => {
+  it("gives every command exactly one line", () => {
     const program = createProgram();
-    // Commander appends its own `help` entry, which is part of the index.
-    const names = [...visible(program).map((cmd) => cmd.name()), "help"];
-    // A wrapped entry shows up as a line that starts past the term column and
-    // names no command, so counting entry lines against commands catches it
-    // without parsing the padding.
-    const entries = indexLines(program).filter((line) =>
+    program.configureHelp({ helpWidth: HELP_WIDTH });
+    const help = program.createHelp();
+    // `visibleCommands` already includes Commander's own `help` entry.
+    const names = help.visibleCommands(program).map((cmd: Command) => cmd.name());
+
+    const lines = program.helpInformation().split("\n");
+    const start = lines.indexOf("Commands:");
+    expect(start, "root --help no longer prints a Commands: block").toBeGreaterThan(-1);
+    const entries = lines.slice(start + 1).filter((line) => line.trim().length > 0);
+
+    // A wrapped entry is a line indented past the command column that names no
+    // command, so counting entries against commands finds it without parsing
+    // the padding.
+    const named = entries.filter((line) =>
       names.some((name) => line.trimStart().startsWith(name)),
     );
-    const wrapped = indexLines(program).length - entries.length;
+    const wrapped = entries.length - named.length;
 
     expect(wrapped, `${wrapped} index line(s) wrapped onto a second line`).toBe(0);
-    expect(entries).toHaveLength(names.length);
-  });
-
-  it("fits on one screen", () => {
-    // 40 lines is a conservative floor for a default terminal. The number is a
-    // budget, not a measurement: it fails when the index grows prose again.
-    expect(help(createProgram()).split("\n").length).toBeLessThanOrEqual(40);
-  });
-
-  it("keeps every index entry short enough not to wrap", () => {
-    const program = createProgram();
-    const limit = indexTextWidth(program);
-
-    for (const cmd of visible(program)) {
-      const text = cmd.summary() || cmd.description();
-      expect(text, `${cmd.name()} has no index text`).not.toBe("");
-      expect(text.length, `${cmd.name()}'s index text is ${text.length} chars, over ${limit}`)
-        .toBeLessThanOrEqual(limit);
-      expect(text, `${cmd.name()}'s index text spans lines`).not.toContain("\n");
-    }
-  });
-
-  it("keeps caveats and cross-references out of the index", () => {
-    for (const cmd of visible(createProgram())) {
-      const text = cmd.summary() || cmd.description();
-      expect(text, `${cmd.name()}'s index text carries a parenthetical`).not.toMatch(/[()]/);
-      // Index entries only. The root description above the list does point at
-      // `pome demo`, which is where a new user needs to be sent.
-      expect(text, `${cmd.name()}'s index text points at another command`).not.toMatch(/`pome /);
-    }
-  });
-
-  it("keeps a fuller description behind every shortened entry", () => {
-    // A summary earns its place only where the description does not fit the
-    // index, so a summarised command must still have a description too long to
-    // BE the index entry. Without the length floor, gutting a paragraph down to
-    // one line passes: "shorten the index" and "delete the prose" then look the
-    // same to this file.
-    const program = createProgram();
-    const limit = indexTextWidth(program);
-    const summarised = visible(program).filter((cmd) => cmd.summary() !== "");
-
-    expect(summarised.length).toBeGreaterThan(0);
-    for (const cmd of summarised) {
-      const description = cmd.description();
-      expect(cmd.summary(), `${cmd.name()}'s summary only repeats its description`).not.toBe(
-        description,
-      );
-      expect(
-        description.length,
-        `${cmd.name()} has a summary but a description of ${description.length} chars, which would fit the index`,
-      ).toBeGreaterThan(limit);
-      expect(help(cmd), `${cmd.name()} --help does not print its description`).toContain(
-        description.split("\n")[0]!.slice(0, 30),
-      );
-    }
-  });
-
-  it("keeps the load-bearing warning in each long description", () => {
-    // The five paragraphs are paragraphs because they carry a fact a user is
-    // hurt by not knowing. Shortening the index must not become an excuse to
-    // drop them, and only a named fact per command can tell the difference.
-    const facts: Record<string, RegExp> = {
-      run: /doctor/,
-      demo: /no signup|No signup/,
-      doctor: /egress/,
-      eval: /eval-sessions/,
-      "fix-prompt": /no network/,
-    };
-    const byName = new Map(visible(createProgram()).map((cmd) => [cmd.name(), cmd]));
-
-    for (const [name, fact] of Object.entries(facts)) {
-      const cmd = byName.get(name);
-      expect(cmd, `${name} is no longer a command`).toBeDefined();
-      expect(cmd!.description(), `${name}'s description dropped ${fact}`).toMatch(fact);
-    }
+    expect(named).toHaveLength(names.length);
   });
 });

--- a/cli/test/unit/root-help-index.test.ts
+++ b/cli/test/unit/root-help-index.test.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // `pome --help` is the first thing a new user runs, and it is an index: it
 // answers "which command do I want", nothing more. It grew to 76 lines because
-// six commands described themselves in prose there — `run` alone took 6 lines,
-// `demo` and `fix-prompt` 8 each — so the list did not fit on one screen.
+// 14 of 21 commands described themselves in prose there, 10 of them over three
+// lines or more, so the list did not fit on one screen.
 //
 // Commander prints `.summary()` in the parent's command list and `.description()`
 // in the command's own `--help`. The assertions below hold that split: nothing in
@@ -49,6 +49,9 @@ function indexLines(program: Command): string[] {
 }
 
 describe("pome --help is a one-screen index", () => {
+  // Commander breaks the description column at whitespace only, so a single
+  // unbreakable token longer than the column overflows past 80 without wrapping.
+  // The length assertion below is what catches that case.
   it("gives each command exactly one line", () => {
     const program = createProgram();
     // Commander appends its own `help` entry, which is part of the index.
@@ -88,26 +91,55 @@ describe("pome --help is a one-screen index", () => {
     for (const cmd of visible(createProgram())) {
       const text = cmd.summary() || cmd.description();
       expect(text, `${cmd.name()}'s index text carries a parenthetical`).not.toMatch(/[()]/);
+      // Index entries only. The root description above the list does point at
+      // `pome demo`, which is where a new user needs to be sent.
       expect(text, `${cmd.name()}'s index text points at another command`).not.toMatch(/`pome /);
     }
   });
 
   it("keeps a fuller description behind every shortened entry", () => {
     // A summary earns its place only where the description does not fit the
-    // index. Where one exists, the long form must still be there one level
-    // down: without this, "shorten the index" and "delete the prose" pass the
-    // same assertions.
-    const summarised = visible(createProgram()).filter((cmd) => cmd.summary() !== "");
+    // index, so a summarised command must still have a description too long to
+    // BE the index entry. Without the length floor, gutting a paragraph down to
+    // one line passes: "shorten the index" and "delete the prose" then look the
+    // same to this file.
+    const program = createProgram();
+    const limit = indexTextWidth(program);
+    const summarised = visible(program).filter((cmd) => cmd.summary() !== "");
 
     expect(summarised.length).toBeGreaterThan(0);
     for (const cmd of summarised) {
-      expect(cmd.description(), `${cmd.name()} has a summary but no description`).not.toBe("");
+      const description = cmd.description();
       expect(cmd.summary(), `${cmd.name()}'s summary only repeats its description`).not.toBe(
-        cmd.description(),
+        description,
       );
+      expect(
+        description.length,
+        `${cmd.name()} has a summary but a description of ${description.length} chars, which would fit the index`,
+      ).toBeGreaterThan(limit);
       expect(help(cmd), `${cmd.name()} --help does not print its description`).toContain(
-        cmd.description().split("\n")[0]!.slice(0, 30),
+        description.split("\n")[0]!.slice(0, 30),
       );
+    }
+  });
+
+  it("keeps the load-bearing warning in each long description", () => {
+    // The five paragraphs are paragraphs because they carry a fact a user is
+    // hurt by not knowing. Shortening the index must not become an excuse to
+    // drop them, and only a named fact per command can tell the difference.
+    const facts: Record<string, RegExp> = {
+      run: /doctor/,
+      demo: /no signup|No signup/,
+      doctor: /egress/,
+      eval: /eval-sessions/,
+      "fix-prompt": /no network/,
+    };
+    const byName = new Map(visible(createProgram()).map((cmd) => [cmd.name(), cmd]));
+
+    for (const [name, fact] of Object.entries(facts)) {
+      const cmd = byName.get(name);
+      expect(cmd, `${name} is no longer a command`).toBeDefined();
+      expect(cmd!.description(), `${name}'s description dropped ${fact}`).toMatch(fact);
     }
   });
 });

--- a/cli/test/unit/root-help-index.test.ts
+++ b/cli/test/unit/root-help-index.test.ts
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// `pome --help` is the first thing a new user runs, and it is an index: it
+// answers "which command do I want", nothing more. It grew to 76 lines because
+// six commands described themselves in prose there — `run` alone took 6 lines,
+// `demo` and `fix-prompt` 8 each — so the list did not fit on one screen.
+//
+// Commander prints `.summary()` in the parent's command list and `.description()`
+// in the command's own `--help`. The assertions below hold that split: nothing in
+// the index wraps, and no fact moved out of the index was deleted rather than
+// relocated.
+
+import type { Command } from "commander";
+import { describe, expect, it } from "vitest";
+
+import { createProgram } from "../../src/cli/main.js";
+
+/** A fixed help width, so the assertions do not depend on the terminal that
+ *  runs them. 80 columns is Commander's own default when stdout is not a TTY,
+ *  which is what CI reads. */
+const HELP_WIDTH = 80;
+
+/** Width of the description column at HELP_WIDTH: two spaces of indent, the
+ *  longest command term, two spaces of gutter, then the text. A summary longer
+ *  than this wraps onto a second line, which is the defect. */
+function indexTextWidth(program: Command): number {
+  const longestTerm = Math.max(
+    ...visible(program).map((cmd) => `${cmd.name()} ${cmd.usage()}`.trim().length),
+  );
+  return HELP_WIDTH - (2 + longestTerm + 2);
+}
+
+function visible(program: Command): Command[] {
+  return program.commands.filter(
+    (cmd) => !(cmd as unknown as { _hidden?: boolean })._hidden && cmd.name() !== "help",
+  );
+}
+
+function help(cmd: Command): string {
+  cmd.configureHelp({ helpWidth: HELP_WIDTH });
+  return cmd.helpInformation();
+}
+
+/** The lines of the `Commands:` block, which is the index itself. */
+function indexLines(program: Command): string[] {
+  const lines = help(program).split("\n");
+  const start = lines.findIndex((line) => line === "Commands:");
+  expect(start, "root --help no longer prints a Commands: block").toBeGreaterThan(-1);
+  return lines.slice(start + 1).filter((line) => line.trim().length > 0);
+}
+
+describe("pome --help is a one-screen index", () => {
+  it("gives each command exactly one line", () => {
+    const program = createProgram();
+    // Commander appends its own `help` entry, which is part of the index.
+    const names = [...visible(program).map((cmd) => cmd.name()), "help"];
+    // A wrapped entry shows up as a line that starts past the term column and
+    // names no command, so counting entry lines against commands catches it
+    // without parsing the padding.
+    const entries = indexLines(program).filter((line) =>
+      names.some((name) => line.trimStart().startsWith(name)),
+    );
+    const wrapped = indexLines(program).length - entries.length;
+
+    expect(wrapped, `${wrapped} index line(s) wrapped onto a second line`).toBe(0);
+    expect(entries).toHaveLength(names.length);
+  });
+
+  it("fits on one screen", () => {
+    // 40 lines is a conservative floor for a default terminal. The number is a
+    // budget, not a measurement: it fails when the index grows prose again.
+    expect(help(createProgram()).split("\n").length).toBeLessThanOrEqual(40);
+  });
+
+  it("keeps every index entry short enough not to wrap", () => {
+    const program = createProgram();
+    const limit = indexTextWidth(program);
+
+    for (const cmd of visible(program)) {
+      const text = cmd.summary() || cmd.description();
+      expect(text, `${cmd.name()} has no index text`).not.toBe("");
+      expect(text.length, `${cmd.name()}'s index text is ${text.length} chars, over ${limit}`)
+        .toBeLessThanOrEqual(limit);
+      expect(text, `${cmd.name()}'s index text spans lines`).not.toContain("\n");
+    }
+  });
+
+  it("keeps caveats and cross-references out of the index", () => {
+    for (const cmd of visible(createProgram())) {
+      const text = cmd.summary() || cmd.description();
+      expect(text, `${cmd.name()}'s index text carries a parenthetical`).not.toMatch(/[()]/);
+      expect(text, `${cmd.name()}'s index text points at another command`).not.toMatch(/`pome /);
+    }
+  });
+
+  it("keeps a fuller description behind every shortened entry", () => {
+    // A summary earns its place only where the description does not fit the
+    // index. Where one exists, the long form must still be there one level
+    // down: without this, "shorten the index" and "delete the prose" pass the
+    // same assertions.
+    const summarised = visible(createProgram()).filter((cmd) => cmd.summary() !== "");
+
+    expect(summarised.length).toBeGreaterThan(0);
+    for (const cmd of summarised) {
+      expect(cmd.description(), `${cmd.name()} has a summary but no description`).not.toBe("");
+      expect(cmd.summary(), `${cmd.name()}'s summary only repeats its description`).not.toBe(
+        cmd.description(),
+      );
+      expect(help(cmd), `${cmd.name()} --help does not print its description`).toContain(
+        cmd.description().split("\n")[0]!.slice(0, 30),
+      );
+    }
+  });
+});


### PR DESCRIPTION
- `pome --help` was 76 lines: 14 of 21 commands described themselves in prose in the command list, where a reader is only choosing which command to run. The list is now 22 lines, down from 66, and the whole output is 31 lines.
- The long form is relocated, not deleted. Commander prints `.summary()` in the parent's list and `.description()` in the command's own `--help`, so `pome run --help` still carries every caveat it did.
- Four entries also stopped misdescribing their command: `pome docs` prints a URL rather than opening a browser, `pome checks` names the `add` subcommand that writes to a task file, `pome endpoints` answers for github and gmail only, and `pome twin` lists the subcommands it actually has.
- One test, `cli/test/unit/root-help-index.test.ts`: no entry in the command list wraps onto a second line. That is the property a command added later regresses silently, and it was perturbed red with a paragraph summary and restored.
- Also corrects two places that named a filename the CLI stopped reading and a docs command that opens nothing: the README quickstart and the npm package description.

Follow-up, not in this PR: `apps/docs/docs/cli/index.mdx` in pome-cloud repeats the old command descriptions. That page tracks the pinned CLI, so it moves with the next pin bump.