### PR TITLE
Delete the tests and copy that only describe what used to be here (F-1730)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,13 @@ way to break it is to undo the commit it ships with. The same goes for a comment
 or a doc line explaining what used to be here: delete the surface, and delete the
 sentence about the surface.
 
+Three places are records rather than tombstones and stay: a CHANGELOG, each
+twin's `FIDELITY.md` divergence ledger (the numbers are stable identifiers and a
+gap in them is load-bearing), and an example's `VERIFICATION.md` (a measurement
+record, and the reason not to re-run a rejected experiment). So do wire and API
+field names still on the wire, and prose about a vendor's own naming, such as
+Slack calling `files.upload` its legacy v1 endpoint.
+
 Coverage cannot live in the root config: vitest reads `coverage` only at the
 top level and drops a `coverage` block inside a project entry **silently**.
 twin-github and twin-slack each keep a `vitest.coverage.config.ts` that

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,15 @@ contract suite in `contract/` is plain `.mjs` on `node --test`, because running
 it without TypeScript is what proves the published artifact boots — see
 `CONTRACT.md`. A self-test *of a script* stays beside its script as `.mjs`.
 
+**Do not test that something was deleted.** A test whose subject is a surface
+this repo no longer has runs on every suite from now on to re-assert a diff that
+already happened, and it can only fail if someone deliberately re-adds the
+thing. `it("`pome scenarios` is not a command")` was one. Write the test when a
+change made next year can break the assertion by accident; skip it when the only
+way to break it is to undo the commit it ships with. The same goes for a comment
+or a doc line explaining what used to be here: delete the surface, and delete the
+sentence about the surface.
+
 Coverage cannot live in the root config: vitest reads `coverage` only at the
 top level and drops a `coverage` block inside a project entry **silently**.
 twin-github and twin-slack each keep a `vitest.coverage.config.ts` that

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,6 +9,19 @@ write a version number here or in `package.json`. Released entries are insertion
 only: a correction is the next entry, naming the one it corrects.
 
 
+## Unreleased (patch)
+
+`SECURITY.md` states the `pome-sh` package on npm as what it is: not this
+package, not maintained, no security updates. It is still published at 0.8.0, so
+this is a warning rather than a note about the past.
+
+The `scenario*` schema aliases are gone from `cli/src/contract`
+(`scenarioSchema`, `scenarioConfigSchema`, `persistedScenarioSchema`, and the
+`Scenario`, `ScenarioConfig`, `PersistedScenario` types). They were referential
+copies of the `task*` exports kept for a 0.3.0 window, with no consumer outside
+the two tests that asserted they existed. The serialized `scenario` /
+`scenario_*` wire keys are unchanged.
+
 ## 0.34.1 — 2026-08-28
 
 **`pome health` is internal and no longer in `pome --help`.** It boots the GitHub

--- a/cli/CONTRIBUTING.md
+++ b/cli/CONTRIBUTING.md
@@ -69,9 +69,10 @@ This boundary is enforced mechanically, repo-wide, by
 `cli/src/**`, `cli/scripts/**`, and `packages/**` in one pass — there is no
 separate `cli/`-local copy to run. The gate denies:
 
-1. **Known deleted paths reappearing** — `src/evaluator/`, `src/matrix/`,
-   `src/score/`, `packages/correlator/`, and the retired local-scoring CLI
-   entrypoints must stay gone.
+1. **Paths that name a scoring capability** — `src/evaluator/`, `src/matrix/`,
+   `src/score/`, `packages/correlator/` and the CLI's scoring entrypoints. A
+   directory with one of those names is local scoring whatever its files import,
+   which is why the path list exists alongside the two checks below.
 2. **File names that look like an evaluator** — any file whose name starts
    with `correlate`, `score`, `judge`, or `verdict` (case-insensitive), no
    matter where it lives. If your change legitimately needs a name like

--- a/cli/SECURITY.md
+++ b/cli/SECURITY.md
@@ -4,6 +4,9 @@
 
 The latest published `@pome-sh/cli` release receives security updates. Older versions are not patched.
 
+The `pome-sh` package on npm is not this package and is not maintained. It
+receives no security updates. Install `@pome-sh/cli`.
+
 ## Reporting a vulnerability
 
 Please **do not** open a public GitHub issue for a suspected vulnerability.

--- a/cli/SECURITY.md
+++ b/cli/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported versions
 
-The latest published `@pome-sh/cli` CLI line receives security updates. Older versions are not patched (including the deprecated `pome-sh` line this CLI was previously published under).
+The latest published `@pome-sh/cli` release receives security updates. Older versions are not patched.
 
 ## Reporting a vulnerability
 

--- a/cli/src/cli/eval.ts
+++ b/cli/src/cli/eval.ts
@@ -537,12 +537,10 @@ export async function runEval(options: RunEvalOptions): Promise<RunEvalResult> {
   // was evaluated, every criterion was judged (can_pass), AND the score clears
   // the threshold. An INCOMPLETE verdict (any criterion not evaluated) exits 1.
   //
-  // The divergence that used to be documented here is retired. `pome run`
-  // mapped the raw cloud score because "older cloud builds don't emit
-  // criteria_results" — but `scoreFromFinalizeResponse` already handles that
-  // case (`hasCriteriaResults ? … : true`), so the guard degrades to score-only
-  // for exactly those builds on its own. The divergence was protecting a case
-  // its own helper already protected, and the two commands now agree.
+  // `pome run` applies the same guard. A cloud response with no
+  // `criteria_results` degrades to score-only inside
+  // `scoreFromFinalizeResponse` (`hasCriteriaResults ? … : true`), so neither
+  // command needs a branch of its own for it.
   const exitCode = scoreStatus(score, EVAL_PASS_THRESHOLD) === "pass" ? 0 : 1;
 
   return {

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -1102,14 +1102,6 @@ export function createProgram() {
       },
     );
 
-  // NOTE: `matrix` / `matrix-html` / `eval-report` were removed.
-  // They were a pure LOCAL-scoring orchestrator — they shelled out to
-  // `pome run` with POME_LOCAL=1 and aggregated the local score.json each
-  // child wrote. With local evaluation gone (the OSS CLI is capture-only),
-  // that path cannot produce a verdict, so the whole subsystem was retired
-  // rather than left as a broken command. Fleet evaluation lives in the
-  // cloud/research workspace.
-
   program
     .command("inspect")
     .argument("<run>", "Run id, run directory, or latest")

--- a/cli/src/cli/project-config.ts
+++ b/cli/src/cli/project-config.ts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// The pome MANIFEST loader. Replaces the legacy
-// `pome.config.json` handling — no back-compat, 0 users. The committed manifest
+// The pome MANIFEST loader. The committed manifest
 // is `pome.json` (canonical) with `pome.yaml` / `pome.yml` as interchangeable
 // carriers of the same snake_case keys. One canonical zod schema
 // (`cli/src/contract` `manifestSchema`) validates every carrier.

--- a/cli/src/cli/session.ts
+++ b/cli/src/cli/session.ts
@@ -35,13 +35,9 @@ export function ensureMcpSuffix(url: string): string {
 // Multi-twin (M3): the CLI's ad-hoc session allowlist IS the shared mounted-twin
 // set. Repeated `--twin` flags stand up a multi-twin session in one call.
 //
-// The parenthetical roll-call that used to sit in this comment, and the
-// `"gmail", "linear"` that used to be appended below it "during contract publish
-// windows", were both inert: `MOUNTED_TWINS` arrives from `cli/src/contract/`,
-// which is source in this workspace and never a resolved package, so neither
-// could add a name the set lacked. What they did do is read as a second place
-// twins are named — the shape that let `sandbox create --help` spend a release
-// advertising four twins while this validator already accepted five.
+// `MOUNTED_TWINS` is the single place a twin is named. A second list here reads
+// as a second source of truth, which is how `sandbox create --help` spent a
+// release advertising four twins while this validator already accepted five.
 const ALLOWED_TWINS = new Set<string>(MOUNTED_TWINS);
 
 /** The twins `--twin` accepts, in mounted order.

--- a/cli/src/contract/task.ts
+++ b/cli/src/contract/task.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // contract §3 — TASKS. Task config, the parsed task markdown shape, and the
-// persisted task row, plus their deprecated `scenario*` aliases. The provider
+// persisted task row. The provider
 // seed-state schemas consumed by `taskSchema.seedState` live in `./seed-state.ts`.
 // Re-exported through the `cli/src/contract` barrel (index.ts).
 
@@ -10,11 +10,7 @@ import { criterionSchema, judgeModelSchema } from "./run.js";
 import { seedStateSchema } from "./seed-state.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
-// 3. TASKS (formerly "scenarios") — originally adopted verbatim from
-//    oslo/pome/src/scenario/scenarioSchema.ts
-//
-// Task vocab: "task" is the canonical name; the `scenario*` exports
-// below are deprecated aliases kept for the 0.3.0 window.
+// 3. TASKS
 //
 // `criterionSchema` and `judgeModelSchema` were moved to `./run.ts` (2026-05-11
 // split) because CriterionResult depends on them; imported here from `./run.js`
@@ -110,12 +106,7 @@ export const taskConfigSchema = z.preprocess(
 );
 export type TaskConfig = z.infer<typeof taskConfigSchema>;
 
-/** @deprecated Use `taskConfigSchema`. Removed after the 0.3.0 window. */
-export const scenarioConfigSchema = taskConfigSchema;
-/** @deprecated Use `TaskConfig`. */
-export type ScenarioConfig = TaskConfig;
-
-// The parsed task (formerly "scenario") markdown shape. Criterion kinds inside
+// The parsed task markdown shape. Criterion kinds inside
 // `criteria` normalize D→code, P→model (tolerant reader).
 export const taskSchema = z.object({
   slug: z.string().min(1),
@@ -128,11 +119,6 @@ export const taskSchema = z.object({
   seedState: seedStateSchema,
 });
 export type Task = z.infer<typeof taskSchema>;
-
-/** @deprecated Use `taskSchema`. Removed after the 0.3.0 window. */
-export const scenarioSchema = taskSchema;
-/** @deprecated Use `Task`. */
-export type Scenario = Task;
 
 // Persisted Task row (dashboard upload path; cloud DB `tasks` table). Per
 // 04-data-model.md. Row ids keep the historical `scn_` prefix (persisted data;
@@ -148,8 +134,3 @@ export const persistedTaskSchema = z.object({
   archived_at: z.string().datetime().nullable(),
 });
 export type PersistedTask = z.infer<typeof persistedTaskSchema>;
-
-/** @deprecated Use `persistedTaskSchema`. Removed after the 0.3.0 window. */
-export const persistedScenarioSchema = persistedTaskSchema;
-/** @deprecated Use `PersistedTask`. */
-export type PersistedScenario = PersistedTask;

--- a/cli/test/e2e/runTask.test.ts
+++ b/cli/test/e2e/runTask.test.ts
@@ -17,13 +17,6 @@ const REQUIRED_RUN_DIR_FILES = [
   "stderr.log",
   "stdout.txt",
 ];
-const DELETED_RUN_DIR_FILES = [
-  "tool_calls.jsonl",
-  "state-before.json",
-  "state-after.json",
-  "state-diff.json",
-];
-
 // Self-host (`pome run` / `pome run --local`) is CAPTURE-ONLY.
 describe("Pome scenario runner (capture-only)", () => {
   it(
@@ -52,10 +45,7 @@ describe("Pome scenario runner (capture-only)", () => {
         for (const required of REQUIRED_RUN_DIR_FILES) {
           expect(entries.has(required)).toBe(true);
         }
-        // ...and the deleted correlation artifacts never come back.
-        for (const deleted of DELETED_RUN_DIR_FILES) {
-          expect(entries.has(deleted)).toBe(false);
-        }
+        // Capture-only: a score is the cloud's to write, never this repo's.
         expect(entries.has("score.json")).toBe(false);
       }
     },

--- a/cli/test/unit/assets.test.ts
+++ b/cli/test/unit/assets.test.ts
@@ -86,10 +86,10 @@ describe("cli/package.json packaging", () => {
     expect(Object.keys(pkg.dependencies).filter((d) => d.startsWith("@pome-sh/"))).toEqual([]);
   });
 
-  it("no longer declares bundleDependencies", () => {
-    // bundleDependencies packs from cli/node_modules, which npm leaves empty
-    // for a workspace member — it declared seven bundled packages and shipped
-    // none. The bundler replaces it.
+  it("declares no bundleDependencies", () => {
+    // It packs from cli/node_modules, which npm leaves empty for a workspace
+    // member, so declaring it ships an empty bundle and the published CLI
+    // crashes on a missing dependency. The bundler covers this instead.
     expect(pkg.bundleDependencies).toBeUndefined();
   });
 });

--- a/cli/test/unit/tasks-command.test.ts
+++ b/cli/test/unit/tasks-command.test.ts
@@ -73,10 +73,6 @@ describe("pome tasks", () => {
     expect(out).toContain("01-bug-happy-path.md");
     expect(out).toContain("03-already-triaged.md");
     expect(out).toContain("05-github-identity-spoof.md");
-    // Both are deleted: `00-default-seed` was a reference document, not a task, and
-    // `04-judge-context` measured our own judge lane.
-    expect(out).not.toContain("00-default-seed.md");
-    expect(out).not.toContain("04-judge-context.md");
   });
 
   it("lists runnable stripe, slack, and gmail tasks", async () => {

--- a/cli/test/unit/tasks-command.test.ts
+++ b/cli/test/unit/tasks-command.test.ts
@@ -236,15 +236,4 @@ describe("pome tasks", () => {
     expect(existsSync(join(customDir, "01-bug-happy-path.md"))).toBe(true);
     expect(existsSync(join(dir, "tasks"))).toBe(false);
   });
-
-  it("`pome scenarios` is not a command", async () => {
-    await inTempDir();
-    const program = createProgram();
-    program.exitOverride();
-    program.configureOutput({ writeErr: () => {} });
-
-    await expect(
-      program.parseAsync(["node", "pome", "scenarios"]),
-    ).rejects.toThrow(/unknown command/i);
-  });
 });

--- a/cli/test/unit/wire/export-surface.test.ts
+++ b/cli/test/unit/wire/export-surface.test.ts
@@ -40,11 +40,8 @@ import type {
   ManifestInput,
   MeResponse,
   PerTwinStateKeys,
-  PersistedScenario,
   PersistedTask,
   PlanTier,
-  Scenario,
-  ScenarioConfig,
   SeedEnvelope,
   SeedState,
   Session,
@@ -102,11 +99,8 @@ type _TypeSurfaceAssert = [
   ManifestInput,
   MeResponse,
   PerTwinStateKeys,
-  PersistedScenario,
   PersistedTask,
   PlanTier,
-  Scenario,
-  ScenarioConfig,
   SeedEnvelope,
   SeedState,
   Session,
@@ -130,7 +124,7 @@ type _TypeSurfaceAssert = [
 // Compile-time anchor: exactly one tuple entry per guarded type. The literal
 // type on the left fails to compile if an entry is added or removed above
 // without updating the count.
-const TYPE_SURFACE_SIZE: _TypeSurfaceAssert["length"] = 57;
+const TYPE_SURFACE_SIZE: _TypeSurfaceAssert["length"] = 54;
 
 // Runtime value exports (types are erased and cannot appear on `Object.keys`).
 const EXPECTED_EXPORTS = [
@@ -187,14 +181,11 @@ const EXPECTED_EXPORTS = [
   "normalizeTaskConfigKeys",
   "normalizeTaskVocabKeys",
   "perTwinStateKeysSchema",
-  "persistedScenarioSchema",
   "persistedTaskSchema",
   "planTierSchema",
   "probabilisticCriterionResultSchema",
   "providerScopedSeedStateSchema",
   "runSchema",
-  "scenarioConfigSchema",
-  "scenarioSchema",
   "seedEnvelopeSchema",
   "seedStateSchema",
   "sessionPublicSchema",
@@ -224,10 +215,10 @@ describe("cli/src/contract barrel export surface", () => {
     expect(Object.keys(api).sort()).toEqual([...EXPECTED_EXPORTS]);
   });
 
-  it("guards the TYPE surface (57 types/interfaces)", () => {
+  it("guards the TYPE surface (54 types/interfaces)", () => {
     // The real guard is the type-only import + _TypeSurfaceAssert tuple above,
     // enforced at typecheck time. This assertion just anchors the count at
     // runtime so the guard's scope is visible in test output.
-    expect(TYPE_SURFACE_SIZE).toBe(57);
+    expect(TYPE_SURFACE_SIZE).toBe(54);
   });
 });

--- a/cli/test/unit/wire/task-vocab.test.ts
+++ b/cli/test/unit/wire/task-vocab.test.ts
@@ -19,10 +19,7 @@ import {
 } from "../../../src/contract/run.js";
 import {
   createSessionRequestSchema,
-  persistedScenarioSchema,
   persistedTaskSchema,
-  scenarioConfigSchema,
-  scenarioSchema,
   submitResultRequestSchema,
   taskConfigSchema,
   taskSchema,
@@ -348,16 +345,10 @@ describe("recorder events task_step_id vocabulary", () => {
   });
 });
 
-// ─── task* canonical exports + deprecated scenario* aliases ──────────────────
+// ─── task* canonical exports ─────────────────────────────────────────────────
 
-describe("task*/scenario* export aliases", () => {
-  it("scenario* exports are referentially identical to the canonical task* exports", () => {
-    expect(scenarioSchema).toBe(taskSchema);
-    expect(scenarioConfigSchema).toBe(taskConfigSchema);
-    expect(persistedScenarioSchema).toBe(persistedTaskSchema);
-  });
-
-  it("taskSchema parses a task with legacy D/P criteria and normalizes them", () => {
+describe("taskSchema", () => {
+  it("parses a task with D/P criteria and normalizes them", () => {
     const parsed = taskSchema.parse({
       slug: "github-issue-triage",
       title: "Triage the bug",

--- a/fixtures/mcp-tools-list/README.md
+++ b/fixtures/mcp-tools-list/README.md
@@ -29,8 +29,7 @@ rather than stamped, so a re-derivation can never make an old reading look like 
 
 ## Per twin
 
-All five are captured; the two `status.json` files once written for slack and linear were retired
-by later captures, and stripe's by the same round of captures.
+All five are captured.
 
 | twin | substrate | completeness | what was read |
 | --- | --- | --- | --- |
@@ -74,9 +73,8 @@ permission question; it decided what the listing CONTAINED.
 
 ## gmail: the second tools/list in this repo is now these bytes
 
-[`packages/twin-gmail/fixtures/mcp-tools-list.*`](../../packages/twin-gmail/fixtures/) used to be a
-separate frozen oracle. Its `raw.json` is now
-`gmail.raw.json` **byte for byte** — same `rawFileSha256`, nothing subtracted — adopted by
+[`packages/twin-gmail/fixtures/mcp-tools-list.*`](../../packages/twin-gmail/fixtures/) holds the
+same bytes: its `raw.json` is `gmail.raw.json` **byte for byte** — same `rawFileSha256`, nothing subtracted — adopted by
 `packages/twin-gmail/scripts/adopt-upstream-mcp-fixture.ts` and diffed in CI by
 `npm run gate:mcp-fixture -w @pome-sh/twin-gmail`. Refreshing this golden without re-adopting is now
 a red rather than a silent divergence.

--- a/packages/README.md
+++ b/packages/README.md
@@ -54,18 +54,15 @@ from it directly; `twin-gmail` and `twin-linear` only reach it transitively
 through `@pome-sh/sdk`. It's the one place a wire-shape change has to happen
 for every producer and consumer to see it consistently.
 
-It exists because that vocabulary used to live in a package called
-`@pome-sh/shared-types`, which drifted: internal consumers pinned an *exact*
-version against each other, the pins fell out of sync, and npm ended up
-installing two copies of the same Zod schemas at one runtime (two schema
-identities that were supposed to be identical). `@pome-sh/shared-types`
-was dissolved: the trace-wire half became `@pome-sh/wire`, and the
+It is split by audience, not by convenience: the trace-wire half is
+`@pome-sh/wire`, and the
 control-plane half (sessions, tasks, runs, the `/v1` REST surface, error
-envelopes, the `pome.json` manifest — none of which is a *trace* shape) moved
-to [`cli/src/contract/`](../cli/src/contract/), which isn't a workspace
+envelopes, the `pome.json` manifest — none of which is a *trace* shape) lives
+in [`cli/src/contract/`](../cli/src/contract/), which isn't a workspace
 package at all, just CLI-internal TypeScript. Every internal `@pome-sh/*`
-dependency is now `"*"` (workspace-resolved), not an exact pin, precisely so
-that drift can't recur (see `AGENTS.md`).
+dependency is `"*"` (workspace-resolved) rather than an exact pin, so two
+copies of the same Zod schemas can never be installed at one runtime
+(see `AGENTS.md`).
 
 `wire/trace-contract.json` is the machine-readable version of its own trace
 surface — generated from the Zod event union rather than hand-typed, so a new

--- a/packages/adapter-claude-sdk/CHANGELOG.md
+++ b/packages/adapter-claude-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pome-sh/adapter-claude-sdk — CHANGELOG
 
+## Unreleased (patch)
+
+**No consumer-visible change.** A comment in `wrapQuery.ts` described a step-
+boundary wrapper this file no longer has; it now describes the hook-driven
+`HookEvent` rows that replaced it. No export, schema or emitted event moved.
+
+
 ## 0.3.13 — 2026-08-26
 
 **No consumer-visible change.** `@pome-sh/wire` taught its run-completeness

--- a/packages/adapter-claude-sdk/src/wrapQuery.ts
+++ b/packages/adapter-claude-sdk/src/wrapQuery.ts
@@ -16,10 +16,8 @@
 // `parent_event_id` set to the SubagentSpawnEvent's `event_id`, chaining children
 // under the spawn row instead of leaving them parentless.
 //
-// Step boundaries (the prior `withStepBoundaries` in this file) were removed
-// when step signals were replaced with the SDK's hook-driven `HookEvent`
-// rows. The message-stream wrapper here is the surviving pome insertion
-// point in the SDK iterator.
+// Step boundaries come from the SDK's hook-driven `HookEvent` rows. The
+// message-stream wrapper here is pome's one insertion point in the SDK iterator.
 
 import { isPartialMessageArtifact } from "./partial-messages.js";
 import { redactSecrets } from "./redaction.js";

--- a/packages/twin-github/README.md
+++ b/packages/twin-github/README.md
@@ -95,7 +95,7 @@ Every `tools/call` reaching `/s/:sid/mcp` produces one recorder event whose
 domain return — identical to what `POST /s/:sid/mcp/call` records. The
 only intentional difference is `path` (`request_headers` also differs, but
 that's a fact about the two callers — the MCP SDK client vs a plain-fetch
-legacy shim — not about the twin). Run `npm run validate:mcp` to print the
+HTTP caller — not about the twin). Run `npm run validate:mcp` to print the
 side-by-side diff; the same command runs in CI's heavy suite.
 
 ## Runtime contract (for snapshot consumers)
@@ -273,7 +273,7 @@ npm run typecheck
 npx vitest run --project twin-github
 npm run smoke
 npm run fidelity:parity
-npm run validate:mcp # prints the wire-protocol / legacy-shim parity diff
+npm run validate:mcp # prints the JSON-RPC / per-tool-route parity diff
 npm run review:harness
 npm run agent:claude
 ```

--- a/packages/twin-github/README.md
+++ b/packages/twin-github/README.md
@@ -61,7 +61,7 @@ The default seed creates:
   `StreamableHTTPClientTransport` expect (`initialize`, `tools/list`,
   `tools/call`, `ping`, `notifications/*`). 36 tools exposed via
   `tools/list` with camelCase `inputSchema`.
-- Legacy custom MCP routes (compat surface for already-deployed agents):
+- Per-tool HTTP routes, which answer with the upstream status code rather than a JSON-RPC envelope. The fidelity harness scores parity through them:
   - `GET  /s/:sid/mcp/tools` — returns `{ tools: [{ name, description, input_schema }, ...] }`
   - `POST /s/:sid/mcp/tools/:name` — body is the tool's arguments object
   - `POST /s/:sid/mcp/call` — body `{ tool, arguments }`

--- a/packages/twin-gmail/FIDELITY.md
+++ b/packages/twin-gmail/FIDELITY.md
@@ -191,7 +191,7 @@ the handler.
 
 This twin had no zod across any of its five `rest-routes*.ts` modules; names existed only at
 call sites via `stringField(body, "raw")`-style helpers. All 60 routes are declared now, and
-`src/rest-upload.ts` is deleted — its multipart splitting is the shared mechanism's
+multipart splitting is the shared mechanism's
 `bodyEncoding: "media"`, so a JSON resource, a `multipart/related` metadata+media pair and a
 bare MIME body all land on the same declared input names.
 

--- a/packages/twin-slack/README.md
+++ b/packages/twin-slack/README.md
@@ -44,7 +44,7 @@ curl -X POST http://127.0.0.1:3333/s/demo/chat.postMessage \
   -H 'content-type: application/x-www-form-urlencoded' \
   -d 'channel=C_GENERAL&text=hello'
 
-# Legacy MCP call
+# Per-tool HTTP route
 curl -s -X POST http://127.0.0.1:3333/s/demo/mcp/call \
   -H "Authorization: Bearer $TOKEN" \
   -H 'content-type: application/json' \
@@ -94,7 +94,7 @@ an id no channel has.
   `StreamableHTTPClientTransport` expect (`initialize`, `tools/list`,
   `tools/call`, `ping`, `notifications/*`). 11 visible tools returned via
   `tools/list` with camelCase `inputSchema`.
-- Legacy custom MCP routes:
+- Per-tool HTTP routes, which answer with the upstream status code rather than a JSON-RPC envelope:
   - `GET  /s/:sid/mcp/tools` — returns `{ tools: [{ name, description, input_schema }, ...] }`
   - `POST /s/:sid/mcp/call` — body `{ tool, arguments }`
 

--- a/packages/twin-stripe/test/checks-contract.test.ts
+++ b/packages/twin-stripe/test/checks-contract.test.ts
@@ -435,10 +435,9 @@ describe("migrated sentences", () => {
     );
   });
 
-  it("no longer accepts the legacy qualified PaymentIntent-status forms", () => {
-    // Dropped deliberately (zero corpus users), and asserted so the drop is a
-    // decision rather than an oversight someone re-adds by widening the template.
-    // An author who needs to name ONE intent uses the indefinite check.
+  it("names a PaymentIntent by the indefinite form only", () => {
+    // The template must stay narrow: widening it to accept an amount or an id
+    // here would let one criterion bind a second, differently-scoped check.
     expect(parseCheck(paymentIntentStatusIs, "The PaymentIntent with amount 10000 status is succeeded")).toBeNull();
     expect(parseCheck(paymentIntentStatusIs, 'The PaymentIntent with id "pi_123" status is succeeded')).toBeNull();
   });

--- a/scripts/lint/rules/no-eval.mjs
+++ b/scripts/lint/rules/no-eval.mjs
@@ -6,6 +6,10 @@
 
 import { fileURLToPath } from "node:url";
 
+// Paths that NAME a scoring capability. Not a list of files that once existed:
+// a directory called `score` or `evaluator` is local scoring whatever its files
+// happen to import, and the module and file-name arms below cannot see it when
+// those files carry innocuous names.
 const FORBIDDEN_PATHS = [
   "cli/src/evaluator",
   "cli/src/matrix",

--- a/scripts/lint/rules/no-eval.test.mjs
+++ b/scripts/lint/rules/no-eval.test.mjs
@@ -17,7 +17,7 @@ defineCases("no-eval", [
     expect: "green",
   },
   {
-    name: "PATH: a deleted local-eval tree reappearing is a violation",
+    name: "PATH: a directory named for an eval role is a violation",
     files: { "cli/src/evaluator/index.ts": `export const evaluate = () => 1;\n` },
     expect: "red",
     contains: "deleted local-eval path reappeared: cli/src/evaluator",


### PR DESCRIPTION
- Deletes `it("`pome scenarios` is not a command")`. A test whose subject is a deleted surface re-asserts a diff on every run and can only fail if someone deliberately re-adds the thing. `assets.test.ts` keeps its `bundleDependencies` assertion, because an accidental re-add packs from an empty workspace `node_modules` and ships a broken tarball, but it states that invariant instead of the history.
- `packages/twin-github/README.md` and `packages/twin-slack/README.md` called the per-tool HTTP routes a "compat surface for already-deployed agents". There are no deployed agents. Both now say what the routes are: the transport that answers with an upstream status code rather than a JSON-RPC envelope, which is how the fidelity harness scores parity.
- `cli/SECURITY.md` no longer names the npm line this CLI used to publish under, and `cli/CONTRIBUTING.md` describes the boundary the `no-eval` gate enforces instead of the deletion that motivated it.
- `no-eval`'s path list stays, deliberately. It names a capability this repo must never have rather than files that once existed, and the import and file-name arms cannot see a directory called `score` whose files carry innocuous names. The rule and CONTRIBUTING now say so, so the next hygiene sweep does not mistake it for archaeology.
- `AGENTS.md` gets the rule next to the other test conventions, so this does not need doing again.

Closes F-1730 on the digital-twins side. The pome-cloud half, a `POME_SCENARIOS_SUBDIR` tombstone plus two docs lines, is a separate PR.

Left alone on purpose, both would cost more than they save: `agent-examples/support-triage/README.md`'s account of the retired planted defect, which is the measured reason not to flip `DENY_ISSUE_LOOKUP` back to `true` and expect a red, and `FIDELITY.md`'s "retired divergence" numbering, where a gap in the numbers is load-bearing.