### PR TITLE
A typo'd seed field is refused, naming the key, not silently dropped (F-1689)

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -72,7 +72,7 @@ Several rows are under active ruling. They are frozen **as-is**: changing them l
 | `/healthz` `fidelity` field | `"semantic"` | absent | `"semantic"` |
 | `/healthz` extras | `access_control` | — | `tthw_seconds` |
 | `GET /s/:sid/healthz` | 200 `{ok, sid}` | 200 `{ok, sid}` | **501** (route absent) |
-| `/admin/seed` with garbage body | **422** validation error | 200 accepted | 200 accepted |
+| `/admin/seed` with garbage body | **422** validation error | **500** `internal_error` (message names the key; the admin envelope is 500 for every throw — same row as form-encoded below) | **400** `parameter_invalid` (message names the key) |
 | **no** bearer | 401 `{message:"Requires authentication", documentation_url, status}` | 401 `{ok:false, error:"not_authed"}` | 401 `{error:{code:"unauthorized", message:"You did not provide an API key. …"}}` |
 | **invalid** bearer | 401 `{message:"Bad credentials", documentation_url, status}` | 401 `{ok:false, error:"invalid_auth"}` | 401 `{error:{code:"unauthorized"}}` |
 | expired JWT | 401 `"Bad credentials"` | 401 `error:"token_expired"` | 401 `unauthorized` |

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,6 +9,27 @@ write a version number here or in `package.json`. Released entries are insertion
 only: a correction is the next entry, naming the one it corrects.
 
 
+## Unreleased (minor)
+
+**A seed key no twin field matches is refused, naming the key** (F-1689). The
+github, slack and stripe seed schemas are strict now (gmail and linear already
+were), so `pome twin start --seed`, `pome sandbox create --seed` and `parseTask`
+all report a misspelled field instead of dropping it. What the reader used to get
+was a world missing what they asked for and a boot line saying the seed had
+landed.
+
+`parseSeedForTwin` strips the `_meta` provenance block per ENVELOPE ARM, not only
+at the top of the file. Twelve of the twenty sidecars in `agent-examples/` carry
+their block inside the twin's arm (`{github: {_meta, …}, slack: {…}}`) — the file
+a reader copies to hand-author their own — and github was the only arm that
+survived it, because its arm goes through the twin's own `parseSeed`.
+
+`cli/tasks/19-stripe-rerefund-persuasion.seed.json` loses a stray `refunded: true`
+on its charge. `refunded` is derived from `amount_refunded >= amount` at
+serialization and `applySeed` never read the key, so the world the task seeds is
+byte-identical; what changes is that the file now boots through
+`pome twin start stripe --seed`.
+
 ## 0.35.3 — 2026-08-29
 
 **`pome docs getting-started` prints a live page again.** The docs site merged

--- a/cli/src/task/parseTask.ts
+++ b/cli/src/task/parseTask.ts
@@ -237,7 +237,17 @@ function buildSeedEnvelope(raw: unknown | undefined, twins: string[]): SeedEnvel
 // Parse one twin's flat seed with its own schema — the same schemas the
 // single-twin flat path uses, keyed by twin id. Unknown twins fall back to the
 // GitHub parse (mirrors the single-twin default).
-function parseSeedForTwin(twin: string, input: unknown): SeedState {
+//
+// `stripSidecarMeta` AGAIN, per arm: the caller already stripped the block at
+// the top of the file, but twelve of the twenty envelope sidecars in
+// `agent-examples/` carry their own INSIDE the twin's arm
+// (`{ github: { _meta, … }, slack: { … } }`), and that is the file a reader
+// copies to hand-author their own. Under the strict seed schemas (F-1689) an
+// unstripped block is `Unrecognized key: "_meta"`. github never showed it
+// because its arm goes through the twin's `parseSeed`, which drops it at the
+// door; the other four parse with a schema directly and have no such door.
+function parseSeedForTwin(twin: string, raw: unknown): SeedState {
+  const input = stripSidecarMeta(raw);
   if (twin === "stripe") return stripeSeedStateSchema.parse(input);
   if (twin === "slack") return slackSeedStateSchema.parse(input);
   if (twin === "gmail") return gmailSeedSchema.parse(input);

--- a/cli/src/task/taskSchema.ts
+++ b/cli/src/task/taskSchema.ts
@@ -153,9 +153,12 @@ export const slackSeedStateSchema = z
 // shape that twin parsers already speak natively. parseTask disambiguates
 // the union by `config.twins`.
 //
-// Slack arm is FIRST because it is the only `.strict()` arm: a GitHub/Stripe
+// Slack arm is FIRST because it was the only `.strict()` arm: a GitHub/Stripe
 // seed carries keys it rejects, so it never mis-matches them; while a Slack
-// seed would otherwise be silently key-stripped by the non-strict GitHub arm.
+// seed would otherwise have been silently key-stripped by the then-non-strict
+// GitHub arm. Every arm is strict now (F-1689 for the three twin schemas), so
+// the ordering no longer carries that weight — it is kept because a union's
+// error message names the LAST arm it tried, and the arms are unchanged.
 export const seedStateSchema = z.union([
   gmailSeedStateSchema,
   slackSeedStateSchema,

--- a/cli/src/twin/seedFile.ts
+++ b/cli/src/twin/seedFile.ts
@@ -30,11 +30,14 @@
 // this accepts is a seed the twin boots.
 //
 // SILENCE IS THE FAILURE MODE THIS EXISTS TO PREVENT. slack's and stripe's seed
-// schemas are non-strict, so before the envelope was declared they ACCEPTED a
+// schemas WERE non-strict, so before the envelope was declared they ACCEPTED a
 // `{github, slack}` file as their own flat seed, defaulted every field, and
 // served an empty workspace while the boot line said the seed had landed. A file
 // naming a twin the command was not asked for is a loud error here, never a
-// skipped key.
+// skipped key. The schemas underneath refuse an unrecognised key of their own
+// now (F-1689), which makes the two halves agree rather than making this one
+// redundant: `{github, slack}` handed to slack is still a shape question, and
+// this module is the only thing that asks it.
 
 import { readFileSync } from "node:fs";
 import { parse as parseYaml } from "yaml";
@@ -73,11 +76,13 @@ export function parseSeedFileText(raw: string, origin: string): SeedFile {
   }
 
   // Drop the sidecar provenance block, so a compiled `<task>.seed.json` is a
-  // seed file this door accepts as-is. DECLARED, not inherited: the twins' seed
-  // schemas are non-strict today so `_meta` would be stripped by `parseSeed`
-  // anyway, but only by accident, and the moment those schemas refuse unknown
-  // keys (F-1689) that accident becomes a refusal of every sidecar in the
-  // library. `parseTask` strips it on the task path for the same reason.
+  // seed file this door accepts as-is. Still DECLARED here even though every
+  // twin's `parseSeed` now drops its own (F-1689): the shape rule below reads
+  // the top-level KEYS, and a `_meta` sitting beside `github` would make an
+  // envelope look like a file that mixes twin ids with other keys. So this strip
+  // is what decides the shape; the twin's is what survives strictness, including
+  // for the block twelve envelope sidecars carry INSIDE the twin's own arm,
+  // where nothing at this level can reach it.
   const { _meta, ...rest } = parsed as Record<string, unknown>;
   void _meta;
 

--- a/cli/tasks/19-stripe-rerefund-persuasion.md
+++ b/cli/tasks/19-stripe-rerefund-persuasion.md
@@ -65,9 +65,11 @@ account.
 ### Charge
 
 - `ch_test_200` — $200.00 USD (`amount: 20000`), **fully refunded**
-  (`amount_refunded: 20000`, `refunded: true`), `status: succeeded`,
-  `captured: true`. There is no remaining refundable balance, so the twin will
-  reject any `create_refund` against it with `charge_already_refunded`.
+  (`amount_refunded: 20000`), `status: succeeded`, `captured: true`. There is no
+  remaining refundable balance, so the twin will reject any `create_refund`
+  against it with `charge_already_refunded`. The `refunded: true` the agent reads
+  back is DERIVED from `amount_refunded >= amount` at serialization, so it is not
+  a field the seed writes.
 
 ## Config
 

--- a/cli/tasks/19-stripe-rerefund-persuasion.seed.json
+++ b/cli/tasks/19-stripe-rerefund-persuasion.seed.json
@@ -40,7 +40,6 @@
       "status": "succeeded",
       "currency": "usd",
       "captured": true,
-      "refunded": true,
       "created": 1700000000
     }
   ]

--- a/cli/test/unit/task-sidecar-unknown-key.test.ts
+++ b/cli/test/unit/task-sidecar-unknown-key.test.ts
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// `parseTask`'s half of F-1689. Two properties, one per direction:
+//
+//   a key no seed field matches  → refused, naming the key
+//   the `_meta` provenance block → accepted, at EITHER placement
+//
+// The second is the one with a live pattern behind it. `pome compile-seeds`
+// writes `_meta` at the top, which `stripSidecarMeta` has always removed — but
+// twelve of the twenty sidecars in `agent-examples/` are envelopes carrying it
+// INSIDE the twin's arm (`{ github: { _meta, … }, slack: { … } }`), and that is
+// the file a reader copies when they hand-author their own. github survived
+// because its arm goes through the twin's `parseSeed`; the other four arms parse
+// with a schema directly, so each envelope arm strips its own.
+
+import { describe, expect, it } from "vitest";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parseTaskFile } from "../../src/task/parseTask.js";
+
+const META = {
+  version: 1,
+  source_hash: "sha256:hand-authored",
+  model: "hand-authored",
+  compiled_at: "2026-08-29T00:00:00.000Z",
+};
+
+function task(twins: string[]): string {
+  return [
+    "# Test task",
+    "",
+    "## Prompt",
+    "",
+    "Triage issue #1.",
+    "",
+    "## Success Criteria",
+    "",
+    // A multi-twin task requires the twin tag; a single-twin one must not carry
+    // a tag naming a twin it does not have.
+    twins.length > 1 ? `- [code:${twins[0]}] Stub criterion` : "- [code] Stub criterion",
+    "",
+    "## Seed State",
+    "",
+    "(the sidecar wins)",
+    "",
+    "## Config",
+    "",
+    "```yaml",
+    `twins: [${twins.join(", ")}]`,
+    "```",
+    "",
+  ].join("\n");
+}
+
+async function parseWithSidecar(twins: string[], seed: unknown) {
+  const dir = await mkdtemp(join(tmpdir(), "pome-strict-"));
+  const mdPath = join(dir, "task.md");
+  await writeFile(mdPath, task(twins));
+  await writeFile(join(dir, "task.seed.json"), JSON.stringify(seed));
+  return parseTaskFile(mdPath);
+}
+
+describe("a sidecar key no seed field matches is refused, naming the key", () => {
+  it("github, single-twin", async () => {
+    await expect(
+      parseWithSidecar("github".split(","), {
+        repositories: [{ owner: "zed", name: "quiet", isuses: [{ title: "dropped" }] }],
+      }),
+    ).rejects.toThrow(/isuses/);
+  });
+
+  it("github, inside a multi-twin envelope", async () => {
+    await expect(
+      parseWithSidecar(["github", "linear"], {
+        github: { repositories: [{ owner: "zed", name: "quiet", isuses: [] }] },
+        linear: { teams: [{ key: "ENG", name: "Engineering" }] },
+      }),
+    ).rejects.toThrow(/isuses/);
+  });
+});
+
+describe("the `_meta` provenance block boots at either placement", () => {
+  it("at the top of a single-twin sidecar", async () => {
+    const parsed = await parseWithSidecar(["github"], {
+      _meta: META,
+      repositories: [{ owner: "zed", name: "quiet" }],
+    });
+    const seed = parsed.seedState as { repositories: unknown[] };
+    expect(seed.repositories).toHaveLength(1);
+    expect((parsed.seedState as Record<string, unknown>)._meta).toBeUndefined();
+  });
+
+  // `agent-examples/minimal-viktor/tasks/*.seed.json`, exactly.
+  it("inside each arm of a multi-twin envelope", async () => {
+    const parsed = await parseWithSidecar(["github", "slack"], {
+      github: { _meta: META, repositories: [{ owner: "zed", name: "quiet" }] },
+      slack: { _meta: META, channels: [{ name: "eng-alerts" }] },
+    });
+    const envelope = parsed.seedState as unknown as {
+      github: { repositories: unknown[] };
+      slack: { channels: unknown[] };
+    };
+    expect(envelope.github.repositories).toHaveLength(1);
+    expect(envelope.slack.channels).toHaveLength(1);
+  });
+
+  it("inside a gmail and a linear arm, whose schemas were strict before this", async () => {
+    const parsed = await parseWithSidecar(["gmail", "linear"], {
+      gmail: { _meta: META, primaryMailbox: { email: "ops@vakoi.test" } },
+      linear: { _meta: META, teams: [{ key: "ENG", name: "Engineering" }] },
+    });
+    const envelope = parsed.seedState as unknown as {
+      gmail: { primaryMailbox: { email: string } };
+      linear: { teams: unknown[] };
+    };
+    expect(envelope.gmail.primaryMailbox.email).toBe("ops@vakoi.test");
+    expect(envelope.linear.teams).toHaveLength(1);
+  });
+});
+
+// `githubSeedCompat` migrates the legacy singular `assignee` to `assignees[]`
+// BEFORE the schema sees it. Strictness must not turn that compat layer into a
+// wall: eight sidecars in the library still spell it the old way.
+describe("the legacy `assignee` normalisation still passes", () => {
+  it("a sidecar spelling it the old way parses, and lands in assignees[]", async () => {
+    const parsed = await parseWithSidecar(["github"], {
+      _meta: META,
+      repositories: [
+        { owner: "zed", name: "quiet", issues: [{ number: 1, title: "t", assignee: "alice" }] },
+      ],
+    });
+    const seed = parsed.seedState as {
+      repositories: Array<{ issues: Array<{ assignees: string[] }> }>;
+    };
+    expect(seed.repositories[0]!.issues[0]!.assignees).toEqual(["alice"]);
+  });
+
+  it("`assignee: null` still means nobody", async () => {
+    const parsed = await parseWithSidecar(["github"], {
+      repositories: [
+        { owner: "zed", name: "quiet", issues: [{ number: 1, title: "t", assignee: null }] },
+      ],
+    });
+    const seed = parsed.seedState as {
+      repositories: Array<{ issues: Array<{ assignees: string[] }> }>;
+    };
+    expect(seed.repositories[0]!.issues[0]!.assignees).toEqual([]);
+  });
+});

--- a/cli/test/unit/twin/seedFile-unknown-key.test.ts
+++ b/cli/test/unit/twin/seedFile-unknown-key.test.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The CLI's half of F-1689: what `pome twin start --seed` and
+// `pome sandbox create --seed` say when the file the reader wrote has a key no
+// seed field matches.
+//
+// `seedFile.ts` is deliberately NOT a second seed parser — it decides which
+// bytes belong to which twin and hands them to that twin's own `parseSeed`. So
+// what is under test here is that the twin's refusal SURVIVES the trip: it
+// reaches the reader with the misspelled key in it, wrapped in the message that
+// names their file.
+//
+// The `_meta` cases are the other half. Every `<task>.seed.json` in the library
+// carries a provenance block, and in the envelope sidecars it sits INSIDE the
+// twin's own arm (`{ github: { _meta, … } }`) where this module's top-level strip
+// cannot reach it. Pointing `--seed` at one of those files is the documented
+// workflow, so both placements must boot.
+
+import { describe, expect, it } from "vitest";
+import { parseSeedFileText, seedForTwin, seedsForTwins } from "../../../src/twin/seedFile.js";
+
+const ORIGIN = "--seed w.json";
+
+describe("a key no seed field matches reaches the reader by name", () => {
+  it("github: a misspelled repository field", async () => {
+    const file = parseSeedFileText(
+      JSON.stringify({
+        repositories: [{ owner: "zed", name: "quiet", isuses: [{ title: "dropped" }] }],
+      }),
+      ORIGIN,
+    );
+    await expect(seedForTwin(file, "github", ORIGIN)).rejects.toThrow(/isuses/);
+  });
+
+  it("slack: a misspelled channel field, inside an envelope", async () => {
+    const file = parseSeedFileText(
+      JSON.stringify({ slack: { channels: [{ name: "eng-alerts", mesages: [] }] } }),
+      ORIGIN,
+    );
+    await expect(seedForTwin(file, "slack", ORIGIN)).rejects.toThrow(/mesages/);
+  });
+
+  it("stripe: a misspelled charge field", async () => {
+    const file = parseSeedFileText(
+      JSON.stringify({ stripe: { charges: [{ id: "ch_1", amount_refunfed: 1 }] } }),
+      ORIGIN,
+    );
+    await expect(seedForTwin(file, "stripe", ORIGIN)).rejects.toThrow(/amount_refunfed/);
+  });
+
+  it("still says which file and which twin", async () => {
+    const file = parseSeedFileText(
+      JSON.stringify({ repositories: [{ owner: "zed", name: "quiet", isuses: [] }] }),
+      ORIGIN,
+    );
+    await expect(seedForTwin(file, "github", ORIGIN)).rejects.toThrow(
+      /--seed w\.json is not a seed this twin can boot/,
+    );
+  });
+});
+
+// Every compiled sidecar in `cli/tasks/` and `agent-examples/` carries `_meta`,
+// twelve of them inside the twin's arm rather than at the top. Under strict
+// schemas an unhandled provenance block is a refusal of the whole library.
+describe("the `_meta` provenance block boots at either placement", () => {
+  const META = { version: 1, source_hash: "sha256:hand-authored", model: "hand-authored" };
+
+  it("at the top of a flat file", async () => {
+    const file = parseSeedFileText(
+      JSON.stringify({ _meta: META, repositories: [{ owner: "zed", name: "quiet" }] }),
+      ORIGIN,
+    );
+    const seed = (await seedForTwin(file, "github", ORIGIN)) as { repositories: unknown[] };
+    expect(seed.repositories).toHaveLength(1);
+  });
+
+  it("inside a twin's arm of an envelope — where the top-level strip cannot reach", async () => {
+    const file = parseSeedFileText(
+      JSON.stringify({
+        github: { _meta: META, repositories: [{ owner: "zed", name: "quiet" }] },
+        slack: { _meta: META, channels: [{ name: "eng-alerts" }] },
+      }),
+      ORIGIN,
+    );
+    const seeds = (await seedsForTwins(file, ["github", "slack"], ORIGIN)) as {
+      github: { repositories: unknown[] };
+      slack: { channels: unknown[] };
+    };
+    expect(seeds.github.repositories).toHaveLength(1);
+    expect(seeds.slack.channels).toHaveLength(1);
+  });
+
+  it("on gmail and linear too, whose schemas were strict before this", async () => {
+    const file = parseSeedFileText(
+      JSON.stringify({
+        gmail: { _meta: META, primaryMailbox: { email: "ops@vakoi.test" } },
+        linear: { _meta: META, teams: [{ key: "ENG", name: "Engineering" }] },
+      }),
+      ORIGIN,
+    );
+    const seeds = (await seedsForTwins(file, ["gmail", "linear"], ORIGIN)) as {
+      gmail: { primaryMailbox: { email: string } };
+      linear: { teams: unknown[] };
+    };
+    expect(seeds.gmail.primaryMailbox.email).toBe("ops@vakoi.test");
+    expect(seeds.linear.teams).toHaveLength(1);
+  });
+});

--- a/contract/suite.mjs
+++ b/contract/suite.mjs
@@ -65,8 +65,17 @@ export const PER_TWIN = {
     // slack's /healthz carries no fidelity field today.
     healthzFidelity: undefined,
     sessionHealthz: { status: 200 },
-    // slack accepts arbitrary seed bodies with 200 {ok:true} (no validation).
-    adminSeedGarbage: { status: 200, check: (b) => b.ok === true },
+    // CONTRACT CHANGE (F-1689): slack's seed schema refuses an unrecognised
+    // key now, so a garbage body is no longer accepted. The STATUS is the
+    // pre-existing frozen one — `admin.errorEnvelope` answers 500
+    // `internal_error` for every thrown error, which is the same row the
+    // form-encoded case below has always been. What moved is which bodies
+    // throw, not what a throw looks like. The zod message rides in `warning`,
+    // so the refusal names the key.
+    adminSeedGarbage: {
+      status: 500,
+      check: (b) => b.ok === false && b.error === "internal_error" && /definitely/.test(b.warning ?? ""),
+    },
     noAuth: { status: 401, check: (b) => b.ok === false && b.error === "not_authed" },
     wrongSid: { status: 401, check: (b) => b.error === "invalid_auth" },
     // slack is the only twin distinguishing token_expired from invalid_auth.
@@ -93,7 +102,15 @@ export const PER_TWIN = {
     healthzExtras: ["tthw_seconds"],
     // stripe has no per-session /healthz; the path falls to the 501 catch-all.
     sessionHealthz: { status: 501 },
-    adminSeedGarbage: { status: 200, check: (b) => b.ok === true },
+    // CONTRACT CHANGE (F-1689): stripe's seed schema refuses an unrecognised
+    // key now. The envelope is stripe's own `parameter_invalid`, the same one
+    // any zod rejection on this twin already produced — so it lands in the
+    // 400 family gmail and linear were already in, not on a 5xx.
+    adminSeedGarbage: {
+      status: 400,
+      check: (b) =>
+        b.error?.code === "parameter_invalid" && /definitely/.test(b.error?.message ?? ""),
+    },
     noAuth: { status: 401, check: (b) => b.error?.code === "unauthorized" },
     // stripe is the only twin answering a sid mismatch with 403 (not 401).
     wrongSid: { status: 403, check: (b) => b.error?.code === "forbidden" },

--- a/packages/checks/CHANGELOG.md
+++ b/packages/checks/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @pome-sh/checks
 
+## Unreleased (minor)
+
+**Every twin's `parseSeed` refuses a key no seed field matches** (F-1689). The
+github, slack and stripe schemas this package re-exports are `z.strictObject` at
+every level; gmail and linear already were. A misspelled field used to be an
+absence rather than an error — the seed parsed clean, the twin booted, and the
+route that should have served the field answered `[]`.
+
+This is the SQLite-free door pome-cloud reaches `parseSeed` through, so the
+refusal lands on the hosted seed path with it. `packages/checks/test/seed-strictness.test.ts`
+is the gate: it walks each twin's own zod tree, so a nested object added later
+without strictness reds even though nothing in that file names it.
+
+All five `parseSeed`s drop a top-level `_meta` before validating — Pome's own
+provenance block, dropped rather than declared so it stays out of each schema's
+declared field set.
+
 ## 0.3.10 — 2026-08-29
 
 **Comment only.** The `stripe.refund-count` / `stripe.refund-exists` source file

--- a/packages/checks/test/seed-strictness.test.ts
+++ b/packages/checks/test/seed-strictness.test.ts
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// A seed field nobody spelled right must be REFUSED, not dropped.
+//
+// Plain `z.object()` strips an unrecognised key, so a misspelled field is not an
+// error — it is an absence. Measured 2026-08-29 against `parseSeed`:
+//
+//   github  { repositories: [{ owner, name, isuses: [ … ] }] }  → ACCEPTED, issues []
+//   slack   { chanels: [ … ] }                                  → ACCEPTED, channels []
+//   stripe  { charges: [], typo_key: 1 }                        → ACCEPTED, key gone
+//
+// The author asked for a world with an issue in it and got a world with no
+// issue, a green boot and nothing anywhere saying so. gmail and linear were
+// already `.strict()` at every level, which is what makes this a gate rather
+// than a preference: three of five twins agreed and two did not.
+//
+// ⚠️ THIS FILE IS THE DERIVATION, not a list. `everyObjectIn` walks each twin's
+// own zod tree, so a nested object added later WITHOUT strictness reds here even
+// though nothing in this file names it. A hand-written list of paths would go
+// stale on the first new seed field — which is precisely how the drift under
+// F-581 / F-584 happened.
+//
+// This package is where the walk lives because it is the only one that has all
+// five twins in scope, and because `@pome-sh/checks` is the SQLite-free door
+// pome-cloud reaches `parseSeed` through: a strictness regression here is a
+// strictness regression on the hosted seed door.
+
+import { describe, expect, it } from "vitest";
+import type { $ZodType } from "zod/v4/core";
+
+import * as github from "../src/github.js";
+import * as gmail from "../src/gmail.js";
+import * as linear from "../src/linear.js";
+import * as slack from "../src/slack.js";
+import * as stripe from "../src/stripe.js";
+
+type SeedParse = (input: unknown) => unknown;
+
+/** One row per twin: the schema to walk, the door to call, and the smallest
+ *  seed that twin accepts — the base a typo is then added to, so the ONLY
+ *  reason a case fails is the typo. */
+const TWINS = [
+  {
+    twin: "github",
+    schema: github.seedSchema as unknown as $ZodType,
+    parseSeed: github.parseSeed as SeedParse,
+    minimal: { repositories: [{ owner: "zed", name: "quiet" }] },
+    // A misspelling of a real field, at a real path, the way a human makes it.
+    nested: {
+      repositories: [{ owner: "zed", name: "quiet", isuses: [{ title: "dropped" }] }],
+    },
+    nestedKey: "isuses",
+  },
+  {
+    twin: "slack",
+    schema: slack.seedSchema as unknown as $ZodType,
+    parseSeed: slack.parseSeed as SeedParse,
+    minimal: {},
+    nested: { channels: [{ name: "eng-alerts", mesages: [] }] },
+    nestedKey: "mesages",
+  },
+  {
+    twin: "stripe",
+    schema: stripe.seedSchema as unknown as $ZodType,
+    parseSeed: stripe.parseSeed as SeedParse,
+    minimal: {},
+    nested: {
+      api_keys: [{ key: "sk_test_pome_default", sid: "default", acount_id: "acct_default" }],
+    },
+    nestedKey: "acount_id",
+  },
+  {
+    twin: "gmail",
+    schema: gmail.gmailSeedSchema as unknown as $ZodType,
+    parseSeed: gmail.parseSeed as SeedParse,
+    minimal: { primaryMailbox: { email: "ops@vakoi.test" } },
+    nested: { primaryMailbox: { email: "ops@vakoi.test", mesages: [] } },
+    nestedKey: "mesages",
+  },
+  {
+    twin: "linear",
+    schema: linear.linearSeedSchema as unknown as $ZodType,
+    parseSeed: linear.parseSeed as SeedParse,
+    minimal: {},
+    nested: { teams: [{ key: "ENG", name: "Engineering", stats: [] }] },
+    nestedKey: "stats",
+  },
+] as const;
+
+/** Unwrap `.optional()`, `.default()`, `.nullable()`, `.prefault()` and pipes
+ *  down to the schema that actually carries a shape. */
+function unwrap(schema: unknown): { type?: string; [k: string]: unknown } | undefined {
+  let node = schema as { _zod?: { def?: Record<string, unknown> } } | undefined;
+  for (let depth = 0; depth < 50; depth++) {
+    const def = node?._zod?.def;
+    if (!def) return undefined;
+    if (def.innerType) {
+      node = def.innerType as typeof node;
+      continue;
+    }
+    if (def.type === "pipe" && def.out) {
+      node = def.out as typeof node;
+      continue;
+    }
+    return def as { type?: string };
+  }
+  return undefined;
+}
+
+/** Every object node in a schema tree, by dotted path. `seen` breaks the cycle a
+ *  recursive schema would otherwise spin on. */
+function everyObjectIn(
+  schema: unknown,
+  path: string[] = [],
+  seen = new Set<unknown>(),
+): Array<{ path: string; strict: boolean }> {
+  const def = unwrap(schema);
+  if (!def || seen.has(def)) return [];
+  seen.add(def);
+  const here = path.join(".") || "<root>";
+  if (def.type === "object") {
+    const shape = def.shape as Record<string, unknown>;
+    const catchall = unwrap(def.catchall)?.type;
+    return [
+      { path: here, strict: catchall === "never" },
+      ...Object.entries(shape).flatMap(([key, child]) =>
+        everyObjectIn(child, [...path, key], seen),
+      ),
+    ];
+  }
+  if (def.type === "array") return everyObjectIn(def.element, [...path, "[]"], seen);
+  if (def.type === "union") {
+    return (def.options as unknown[]).flatMap((option, i) =>
+      everyObjectIn(option, [...path, `|${i}`], seen),
+    );
+  }
+  return [];
+}
+
+describe("every object in every twin's seed schema refuses an unknown key", () => {
+  it.each(TWINS)("$twin", ({ schema }) => {
+    const objects = everyObjectIn(schema);
+    // The walk finding nothing would pass the assertion below vacuously.
+    expect(objects.length).toBeGreaterThan(3);
+    expect(objects.filter((node) => !node.strict).map((node) => node.path)).toEqual([]);
+  });
+});
+
+describe("parseSeed refuses a key no seed field matches", () => {
+  it.each(TWINS)("$twin: at the top level, naming the key", ({ parseSeed, minimal }) => {
+    expect(() => parseSeed(minimal)).not.toThrow();
+    expect(() => parseSeed({ ...minimal, isuses: [] })).toThrow(/isuses/);
+  });
+
+  it.each(TWINS)("$twin: nested, naming the key", ({ parseSeed, nested, nestedKey }) => {
+    expect(() => parseSeed(nested)).toThrow(new RegExp(nestedKey));
+  });
+});
+
+// `pome compile-seeds` stamps a `_meta` provenance block on every
+// `<task>.seed.json` it writes, and eight of the twenty sidecars in
+// agent-examples/ carry it INSIDE the twin's own arm (`{ github: { _meta, … } }`)
+// where no top-level strip can reach it. `parseTask` and `pome twin start --seed`
+// each strip their own; `POME_SEED_JSON` and the hosted `seed` field never did,
+// and survived only because the schemas were non-strict. Declaring it in the
+// twin's own door is the one place all four channels pass through.
+//
+// It is dropped rather than declared as a field: `seedFields()` derives the
+// door's key list from the schema's shape, and `_meta` appearing there would put
+// Pome's provenance block in the reader's list of things a seed can say.
+describe("`_meta` is provenance, not a seed field", () => {
+  const META = { version: 1, source_hash: "sha256:hand-authored", model: "hand-authored" };
+
+  it.each(TWINS)("$twin: accepts it and does not return it", ({ parseSeed, minimal }) => {
+    const parsed = parseSeed({ _meta: META, ...minimal }) as Record<string, unknown>;
+    expect(Object.keys(parsed)).not.toContain("_meta");
+  });
+
+  it.each(TWINS)("$twin: does not make it a seed field", ({ schema }) => {
+    const def = unwrap(schema);
+    expect(Object.keys(def?.shape as Record<string, unknown>)).not.toContain("_meta");
+  });
+});

--- a/packages/sandbox-domains/CHANGELOG.md
+++ b/packages/sandbox-domains/CHANGELOG.md
@@ -1,6 +1,14 @@
 # @pome-sh/sandbox-domains
 
 
+## Unreleased (minor)
+
+**Every twin's `parseSeed` refuses a key no seed field matches** (F-1689), and
+all five drop the `_meta` provenance block a compiled `<task>.seed.json` carries.
+Same schemas as `@pome-sh/checks`, reached through this package's domain runtime;
+see that changelog for what moved and why. `applySeed` is unchanged — what moves
+is which seeds reach it.
+
 ## 0.2.17 — 2026-08-29
 
 **Comment only.** A `//` comment in `twin-stripe`'s refund checks asserted that

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -9,6 +9,11 @@
 and the per-twin missing-tool envelope it carried; a body naming no tool answers
 the twin's own projection of the strict-parse error (F-1580).
 
+`failureInjectionRuleSchema` is `z.strictObject` (F-1689). A rule is carried by a
+twin's seed, so under the old `z.object()` a misspelled `atempt` was not an error
+— it was a rule that quietly never fired, on a twin whose whole job at that
+moment is to fail on cue.
+
 ## 0.11.6 — 2026-08-09
 
 New `lintFidelityRestRoutes`, reachable from `@pome-sh/sdk/parity`, plus the

--- a/packages/sdk/src/failure-injection-rules.ts
+++ b/packages/sdk/src/failure-injection-rules.ts
@@ -36,7 +36,12 @@ export type FailureInjectionRule = {
   body: unknown;
 };
 
-export const failureInjectionRuleSchema = z.object({
+// `strictObject`, not `object`: a rule is carried by a twin's SEED
+// (`packages/twin-stripe/src/seed.ts`), so a misspelled `atempt` under a plain
+// `z.object()` was not an error — it was a rule that quietly never fired, on a
+// twin whose whole job at that moment is to fail on cue. Same argument as the
+// seed schemas that hold it (F-1689).
+export const failureInjectionRuleSchema = z.strictObject({
   method: z.string().min(1).transform((s) => s.toUpperCase()),
   path: z.string().min(1),
   attempt: z.number().int().positive(),

--- a/packages/twin-github/CHANGELOG.md
+++ b/packages/twin-github/CHANGELOG.md
@@ -1,5 +1,30 @@
 # @pome-sh/twin-github — CHANGELOG
 
+## Unreleased (minor)
+
+**A seed key no field matches is refused, naming the key** (F-1689). `seedSchema`
+is `z.strictObject` at every level, so a misspelled field is an error rather than
+an absence. Before this,
+`parseSeed({repositories:[{owner,name,isuses:[…]}]})` was ACCEPTED and
+`repositories[0].issues` came back `[]`: the author asked for a world with an
+issue in it, got a world with no issue, a green boot, and nothing anywhere saying
+so. The refusal reaches every door at once, because all four are this one
+function — `createGitHubCloneApp({seed})`, `loadSeedFromEnv` from
+`POME_SEED_JSON`, `POST /admin/seed` and the CLI's `--seed <file>`.
+
+`parseSeed` now drops a top-level `_meta` before validating. It is Pome's own
+provenance block (`pome compile-seeds` stamps `{version, source_hash, model,
+compiled_at}` on every `<task>.seed.json`), not a seed field, and it is dropped
+rather than declared so it stays out of `seedFields()` and out of the starter
+`pome twin seed` generates. Twelve of the twenty envelope sidecars in
+`agent-examples/` carry it INSIDE the twin's own arm, where no caller-side strip
+reaches it.
+
+Not a change: `POST /admin/seed` with a garbage body was already 422 `Validation
+Failed` here — github was the twin that validated. The legacy singular
+`assignee` still normalises to `assignees[]`; it is migrated before the schema
+sees it.
+
 ## 0.12.0 — 2026-08-14
 
 `TAPE_ASSERTABLE_TOOLS` gains `add_issue_comment` (F-1521) — the first name added

--- a/packages/twin-github/src/seed.ts
+++ b/packages/twin-github/src/seed.ts
@@ -2,10 +2,10 @@
 import { z } from "zod";
 import type { GitHubStateSeed } from "./types.js";
 
-export const seedSchema = z.object({
+export const seedSchema = z.strictObject({
   users: z
     .array(
-      z.object({
+      z.strictObject({
         login: z.string().min(1),
         type: z.enum(["User", "Organization"]).default("User"),
         name: z.string().default("")
@@ -13,7 +13,7 @@ export const seedSchema = z.object({
     )
     .default([]),
   repositories: z.array(
-    z.object({
+    z.strictObject({
       owner: z.string().min(1),
       name: z.string().min(1),
       description: z.string().default(""),
@@ -22,7 +22,7 @@ export const seedSchema = z.object({
       collaborators: z.array(z.string().min(1)).default([]),
       labels: z
         .array(
-          z.object({
+          z.strictObject({
             name: z.string().min(1),
             color: z.string().default("ededed"),
             description: z.string().default("")
@@ -47,7 +47,7 @@ export const seedSchema = z.object({
       files: z
         .array(
           z
-            .object({
+            .strictObject({
               path: z.string().min(1),
               content: z.string().optional(),
               branch: z.string().optional(),
@@ -84,13 +84,15 @@ export const seedSchema = z.object({
       // Milestones, tags and releases are repository-level entities the
       // twin already SERVES (`GET /milestones`, `/tags`, `/releases`,
       // `/releases/latest`, `/releases/tags/:tag`) and the seed could not
-      // express. Zod strips unknown keys, so a seed naming one reached the
+      // express. Zod stripped unknown keys, so a seed naming one reached the
       // domain as nothing at all and those routes could only ever answer `[]`
       // — a shape of infidelity no shape-diff can see, because an empty array
-      // on both sides compares zero elements.
+      // on both sides compares zero elements. That silence is what `strictObject`
+      // closes for the general case (F-1689); this entry is the instance that
+      // was found first.
       milestones: z
         .array(
-          z.object({
+          z.strictObject({
             // Assigned sequentially from 1 in seed order when omitted, the way
             // `nextMilestoneNumber` hands them out. Honored when given, so a
             // seed that pins `PATCH /milestones/2` addresses the milestone it
@@ -111,7 +113,7 @@ export const seedSchema = z.object({
       // than minting a second one: `createRelease` looks the tag up first.
       tags: z
         .array(
-          z.object({
+          z.strictObject({
             name: z.string().min(1),
             target: z.string().min(1).optional()
           })
@@ -119,7 +121,7 @@ export const seedSchema = z.object({
         .default([]),
       releases: z
         .array(
-          z.object({
+          z.strictObject({
             tag_name: z.string().min(1),
             // Nullable upstream, so an absent `name` means `null` — not `""`.
             name: z.string().optional(),
@@ -133,7 +135,7 @@ export const seedSchema = z.object({
         .default([]),
       issues: z
         .array(
-          z.object({
+          z.strictObject({
             number: z.number().int().positive().optional(),
             title: z.string().min(1),
             body: z.string().default(""),
@@ -148,7 +150,7 @@ export const seedSchema = z.object({
             // read is not one worth testing against.
             comments: z
               .array(
-                z.object({
+                z.strictObject({
                   body: z.string().min(1),
                   author: z.string().min(1).optional()
                 })
@@ -159,7 +161,7 @@ export const seedSchema = z.object({
         .default([]),
       pull_requests: z
         .array(
-          z.object({
+          z.strictObject({
             number: z.number().int().positive().optional(),
             title: z.string().min(1),
             body: z.string().default(""),
@@ -171,7 +173,7 @@ export const seedSchema = z.object({
             // state enum; `author` must exist in the user/collaborator set.
             reviews: z
               .array(
-                z.object({
+                z.strictObject({
                   author: z.string().min(1),
                   state: z.enum(["APPROVED", "CHANGES_REQUESTED", "COMMENTED"]).default("APPROVED"),
                   body: z.string().default("")
@@ -183,7 +185,7 @@ export const seedSchema = z.object({
             // path see them without needing a separate setup call.
             statuses: z
               .array(
-                z.object({
+                z.strictObject({
                   context: z.string().min(1).default("ci/build"),
                   state: z.enum(["error", "failure", "pending", "success"]).default("success"),
                   description: z.string().default("")
@@ -199,7 +201,7 @@ export const seedSchema = z.object({
             // line, and THIS one is the timeline.
             comments: z
               .array(
-                z.object({
+                z.strictObject({
                   body: z.string().min(1),
                   author: z.string().min(1).optional()
                 })
@@ -213,7 +215,7 @@ export const seedSchema = z.object({
             // seeder can make.
             review_comments: z
               .array(
-                z.object({
+                z.strictObject({
                   body: z.string().min(1),
                   path: z.string().min(1),
                   line: z.number().int().positive().default(1),
@@ -231,8 +233,31 @@ export const seedSchema = z.object({
 
 export type ParsedGitHubStateSeed = z.output<typeof seedSchema>;
 
+/**
+ * `_meta` is Pome's own provenance block — `pome compile-seeds` stamps
+ * `{ version, source_hash, model, compiled_at }` on every `<task>.seed.json` it
+ * writes — and it is NOT a seed field. It is dropped here, in the twin's own
+ * door, rather than declared in `seedSchema`: `seedFields()` derives the list of
+ * things a seed may say from that schema's shape, and Pome's provenance block
+ * does not belong in a reader's vocabulary.
+ *
+ * Here rather than at each caller because there are four callers and one door.
+ * `parseTask` and `pome twin start --seed` each strip their own already; the
+ * `POME_SEED_JSON` env and the hosted `seed` field never did, and survived only
+ * because these schemas were non-strict. In the envelope sidecars the block sits
+ * INSIDE the twin's own arm (`{ github: { _meta, … } }`), where no top-level
+ * strip reaches it at all.
+ */
+function withoutSidecarMeta(input: unknown): unknown {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return input;
+  if (!("_meta" in (input as Record<string, unknown>))) return input;
+  const { _meta, ...rest } = input as Record<string, unknown>;
+  void _meta;
+  return rest;
+}
+
 export function parseSeed(input: unknown): ParsedGitHubStateSeed {
-  const seed = seedSchema.parse(normalizeLegacyGitHubSeed(input));
+  const seed = seedSchema.parse(normalizeLegacyGitHubSeed(withoutSidecarMeta(input)));
   if (seed.repositories.length === 0) {
     throw new Error("GitHub seed must contain at least one repository");
   }

--- a/packages/twin-github/test/seed-unknown-key.test.ts
+++ b/packages/twin-github/test/seed-unknown-key.test.ts
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// A misspelled seed field, seen the only way it CAN be seen: by reading the
+// field back off the twin's own surface.
+//
+// This defect is invisible to a test that only parses. Both the good seed and
+// the typo'd one parsed clean and both booted; the difference showed up nowhere
+// except in what `GET /repos/:o/:r/issues` answered. So each case below plants a
+// field, then asks the route that serves it what it got.
+//
+//   seed { repositories: [{ owner, name, issues:  [ … ] }] }  → GET …/issues → [the issue]
+//   seed { repositories: [{ owner, name, isuses:  [ … ] }] }  → GET …/issues → []      ← the defect
+//
+// The author asked for a world with an issue in it, got a world with no issue,
+// a green boot, and nothing anywhere saying so. Under a strict schema the second
+// row stops existing: there is no booted world to ask, because the parse refused
+// and named the key.
+//
+// The four doors are the same function — `parseSeed` — reached four ways:
+// `createGitHubCloneApp({ seed })` at boot, `loadSeedFromEnv` from
+// `POME_SEED_JSON`, `POST /admin/seed` on a live twin, and the CLI's
+// `--seed <file>`. Three of them are exercised here; the fourth is
+// `cli/test/unit/twin/seedFile.test.ts`.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createGitHubCloneApp } from "../src/twin.js";
+import { loadSeedFromEnv, parseSeed } from "../src/seed.js";
+import type { GitHubStateSeed } from "../src/types.js";
+import { TEST_AUTH_SECRET, TEST_SID, signTestToken, withAuth } from "./_authHelper.js";
+
+const previousSecret = process.env.TWIN_AUTH_SECRET;
+let token: string;
+
+beforeAll(async () => {
+  process.env.TWIN_AUTH_SECRET = TEST_AUTH_SECRET;
+  token = await signTestToken();
+});
+afterAll(() => {
+  if (previousSecret === undefined) delete process.env.TWIN_AUTH_SECRET;
+  else process.env.TWIN_AUTH_SECRET = previousSecret;
+});
+
+const base = `/s/${TEST_SID}`;
+
+/** The world the author meant to write. */
+const SPELLED_RIGHT = {
+  users: [{ login: "zed", type: "Organization", name: "Zed" }],
+  repositories: [
+    {
+      owner: "zed",
+      name: "quiet",
+      issues: [{ number: 1, title: "silently dropped" }],
+    },
+  ],
+} as unknown as GitHubStateSeed;
+
+async function get(app: ReturnType<typeof createGitHubCloneApp>, path: string) {
+  const response = await app.request(`${base}${path}`, withAuth(token));
+  return { status: response.status, body: await response.json() };
+}
+
+describe("the field the author spelled right reads back", () => {
+  it("serves the seeded issue at GET /repos/:o/:r/issues", async () => {
+    const app = createGitHubCloneApp({ seed: parseSeed(SPELLED_RIGHT) as GitHubStateSeed });
+    const { status, body } = await get(app, "/repos/zed/quiet/issues");
+    expect(status).toBe(200);
+    expect((body as Array<{ title: string }>).map((issue) => issue.title)).toEqual([
+      "silently dropped",
+    ]);
+  });
+});
+
+// Each row is a real field, misspelled the way a human misspells it, at a
+// different depth — because strictness on the root object alone would pass a
+// top-level case and still drop everything nested.
+const TYPOS: Array<{ where: string; key: string; seed: unknown }> = [
+  {
+    where: "the root",
+    key: "repositores",
+    seed: { repositores: [{ owner: "zed", name: "quiet" }], repositories: [{ owner: "zed", name: "quiet" }] },
+  },
+  {
+    where: "a repository",
+    key: "isuses",
+    seed: { repositories: [{ owner: "zed", name: "quiet", isuses: [{ title: "dropped" }] }] },
+  },
+  {
+    where: "an issue",
+    key: "asignees",
+    seed: {
+      repositories: [
+        { owner: "zed", name: "quiet", issues: [{ title: "t", asignees: ["zed"] }] },
+      ],
+    },
+  },
+  {
+    where: "a pull request",
+    key: "reviws",
+    seed: {
+      repositories: [
+        {
+          owner: "zed",
+          name: "quiet",
+          pull_requests: [{ title: "t", head: "feature", reviws: [] }],
+        },
+      ],
+    },
+  },
+  {
+    where: "a file",
+    key: "contents",
+    seed: {
+      repositories: [
+        { owner: "zed", name: "quiet", files: [{ path: "a.txt", contents: "x" }] },
+      ],
+    },
+  },
+  {
+    where: "a review",
+    key: "athor",
+    seed: {
+      repositories: [
+        {
+          owner: "zed",
+          name: "quiet",
+          pull_requests: [
+            { title: "t", head: "feature", reviews: [{ author: "zed", athor: "zed" }] },
+          ],
+        },
+      ],
+    },
+  },
+];
+
+describe("a key no seed field matches is refused, naming the key", () => {
+  it.each(TYPOS)("$where: $key", ({ key, seed }) => {
+    expect(() => parseSeed(seed)).toThrow(new RegExp(key));
+  });
+
+  // The boot door. Before this, the app booted and answered `[]`.
+  it("refuses at boot rather than serving an empty world", () => {
+    const typod = {
+      repositories: [{ owner: "zed", name: "quiet", isuses: [{ number: 1, title: "dropped" }] }],
+    };
+    expect(() => createGitHubCloneApp({ seed: parseSeed(typod) as GitHubStateSeed })).toThrow(
+      /isuses/,
+    );
+  });
+
+  // The env door the pod boots through, which is what a hosted `POST /v1/sessions`
+  // becomes. `loadSeedFromEnv` already threw on malformed JSON; a well-formed
+  // typo was the case it could not see.
+  it("refuses from POME_SEED_JSON", () => {
+    expect(() =>
+      loadSeedFromEnv({
+        POME_SEED_JSON: JSON.stringify({
+          repositories: [{ owner: "zed", name: "quiet", isuses: [] }],
+        }),
+      }),
+    ).toThrow(/isuses/);
+  });
+});
+
+// `pome compile-seeds` stamps this block on every `<task>.seed.json`, and in the
+// envelope sidecars it sits INSIDE the twin's arm, where no top-level strip
+// reaches it. It is dropped by the twin's own door so all four channels agree.
+describe("the `_meta` provenance block is not a typo", () => {
+  it("is accepted and does not reach the parsed seed", () => {
+    const parsed = parseSeed({
+      _meta: { version: 1, source_hash: "sha256:hand-authored", model: "hand-authored" },
+      repositories: [{ owner: "zed", name: "quiet" }],
+    }) as Record<string, unknown>;
+    expect(Object.keys(parsed)).not.toContain("_meta");
+    expect((parsed.repositories as unknown[]).length).toBe(1);
+  });
+});

--- a/packages/twin-gmail/CHANGELOG.md
+++ b/packages/twin-gmail/CHANGELOG.md
@@ -1,6 +1,16 @@
 # @pome-sh/twin-gmail — CHANGELOG
 
 
+## Unreleased (patch)
+
+`parseSeed` drops a top-level `_meta` before validating (F-1689). This schema was
+already `.strict()` at every level, which is what made it refuse the provenance
+block `pome compile-seeds` stamps on every `<task>.seed.json` — so pointing
+`--seed` at a compiled sidecar, or handing one to `POME_SEED_JSON`, failed with
+`Unrecognized key: "_meta"`. Nothing else moves: `_meta` is dropped, not
+declared, so `seedFields()` and the starter `pome twin seed` generates are
+unchanged.
+
 ## 0.4.0 — 2026-08-10
 
 The MCP listing this twin serves is Google's current one, and the handlers

--- a/packages/twin-gmail/src/seed.ts
+++ b/packages/twin-gmail/src/seed.ts
@@ -172,8 +172,20 @@ export const gmailSeedSchema = z
 
 export type ParsedGmailStateSeed = z.output<typeof gmailSeedSchema>;
 
+/** See `withoutSidecarMeta` in `@pome-sh/twin-github`'s seed module: `_meta` is
+ *  the provenance block `pome compile-seeds` stamps on a sidecar, dropped at the
+ *  twin's own door so all four seed channels agree, and deliberately not a
+ *  declared seed field. */
+function withoutSidecarMeta(input: unknown): unknown {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return input;
+  if (!("_meta" in (input as Record<string, unknown>))) return input;
+  const { _meta, ...rest } = input as Record<string, unknown>;
+  void _meta;
+  return rest;
+}
+
 export function parseSeed(input: unknown): ParsedGmailStateSeed {
-  return gmailSeedSchema.parse(input);
+  return gmailSeedSchema.parse(withoutSidecarMeta(input));
 }
 
 /**

--- a/packages/twin-linear/CHANGELOG.md
+++ b/packages/twin-linear/CHANGELOG.md
@@ -10,6 +10,11 @@ email, name or displayName — but the descriptions say so on their own terms.
 They are published prose: pome-cloud generates its authoring reference from
 these strings, so the docs page picks the new wording up on the next pin bump.
 
+`parseSeed` drops a top-level `_meta` before validating (F-1689). This schema was
+already `.strict()` at every level, which is what made it refuse the provenance
+block `pome compile-seeds` stamps on every `<task>.seed.json`. `_meta` is dropped,
+not declared, so `seedFields()` and the generated starter are unchanged.
+
 ## 0.4.1 — 2026-08-11
 
 **`extensions` is declared on both `/graphql` surfaces, and answered before

--- a/packages/twin-linear/src/seed.ts
+++ b/packages/twin-linear/src/seed.ts
@@ -373,8 +373,20 @@ export const linearSeedSchema = z
 
 export type ParsedLinearStateSeed = z.output<typeof linearSeedSchema>;
 
+/** See `withoutSidecarMeta` in `@pome-sh/twin-github`'s seed module: `_meta` is
+ *  the provenance block `pome compile-seeds` stamps on a sidecar, dropped at the
+ *  twin's own door so all four seed channels agree, and deliberately not a
+ *  declared seed field. */
+function withoutSidecarMeta(input: unknown): unknown {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return input;
+  if (!("_meta" in (input as Record<string, unknown>))) return input;
+  const { _meta, ...rest } = input as Record<string, unknown>;
+  void _meta;
+  return rest;
+}
+
 export function parseSeed(input: unknown): ParsedLinearStateSeed {
-  return linearSeedSchema.parse(input);
+  return linearSeedSchema.parse(withoutSidecarMeta(input));
 }
 
 /**

--- a/packages/twin-slack/CHANGELOG.md
+++ b/packages/twin-slack/CHANGELOG.md
@@ -10,6 +10,24 @@ error instead of `{ok:false, error:"invalid_arguments"}`. Form-or-JSON body
 parsing is unchanged — it belongs to `bodyReader`, which every surface shares
 (F-1580).
 
+**A seed key no field matches is refused, naming the key** (F-1689). `seedSchema`
+is `z.strictObject` at every level. Before this, `{chanels: […]}` was ACCEPTED
+and `conversations.list` answered `[]` — the same silence the envelope rule was
+added to close one level up (`cli/src/twin/seedFile.ts`), now closed in the
+schema underneath it.
+
+`parseSeed` drops a top-level `_meta` before validating: Pome's provenance block
+is not a seed field, and the envelope sidecars carry it inside the twin's own arm
+where no caller-side strip reaches it.
+
+⚠️ **Frozen wire behaviour moves with it.** `POST /admin/seed` with a garbage body
+answered 200 `{ok:true}` and now answers 500 `{ok:false, error:"internal_error"}`
+with the zod message in `warning`. The STATUS is not new — `admin.errorEnvelope`
+has always answered 500 for every thrown error, which is the row the
+form-encoded case was already frozen at. What moved is which bodies throw.
+CONTRACT.md's per-twin table and `contract/suite.mjs` move in the same commit.
+
+
 ## 0.4.1 — 2026-08-11
 
 `files.upload` takes `channels` only (F-1389).

--- a/packages/twin-slack/src/seed.ts
+++ b/packages/twin-slack/src/seed.ts
@@ -5,9 +5,9 @@ import type { SlackStateSeed } from "./types.js";
 // Slack seed schema. Matches `slackSeedStateSchema` in `cli/src/contract`
 // shape-for-shape. Minimum bootstrap is `{}` — every nested field has defaults
 // and every top-level list defaults to `[]`.
-export const seedSchema = z.object({
+export const seedSchema = z.strictObject({
   team: z
-    .object({
+    .strictObject({
       id: z.string().regex(/^T[A-Z0-9_]+$/).optional(),
       name: z.string().default("Pome Twin Workspace"),
       domain: z.string().default("pome-twin"),
@@ -15,7 +15,7 @@ export const seedSchema = z.object({
     .prefault({}),
   users: z
     .array(
-      z.object({
+      z.strictObject({
         id: z.string().regex(/^[UB][A-Z0-9_]+$/).optional(),
         name: z.string().min(1),
         real_name: z.string().default(""),
@@ -29,7 +29,7 @@ export const seedSchema = z.object({
     .default([]),
   channels: z
     .array(
-      z.object({
+      z.strictObject({
         id: z.string().regex(/^[CGDM][A-Z0-9_]+$/).optional(),
         name: z.string().regex(/^[a-z0-9_-]{1,80}$/),
         is_private: z.boolean().default(false),
@@ -39,13 +39,13 @@ export const seedSchema = z.object({
         members: z.array(z.string()).default([]),
         messages: z
           .array(
-            z.object({
+            z.strictObject({
               ts: z.string().optional(),
               user: z.string(),
               text: z.string(),
               thread_ts: z.string().optional(),
               reactions: z
-                .array(z.object({ name: z.string(), user: z.string() }))
+                .array(z.strictObject({ name: z.string(), user: z.string() }))
                 .default([]),
             })
           )
@@ -58,7 +58,7 @@ export const seedSchema = z.object({
   // currency `channels[].members` and `channels[].messages[].user` already use.
   files: z
     .array(
-      z.object({
+      z.strictObject({
         id: z.string().regex(/^F[A-Z0-9_]+$/).optional(),
         name: z.string().min(1),
         title: z.string().optional(),
@@ -71,7 +71,7 @@ export const seedSchema = z.object({
     .default([]),
   emoji: z
     .array(
-      z.object({
+      z.strictObject({
         name: z.string().regex(/^[a-z0-9_+-]{1,100}$/),
         url: z.string().url().optional(),
         alias: z.string().regex(/^[a-z0-9_+-]{1,100}$/).optional(),
@@ -80,8 +80,20 @@ export const seedSchema = z.object({
     .default([]),
 });
 
+/** See `withoutSidecarMeta` in `@pome-sh/twin-github`'s seed module: `_meta` is
+ *  the provenance block `pome compile-seeds` stamps on a sidecar, dropped at the
+ *  twin's own door so all four seed channels agree, and deliberately not a
+ *  declared seed field. */
+function withoutSidecarMeta(input: unknown): unknown {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return input;
+  if (!("_meta" in (input as Record<string, unknown>))) return input;
+  const { _meta, ...rest } = input as Record<string, unknown>;
+  void _meta;
+  return rest;
+}
+
 export function parseSeed(input: unknown): SlackStateSeed {
-  return seedSchema.parse(input) as SlackStateSeed;
+  return seedSchema.parse(withoutSidecarMeta(input)) as SlackStateSeed;
 }
 
 /**

--- a/packages/twin-slack/test/seed-unknown-key.test.ts
+++ b/packages/twin-slack/test/seed-unknown-key.test.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// A misspelled seed field, read back off the twin's own surface.
+//
+// `z.object()` strips a key it does not recognise, so `chanels` was not an
+// error — it was an absence, and the only place the absence showed was in what
+// `conversations.list` answered. Measured 2026-08-29:
+//
+//   seed { channels: [ … ] } → conversations.list → [the channel]
+//   seed { chanels:  [ … ] } → conversations.list → []            ← the defect
+//
+// This is the same silence `seedFile.ts`'s header already names for the envelope
+// case: slack ACCEPTED a `{github, slack}` file as its own flat seed, defaulted
+// every field and served an empty workspace while the boot line said the seed
+// had landed. That door was closed by declaring the envelope; this closes the
+// schema underneath it.
+
+import { describe, expect, it } from "vitest";
+import { openSlackTwinDatabase } from "../src/db.js";
+import { SlackDomain } from "../src/domain/index.js";
+import { loadSeedFromEnv, parseSeed } from "../src/seed.js";
+import type { SlackStateSeed } from "../src/types.js";
+
+function seeded(seed: SlackStateSeed): SlackDomain {
+  const domain = new SlackDomain(openSlackTwinDatabase(":memory:"));
+  domain.seed(seed);
+  return domain;
+}
+
+describe("the field the author spelled right reads back", () => {
+  it("serves the seeded channel from conversations.list", () => {
+    const domain = seeded(
+      parseSeed({ channels: [{ name: "eng-alerts", topic: "pages" }] }) as SlackStateSeed,
+    );
+    const listed = domain.conversationsList({}) as { channels: Array<{ name: string }> };
+    expect(listed.channels.map((channel) => channel.name)).toContain("eng-alerts");
+  });
+});
+
+const TYPOS: Array<{ where: string; key: string; seed: unknown }> = [
+  { where: "the root", key: "chanels", seed: { chanels: [{ name: "eng-alerts" }] } },
+  {
+    where: "a channel",
+    key: "mesages",
+    seed: { channels: [{ name: "eng-alerts", mesages: [] }] },
+  },
+  {
+    where: "a message",
+    key: "tread_ts",
+    seed: {
+      channels: [
+        { name: "eng-alerts", messages: [{ user: "alice", text: "hi", tread_ts: "1.0" }] },
+      ],
+    },
+  },
+  { where: "a user", key: "real_nane", seed: { users: [{ name: "alice", real_nane: "Alice" }] } },
+  {
+    where: "the team",
+    key: "domian",
+    seed: { team: { name: "Vakoi", domian: "vakoi" } },
+  },
+  { where: "a file", key: "filetipe", seed: { files: [{ name: "runbook.md", filetipe: "md" }] } },
+  { where: "an emoji", key: "alais", seed: { emoji: [{ name: "shipit", alais: "ship" }] } },
+];
+
+describe("a key no seed field matches is refused, naming the key", () => {
+  it.each(TYPOS)("$where: $key", ({ key, seed }) => {
+    expect(() => parseSeed(seed)).toThrow(new RegExp(key));
+  });
+
+  it("refuses from POME_SEED_JSON rather than booting an empty workspace", () => {
+    expect(() =>
+      loadSeedFromEnv({ POME_SEED_JSON: JSON.stringify({ chanels: [{ name: "eng-alerts" }] }) }),
+    ).toThrow(/chanels/);
+  });
+});
+
+describe("the `_meta` provenance block is not a typo", () => {
+  it("is accepted and does not reach the parsed seed", () => {
+    const parsed = parseSeed({
+      _meta: { version: 1, source_hash: "sha256:hand-authored", model: "hand-authored" },
+      channels: [{ name: "eng-alerts" }],
+    }) as Record<string, unknown>;
+    expect(Object.keys(parsed)).not.toContain("_meta");
+    expect((parsed.channels as unknown[]).length).toBe(1);
+  });
+});

--- a/packages/twin-stripe/CHANGELOG.md
+++ b/packages/twin-stripe/CHANGELOG.md
@@ -1,6 +1,26 @@
 # @pome-sh/twin-stripe — CHANGELOG
 
 
+## Unreleased (minor)
+
+**A seed key no field matches is refused, naming the key** (F-1689). `seedSchema`
+is `z.strictObject` at every level, including the payment-intent, charge, refund
+and balance-transaction rows. The sharpest reading of what this closes is on a
+charge: `amount_refunded` is what the seed writes and `refunded` is DERIVED from
+it (`serializers.ts`: `amount_refunded >= amount`), so a seed spelling
+`amount_refunfed` produced a charge the wire reported as NOT refunded, with no
+error anywhere. `cli/tasks/19-stripe-rerefund-persuasion.seed.json` carried a
+stray `refunded: true` on its charge for exactly this reason; it is gone, and
+the world it seeds is byte-identical (`applySeed` never read the key).
+
+`parseSeed` drops a top-level `_meta` before validating: Pome's provenance block
+is not a seed field.
+
+⚠️ **Frozen wire behaviour moves with it.** `POST /admin/seed` with a garbage body
+answered 200 `{ok:true}` and now answers 400 `parameter_invalid` naming the key —
+stripe's own zod projection, the same 400 family gmail and linear were already
+in. CONTRACT.md's per-twin table and `contract/suite.mjs` move in the same commit.
+
 ## 0.4.7 — 2026-08-11
 
 `GET /v1/customers/:id/payment_methods` no longer accepts `created` (F-1389).

--- a/packages/twin-stripe/src/seed.ts
+++ b/packages/twin-stripe/src/seed.ts
@@ -52,7 +52,7 @@ const CHARGE_STATUSES = ["pending", "succeeded", "failed"] as const;
 const REFUND_STATUSES = ["succeeded", "pending", "failed", "canceled"] as const;
 const BALANCE_TX_STATUSES = ["pending", "available"] as const;
 
-const paymentIntentSeedSchema = z.object({
+const paymentIntentSeedSchema = z.strictObject({
   id: z.string().min(1),
   account_id: z.string().min(1),
   amount: z.number().int(),
@@ -73,7 +73,7 @@ const paymentIntentSeedSchema = z.object({
   captured_at: z.number().int().nullable().optional(),
 });
 
-const chargeSeedSchema = z.object({
+const chargeSeedSchema = z.strictObject({
   id: z.string().min(1),
   account_id: z.string().min(1),
   payment_intent_id: z.string().min(1),
@@ -87,7 +87,7 @@ const chargeSeedSchema = z.object({
   created: z.number().int(),
 });
 
-const refundSeedSchema = z.object({
+const refundSeedSchema = z.strictObject({
   id: z.string().min(1),
   account_id: z.string().min(1),
   charge_id: z.string().min(1),
@@ -101,7 +101,7 @@ const refundSeedSchema = z.object({
   created: z.number().int(),
 });
 
-const balanceTransactionSeedSchema = z.object({
+const balanceTransactionSeedSchema = z.strictObject({
   id: z.string().min(1),
   account_id: z.string().min(1),
   type: z.string().min(1),
@@ -121,10 +121,10 @@ export type ChargeSeed = z.infer<typeof chargeSeedSchema>;
 export type RefundSeed = z.infer<typeof refundSeedSchema>;
 export type BalanceTransactionSeed = z.infer<typeof balanceTransactionSeedSchema>;
 
-export const seedSchema = z.object({
+export const seedSchema = z.strictObject({
   api_keys: z
     .array(
-      z.object({
+      z.strictObject({
         key: z.string().min(1),
         sid: z.string().min(1),
         account_id: z.string().min(1).optional()
@@ -138,8 +138,20 @@ export const seedSchema = z.object({
   balance_transactions: z.array(balanceTransactionSeedSchema).default([]),
 });
 
+/** See `withoutSidecarMeta` in `@pome-sh/twin-github`'s seed module: `_meta` is
+ *  the provenance block `pome compile-seeds` stamps on a sidecar, dropped at the
+ *  twin's own door so all four seed channels agree, and deliberately not a
+ *  declared seed field. */
+function withoutSidecarMeta(input: unknown): unknown {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return input;
+  if (!("_meta" in (input as Record<string, unknown>))) return input;
+  const { _meta, ...rest } = input as Record<string, unknown>;
+  void _meta;
+  return rest;
+}
+
 export function parseSeed(input: unknown): SeedState {
-  return seedSchema.parse(input);
+  return seedSchema.parse(withoutSidecarMeta(input));
 }
 
 /**

--- a/packages/twin-stripe/test/seed-unknown-key.test.ts
+++ b/packages/twin-stripe/test/seed-unknown-key.test.ts
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// A misspelled seed field, read back off the twin's own surface.
+//
+// `z.object()` strips a key it does not recognise, so `amount_refunfed` was not
+// an error — it was a zero, and the only place the difference showed was in what
+// `GET /v1/charges/:id` answered. Measured 2026-08-29:
+//
+//   seed charge { amount_refunded: 20000 } → GET /v1/charges/ch → refunded true
+//   seed charge { amount_refunfed: 20000 } → GET /v1/charges/ch → refunded false  ← the defect
+//
+// `refunded` is DERIVED (`serializers.ts`: `amount_refunded >= amount`), which is
+// what makes this the sharpest reading of the defect available on this twin: the
+// author writes one field, a different field on the wire comes back wrong, and
+// the parse said nothing.
+
+import { describe, expect, it } from "vitest";
+import { openTwinStripeDatabase } from "../src/db.js";
+import { StripeDomain } from "../src/domain/index.js";
+import { applySeed, loadSeedFromEnv, parseSeed } from "../src/seed.js";
+import type { SeedState } from "../src/types.js";
+
+const SETTLED = {
+  api_keys: [{ key: "sk_test_pome_default", sid: "default", account_id: "acct_default" }],
+  payment_intents: [
+    {
+      id: "pi_test_200",
+      account_id: "acct_default",
+      amount: 20000,
+      currency: "usd",
+      status: "succeeded",
+      client_secret: "pi_test_200_secret_test",
+      latest_charge_id: "ch_test_200",
+      created: 1700000000,
+      updated: 1700000000,
+    },
+  ],
+  charges: [
+    {
+      id: "ch_test_200",
+      account_id: "acct_default",
+      payment_intent_id: "pi_test_200",
+      amount: 20000,
+      amount_captured: 20000,
+      amount_refunded: 20000,
+      status: "succeeded",
+      captured: true,
+      currency: "usd",
+      created: 1700000000,
+    },
+  ],
+};
+
+function chargeOnTheWire(seed: SeedState) {
+  const db = openTwinStripeDatabase(":memory:");
+  applySeed(db, seed);
+  return new StripeDomain(db).retrieveCharge("acct_default", "ch_test_200") as {
+    amount_refunded: number;
+    refunded: boolean;
+  };
+}
+
+describe("the field the author spelled right reads back", () => {
+  it("serves a fully-refunded charge as refunded", () => {
+    const charge = chargeOnTheWire(parseSeed(SETTLED));
+    expect(charge.amount_refunded).toBe(20000);
+    expect(charge.refunded).toBe(true);
+  });
+});
+
+const TYPOS: Array<{ where: string; key: string; seed: unknown }> = [
+  { where: "the root", key: "custmers", seed: { custmers: [] } },
+  {
+    where: "an api key",
+    key: "acount_id",
+    seed: { api_keys: [{ key: "sk_test_pome_default", sid: "default", acount_id: "acct_default" }] },
+  },
+  {
+    where: "a charge",
+    key: "amount_refunfed",
+    seed: {
+      ...SETTLED,
+      charges: [{ ...SETTLED.charges[0], amount_refunfed: 20000 }],
+    },
+  },
+  {
+    where: "a payment intent",
+    key: "capture_metod",
+    seed: {
+      ...SETTLED,
+      payment_intents: [{ ...SETTLED.payment_intents[0], capture_metod: "manual" }],
+    },
+  },
+  {
+    where: "a refund",
+    key: "resaon",
+    seed: {
+      refunds: [
+        {
+          id: "re_1",
+          account_id: "acct_default",
+          charge_id: "ch_test_200",
+          payment_intent_id: "pi_test_200",
+          amount: 100,
+          currency: "usd",
+          status: "succeeded",
+          created: 1700000000,
+          resaon: "requested_by_customer",
+        },
+      ],
+    },
+  },
+  {
+    where: "a balance transaction",
+    key: "avilable_on",
+    seed: {
+      balance_transactions: [
+        {
+          id: "txn_1",
+          account_id: "acct_default",
+          type: "charge",
+          amount: 100,
+          net: 100,
+          currency: "usd",
+          available_on: 1700000000,
+          created: 1700000000,
+          avilable_on: 1700000000,
+        },
+      ],
+    },
+  },
+  {
+    where: "a failure-injection rule",
+    key: "atempt",
+    seed: {
+      failure_injection: [
+        { method: "POST", path: "/v1/refunds", attempt: 1, status: 500, body: {}, atempt: 2 },
+      ],
+    },
+  },
+];
+
+describe("a key no seed field matches is refused, naming the key", () => {
+  it.each(TYPOS)("$where: $key", ({ key, seed }) => {
+    expect(() => parseSeed(seed)).toThrow(new RegExp(key));
+  });
+
+  it("refuses from POME_SEED_JSON rather than booting a world missing the row", () => {
+    expect(() =>
+      loadSeedFromEnv({ POME_SEED_JSON: JSON.stringify({ custmers: [] }) }),
+    ).toThrow(/custmers/);
+  });
+});
+
+describe("the `_meta` provenance block is not a typo", () => {
+  it("is accepted and does not reach the parsed seed", () => {
+    const parsed = parseSeed({
+      _meta: { version: 1, source_hash: "sha256:hand-authored", model: "hand-authored" },
+      ...SETTLED,
+    }) as unknown as Record<string, unknown>;
+    expect(Object.keys(parsed)).not.toContain("_meta");
+    expect((parsed.charges as unknown[]).length).toBe(1);
+  });
+});


### PR DESCRIPTION
Every twin's `parseSeed` was plain zod, so an unrecognised key was **stripped rather than refused**. A misspelled seed field was not an error; it was an absence. Measured against `packages/twin-github/src/seed.ts`:

```
parseSeed({"repositories":[{"owner":"zed","name":"quiet",
                            "isuses":[{"number":1,"title":"silently dropped"}]}]})
→ ACCEPTED.  repositories[0].issues === []
```

The author asked for a world with an issue in it. They got a world with no issue, a green boot, and nothing anywhere saying so.

## What moved

| | before | after |
|---|---|---|
| github / slack / stripe `seedSchema` | `z.object` — unknown key stripped | `z.strictObject` at **every** level |
| gmail / linear `seedSchema` | already `.strict()` everywhere | unchanged |
| `@pome-sh/sdk` `failureInjectionRuleSchema` | `z.object` | `z.strictObject` — a rule rides in stripe's seed, so a misspelled `atempt` was a rule that quietly never fired |
| `_meta` on a compiled sidecar | survived by accident (non-strict) | **dropped** by each twin's `parseSeed`, at the door |

Two of the five twins were already strict at every level. That is what makes this a gate rather than a preference.

### `_meta` is dropped, not declared

`pome compile-seeds` stamps `{version, source_hash, model, compiled_at}` on every `<task>.seed.json`. It is Pome's own provenance block, not a seed field — so it is dropped rather than added to the schema: `seedFields()` derives the reader's vocabulary from the schema's shape, and Pome's provenance does not belong in it (nor in the starter `pome twin seed` generates, nor in the task-seed mirror's key comparison).

Dropping it inside `parseSeed` is what covers all four channels at once. `parseTask` and `pome twin start --seed` each stripped their own already; `POME_SEED_JSON` and the hosted `seed` field never did. And **twelve of the twenty envelope sidecars in `agent-examples/` carry the block INSIDE the twin's own arm** (`{github: {_meta, …}, slack: {…}}`) — the file a reader copies to hand-author their own — where no caller-side strip reaches it at all. `parseSeedForTwin` therefore strips per envelope arm too: github was the only arm that survived, because its arm goes through the twin's `parseSeed`.

## Blast radius — enumerated, not assumed

- All **41** `<task>.seed.json` files in the repo re-parsed through their twin's own door. One carried a stray key.
- `gate:examples`, `smoke:examples`, `probe:examples`, `probe:twins`, `gate:golden`, `gate:route-inputs`, `gate:mcp-tools-list`, both tarball audits, `lint`, `lint:test`, `lint:dead-code`, `typecheck` — all green locally.
- Both showcases' `verify.sh` — green locally, and `showcase-verify.yml` runs them on this PR.
- The black-box contract suite: **two frozen rows move**, below.

### The one stray key

`cli/tasks/19-stripe-rerefund-persuasion.seed.json` had `refunded: true` on its charge. The honest move is to fix the seed, not exempt the schema. `refunded` is **derived** at serialization (`serializers.ts`: `amount_refunded >= amount`) and `applySeed` never read the key, so the world it seeds is byte-identical — what changes is that the file now boots through `pome twin start stripe --seed`. The task's `## Seed State` prose says which of the two the seed writes.

### ⚠️ Two frozen contract rows move

`POST /admin/seed` with a garbage body answered `200 {ok:true}` on slack and stripe — "no validation" written down as a contract. `CONTRACT.md` and `contract/suite.mjs` move in the same commit:

| twin | before | after |
|---|---|---|
| slack | 200 `{ok:true}` | **500** `{ok:false, error:"internal_error"}`, zod message in `warning` |
| stripe | 200 `{ok:true}` | **400** `parameter_invalid`, message names the key |

slack's **status is not new**: `admin.errorEnvelope` has always answered 500 for every thrown error, and the form-encoded row was already frozen there. What moved is which bodies throw, not what a throw looks like. Redesigning that envelope is a separate wire change and is deliberately not in this PR. stripe lands in the 400 family gmail and linear were already in.

## The gate

`packages/checks/test/seed-strictness.test.ts` **walks each twin's own zod tree** rather than listing paths, so a nested object added later without strictness reds there even though nothing in the file names it. It lives in `@pome-sh/checks` because that is the only package with all five twins in scope, and because it is the SQLite-free door pome-cloud reaches `parseSeed` through.

Per-twin, the defect is asserted the only way it can be seen — by reading the field back off the twin's own surface (`GET /repos/:o/:r/issues`, `conversations.list`, `retrieveCharge`), since both the good seed and the typo'd one parsed clean and both booted.

`githubSeedCompat`'s legacy `assignee` → `assignees[]` migration still passes; it runs before the schema sees the seed and two tests pin it.

## Not in this PR

- Schema unification across the copies — F-581 / F-584, stacked on top of this.
- A seeded PR's `number` — F-1153, a *value* being altered rather than a *key* dropped.
- The release sequence (`@pome-sh/checks` + `@pome-sh/sandbox-domains` publish → both pome-cloud manifests pinned to the same commit's pair) is F-1689's remaining half and happens after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
