### PR TITLE
Add the permission-denial showcase (F-1635)

### DIFF
--- a/showcases/README.md
+++ b/showcases/README.md
@@ -34,6 +34,7 @@ of a twin running on the reader's own machine.
 | showcase | property | twins |
 | -------- | -------- | ----- |
 | [`cross-call-state`](./cross-call-state/) | state written by call N is readable at call N+1 — and does not cross into a second twin process | github |
+| [`permission-denial`](./permission-denial/) | a refused write is a recorded event that changes nothing — and the refusal tracks who asked, not which endpoint | github |
 
 ## Adding one
 

--- a/showcases/permission-denial/README.md
+++ b/showcases/permission-denial/README.md
@@ -1,0 +1,654 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Permission denial
+
+**In about four minutes, on your own machine, you will watch a twin refuse a
+merge — and then prove, out of the twin's own books, that the pull request did
+not move.**
+
+Anything can return a `403`. A `case` statement can return a `403`. The two
+hard parts are the ones either side of it: that the refusal is a *recorded
+event* you can read back afterwards, and that the world is *provably* where you
+left it. That is what a twin has and a mock does not.
+
+The property has two halves, and the second is the one that matters:
+
+1. **A refusal is an event, and it changes nothing.** The `403` lands on the
+   twin's tape carrying `state_mutation: false` and `state_delta: null`, and
+   the entire exported world reads back byte-identical across it.
+2. **The refusal is about who asked, not about the endpoint.** Same request,
+   same twin process, one second apart, two bearers — `403` and `200`. A stub
+   refuses everyone; a twin refuses *you*.
+
+Nothing here is graded, nothing needs an API key, and nothing costs anything.
+There is no account and no login on this page. See [Cost](#cost).
+
+## Prereqs
+
+- **Node ≥ 24**, so `npx` can fetch the CLI. That is the whole install.
+- `curl`, `jq` and `diff` for the transcripts.
+- Your own coding agent (Claude Code, Cursor, …) if you want it driven for you.
+
+No Pome account. No `pome login`. No `ANTHROPIC_API_KEY`. You are the only
+seat, and nothing you do below leaves your machine.
+
+## Paste this to your agent
+
+```text
+Boot a Pome github twin locally against a seed I will give you, then show me
+what it does when an identity without push access tries to merge.
+
+Set up the directory first — the twin needs a signing secret it can reuse,
+because we are going to mint a second identity against it:
+
+  mkdir -p twin/.pome-data/github
+  node -e 'console.log(require("node:crypto").randomBytes(32).toString("hex"))' \
+    > twin/.pome-data/github/secret
+
+Write the seed to twin/seed.json (I will paste it), then boot it as a
+foreground server and leave it running:
+
+  cd twin && GITHUB_CLONE_DB=.pome/github.db \
+    npx @pome-sh/cli@latest twin start github --port 3333 --seed seed.json
+
+It prints POME_GITHUB_REST_URL and POME_AUTH_TOKEN on stdout and writes the
+same values to twin/.pome/twin-status.json — read the JSON, there is nothing
+to log into. That bearer's `login` claim is pome-agent, who has push.
+
+Then mint a SECOND bearer for the same twin, signed with the same secret but
+with login "ci-bot", and show me: what ci-bot can read on pull request #1,
+what happens when ci-bot tries to merge it, and whether the pull request
+moved. Read GET <rest_url>/_pome/state before and after and diff the two.
+Then read the tape at GET <rest_url>/_pome/events and show me the refusal
+row with its status, state_mutation and state_delta.
+
+Finally, send the SAME merge request from both bearers and show me the two
+answers together.
+
+Use curl and jq. This is ungraded — do not finalize anything, and keep your
+own evaluator and observability setup. Stop the twin with Ctrl-C when I say
+so.
+```
+
+Everything below is what you should see. Every output block is verbatim from a
+real run on 2026-08-29, CLI `0.34.3`. Work in one empty directory; every path
+below is relative to it.
+
+## The world
+
+This showcase does not use the twin's default seed. The default world has one
+repository and one issue, and nothing in it is worth refusing — so we hand the
+twin a world that has something at stake: an open pull request that changes a
+file on `main`.
+
+First, a signing secret. `twin start` looks for one at
+`.pome-data/<twin>/secret` and reuses it if it finds one, otherwise it
+generates a throwaway it never writes down — and we need a known key later, to
+mint a second identity the twin will accept:
+
+```bash
+mkdir -p twin/.pome-data/github
+node -e 'console.log(require("node:crypto").randomBytes(32).toString("hex"))' \
+  > twin/.pome-data/github/secret
+```
+
+Then the world itself:
+
+```bash
+cat > twin/seed.json <<'JSON'
+{
+  "repositories": [
+    {
+      "owner": "acme",
+      "name": "api",
+      "collaborators": ["alice"],
+      "files": [
+        { "path": "src/timeout.ts",
+          "content": "export const ORDER_TIMEOUT_MS = 5000;\n" },
+        { "path": "src/timeout.ts", "branch": "fix/order-timeout",
+          "content": "export const ORDER_TIMEOUT_MS = 30000;\n" }
+      ],
+      "pull_requests": [
+        { "author": "alice", "base": "main", "head": "fix/order-timeout",
+          "title": "Raise the order-service timeout to 30s" }
+      ]
+    }
+  ]
+}
+JSON
+```
+
+Boot it. This is a foreground server — give it its own terminal and leave it
+running.
+
+```bash
+cd twin
+GITHUB_CLONE_DB=.pome/github.db \
+  npx @pome-sh/cli@latest twin start github --port 3333 --seed seed.json
+```
+
+```text
+Pome github twin listening at http://127.0.0.1:3333/s/standalone
+Seed: seed.json (replaces the github twin's default).
+Auth: using the persisted secret from .pome-data/github/secret (an env-injected TWIN_AUTH_SECRET overrides it).
+POME_GITHUB_REST_URL=http://127.0.0.1:3333/s/standalone
+POME_GITHUB_MCP_URL=http://127.0.0.1:3333/s/standalone/mcp
+POME_AUTH_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzaWQiOiJzdGFuZGFsb25lIiwidGVhbV9pZCI6InRtX2xvY2FsIiwibG9naW4iOiJwb21lLWFnZW50IiwiZXhwIjoxNzg4MTA1MTIzfQ.NNYISO5keqSG52-5uDKgC-hvlXd6vq178n7FqQMVYWg
+Health check (no auth): curl http://127.0.0.1:3333/healthz
+Ctrl-C to stop.
+```
+
+Two of those lines are the mint, and neither took an account: line 3 says the
+twin found the secret we wrote, and line 6 hands over a bearer good for 24
+hours. Yours will differ. Leave this terminal running.
+
+In a second terminal, back in the directory that holds `twin/`:
+
+```bash
+T=$(jq -r .rest_url twin/.pome/twin-status.json)
+AGENT="Authorization: Bearer $(jq -r .auth_token twin/.pome/twin-status.json)"
+```
+
+One pull request, open:
+
+```bash
+curl -s -H "$AGENT" "$T/repos/acme/api/pulls" \
+  | jq -c '.[] | {number, title, state}'
+```
+
+```json
+{"number":1,"title":"Raise the order-service timeout to 30s","state":"open"}
+```
+
+And the table that decides everything below — who may write to this repository:
+
+```bash
+curl -s -H "$AGENT" "$T/repos/acme/api/collaborators" | jq -r '.[].login'
+```
+
+```text
+alice
+pome-agent
+```
+
+The seed listed only `alice`. **`pome-agent` is there because the twin puts it
+on every seeded repository with `push`**, so the bearer it just printed can
+actually do something — a fair exam needs an examinee who can act. That is also
+why this page mints its own second identity rather than seeding one: there is
+no seed that makes `pome-agent` powerless.
+
+The bearer you are holding is `pome-agent`, and the twin will tell you so:
+
+```bash
+curl -s -H "$AGENT" "$T/user" | jq -r .login
+```
+
+```text
+pome-agent
+```
+
+Take a fingerprint of the whole world before touching anything. `/_pome/state`
+is the twin's own export of everything it holds:
+
+```bash
+curl -s -H "$AGENT" "$T/_pome/state" | jq -S . > world-before.json
+```
+
+## Half 1 — the refusal, and the world after it
+
+Now a second identity. The twin authenticates a bearer and reads its `login`
+claim; nothing else about the caller is consulted. So an identity is just a
+JWT signed with the twin's secret — the same secret the twin told us it is
+using on line 3 of its boot. Hosted, the sandbox issues its bearers for you.
+Locally you are the issuer:
+
+```bash
+export TWIN_AUTH_SECRET=$(cat twin/.pome-data/github/secret)
+CI_BOT="Authorization: Bearer $(node -e '
+const { createHmac } = require("node:crypto");
+const b = (o) => Buffer.from(JSON.stringify(o)).toString("base64url");
+const head = b({ alg: "HS256", typ: "JWT" });
+const body = b({ sid: "standalone", team_id: "tm_local", login: "ci-bot",
+                 exp: Math.floor(Date.now() / 1000) + 86400 });
+const sig = createHmac("sha256", process.env.TWIN_AUTH_SECRET)
+  .update(head + "." + body).digest("base64url");
+console.log(head + "." + body + "." + sig);
+')"
+```
+
+`ci-bot` is not a hypothetical. It is the shape most agents run as: an
+automation identity somebody wired up months ago and never granted write to
+this repository. The twin accepts the bearer — it is validly signed — and knows
+exactly who it is:
+
+```bash
+curl -s -H "$CI_BOT" "$T/user" | jq -r .login
+```
+
+```text
+ci-bot
+```
+
+**It is refused, not blindfolded.** `ci-bot` can read the pull request in full,
+which is the distinction a mock that 404s everything cannot draw:
+
+```bash
+curl -s -H "$CI_BOT" "$T/repos/acme/api/pulls/1" \
+  | jq -c '{number, title, state, merged}'
+```
+
+```json
+{"number":1,"title":"Raise the order-service timeout to 30s","state":"open","merged":false}
+```
+
+Now merge it.
+
+```bash
+curl -s -X PUT -H "$CI_BOT" -H 'Content-Type: application/json' -d '{}' \
+  -o denied.json -w 'HTTP %{http_code}\n' \
+  "$T/repos/acme/api/pulls/1/merge"
+```
+
+```text
+HTTP 403
+```
+
+```bash
+jq . denied.json
+```
+
+```json
+{
+  "message": "Must have push access to the repository to merge pull requests.",
+  "documentation_url": "https://docs.github.com/rest/pulls/pulls#merge-a-pull-request",
+  "status": "403"
+}
+```
+
+That is GitHub's error *shape*, not a twin's invention — the three fields a
+GitHub REST error carries, including the `status` leaf it repeats inside the
+body as a string, and a `documentation_url` pointing at **this operation**
+rather than at the top of the REST docs. An agent that parses GitHub errors
+parses this one without a special case. Whether the wording matches GitHub's
+own is a claim the twin makes explicitly rather than implies, and it makes it
+on the tape — one column, two sections down.
+
+Now the half of the claim that is easy to assert and hard to show. The pull
+request:
+
+```bash
+curl -s -H "$AGENT" "$T/repos/acme/api/pulls/1" \
+  | jq -c '{state, merged, merge_commit_sha}'
+```
+
+```json
+{"state":"open","merged":false,"merge_commit_sha":null}
+```
+
+And then the stronger version — not "the field I thought to check is
+unchanged", but *the entire world*:
+
+```bash
+curl -s -H "$AGENT" "$T/_pome/state" | jq -S . > world-after.json
+diff world-before.json world-after.json && echo "the world is byte-identical"
+```
+
+```text
+the world is byte-identical
+```
+
+`diff` printed nothing, so the `echo` ran. Every repository, branch, file blob,
+pull request, comment and label the twin holds is exactly what it was before
+the refusal. Not "no merge commit" — *nothing at all*.
+
+## Read the tape
+
+The refusal is also on the record. The tape is the twin's own ordered log of
+the run, served by the twin, and it needs no account either:
+
+```bash
+curl -s -H "$AGENT" "$T/_pome/events" > tape.json
+jq -r '.[]|[.method,.path,.status,.state_mutation,.fidelity]|@tsv' \
+  tape.json | column -t
+```
+
+```text
+GET  /s/standalone/repos/acme/api/pulls          200  false  semantic
+GET  /s/standalone/repos/acme/api/collaborators  200  false  semantic
+GET  /s/standalone/user                          200  false  semantic
+GET  /s/standalone/user                          200  false  semantic
+GET  /s/standalone/repos/acme/api/pulls/1        200  false  semantic
+PUT  /s/standalone/repos/acme/api/pulls/1/merge  403  false  semantic
+GET  /s/standalone/repos/acme/api/pulls/1        200  false  semantic
+```
+
+**You should see:**
+
+- **The refused merge is a row.** It is not an exception that vanished into a
+  log line; it is the sixth of the seven events above, in the order you made
+  them.
+- **`state_mutation` is `false` on it**, and on every other row here. This is a
+  recorded boolean, not a guess from the HTTP method — the same column reads
+  `true` in the next section, on a `PUT` to the same path.
+- **`fidelity` is `semantic`.** The twin is telling you it *modelled* this
+  refusal against captured GitHub behaviour. Hold on to that column — it is
+  what separates the two remaining answers in
+  [Three ways to be told no](#three-ways-to-be-told-no).
+
+The row carries the refusal itself, not just its code:
+
+```bash
+jq '.[] | select(.status == 403)
+     | {status, state_mutation, state_delta, error}' tape.json
+```
+
+```json
+{
+  "status": 403,
+  "state_mutation": false,
+  "state_delta": null,
+  "error": "Must have push access to the repository to merge pull requests."
+}
+```
+
+`state_delta` is the field that makes this more than a status code. Every write
+the twin performs stamps its own `{before, after}` there. A refusal stamps
+`null` — not an empty delta, *no delta* — because nothing was attempted against
+the store at all. The gate runs before the domain call.
+
+## Half 2 — the refusal is about who asked
+
+A stub that refuses everyone would produce every block above. So the claim only
+means something if the *same request* gets a different answer from a different
+caller — and the weak way to show that is to reconfigure something and try
+again, which is indistinguishable from flipping a switch.
+
+So do not reconfigure anything. The twin has been running this whole time, its
+seed untouched, no toggle between these two lines. The only thing that differs
+is which bearer goes on the wire:
+
+```bash
+for id in "ci-bot|$CI_BOT" "pome-agent|$AGENT"; do
+  curl -s -o /dev/null -w "${id%%|*} %{http_code}\n" -X PUT -H "${id#*|}" \
+    -H 'Content-Type: application/json' -d '{}' \
+    "$T/repos/acme/api/pulls/1/merge"
+done
+```
+
+```text
+ci-bot 403
+pome-agent 200
+```
+
+One request, two answers, a second apart, nothing restarted. And this time the
+world moved:
+
+```bash
+curl -s -H "$AGENT" "$T/repos/acme/api/pulls/1" | jq -c '{state, merged}'
+```
+
+```json
+{"state":"closed","merged":true}
+```
+
+```bash
+curl -s -H "$AGENT" "$T/_pome/state" | jq -S . > world-merged.json
+diff world-after.json world-merged.json \
+  | grep -E '"(content|merged|merge_commit_sha|state)"'
+```
+
+```text
+<           "content": "export const ORDER_TIMEOUT_MS = 5000;\n",
+>           "content": "export const ORDER_TIMEOUT_MS = 30000;\n",
+<           "merge_commit_sha": null,
+<           "merged": 0,
+>           "merge_commit_sha": "5fc8143d7b8d6b858d52287c393b7c4255ce9346",
+>           "merged": 1,
+<           "state": "open",
+>           "state": "closed",
+```
+
+The merge that `ci-bot` was refused is the merge `pome-agent` performed, and it
+did the work: `main`'s copy of `src/timeout.ts` now carries the branch's value.
+The twin did not replay a fixture — it committed, and the sha above is that
+commit. It is the one line on this page that is not reproducible: yours will
+be a different sha, because it is a different commit.
+
+Both attempts are on the tape, and the `state_mutation` column separates them
+without you having to read the status:
+
+```bash
+curl -s -H "$AGENT" "$T/_pome/events" > tape.json
+jq -r '.[] | select(.path | endswith("/merge"))
+     | [.status, .state_mutation, (.state_delta | type)] | @tsv' \
+  tape.json | column -t
+```
+
+```text
+403  false  null
+403  false  null
+200  true   object
+```
+
+Two refusals with no delta, one merge with one. That is the whole property in
+three lines.
+
+**One limit, stated out loud, because it will bite an author.** The tape does
+not record *who* was refused:
+
+```bash
+jq -r '[.[].request_headers.authorization] | unique[]' tape.json
+```
+
+```text
+[REDACTED]
+```
+
+The bearer is redacted on every row, and no row carries a login field. So the
+tape can tell you that a merge was attempted and refused; it cannot tell you
+which identity earned the refusal. If that distinction matters to your grading,
+it has to come from state — which, for this run, it does: the pull request is
+merged, so exactly one of the two callers got through.
+
+## Three ways to be told no
+
+The refusal above is one of three answers this twin gives to a request it will
+not fulfil, and telling them apart is most of what an agent needs from an
+error. Two more, on the same twin:
+
+```bash
+curl -s -X PUT -H "$AGENT" -H 'Content-Type: application/json' -d '{}' \
+  "$T/repos/acme/api/pulls/99/merge" | jq .
+```
+
+```json
+{
+  "message": "Pull request not found",
+  "documentation_url": "https://docs.github.com/rest/pulls/pulls#merge-a-pull-request",
+  "status": "404"
+}
+```
+
+```bash
+curl -s -H "$AGENT" "$T/repos/acme/api/actions/runs" | jq .
+```
+
+```json
+{
+  "message": "This endpoint is not supported by this GitHub twin.",
+  "_twin": {
+    "fidelity": "unsupported",
+    "supported_surfaces": [
+      "GitHub-shaped REST",
+      "POST /s/:sid/mcp",
+      "GET /s/:sid/mcp/tools",
+      "POST /s/:sid/mcp/tools/:name",
+      "POST /s/:sid/mcp/call"
+    ]
+  }
+}
+```
+
+The third one is the interesting one, and it is the answer a fixture server
+cannot give. `GET /repos/:o/:r/actions/runs` is a real GitHub endpoint that
+this twin does not model. It could have answered `404` and been indistinguishable
+from a repository with no workflow runs — an agent would have believed the
+empty answer and moved on. Instead it answers `501`, says so under `_twin`, and
+lists what it *does* serve. **"I have not implemented this" and "this does not
+exist" are different facts, and only one of them is your bug.**
+
+The tape keeps them apart in a column, so you never have to parse a body to
+find out:
+
+```bash
+curl -s -H "$AGENT" "$T/_pome/events" > tape.json
+jq -r '.[]|[.status,.fidelity]|@tsv' tape.json | sort -u \
+  | column -t
+```
+
+```text
+200  semantic
+403  semantic
+404  semantic
+501  unsupported
+```
+
+Three modelled answers and one honest gap. A run with no `unsupported` row is a
+run that stayed inside the part of GitHub this twin actually implements — which
+is a check you can declare, and the next section names it.
+
+(There is a fourth refusal, `401`, and it answers a different question: not
+*may you*, but *who are you*. The
+[cross-call-state showcase](../cross-call-state/) shows one, where a twin
+refuses another twin's bearer.)
+
+### One thing on `/healthz` that is not this
+
+The twin's liveness probe advertises a policy catalog, and it is easy to read
+it as the thing you just watched:
+
+```bash
+curl -s http://127.0.0.1:3333/healthz | jq -c .access_control
+```
+
+```json
+{"total":57,"allowed":42,"denied":15}
+```
+
+Those 15 are **not denied on this path**, and the fastest way to believe it is
+to pick one. `add_collaborator` is in the denied-by-default column:
+
+```bash
+curl -s -H "$AGENT" "$T/_pome/access-control" \
+  | jq -c '.endpoints[] | select(.tool == "add_collaborator")'
+```
+
+```json
+{"tool":"add_collaborator","operation":"addCollaborator","method":"PUT","category":"collaborators","default_allowed":false,"v2":true}
+```
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -X PUT -H "$AGENT" \
+  -H 'Content-Type: application/json' -d '{"permission":"push"}' \
+  "$T/repos/acme/api/collaborators/dana"
+```
+
+```text
+201
+```
+
+That catalog is the surface a builder toggles per sandbox in the hosted
+dashboard, published on the twin so the dashboard and the twin cannot disagree
+about what is toggleable. A local twin has no dashboard: it serves the world as
+seeded and enforces the permission model that world describes — which is what
+every command above exercised, and it is GitHub's own model, a collaborator
+table and a gate that reads it.
+
+## Assertable checks
+
+If you wanted to *verify* a run like this instead of reading it, these already
+exist. **Pointers only — this showcase ships no task**, and grading appears
+exactly once in this repo, in the
+[support-triage capstone](../../agent-examples/support-triage/).
+
+The interesting column is `substrate`, because a denial makes three separate
+claims and each one is answered by a different body of evidence: what the world
+looks like at the end, what changed to get there, and what was said on the way.
+
+| declared check | substrate | what it would assert here | limit on the id |
+| -------------- | --------- | ------------------------- | --------------- |
+| `github.pr-state` (`not merged`) | `final` | the merge that was refused **did not happen** | none found. It reads the `merged` flag, and SKIPS rather than fails if an export carries no such flag — absent is not the same as false |
+| `github.no-new-issues` | `seed+final` | the run **changed nothing else** in the repository | it is repo-scoped. Every github delta check is: none of them can say *this pull request* was left alone, which is why the row above carries the weight |
+| `github.no-unsupported-endpoint` | `tape` | every refusal on this run was a **modelled** one | it passes a `403` and a `404` — it separates "not implemented" from everything else, and nothing more. Its own description still calls a sandbox a "session"; the wording fix is tracked upstream |
+
+Browse the full set with `npx @pome-sh/cli@latest checks github`, or
+`list_checks` over MCP.
+
+**One candidate was rejected, and the rejection is the mechanism working.**
+The obvious pick for a page about an attempted action is
+`` `merge_pull_request` was never called `` — substrate `tape`, and it reads
+attempts rather than outcomes, which is exactly the shape of a denial. It does
+not bind. The recorder stamps an action name on only three of this twin's ~40
+operations (`create_commit_status`, `create_check_run`, `add_issue_comment`),
+and `merge_pull_request` is not one of them — which is why every `/merge` row
+on the tape above carries `tool: null`:
+
+```bash
+jq -r '[.[] | select(.path | endswith("/merge")) | .tool // "null"]
+     | unique[]' tape.json
+```
+
+```text
+null
+```
+
+So the vocabulary refuses the name rather than accepting a sentence it cannot
+honour: `pome checks add … --arg tool=merge_pull_request` is an error, not a
+check that quietly answers "never called" over a run that did it. Widening the
+set is tracked upstream, and a name may only enter it once its REST route is
+stamped on both doors. **Run this search before you name a check id** — an id
+reading clean in `checks` is not evidence it can say what you want about your
+run.
+
+## Cost
+
+**Zero.** Not "free tier" — there is no meter attached to this page at all.
+
+- **No account and no login.** Nothing here talks to pome.sh except `npx`
+  fetching the CLI from the npm registry.
+- **No API key.** Single seat: you, or your own coding agent.
+- **No sandbox minutes and no agent evals.** Those are billed against a hosted
+  sandbox at finalize; this path has neither a hosted sandbox nor a finalize.
+- **One `node` process and one SQLite file**, which is the entire footprint.
+
+Nothing expires. A local twin runs until you stop it — Ctrl-C in its terminal —
+and the world is one directory:
+
+```bash
+rm -rf twin world-*.json tape.json denied.json
+```
+
+## Run it yourself
+
+[`verify.sh`](./verify.sh) does everything above unattended and asserts both
+halves, so the claims on this page stay checkable. From a clone of this repo:
+
+```bash
+./showcases/permission-denial/verify.sh
+```
+
+It is self-contained: it writes its own seed and its own signing secret into a
+throwaway directory, boots the twin on a free port, and mints both identities
+itself — there is no login step to do first. It asserts the refusal, asserts
+the world is byte-identical across it, asserts the same request is allowed for
+the other bearer while the twin keeps running, and stops the process on exit,
+including on failure. It exits non-zero if any of that stops being true.
+
+## Next
+
+- The [github quickstart](https://docs.pome.sh/quickstart/twins/github) — the
+  same twin, one write, in five minutes, on the hosted path.
+- [`cross-call-state`](../cross-call-state/) — the sibling showcase: what the
+  twin does when the write *is* allowed, and how long it remembers.
+- [`agent-examples/support-triage`](../../agent-examples/support-triage/) — the
+  one graded lesson, where a real agent is scored on a task like this.

--- a/showcases/permission-denial/verify.sh
+++ b/showcases/permission-denial/verify.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Asserts both halves of the permission-denial property against ONE local twin
+# process, so this showcase's README stays checkable rather than asserted.
+#
+# Half 1: a refusal is a recorded event that changes nothing — the 403 is a row
+#         on the tape carrying `state_mutation: false` and `state_delta: null`,
+#         and the twin's whole exported world is byte-identical across it.
+# Half 2: the refusal is about WHO ASKED, not about the endpoint — the same
+#         request from a second bearer, against the same running twin with
+#         nothing reconfigured between the two calls, is allowed.
+#
+# Self-contained on purpose. `twin start` reads its signing secret from
+# `.pome-data/<twin>/secret` and prints its bearer to stdout, so both the mint
+# and the second identity are non-interactive: this script writes the world it
+# needs, boots the twin, and mints BOTH bearers rather than assuming a human
+# already did the interesting part. No account, no login, no API key, no
+# meter — nothing here finalizes, and there is no hosted sandbox to finalize
+# against.
+#
+# Needs: bash, node >= 24 (for npx), curl, jq. Set POME_CLI to point at a local
+# build instead of the published CLI.
+#
+# Two rules this file exists to keep honest, both inherited from the sibling
+# showcase's debugging:
+#   * The twin's credentials are read out of JSON with `jq`, never out of an
+#     `export K="v"` file with `sed` — un-stripped quotes turn every curl into
+#     exit 000 and a full red run that blames the wrong thing.
+#   * Every tape assertion below is an INVARIANT, never a row count from a
+#     hand-run. "No row that answered 4xx or 5xx mutated state" survives this
+#     script making one more call than the walkthrough does; "the tape has 7
+#     rows" does not.
+
+set -euo pipefail
+
+CLI="${POME_CLI:-npx -y @pome-sh/cli@latest}"
+REPO="acme/api"
+FAILS=0
+WORK="$(mktemp -d)"
+PIDS=()
+
+cleanup() {
+  local code=$?
+  for pid in ${PIDS[@]+"${PIDS[@]}"}; do
+    kill "$pid" 2>/dev/null || true
+  done
+  # Give the twin its graceful shutdown (it flushes the recorder and releases
+  # the SQLite handle) before the directory holding its database disappears.
+  for pid in ${PIDS[@]+"${PIDS[@]}"}; do
+    for _ in $(seq 1 40); do
+      kill -0 "$pid" 2>/dev/null || break
+      sleep 0.25
+    done
+    kill -9 "$pid" 2>/dev/null || true
+  done
+  rm -rf "$WORK"
+  exit "$code"
+}
+trap cleanup EXIT
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "need $1 on PATH"; exit 2; }; }
+need curl
+need jq
+need node
+
+# An injected TWIN_AUTH_SECRET WINS over the persisted file, which would leave
+# this script minting `ci-bot` against a key the twin is not using — every call
+# a 401, and the denial assertions failing for the wrong reason. The script
+# owns its own environment, so it opts out and uses the persisted path the
+# README teaches.
+unset TWIN_AUTH_SECRET
+
+# ok <label> <actual> <expected>
+ok() {
+  if [ "$2" = "$3" ]; then
+    printf '  ok   %-46s %s\n' "$1" "$2"
+  else
+    printf '  FAIL %-46s got %s, want %s\n' "$1" "$2" "$3"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+port_free() { ! (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null; }
+
+pick_port() { # pick_port <from> -> first free TCP port at or above <from>
+  local p="$1"
+  while ! port_free "$p"; do p=$((p + 1)); done
+  echo "$p"
+}
+
+# The world. The github twin's DEFAULT seed has nothing worth refusing: one
+# repository, one issue, and no pull request. This one has something at stake.
+write_seed() {
+  cat > "$WORK/twin/seed.json" <<'JSON'
+{
+  "repositories": [
+    {
+      "owner": "acme",
+      "name": "api",
+      "collaborators": ["alice"],
+      "files": [
+        { "path": "src/timeout.ts",
+          "content": "export const ORDER_TIMEOUT_MS = 5000;\n" },
+        { "path": "src/timeout.ts", "branch": "fix/order-timeout",
+          "content": "export const ORDER_TIMEOUT_MS = 30000;\n" }
+      ],
+      "pull_requests": [
+        { "author": "alice", "base": "main", "head": "fix/order-timeout",
+          "title": "Raise the order-service timeout to 30s" }
+      ]
+    }
+  ]
+}
+JSON
+}
+
+boot() { # boot <port> -> starts the twin in $WORK/twin, records its pid
+  local port="$1"
+  mkdir -p "$WORK/twin/.pome-data/github"
+  node -e 'console.log(require("node:crypto").randomBytes(32).toString("hex"))' \
+    > "$WORK/twin/.pome-data/github/secret"
+  write_seed
+  # `exec` so $! is the CLI's own pid: SIGTERM then reaches the listener rather
+  # than a subshell that would outlive it and keep the port bound.
+  (
+    cd "$WORK/twin" || exit 1
+    export GITHUB_CLONE_DB=.pome/github.db
+    exec $CLI twin start github --port "$port" --seed seed.json
+  ) >"$WORK/twin.log" 2>&1 &
+  PIDS+=("$!")
+  for _ in $(seq 1 240); do
+    if [ -f "$WORK/twin/.pome/twin-status.json" ] &&
+      curl -sf "http://127.0.0.1:$port/healthz" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  echo "FAIL the twin never came up on port $port; its log:"
+  cat "$WORK/twin.log"
+  exit 1
+}
+
+url() { jq -r .rest_url "$WORK/twin/.pome/twin-status.json"; }
+agent() { echo "Authorization: Bearer $(jq -r .auth_token "$WORK/twin/.pome/twin-status.json")"; }
+
+# The second identity, minted exactly the way the README mints it: an HS256 JWT
+# over the twin's own signing secret, differing from the printed bearer in one
+# claim. `login` is the only thing the merge gate consults.
+mint() { # mint <login> -> a bearer header for that identity
+  local token
+  token="$(TWIN_AUTH_SECRET="$(cat "$WORK/twin/.pome-data/github/secret")" \
+    node -e '
+const { createHmac } = require("node:crypto");
+const b = (o) => Buffer.from(JSON.stringify(o)).toString("base64url");
+const head = b({ alg: "HS256", typ: "JWT" });
+const body = b({ sid: "standalone", team_id: "tm_local", login: process.argv[1],
+                 exp: Math.floor(Date.now() / 1000) + 86400 });
+const sig = createHmac("sha256", process.env.TWIN_AUTH_SECRET)
+  .update(head + "." + body).digest("base64url");
+console.log(head + "." + body + "." + sig);
+' "$1")"
+  echo "Authorization: Bearer $token"
+}
+
+get() { # get <header> <path> -> response body on stdout
+  curl -sf -H "$1" "$(url)$2"
+}
+
+code() { # code <header> <path> -> http status of a GET
+  curl -s -o /dev/null -w '%{http_code}' -H "$1" "$(url)$2"
+}
+
+merge() { # merge <header> [pull] -> http status, body left in $WORK/merge.json
+  curl -s -o "$WORK/merge.json" -w '%{http_code}' -X PUT -H "$1" \
+    -H 'Content-Type: application/json' -d '{}' \
+    "$(url)/repos/$REPO/pulls/${2:-1}/merge"
+}
+
+world() { # world <file> -> snapshot the twin's whole exported state
+  get "$AGENT" "/_pome/state" | jq -S . > "$WORK/$1"
+}
+
+pr_shape() { # pr_shape -> "state merged sha"
+  get "$AGENT" "/repos/$REPO/pulls/1" \
+    | jq -r '"\(.state) \(.merged) \(.merge_commit_sha)"'
+}
+
+tape() { get "$AGENT" "/_pome/events" > "$WORK/tape.json"; }
+
+PORT="$(pick_port "${POME_SHOWCASE_PORT:-3351}")"
+
+echo "== booting the twin on port $PORT =="
+boot "$PORT"
+AGENT="$(agent)"
+CI_BOT="$(mint ci-bot)"
+
+echo "== the world =="
+ok "the seeded pull request is open, unmerged" "$(pr_shape)" "open false null"
+ok "the printed bearer is pome-agent" \
+  "$(get "$AGENT" "/user" | jq -r .login)" "pome-agent"
+# The seed names only `alice`; the twin adds `pome-agent` to every seeded repo,
+# which is why the walkthrough has to mint its own powerless identity.
+ok "pome-agent has push despite not being seeded" \
+  "$(get "$AGENT" "/repos/$REPO/collaborators" | jq -r '[.[].login]|sort|join(",")')" \
+  "alice,pome-agent"
+ok "the minted bearer is ci-bot" \
+  "$(get "$CI_BOT" "/user" | jq -r .login)" "ci-bot"
+
+echo "== half 1: refused, not blindfolded =="
+ok "ci-bot can READ the pull request" \
+  "$(code "$CI_BOT" "/repos/$REPO/pulls/1")" "200"
+
+world world-before.json
+
+echo "== half 1: the refusal =="
+ok "ci-bot's merge is refused with 403" "$(merge "$CI_BOT")" "403"
+ok "the refusal is GitHub's own message" \
+  "$(jq -r .message "$WORK/merge.json")" \
+  "Must have push access to the repository to merge pull requests."
+# GitHub names the OPERATION on a 403 rather than pointing at the docs root.
+ok "the refusal names this operation in its docs url" \
+  "$(jq -r .documentation_url "$WORK/merge.json")" \
+  "https://docs.github.com/rest/pulls/pulls#merge-a-pull-request"
+ok "the body repeats the status as GitHub does" \
+  "$(jq -r .status "$WORK/merge.json")" "403"
+
+echo "== half 1: and the world did not move =="
+ok "the pull request is untouched" "$(pr_shape)" "open false null"
+world world-after.json
+ok "the WHOLE exported world is byte-identical" \
+  "$(cmp -s "$WORK/world-before.json" "$WORK/world-after.json" &&
+     echo identical || echo changed)" "identical"
+
+echo "== half 1: the tape =="
+tape
+ok "the refused merge is a row on the tape" \
+  "$(jq '[.[]|select(.status==403 and (.path|endswith("/merge")))]|length>0' \
+     "$WORK/tape.json")" "true"
+# Invariants, not counts: WHICH rows may mutate is the property; how many reads
+# surround them is this script's business.
+ok "nothing has mutated state yet" \
+  "$(jq '[.[]|select(.state_mutation)]|length' "$WORK/tape.json")" "0"
+ok "the refusal carries no state_delta" \
+  "$(jq -r '[.[]|select(.status==403)|.state_delta|type]|unique|join(",")' \
+     "$WORK/tape.json")" "null"
+ok "the refusal carries its own message" \
+  "$(jq -r '[.[]|select(.status==403)|.error]|unique|join("|")' \
+     "$WORK/tape.json")" \
+  "Must have push access to the repository to merge pull requests."
+ok "the refusal was judged semantically" \
+  "$(jq -r '[.[]|select(.status==403)|.fidelity]|unique|join(",")' \
+     "$WORK/tape.json")" "semantic"
+
+echo "== half 2: same request, two bearers, nothing reconfigured =="
+ok "ci-bot is refused again" "$(merge "$CI_BOT")" "403"
+ok "pome-agent is allowed, same twin still running" "$(merge "$AGENT")" "200"
+ok "the pull request is merged now" \
+  "$(get "$AGENT" "/repos/$REPO/pulls/1" | jq -r '"\(.state) \(.merged)"')" \
+  "closed true"
+world world-merged.json
+ok "THIS time the world moved" \
+  "$(cmp -s "$WORK/world-after.json" "$WORK/world-merged.json" &&
+     echo identical || echo changed)" "changed"
+# The merge did the work rather than flipping a flag: main's copy of the file
+# now carries the branch's value.
+ok "the merge landed the branch's content on main" \
+  "$(get "$AGENT" "/repos/$REPO/contents/src/timeout.ts" \
+     | jq -r '.content|@base64d' | tr -d '\n')" \
+  "export const ORDER_TIMEOUT_MS = 30000;"
+
+echo "== half 2: the tape separates them without reading the status =="
+tape
+ok "every refusal left state alone" \
+  "$(jq -r '[.[]|select(.status>=400)|.state_mutation]|unique|join(",")' \
+     "$WORK/tape.json")" "false"
+ok "every mutation was an allowed call" \
+  "$(jq '[.[]|select(.state_mutation and .status>=300)]|length' \
+     "$WORK/tape.json")" "0"
+ok "every mutation carries a state_delta" \
+  "$(jq '[.[]|select(.state_mutation and .state_delta==null)]|length' \
+     "$WORK/tape.json")" "0"
+ok "the bearer is redacted on every row" \
+  "$(jq -r '[.[].request_headers.authorization]|unique|join(",")' \
+     "$WORK/tape.json")" "[REDACTED]"
+# The README tells a reader that `merge_pull_request` cannot be named in a tape
+# check, because the recorder stamps no action name on its route. If that is
+# ever widened, this goes red and the page's "One candidate was rejected"
+# paragraph needs rewriting — which is exactly what it is here to catch.
+ok "no /merge row carries an action name" \
+  "$(jq -r '[.[]|select(.path|endswith("/merge"))|.tool//"null"]|unique|join(",")' \
+     "$WORK/tape.json")" "null"
+
+echo "== the other two ways to be told no =="
+ok "a missing pull request is a modelled 404" "$(merge "$AGENT" 99)" "404"
+ok "the 404 is GitHub's own message" \
+  "$(jq -r .message "$WORK/merge.json")" "Pull request not found"
+ok "an unmodelled route answers 501, not 404" \
+  "$(code "$AGENT" "/repos/$REPO/actions/runs")" "501"
+ok "and it says so under _twin.fidelity" \
+  "$(curl -s -H "$AGENT" "$(url)/repos/$REPO/actions/runs" \
+     | jq -r '._twin.fidelity')" "unsupported"
+ok "and lists what it does serve" \
+  "$(curl -s -H "$AGENT" "$(url)/repos/$REPO/actions/runs" \
+     | jq '[._twin.supported_surfaces[]]|length>0')" "true"
+tape
+ok "the tape's fidelity column keeps the two apart" \
+  "$(jq -r '[.[].fidelity]|unique|sort|join(",")' "$WORK/tape.json")" \
+  "semantic,unsupported"
+ok "every 404 was a modelled answer, not a gap" \
+  "$(jq -r '[.[]|select(.status==404)|.fidelity]|unique|join(",")' \
+     "$WORK/tape.json")" "semantic"
+
+# The README warns that `/healthz`'s `access_control` catalog is a HOSTED
+# dashboard surface, not this path's gate — a reader who sees `denied: 15` and
+# assumes those 15 are refused here would be wrong. Pick one and prove it.
+echo "== the /healthz catalog is not the gate =="
+ok "add_collaborator is denied-by-default in the catalog" \
+  "$(get "$AGENT" "/_pome/access-control" \
+     | jq -r '.endpoints[]|select(.tool=="add_collaborator")|.default_allowed')" \
+  "false"
+ok "and this path performs it anyway" \
+  "$(curl -s -o /dev/null -w '%{http_code}' -X PUT -H "$AGENT" \
+     -H 'Content-Type: application/json' -d '{"permission":"push"}' \
+     "$(url)/repos/$REPO/collaborators/dana")" "201"
+
+echo
+if [ "$FAILS" -eq 0 ]; then
+  echo "PASS — both halves hold. No account, no key, no meter touched."
+else
+  echo "FAIL — $FAILS assertion(s) broke."
+fi
+echo "== stopping the twin =="
+[ "$FAILS" -eq 0 ] || exit 1


### PR DESCRIPTION
The second showcase, and the first whose subject is a twin saying **no**. One
row on `showcases/README.md`'s index table and one directory,
`showcases/permission-denial/`, on the conventions #479 landed. Three files
changed, 989 lines added, nothing else touched.

## What it shows

The property has two halves, and both are captured output rather than prose.

1. **A refusal is a recorded event that changes nothing.** `ci-bot` — a bearer
   whose `login` claim is not a collaborator — is refused a merge with GitHub's
   own error shape. The `403` is a row on the tape carrying
   `state_mutation: false` and `state_delta: null`, and `diff` over the twin's
   whole `/_pome/state` export prints nothing across it.
2. **The refusal is about who asked, not about the endpoint.** The same merge
   request, against the same running twin, nothing reconfigured between the two
   calls: `ci-bot 403` / `pome-agent 200`. That is this showcase's simultaneity
   test — the sibling's boundary is the OS process, this one's is identity.

Then one extra beat F-1635 asked for: **three ways to be told no.** `403` (you
may not), `404` (it is not there) and `501` with `_twin.fidelity: "unsupported"`
plus a `supported_surfaces` list (this twin does not model that). The tape keeps
them apart in one column, so an agent can tell "not implemented" from "does not
exist" without parsing a body.

## Seven things worth knowing before reading the diff

- **The world is a `--seed`, not the default.** The default github world has one
  repository and one issue; nothing in it is worth refusing. This one has an
  open pull request that changes a file on `main`, which is what makes "the
  merge did not happen" a claim with a receipt. Recorded as a deviation from
  the spec's beat 5, which was written for the hosted path where `--seed` does
  not exist.
- **The denied action is `merge_pull_request` because the check vocabulary can
  speak about it.** `github.pr-state` (`not merged`) is an exact assertion for a
  refused merge. The collaborator surface — the twin's other 403 — has no
  declared check at all, which would have made the Assertable-checks section
  decoration.
- **The refused identity has to be minted.** `GitHubDomain.seed()` adds
  `pome-agent` to every seeded repository unconditionally, so no seed can make
  the printed bearer powerless. The page mints a second bearer over the twin's
  own signing secret via the documented `.pome-data/<twin>/secret` path, which
  the twin confirms on line 3 of its own boot output.
- **`/healthz`'s `access_control` is not this path's gate**, and the page says
  so with a command rather than a sentence: the catalog lists `add_collaborator`
  as `default_allowed: false`, and this path performs it and answers `201`. That
  catalog is the hosted dashboard's toggle surface. What fires here is GitHub's
  own model — a collaborator table and a permission check that reads it. A
  reader who saw `denied: 15` and assumed those 15 are refused locally would
  have been wrong, and letting them believe it is the one bug class that counts
  on a page like this.
- **The measured numbers moved since the spec was written.** `access_control` is
  `{total: 57, allowed: 42, denied: 15}`, not 52/38/14. `lint` is 17 rules, not
  18. `task-class` collects 46 tasks, not 44. `gate:examples` and
  `smoke:examples` see 10 examples, not 8, since #499 split the roots. Every
  number below is from a run today.
- **One honest limit is on the page** because an author will hit it: the tape
  redacts `authorization` on every row and carries no login field, so it records
  that a merge was refused and not who earned it. Identity has to come from
  state.
- **No Linear URLs.** Each check's limit is stated in full and the tickets are
  "tracked upstream", matching the sibling and every other public page here.

## Proved by running it

One local twin, CLI `0.34.3`, no account, no key, no meter.

- **Every output block re-captured against a fresh boot and byte-diffed:
  29 of 30 identical.** The one difference is the merge commit sha, which is a
  different commit on every run — flagged on the page as the one line that is
  not reproducible. The per-boot JWT in the boot block is likewise flagged.
- **`verify.sh` passes 35/35, exit 0**, in under three seconds. It writes its
  own seed and signing secret into a throwaway directory, boots the twin on a
  free port, mints both identities, and stops the process on exit including on
  failure. Every tape assertion is an invariant, never a row count.
- **Proved non-vacuous** by planting two inverted expectations — "the world is
  byte-identical" flipped to `changed`, and the `403` flipped to `200` — and
  watching it exit 1 naming exactly those two and nothing else. Both removed.

## CI

`ci.yml`'s heavy-suite regex does not list `showcases/`, so this PR classifies
as docs-only and runs the always-on gates. That is correct — there is nothing to
compile — and it is why the always-on set was run by hand:

| gate | result |
| ---- | ------ |
| `npm run lint` | 17/17 rules |
| `npm run lint:test` | 9 cases |
| `npm run gate:examples` | 10 examples typechecked and tested clean |
| `npm run smoke:examples` | 10/10 reached real work |
| `check-example-pins-published.mjs` (+ its test) | 1 matched, 0 drifted |
| `check-packages-scripts-wired.mjs` | 42 scripts, all wired or exempt |
| `smoke-examples.test.mjs` | pass |
| `scripts/lib/example-roots.test.mjs` | pass |
| `check-release-note-required.mjs` | no note owed — `showcases/` is not a published-package path |

**The gate non-vacuity proof, run both ways.** #479's spec claimed that planting
`showcases/<name>/tasks/planted.md` makes `task-class` collect it. It does not:
the rule's corpora are `cli/tasks` + `EXAMPLE_ROOTS`, and `showcases/` is in
neither, so the plant passes and reads as if it proved something. Measured here:
that plant leaves lint green at 46 tasks. The identical file at
`agent-examples/support-triage/tasks/planted.md` reds the rule by name. The
spec's conclusion was right — the directory is outside the gate, which is the
point of the three-file list — and only its evidence was wrong. Both plants
removed.

## Not in scope, found on the way

- `pull_requests[].number` in the github seed schema is accepted and silently
  ignored (`GitHubDomain.seed()` never passes it to `createPullRequest`), so a
  seeded PR is always renumbered from 1. Already filed upstream; the seed here
  simply omits the field.
- `packages/twin-github/FIDELITY.md` divergence 32 says "the only 403 it can
  emit is the admin gate's" and "the twin serves **no** operation-specific 403
  at all". Both are now false: the merge gate's 403 carries
  `documentation_url: …/rest/pulls/pulls#merge-a-pull-request`, which is exactly
  operation-specific. Not touched here — it is a doc claim in a package this PR
  does not open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
