### PR TITLE
The narrator's advisory rows render as narrative, not as instrument gaps (F-1754)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,6 +9,44 @@ write a version number here or in `package.json`. Released entries are insertion
 only: a correction is the next entry, naming the one it corrects.
 
 
+## Unreleased (patch)
+
+**A `[model]` criterion the narrator read now prints as a reading, not as a
+gap.** `scoreFromFinalizeResponse` already stopped counting an advisory row as
+an abstention, so a mixed-criteria run scores off its `[code]` denominator and
+passes. Every surface that PRINTS those rows still called them something else.
+`outcomeOf` maps a narrated row to `skipped` — deliberately, since the three
+exemptions are subtracted from that tally — and `markerFor` renders `skipped`
+with `-`, whose sentence is "the cloud could not evaluate this criterion". So
+`pome eval` listed the demo task's three `[model]` rows as three instrument gaps
+beside a `PASS`, and `pome run` and `pome demo` printed a verdict with no
+mention of them at all.
+
+`criterionMarker` now gives a narrated row `~`, a fifth glyph chosen off
+`score_state` BESIDE `outcomeOf` rather than by widening it — so `outcome` stays
+reserved for the cloud's four-state vocabulary — and `narratorSuffix` names
+which of the two states it is and what that state means. A hosted `pome run`, a
+trial group's summary and `pome demo`'s summary print the same block beside
+their fraction:
+
+```
+the narrator also read these, and scored none of them:
+  ~ advisory · the existing `bug` label was applied to the issue reporting t…
+```
+
+Deduped and run-level rather than per-trial: the criteria belong to the task, so
+k trials would otherwise print the same sentences k times. The narrator's own
+prose stays on the dashboard the verdict already links to — on the packaged demo
+task it is an eight-sentence walk through the trace.
+
+`pome demo`'s trial line also names the denominator its word came from
+(`trial 1  ✓  passed   7.3s  2 of 2 checks`), and the criteria counts state the
+narrator's rows apart from the skips instead of folding them in, so a run that
+passes with three readings beside it no longer reports "3 skipped".
+
+A bare `skipped: true` with no `score_state` is untouched — still an instrument
+gap, still the `-` marker, still disqualifying for `can_pass`.
+
 ## 0.35.1 — 2026-08-29
 
 **`pome demo` reports a verdict again.** Every trial of the zero-auth door was

--- a/cli/src/cli/eval.ts
+++ b/cli/src/cli/eval.ts
@@ -44,13 +44,10 @@ import {
 import { readLatestRun, toTwinHttpEvent } from "../recorder/artifacts.js";
 import { redactEvent, redactSecrets } from "../recorder/redaction.js";
 import {
-  criterionMarkerLabel,
-  markerFor,
-  outcomeOf,
+  criterionRowLine,
   runScoreLine,
   scoreCountsSummary,
   scoreStatus,
-  twinSkipSuffix,
   type Score,
 } from "../hosted/evalResultView.js";
 import { resolveCredentials } from "./credentials.js";
@@ -627,9 +624,7 @@ export async function runEvalCommand(
     if (result.score.results.length > 0) {
       console.error(`  criteria: ${scoreCountsSummary(result.score)}`);
       for (const criterionResult of result.score.results) {
-        console.error(
-          `  ${markerFor(outcomeOf(criterionResult))} ${criterionMarkerLabel(criterionResult.criterion)} ${criterionResult.criterion.text}${twinSkipSuffix(criterionResult)}`,
-        );
+        console.error(`  ${criterionRowLine(criterionResult)}`);
       }
     }
     if (result.reusedSession) {

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -22,7 +22,12 @@ import {
 import { runTask } from "../runner/runTask.js";
 import { runTaskHosted } from "../runner/runTaskHosted.js";
 import { effectiveTrialCount, parseTrialsFlag } from "../runner/trialCount.js";
-import { outcomeOf, runScoreLine, scoreStatus } from "../hosted/evalResultView.js";
+import {
+  narratorReadingLines,
+  outcomeOf,
+  runScoreLine,
+  scoreStatus,
+} from "../hosted/evalResultView.js";
 import { HostedUsageError, exitCodeFor } from "../hosted/errors.js";
 import { resolveCredentials, clearLocalCredentials } from "./credentials.js";
 import { loginWithClerk } from "./login.js";
@@ -998,6 +1003,13 @@ export function createProgram() {
                 status === "pass" ? "PASS" : status === "fail" ? "FAIL" : "INCOMPLETE";
               console.error(`${label} ${result.scenario.title}`);
               console.error(`  ${runScoreLine(result.score, result.scenario.config.passThreshold, "cloud score")}`);
+              // The narrator's rows, beside the score and never inside it. A
+              // mixed task's `[model]` rows are the reading the run produced;
+              // printing only the fraction drops them, and printing them
+              // through the criteria list's `-` would call each one a gap.
+              for (const line of narratorReadingLines(result.score.results)) {
+                console.error(`  ${line}`);
+              }
               console.error(`  local: ${result.artifacts.runDir}`);
               console.error(`  cloud: ${result.cloudDashboardUrl}`);
               if (result.exitCode !== 0) worstExit = result.exitCode;

--- a/cli/src/demo/render.ts
+++ b/cli/src/demo/render.ts
@@ -6,21 +6,38 @@
 //   [bordered reassurance box]
 //   spinning up github twin … ready (1.2s)
 //   running 5 isolated trials of first-run-demo …
-//   trial 1  ✓  passed   14.3s
-//   trial 3  ✗  failed   15.9s  <criterion failure note>
+//   trial 1  ✓  passed   14.3s  2 of 2 checks
+//   trial 3  ✗  failed   15.9s  1 of 2 checks  <criterion failure note>
 //   trial 5  ⚠  errored         <reason> — excluded
 //   ─────
 //   2 of 4 passed · 1 trial errored on <reason>, excluded from the fraction
+//   the narrator also read these, and scored none of them:
+//     ~ advisory · <criterion phrase>
 //   <failing-criterion phrase> in 2 of 4 — start there
 //   see the full breakdown — read-only, still no account:
 //   → https://app.pome.sh/demo/<group_id>
 //
 // Demo verdicts are WORDS (passed/failed), never scores; errored rows show
-// no duration and are EXCLUDED from the fraction's denominator.
+// no duration and are EXCLUDED from the fraction's denominator. The check
+// fraction is a COUNT of scored criteria, not a 0-100 wearing a disguise.
+
+import {
+  narratorReadingLines,
+  type CriterionResult,
+} from "../hosted/evalResultView.js";
+
+/** The criteria this trial satisfied over the ones it was SCORED on — the
+ *  deterministic denominator behind the trial's word. `score.total_required`,
+ *  which is every criterion that reached a pass/fail: normally the `[code]`
+ *  rows, plus any `[model]` row the task marked always-scored. */
+export interface TrialChecks {
+  passed: number;
+  total: number;
+}
 
 export type TrialVerdict =
-  | { kind: "passed"; seconds: number }
-  | { kind: "failed"; seconds: number; note: string }
+  | { kind: "passed"; seconds: number; checks: TrialChecks }
+  | { kind: "failed"; seconds: number; note: string; checks: TrialChecks }
   | { kind: "errored"; reason: string };
 
 /** Reassurance frame. "No signup. No API keys." is verbatim copy of record
@@ -56,12 +73,16 @@ export function evaluatingLine(index: number): string {
 export function trialLine(index: number, verdict: TrialVerdict): string {
   switch (verdict.kind) {
     case "passed":
-      return `trial ${index}  ✓  passed   ${formatSeconds(verdict.seconds)}`;
+      return `trial ${index}  ✓  passed   ${formatSeconds(verdict.seconds)}  ${checksPhrase(verdict.checks)}`;
     case "failed":
-      return `trial ${index}  ✗  failed   ${formatSeconds(verdict.seconds)}  ${verdict.note}`;
+      return `trial ${index}  ✗  failed   ${formatSeconds(verdict.seconds)}  ${checksPhrase(verdict.checks)}  ${verdict.note}`;
     case "errored":
       return `trial ${index}  ⚠  errored         ${verdict.reason} — excluded`;
   }
+}
+
+function checksPhrase(checks: TrialChecks): string {
+  return `${checks.passed} of ${checks.total} checks`;
 }
 
 function formatSeconds(seconds: number): string {
@@ -74,6 +95,10 @@ export interface SummaryInput {
   failingCriterionPhrase?: string;
   /** How many evaluated trials failed that criterion. */
   failingCriterionCount?: number;
+  /** Every narrated row the evaluated trials carried, in the order they were
+   *  collected. Deduped into one block by `narratorReadingLines` — the criteria
+   *  are the task's, so k trials repeat them k times. */
+  narrated?: CriterionResult[];
   previewUrl: string;
 }
 
@@ -100,6 +125,12 @@ export function summaryLines(input: SummaryInput): string[] {
   }
   lines.push(fraction);
 
+  // The narrator's rows, beside the fraction and never inside it. Same block
+  // and same glyph a hosted `pome run` prints — imported rather than shaped
+  // again here, so the front door and the logged-in surface cannot describe
+  // this state two ways.
+  lines.push(...narratorReadingLines(input.narrated ?? []));
+
   if (
     input.failingCriterionPhrase &&
     typeof input.failingCriterionCount === "number" &&
@@ -117,12 +148,4 @@ export function summaryLines(input: SummaryInput): string[] {
   }
 
   return lines;
-}
-
-/** Compress a criterion's text into the short "start there" phrase: first
- *  clause, lower-cased lead, ~60 chars. */
-export function criterionPhrase(text: string): string {
-  const clause = text.split(/[.;]/)[0]?.trim() ?? text.trim();
-  const lowered = clause.length > 0 ? clause[0]!.toLowerCase() + clause.slice(1) : clause;
-  return lowered.length > 64 ? `${lowered.slice(0, 61).trimEnd()}…` : lowered;
 }

--- a/cli/src/demo/runDemo.ts
+++ b/cli/src/demo/runDemo.ts
@@ -32,7 +32,13 @@ import {
   scoreFromFinalizeResponse,
   uploadRunBlobs,
 } from "../hosted/uploadAndFinalize.js";
-import { outcomeOf, scoreStatus } from "../hosted/evalResultView.js";
+import {
+  criterionPhrase,
+  isNarrated,
+  outcomeOf,
+  scoreStatus,
+  type CriterionResult,
+} from "../hosted/evalResultView.js";
 import { HostedQuotaError } from "../hosted/errors.js";
 import {
   DemoCapacityError,
@@ -43,7 +49,6 @@ import {
 import { newGroupId } from "./ids.js";
 import { mintDemoSessions, type DemoSession } from "./mint.js";
 import {
-  criterionPhrase,
   evaluatingLine,
   reassuranceBox,
   summaryLines,
@@ -164,6 +169,12 @@ export async function runDemo(options: RunDemoOptions): Promise<RunDemoResult> {
   const verdicts: TrialVerdict[] = [];
   // Failed-criterion texts across evaluated trials, for the "start there" line.
   const collectedFailures: string[] = [];
+  // The narrator's rows across the GRADED trials, for the reading block beside
+  // the fraction. Collected the same way `collectedFailures` is and for the
+  // same reason: it is a statement about the TASK, so it belongs to the run and
+  // not to a trial line that would repeat it k times. An ungradable trial
+  // contributes nothing — same rule `runTrialGroup` applies to the same block.
+  const collectedReadings: CriterionResult[] = [];
   let capacityAbort: string | null = null;
 
   for (let i = 0; i < trials; i += 1) {
@@ -190,6 +201,7 @@ export async function runDemo(options: RunDemoOptions): Promise<RunDemoResult> {
         captureServerCommand: options.captureServerCommand,
         out,
         collectedFailures,
+        collectedReadings,
         progress,
       });
     } catch (err) {
@@ -242,6 +254,7 @@ export async function runDemo(options: RunDemoOptions): Promise<RunDemoResult> {
     verdicts,
     failingCriterionPhrase: failing?.phrase,
     failingCriterionCount: failing?.count,
+    narrated: collectedReadings,
     previewUrl: `${options.dashboardBase.replace(/\/$/, "")}/demo/${groupId}`,
   })) {
     out(line);
@@ -264,6 +277,8 @@ interface RunOneTrialInput {
   captureServerCommand?: RunTaskOptions["captureServerCommand"];
   out: (line: string) => void;
   collectedFailures: string[];
+  /** Appended to, not read: the caller renders the run-level reading block. */
+  collectedReadings: CriterionResult[];
   /** Set once finalize succeeds, so the caller's error handling
    *  never abandons a session that already has a judged run row. */
   progress: { finalized: boolean };
@@ -344,8 +359,15 @@ async function runOneTrial(input: RunOneTrialInput): Promise<TrialVerdict> {
 
   const score = scoreFromFinalizeResponse(finalized);
   const status = scoreStatus(score, 100);
+  // The deterministic denominator behind the trial's word, off the SAME cloud
+  // score the word comes from — so the fraction can never disagree with the
+  // verdict printed next to it.
+  const checks = { passed: score.passed, total: score.total_required };
+  if (status !== "incomplete") {
+    input.collectedReadings.push(...score.results.filter(isNarrated));
+  }
   if (status === "pass") {
-    return { kind: "passed", seconds: agentSeconds };
+    return { kind: "passed", seconds: agentSeconds, checks };
   }
   if (status === "fail") {
     const failedResults = score.results.filter((r) => outcomeOf(r) === "failed");
@@ -353,7 +375,7 @@ async function runOneTrial(input: RunOneTrialInput): Promise<TrialVerdict> {
     const note = failedResults[0]
       ? criterionPhrase(failedResults[0].criterion.text)
       : "criterion not met";
-    return { kind: "failed", seconds: agentSeconds, note };
+    return { kind: "failed", seconds: agentSeconds, note, checks };
   }
   // Un-evaluated: the judge could not produce a verdict for this trace —
   // honest exclusion, not a fabricated word.

--- a/cli/src/hosted/evalResultView.ts
+++ b/cli/src/hosted/evalResultView.ts
@@ -94,11 +94,13 @@ export type Score = {
   // `runScoreLine` subtract this count back out of the "not evaluated" tally.
   preSatisfied: number;
   // The two narrator subsets of `skipped`, on the same footing as
-  // `preSatisfied` above: still counted in `skipped`, still rendered with the
-  // `-` marker, but not abstentions — so `can_pass` and `runScoreLine` subtract
-  // them back out of the "not evaluated" tally. Named separately because the
-  // two read differently to a human: an advisory row has a reading to show, an
-  // abstain has a missing subject to name.
+  // `preSatisfied` above: still counted in `skipped`, but not abstentions — so
+  // `can_pass` and `runScoreLine` subtract them back out of the "not evaluated"
+  // tally. Named separately because the two read differently to a human: an
+  // advisory row has a reading to show, an abstain has a missing subject to
+  // name. Unlike `preSatisfied` they do NOT render with the `-` marker —
+  // `criterionMarker` gives them `NARRATED_MARKER` and `narratorSuffix` names
+  // which of the two they are.
   advisory: number;
   abstained: number;
   // = passed + failed. The satisfaction denominator.
@@ -185,6 +187,26 @@ export function isNarrated(
   );
 }
 
+/**
+ * `advisory` / `abstained` as the word to PRINT beside a narrated row, or null
+ * on every row the narrator did not name.
+ *
+ * Goes through `isNarrated`, so the closed vocabulary is applied in exactly one
+ * place: an unrecognised `score_state` spelling (the tolerant reader's whole
+ * point — see `criterionResultSchema`'s note on why this field is not an enum
+ * on this side) prints nothing rather than a fabricated state, and a
+ * `score_state` on a row that was not skipped is ignored the way the wire
+ * reduction ignores it.
+ */
+export function narratorStateLabel(
+  result: Pick<CriterionResult, "skipped" | "score_state">,
+): string | null {
+  if (!isNarrated(result)) return null;
+  return result.score_state === ADVISORY_SCORE_STATE
+    ? ADVISORY_SCORE_STATE
+    : ABSTAINED_SCORE_STATE;
+}
+
 export type ScoreStatus = "pass" | "fail" | "incomplete";
 
 // Single source of truth for "did this run pass?", applied to a CLOUD score.
@@ -257,6 +279,90 @@ export function markerFor(outcome: CriterionOutcome): string {
   }
 }
 
+// The narrator's marker, and a FIFTH glyph rather than a reuse of one of
+// `markerFor`'s four. Those four are already two disjoint claims — ✓/✗ are
+// verdicts about the CRITERION, `-`/`!` are statements about the GRADER — and a
+// narrated row is neither: the grader reached the row and reported that it had
+// no score authority over it.
+//
+// `-` in particular is the one that has to go. Its sentence is "the cloud could
+// not evaluate this criterion", which is exactly the claim the narrator states
+// exist to stop making about a `[model]` row, and it is the glyph a narrated row
+// lands on by default because `outcomeOf` maps it to `skipped`. That mapping is
+// deliberate and stays: the three exemptions are SUBTRACTED from the `skipped`
+// tally, so a row that left the tally would be subtracted from a count it was
+// never in. The marker is therefore chosen BESIDE `outcomeOf`, off
+// `isNarrated`, and never by widening the four-state union — which is also what
+// keeps `outcome` reserved for the cloud to fill.
+export const NARRATED_MARKER = "~";
+
+/** The marker to print beside one cloud criterion row. */
+export function criterionMarker(result: CriterionResult): string {
+  return isNarrated(result) ? NARRATED_MARKER : markerFor(outcomeOf(result));
+}
+
+/**
+ * The trailing clause that says what a narrated row IS, so the marker never has
+ * to carry the meaning alone. Empty on every row that is not narrated.
+ *
+ * Says "never scored" rather than "not evaluated": the row WAS read, and the
+ * distinction between those two sentences is the whole of this ticket.
+ */
+export function narratorSuffix(result: CriterionResult): string {
+  const label = narratorStateLabel(result);
+  if (label === null) return "";
+  return label === ADVISORY_SCORE_STATE
+    ? " — advisory: read by the narrator, never scored"
+    : " — abstained: nothing in this run to read";
+}
+
+/** One criterion row as a terminal prints it: marker, lane label, the criterion
+ *  itself, then whichever trailing clause applies. ONE renderer, because the
+ *  surfaces that print rows (`pome eval`'s full list, a hosted run's narrative
+ *  block) have to agree on the marker or the state means two things. */
+export function criterionRowLine(result: CriterionResult): string {
+  return `${criterionMarker(result)} ${criterionMarkerLabel(result.criterion)} ${result.criterion.text}${narratorSuffix(result)}${twinSkipSuffix(result)}`;
+}
+
+/**
+ * The narrative block a verdict prints beside its score: a header sentence and
+ * one `~` line per narrated row, or `[]` when the run has none.
+ *
+ * DEDUPED by state + phrase, and that is what makes it a run-level block rather
+ * than a per-trial one. Every trial of a task is graded against the SAME
+ * criteria, and this prints the criterion rather than the narrator's per-trial
+ * prose — so a 5-trial set would otherwise print the same three sentences five
+ * times. The prose itself stays on the dashboard, where a reader who wants the
+ * walk through the trace can have it in full instead of truncated to a terminal
+ * width.
+ */
+export function narratorReadingLines(results: CriterionResult[]): string[] {
+  const seen = new Set<string>();
+  const rows: string[] = [];
+  for (const result of results) {
+    const state = narratorStateLabel(result);
+    if (state === null) continue;
+    const line = `  ${NARRATED_MARKER} ${state} · ${criterionPhrase(result.criterion.text)}`;
+    if (seen.has(line)) continue;
+    seen.add(line);
+    rows.push(line);
+  }
+  if (rows.length === 0) return [];
+  // Says what the block IS before the reader meets an unfamiliar glyph, so `~`
+  // never has to read as a fourth verdict on its own.
+  return ["the narrator also read these, and scored none of them:", ...rows];
+}
+
+/** Compress a criterion's text for a one-line display: first clause,
+ *  lower-cased lead, ~60 chars. Shared by the narrative block above, the demo's
+ *  "start there" line and the trial group's failing-criteria note — one
+ *  compression, so a criterion reads the same wherever it is abbreviated. */
+export function criterionPhrase(text: string): string {
+  const clause = text.split(/[.;]/)[0]?.trim() ?? text.trim();
+  const lowered = clause.length > 0 ? clause[0]!.toLowerCase() + clause.slice(1) : clause;
+  return lowered.length > 64 ? `${lowered.slice(0, 61).trimEnd()}…` : lowered;
+}
+
 // Multi-twin (M3): the per-criterion bracket for terminal display —
 // `[code]` / `[model]`, plus the `:<twin>` suffix when the criterion attributes
 // to a specific twin (so a `[code:slack]`/`[model:github]` marker survives into the
@@ -270,9 +376,15 @@ export function criterionMarkerLabel(criterion: WireCriterion): string {
 // twin-related reason (a twin-tagged criterion, or a `no_matching_predicate`
 // skip), name the twin inline so the INCOMPLETE line explains WHICH twin's timeline
 // came up empty. Returns "" when there's nothing twin-specific to add.
+//
+// A NARRATED ROW GETS NOTHING, because nothing came up empty on it. The suffix
+// is an instrument-gap explanation, and `outcomeOf` maps a narrated row to
+// `skipped` — so without this guard a twin-tagged advisory row would carry the
+// gap claim a second time, in the twin's name, right beside the clause saying
+// it was read.
 export function twinSkipSuffix(result: CriterionResult): string {
   const twin = result.criterion.twin;
-  if (!twin) return "";
+  if (!twin || isNarrated(result)) return "";
   const outcome = outcomeOf(result);
   const twinRelated =
     outcome === "skipped" ||
@@ -325,8 +437,25 @@ export function evaluationCounts(score: Score): EvaluationCounts {
   };
 }
 
+// The narrator's rows are named APART from the skips rather than folded into
+// them, for the reason `runScoreLine` names `preSatisfied` apart: `skipped` in
+// this sentence means "the grader never reached it", and a run that passes with
+// three readings beside it printing "3 skipped" says the opposite of the state
+// those three rows are actually in. They are subtracted from the printed
+// `skipped` and re-stated under their own words, so the numbers still sum to
+// the rows the run recorded.
+//
+// `preSatisfied` stays inside `skipped` here — `runScoreLine` already says
+// "(N already true in the seed)" beside this string, and saying it twice in one
+// line would be the drift this factoring exists to prevent.
 export function scoreCountsSummary(score: Score): string {
-  return `${score.passed ?? 0} passed, ${score.failed ?? 0} failed, ${score.skipped ?? 0} skipped, ${score.errored ?? 0} errored`;
+  const advisory = score.advisory ?? 0;
+  const abstained = score.abstained ?? 0;
+  const narrated =
+    (advisory > 0 ? `, ${advisory} advisory` : "") +
+    (abstained > 0 ? `, ${abstained} abstained` : "");
+  const skipped = (score.skipped ?? 0) - advisory - abstained;
+  return `${score.passed ?? 0} passed, ${score.failed ?? 0} failed, ${skipped} skipped, ${score.errored ?? 0} errored${narrated}`;
 }
 
 export function runScoreLine(

--- a/cli/src/runner/groupRender.ts
+++ b/cli/src/runner/groupRender.ts
@@ -12,6 +12,8 @@
 //   trial 5  ⚠  errored         <reason> — excluded
 //   ─────
 //   2 of 4 passed · 1 errored, excluded from the fraction
+//   the narrator also read these, and scored none of them:
+//     ~ advisory · <criterion phrase>
 //   <failing-criterion phrase> failed in 2 of 4 — start there
 //   full trace, per-criterion diffs, and the trial spread:
 //   → <reliability page url>
@@ -20,8 +22,12 @@
 // vocabulary belongs to `pome demo`, moment 01). Errored rows show no
 // duration and are EXCLUDED from the fraction's denominator.
 
-import { criterionPhrase } from "../demo/render.js";
-import type { ScoreStatus } from "../hosted/evalResultView.js";
+import {
+  criterionPhrase,
+  narratorReadingLines,
+  type CriterionResult,
+  type ScoreStatus,
+} from "../hosted/evalResultView.js";
 
 export type TrialRow =
   | {
@@ -92,6 +98,11 @@ export interface GroupSummaryInput {
   failingCriterionPhrase?: string;
   /** How many completed trials failed that criterion. */
   failingCriterionCount?: number;
+  /** Every narrated row the completed trials carried. Deduped into one block
+   *  by `narratorReadingLines`: the criteria belong to the TASK, so k trials
+   *  repeat them k times and a per-trial line would print the same sentence
+   *  once per trial. */
+  narrated?: CriterionResult[];
   /** The task's reliability page (dashboard /runs/task/<taskName>). */
   reliabilityUrl: string;
 }
@@ -130,6 +141,11 @@ export function groupSummaryLines(input: GroupSummaryInput): string[] {
     fraction += ` · ${errored} errored, excluded from the fraction`;
   }
   lines.push(fraction);
+
+  // Same block, same glyph and same words as `pome demo`'s summary and a
+  // single hosted run's verdict — one renderer, so this state cannot come to
+  // mean three things across the three surfaces that print it.
+  lines.push(...narratorReadingLines(input.narrated ?? []));
 
   if (
     input.failingCriterionPhrase &&

--- a/cli/src/runner/runTrialGroup.ts
+++ b/cli/src/runner/runTrialGroup.ts
@@ -40,9 +40,13 @@ import { dirname } from "node:path";
 import { createHostedClient, type HostedClient } from "../hosted/client.js";
 import { HostedQuotaError, HostedTrialError } from "../hosted/errors.js";
 import { newGroupId } from "../demo/ids.js";
-import { criterionPhrase } from "../demo/render.js";
 import { parseTaskFile } from "../task/parseTask.js";
-import { outcomeOf } from "../hosted/evalResultView.js";
+import {
+  criterionPhrase,
+  isNarrated,
+  outcomeOf,
+  type CriterionResult,
+} from "../hosted/evalResultView.js";
 import { resolveRunAgentIdentity } from "../cli/agent-identity.js";
 import { runTaskHosted } from "./runTaskHosted.js";
 import {
@@ -219,6 +223,16 @@ export async function runTrialGroup(
   // earlier trial's line.
   const rows: TrialRow[] = new Array<TrialRow>(options.trials);
   const failedCriteria: string[] = [];
+  // The narrator's rows across the GRADED trials, for the reading block in the
+  // summary. Collected exactly the way `failedCriteria` is, and for the same
+  // reason: it is a statement about the TASK's criteria, so it belongs to the
+  // set and not to a trial line that would repeat it k times.
+  //
+  // A trial that could not be graded contributes nothing — same rule
+  // `runDemo` applies to the same block. A reader looking at "no trials could
+  // be graded" is asking what went ungraded, and three readings printed under
+  // that question answer a different one.
+  const narrated: CriterionResult[] = [];
   let printedRows = 0;
   const flushRows = () => {
     while (printedRows < options.trials && rows[printedRows] !== undefined) {
@@ -247,6 +261,9 @@ export async function runTrialGroup(
         (r) => outcomeOf(r) === "failed",
       );
       for (const r of failing) failedCriteria.push(r.criterion.text);
+      if (result.verdict !== "incomplete") {
+        narrated.push(...result.score.results.filter(isNarrated));
+      }
       row = {
         kind: "completed",
         score: result.score.satisfaction,
@@ -312,6 +329,7 @@ export async function runTrialGroup(
     rows,
     failingCriterionPhrase: failing?.phrase,
     failingCriterionCount: failing?.count,
+    narrated,
     reliabilityUrl,
   })) {
     out(line);

--- a/cli/test/e2e/demo-e2e.test.ts
+++ b/cli/test/e2e/demo-e2e.test.ts
@@ -208,6 +208,13 @@ async function startStubCloud(): Promise<StubCloud> {
           score: 100,
           judge_model: "google/gemini-3.1-flash-lite",
           dashboard_url: `http://127.0.0.1:${port}/runs/run_${sessionId}`,
+          // The shape prod returns for this task (evaluator
+          // f1643-narrator-abstain.1, measured 2026-08-29): two `[code]` rows
+          // carry the score, three `[model]` rows ride beside them as the
+          // narrator's readings — `passed: false, skipped: true` plus a
+          // `score_state`, and no `outcome` anywhere. The first row keeps the
+          // legacy `P` kind + explicit `outcome` so the vocabulary
+          // normalization stays exercised alongside it.
           criteria_results: [
             {
               criterion: { type: "P", text: "The bug label was applied." },
@@ -215,6 +222,45 @@ async function startStubCloud(): Promise<StubCloud> {
               passed: true,
               skipped: false,
               reason: "ok",
+            },
+            {
+              criterion: {
+                type: "code",
+                text: 'A comment containing "POST /orders" exists on issue #1 in `acme/api`',
+              },
+              passed: true,
+              skipped: false,
+              reason: 'issue #1 has a comment containing "POST /orders"',
+            },
+            {
+              criterion: {
+                type: "model",
+                text: "The existing `bug` label was applied to the issue reporting the 500 error on POST /orders, and to no other issue.",
+              },
+              passed: false,
+              skipped: true,
+              reason: "1. The trace shows one POST to /repos/acme/api/issues/1/labels. 2. No other issue was labelled.",
+              score_state: "advisory",
+            },
+            {
+              criterion: {
+                type: "model",
+                text: "Exactly one comment was left on that issue, and it names the failing endpoint (POST /orders).",
+              },
+              passed: false,
+              skipped: true,
+              reason: "1. One POST to /issues/1/comments. 2. Its body names POST /orders.",
+              score_state: "advisory",
+            },
+            {
+              criterion: {
+                type: "model",
+                text: "No other issue was modified and no new label was created.",
+              },
+              passed: false,
+              skipped: true,
+              reason: "1. No writes to issues 2 or 3. 2. No POST to /labels.",
+              score_state: "advisory",
             },
           ],
         });
@@ -268,9 +314,21 @@ describe("pome demo end-to-end against a stub cloud", () => {
     expect(text).toContain("No signup. No API keys.");
     expect(text).toMatch(/spinning up github twin … ready \(\d+\.\ds\)/);
     expect(text).toContain("running 2 isolated trials of first-run-demo …");
-    expect(text).toMatch(/trial 1 {2}✓ {2}passed {3}\d+\.\ds/);
-    expect(text).toMatch(/trial 2 {2}✓ {2}passed {3}\d+\.\ds/);
+    expect(text).toMatch(/trial 1 {2}✓ {2}passed {3}\d+\.\ds {2}2 of 2 checks/);
+    expect(text).toMatch(/trial 2 {2}✓ {2}passed {3}\d+\.\ds {2}2 of 2 checks/);
     expect(text).toContain("2 of 2 passed");
+
+    // F-1754 — the mixed run's `[model]` rows render as the narrator's
+    // readings, and never as the shortfall the `-` glyph used to make them look
+    // like beside a passing fraction. THREE lines for two trials, not six: the
+    // criteria belong to the task, so the block is deduped for the whole set.
+    const readings = out.filter((line) => line.includes("~ advisory · "));
+    expect(readings).toHaveLength(3);
+    expect(readings[0]).toContain("the existing `bug` label was applied");
+    expect(text).toContain("the narrator also read these, and scored none of them:");
+    expect(text).not.toContain("cloud could not evaluate the trace");
+    // The narrator's prose belongs on the share page, not in the front door.
+    expect(text).not.toContain("The trace shows one POST");
     expect(text).toContain(`→ https://app.pome.sh/demo/${result.groupId}`);
     expect(result.exitCode).toBe(0);
 

--- a/cli/test/unit/demo/render.test.ts
+++ b/cli/test/unit/demo/render.test.ts
@@ -3,14 +3,36 @@
 // scores, errored rows show no duration, the summary fraction excludes errored.
 import { describe, expect, it } from "vitest";
 import {
-  criterionPhrase,
   reassuranceBox,
   summaryLines,
   trialLine,
   trialsHeaderLine,
   twinReadyLine,
+  type TrialVerdict,
 } from "../../../src/demo/render.js";
 import { capacityLabel } from "../../../src/demo/capacity.js";
+import {
+  criterionPhrase,
+  type CriterionResult,
+} from "../../../src/hosted/evalResultView.js";
+
+/** A scored trial — the shape every fraction-only assertion below needs and
+ *  nothing more. */
+const scored = (kind: "passed" | "failed", seconds: number): TrialVerdict =>
+  ({
+    kind,
+    seconds,
+    checks: { passed: kind === "passed" ? 2 : 1, total: 2 },
+    ...(kind === "failed" ? { note: "n" } : {}),
+  }) as TrialVerdict;
+
+const advisoryRow = (text: string): CriterionResult => ({
+  criterion: { type: "model", text },
+  passed: false,
+  skipped: true,
+  reason: "1. The trace shows one POST to /issues/1/labels. 2. Therefore …",
+  score_state: "advisory",
+});
 
 describe("reassurance box", () => {
   it("keeps the copy of record verbatim and names all three surfaces honestly", () => {
@@ -49,17 +71,34 @@ describe("progress lines", () => {
 });
 
 describe("trial verdict lines", () => {
-  it("passed / failed use words + duration", () => {
-    expect(trialLine(1, { kind: "passed", seconds: 14.31 })).toBe(
-      "trial 1  ✓  passed   14.3s",
-    );
+  it("passed / failed use words + duration + the deterministic denominator", () => {
+    // The fraction is the `[code]` denominator, and naming it is what makes
+    // the narrator lines beneath legible as something other than a shortfall:
+    // 2 of 2 checks passed, and three rows nobody scored sit beside them.
+    expect(
+      trialLine(1, { kind: "passed", seconds: 14.31, checks: { passed: 2, total: 2 } }),
+    ).toBe("trial 1  ✓  passed   14.3s  2 of 2 checks");
     expect(
       trialLine(3, {
         kind: "failed",
         seconds: 15.94,
         note: "the comment never names the failing endpoint",
+        checks: { passed: 1, total: 2 },
       }),
-    ).toBe("trial 3  ✗  failed   15.9s  the comment never names the failing endpoint");
+    ).toBe(
+      "trial 3  ✗  failed   15.9s  1 of 2 checks  the comment never names the failing endpoint",
+    );
+  });
+
+  it("counts checks, never a score", () => {
+    // `2 of 2 checks` is a count of `[code]` criteria, not the 0-100 the
+    // demo's design of record keeps off this surface.
+    const line = trialLine(1, {
+      kind: "passed",
+      seconds: 14.31,
+      checks: { passed: 2, total: 2 },
+    });
+    expect(line).not.toMatch(/\/100|\d+%/);
   });
 
   it("errored shows no duration and is marked excluded", () => {
@@ -69,10 +108,9 @@ describe("trial verdict lines", () => {
   });
 
   it("never renders a numeric score", () => {
-    for (const line of [
-      trialLine(1, { kind: "passed", seconds: 2 }),
-      trialLine(2, { kind: "failed", seconds: 2, note: "x" }),
-    ]) {
+    for (const line of [scored("passed", 2), scored("failed", 2)].map((v, i) =>
+      trialLine(i + 1, v),
+    )) {
       expect(line).not.toMatch(/\/100|\d+%/);
     }
   });
@@ -82,10 +120,10 @@ describe("summary", () => {
   it("excludes errored trials from the fraction and names the errored reason", () => {
     const lines = summaryLines({
       verdicts: [
-        { kind: "passed", seconds: 14.3 },
-        { kind: "passed", seconds: 12.1 },
-        { kind: "failed", seconds: 15.9, note: "n" },
-        { kind: "failed", seconds: 13.5, note: "n" },
+        scored("passed", 14.3),
+        scored("passed", 12.1),
+        scored("failed", 15.9),
+        scored("failed", 13.5),
         { kind: "errored", reason: "gateway timeout" },
       ],
       failingCriterionPhrase: "the comment never names the failing endpoint",
@@ -106,11 +144,11 @@ describe("summary", () => {
   it("renders a clean fraction when nothing errored", () => {
     const lines = summaryLines({
       verdicts: [
-        { kind: "passed", seconds: 1 },
-        { kind: "passed", seconds: 1 },
-        { kind: "passed", seconds: 1 },
-        { kind: "failed", seconds: 1, note: "n" },
-        { kind: "passed", seconds: 1 },
+        scored("passed", 1),
+        scored("passed", 1),
+        scored("passed", 1),
+        scored("failed", 1),
+        scored("passed", 1),
       ],
       previewUrl: "https://app.pome.sh/demo/grp_x",
     });
@@ -120,10 +158,7 @@ describe("summary", () => {
 
   it("omits the start-there line when nothing failed", () => {
     const lines = summaryLines({
-      verdicts: [
-        { kind: "passed", seconds: 1 },
-        { kind: "passed", seconds: 1 },
-      ],
+      verdicts: [scored("passed", 1), scored("passed", 1)],
       previewUrl: "https://app.pome.sh/demo/grp_x",
     });
     expect(lines.join("\n")).not.toContain("start there");
@@ -141,6 +176,48 @@ describe("summary", () => {
       "no trials were evaluated · 2 trials errored on trial timed out, excluded from the fraction",
     );
     expect(lines.join("\n")).not.toContain("app.pome.sh/demo");
+  });
+
+  // F-1754 — the narrator's rows are what the demo exists to SHOW: an advisory
+  // reading beside a deterministic fraction. This surface printed neither.
+  it("prints the narrator's readings once, beside the fraction", () => {
+    const lines = summaryLines({
+      verdicts: [scored("passed", 1), scored("passed", 1)],
+      // Two trials of the same task — the same three criteria, twice.
+      narrated: [
+        advisoryRow("The `bug` label went to the 500-error issue and no other."),
+        advisoryRow("No other issue was modified and no new label was created."),
+        advisoryRow("The `bug` label went to the 500-error issue and no other."),
+        advisoryRow("No other issue was modified and no new label was created."),
+      ],
+      previewUrl: "https://app.pome.sh/demo/grp_x",
+    });
+    expect(lines[1]).toBe("2 of 2 passed");
+    // Deduped: the criteria belong to the task, not to a trial.
+    expect(lines[2]).toBe("the narrator also read these, and scored none of them:");
+    expect(lines[3]).toBe(
+      "  ~ advisory · the `bug` label went to the 500-error issue and no other",
+    );
+    expect(lines[4]).toBe(
+      "  ~ advisory · no other issue was modified and no new label was created",
+    );
+    expect(lines[5]).toBe("see the full breakdown — read-only, still no account:");
+    // Not a shortfall and not a gap.
+    for (const line of lines.slice(2, 5)) {
+      expect(line).not.toMatch(/[✓✗⚠]/);
+      expect(line).not.toMatch(/^\s*- /);
+    }
+    // The narrator's prose belongs on the share page.
+    expect(lines.join("\n")).not.toContain("The trace shows one POST");
+  });
+
+  it("says nothing about the narrator when a run has no narrated rows", () => {
+    const lines = summaryLines({
+      verdicts: [scored("passed", 1)],
+      previewUrl: "https://app.pome.sh/demo/grp_x",
+    });
+    expect(lines.join("\n")).not.toContain("narrator");
+    expect(lines.join("\n")).not.toContain("~");
   });
 });
 

--- a/cli/test/unit/demo/runDemo.test.ts
+++ b/cli/test/unit/demo/runDemo.test.ts
@@ -82,6 +82,55 @@ function failedResult(): FinalizeResponse["criteria_results"] {
   ];
 }
 
+// The wire shape prod actually returns for the packaged demo task, measured on
+// 2026-08-29 by replaying a captured trial's own blobs through mint → upload →
+// finalize (evaluator f1643-narrator-abstain.1): two `[code]` rows carry the
+// score, three `[model]` rows ride beside it as the narrator's readings. Every
+// one of those five is `passed`/`skipped` only — `outcome` is never on the
+// wire, which is why the CLI reads `score_state`.
+function mixedResult(): FinalizeResponse["criteria_results"] {
+  return [
+    {
+      criterion: {
+        type: "code" as const,
+        text: "Issue #1 in `acme/api` has exactly one classification label, and it is `bug`",
+      },
+      passed: true,
+      skipped: false,
+      reason: 'issue #1 has exactly one label ("bug")',
+    },
+    {
+      criterion: {
+        type: "code" as const,
+        text: 'A comment containing "POST /orders" exists on issue #1 in `acme/api`',
+      },
+      passed: true,
+      skipped: false,
+      reason: 'issue #1 has a comment containing "POST /orders"',
+    },
+    advisoryRow(
+      "The existing `bug` label was applied to the issue reporting the 500 error on POST /orders, and to no other issue.",
+    ),
+    advisoryRow(
+      "Exactly one comment was left on that issue, and it names the failing endpoint (POST /orders).",
+    ),
+    advisoryRow("No other issue was modified and no new label was created."),
+  ];
+}
+
+function advisoryRow(text: string) {
+  return {
+    criterion: { type: "model" as const, text },
+    passed: false,
+    skipped: true,
+    // The narrator's own numbered walk through the trace. Long on purpose:
+    // the terminal must not print it.
+    reason:
+      "1. The scenario requires applying the 'bug' label. 2. The trace shows a POST to /repos/acme/api/issues/1/labels. 3. Therefore the label was applied correctly.",
+    score_state: "advisory",
+  };
+}
+
 function criterion(text: string, outcome: "passed" | "failed") {
   return {
     criterion: { type: "model" as const, text },
@@ -227,7 +276,7 @@ describe("runDemo", () => {
     expect(text).toContain("No signup. No API keys.");
     expect(text).toContain("running 5 isolated trials of first-run-demo …");
     expect(text).toMatch(/trial 1 {2}✓ {2}passed {3}\d+\.\ds/);
-    expect(text).toMatch(/trial 3 {2}✗ {2}failed {3}\d+\.\ds {2}exactly one comment/);
+    expect(text).toMatch(/trial 3 {2}✗ {2}failed {3}\d+\.\ds {2}1 of 2 checks {2}exactly one comment/);
     expect(text).toContain("trial 5  ⚠  errored         trial timed out — excluded");
     expect(text).toContain(
       "2 of 4 passed · 1 trial errored on trial timed out, excluded from the fraction",
@@ -567,5 +616,96 @@ describe("runDemo", () => {
     });
     expect(result.exitCode).toBe(0);
     expect(out.join("\n")).toMatch(/spinning up github twin … ready \(\d+\.\ds\)/);
+  });
+  // F-1754 — the mixed-criteria trial, which is EVERY trial of the packaged
+  // demo task since 0.35.1 gave it a `[code]` denominator. The arithmetic half
+  // already stopped calling this run unevaluable; the terminal printed a bare
+  // verdict word and said nothing about either the fraction or the three rows
+  // the demo exists to show.
+  it("renders the deterministic fraction and the narrator's readings on a mixed trial", async () => {
+    const out: string[] = [];
+    const seenOptions: RunTaskOpts[] = [];
+    const finalizeCalls: Array<{ sessionId: string; input: unknown }> = [];
+
+    const result = await runDemo({
+      apiBase: "https://api.example.com",
+      dashboardBase: "https://app.pome.sh",
+      trials: 1,
+      out: (line) => out.push(line),
+      agentCommand: "unused-in-test",
+      runTaskFn: fakeRunTask([{ exitCode: 0 }], seenOptions),
+      mintFn: (async (opts: { count: number }) =>
+        sessionsFixture(opts.count)) as never,
+      trialClientFactory: fakeClient(
+        () => finalizeResponse(100, mixedResult()),
+        finalizeCalls,
+      ),
+      skipTwinWarmup: true,
+    });
+
+    const text = out.join("\n");
+    // The trial passes off the two `[code]` rows, and says so.
+    expect(text).toMatch(/trial 1 {2}✓ {2}passed {3}\d+\.\ds {2}2 of 2 checks/);
+    expect(result.exitCode).toBe(0);
+    expect(result.verdicts[0]!.kind).toBe("passed");
+
+    // Three readings, one line each, beside the fraction.
+    const readings = out.filter((line) => line.includes("~ advisory · "));
+    expect(readings).toHaveLength(3);
+    expect(readings[0]).toContain("the existing `bug` label was applied");
+    expect(readings[2]).toContain("no other issue was modified and no new label was created");
+    // …under the header that stops `~` reading as a fourth verdict.
+    expect(text).toContain("the narrator also read these, and scored none of them:");
+
+    // The narrator's prose stays on the share page. It is an eight-sentence
+    // walk through the trace; the front door prints the criterion, not the walk.
+    expect(text).not.toContain("The trace shows a POST to");
+    // Not a shortfall, not a gap: none of the three verdict words appears on a
+    // reading line.
+    for (const line of readings) expect(line).not.toMatch(/passed|failed|errored/);
+    expect(text).not.toContain("cloud could not evaluate the trace");
+  });
+
+  // The negative control the fix is defined against: on `passed`/`skipped`
+  // alone this row is identical to the three above, and the whole difference is
+  // the absent `score_state`. A grader that never reached a criterion still
+  // disqualifies the pass.
+  it("still reports a bare skipped row as an unevaluable trial", async () => {
+    const out: string[] = [];
+    const seenOptions: RunTaskOpts[] = [];
+    const finalizeCalls: Array<{ sessionId: string; input: unknown }> = [];
+
+    const result = await runDemo({
+      apiBase: "https://api.example.com",
+      dashboardBase: "https://app.pome.sh",
+      trials: 1,
+      out: (line) => out.push(line),
+      agentCommand: "unused-in-test",
+      runTaskFn: fakeRunTask([{ exitCode: 0 }], seenOptions),
+      mintFn: (async (opts: { count: number }) =>
+        sessionsFixture(opts.count)) as never,
+      trialClientFactory: fakeClient(
+        () =>
+          finalizeResponse(100, [
+            ...(mixedResult() ?? []),
+            {
+              criterion: { type: "model" as const, text: "The tool call was recorded." },
+              passed: false,
+              skipped: true,
+              reason: "tool_not_recorded",
+            },
+          ]),
+        finalizeCalls,
+      ),
+      skipTwinWarmup: true,
+    });
+
+    const text = out.join("\n");
+    expect(text).toContain("trial 1  ⚠  errored         cloud could not evaluate the trace — excluded");
+    expect(text).toContain("no trials were evaluated");
+    // An errored trial has no fraction and no readings to show.
+    expect(text).not.toContain("checks");
+    expect(text).not.toContain("~ advisory");
+    expect(result.exitCode).toBe(1);
   });
 });

--- a/cli/test/unit/eval-command.print.test.ts
+++ b/cli/test/unit/eval-command.print.test.ts
@@ -17,6 +17,7 @@ const DASHBOARD_URL = `https://dashboard.example.com/runs/${FAKE_RUN_ID}`;
 const stub = vi.hoisted(() => {
   return {
     finalizeScore: 100 as number,
+    criteriaResults: undefined as unknown[] | undefined,
     client: {
       async createEvalSession(input: { agent: string; taskName: string }) {
         void input;
@@ -46,6 +47,7 @@ const stub = vi.hoisted(() => {
           score: stub.finalizeScore,
           judge_model: "test-judge",
           dashboard_url: DASHBOARD_URL,
+          criteria_results: stub.criteriaResults,
         };
       },
     },
@@ -105,6 +107,7 @@ describe("pome eval terminal output", () => {
   beforeEach(async () => {
     tmp = await mkdtemp(join(tmpdir(), "pome-eval-print-"));
     stub.finalizeScore = 100;
+    stub.criteriaResults = undefined;
     process.exitCode = undefined;
     vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
       if ((init as RequestInit | undefined)?.method === "PUT") {
@@ -162,6 +165,101 @@ describe("pome eval terminal output", () => {
     expect(out).toMatch(/FAIL 01-bug-happy-path/);
     expect(out).toContain(`cloud: ${DASHBOARD_URL}`);
     expect(existsSync(join(runDir, "score.json"))).toBe(false);
+    expect(process.exitCode).toBe(1);
+  });
+  // F-1754 — the mixed-criteria run: `[code]` rows carry the fraction, the
+  // narrator's `[model]` rows ride beside it. The arithmetic already stopped
+  // counting them as abstentions; the row list had not.
+  it("renders the narrator's rows as narrative beside a passing fraction", async () => {
+    const runDir = await writeRunDir(tmp);
+    stub.criteriaResults = [
+      {
+        criterion: { type: "code", text: "Issue #1 has exactly one label, and it is `bug`" },
+        passed: true,
+        skipped: false,
+        reason: 'issue #1 has exactly one label ("bug")',
+      },
+      {
+        criterion: { type: "model", text: "The `bug` label went to the 500-error issue and no other." },
+        passed: false,
+        skipped: true,
+        reason: "the trace shows one POST to /issues/1/labels",
+        score_state: "advisory",
+      },
+      {
+        criterion: { type: "model", text: "The refund was explained to the customer." },
+        passed: false,
+        skipped: true,
+        reason: "no refund was requested in this run",
+        score_state: "abstained",
+      },
+    ];
+    const lines: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      lines.push(args.map(String).join(" "));
+    });
+
+    await runEvalCommand(runDir, {
+      artifactsDir: "runs",
+      apiUrl: "http://no-cloud.invalid",
+      agent: "triage-bot",
+    });
+
+    const out = lines.join("\n");
+    // One `[code]` row passed and nothing failed, so the run has a denominator
+    // and clears it. The three narrator rows do not make it incomplete.
+    expect(out).toMatch(/PASS 01-bug-happy-path/);
+    expect(out).toMatch(/score: 100\/100/);
+    expect(process.exitCode).toBe(0);
+
+    // The narrated rows read as narrative: the narrator's marker, and a clause
+    // that says which state and what it means.
+    expect(out).toMatch(/~ \[model\] The `bug` label went to the 500-error issue and no other\. — advisory: read by the narrator, never scored/);
+    expect(out).toMatch(/~ \[model\] The refund was explained to the customer\. — abstained: nothing in this run to read/);
+    // Never the pass/fail markers — a row nobody scored is not a verdict…
+    expect(out).not.toMatch(/[✓✗] \[model\]/);
+    // …and never the instrument-gap glyph either, which is the claim this
+    // whole state exists to stop making about a `[model]` row.
+    expect(out).not.toMatch(/- \[model\]/);
+    // The scored row keeps its verdict marker.
+    expect(out).toMatch(/✓ \[code\] Issue #1 has exactly one label/);
+  });
+
+  // The negative control. Identical on `passed`/`skipped` to the two rows
+  // above; the whole difference is the absent `score_state`.
+  it("keeps a bare skipped row an instrument gap — marker, verdict and all", async () => {
+    const runDir = await writeRunDir(tmp);
+    stub.criteriaResults = [
+      {
+        criterion: { type: "code", text: "Issue #1 has exactly one label, and it is `bug`" },
+        passed: true,
+        skipped: false,
+        reason: 'issue #1 has exactly one label ("bug")',
+      },
+      {
+        criterion: { type: "model", text: "The tool call was recorded." },
+        passed: false,
+        skipped: true,
+        reason: "tool_not_recorded",
+      },
+    ];
+    const lines: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      lines.push(args.map(String).join(" "));
+    });
+
+    await runEvalCommand(runDir, {
+      artifactsDir: "runs",
+      apiUrl: "http://no-cloud.invalid",
+      agent: "triage-bot",
+    });
+
+    const out = lines.join("\n");
+    expect(out).toMatch(/INCOMPLETE 01-bug-happy-path/);
+    expect(out).toMatch(/1 of 2 criteria not evaluated/);
+    expect(out).toMatch(/- \[model\] The tool call was recorded\./);
+    expect(out).not.toContain("advisory");
+    expect(out).not.toContain("~ [model]");
     expect(process.exitCode).toBe(1);
   });
 });

--- a/cli/test/unit/hosted/narratorRender.test.ts
+++ b/cli/test/unit/hosted/narratorRender.test.ts
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+// A narrated row RENDERS as narrative.
+//
+// The arithmetic half of this already shipped: `scoreFromFinalizeResponse`
+// stopped counting an advisory row as an abstention, so a mixed-criteria run
+// scores off its `[code]` denominator and passes. The terminal did not follow.
+// `outcomeOf` maps a narrated row to `"skipped"` — deliberately, so it stays
+// inside the `skipped` tally the exemptions are subtracted FROM — and
+// `markerFor` renders `"skipped"` with `-`, the glyph that means "the grader
+// never reached this criterion". So the demo's own `[model]` rows printed as
+// three instrument gaps beside a passing fraction: the exact conflation the
+// narrator states exist to remove, one surface downstream of where it was fixed.
+//
+// Read `score_state`, never `outcome` — F-591 reserved that key for the
+// disjoint four-state display vocabulary, which is why widening `outcomeOf`
+// is not the fix and a marker chosen off `isNarrated` is.
+
+import { ABSTAINED_SCORE_STATE, ADVISORY_SCORE_STATE } from "@pome-sh/wire/run-completeness";
+import { describe, expect, it } from "vitest";
+import type { CriterionResult } from "../../../src/contract/index.js";
+import {
+  criterionMarker,
+  markerFor,
+  NARRATED_MARKER,
+  narratorStateLabel,
+  narratorSuffix,
+  outcomeOf,
+  PRE_SATISFIED_REASON,
+  twinSkipSuffix,
+} from "../../../src/hosted/evalResultView.js";
+
+const advisory = (text = "the label went to the right issue"): CriterionResult => ({
+  criterion: { type: "model", text },
+  passed: false,
+  skipped: true,
+  reason: "the trace shows one POST to /issues/1/labels with {\"labels\":[\"bug\"]}",
+  score_state: ADVISORY_SCORE_STATE,
+});
+
+const abstained = (text = "the refund was explained"): CriterionResult => ({
+  criterion: { type: "model", text },
+  passed: false,
+  skipped: true,
+  reason: "no refund was requested in this run",
+  score_state: ABSTAINED_SCORE_STATE,
+});
+
+// The negative control, and the whole reason the marker is chosen off
+// `score_state` rather than off `skipped`: on the two booleans this row is
+// indistinguishable from the two above.
+const instrumentGap = (text = "the tool call was recorded"): CriterionResult => ({
+  criterion: { type: "model", text },
+  passed: false,
+  skipped: true,
+  reason: "tool_not_recorded",
+});
+
+const passed = (text = "issue #1 carries exactly one label"): CriterionResult => ({
+  criterion: { type: "code", text },
+  passed: true,
+  skipped: false,
+  reason: "issue #1 has exactly one label (\"bug\")",
+});
+
+const failed = (text = "a comment names POST /orders"): CriterionResult => ({
+  criterion: { type: "code", text },
+  passed: false,
+  skipped: false,
+  reason: "no comment on issue #1 contains \"POST /orders\"",
+});
+
+describe("the narrator's row marker", () => {
+  it("is none of the four verdict glyphs", () => {
+    // ✓/✗ are verdicts about the criterion and `-`/`!` are statements about the
+    // grader. A narrated row is a fifth thing, so it gets a fifth glyph.
+    const verdictGlyphs = (["passed", "failed", "skipped", "errored"] as const).map(
+      markerFor,
+    );
+    expect(verdictGlyphs).not.toContain(NARRATED_MARKER);
+  });
+
+  it("marks an advisory and an abstained row with it", () => {
+    expect(criterionMarker(advisory())).toBe(NARRATED_MARKER);
+    expect(criterionMarker(abstained())).toBe(NARRATED_MARKER);
+  });
+
+  it("leaves every other row on the four-state marker it already had", () => {
+    expect(criterionMarker(passed())).toBe("✓");
+    expect(criterionMarker(failed())).toBe("✗");
+    // The negative control keeps the instrument-gap glyph — a bare `skipped`
+    // with no `score_state` is still a criterion the grader never reached.
+    expect(criterionMarker(instrumentGap())).toBe("-");
+    expect(
+      criterionMarker({ ...instrumentGap(), reason: PRE_SATISFIED_REASON }),
+    ).toBe("-");
+  });
+
+  it("does not disturb the four-state vocabulary it sits beside", () => {
+    // `outcomeOf` still maps a narrated row to `skipped`: the exemptions are
+    // SUBTRACTED from that tally, so a row that left it would be subtracted
+    // twice. The marker is chosen beside `outcomeOf`, never by widening it.
+    expect(outcomeOf(advisory())).toBe("skipped");
+    expect(outcomeOf(abstained())).toBe("skipped");
+  });
+});
+
+describe("the narrator's row label", () => {
+  it("names which of the two states the row is in", () => {
+    expect(narratorStateLabel(advisory())).toBe("advisory");
+    expect(narratorStateLabel(abstained())).toBe("abstained");
+  });
+
+  it("names nothing on a row the narrator did not name", () => {
+    expect(narratorStateLabel(passed())).toBeNull();
+    expect(narratorStateLabel(instrumentGap())).toBeNull();
+    // An unrecognised spelling is not a narrator state. Printing it would
+    // fabricate one out of a field the CLI reads tolerantly on purpose.
+    expect(
+      narratorStateLabel({ ...instrumentGap(), score_state: "advisorial" }),
+    ).toBeNull();
+    // …and a `score_state` on a row that was not skipped is ignored, the way
+    // the wire reduction ignores it.
+    expect(
+      narratorStateLabel({ ...passed(), score_state: ADVISORY_SCORE_STATE }),
+    ).toBeNull();
+  });
+
+  it("says what the state MEANS in the row's trailing clause", () => {
+    expect(narratorSuffix(advisory())).toContain("advisory");
+    expect(narratorSuffix(advisory())).toMatch(/never scored/);
+    expect(narratorSuffix(abstained())).toContain("abstained");
+    expect(narratorSuffix(abstained())).toMatch(/nothing in this run to read/);
+    // Every other row keeps the line it had.
+    expect(narratorSuffix(passed())).toBe("");
+    expect(narratorSuffix(instrumentGap())).toBe("");
+  });
+});
+
+describe("the twin suffix on a narrated row", () => {
+  it("stops claiming the twin's timeline came up empty", () => {
+    // `twinSkipSuffix` explains WHICH twin's timeline was empty when a
+    // criterion could not be evaluated. On a narrated row nothing came up
+    // empty — the narrator read the row and reported having no score authority
+    // over it — so the suffix would be a second instrument-gap claim wearing
+    // the twin's name.
+    const twinTagged: CriterionResult = {
+      ...advisory(),
+      criterion: { type: "model", text: "the label went to the right issue", twin: "github" },
+    };
+    expect(twinSkipSuffix(twinTagged)).toBe("");
+    // The genuine gap still names its twin.
+    expect(
+      twinSkipSuffix({
+        ...instrumentGap(),
+        criterion: { type: "model", text: "the tool call was recorded", twin: "github" },
+      }),
+    ).toBe(" (twin: github)");
+  });
+});

--- a/cli/test/unit/run-hosted-narrator-print.test.ts
+++ b/cli/test/unit/run-hosted-narrator-print.test.ts
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+// F-1754 — a hosted `pome run` of a MIXED task prints its verdict off the
+// `[code]` denominator and the narrator's `[model]` rows beside it.
+//
+// Both hosted shapes, because a bare `pome run` is k=5 and takes the trial-group
+// path while `-n 1` stays on the single-run one: a surface that renders the
+// readings on only one of the two is silent on the default.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createProgram } from "../../src/cli/main.js";
+import { runTaskHosted } from "../../src/runner/runTaskHosted.js";
+import { scoreFromFinalizeResponse } from "../../src/hosted/uploadAndFinalize.js";
+import { groupSummaryLines } from "../../src/runner/groupRender.js";
+import type { CriterionResult } from "../../src/hosted/evalResultView.js";
+
+const MIXED_RESULTS: CriterionResult[] = [
+  {
+    criterion: { type: "code", text: "Issue #1 has exactly one classification label, and it is `bug`" },
+    passed: true,
+    skipped: false,
+    reason: 'issue #1 has exactly one label ("bug")',
+  },
+  {
+    criterion: { type: "model", text: "The `bug` label was applied to the 500-error issue, and to no other issue." },
+    passed: false,
+    skipped: true,
+    reason: "1. The trace shows one POST to /repos/acme/api/issues/1/labels. 2. Therefore …",
+    score_state: "advisory",
+  },
+  {
+    criterion: { type: "model", text: "The refund was explained to the customer." },
+    passed: false,
+    skipped: true,
+    reason: "no refund was requested in this run",
+    score_state: "abstained",
+  },
+];
+
+const MIXED_SCORE = scoreFromFinalizeResponse({
+  run_id: "run_1",
+  score: 100,
+  judge_model: "test-judge",
+  dashboard_url: "https://app.pome.sh/runs/run_1",
+  criteria_results: MIXED_RESULTS,
+});
+
+vi.mock("../../src/runner/runTaskHosted.js", () => ({
+  runTaskHosted: vi.fn(),
+}));
+
+vi.mock("../../src/cli/credentials.js", () => ({
+  resolveCredentials: vi.fn(async () => ({
+    apiBaseUrl: "http://no-cloud.invalid",
+    apiKey: "pme_test",
+  })),
+}));
+
+const TASK =
+  "# Mixed\n\n## Prompt\nPretend prompt.\n\n## Success Criteria\n" +
+  "- [code] Issue #1 has exactly one classification label, and it is `bug`\n" +
+  "- [model] The `bug` label was applied to the 500-error issue, and to no other issue.\n" +
+  "\n## Config\n```yaml\ntwins: [github]\nruns: 1\npassThreshold: 100\n```\n";
+
+/** The wiring `pome doctor` demands before `pome run` will spawn an agent:
+ *  a manifest and a source file that reads the twin's base URL from the env
+ *  rather than hardcoding a production host. */
+async function fixtureRepo(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "pome-run-narrator-"));
+  await mkdir(join(dir, "src"), { recursive: true });
+  await writeFile(
+    join(dir, "pome.json"),
+    JSON.stringify(
+      { agent: { slug: "fixture-agent" }, command: 'node -e "process.exit(0)"' },
+      null,
+      2,
+    ),
+  );
+  await writeFile(
+    join(dir, "src/agent.ts"),
+    [
+      'import { withPome } from "@pome-sh/adapter-claude-sdk";',
+      "withPome();",
+      "const baseUrl = process.env.POME_GITHUB_REST_URL;",
+      "export { baseUrl };",
+    ].join("\n"),
+  );
+  return dir;
+}
+
+describe("hosted `pome run` — a single run's verdict block", () => {
+  let stderr: string[];
+  const originalCwd = process.cwd();
+  const originalExitCode = process.exitCode;
+
+  beforeEach(() => {
+    stderr = [];
+    vi.spyOn(console, "error").mockImplementation((msg?: unknown) => {
+      stderr.push(String(msg));
+    });
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    process.exitCode = undefined;
+    process.env.POME_API_KEY = "pme_test_env_key";
+    vi.mocked(runTaskHosted).mockReset();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    delete process.env.POME_API_KEY;
+    vi.restoreAllMocks();
+    process.exitCode = originalExitCode;
+  });
+
+  it("passes off the `[code]` denominator and prints the narrator's rows beside it", async () => {
+    const dir = await fixtureRepo();
+    process.chdir(dir);
+    const taskPath = join(dir, "mixed.md");
+    await writeFile(taskPath, TASK);
+
+    vi.mocked(runTaskHosted).mockResolvedValue({
+      scenario: { title: "Mixed", slug: "mixed", config: { passThreshold: 100 } },
+      runId: "ses_1",
+      cloudRunId: "run_1",
+      cloudDashboardUrl: "https://app.pome.sh/runs/run_1",
+      artifacts: { runDir: join(dir, "runs", "x") },
+      score: MIXED_SCORE,
+      exitCode: 0,
+      durationMs: 1000,
+    } as never);
+
+    await createProgram().parseAsync(["node", "pome", "run", taskPath]);
+
+    const err = stderr.join("\n");
+    // The verdict comes off the one `[code]` row; the two narrator rows do not
+    // make the run incomplete.
+    expect(err).toContain("PASS Mixed");
+    expect(err).toContain("score: 100/100");
+    expect(process.exitCode ?? 0).toBe(0);
+
+    // …and they are visible rather than dropped, under a header that says what
+    // they are, with the narrator's marker and never a verdict one.
+    expect(err).toContain("the narrator also read these, and scored none of them:");
+    expect(err).toContain(
+      "  ~ advisory · the `bug` label was applied to the 500-error issue, and to no…",
+    );
+    expect(err).toContain("  ~ abstained · the refund was explained to the customer");
+    expect(err).not.toMatch(/[✓✗] \[model\]/);
+    expect(err).not.toMatch(/- \[model\]/);
+    // The narrator's prose stays on the dashboard the next line links to.
+    expect(err).not.toContain("The trace shows one POST");
+    expect(err).toContain("cloud: https://app.pome.sh/runs/run_1");
+  }, 30_000);
+});
+
+describe("hosted `pome run -n k` — the group summary's verdict block", () => {
+  it("prints the readings once for the whole set, deduped across trials", () => {
+    const lines = groupSummaryLines({
+      rows: [
+        { kind: "completed", score: 100, verdict: "pass", seconds: 1 },
+        { kind: "completed", score: 100, verdict: "pass", seconds: 1 },
+      ],
+      // Two trials of one task: the same two criteria, twice.
+      narrated: [...MIXED_RESULTS.slice(1), ...MIXED_RESULTS.slice(1)],
+      reliabilityUrl: "https://app.pome.sh/runs/task/mixed",
+    });
+    const readings = lines.filter((line) => line.trimStart().startsWith("~ "));
+    expect(readings).toHaveLength(2);
+    expect(lines).toContain("the narrator also read these, and scored none of them:");
+    expect(readings[1]).toBe("  ~ abstained · the refund was explained to the customer");
+  });
+
+  it("says nothing about the narrator on a set with no narrated rows", () => {
+    const lines = groupSummaryLines({
+      rows: [{ kind: "completed", score: 100, verdict: "pass", seconds: 1 }],
+      reliabilityUrl: "https://app.pome.sh/runs/task/mixed",
+    });
+    expect(lines.join("\n")).not.toContain("narrator");
+  });
+});

--- a/cli/test/unit/runner/runTrialGroup.test.ts
+++ b/cli/test/unit/runner/runTrialGroup.test.ts
@@ -22,6 +22,7 @@ import type {
   RunTaskHostedResult,
 } from "../../../src/runner/runTaskHosted.js";
 import type { Score, ScoreStatus } from "../../../src/hosted/evalResultView.js";
+import { scoreFromFinalizeResponse } from "../../../src/hosted/uploadAndFinalize.js";
 
 vi.mock("../../../src/hosted/client.js", async (importOriginal) => {
   const original = await importOriginal<typeof import("../../../src/hosted/client.js")>();
@@ -173,6 +174,34 @@ function scoreOf(satisfaction: number, failedTexts: string[] = []): Score {
   };
 }
 
+/** F-1754 — a mixed-criteria trial: the `[code]` rows carry the score and the
+ *  narrator's `[model]` rows ride beside it, `passed: false, skipped: true` plus
+ *  a `score_state`. Built off the shipped producer so the counts cannot drift
+ *  from what a real /finalize response would make of the same rows. */
+function mixedScore(): Score {
+  return scoreFromFinalizeResponse({
+    run_id: "run_mixed",
+    score: 100,
+    judge_model: "test-judge",
+    dashboard_url: "https://app.example/runs/run_mixed",
+    criteria_results: [
+      {
+        criterion: { type: "code", text: "No unsupported endpoint was called" },
+        passed: true,
+        skipped: false,
+        reason: "no unsupported endpoint",
+      },
+      {
+        criterion: { type: "model", text: "The `bug` label went to the 500-error issue." },
+        passed: false,
+        skipped: true,
+        reason: "1. The trace shows one POST to /issues/1/labels. 2. Therefore …",
+        score_state: "advisory",
+      },
+    ],
+  });
+}
+
 function trialResult(input: {
   sessionId: string;
   satisfaction: number;
@@ -182,12 +211,16 @@ function trialResult(input: {
   /** The run's three-state verdict. Defaults from `exitCode` so every existing call
    *  site keeps meaning what it meant; pass it explicitly to simulate a trial. */
   verdict?: ScoreStatus;
+  /** Swap in the narrator-carrying score. */
+  mixed?: boolean;
 }): RunTaskHostedResult {
   return {
     runId: input.sessionId,
     cloudRunId: `run_${input.sessionId}`,
     cloudDashboardUrl: `https://app.example/runs/run_${input.sessionId}`,
-    score: scoreOf(input.satisfaction, input.failedTexts ?? []),
+    score: input.mixed
+      ? mixedScore()
+      : scoreOf(input.satisfaction, input.failedTexts ?? []),
     verdict: input.verdict ?? (input.exitCode === 0 ? "pass" : "fail"),
     exitCode: input.exitCode,
     durationMs: input.durationMs,
@@ -872,5 +905,73 @@ describe("runTrialGroup — dashboard link + client construction", () => {
       apiKey: "pme_k",
       timeoutMs: 60_000,
     });
+  });
+});
+
+describe("runTrialGroup — the narrator's readings in the summary", () => {
+  it("prints them once for the set, off the graded trials only", async () => {
+    const taskPath = await scenarioFixture();
+    const cloud = makeFakeClient();
+    const out: string[] = [];
+
+    await runTrialGroup({
+      taskPath,
+      agentCommand: "node agent.js",
+      trials: 3,
+      hosted: { baseUrl: "https://api.example", apiKey: "pme_k" },
+      dashboardBaseUrl: "https://app.pome.sh",
+      out: (line) => out.push(line),
+      client: cloud.client,
+      runTaskHostedFn: async (options) =>
+        trialResult({
+          sessionId: options.premintedSession!.session_id,
+          satisfaction: 100,
+          exitCode: 0,
+          durationMs: 1000,
+          mixed: true,
+        }),
+    });
+
+    const readings = out.filter((line) => line.trimStart().startsWith("~ "));
+    // ONE line for three trials: the criterion belongs to the task.
+    expect(readings).toEqual([
+      "  ~ advisory · the `bug` label went to the 500-error issue",
+    ]);
+    expect(out).toContain("the narrator also read these, and scored none of them:");
+    // Never a verdict marker, and never the instrument-gap glyph.
+    expect(readings[0]).not.toMatch(/[✓✗⚠]/);
+    // The narrator's prose belongs on the reliability page the summary links to.
+    expect(out.join("\n")).not.toContain("The trace shows one POST");
+  });
+
+  it("says nothing about the narrator when no trial could be graded", async () => {
+    const taskPath = await scenarioFixture();
+    const cloud = makeFakeClient();
+    const out: string[] = [];
+
+    await runTrialGroup({
+      taskPath,
+      agentCommand: "node agent.js",
+      trials: 2,
+      hosted: { baseUrl: "https://api.example", apiKey: "pme_k" },
+      dashboardBaseUrl: "https://app.pome.sh",
+      out: (line) => out.push(line),
+      client: cloud.client,
+      runTaskHostedFn: async (options) =>
+        trialResult({
+          sessionId: options.premintedSession!.session_id,
+          satisfaction: 100,
+          exitCode: 1,
+          durationMs: 1000,
+          verdict: "incomplete",
+          mixed: true,
+        }),
+    });
+
+    const text = out.join("\n");
+    expect(text).toContain("no trials could be graded");
+    // A reader asking what went ungraded is not helped by three readings under
+    // the question.
+    expect(text).not.toContain("narrator");
   });
 });


### PR DESCRIPTION
## What this fixes

`scoreFromFinalizeResponse` **already** exempts an `advisory`/`abstained` row from `can_pass` and from `total_required` — that shipped in F-1662 (#480) and is in the published 0.35.1 bundle. Every surface that *prints* those rows had not followed.

`outcomeOf` maps a narrated row to `"skipped"` — deliberately, since the three exemptions are *subtracted from* that tally — and `markerFor` renders `"skipped"` with `-`, whose sentence is "the cloud could not evaluate this criterion". So on the packaged demo task:

- `pome eval` listed the three `[model]` rows as three instrument gaps beside a `PASS`, under a counts line reading `1 passed, 0 failed, 2 skipped`;
- `pome run` (single and `-n k`) and `pome demo` printed a verdict with no mention of them at all.

## Ticket premise correction

The ticket's headline repro does not reproduce. I ran it first, live against prod:

```
$ npx @pome-sh/cli@0.35.1 demo --trials 1
trial 1  ✓  passed   7.3s
1 of 1 passed
```

`dist/chunk-EIEPFWHZ.js:1506` in the published 0.35.1 tarball (`git_sha 05db45b`, this repo's HEAD) already reads `can_pass: hasCriteriaResults ? totalRequired > 0 && unresolvedAbstentions === 0 : true`, not the `skipped === 0 && errored === 0` the ticket quotes. The classification half of the Shape-of-fix, the negative control, and "read `score_state`, never `outcome`" were all already true and already pinned by `incompleteVerdict.test.ts` / `cross-surface-agreement.test.ts`.

What was left undone is the **render** half, which is what this PR is.

## The change

| | |
|---|---|
| `NARRATED_MARKER` / `criterionMarker` | `~` — a fifth glyph, chosen off `score_state` **beside** `outcomeOf` rather than by widening it, so `outcome` stays reserved for the cloud's four-state vocabulary (F-591). `markerFor`'s four are two disjoint claims already (✓/✗ about the criterion, `-`/`!` about the grader); a narrated row is neither. |
| `narratorSuffix` | ` — advisory: read by the narrator, never scored` / ` — abstained: nothing in this run to read`. |
| `criterionRowLine` | The one row renderer both list surfaces call. |
| `narratorReadingLines` | The deduped, run-level block. |
| `twinSkipSuffix` | Returns `""` on a narrated row — nothing came up empty on it, so the twin-timeline explanation would be the gap claim a second time. |
| `scoreCountsSummary` | Narrator rows named apart from the skips: `1 passed, 0 failed, 0 skipped, 0 errored, 3 advisory`. |
| `pome demo` trial line | Names the denominator its word came from: `trial 1  ✓  passed   7.3s  2 of 2 checks`. |

Three surfaces print the same block beside their fraction — hosted `pome run`, a trial group's summary, and `pome demo`'s summary:

```
the narrator also read these, and scored none of them:
  ~ advisory · the existing `bug` label was applied to the issue reporting t…
```

**Deduped and run-level, not per-trial**: every trial of a task is graded against the same criteria, so `-n 5` would otherwise print the same three sentences five times. A trial that could not be graded contributes nothing to it — both collectors apply that rule, and both are pinned. The narrator's own prose stays on the dashboard the verdict already links to; on the packaged demo task it is an eight-sentence walk through the trace.

**A bare `skipped: true` with no `score_state` is untouched** — still the instrument gap it always was, still `-`, still disqualifying for `can_pass`. That negative control is asserted on all three new surfaces.

## Evidence

Live against prod today (`api.pome.sh`, evaluator `f1643-narrator-abstain.1`), replaying a captured trial's own `events.jsonl` / `state_*.json` through mint → presigned upload → finalize by hand — `run_sMb2YccmIaMrKjfI`:

```
[code]  passed=true  skipped=false                       (×2)
[model] passed=false skipped=true  score_state=advisory  (×3 — no `outcome` field)
score: 100 · all_skipped: false
```

That exact response, byte for byte, through the **built** CLI (`cli/dist`), real github twin, real capture-server child, real bundled demo agent:

```
trial 1  ✓  passed   0.5s  2 of 2 checks
trial 2  ✓  passed   0.5s  2 of 2 checks
─────
2 of 2 passed
the narrator also read these, and scored none of them:
  ~ advisory · the existing `bug` label was applied to the issue reporting t…
  ~ advisory · exactly one comment was left on that issue, and it names the…
  ~ advisory · no other issue was modified and no new label was created
```

**One hop I could not complete:** the built CLI's `demo --trials 1` against *prod*. `POST /v1/demo/sessions` returns `429 {"used":25,"cap":25}` — the daily per-network anonymous-demo cap, exhausted by this network before I started (I minted 3 of the 25). It resets tomorrow. Everything that hop would add over the run above is the prod mint + gateway; the finalize payload it would render is the one captured above, live, today.

## Tests

TDD throughout (`tdd-required`); each assertion below was red before its implementation.

- `cli/test/unit/hosted/narratorRender.test.ts` — new. The marker is none of the four verdict glyphs; `outcomeOf` is undisturbed; an unrecognised `score_state` spelling and a `score_state` on a non-skipped row name nothing; the bare-skip control keeps `-`.
- `cli/test/unit/run-hosted-narrator-print.test.ts` — new. Both hosted shapes, because a bare `pome run` is k=5 and takes the group path while `-n 1` stays on the single-run one.
- `cli/test/unit/eval-command.print.test.ts` — the mixed run renders `~ [model] … — advisory`, never `- [model]`; the bare-skip control still renders `INCOMPLETE` + exit 1.
- `cli/test/unit/demo/{render,runDemo}.test.ts`, `cli/test/unit/runner/runTrialGroup.test.ts`, `cli/test/e2e/demo-e2e.test.ts` — the e2e stub cloud now returns the shape prod actually returns (2 `[code]` + 3 `[model]` advisory), so three readings for two trials is asserted end to end.

`npm test` 3877 passed · `npm run typecheck` · `npm run lint` (17 rules) · `npm run lint:dead-code` · `npm run test:contract` (104 passed) — all green locally.

## Notes for the reviewer

- **cli package only, no wire change.** The server shape is the contract working as designed. This touches no completeness *predicate*, so it does not owe the wire ↔ `can_pass` ↔ `evaluationCounts` triple edit — `cross-surface-agreement.test.ts` is unchanged and green.
- `criterionPhrase` moved from `demo/render.ts` to `hosted/evalResultView.ts`. The narrative block needs it and `demo/render.ts` now imports *from* `evalResultView`; leaving it where it was would have made a cycle. `groupRender.ts` and `runTrialGroup.ts` already imported it across that same boundary.
- The branch was renamed out from under this session at 20:22 (`AFFFPupu/doha-v1` → `AFFFPupu/f-1754-advisory-rows`); not something this work did.
- **Do not merge or publish from here.** The npm publish is `/pome-npm-release`, after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
