### PR TITLE
Re-point the docs links the capstone/twins merge moved, and run the showcases in CI

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pome-coach",
   "description": "The Pome coach skill set — register an agent, author and verify graded tasks, run them against the digital twins, and read the scored report.",
-  "homepage": "https://docs.pome.sh/quickstart/claude-code",
+  "homepage": "https://docs.pome.sh/quickstart/coding-agent",
   "skills": [
     "./skills/pome",
     "./skills/pome-intake",

--- a/.github/workflows/showcase-verify.yml
+++ b/.github/workflows/showcase-verify.yml
@@ -1,0 +1,108 @@
+name: showcase-verify
+# Runs each showcase's `verify.sh` — the regression test that keeps its
+# walkthrough's claims true. Both scripts boot their own LOCAL twins, mint their
+# own bearers and assert the property unattended: no account, no login, no
+# ANTHROPIC_API_KEY, no hosted sandbox, no meter. Nothing here finalizes, so
+# there is nothing to spend.
+#
+# Until this file landed, `showcases/{cross-call-state,permission-denial}` shipped
+# their assertions and NOTHING ran them. ci.yml cannot be that runner: its
+# heavy-suite path filter does not list `showcases/`, so a showcase-only PR is
+# classified docs-only and the heavy block is skipped — the gate would be absent
+# from exactly the PR that edits a showcase — and the always-on block above it is
+# dependency-free by contract, running before `npm ci`. This needs a built CLI.
+#
+# WHY THE LOCAL BUILD, NOT `npx @pome-sh/cli@latest`. Each script defaults
+# `POME_CLI` to the published CLI, which is right for a reader on their own
+# machine and wrong for a gate: the published tarball is blind to this PR's diff,
+# so a `packages/twin-github/` change that breaks the property would leave this
+# job green while proving nothing about the code under review. `POME_CLI` is set
+# to the CLI built from this checkout, which is what makes a twin regression red
+# the PR that caused it.
+on:
+  pull_request:
+    paths:
+      - 'showcases/**'
+      # Both showcases boot the github twin today. The glob covers every twin on
+      # purpose: a showcase that later boots a second one is then covered with no
+      # edit here, and the failure this avoids is silent — an uncovered twin's
+      # change simply would not run the showcase that asserts against it.
+      - 'packages/twin-*/**'
+      # The twins' shared substrate: the recorder behind `_pome/events`, the
+      # `state_delta` column and the redaction both scripts assert on.
+      - 'packages/sdk/**'
+      - 'packages/wire/**'
+      # `twin start` itself — the front door both scripts drive.
+      - 'cli/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/showcase-verify.yml'
+  push:
+    branches: [main]
+    # Match the PR paths — do not pay the build cost on unrelated main merges.
+    paths:
+      - 'showcases/**'
+      - 'packages/twin-*/**'
+      - 'packages/sdk/**'
+      - 'packages/wire/**'
+      - 'cli/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/showcase-verify.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: showcase-verify-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  # Deliberately NOT fork-guarded, unlike quickstart-smoke.yml. That job's guard
+  # exists to keep fork PRs off a build this repo pays for; this one reads no
+  # secret, touches no registry and mints nothing that outlives the runner, and a
+  # contributed twin change is precisely the diff a showcase should be asserted
+  # against. Nothing here is reachable from `secrets`.
+  verify:
+    runs-on: ubuntu-latest
+    # A twin that boots but never answers /healthz leaves each script in its
+    # 120s wait, not a hang — but a wedged `npm ci` or build has no such bound.
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm ci
+      # `cli/` is a root workspace member, so the install above already linked
+      # the @pome-sh/twin-* packages out of packages/*. The root build runs them
+      # in dependency order and ends with the CLI, producing the entry point the
+      # POME_CLI below names.
+      - name: Build the CLI and twins from this checkout
+        run: npm run build
+
+      # Both scripts word-split `$CLI` unquoted (`exec $CLI twin start …`), which
+      # is what lets a two-word interpreter+path value work here.
+      - name: Resolve the CLI built above
+        run: |
+          set -euo pipefail
+          entry="$GITHUB_WORKSPACE/cli/dist/src/cli/main.js"
+          test -f "$entry" || { echo "::error::$entry missing after npm run build"; exit 1; }
+          echo "POME_CLI=node $entry" >> "$GITHUB_ENV"
+
+      # One step per showcase so a failure names which property broke. Each
+      # script boots its own twins on the first free port at or above its
+      # default, asserts, prints a per-assertion pass/fail table and exits
+      # non-zero on any FAIL.
+      - name: 'Showcase: cross-call-state'
+        run: bash showcases/cross-call-state/verify.sh
+
+      # `!cancelled()` rather than the default: a red cross-call-state must not
+      # hide a second, independent regression here. The job still fails on the
+      # first step's failure — this only makes both verdicts visible in one run.
+      - name: 'Showcase: permission-denial'
+        if: ${{ !cancelled() }}
+        run: bash showcases/permission-denial/verify.sh

--- a/README.md
+++ b/README.md
@@ -69,15 +69,15 @@ file seeds a hosted sandbox: `pome sandbox create --seed seed.json`.
 
 For a persistent `pome` command: `npm install -g @pome-sh/cli`.
 
-<!-- One generic quickstart above; the per-twin walkthroughs live on the docs
-     site and are LINKED, never copied — one source per walkthrough. -->
+<!-- One generic quickstart above; the walkthrough lives on the docs site and
+     is LINKED, never copied. The five per-twin pages this block used to list
+     merged into ONE page, and all five old paths now 308 to it — so this is
+     one link, not five. Re-point it here rather than leaning on the redirect. -->
 
-Per-twin walkthroughs — one twin end to end on a hosted sandbox, five
-minutes each: [GitHub](https://docs.pome.sh/quickstart/twins/github) ·
-[Stripe](https://docs.pome.sh/quickstart/twins/stripe) ·
-[Slack](https://docs.pome.sh/quickstart/twins/slack) ·
-[Gmail](https://docs.pome.sh/quickstart/twins/gmail) ·
-[Linear](https://docs.pome.sh/quickstart/twins/linear).
+The walkthrough — all five twins end to end, each started on your own machine
+and driven by your own coding agent, with the twin's recorded tape read back at
+the end: [Get started](https://docs.pome.sh/quickstart/twins). No account and no
+API key on that path.
 
 ## Running an agent
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,6 +9,21 @@ write a version number here or in `package.json`. Released entries are insertion
 only: a correction is the next entry, naming the one it corrects.
 
 
+## Unreleased (patch)
+
+**`pome docs getting-started` prints a live page again.** The docs site merged
+its per-client capstones into one client-neutral page, so `/quickstart/claude-code`
+is now a 308 to `/quickstart/coding-agent`. The topic table names the new path.
+
+This is a patch and not a fix to a broken command — the old path redirects, so
+every published CLI still lands a reader somewhere real. What it protects is the
+table's own rule, stated at the top of `docs-topics.ts`: every `path` must be a
+page `docs.json` actually serves, because the table is a static index rather than
+something that follows redirects. A path kept alive only by a redirect reads as
+compliant while the invariant behind it has already gone. pome-cloud's
+`check-cli-docs-topics.ts` says the same thing from the other side, verbatim:
+"Fix the path in digital-twins, or add the page here. Do not add a redirect."
+
 ## 0.35.2 — 2026-08-29
 
 **A `[model]` criterion the narrator read now prints as a reading, not as a

--- a/cli/src/cli/docs-topics.ts
+++ b/cli/src/cli/docs-topics.ts
@@ -24,7 +24,7 @@ export const DOCS_TOPICS: DocsTopic[] = [
   {
     id: "getting-started",
     title: "Quickstart",
-    path: "/quickstart/claude-code",
+    path: "/quickstart/coding-agent",
     keywords: ["install", "quickstart", "setup", "begin"],
   },
   {

--- a/cli/test/unit/docs-command.test.ts
+++ b/cli/test/unit/docs-command.test.ts
@@ -55,14 +55,14 @@ describe("pome docs helpers", () => {
   it("prints the canonical URL for a topic", async () => {
     await runDocsCommand("getting-started", {});
 
-    expect(stdout).toEqual(["https://docs.pome.sh/quickstart/claude-code"]);
+    expect(stdout).toEqual(["https://docs.pome.sh/quickstart/coding-agent"]);
     expect(stderr).toEqual([]);
   });
 
   it("prints topic URL rows without requiring bundled docs", async () => {
     await runDocsCommand(undefined, { urlOnly: true });
 
-    expect(stdout).toContain("getting-started\thttps://docs.pome.sh/quickstart/claude-code");
+    expect(stdout).toContain("getting-started\thttps://docs.pome.sh/quickstart/coding-agent");
     expect(stdout.some((line) => line.includes("docs/cli/run"))).toBe(true);
   });
 });


### PR DESCRIPTION
Housekeeping after the docs re-cut (pome-cloud #885/#888), plus M4's second
pre-authorized cheap gate. Three independent items; no single ticket is
completed, so there is no `F-` id in the title.

## 1 · The topic table points at a page that no longer exists

`/quickstart/claude-code` now answers **308** to `/quickstart/coding-agent`
(F-1733's capstone merge). `cli/src/cli/docs-topics.ts` names the old path, and
its own header states the rule that makes this matter:

> Every `path` must be a page docs.json actually serves: there are no redirects
> from old doc URLs to lean on, so a stale path here prints a 404 to a user.

pome-cloud's `check-cli-docs-topics.ts` says the same from the other side,
verbatim: *"Fix the path in digital-twins, or add the page here. **Do not add a
redirect.**"* A path kept alive only by a redirect reads as compliant while the
invariant behind it has already gone.

`cli/test/unit/docs-command.test.ts` pins the table in two places (the
single-topic print and the `--url-only` row). Both moved. **Checked, not
assumed:** reverting the table alone reds exactly those two tests.

`cli/CHANGELOG.md` carries the `## Unreleased (patch)` entry the topic-table
edit owes — `cli/` is a `@pome-sh/cli` path prefix, so the release gate demands
one. The old path is also named under `## 0.30.0`; that is a *released* entry and
the gate forbids rewriting one, so it stays.

### One file beyond the brief

`.claude-plugin/plugin.json:4` carried the **identical** stale URL as its
`homepage`. Not named in the brief — found by grep. Same redirect, one line,
same wave; leaving it would have been a knowing half-fix. It sits outside every
published package's path prefixes, so it owes no release note. Flagging it
rather than burying it.

## 2 · The five per-twin README links all redirect to the same page

All five `https://docs.pome.sh/quickstart/twins/<twin>` paths now **308 to one
page**, `/quickstart/twins`. So the block collapses to a single link.

**The prose had to move too, and this is the part worth reviewing.** The old
text promised *"one twin end to end on a **hosted sandbox**, five minutes
each"*. The merged page is the **local** path — its own description reads
*"Start a digital twin on **your own machine** … No account, no API key, nothing
graded."* Re-pointing the URLs and keeping the sentence would have shipped a
README that describes a page that does not exist. All five twins do still appear
on the merged page (checked), so "all five twins end to end" is still true.

### Link check

| path | before |
| --- | --- |
| `/quickstart/coding-agent` | **200** |
| `/quickstart/twins` | **200** |
| `/quickstart/claude-code` | 308 → `/quickstart/coding-agent` |
| `/quickstart/twins/{github,stripe,slack,gmail,linear}` | 308 → `/quickstart/twins` (all five) |

## 3 · CI runs the showcases' verify.sh

`showcases/{cross-call-state,permission-denial}` have shipped their assertions
since F-1636 / F-1635 and **nothing has ever run them**. This is the wiring:
`.github/workflows/showcase-verify.yml`.

Both are local-twin, no account, no credential, per F-1636's spec: each script
boots its own twins, mints its own bearers, asserts, and exits non-zero on any
FAIL. Nothing finalizes, so there is nothing to spend.

### Why a new workflow and not `ci.yml`

F-1636's own spec records the trap: **`ci.yml`'s heavy-suite path filter does not
list `showcases/`**, so a showcase-only PR is classified docs-only and the heavy
block is skipped — the gate would be absent from exactly the PR that edits a
showcase. The always-on block above it is dependency-free by contract and runs
*before* `npm ci`; this needs a built CLI. `quickstart-smoke.yml` is the
precedent for the shape: path-filtered, builds from the checkout, boots a twin.

### Why the local build, not `npx @pome-sh/cli@latest`

Each script defaults `POME_CLI` to the published CLI — right for a reader on
their own machine, **wrong for a gate**: the published tarball is blind to the
PR's diff, so a `packages/twin-*` regression would leave the job green while
proving nothing. `POME_CLI` points at the CLI built from this checkout.

That turned out to be load-bearing rather than tidy, and I only know because the
negative control failed the first time: `cli/tsup.config.ts:96` sets
`noExternal: [/^@pome-sh\//]`, so the twins are **inlined into the CLI bundle at
CLI build time**. A `twin-github`-only rebuild does *not* move what the showcase
runs. Only the full `npm run build` does — which is what the workflow runs.

### Negative control — against the subject, not the script

Flipping an expectation inside `verify.sh` only proves bash works. So the defect
went into the **twin**: `packages/twin-github/src/routes.ts:249`, the merge
route's 403 message.

```
FAIL the refusal is GitHub's own message   got Must have push access to merge., want Must have push access to the repository to merge pull requests.
FAIL the refusal carries its own message   got Must have push access to merge., want Must have push access to the repository to merge pull requests.
FAIL — 2 assertion(s) broke.
=== EXIT CODE: 1 ===
```

Restored, rebuilt, both green again. That is the property the gate exists for: a
twin change reds the PR that caused it.

### Local runs (against the built CLI)

| showcase | assertions | exit |
| --- | --- | --- |
| `cross-call-state` | 24 ok | 0 |
| `permission-denial` | 35 ok | 0 |

~3s for the pair, so the job cost is the `npm ci` + build, not the showcases.

### Notes for the reviewer

- **Not added to `config/required-checks.json`.** Per `repo-policy.yml`'s
  ordering note, requiring a context before its ruleset is updated by hand
  leaves every PR waiting on a check that never reports. That is a deliberate
  omission, not an oversight.
- **Deliberately not fork-guarded**, unlike `quickstart-smoke.yml`. This job
  reads no secret and mints nothing outliving the runner, and a contributed twin
  change is exactly the diff a showcase should be asserted against.
- **Path filter uses `packages/twin-*/**`** rather than just `twin-github`.
  Both showcases boot github today; the glob means a showcase that later boots a
  second twin is covered with no edit here. The failure that avoids is silent.
- `first-party-twins.mjs` enumerates two named workflows for its per-twin path
  filter and this is not one of them, so the glob does not conflict with it.

## Gates run locally

| gate | result |
| --- | --- |
| `cli/test/unit/docs-command.test.ts` | 6/6 pass (and 2 red on a reverted table) |
| `check-release-note-required.mjs` | OK — 1 package moved: `@pome-sh/cli`, entry found |
| `actionlint -color` (v1.7.12, the pinned version) | exit 0 |
| `npm run lint` | 17/17 rules |
| `assert-hardened-cdn-fetches.mjs` | OK — 13 actions classified |
| `list-scheduled-workflows.mjs` | OK — new workflow is unscheduled, adds no alarm duty |
| `assert-schedule-alarm-coverage.mjs` | OK — 2 scheduled workflows still covered |

Refs F-1733 (item 1, and the audit that named the plugin manifest and the README
block), F-1636 and F-1635 (the two showcases item 3 wires up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

