### PR TITLE
Give the packaged demo task a deterministic denominator (F-1749)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,6 +9,34 @@ write a version number here or in `package.json`. Released entries are insertion
 only: a correction is the next entry, naming the one it corrects.
 
 
+## Unreleased (patch)
+
+**`pome demo` reports a verdict again.** Every trial of the zero-auth door was
+printing `⚠ errored · cloud could not evaluate the trace` in production, and the
+demo share page read `0 of 0`. Nothing errored: the packaged `first-run-demo`
+task declared three `[model]` criteria and zero `[code]`, and since `[model]`
+left the score denominator there was simply nothing to grade — `total_required`
+0, so the CLI's `scoreStatus` returned neither `pass` nor `fail` and `runDemo`
+fell through to its errored branch. Every trial, every time; no input produced a
+different outcome.
+
+The task now declares two `[code]` criteria alongside the three `[model]` ones —
+`github.issue-exactly-one-label` and `github.issue-comment-contains`, both
+already-published check sentences, no new vocabulary. Neither is true of the
+seed, which is what keeps them in the denominator: the cloud drops a criterion
+the seed already satisfied, so a prohibition would have left again and taken the
+fraction with it. The `[model]` rows stay, as the advisory reading beside the
+fraction, and they still carry the two clauses no declared check can state — "and
+to no other issue", and "exactly one comment".
+
+The same markdown is what a bare `pome run` copies to `tasks/first-run-demo.md`,
+so the "run yours" default now scores a deterministic fraction too. An existing
+copy is not rewritten; delete it and the next bare `pome run` re-copies.
+
+The judge scores the cloud's own mirror of this file, so the fraction only
+reaches `npx @pome-sh/cli demo` once pome-cloud deploys the matching definition.
+
+
 ## 0.35.0 — 2026-08-29
 
 **`pome init --example <id>` scaffolds a complete bundled example.** It fetches

--- a/cli/assets/demo/first-run-demo.md
+++ b/cli/assets/demo/first-run-demo.md
@@ -13,6 +13,26 @@ different task than the one the bundled agent ran.
 The three tools the bundled demo agent exposes (src/demo/agent.ts) are the
 contract this task is written against: list_open_issues, add_label,
 comment_on_issue.
+
+THE `[code]` ROWS ARE THE DEMO'S SCORE — keep at least one (F-1749). Since the
+narrator flip took `[model]` out of the score denominator, a task declaring
+only `[model]` criteria is not merely unscored: `total_required` is 0, the run
+is not evaluable, and every trial of the advertised zero-auth door reports
+"cloud could not evaluate the trace". Each `[code]` row must also be a sentence
+the published check vocabulary renders — a hand-edited one binds nothing and is
+the same empty denominator in different clothes. Both are asserted in
+test/unit/demo/demo-task-criteria.test.ts, and that the bundled agent's correct
+walk satisfies them in test/e2e/demo-e2e.test.ts.
+
+Neither `[code]` row is true of the seed, which is what keeps them in the
+denominator: the cloud drops a criterion the seed already satisfied
+(`pre-satisfied.ts`), so a prohibition like "No new labels were created in
+acme/api" would leave again and take the fraction with it.
+
+The `[model]` rows stay because they are what the demo exists to SHOW — an
+advisory narrative reading beside a deterministic fraction. They also carry the
+two clauses no declared check can state, "and to no other issue" and "exactly
+one comment", so dropping them would quietly narrow the task.
 -->
 
 ## Prompt
@@ -32,6 +52,8 @@ issue.
 
 ## Success Criteria
 
+- [code] Issue #1 in `acme/api` has exactly one classification label, and it is `bug`
+- [code] A comment containing "POST /orders" exists on issue #1 in `acme/api`
 - [model] The existing `bug` label was applied to the issue reporting the 500 error on POST /orders, and to no other issue.
 - [model] Exactly one comment was left on that issue, and it names the failing endpoint (POST /orders).
 - [model] No other issue was modified and no new label was created.

--- a/cli/assets/demo/first-run-demo.md
+++ b/cli/assets/demo/first-run-demo.md
@@ -4,11 +4,14 @@
 The packaged `npx @pome-sh/cli demo` task. This markdown is the
 CANONICAL source of the demo task content: the cloud's server-owned judge
 definition (pome-cloud apps/control-plane/src/lib/demo.ts,
-DEMO_TASK_DEFINITIONS["first-run-demo"]) is regenerated FROM this file — the
-judge scores the server copy, never a client-supplied body, so the two must
-stay in lockstep. Changing the prompt / expected behavior / criteria here
-without regenerating the server definition means the cloud judges a
-different task than the one the bundled agent ran.
+DEMO_TASK_DEFINITIONS["first-run-demo"]) mirrors this file — the judge scores
+the server copy, never a client-supplied body, so the two must stay in
+lockstep. Changing the prompt / expected behavior / criteria here without
+updating the server definition means the cloud judges a different task than
+the one the bundled agent ran.
+
+MIRROR IT BY HAND. There is no generator and no gate — F-1752 is the ticket to
+close that, and until it lands nothing but a reviewer notices a half-done sync.
 
 The three tools the bundled demo agent exposes (src/demo/agent.ts) are the
 contract this task is written against: list_open_issues, add_label,

--- a/cli/test/e2e/demo-e2e.test.ts
+++ b/cli/test/e2e/demo-e2e.test.ts
@@ -2,15 +2,57 @@
 // `pome demo` end-to-end against a STUB cloud: real runTask (in-process github twin +
 // real capture-server child), the REAL bundled demo agent spawned as.
 import { createServer, type Server } from "node:http";
-import { mkdtemp } from "node:fs/promises";
+import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { gunzipSync } from "node:zlib";
 import { afterAll, describe, expect, it } from "vitest";
+import { parseCheck } from "@pome-sh/sdk/checks";
+import { checksFor } from "../../src/cli/checks.js";
 import { runDemo } from "../../src/demo/runDemo.js";
+import { DEMO_TASK_NAME, demoTaskPath } from "../../src/demo/task.js";
+import { parseTask } from "../../src/task/parseTask.js";
 import { captureServerForTests } from "../fixtures/captureServerForTests.js";
 import { demoLlmRequestSchema } from "../fixtures/demo/demoLlmSchema.js";
 import { inCli } from "../fixtures/cliDir.js";
+
+/**
+ * Evaluate the packaged demo task's `[code]` criteria against one captured
+ * state blob, through the SAME declarations the cloud grades with.
+ *
+ * F-1749: the markdown-level test proves those criteria bind. It cannot prove
+ * the bundled agent's walk SATISFIES them — that needs the twin's exported
+ * state, which only a real run produces. Hence here, off the bytes the CLI
+ * actually uploaded.
+ */
+async function gradeCodeCriteria(
+  stateJson: string,
+): Promise<Array<{ text: string; passed: boolean; reason: string }>> {
+  const markdown = await readFile(demoTaskPath(), "utf8");
+  const sidecar = JSON.parse(
+    await readFile(demoTaskPath().replace(/\.md$/, ".seed.json"), "utf8"),
+  ) as unknown;
+  const task = parseTask(markdown, DEMO_TASK_NAME, sidecar);
+  const final: unknown = JSON.parse(stateJson);
+  // Args-erased, the way every uniform consumer of the declarations takes them
+  // (`checksFor`'s own note) — the tuple is heterogeneous in its slot types.
+  const declared = checksFor("github");
+
+  return task.criteria
+    .filter((criterion) => criterion.type === "code")
+    .map((criterion) => {
+      for (const check of declared) {
+        const args = parseCheck(check, criterion.text);
+        if (args === null) continue;
+        // `seed`/`tape` are null: both declarations read `final` only, and a
+        // predicate handed a substrate it did not ask for is a different test
+        // from the one the cloud runs.
+        const outcome = check.evaluate(args, { seed: null, final, tape: null });
+        return { text: criterion.text, passed: outcome.passed, reason: outcome.reason };
+      }
+      throw new Error(`packaged demo criterion binds no check: ${criterion.text}`);
+    });
+}
 
 interface StubCloud {
   server: Server;
@@ -263,6 +305,31 @@ describe("pome demo end-to-end against a stub cloud", () => {
       expect(body).toContain("TwinHttpEvent");
       expect(body).toContain("/repos/acme/api/issues/1/labels");
       expect(body).toContain("/repos/acme/api/issues/1/comments");
+    }
+
+    // F-1749 — the demo's deterministic denominator, measured rather than
+    // asserted about the markdown: the bundled agent's correct walk satisfies
+    // every `[code]` criterion against the state the twin actually exported,
+    // and NONE of them was already true of the seed. A criterion the seed
+    // satisfies is dropped from the denominator cloud-side
+    // (`pre-satisfied.ts`), so a seed-true `[code]` row would put the demo
+    // straight back to "no trials were evaluated".
+    const stateUploads = (suffix: string): string[] =>
+      [...cloud!.putBodies.entries()].filter(([key]) => key.endsWith(suffix)).map(([, body]) => body);
+
+    const finalStates = stateUploads("/state_final.json");
+    const seedStates = stateUploads("/state_initial.json");
+    expect(finalStates).toHaveLength(2);
+    expect(seedStates).toHaveLength(2);
+
+    for (const stateJson of finalStates) {
+      const graded = await gradeCodeCriteria(stateJson);
+      expect(graded.length).toBeGreaterThan(0);
+      expect(graded.filter((row) => !row.passed)).toEqual([]);
+    }
+    for (const stateJson of seedStates) {
+      const graded = await gradeCodeCriteria(stateJson);
+      expect(graded.filter((row) => row.passed)).toEqual([]);
     }
 
     // Finalize: bearer demo_token, criteria [] (server-owned judge content),

--- a/cli/test/unit/demo/demo-task-criteria.test.ts
+++ b/cli/test/unit/demo/demo-task-criteria.test.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The packaged demo task has to be GRADABLE, not merely well-formed.
+//
+// F-1749: `first-run-demo` shipped three `[model]` criteria and zero `[code]`.
+// That parsed, bound and rendered fine — and since the narrator flip took
+// `[model]` out of the score denominator it left `total_required === 0`, so
+// every trial of the advertised zero-auth door reported "cloud could not
+// evaluate the trace". The task was never wrong; it was unscoreable.
+//
+// So the assertion this file exists to make is about the DENOMINATOR: the
+// packaged task must declare at least one `[code]` criterion, and every one it
+// declares must bind to a check the graders already publish. A criterion that
+// binds nothing is the same zero denominator wearing a different hat.
+//
+// The other half — that the bundled agent's correct walk actually SATISFIES
+// these criteria against the twin's exported state — cannot be read off the
+// markdown and is asserted in `test/e2e/demo-e2e.test.ts`, where the real twin,
+// the real agent and the real capture path run.
+
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { auditCodeCriteria } from "../../../src/cli/criterion-binding.js";
+import { DEMO_TASK_NAME, demoTaskPath } from "../../../src/demo/task.js";
+import { parseTask } from "../../../src/task/parseTask.js";
+
+async function packagedDemoTask() {
+  const markdown = await readFile(demoTaskPath(), "utf8");
+  const sidecar = JSON.parse(
+    await readFile(demoTaskPath().replace(/\.md$/, ".seed.json"), "utf8"),
+  ) as unknown;
+  return { markdown, task: parseTask(markdown, DEMO_TASK_NAME, sidecar) };
+}
+
+describe("packaged first-run-demo task — scoreability (F-1749)", () => {
+  it("declares at least one [code] criterion, so a graded trial has a denominator", async () => {
+    const { task } = await packagedDemoTask();
+    const code = task.criteria.filter((c) => c.type === "code");
+    expect(code.length).toBeGreaterThan(0);
+  });
+
+  it("binds every [code] criterion to an already-published check", async () => {
+    const { markdown } = await packagedDemoTask();
+    const audit = auditCodeCriteria(markdown);
+    // `findings` is the unbound/corrupted set — a criterion in it grades
+    // nothing, which is the defect this file guards against.
+    expect(audit.findings).toEqual([]);
+    expect(audit.unanswerable).toEqual([]);
+    expect(audit.bound).toBeGreaterThan(0);
+  });
+
+  it("keeps the three [model] criteria — the advisory narrative the demo exists to show", async () => {
+    const { task } = await packagedDemoTask();
+    const model = task.criteria.filter((c) => c.type === "model");
+    expect(model).toHaveLength(3);
+  });
+
+  // The [code] rows come first so the demo share page reads a deterministic
+  // fraction before the advisory prose that qualifies it.
+  it("lists the [code] criteria ahead of the [model] ones", async () => {
+    const { task } = await packagedDemoTask();
+    const kinds = task.criteria.map((c) => c.type);
+    expect(kinds).toEqual([...kinds].sort((a, b) => (a === b ? 0 : a === "code" ? -1 : 1)));
+  });
+});


### PR DESCRIPTION
## What

`cli/assets/demo/first-run-demo.md` — the packaged `npx @pome-sh/cli demo` task — gains two `[code]` criteria beside its three `[model]` ones:

```
- [code] Issue #1 in `acme/api` has exactly one classification label, and it is `bug`
- [code] A comment containing "POST /orders" exists on issue #1 in `acme/api`
```

Both are sentences the already-published check vocabulary renders (`github.issue-exactly-one-label`, `github.issue-comment-contains`). **No new check id**, so no pin chain.

## Why

F-1749. The task declared three `[model]` criteria and zero `[code]`. Since the narrator flip took `[model]` out of the score denominator, that leaves `total_required` at 0 → `evaluated === false` → the CLI's `scoreStatus` returns neither `pass` nor `fail`, and `runDemo` falls through to `{ kind: "errored", reason: "cloud could not evaluate the trace" }`.

Reproduced against prod on 2026-08-29 before touching anything:

```
running 3 isolated trials of first-run-demo …
trial 1  ⚠  errored         cloud could not evaluate the trace — excluded
trial 2  ⚠  errored         cloud could not evaluate the trace — excluded
trial 3  ⚠  errored         cloud could not evaluate the trace — excluded

no trials were evaluated · 3 trials errored on cloud could not evaluate the
trace, excluded from the fraction
```

Every trial, every time. The agent's local half was clean in all three: exactly one `bug` label on issue #1, exactly one comment, issues #2 and #3 untouched.

**Lockstep:** the cloud judges its own copy of this content, so this PR pairs with pome-sh/pome-cloud#887. The two are not strictly ordered, though — the demo agent never sees the criteria (`runTask` sets `POME_TASK: scenario.prompt`, and the rest is the server-owned `agentSystemPrompt`, both unchanged here), so the cloud half can deploy first and a stranger on the published `0.35.0` starts getting 2/2 immediately. What this PR is needed for is the canonical file itself and the bare-`pome run` user copy. There is no regen script between the two — I looked; "regenerated from" is prose in a comment and nothing reconciles them. This is a hand-sync, and both sides now pin the counts (2 `[code]`, 3 `[model]`) and the binding, so a typo'd sync reds a test rather than silently emptying the fraction.

## Notes for reviewer

**Why these two criteria, and not the obvious third.** The natural `[code]` reading of the third `[model]` row is `No new labels were created in `acme/api``. It is *pre-satisfied by the seed*, so `finalize-run.ts` (`excludePreSatisfied: true`) drops it from the denominator — it would have left again and taken the fraction with it. Both rows here assert something only an acting agent produces.

**The `[model]` rows stay on purpose.** They are the advisory narrative the demo exists to show, and they carry the two clauses no declared check can state: *"and to no other issue"*, and *"exactly one comment"*. `[code]` is listed first so the share page opens with the deterministic fraction and the prose qualifies it.

**The needle is measured, not guessed.** Seven live trials through the real gateway on 2026-08-29 — all seven wrote a comment containing the literal `POST /orders` ("The failing endpoint is POST /orders…", "The endpoint POST /orders is failing with a 500…", …). The issue title carries the string, and the task prompt names it. A rare paraphrase would make the trial read `failed`, not `errored` — still a working demo.

**Tests.**
* `cli/test/unit/demo/demo-task-criteria.test.ts` — the task declares `[code]` criteria, every one binds (`auditCodeCriteria` findings empty), the three `[model]` rows survive, `[code]` sorts first.
* `cli/test/e2e/demo-e2e.test.ts` — the existing real-twin/real-agent/real-capture e2e now grades the packaged `[code]` criteria off **the bytes the CLI actually uploaded**, through the same declarations the cloud uses. Correct walk passes all; the seed passes none. Negative control run: flipping the needle to `POST /nowhere` reds it with `issue #1 has no comment containing "POST /nowhere" (1 comment(s) scanned)`.

**Blast radius beyond `pome demo`.** This markdown is also what a bare `pome run` copies to `tasks/first-run-demo.md`, so the "run yours" default now scores a deterministic fraction too. An existing copy is never rewritten.

**Also in this diff:** both files claimed the server definition is *"regenerated FROM"* this markdown. There is no generator and no gate — I looked before syncing. The comment now says so and points at **F-1752**, filed for closing it (a cross-repo gate, or deleting one of the copies).

`cli/CHANGELOG.md` gains an `## Unreleased (patch)` entry.

Full suite green: 346 files / 3857 tests. `npm run lint` 17/17, `knip` clean, `npm run typecheck` clean.

