### PR TITLE
Give the checks clean room the ambient libs a real consumer has

### DIFF
--- a/scripts/clean-room-pack-test.mjs
+++ b/scripts/clean-room-pack-test.mjs
@@ -324,6 +324,8 @@ writeFileSync(
   join(checksInstall, "package.json"),
   JSON.stringify({ name: "checks-room", private: true, type: "module" }, null, 2),
 );
+// The range, not the workspace lockfile's pin: a fresh consumer resolves the
+// newest zod satisfying `^4.x`, and this room exists to be that consumer.
 const zodRange = JSON.parse(
   readFileSync(join(ROOT, "packages", "checks", "package.json"), "utf8"),
 ).peerDependencies.zod;
@@ -334,6 +336,7 @@ run(
     checksTarball,
     `zod@${zodRange}`,
     "typescript",
+    "@types/node",
     "--no-audit",
     "--no-fund",
     "--ignore-scripts",
@@ -416,13 +419,23 @@ export function main(): void {
 }
 `,
 );
+// `skipLibCheck: false` is the whole point — it is what makes a shipped `.d.ts`
+// that names an unresolvable specifier a failure instead of a warning. The price
+// is that the peer's declarations are checked too, so the room needs the ambient
+// libs a real consumer has. `lib: ["ES2022"]` alone declares no `URL`, and zod
+// 4.5 types `parseURLObject` as returning one: the gate reddened on zod's own
+// `schemas.d.cts`, naming @pome-sh/checks. The two other rooms below and above
+// carried DOM + node types already and were unaffected; this one was the outlier.
+// Do NOT "fix" a future recurrence by turning `skipLibCheck` on or by pinning zod
+// here — either mutes the failure class this gate exists to catch.
 writeFileSync(
   join(checksInstall, "tsconfig.json"),
   JSON.stringify(
     {
       compilerOptions: {
         target: "ES2022",
-        lib: ["ES2022"],
+        lib: ["ES2022", "DOM"],
+        types: ["node"],
         module: "NodeNext",
         moduleResolution: "NodeNext",
         strict: true,


### PR DESCRIPTION
## What broke

`typecheck-test` — a **required** check — is red on every heavy PR, and on `main` itself. The failing step is `Clean-room pack test (both published packages)` (`npm run test:pack` → `scripts/clean-room-pack-test.mjs`):

```
❌ @pome-sh/checks: a consumer file failed to typecheck against the shipped declarations.
node_modules/zod/v4/core/schemas.d.cts(192,107): error TS2304: Cannot find name 'URL'.
node_modules/zod/v4/core/schemas.d.cts(195,44): error TS2304: Cannot find name 'URL'.
node_modules/zod/v4/core/schemas.d.cts(196,44): error TS2304: Cannot find name 'URL'.
```

Nothing in this repo changed. `packages/checks/package.json` declares `zod` as a peer at `^4.4.3`. The workspace lockfile pins `4.4.3`, but the clean room installs the packed tarball into a temp directory with **no** lockfile, so npm resolves the newest 4.x. zod shipped `4.5.0`/`4.5.1` on 2026-08-28 and `4.5.2` on 2026-08-29; `^4.4.3` now resolves to **4.5.2**, whose `v4/core/schemas.d.cts` types `parseURLObject` as returning a `URL`.

The checks room compiled its consumer under `lib: ["ES2022"]` with no `types` — which declares no `URL` — and with `skipLibCheck: false`, so zod's own declarations get checked. `main`'s last CI run predates the zod release, which is why `main` looks green and is not.

## The fix

Bring the checks room in line with the two sibling rooms **in this same file**, which were unaffected because they already carried the right ambient libs:

| room | `lib` | `types` | `@types/node` installed |
|---|---|---|---|
| `adapter-claude-sdk` | `["ESNext", "DOM"]` | `["node"]` | yes |
| `sandbox-domains` | `["ES2022", "DOM"]` | `["node"]` | yes |
| `checks` — **before** | `["ES2022"]` | — | no |
| `checks` — **after** | `["ES2022", "DOM"]` | `["node"]` | yes |

`sandbox-domains` installs the same floating `zod@^4.4.3` and also runs with `skipLibCheck: false`; it resolves 4.5.2 too and passes. The checks room was the lone holdout.

`skipLibCheck` stays `false`. Turning it on would silence this class permanently, and the class is real: a dependency shipping declarations a consumer cannot compile is exactly what this gate is for. What was *not* real here is the consumer being modelled — nobody compiles against `@pome-sh/checks` with neither DOM nor `@types/node`. The fix restores a true signal instead of muting one.

## Why not pin zod in the clean room

Pinning `zod@4.4.3` in the room's install is cheaper and more deterministic, and it would make CI green today. It was rejected because it deletes the thing the room measures. `scripts/ci/check-checks-tarball.mjs`'s header states the gate's subject — what a **consumer's** `npm i` gets, as against what the workspace has — and the whole reason the room installs from the peer *range* rather than the lockfile is that a fresh consumer resolves latest-4.x. Pinning would have made this exact breakage invisible, and would keep it invisible the next time a floating peer ships something a consumer cannot compile. A comment now states the range is deliberate, so it does not get "tidied" into a pin later.

## Verification

**Reproduction, before the fix.** Fresh worktree at `origin/main` (`bd32fda`), `npm ci` + `npm run build` + `npm run test:pack` → exit 1, the three `TS2304: Cannot find name 'URL'` errors above. Resolved zod in the room: **4.5.2** (confirmed independently: `npm install zod@^4.4.3` in an empty directory installs 4.5.2, and its `schemas.d.cts` names `URL` at lines 192/195/196).

**After the fix.** Same worktree, `npm run test:pack` → exit 0, all four packages green, including `sandbox-domains` which the run had never reached before.

**Negative control — the gate can still red for the reason it exists.** Two injections, on top of the fix:

1. *Declaration-side (the class the gate is for).* Prepended `import type { Leaked } from "@pome-sh/sdk/server";` to `packages/checks/dist/index.d.ts` before packing. Result: exit 1, `node_modules/@pome-sh/checks/dist/index.d.ts(1,29): error TS2307: Cannot find module '@pome-sh/sdk/server' or its corresponding type declarations.` This error lives inside a `node_modules` declaration file, so it is *only* reported because `skipLibCheck` is still off — the control proves both that the gate bites and that the fix did not weaken it.
2. *Consumer-side.* Changed `const id: string = first.id` to `const id: number`. Result: exit 1, `consumer.ts(26,7): error TS2322: Type 'string' is not assignable to type 'number'.`

Both restored; the diff is the 14-line change shown here and nothing else.

**Lint.** `npm run lint` → `lint passed — 17 rule(s).`

## Scope

One file, `scripts/clean-room-pack-test.mjs`. No published package moves (`packagesTouchedBy(["scripts/clean-room-pack-test.mjs"])` returns `[]`), so no changelog entry is owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
