### PR TITLE
The adapter's query() seals examinee isolation by default (F-1522)

### DIFF
--- a/packages/adapter-claude-sdk/CHANGELOG.md
+++ b/packages/adapter-claude-sdk/CHANGELOG.md
@@ -1,5 +1,49 @@
 # @pome-sh/adapter-claude-sdk — CHANGELOG
 
+## Unreleased (minor)
+
+**Behavioural default change — `query()` now seals the examinee.**
+`options.settingSources` defaults to `[]`, the SDK's documented isolation mode,
+when the caller does not choose one. Every other option is still forwarded
+verbatim.
+
+Before this, an agent driven through this wrapper inherited the filesystem
+settings of whatever machine it ran on — user (`~/.claude/settings.json`),
+project and local — **including the Claude Code plugin MCP servers configured
+there**. Measured 2026-08-05: a `claude-haiku-4-5` trial of the
+`support-triage` exam, launched from a developer shell with `tools: []` already
+set, called `mcp__plugin_slack_slack__slack_search_channels`,
+`…__slack_search_public` and `…__slack_list_channel_members`. It searched the
+developer's real Slack workspace, made zero twin calls, and would have scored
+as *the agent failed to triage* — a verdict about the wrong workspace entirely.
+`tools` and `settingSources` are different doors; shutting one says nothing
+about the other, and `allowedTools` only auto-approves rather than restricts.
+
+**Who is affected.** Any consumer that called `query()` without passing
+`settingSources` and *relied* on the host's `~/.claude/settings.json`,
+`.claude/settings.json` or `.claude/settings.local.json` reaching the agent —
+permissions, `enabledPlugins`, `mcpServers`, and `CLAUDE.md` (which the SDK
+loads only when `'project'` is among the sources). Consumers that already pass
+`settingSources`, and consumers that never wanted host settings, see no change.
+
+**Opting out**, by naming what you want rather than by omission:
+
+```ts
+// The pre-0.4.0 behaviour, exactly.
+query({ prompt, options: { settingSources: ["user", "project", "local"] } });
+// Narrower, and usually the real intent — 'project' is what loads CLAUDE.md.
+query({ prompt, options: { settingSources: ["project"] } });
+```
+
+An explicit `settingSources: undefined` counts as *not chosen* and is sealed,
+matching the SDK's own `!== undefined` branch.
+
+`options.tools` is deliberately **not** defaulted. `settingSources: []` removes
+configuration the host supplied and the caller never asked for; `tools: []`
+would remove the agent's own hands from every consumer of a drop-in wrapper.
+Only the first is the adapter's to shut. An exam that wants the closed sandbox
+passes `tools: []` itself, as the bundled examples do.
+
 ## 0.3.14 — 2026-08-28
 
 **No consumer-visible change.** A comment in `wrapQuery.ts` described a step-

--- a/packages/adapter-claude-sdk/README.md
+++ b/packages/adapter-claude-sdk/README.md
@@ -18,7 +18,9 @@ import { withPome, tool, query } from "@pome-sh/adapter-claude-sdk";
 withPome();   // installs globalThis.fetch hook + signals writer
 
 // `tool` and `query` are drop-in replacements for the Anthropic SDK exports
-// — wrap your handlers and iterate `query()` exactly the same way.
+// — wrap your handlers and iterate `query()` exactly the same way. One
+// deliberate difference: `query()` defaults `options.settingSources` to `[]`.
+// See "Isolation: sealed by default" below.
 const myTool = tool(
   "list_open_issues",
   "List open issues on the GitHub twin.",
@@ -32,6 +34,59 @@ for await (const msg of query({ prompt, options })) {
 ```
 
 That's the whole user-facing surface.
+
+## Isolation: sealed by default
+
+**Since 0.4.0**, `query()` defaults `options.settingSources` to `[]` — the
+SDK's own documented isolation mode — when you do not choose one. Everything
+else is still forwarded verbatim.
+
+Without it, an agent inherits the **filesystem settings of whatever machine it
+runs on**: user (`~/.claude/settings.json`), project (`.claude/settings.json`)
+and local (`.claude/settings.local.json`), *including the Claude Code plugin
+MCP servers configured there*. The SDK loads all three when the option is
+omitted, "matching CLI defaults" — sensible for the `claude` CLI, wrong for a
+programmatic agent, and actively dangerous for one being graded.
+
+Measured 2026-08-05: a `claude-haiku-4-5` trial of the `support-triage` exam,
+launched from a developer shell with `tools: []` **already set**, called
+`mcp__plugin_slack_slack__slack_search_channels`, `…__slack_search_public` and
+`…__slack_list_channel_members`. It searched the developer's real Slack
+workspace, made zero twin calls, and would have scored as *the agent failed to
+triage* — a verdict about the wrong workspace entirely. Re-run with
+`settingSources: []`, the same trial called only `mcp__github__*` /
+`mcp__slack__*` and scored 75.
+
+`tools` and `settingSources` are **different doors**, and shutting one says
+nothing about the other:
+
+| option | governs | adapter default |
+| --- | --- | --- |
+| `options.tools` | the SDK's **built-in** base set (`Bash`, `Read`, `Grep`, …) | **none** — yours to choose |
+| `options.settingSources` | **filesystem settings** — user + project + local, *including plugin MCP servers* | **`[]`** |
+
+`allowedTools` is not a substitute for either: it only auto-approves, it does
+not restrict.
+
+**Why `tools` is not defaulted.** `settingSources: []` removes configuration
+the *host* supplied and you never asked for. `tools: []` would remove your
+agent's own hands. Only the first is this adapter's to shut. If you want the
+closed sandbox an exam wants, pass `tools: []` yourself.
+
+**Opting out** is by naming what you want, never by omission:
+
+```ts
+// Restores the pre-0.4.0 behaviour exactly.
+query({ prompt, options: { settingSources: ["user", "project", "local"] } });
+
+// Narrower, and usually what you actually want: the SDK loads CLAUDE.md only
+// when 'project' is among the sources.
+query({ prompt, options: { settingSources: ["project"] } });
+```
+
+Passing `settingSources` — any value, including `[]` — always wins. An explicit
+`undefined` counts as *not chosen*, matching the SDK's own `!== undefined`
+branch, so the seal cannot depend on how you spelled "I didn't choose".
 
 ## What it does
 

--- a/packages/adapter-claude-sdk/fixtures/fake-claude-cli.mjs
+++ b/packages/adapter-claude-sdk/fixtures/fake-claude-cli.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+//
+// A stand-in for the `claude` executable that the Claude Agent SDK spawns.
+// Writes the argv it was launched with to `POME_FAKE_CLI_ARGV_PATH`, then
+// speaks the two stream-json messages the SDK needs to finish a query cleanly.
+//
+// It exists so `test/isolation-argv.test.ts` can assert on the FLAG that
+// reaches the CLI rather than on a property of an options object. The SDK turns
+// `settingSources` into argv with `if (v !== undefined) push(\`--setting-sources=${v.join(",")}\`)`
+// — omitted means the flag is absent and the CLI loads user + project + local
+// settings — so the argv is where "sealed" is either true or not.
+//
+// Spawned directly (`spawn(executable, args)`, no shell), so this file needs
+// its executable bit committed. `test/isolation-argv.test.ts` asserts that.
+
+import { writeFileSync } from "node:fs";
+
+const argvPath = process.env.POME_FAKE_CLI_ARGV_PATH;
+if (!argvPath) {
+  console.error("fake-claude-cli: POME_FAKE_CLI_ARGV_PATH is unset");
+  process.exit(2);
+}
+writeFileSync(argvPath, JSON.stringify(process.argv.slice(2)));
+
+// Enough of the stream for the SDK to resolve the query rather than throw, so a
+// test that fails does so on its assertion instead of on a transport error.
+const sessionId = "00000000-0000-4000-8000-000000000000";
+const line = (msg) => process.stdout.write(`${JSON.stringify({ ...msg, session_id: sessionId, uuid: sessionId })}\n`);
+
+line({
+  type: "system",
+  subtype: "init",
+  tools: [],
+  mcp_servers: [],
+  model: "fake-claude-cli",
+  cwd: process.cwd(),
+  apiKeySource: "none",
+  permissionMode: "default",
+  slash_commands: [],
+  output_style: "default",
+});
+line({
+  type: "result",
+  subtype: "success",
+  result: "ok",
+  is_error: false,
+  duration_ms: 0,
+  duration_api_ms: 0,
+  num_turns: 1,
+  total_cost_usd: 0,
+  usage: {},
+});
+process.stdout.end();

--- a/packages/adapter-claude-sdk/src/query.ts
+++ b/packages/adapter-claude-sdk/src/query.ts
@@ -37,6 +37,11 @@ export const OUTBOUND_MARKER = "POME_SMOKE_REACHED_OUTBOUND";
  * User-supplied hooks in `params.options.hooks` are preserved — pome's
  * matchers are prepended per event so they fire alongside user callbacks.
  *
+ * ISOLATION, ON BY DEFAULT. Since 0.4.0 this wrapper defaults
+ * `options.settingSources` to `[]` — the SDK's documented isolation mode — when
+ * the caller does not choose one. `withSealedSettingSources` below carries the
+ * measurement behind it, the `tools` posture, and how to opt out.
+ *
  * Pinning the model: pass `params.options.model` (an alias like `"haiku"` /
  * `"sonnet"` / `"opus"`, or a full id like `"claude-haiku-4-5"`). This wrapper
  * forwards it verbatim to the upstream SDK, which passes it to the `claude` CLI
@@ -67,7 +72,7 @@ export function query(params: QueryParams): AsyncGenerator<SDKMessage, void, unk
   // injection is hidden again.
   const inject =
     shouldInjectPartialMessages() && params.options?.includePartialMessages !== true;
-  const prepared = withPomeHooks(params, inject);
+  const prepared = withSealedSettingSources(withPomeHooks(params, inject));
 
   // Three read-only stream wrappers, composed innermost-first:
   //   • withToolEvents   — ToolUse/ToolResult/SubagentSpawn rows → signals JSONL
@@ -114,6 +119,60 @@ async function* withoutPartialMessages(
     if (isPartialMessageArtifact(msg)) continue;
     yield msg;
   }
+}
+
+/**
+ * Defaults `options.settingSources` to `[]` — the SDK's own documented
+ * isolation mode: *"When omitted, all sources are loaded (matches CLI
+ * defaults). Pass `[]` to disable filesystem settings (SDK isolation mode)."*
+ * — unless the caller chose their own.
+ *
+ * WHY THIS IS A DEFAULT AND NOT A SUGGESTION. Measured 2026-08-05: a
+ * `claude-haiku-4-5` trial of the `support-triage` exam, launched from a
+ * developer shell with `tools: []` ALREADY SET, called
+ * `mcp__plugin_slack_slack__slack_search_channels`, `…__slack_search_public`
+ * and `…__slack_list_channel_members`. It searched the developer's REAL Slack
+ * workspace, made zero twin calls, and would have scored as "the agent failed
+ * to triage" — a verdict about the wrong workspace entirely. Re-run with
+ * `settingSources: []` the same trial called only `mcp__github__*` /
+ * `mcp__slack__*` and scored 75.
+ *
+ * `tools` and `settingSources` are DIFFERENT DOORS, and shutting one says
+ * nothing about the other. `tools` governs the SDK's built-in base set (`Bash`,
+ * `Read`, `Grep`, …); `settingSources` governs FILESYSTEM settings — user
+ * (`~/.claude/settings.json`), project (`.claude/settings.json`) and local
+ * (`.claude/settings.local.json`) — INCLUDING the Claude Code plugin MCP
+ * servers configured on whoever's machine the agent runs on. That is the one
+ * surface that changes depending on who runs it, which is what makes it a
+ * default rather than an option: an agent is not sealed by everyone remembering.
+ *
+ * THE `tools` POSTURE: deliberately NOT defaulted. `settingSources: []` removes
+ * configuration the HOST supplied and the caller never asked for; `tools: []`
+ * would remove the agent's own hands from every consumer of a drop-in wrapper.
+ * Only the first is the adapter's to shut. A caller who wants the closed
+ * sandbox passes `tools: []` themselves, as every bundled example does.
+ *
+ * OPTING OUT is by naming what you want, never by omission — omission is what
+ * shipped the defect above:
+ *
+ * ```ts
+ * query({ prompt, options: { settingSources: ["user", "project", "local"] } })
+ * ```
+ *
+ * That restores the pre-0.4.0 behaviour exactly. `["project"]` is the narrower
+ * choice worth knowing about: the SDK loads `CLAUDE.md` only when `'project'`
+ * is among the sources, so an agent that needs its repo's instructions asks for
+ * that source rather than dropping the seal.
+ *
+ * The test is `=== undefined`, matching the SDK's own branch
+ * (`if (settingSources !== undefined) push('--setting-sources=' + …)`), so
+ * `{ settingSources: undefined }` and an omitted key are treated as the same
+ * request. Sealing only one of the two spellings would make isolation depend on
+ * how a caller wrote "I didn't choose".
+ */
+function withSealedSettingSources(params: QueryParams): QueryParams {
+  if (params.options?.settingSources !== undefined) return params;
+  return { ...params, options: { ...(params.options ?? {}), settingSources: [] } };
 }
 
 function withPomeHooks(params: QueryParams, includePartialMessages: boolean): QueryParams {

--- a/packages/adapter-claude-sdk/test/isolation-argv.test.ts
+++ b/packages/adapter-claude-sdk/test/isolation-argv.test.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Acceptance: the seal survives the trip to the CLI.
+//
+// `isolation.test.ts` asserts the options object the adapter hands the SDK.
+// That is necessary and not sufficient — a property nobody reads passes forever,
+// which is the failure shape this family keeps hitting. So this file drives the
+// REAL `@anthropic-ai/claude-agent-sdk` against a stand-in `claude` executable
+// and asserts on argv, where the seal is either applied or it is not:
+//
+//   settingSources omitted   → no `--setting-sources` flag → CLI loads
+//                              user + project + local, plugin MCP servers
+//                              included. This is the defect.
+//   settingSources: []       → `--setting-sources=`        → isolation.
+//   settingSources: ['project'] → `--setting-sources=project`
+//
+// It is also the case that catches a future SDK renaming or reinterpreting the
+// option: the unit tier would stay green while the sandbox reopened.
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { query } from "../src/query.js";
+
+const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const FAKE_CLI = join(PACKAGE_ROOT, "fixtures", "fake-claude-cli.mjs");
+
+let tmp: string;
+let argvPath: string;
+const ORIGINAL_ARGV_PATH = process.env.POME_FAKE_CLI_ARGV_PATH;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "pome-isolation-"));
+  argvPath = join(tmp, "argv.json");
+  process.env.POME_FAKE_CLI_ARGV_PATH = argvPath;
+});
+
+afterEach(() => {
+  if (ORIGINAL_ARGV_PATH === undefined) delete process.env.POME_FAKE_CLI_ARGV_PATH;
+  else process.env.POME_FAKE_CLI_ARGV_PATH = ORIGINAL_ARGV_PATH;
+});
+
+/** Runs the adapter's `query()` against the stand-in CLI, returns its argv. */
+async function argvReachingTheCli(options?: Record<string, unknown>): Promise<string[]> {
+  const merged = { pathToClaudeCodeExecutable: FAKE_CLI, ...(options ?? {}) };
+  for await (const _ of query({ prompt: "triage the queue", options: merged } as never)) {
+    // drained
+  }
+  return JSON.parse(readFileSync(argvPath, "utf8")) as string[];
+}
+
+const settingSourcesFlag = (argv: string[]): string | undefined =>
+  argv.find((arg) => arg.startsWith("--setting-sources"));
+
+describe("the seal reaches the CLI", () => {
+  it("passes --setting-sources= when the caller asked for no isolation", async () => {
+    // Red before the fix: the flag is absent entirely, and an absent flag is
+    // the CLI default — user + project + local settings, plugin MCP servers
+    // included.
+    expect(settingSourcesFlag(await argvReachingTheCli())).toBe("--setting-sources=");
+  }, 30_000);
+
+  it("passes the caller's narrowed sources when they chose", async () => {
+    const argv = await argvReachingTheCli({ settingSources: ["project"] });
+    expect(settingSourcesFlag(argv)).toBe("--setting-sources=project");
+  }, 30_000);
+
+  it("passes all three when the caller opts back into the host's settings", async () => {
+    const argv = await argvReachingTheCli({ settingSources: ["user", "project", "local"] });
+    expect(settingSourcesFlag(argv)).toBe("--setting-sources=user,project,local");
+  }, 30_000);
+
+  it("leaves --tools to the caller and forwards an explicit empty allowlist", async () => {
+    const sealedOnly = await argvReachingTheCli();
+    expect(sealedOnly).not.toContain("--tools");
+
+    const closed = await argvReachingTheCli({ tools: [] });
+    expect(closed[closed.indexOf("--tools") + 1]).toBe("");
+  }, 30_000);
+});
+
+describe("the stand-in CLI fixture", () => {
+  it("is committed executable, since the SDK spawns it without a shell", () => {
+    // `spawn(executable, args)` with no shell: a fixture that lost its
+    // executable bit in git would red every case above with EACCES, which reads
+    // as "the seal broke" rather than "the fixture did".
+    const mode = execFileSync("git", ["ls-files", "-s", "--", relative(PACKAGE_ROOT, FAKE_CLI)], {
+      cwd: PACKAGE_ROOT,
+      encoding: "utf8",
+    }).trim();
+    expect(mode.startsWith("100755")).toBe(true);
+    expect(statSync(FAKE_CLI).mode & 0o111).toBeGreaterThan(0);
+  });
+});

--- a/packages/adapter-claude-sdk/test/isolation.test.ts
+++ b/packages/adapter-claude-sdk/test/isolation.test.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Acceptance: `query()` seals the examinee by default.
+//
+// The measured defect this pins (2026-08-05, and still reproducible on a
+// developer machine today): an examinee launched through this adapter with no
+// isolation options inherits the HOST's filesystem settings — user
+// (`~/.claude/settings.json`), project and local — including the Claude Code
+// plugin MCP servers configured there. A `claude-haiku-4-5` trial of
+// `support-triage` searched the developer's real Slack workspace, made zero twin
+// calls, and would have scored as "the agent failed to triage": a verdict about
+// the wrong workspace entirely. `tools: []` was already set and did not stop it,
+// because `tools` and `settingSources` are different doors.
+//
+// The SDK's own resolver states the inheritance plainly. On this repo's
+// developer machine, `resolveSettings({})` — the omitted case — returns
+// `mcpServers` and `enabledPlugins` provenanced to `~/.claude/settings.json`,
+// among them `slack@claude-plugins-official`, the very server family that
+// trial called. `resolveSettings({ settingSources: [] })` returns nothing.
+//
+// These cases assert the params the adapter hands the SDK.
+// `isolation-argv.test.ts` asserts the flag that reaches the CLI — the seal has
+// to survive the trip, not just be present on an object.
+
+import { describe, expect, it, vi } from "vitest";
+
+type CapturedParams = { prompt: unknown; options?: Record<string, unknown> };
+
+let capturedQueryParams: CapturedParams | null = null;
+// Read and reset through functions: the mock assigns from outside any caller's
+// control flow, so a direct read after `capturedQueryParams = null` narrows to
+// `never` and stops typechecking.
+const readCapture = (): CapturedParams | null => capturedQueryParams;
+const resetCapture = (): void => {
+  capturedQueryParams = null;
+};
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: CapturedParams) => {
+    capturedQueryParams = params;
+    return (async function* () {})();
+  },
+  HOOK_EVENTS: ["PreToolUse", "PostToolUse", "SessionStart", "Stop"],
+}));
+
+const { query } = await import("../src/query.js");
+
+/** Drives the wrapper to completion and returns the options the SDK saw. */
+async function optionsSeenBySdk(
+  options?: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  resetCapture();
+  for await (const _ of query({ prompt: "triage the queue", ...(options ? { options } : {}) } as never)) {
+    // drained: the wrapper calls the SDK eagerly, but pull anyway
+  }
+  const captured = readCapture();
+  if (!captured) throw new Error("the SDK was never called");
+  return captured.options ?? {};
+}
+
+describe("query(): sealed by default", () => {
+  it("defaults settingSources to [] when the caller passes no options at all", async () => {
+    expect((await optionsSeenBySdk()).settingSources).toEqual([]);
+  });
+
+  it("defaults settingSources to [] when the caller passes options without it", async () => {
+    const seen = await optionsSeenBySdk({ model: "haiku", maxTurns: 30 });
+    expect(seen.settingSources).toEqual([]);
+    // The seal is additive: everything else the caller asked for still arrives.
+    expect(seen.model).toBe("haiku");
+    expect(seen.maxTurns).toBe(30);
+  });
+
+  it("treats an explicit `undefined` as unset, exactly as the SDK does", async () => {
+    // The SDK's own branch is `if (settingSources !== undefined)`, so
+    // `{ settingSources: undefined }` and an omitted key are the same request.
+    // Sealing only one of the two would make the seal depend on how a caller
+    // spelled "I didn't choose".
+    const seen = await optionsSeenBySdk({ settingSources: undefined });
+    expect(seen.settingSources).toEqual([]);
+  });
+});
+
+describe("query(): an explicit choice wins", () => {
+  it("does not clobber a caller's narrowed settingSources", async () => {
+    const seen = await optionsSeenBySdk({ settingSources: ["project"] });
+    expect(seen.settingSources).toEqual(["project"]);
+  });
+
+  it("lets a caller opt back into the host's settings by naming all three", async () => {
+    // The documented restore path for the pre-seal behaviour. Naming the three
+    // sources is the opt-out; there is deliberately no way to spell it by
+    // omission, because omission is what shipped the defect.
+    const seen = await optionsSeenBySdk({ settingSources: ["user", "project", "local"] });
+    expect(seen.settingSources).toEqual(["user", "project", "local"]);
+  });
+
+  it("forwards an explicit empty array unchanged", async () => {
+    expect((await optionsSeenBySdk({ settingSources: [] })).settingSources).toEqual([]);
+  });
+});
+
+describe("query(): `tools` stays the caller's call", () => {
+  it("does not inject `tools` — the adapter seals ambient config, not capability", async () => {
+    // `settingSources: []` removes configuration the HOST supplied and the
+    // caller never asked for. `tools: []` would remove Bash/Read/Grep — the
+    // agent's own hands — from every consumer of a drop-in wrapper. Different
+    // doors, and only one of them is the adapter's to shut. An exam that wants
+    // the closed sandbox sets `tools: []` itself, as the bundled examples do.
+    expect(await optionsSeenBySdk()).not.toHaveProperty("tools");
+  });
+
+  it("forwards an explicit `tools: []` verbatim", async () => {
+    expect((await optionsSeenBySdk({ tools: [] })).tools).toEqual([]);
+  });
+
+  it("forwards an explicit tool allowlist verbatim", async () => {
+    const seen = await optionsSeenBySdk({ tools: ["Read", "Grep"] });
+    expect(seen.tools).toEqual(["Read", "Grep"]);
+  });
+});
+
+describe("query(): the seal composes with the wrapper's other work", () => {
+  it("still attaches pome's hooks", async () => {
+    const seen = await optionsSeenBySdk();
+    expect(seen.settingSources).toEqual([]);
+    expect(Object.keys((seen.hooks ?? {}) as Record<string, unknown>).length).toBeGreaterThan(0);
+  });
+
+  it("preserves a caller's own hook callbacks alongside the seal", async () => {
+    const userHook = vi.fn();
+    const seen = await optionsSeenBySdk({
+      hooks: { PreToolUse: [{ hooks: [userHook] }] },
+    });
+    expect(seen.settingSources).toEqual([]);
+    const pre = (seen.hooks as Record<string, unknown[]>).PreToolUse;
+    expect(pre.length).toBeGreaterThan(1);
+    expect(JSON.stringify(pre)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## What

`@pome-sh/adapter-claude-sdk`'s `query()` now defaults `options.settingSources`
to `[]` — the SDK's own documented isolation mode — when the caller does not
choose one. Every other option is still forwarded verbatim.

This is the **central half** of F-1295's `[DECISION]`, deliberately deferred
there because it changes a published package's documented drop-in contract and
so wanted its own release, README and CHANGELOG.

## Reproduced first, at the process boundary

Per M2's carried rule, the defect was verified rather than taken from the
description. The SDK turns the option into argv with:

```js
if (settingSources !== undefined) push(`--setting-sources=${settingSources.join(",")}`)
```

so an omitted option means the flag is **absent**, and an absent flag is the CLI
default: user + project + local settings, plugin MCP servers included.

Driving the real SDK against a stand-in `claude` executable and capturing argv,
then feeding the resulting source list to the SDK's own `resolveSettings()` on a
developer machine:

| | flag reaching the CLI | settings resolved | inherited MCP servers | enabled plugins |
| --- | --- | --- | --- | --- |
| **before** | *(none)* | 12 keys from `~/.claude/settings.json` | `apify`, `github` | 8, incl. `slack@claude-plugins-official` |
| **after** | `--setting-sources=` | none | none | 0 |

`slack@claude-plugins-official` is the very server family the 2026-08-05 trial
used to search a real Slack workspace, make zero twin calls, and earn a verdict
about the wrong workspace entirely. The incident F-1295 measured is still live
at this call site today; that is what this seals.

The red was watched at both tiers before any fix — the process-level case
failed with `expected undefined to be '--setting-sources='`.

## Why `tools` is documented, not defaulted

`settingSources: []` removes configuration the **host** supplied and the caller
never asked for. `tools: []` would remove the agent's own hands from every
consumer of a drop-in wrapper. Only the first is the adapter's to shut. An exam
that wants the closed sandbox passes `tools: []` itself, as every bundled
example does. The posture is stated in the README, the CHANGELOG and at the call
site rather than being silently imposed.

## Opting out

By naming what you want, never by omission — omission is what shipped the defect:

```ts
// The pre-0.4.0 behaviour, exactly.
query({ prompt, options: { settingSources: ["user", "project", "local"] } });
// Narrower, usually the real intent — 'project' is what loads CLAUDE.md.
query({ prompt, options: { settingSources: ["project"] } });
```

An explicit `settingSources: undefined` counts as *not chosen* and is sealed,
matching the SDK's own `!== undefined` branch, so the seal cannot depend on how
a caller spelled "I didn't choose".

## Tests — two tiers on purpose

A property nobody reads passes forever, which is the failure shape this family
keeps hitting.

- `test/isolation.test.ts` (11 cases) pins the params the adapter hands the SDK:
  sealed by default, explicit choice wins, `undefined` treated as unset, `tools`
  never injected, seal composes with the hooks/partial-message wrappers.
- `test/isolation-argv.test.ts` (5 cases) drives the **real** SDK against a
  committed stand-in CLI and asserts the flag that actually arrives. This is the
  tier that catches a future SDK renaming or reinterpreting the option while the
  unit tier stays green. It also asserts its own fixture is committed `100755`,
  since the SDK spawns without a shell and a lost executable bit would read as
  "the seal broke" rather than "the fixture did".

## What deliberately does not change

The per-example options and the `example-isolation` lint rule stay, per the
ticket: an `npx degit`-copied example leaves the repo and must carry its own
seal, and the call-site comment is the teaching surface. `npm run lint` still
reports all 4 `query()` call sites in 4 SDK examples setting both options.

## Release

`## Unreleased (minor)` in the adapter's CHANGELOG per F-1511 — a behavioural
default change for external consumers. No version number is written here; the
allocator writes it at merge. `scripts/ci/check-release-note-required.mjs`
verified green against the merge base.

One coupling worth knowing: the prose says **0.4.0** in the README, the
CHANGELOG body and the `query()` JSDoc, which is what `minor` allocates from
0.3.14. That is a prediction, not an allocated number — the allocator rewrites
the `## Unreleased` *heading* but not prose. It holds as long as no other
adapter-moving PR merges first; checked at time of writing, this is the only
open PR touching `packages/adapter-claude-sdk`.

## Verification

| check | result |
| --- | --- |
| `npm test` | 350 files, **3893 passed** |
| `npm run typecheck` (all workspaces) | clean |
| `npm run lint` | 17 rules pass, incl. `example-isolation` |
| `node scripts/ci/check-release-note-required.mjs <base>` | OK — 1 package moved |
| `npm ci --dry-run` | clean |

## Noted, not fixed (out of this ticket's scope)

- **`cli/src/cli/init-sdk.ts`** — the `pome init --sdk claude` scaffold calls the
  adapter's `query()` with no `settingSources` and no `tools`, relying only on
  `allowedTools`, which merely auto-approves. It is a **fourth launcher** nobody
  enumerated, and the one the CLI ships to new users. This PR fixes its
  behaviour for free, which is exactly the argument for placing the seal
  centrally — but by the same degit logic that keeps the examples sealed, the
  scaffold arguably deserves its own explicit options. That is a `cli/` change
  with its own release note; happy to file it.
- Two stale path references to the pre-consolidation
  `scripts/check-example-sdk-isolation.mjs` survive in
  `agent-examples/support-triage/{src/index.ts,test/example.test.ts}`. Unrelated
  drift; left alone to keep this diff to one package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


