### PR TITLE
The /v1 seed declaration is the twin's github schema, not a copy of it (F-581)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -30,6 +30,28 @@ serialization and `applySeed` never read the key, so the world the task seeds is
 byte-identical; what changes is that the file now boots through
 `pome twin start stripe --seed`.
 
+**The `/v1` seed declaration is the twin's schema, not a copy of it** (F-581).
+`cli/src/contract/seed-state.ts` hand-wrote the github seed shape and nothing
+compared it to `packages/twin-github/src/seed.ts`. Measured against a maximal
+github seed, the copy silently dropped eight fields the twin models:
+
+    repositories[].private, .milestones, .tags, .releases
+    issues[].assignees        (replaced by a fabricated `assignee: null`)
+    issues[].comments
+    pull_requests[].comments, .review_comments
+
+Nothing in this repo `.parse()`s that declaration — the create-session boundary
+is a permissive `z.record` on purpose (F-580) — which is why the drift was
+invisible. What it cost was every reader and type-checker that trusted it:
+`GithubSeedState` is `z.infer` of the schema, so the TYPE said a seeded milestone
+did not exist. The arm is now `export { seedSchema as githubSeedStateSchema }
+from "@pome-sh/twin-github/seed"` — the move `cli/src/task/taskSchema.ts` made
+when it was written. Two schemas that are the same object cannot drift.
+
+No exported name changes and no runtime behaviour moves. `GithubSeedState` is
+`ParsedGitHubStateSeed` under its old name, which is a WIDER type: it gains the
+eight fields above and `issues[].assignee` becomes `issues[].assignees`.
+
 ## 0.35.3 — 2026-08-29
 
 **`pome docs getting-started` prints a live page again.** The docs site merged

--- a/cli/src/contract/CHANGELOG.md
+++ b/cli/src/contract/CHANGELOG.md
@@ -457,6 +457,37 @@ FDRS-398 — unified `events.jsonl` discriminated-union schema for Agent Trace v
 - OtelSpanEvent dropped from the v1 union (FDRS-400 cancelled by the 2026-05-26 `/plan-eng-review`). Adding it in v2 is a non-breaking extension via the `kind` discriminator.
 - No version bump — `@pome-sh/shared-types` is held off npm until OSS Stage 1; consumers pick this up via workspace dep.
 
+---
+
+F-581 — the github seed arm of `seed-state.ts` is `@pome-sh/twin-github`'s own
+`seedSchema`, re-exported, rather than a hand-written declaration of it.
+
+### Changed
+
+- `githubSeedStateSchema` is the twin's object. The declared shape gains
+  `repositories[].private`, `.milestones[]`, `.tags[]`, `.releases[]`,
+  `issues[].comments[]`, `pull_requests[].comments[]`,
+  `pull_requests[].review_comments[]` and `files[].renamed_from`, and
+  `issues[].assignee` becomes `issues[].assignees[]` (F-577/F-578 settled
+  `assignees` as canonical and added a normalizer; this declaration never caught
+  up). Every one of those was already what the twin booted.
+- `GithubSeedState` is `ParsedGitHubStateSeed` under its old name — a wider type,
+  same name, same import site.
+
+### Notes
+
+- **Nothing in digital-twins parses this schema.** `contract/task.ts`'s
+  `taskSchema` is a declaration; the create-session boundary is a permissive
+  `z.record` by design (F-580), and pome-cloud's `parse-scenario-seed.ts` is
+  `JSON.parse` plus an object check. So this is a declaration correction, not a
+  behaviour change — but it is the declaration pome-cloud reads, which is why it
+  is recorded here.
+- Consequence of F-1689: the twin's schema is `z.strictObject`, so a consumer
+  that copies this shape inherits strictness. The boundary is deliberately not
+  the place to narrow (F-580), so nothing in the create-session path changes.
+- The stripe, slack, gmail and linear arms are still hand-written here. stripe
+  and slack are F-584; gmail and linear are covered by neither ticket.
+
 ## 0.3.0 — 2026-05-11
 
 FDRS-318 — file split + correlator/state-inspector field surface for M1+M2.

--- a/cli/src/contract/seed-state.ts
+++ b/cli/src/contract/seed-state.ts
@@ -1,4 +1,3 @@
-// file-size: Shared seed-state Zod schemas across twins — kept together so seed contracts stay one module.
 // SPDX-License-Identifier: Apache-2.0
 //
 // contract — provider seed-state schemas (part of §3 TASKS). The
@@ -7,112 +6,40 @@
 // `taskSchema`. Re-exported through the `cli/src/contract` barrel.
 
 import { z } from "zod";
+// The github seed shape is the TWIN's — see the block below. Imported as well
+// as re-exported because `providerScopedSeedStateSchema` needs the value.
+import { seedSchema as githubSeedSchema } from "@pome-sh/twin-github/seed";
 
-// SeedState — adopted as-is from oslo (nested shape; matches OSS code).
-// Future twins (Linear, Slack) will add their own seed shapes; we union those
-// in here as the family grows.
+// ── GITHUB: THE TWIN'S OWN SCHEMA, NOT A DECLARATION OF IT ─────────────────
 //
-// Ported from pome-cloud: this schema used to model only the
-// issue-triage subset (repositories[].{issues,labels,collaborators}). Anywhere
-// it is used as a narrowing boundary, a field MISSING here is silently
-// zod-stripped before it reaches the twin pod's own parseSeed — which is
-// exactly how PR-based scenarios lost their `users`, `pull_requests`, and
-// `files` and booted into an empty repo (the agent saw `GET /pulls → []`).
-// The full GitHub world (top-level users, default_branch, files,
-// pull_requests with reviews/statuses) is modeled below, matching the
-// canonical twin-github seed shape.
-export const githubSeedStateSchema = z.object({
-  users: z
-    .array(
-      z.object({
-        login: z.string().min(1),
-        type: z.enum(["User", "Organization"]).default("User"),
-        name: z.string().default(""),
-      })
-    )
-    .optional(),
-  repositories: z
-    .array(
-      z.object({
-        owner: z.string().min(1),
-        name: z.string().min(1),
-        description: z.string().optional(),
-        default_branch: z.string().min(1).optional(),
-        labels: z
-          .array(
-            z.object({
-              name: z.string().min(1),
-              color: z.string().default("ededed"),
-              description: z.string().default(""),
-            })
-          )
-          .default([]),
-        collaborators: z.array(z.string().min(1)).default([]),
-        files: z
-          .array(
-            z.object({
-              path: z.string().min(1),
-              content: z.string(),
-              branch: z.string().optional(),
-            })
-          )
-          .optional(),
-        issues: z
-          .array(
-            z.object({
-              number: z.number().int().positive(),
-              title: z.string().min(1),
-              body: z.string().default(""),
-              state: z.enum(["open", "closed"]).default("open"),
-              labels: z.array(z.string().min(1)).default([]),
-              assignee: z.string().nullable().default(null),
-            })
-          )
-          .default([]),
-        pull_requests: z
-          .array(
-            z.object({
-              number: z.number().int().positive().optional(),
-              title: z.string().min(1),
-              body: z.string().default(""),
-              head: z.string().min(1),
-              base: z.string().min(1).default("main"),
-              state: z.enum(["open", "closed"]).default("open"),
-              author: z.string().min(1).optional(),
-              // Reviews seeded on this PR. State mirrors GitHub's review state
-              // enum; author must exist in users or collaborators.
-              reviews: z
-                .array(
-                  z.object({
-                    author: z.string().min(1),
-                    state: z
-                      .enum(["APPROVED", "CHANGES_REQUESTED", "COMMENTED"])
-                      .default("APPROVED"),
-                    body: z.string().default(""),
-                  })
-                )
-                .default([]),
-              // Commit statuses on the PR head SHA, wired into commit_statuses
-              // so get_pull_request_status and merge_pull_request see them.
-              statuses: z
-                .array(
-                  z.object({
-                    context: z.string().min(1).default("ci/build"),
-                    state: z
-                      .enum(["error", "failure", "pending", "success"])
-                      .default("success"),
-                    description: z.string().default(""),
-                  })
-                )
-                .default([]),
-            })
-          )
-          .optional(),
-      })
-    )
-    .min(1),
-});
-export type GithubSeedState = z.infer<typeof githubSeedStateSchema>;
+// This arm was hand-written, and nothing compared it to
+// `packages/twin-github/src/seed.ts`. Measured 2026-08-29 against a maximal
+// github seed, the copy silently dropped EIGHT fields the twin models:
+//
+//     repositories[].private, .milestones, .tags, .releases
+//     issues[].assignees        (replaced by a fabricated `assignee: null`)
+//     issues[].comments
+//     pull_requests[].comments, .review_comments
+//
+// The visible cost is not a type error. `GithubSeedState` is `z.infer` of this
+// schema, so the TYPE said a seeded milestone did not exist — and its own header
+// claimed to be "matching the canonical twin-github seed shape" while four of
+// those five entities had landed in the twin since it was written. Nothing in
+// this repo `.parse()`s it (the create-session boundary is a permissive
+// `z.record` on purpose, F-580), which is why the drift was invisible: a
+// declaration no test runs is a claim nothing checks.
+//
+// So it is the twin's object, re-exported under this module's name —
+// `cli/src/task/taskSchema.ts` has done exactly this since it was written, and
+// two schemas that are the SAME schema cannot drift. The seed shape is the
+// twin's to own (ADR-015): this file declares the /v1 surface, and for a seed
+// the /v1 surface IS whatever the twin boots.
+//
+// `@pome-sh/twin-github/seed` is a zod-only leaf — it imports nothing but `zod`
+// and its own types — so naming it here costs the CLI startup graph nothing.
+// `taskSchema.ts` and `parseTask.ts` already reach it the same way.
+export { seedSchema as githubSeedStateSchema } from "@pome-sh/twin-github/seed";
+export type { ParsedGitHubStateSeed as GithubSeedState } from "@pome-sh/twin-github/seed";
 
 export const stripeSeedStateSchema = z.object({
   api_keys: z
@@ -535,7 +462,7 @@ export type LinearSeedState = z.infer<typeof linearSeedStateSchema>;
 
 export const providerScopedSeedStateSchema = z
   .object({
-    github: z.object({ seed: githubSeedStateSchema }).optional(),
+    github: z.object({ seed: githubSeedSchema }).optional(),
     stripe: z.object({ seed: stripeSeedStateSchema }).optional(),
     slack: z.object({ seed: slackSeedStateSchema }).optional(),
     gmail: z.object({ seed: gmailSeedStateSchema }).optional(),
@@ -551,5 +478,5 @@ export const providerScopedSeedStateSchema = z
 
 // SeedState accepts the legacy GitHub shape and the provider-scoped shape
 // used by GitHub + Stripe scenario templates.
-export const seedStateSchema = z.union([githubSeedStateSchema, providerScopedSeedStateSchema]);
+export const seedStateSchema = z.union([githubSeedSchema, providerScopedSeedStateSchema]);
 export type SeedState = z.infer<typeof seedStateSchema>;

--- a/cli/test/unit/wire/seed-state-is-the-twins.test.ts
+++ b/cli/test/unit/wire/seed-state-is-the-twins.test.ts
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// `cli/src/contract/seed-state.ts` declares the `/v1` seed surface, and its
+// github arm was a HAND-WRITTEN copy of a shape the twin owns. Nothing compared
+// the two. Measured 2026-08-29 against a maximal github seed, the copy silently
+// dropped eight fields the twin models:
+//
+//     repositories[].private, .milestones, .tags, .releases
+//     issues[].assignees        (replaced by a fabricated `assignee: null`)
+//     issues[].comments
+//     pull_requests[].comments, .review_comments
+//
+// It misled every reader and type-checker that trusted it — `GithubSeedState`
+// is `z.infer` of this schema, so the TYPE said a seeded milestone did not
+// exist. Nothing in this repo `.parse()`s it (the create-session boundary is a
+// permissive `z.record` by design, F-580), which is exactly why the drift was
+// invisible: a declaration that no test runs is a claim nothing checks.
+//
+// The fix is the one `cli/src/task/taskSchema.ts` already made — import the
+// twin's own `seedSchema`. This file pins that by IDENTITY rather than by
+// comparison: two objects that are the same object cannot drift, and a future
+// hand-written re-fork fails here instead of in review.
+
+import { describe, expect, it } from "vitest";
+import { seedSchema as twinGithubSeedSchema } from "@pome-sh/twin-github/seed";
+import {
+  githubSeedStateSchema,
+  providerScopedSeedStateSchema,
+  seedStateSchema,
+} from "../../../src/contract/seed-state.js";
+import { seedStateSchema as taskSeedStateSchema } from "../../../src/task/taskSchema.js";
+
+/** Every leaf-bearing field the deleted copy failed to model, with a value that
+ *  is not the default, so a schema that dropped one shows it. */
+const MAXIMAL_GITHUB_SEED = {
+  users: [{ login: "vakoi", type: "Organization", name: "Vakoi Systems" }],
+  repositories: [
+    {
+      owner: "vakoi",
+      name: "billing",
+      description: "Invoice and dunning service",
+      private: true,
+      default_branch: "trunk",
+      collaborators: ["alice"],
+      labels: [{ name: "bug", color: "d73a4a", description: "Something is not working" }],
+      files: [{ path: "README.md", content: "# Billing\n", branch: "trunk" }],
+      milestones: [{ number: 4, title: "v2.1", description: "d", state: "open", due_on: "2026-09-30T00:00:00Z" }],
+      tags: [{ name: "v2.0.0", target: "trunk" }],
+      releases: [{ tag_name: "v2.0.0", name: "Billing 2.0", body: "b", author: "alice" }],
+      issues: [
+        {
+          number: 3,
+          title: "Dunning retries fire twice on a 429",
+          body: "Reproduced on staging.",
+          state: "closed",
+          labels: ["bug"],
+          assignees: ["alice"],
+          comments: [{ body: "Only under the read replica.", author: "bob" }],
+        },
+      ],
+      pull_requests: [
+        {
+          number: 9,
+          title: "Cap the dunning retry window",
+          body: "Closes #3.",
+          head: "retry-window",
+          base: "trunk",
+          state: "closed",
+          author: "alice",
+          reviews: [{ author: "bob", state: "CHANGES_REQUESTED", body: "One blocker." }],
+          statuses: [{ context: "ci/dunning", state: "failure", description: "2 of 41 failing" }],
+          comments: [{ body: "Rebased on trunk.", author: "alice" }],
+          review_comments: [
+            { body: "Drop the sleep.", path: "README.md", line: 1, side: "RIGHT", author: "bob" },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+describe("the /v1 seed declaration is the twin's schema, not a copy of it", () => {
+  it("`githubSeedStateSchema` IS `@pome-sh/twin-github`'s `seedSchema`", () => {
+    expect(githubSeedStateSchema).toBe(twinGithubSeedSchema);
+  });
+
+  it("and so is the task parser's github arm — one object, three import sites", () => {
+    expect(githubSeedStateSchema).toBe(twinGithubSeedSchema);
+    // `taskSeedStateSchema` unions the five arms; the github one is the same
+    // object, which is what makes "three copies" one.
+    const options = (taskSeedStateSchema as unknown as { _zod: { def: { options: unknown[] } } })._zod
+      .def.options;
+    expect(options).toContain(twinGithubSeedSchema);
+  });
+});
+
+describe("the eight fields the copy dropped now survive the declaration", () => {
+  const parsed = githubSeedStateSchema.parse(MAXIMAL_GITHUB_SEED) as unknown as {
+    repositories: Array<Record<string, unknown>>;
+  };
+  const repo = parsed.repositories[0]!;
+
+  it.each(["private", "milestones", "tags", "releases"])("repositories[].%s", (field) => {
+    expect(Object.keys(repo)).toContain(field);
+  });
+
+  it("issues[].assignees, not a fabricated singular `assignee`", () => {
+    const issue = (repo.issues as Array<Record<string, unknown>>)[0]!;
+    expect(issue.assignees).toEqual(["alice"]);
+    expect(Object.keys(issue)).not.toContain("assignee");
+  });
+
+  it("issues[].comments", () => {
+    const issue = (repo.issues as Array<Record<string, unknown>>)[0]!;
+    expect(issue.comments).toEqual([{ body: "Only under the read replica.", author: "bob" }]);
+  });
+
+  it("pull_requests[].comments and .review_comments", () => {
+    const pull = (repo.pull_requests as Array<Record<string, unknown>>)[0]!;
+    expect(pull.comments).toEqual([{ body: "Rebased on trunk.", author: "alice" }]);
+    expect((pull.review_comments as unknown[]).length).toBe(1);
+  });
+});
+
+// The declaration is a union and a wrapper, and both still work — a github seed
+// must not start matching some other twin's arm because the shape widened.
+describe("the shapes around it still resolve to github", () => {
+  it("the provider-scoped wrapper takes `{github: {seed}}`", () => {
+    const parsed = providerScopedSeedStateSchema.parse({
+      github: { seed: MAXIMAL_GITHUB_SEED },
+    }) as { github?: { seed: { repositories: unknown[] } } };
+    expect(parsed.github?.seed.repositories).toHaveLength(1);
+  });
+
+  it("the legacy-or-scoped union still takes a flat github seed", () => {
+    const parsed = seedStateSchema.parse(MAXIMAL_GITHUB_SEED) as { repositories: unknown[] };
+    expect(parsed.repositories).toHaveLength(1);
+  });
+
+  it("and still refuses a seed naming no twin at all", () => {
+    expect(seedStateSchema.safeParse({ notion: { pages: [] } }).success).toBe(false);
+  });
+});

--- a/packages/checks/test/_seedLeaves.ts
+++ b/packages/checks/test/_seedLeaves.ts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// `(schema, fixture)` — the two halves of "a seed field survives its schema".
+//
+//   leavesOf(fixture)        every scalar leaf the author WROTE, by path
+//   leafFieldsOf(schema)     every leaf-bearing field the schema DECLARES, by
+//                            generic path (array indices collapsed to `[]`)
+//
+// A guard built from these asserts two things that a `toEqual` cannot:
+//
+//   PRESERVATION  every leaf in the fixture is present and JSON-equal after
+//                 `.parse()`. Not deep-equal, because zod ADDS defaulted keys
+//                 and LEAVES absent optionals absent, so a deep-equal comparison
+//                 false-fails on a schema that is behaving correctly.
+//
+//   COVERAGE      every leaf-bearing field the schema declares has a fixture
+//                 leaf under it. Without this the preservation assert is
+//                 vacuous in exactly the direction that matters: a fixture
+//                 missing a field cannot notice the field being dropped, and a
+//                 NEW schema field could land uncovered forever.
+//
+// The pair is what makes "no hand-written copy of a seed shape is compared to
+// nothing" (F-581) a property rather than a review habit, and F-584 reuses it
+// for stripe and slack.
+
+import type { $ZodType } from "zod/v4/core";
+
+type Def = { type?: string; [k: string]: unknown };
+
+/** Unwrap `.optional()` / `.default()` / `.nullable()` / `.prefault()` / pipes
+ *  down to the node that carries a shape. */
+function unwrap(schema: unknown): Def | undefined {
+  let node = schema as { _zod?: { def?: Record<string, unknown> } } | undefined;
+  for (let depth = 0; depth < 50; depth++) {
+    const def = node?._zod?.def;
+    if (!def) return undefined;
+    if (def.innerType) {
+      node = def.innerType as typeof node;
+      continue;
+    }
+    if (def.type === "pipe" && def.out) {
+      node = def.out as typeof node;
+      continue;
+    }
+    return def as Def;
+  }
+  return undefined;
+}
+
+/** A path segment list rendered the way both halves render it. */
+const render = (path: string[]) => path.join(".");
+
+/** Array indices collapsed, so a fixture path and a schema path compare. */
+export const generic = (path: string) => path.replace(/\[\d+\]/g, "[]");
+
+/**
+ * Every scalar leaf in a value, by path. `null` counts — it is a value an
+ * author can write and a schema can lose. An EMPTY array or object is a leaf
+ * too, so that "the author wrote `[]` and got `[]`" is asserted rather than
+ * skipped; it just never satisfies coverage, which is why the fixtures are
+ * required to be non-empty.
+ */
+export function leavesOf(value: unknown, path: string[] = []): Array<{ path: string; value: unknown }> {
+  if (Array.isArray(value)) {
+    if (value.length === 0) return [{ path: render(path), value }];
+    return value.flatMap((item, i) => leavesOf(item, [...path, `[${i}]`]));
+  }
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length === 0) return [{ path: render(path), value }];
+    return entries.flatMap(([key, child]) => leavesOf(child, [...path, key]));
+  }
+  return [{ path: render(path), value }];
+}
+
+/** Resolve a `leavesOf` path against a parsed value. `undefined` means the
+ *  field did not survive — dropped, renamed, or moved. */
+export function at(value: unknown, path: string): unknown {
+  if (path === "") return value;
+  let cursor: unknown = value;
+  for (const segment of path.split(".")) {
+    if (cursor === null || cursor === undefined) return undefined;
+    const index = segment.match(/^\[(\d+)\]$/);
+    cursor = index
+      ? (cursor as unknown[])[Number(index[1])]
+      : (cursor as Record<string, unknown>)[segment];
+  }
+  return cursor;
+}
+
+const SCALAR_TYPES = new Set([
+  "string",
+  "number",
+  "bigint",
+  "boolean",
+  "date",
+  "enum",
+  "literal",
+  "unknown",
+  "any",
+  "null",
+  "undefined",
+  "void",
+  "never",
+  "nan",
+  "symbol",
+  "file",
+  "record",
+  "map",
+  "set",
+  "tuple",
+]);
+
+/**
+ * Every leaf-bearing field a schema declares, by generic path.
+ *
+ * A field is leaf-bearing when it bottoms out in a value an author writes: a
+ * scalar, an array of scalars, or a record/tuple whose interior this walk does
+ * not model. Objects and arrays-of-objects are recursed into instead, so the
+ * result names the fields a fixture has to carry — never the containers.
+ */
+export function leafFieldsOf(schema: $ZodType, path: string[] = [], seen = new Set<unknown>()): string[] {
+  const def = unwrap(schema);
+  if (!def) return [];
+  if (def.type === "object") {
+    // A recursive schema would spin here; a repeated shape is already covered.
+    if (seen.has(def)) return [];
+    seen.add(def);
+    return Object.entries(def.shape as Record<string, unknown>).flatMap(([key, child]) =>
+      leafFieldsOf(child as $ZodType, [...path, key], seen),
+    );
+  }
+  if (def.type === "array") return leafFieldsOf(def.element as $ZodType, [...path, "[]"], seen);
+  if (def.type === "union") {
+    const options = def.options as $ZodType[];
+    // A union with a scalar arm is a field an author writes directly; only a
+    // union of pure objects is worth recursing into.
+    if (options.some((option) => SCALAR_TYPES.has(unwrap(option)?.type ?? ""))) {
+      return [render(path)];
+    }
+    return options.flatMap((option) => leafFieldsOf(option, path, seen));
+  }
+  if (SCALAR_TYPES.has(def.type ?? "")) return [render(path)];
+  return [];
+}
+
+/** The generic paths a fixture actually reaches with a NON-empty value.
+ *  Empty arrays/objects are excluded on purpose: `labels: []` covers nothing. */
+export function coveredBy(fixture: unknown): Set<string> {
+  const covered = new Set<string>();
+  for (const leaf of leavesOf(fixture)) {
+    const isEmptyContainer =
+      (Array.isArray(leaf.value) && leaf.value.length === 0) ||
+      (leaf.value !== null && typeof leaf.value === "object" && Object.keys(leaf.value).length === 0);
+    if (isEmptyContainer) continue;
+    covered.add(generic(leaf.path));
+  }
+  return covered;
+}
+
+/** Is this declared field reached by the fixture? A `z.record` / `z.unknown()`
+ *  field is a schema leaf whose fixture value has leaves BELOW it
+ *  (`metadata.order_id` under the declared `metadata`), so a prefix match is the
+ *  honest test — an exact one would report every open-shaped field uncovered. */
+export function covers(covered: Set<string>, field: string): boolean {
+  if (covered.has(field)) return true;
+  const prefix = `${field}.`;
+  for (const path of covered) if (path.startsWith(prefix)) return true;
+  return false;
+}

--- a/packages/checks/test/fixtures/seed-maximal.github.json
+++ b/packages/checks/test/fixtures/seed-maximal.github.json
@@ -1,0 +1,84 @@
+{
+  "users": [
+    { "login": "vakoi", "type": "Organization", "name": "Vakoi Systems" },
+    { "login": "alice", "type": "User", "name": "Alice Ferrer" },
+    { "login": "bob", "type": "User", "name": "Bob Ochieng" }
+  ],
+  "repositories": [
+    {
+      "owner": "vakoi",
+      "name": "billing",
+      "description": "Invoice and dunning service",
+      "private": true,
+      "default_branch": "trunk",
+      "collaborators": ["alice", "bob"],
+      "labels": [
+        { "name": "bug", "color": "d73a4a", "description": "Something is not working" }
+      ],
+      "files": [
+        { "path": "README.md", "content": "# Billing\n", "branch": "trunk" },
+        { "path": "src/dunning.ts", "content": "export const retries = 3;\n", "branch": "retry-window" },
+        { "path": "src/renamed.ts", "branch": "retry-window", "renamed_from": "src/dunning.ts" }
+      ],
+      "milestones": [
+        {
+          "number": 4,
+          "title": "v2.1 — dunning hardening",
+          "description": "Everything blocking the next tag.",
+          "state": "open",
+          "due_on": "2026-09-30T00:00:00Z"
+        }
+      ],
+      "tags": [{ "name": "v2.0.0", "target": "trunk" }],
+      "releases": [
+        {
+          "tag_name": "v2.0.0",
+          "name": "Billing 2.0",
+          "body": "First cut of the dunning path.",
+          "target_commitish": "trunk",
+          "draft": true,
+          "prerelease": true,
+          "author": "alice"
+        }
+      ],
+      "issues": [
+        {
+          "number": 3,
+          "title": "Dunning retries fire twice on a 429",
+          "body": "Reproduced on staging at 14:07.",
+          "state": "closed",
+          "labels": ["bug"],
+          "assignees": ["alice"],
+          "comments": [{ "body": "Only reproduces under the read replica.", "author": "bob" }]
+        }
+      ],
+      "pull_requests": [
+        {
+          "number": 9,
+          "title": "Cap the dunning retry window",
+          "body": "Closes #3.",
+          "head": "retry-window",
+          "base": "trunk",
+          "state": "closed",
+          "author": "alice",
+          "reviews": [
+            { "author": "bob", "state": "CHANGES_REQUESTED", "body": "One blocker before this lands." }
+          ],
+          "statuses": [
+            { "context": "ci/dunning", "state": "failure", "description": "2 of 41 failing" }
+          ],
+          "comments": [{ "body": "Rebased on trunk.", "author": "alice" }],
+          "review_comments": [
+            {
+              "body": "Drop the sleep, it hides the race.",
+              "path": "src/dunning.ts",
+              "line": 1,
+              "side": "RIGHT",
+              "author": "bob"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/checks/test/seed-leaf-preservation.test.ts
+++ b/packages/checks/test/seed-leaf-preservation.test.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// A seed field a human writes comes back unchanged, or the parse says so.
+//
+// This is the milestone property stated as a test, and it is the guard F-581
+// asks for. Two halves, and NEITHER is sufficient alone:
+//
+//   PRESERVATION  every scalar leaf in a maximal fixture is present and
+//                 JSON-equal after `.parse()`. Not `toEqual`: zod ADDS defaulted
+//                 keys and LEAVES absent optionals absent, so a deep comparison
+//                 false-fails against a schema that is behaving.
+//
+//   COVERAGE      every leaf-bearing field the schema declares is reached by the
+//                 fixture. Without it the first half is vacuous in exactly the
+//                 direction that matters — a fixture missing a field cannot
+//                 notice the field being dropped, and a NEW seed field could
+//                 land uncovered forever. This is the half that reds when
+//                 someone widens a twin's seed schema and writes no fixture.
+//
+// ⚠️ WHY THIS EXISTS AT ALL. `cli/src/contract/seed-state.ts` hand-wrote the
+// github seed shape and nothing compared it to the twin's. Measured 2026-08-29
+// against the fixture below, it silently dropped EIGHT fields the twin models:
+//
+//     repositories[].private, .milestones, .tags, .releases
+//     issues[].assignees        (replaced by a fabricated `assignee: null`)
+//     issues[].comments
+//     pull_requests[].comments, .review_comments
+//
+// That copy is gone — it imports the twin's `seedSchema` now, the way
+// `cli/src/task/taskSchema.ts` already did — so the drift cannot recur by
+// construction. What CAN still recur is a schema that loses a field on its own,
+// or a fixture that stops being maximal, and that is what this file holds.
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import type { $ZodType } from "zod/v4/core";
+
+import * as github from "../src/github.js";
+import { at, coveredBy, covers, generic, leafFieldsOf, leavesOf } from "./_seedLeaves.js";
+
+const fixture = (name: string): unknown =>
+  JSON.parse(readFileSync(new URL(`./fixtures/seed-maximal.${name}.json`, import.meta.url), "utf8"));
+
+/** One row per twin. F-584 adds stripe and slack here; the helper takes
+ *  `(schema, fixture)` for exactly that reason. */
+const TWINS = [
+  {
+    twin: "github",
+    schema: github.seedSchema as unknown as $ZodType,
+    parseSeed: github.parseSeed as (input: unknown) => unknown,
+    fixture: fixture("github"),
+  },
+] as const;
+
+describe("a maximal seed survives its twin's own schema, leaf by leaf", () => {
+  it.each(TWINS)("$twin", ({ parseSeed, fixture: input }) => {
+    const parsed = parseSeed(input);
+    const leaves = leavesOf(input);
+    // A walk that found nothing would pass every assertion below.
+    expect(leaves.length).toBeGreaterThan(40);
+
+    const altered: Array<{ path: string; wrote: unknown; got: unknown }> = [];
+    for (const leaf of leaves) {
+      const got = at(parsed, leaf.path);
+      if (JSON.stringify(got) !== JSON.stringify(leaf.value)) {
+        altered.push({ path: leaf.path, wrote: leaf.value, got });
+      }
+    }
+    expect(altered).toEqual([]);
+  });
+});
+
+describe("the fixture reaches every field the schema declares", () => {
+  it.each(TWINS)("$twin", ({ schema, fixture: input }) => {
+    const declared = leafFieldsOf(schema);
+    expect(declared.length).toBeGreaterThan(20);
+
+    const covered = coveredBy(input);
+    const uncovered = declared.filter((field) => !covers(covered, field));
+    expect(uncovered).toEqual([]);
+  });
+
+  // The inverse direction. A fixture path the schema does not declare would be
+  // refused outright now that the seed schemas are strict (F-1689), so this is
+  // belt and braces — but it also catches a path the walk MISREADS, which
+  // strictness cannot.
+  it.each(TWINS)("$twin: and reaches nothing the schema does not", ({ schema, fixture: input }) => {
+    const declared = new Set(leafFieldsOf(schema));
+    const stray = [...coveredBy(input)].filter((path) => {
+      for (const field of declared) if (path === field || path.startsWith(`${field}.`)) return false;
+      return true;
+    });
+    expect(stray).toEqual([]);
+  });
+});
+
+// The contract copy is gone; this is what says so, by identity rather than by
+// comparison. `cli/src/contract/seed-state.ts` and `cli/src/task/taskSchema.ts`
+// both name the SAME object the twin exports, so there is no second shape left
+// to drift — and a future hand-written re-fork reds here, not in review.
+describe("nothing re-forks the github seed shape", () => {
+  it("`@pome-sh/checks` re-exports the twin's own object, not a copy of it", async () => {
+    const twin = await import("@pome-sh/twin-github/seed");
+    expect(github.seedSchema).toBe(twin.seedSchema);
+    expect(github.parseSeed).toBe(twin.parseSeed);
+  });
+
+  it("a maximal seed and its parse agree on the field set at every level", () => {
+    const parsed = github.parseSeed(fixture("github")) as {
+      repositories: Array<Record<string, unknown>>;
+    };
+    const repo = parsed.repositories[0]!;
+    // The eight fields the deleted copy dropped, asserted by name so the
+    // regression this closes is readable without running git.
+    for (const field of ["private", "milestones", "tags", "releases"]) {
+      expect(Object.keys(repo)).toContain(field);
+    }
+    const issue = (repo.issues as Array<Record<string, unknown>>)[0]!;
+    expect(Object.keys(issue)).toContain("assignees");
+    expect(Object.keys(issue)).toContain("comments");
+    expect(Object.keys(issue)).not.toContain("assignee");
+    const pull = (repo.pull_requests as Array<Record<string, unknown>>)[0]!;
+    expect(Object.keys(pull)).toContain("comments");
+    expect(Object.keys(pull)).toContain("review_comments");
+  });
+});
+
+// A path helper that silently returned `undefined` for everything would make
+// the preservation assert pass on any schema at all.
+describe("the walk itself", () => {
+  it("reports an altered leaf rather than skipping it", () => {
+    const wrote = { a: [{ b: "kept", c: "lost" }] };
+    const got = { a: [{ b: "kept" }] };
+    const altered = leavesOf(wrote).filter(
+      (leaf) => JSON.stringify(at(got, leaf.path)) !== JSON.stringify(leaf.value),
+    );
+    expect(altered.map((leaf) => leaf.path)).toEqual(["a.[0].c"]);
+  });
+
+  it("collapses array indices so a fixture path and a schema path compare", () => {
+    expect(generic("repositories.[0].issues.[2].labels.[0]")).toBe(
+      "repositories.[].issues.[].labels.[]",
+    );
+  });
+});


### PR DESCRIPTION
> Stacked on #508 (F-1689). Base is `ao/f-1689-strict-seed-schemas`; review that one first.

`cli/src/contract/seed-state.ts` hand-wrote the github seed shape and **nothing compared it to `packages/twin-github/src/seed.ts`**. Measured against a maximal github seed, the copy silently dropped eight fields the twin models:

```
repositories[].private, .milestones, .tags, .releases
issues[].assignees        (replaced by a fabricated `assignee: null`)
issues[].comments
pull_requests[].comments, .review_comments
```

Nothing in this repo `.parse()`s that declaration — the create-session boundary is a permissive `z.record` on purpose (F-580) — which is exactly why the drift was invisible. What it cost was every reader and type-checker that trusted it: `GithubSeedState` is `z.infer` of the schema, so **the TYPE said a seeded milestone did not exist**, while the schema's own header claimed to be "matching the canonical twin-github seed shape".

## Ticket premise, corrected

The ticket says three copies. There are **two**:

| copy | state |
|---|---|
| `packages/twin-github/src/seed.ts` | the truth |
| `packages/contract/src/seed-state.ts` | **does not exist** — that package is gone |
| `cli/src/task/taskSchema.ts` | already `import { seedSchema } from "@pome-sh/twin-github/seed"` |
| `cli/src/contract/seed-state.ts` | the one hand-written copy, fixed here |

So the ticket's *preferred* fix applies directly: `export { seedSchema as githubSeedStateSchema } from "@pome-sh/twin-github/seed"`. Two schemas that are the same object cannot drift. `twin-chunks` stays green — that subpath is a zod-only leaf `parseTask.ts` already reaches.

## The guard

A deleted copy does not stop a schema losing a field on its own, so the `(schema, fixture)` helper the ticket specifies is built too — `packages/checks/test/_seedLeaves.ts`, which **F-584 reuses for stripe and slack**. Two halves, neither sufficient alone:

- **Preservation** — every scalar leaf of a maximal fixture is present and `JSON.stringify`-equal after `.parse()`. Not deep-equal: zod *adds* defaulted keys and *leaves* absent optionals absent, so `toEqual` false-fails on a schema that is behaving.
- **Coverage** — every leaf-bearing field the schema *declares* is reached by the fixture. Without it the first half is vacuous in the direction that matters: a fixture missing a field cannot notice the field being dropped, and a new seed field could land uncovered forever.

The fixture (`packages/checks/test/fixtures/seed-maximal.github.json`) reaches all **58** declared leaf fields, each with non-default data.

### Narrowing the twin schema reds the guard — demonstrated

Temporary local edits to `packages/twin-github/src/seed.ts`, rebuilt each time:

| edit | result |
|---|---|
| drop `repositories[].private` | ✗ 3 failed — `Unrecognized key: "private"` |
| drop `issues[].comments` | ✗ 3 failed — `Unrecognized key: "comments"` |
| rename `assignees` → `assignee` | ✗ 4 failed — `Unrecognized key: "assignees"` + coverage |
| **add** `repositories[].archived`, no fixture leaf | ✗ 1 failed — `expected [ 'repositories.[].archived' ] to deeply equal []` |
| restored | ✓ 7 passed |

The last row is the coverage half doing its own job, and it is F-584's "Done when" clause working ahead of time.

## Where the guard runs

`packages/checks/test/` — the only package with all five twins in scope, and the SQLite-free door pome-cloud reaches `parseSeed` through. `ci.yml`'s heavy-suite filter matches `^packages/`, so any change to a twin's seed schema runs it. (The ticket's `cli-ci.yml` note is stale — that workflow no longer exists; `ci.yml` runs everything.)

`cli/test/unit/wire/seed-state-is-the-twins.test.ts` pins the fix by **identity** rather than by comparison, so a future hand-written re-fork fails there instead of in review.

## Trap honoured

No round-trip guard was added at the create-session boundary. Nothing narrows there: `cli/src/contract/rest.ts` makes `seed` a permissive `z.record` and pome-cloud's `parse-scenario-seed.ts` is `JSON.parse` plus an object check. There is nothing to catch.

## Left hand-written in that file

The stripe and slack arms (**F-584**, next in this stack), and gmail and linear — which neither ticket covers. Flagged in `cli/src/contract/CHANGELOG.md` rather than fixed here.

## Verification

Full suite (356 files / 3965 tests), `lint`, `lint:test`, `typecheck`, `lint:dead-code`, `test:contract`, `gate:examples`, `gate:golden`, `gate:route-inputs`, `gate:mcp-tools-list`, both tarball audits, `smoke:examples`, `probe:examples`, `probe:twins`, and both showcases' `verify.sh` — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
