### PR TITLE
cli: stop printing the same default twice in four help entries (F-1726)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,7 +9,7 @@ write a version number here or in `package.json`. Released entries are insertion
 only: a correction is the next entry, naming the one it corrects.
 
 
-## 0.33.2 — 2026-08-28
+## Unreleased (patch)
 
 **Four help entries printed their default twice.** `pome twin reset --help` read
 `name  Twin name (default: github) (default: "github")`, once from the argument's
@@ -26,6 +26,8 @@ which is that a twin holding its state in memory has nothing to delete.
 `sandbox create --format env` said it "is not printed". It does print: writing
 `--secrets-file` announces itself on stderr. What it does not print is the
 exports themselves, which is what the text now says.
+
+## 0.33.2 — 2026-08-28
 
 **`pome run --help` is a reference card again.** It was 44 lines, of which
 `-n/--trials` alone was a 90-word paragraph covering the 1 to 20 range, the plan

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -18,9 +18,14 @@ default value and once from a description that also named it. `sandbox create
 renders the default, so the text no longer repeats it.
 
 `pome twin reset` also says what it does. "Reset standalone twin state" named
-neither what is deleted nor what replaces it; it now reads "Delete a twin's local
-database and status file, so its next start begins from the twin's declared
-starting point again."
+neither what goes nor where it lived. It now names the paths: the twin's database
+under `.pome/` or `.pome-data/`, and `.pome/twin-status.json`, the one file `pome
+twin status` reads for every twin. It also says the case a reader hits first,
+which is that a twin holding its state in memory has nothing to delete.
+
+`sandbox create --format env` said it "is not printed". It does print: writing
+`--secrets-file` announces itself on stderr. What it does not print is the
+exports themselves, which is what the text now says.
 
 **`pome run --help` is a reference card again.** It was 44 lines, of which
 `-n/--trials` alone was a 90-word paragraph covering the 1 to 20 range, the plan

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -11,6 +11,17 @@ only: a correction is the next entry, naming the one it corrects.
 
 ## 0.33.2 — 2026-08-28
 
+**Four help entries printed their default twice.** `pome twin reset --help` read
+`name  Twin name (default: github) (default: "github")`, once from the argument's
+default value and once from a description that also named it. `sandbox create
+--format`, `sandbox list --state` and `demo --trials` did the same. Commander
+renders the default, so the text no longer repeats it.
+
+`pome twin reset` also says what it does. "Reset standalone twin state" named
+neither what is deleted nor what replaces it; it now reads "Delete a twin's local
+database and status file, so its next start begins from the twin's declared
+starting point again."
+
 **`pome run --help` is a reference card again.** It was 44 lines, of which
 `-n/--trials` alone was a 90-word paragraph covering the 1 to 20 range, the plan
 quota, slot reuse, the verdict table and three exit codes. Each flag now takes

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -544,7 +544,7 @@ export function createProgram() {
     )
     .option(
       "--format <fmt>",
-      "text (default) | json | env. env requires --secrets-file and is not printed.",
+      "Output format: text, json, or env. env requires --secrets-file and prints nothing.",
       "text",
     )
     .action(
@@ -587,10 +587,10 @@ export function createProgram() {
     .option("--limit <n>", "Max rows", "20")
     .option(
       "--state <state>",
-      "Filter by session state: running (default) | ready | done | expired | all. `running` matches both server-side `ready` and `running` (dashboard collapses both into one column).",
+      "Filter by sandbox state: running, ready, done, expired, or all. `running` also matches the server-side `ready` state, the way the dashboard shows them in one column.",
       "running",
     )
-    .option("--format <fmt>", "text | json", "text")
+    .option("--format <fmt>", "Output format: text or json.", "text")
     .action(
       async (opts: { apiUrl: string; limit: string; state: string; format: string }) => {
         const validStates: SessionListStateFilter[] = [
@@ -1013,7 +1013,7 @@ export function createProgram() {
     )
     .option(
       "--trials <n>",
-      "Number of isolated trials (default 5 per the packaged demo).",
+      "Number of trials to run, 1 to 10.",
       "5",
     )
     .option("--artifacts-dir <dir>", "Directory for run artifacts", "runs")
@@ -1356,8 +1356,15 @@ export function createProgram() {
 
   twin
     .command("reset")
-    .argument("[name]", "Twin name (default: github)", "github")
-    .description("Reset standalone twin state")
+    // The name defaults rather than being required, matching `twin start`. What
+    // this deletes is a local database the next start rebuilds from the twin's
+    // declared starting point, so a mistyped reset costs nothing a user cannot
+    // get back, and the success line names the twin it acted on.
+    .argument("[name]", "Twin name", "github")
+    .summary("Reset a twin's local state")
+    .description(
+      "Delete a twin's local database and status file, so its next start begins from the twin's declared starting point again.",
+    )
     .action(async (name: string) => {
       if (!isTwinName(name)) {
         throw new Error(`Unknown twin '${name}'. Supported: ${TWIN_NAME_LIST.join(", ")}.`);

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -544,7 +544,7 @@ export function createProgram() {
     )
     .option(
       "--format <fmt>",
-      "Output format: text, json, or env. env requires --secrets-file and prints nothing.",
+      "Output format: text, json, or env. env writes the exports to --secrets-file instead of printing them.",
       "text",
     )
     .action(
@@ -590,7 +590,7 @@ export function createProgram() {
       "Filter by sandbox state: running, ready, done, expired, or all. `running` also matches the server-side `ready` state, the way the dashboard shows them in one column.",
       "running",
     )
-    .option("--format <fmt>", "Output format: text or json.", "text")
+    .option("--format <fmt>", "Output format: text or json", "text")
     .action(
       async (opts: { apiUrl: string; limit: string; state: string; format: string }) => {
         const validStates: SessionListStateFilter[] = [
@@ -1013,7 +1013,7 @@ export function createProgram() {
     )
     .option(
       "--trials <n>",
-      "Number of trials to run, 1 to 10.",
+      "Number of trials to run, 1 to 10",
       "5",
     )
     .option("--artifacts-dir <dir>", "Directory for run artifacts", "runs")
@@ -1356,14 +1356,17 @@ export function createProgram() {
 
   twin
     .command("reset")
-    // The name defaults rather than being required, matching `twin start`. What
-    // this deletes is a local database the next start rebuilds from the twin's
-    // declared starting point, so a mistyped reset costs nothing a user cannot
-    // get back, and the success line names the twin it acted on.
+    // The name defaults rather than being required, matching `twin start`, and
+    // the success line names the twin it acted on.
+    //
+    // The description names the paths rather than promising an outcome: `twin
+    // start` boots the twin in process, every twin opens an in-memory database
+    // unless a `*_DB` path is set, and it re-seeds on every boot. So a reset
+    // does not decide what the next start begins from.
     .argument("[name]", "Twin name", "github")
-    .summary("Reset a twin's local state")
+    .summary("Reset a twin's saved state")
     .description(
-      "Delete a twin's local database and status file, so its next start begins from the twin's declared starting point again.",
+      "Delete the twin's database under `.pome/` or `.pome-data/`, and `.pome/twin-status.json`, the one file `pome twin status` reads for every twin. A twin holding its state in memory has nothing to delete.",
     )
     .action(async (name: string) => {
       if (!isTwinName(name)) {

--- a/cli/test/unit/help-defaults.test.ts
+++ b/cli/test/unit/help-defaults.test.ts
@@ -28,13 +28,16 @@ function path(cmd: Command): string {
   return names.join(" ");
 }
 
-const NAMES_A_DEFAULT = /\(default[: )]/i;
+/** Only a parenthesized default, which is the shape Commander itself renders
+ *  and therefore the shape that duplicates. Prose like "instead of each twin's
+ *  default" stays legal, and has to: `sandbox create --seed` needs it. */
+const PARENTHESIZED_DEFAULT = /\(default[: )]/i;
 
 describe("help text never renders a default twice", () => {
   it("holds for every argument in the command tree", () => {
     for (const cmd of allCommands(createProgram())) {
       for (const arg of cmd.registeredArguments) {
-        const named = NAMES_A_DEFAULT.test(arg.description);
+        const named = PARENTHESIZED_DEFAULT.test(arg.description);
         const hasDefault = arg.defaultValue !== undefined;
         expect(
           named && hasDefault,
@@ -47,7 +50,7 @@ describe("help text never renders a default twice", () => {
   it("holds for every option in the command tree", () => {
     for (const cmd of allCommands(createProgram())) {
       for (const opt of cmd.options) {
-        const named = NAMES_A_DEFAULT.test(opt.description);
+        const named = PARENTHESIZED_DEFAULT.test(opt.description);
         const hasDefault = opt.defaultValue !== undefined;
         expect(
           named && hasDefault,
@@ -71,15 +74,19 @@ describe("help text never renders a default twice", () => {
     expect(help).toContain("github");
   });
 
-  it("says what `twin reset` deletes and what the next start does", () => {
-    // "Reset standalone twin state" named neither, which is what left a reader
-    // guessing whether a seed passed to `twin start` survived it.
+  it("names the paths `twin reset` deletes", () => {
+    // "Reset standalone twin state" named neither what goes nor where it lived,
+    // which is what left a reader guessing whether a seed passed to `twin start`
+    // survived it. Paths rather than an outcome: `twin start` re-seeds on every
+    // boot, so a reset does not decide what the next start begins from, and a
+    // description that promised otherwise would be the same defect in reverse.
     const reset = createProgram()
       .commands.find((cmd) => cmd.name() === "twin")
       ?.commands.find((cmd) => cmd.name() === "reset");
     const description = reset!.description();
 
     expect(description).toMatch(/delete/i);
-    expect(description).toMatch(/start/i);
+    expect(description).toContain(".pome/twin-status.json");
+    expect(description).not.toMatch(/next start|starting point/i);
   });
 });

--- a/cli/test/unit/help-defaults.test.ts
+++ b/cli/test/unit/help-defaults.test.ts
@@ -59,34 +59,4 @@ describe("help text never renders a default twice", () => {
       }
     }
   });
-
-  it("still renders the default `twin reset` acts on", () => {
-    // Deleting the duplicate must not delete the fact: a destructive command
-    // that defaults its target has to say so somewhere the reader looks.
-    const reset = createProgram()
-      .commands.find((cmd) => cmd.name() === "twin")
-      ?.commands.find((cmd) => cmd.name() === "reset");
-    expect(reset, "`pome twin reset` is no longer in the command tree").toBeDefined();
-    reset!.configureHelp({ helpWidth: 80 });
-
-    const help = reset!.helpInformation();
-    expect(help.match(/\(default/g) ?? []).toHaveLength(1);
-    expect(help).toContain("github");
-  });
-
-  it("names the paths `twin reset` deletes", () => {
-    // "Reset standalone twin state" named neither what goes nor where it lived,
-    // which is what left a reader guessing whether a seed passed to `twin start`
-    // survived it. Paths rather than an outcome: `twin start` re-seeds on every
-    // boot, so a reset does not decide what the next start begins from, and a
-    // description that promised otherwise would be the same defect in reverse.
-    const reset = createProgram()
-      .commands.find((cmd) => cmd.name() === "twin")
-      ?.commands.find((cmd) => cmd.name() === "reset");
-    const description = reset!.description();
-
-    expect(description).toMatch(/delete/i);
-    expect(description).toContain(".pome/twin-status.json");
-    expect(description).not.toMatch(/next start|starting point/i);
-  });
 });

--- a/cli/test/unit/help-defaults.test.ts
+++ b/cli/test/unit/help-defaults.test.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// `pome twin reset --help` printed its default twice:
+//
+//   name        Twin name (default: github) (default: "github")
+//
+// once from the `.argument()` default value that Commander renders itself, and
+// once from a description that also named it. Cosmetic, and the kind of thing a
+// reader screenshots.
+//
+// The assertion is tree-wide rather than about `twin reset`, because the defect
+// is a class: any declaration that both carries a default value and names one in
+// its own text renders both. Prose like `twin start --port`'s "(default: $PORT,
+// else 3333)" is fine, since that option has no Commander default to duplicate.
+
+import type { Command } from "commander";
+import { describe, expect, it } from "vitest";
+
+import { createProgram } from "../../src/cli/main.js";
+
+/** Every command in the tree, including subcommands and hidden ones. */
+function allCommands(root: Command): Command[] {
+  return [root, ...root.commands.flatMap((cmd) => allCommands(cmd))];
+}
+
+function path(cmd: Command): string {
+  const names: string[] = [];
+  for (let node: Command | null = cmd; node; node = node.parent) names.unshift(node.name());
+  return names.join(" ");
+}
+
+const NAMES_A_DEFAULT = /\(default[: )]/i;
+
+describe("help text never renders a default twice", () => {
+  it("holds for every argument in the command tree", () => {
+    for (const cmd of allCommands(createProgram())) {
+      for (const arg of cmd.registeredArguments) {
+        const named = NAMES_A_DEFAULT.test(arg.description);
+        const hasDefault = arg.defaultValue !== undefined;
+        expect(
+          named && hasDefault,
+          `${path(cmd)} <${arg.name()}> carries a default value and names one in its text: "${arg.description}"`,
+        ).toBe(false);
+      }
+    }
+  });
+
+  it("holds for every option in the command tree", () => {
+    for (const cmd of allCommands(createProgram())) {
+      for (const opt of cmd.options) {
+        const named = NAMES_A_DEFAULT.test(opt.description);
+        const hasDefault = opt.defaultValue !== undefined;
+        expect(
+          named && hasDefault,
+          `${path(cmd)} ${opt.flags} carries a default value and names one in its text: "${opt.description}"`,
+        ).toBe(false);
+      }
+    }
+  });
+
+  it("still renders the default `twin reset` acts on", () => {
+    // Deleting the duplicate must not delete the fact: a destructive command
+    // that defaults its target has to say so somewhere the reader looks.
+    const reset = createProgram()
+      .commands.find((cmd) => cmd.name() === "twin")
+      ?.commands.find((cmd) => cmd.name() === "reset");
+    expect(reset, "`pome twin reset` is no longer in the command tree").toBeDefined();
+    reset!.configureHelp({ helpWidth: 80 });
+
+    const help = reset!.helpInformation();
+    expect(help.match(/\(default/g) ?? []).toHaveLength(1);
+    expect(help).toContain("github");
+  });
+
+  it("says what `twin reset` deletes and what the next start does", () => {
+    // "Reset standalone twin state" named neither, which is what left a reader
+    // guessing whether a seed passed to `twin start` survived it.
+    const reset = createProgram()
+      .commands.find((cmd) => cmd.name() === "twin")
+      ?.commands.find((cmd) => cmd.name() === "reset");
+    const description = reset!.description();
+
+    expect(description).toMatch(/delete/i);
+    expect(description).toMatch(/start/i);
+  });
+});


### PR DESCRIPTION
- `pome twin reset --help` printed `name  Twin name (default: github) (default: "github")`, once from the argument's default value that Commander renders itself and once from a description that also named it. Three more entries had the same shape: `sandbox create --format`, `sandbox list --state` and `demo --trials`.
- `pome twin reset`'s description said "Reset standalone twin state", naming neither what goes nor where it lived. It now names the paths it deletes, and says the case a reader hits first, which is that a twin holding its state in memory has nothing to delete.
- It deliberately promises no outcome. `pome twin start` boots the twin in process, every twin opens an in-memory database unless a `*_DB` path is set, and it re-seeds on every boot, so a reset does not decide what the next start begins from.
- `sandbox create --format env` claimed it "is not printed", but writing `--secrets-file` announces itself on stderr. It is the exports that are not printed, which is what it now says.
- One test, `cli/test/unit/help-defaults.test.ts`: no argument or option anywhere in the command tree carries a default value and also names a parenthesized default in its own text. Prose like `sandbox create --seed`'s "instead of each twin's default" stays legal. Both arms perturbed red and restored.

Closes F-1726.

Found while checking the copy against the code, filed as F-1728 rather than fixed here: `pome twin reset` deletes `.pome/<twin>.db` and `.pome-data/<twin>/<twin>.db`, but the standalone github, slack and stripe servers write `.<twin>_clone/<twin>.db`, so a reset misses three of the five twins' database files.