### PR TITLE
A seeded pull request gets the number the seed asked for (F-1153)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -83,6 +83,12 @@ BESIDES the key sets (the legacy `{ <twin>: { seed } }` wrapper failing loudly,
 the union not greedily mis-matching, the empty-seed defaults) moves to
 `cli/test/unit/task-seed-is-the-twins.test.ts` intact.
 
+A seeded pull request's `number` is honoured (F-1153, in `@pome-sh/twin-github`).
+No bundled task's seed changes number — all of them already got the numbers they
+asked for by the ascending-order accident that is now a guarantee — but a task
+seed claiming one number for both an issue and a pull request is refused at parse
+now, naming both claimants.
+
 ## 0.35.3 — 2026-08-29
 
 **`pome docs getting-started` prints a live page again.** The docs site merged

--- a/packages/checks/CHANGELOG.md
+++ b/packages/checks/CHANGELOG.md
@@ -27,6 +27,12 @@ hand-copying the stripe seed shape.
 
 `slack` gains the `SlackStateSeed` type, matching the other four twins.
 
+`github.parseSeed` refuses a seed that claims one number for two entities in a
+repository (F-1153) — an issue and a pull request, two pull requests, or two
+issues. Issues and pull requests share one per-repo counter, so a number names
+one entity or the other. This is a NEW refusal on a seed that parsed clean
+before, and it is what makes the applier's renumber unambiguous.
+
 ## 0.3.10 — 2026-08-29
 
 **Comment only.** The `stripe.refund-count` / `stripe.refund-exists` source file

--- a/packages/sandbox-domains/CHANGELOG.md
+++ b/packages/sandbox-domains/CHANGELOG.md
@@ -15,6 +15,10 @@ and the write half lives in the twin's `apply-seed.ts`. **This package's exporte
 names, types and shapes are unchanged** — `applySeed` and `applyStripeSeed` both
 still export the same function. Only the specifier one line reads it from moves.
 
+A seeded pull request's `number` is honoured by `applySeed`'s github half
+(F-1153), and a seed claiming one number for two entities in a repository is
+refused at parse. See `@pome-sh/twin-github`'s changelog for the mechanism.
+
 ## 0.2.17 — 2026-08-29
 
 **Comment only.** A `//` comment in `twin-stripe`'s refund checks asserted that

--- a/packages/twin-github/CHANGELOG.md
+++ b/packages/twin-github/CHANGELOG.md
@@ -25,6 +25,44 @@ Failed` here — github was the twin that validated. The legacy singular
 `assignee` still normalises to `assignees[]`; it is migrated before the schema
 sees it.
 
+**A seeded pull request gets the number the seed asked for** (F-1153).
+`seedSchema` has accepted `number` on a pull request since the field existed and
+the applier kept whatever `nextNumber()` handed out: a repo seeded with issue
+`number: 1` and pull request `number: 7` exported issues `[1]` and pulls `[2]`.
+
+That is not a missing check. Criteria resolve a pull request BY number, so a
+criterion naming #7 either failed at lookup with `pull request #7 not found` —
+which reads like an agent defect — or resolved to whatever #7 happened to be and
+graded the wrong pull request confidently. `createIssue`'s renumber right beside
+it was already correct; this is that path, for pull requests.
+
+`renumberPullRequest` runs IMMEDIATELY after create, the position the issue
+renumber already sits in, so the only child that exists yet is
+`pull_request_files`. Reviews, statuses, conversation comments and review
+comments are seeded afterwards against the returned number, so no table is ever
+written to a number that then moves — the "a missed table is a silent orphan"
+hazard is removed rather than enumerated. `bumpEntityCounter` moves with it, so a
+pull request or issue created after a seeded #7 gets #8.
+
+⚠️ `PRAGMA foreign_keys` is the wrong lever for this and silently so: SQLite makes
+it a no-op inside a transaction, and `seed()` runs entirely inside one. The
+PR-child FKs declare `ON DELETE CASCADE` and not `ON UPDATE CASCADE` (unlike
+`issue_labels` / `issue_assignees`, which is why the issue path needs no such
+dance), so `defer_foreign_keys` is what holds enforcement to COMMIT — by which
+point parent and child agree.
+
+**A number claimed twice in one repository is refused at parse, naming both
+claimants by path.** Issues and pull requests share one per-repo counter, so
+within a repo a number names one entity or the other and there is no correct
+silent resolution: honour the first and the second entity is unreachable, honour
+the last and the first is. The refinement covers issue-vs-pull-request,
+pull-request-vs-pull-request and issue-vs-issue, since all three are the same
+shared counter. The same number in two different repositories is still fine.
+
+No bundled task, example or showcase seed changes number: all 22 seeded
+repositories with pull requests already got the numbers they asked for, by the
+ascending-order accident this replaces with a guarantee.
+
 ## 0.12.0 — 2026-08-14
 
 `TAPE_ASSERTABLE_TOOLS` gains `add_issue_comment` (F-1521) — the first name added

--- a/packages/twin-github/src/domain/github-domain.ts
+++ b/packages/twin-github/src/domain/github-domain.ts
@@ -179,7 +179,7 @@ export class GitHubDomain {
         }
         for (const pull of repoSeed.pull_requests ?? []) {
           const createdPr = this.createPullRequest({ owner: repo.owner, repo: repo.name, title: pull.title, body: pull.body ?? "", head: pull.head, base: pull.base ?? repo.default_branch, actor: pull.author });
-          const prNumber = (createdPr as { number: number }).number;
+          const prNumber = this.renumberPullRequest(repo.id, (createdPr as { number: number }).number, pull.number);
           // The PR row and its head branch don't change across seeded reviews /
           // statuses, so resolve the head SHA once rather than re-querying it on
           // every iteration (and in both blocks below).
@@ -1451,6 +1451,49 @@ export class GitHubDomain {
 
   bumpEntityCounter(repoId: number, number: number) {
     this.db.prepare("UPDATE repositories SET entity_counter = CASE WHEN entity_counter < ? THEN ? ELSE entity_counter END WHERE id = ?").run(number, number, repoId);
+  }
+
+  /**
+   * Move a just-created pull request onto the number its seed asked for, and
+   * return the number it ends up with (F-1153).
+   *
+   * `createPullRequest` takes `nextNumber()` and the seed's `number` was simply
+   * kept out of it: a repo seeded with issue #1 and pull request #7 exported
+   * issues `[1]` and pulls `[2]`. Criteria resolve a pull request BY number, so
+   * that is not a missing check — it is a check grading whichever pull request
+   * happens to occupy the number the criterion names.
+   *
+   * CALLED IMMEDIATELY AFTER CREATE, before any child is seeded, which is the
+   * same position `createIssue`'s renumber sits in. That ordering is what keeps
+   * the table list short and honest: at this moment the only child that exists is
+   * `pull_request_files`, written by `createPullRequest` itself. Reviews,
+   * statuses, conversation comments and review comments are all seeded AFTER,
+   * against the returned number, so they are never written to a number that then
+   * moves — the "missed table is a silent orphan" hazard is removed rather than
+   * enumerated.
+   *
+   * `defer_foreign_keys` is what makes the pair of updates possible at all. The
+   * PR-child FKs declare `ON DELETE CASCADE` and NOT `ON UPDATE CASCADE` — unlike
+   * `issue_labels` / `issue_assignees`, which is exactly why the issue path needs
+   * no such dance — so with immediate enforcement there is no order that works:
+   * updating the parent first strands `pull_request_files` on a key that no
+   * longer exists, and updating the child first points it at a parent that does
+   * not exist yet.
+   *
+   * `PRAGMA foreign_keys` is the WRONG lever here and silently so: SQLite makes
+   * it a no-op inside a transaction, and `seed()` runs entirely inside one, so
+   * toggling it changes nothing and the FK still fails. `defer_foreign_keys`
+   * IS settable inside a transaction, holds enforcement until COMMIT — by which
+   * point both rows agree — and resets itself when the transaction ends, so it
+   * cannot leak into the rest of the seed.
+   */
+  renumberPullRequest(repoId: number, from: number, requested: number | undefined): number {
+    if (!requested || requested === from) return from;
+    this.db.pragma("defer_foreign_keys = ON");
+    this.db.prepare("UPDATE pull_requests SET number = ? WHERE repo_id = ? AND number = ?").run(requested, repoId, from);
+    this.db.prepare("UPDATE pull_request_files SET pull_number = ? WHERE repo_id = ? AND pull_number = ?").run(requested, repoId, from);
+    this.bumpEntityCounter(repoId, requested);
+    return requested;
   }
 
 

--- a/packages/twin-github/src/seed.ts
+++ b/packages/twin-github/src/seed.ts
@@ -228,6 +228,39 @@ export const seedSchema = z.strictObject({
         )
         .default([])
     })
+      // Issues and pull requests share ONE per-repo counter — GitHub's own
+      // model, and this twin's (`repositories.entity_counter`). Within a repo a
+      // number therefore names an issue OR a pull request, never both, and there
+      // is no correct SILENT resolution for a seed that claims one twice: honour
+      // the first and the second entity is unreachable; honour the last and the
+      // first is. So it is refused here, where the author is still looking at
+      // their own file, with both claimants named by path (F-1153).
+      .superRefine((repo, ctx) => {
+        const claimed = new Map<number, string>();
+        const entries: Array<[string, ReadonlyArray<{ number?: number }>]> = [
+          ["issues", repo.issues ?? []],
+          ["pull_requests", repo.pull_requests ?? []]
+        ];
+        for (const [field, rows] of entries) {
+          for (const [index, row] of rows.entries()) {
+            if (row.number === undefined) continue;
+            const where = `${field}[${index}]`;
+            const first = claimed.get(row.number);
+            if (first === undefined) {
+              claimed.set(row.number, where);
+              continue;
+            }
+            ctx.addIssue({
+              code: "custom",
+              path: [field, index, "number"],
+              message:
+                `number ${row.number} is claimed by both ${first} and ${where} in ` +
+                `${repo.owner}/${repo.name}. Issues and pull requests share one ` +
+                `per-repo counter, so a number names one entity or the other.`
+            });
+          }
+        }
+      })
   )
 });
 

--- a/packages/twin-github/test/seed-pull-request-number.test.ts
+++ b/packages/twin-github/test/seed-pull-request-number.test.ts
@@ -1,0 +1,341 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// A seeded pull request gets the number the seed asked for.
+//
+// `seedSchema` has accepted `number` on a pull request since the field existed;
+// the applier called `createPullRequest` and kept whatever `nextNumber()` handed
+// out. Measured 2026-08-29: a repo seeded with issue `number: 1` and pull request
+// `number: 7` exported issues `[1]` and pulls `[2]`.
+//
+// The failure that produces is not a missing check. Criteria resolve a pull
+// request BY NUMBER, so a criterion naming #7 either fails at lookup with
+// `pull request #7 not found` — which reads like an agent defect — or, worse,
+// resolves to whatever #7 happens to be and grades the wrong pull request
+// confidently. Six `github.pr-comment-exists` criteria in `agent-examples/` ride
+// on the coincidence today: their seeds carry `issues: []` and list pull requests
+// in ascending order, so the shared `entity_counter` happens to hand out the
+// numbers they asked for.
+//
+// `createIssue` right next to it already did this correctly. This is that path,
+// for pull requests.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { openGitHubCloneDatabase } from "../src/db.js";
+import { GitHubDomain } from "../src/domain/index.js";
+import { parseSeed } from "../src/seed.js";
+import { createGitHubCloneApp } from "../src/twin.js";
+import type { GitHubStateSeed } from "../src/types.js";
+import { TEST_AUTH_SECRET, TEST_SID, signTestToken, withAuth } from "./_authHelper.js";
+
+const previousSecret = process.env.TWIN_AUTH_SECRET;
+let token: string;
+
+beforeAll(async () => {
+  process.env.TWIN_AUTH_SECRET = TEST_AUTH_SECRET;
+  token = await signTestToken();
+});
+afterAll(() => {
+  if (previousSecret === undefined) delete process.env.TWIN_AUTH_SECRET;
+  else process.env.TWIN_AUTH_SECRET = previousSecret;
+});
+
+const base = `/s/${TEST_SID}`;
+
+/** The ticket's `Do:` — one issue #1, one pull request #7, every child a
+ *  renumber could orphan. */
+const WORLD = {
+  users: [
+    { login: "vakoi", type: "Organization", name: "Vakoi" },
+    { login: "alice", type: "User", name: "Alice" },
+    { login: "bob", type: "User", name: "Bob" },
+  ],
+  repositories: [
+    {
+      owner: "vakoi",
+      name: "billing",
+      collaborators: ["alice", "bob"],
+      files: [
+        { path: "README.md", content: "# Billing\n" },
+        { path: "src/dunning.ts", content: "export const retries = 3;\n", branch: "retry-window" },
+      ],
+      issues: [{ number: 1, title: "Dunning retries fire twice", comments: [{ body: "on the issue", author: "alice" }] }],
+      pull_requests: [
+        {
+          number: 7,
+          title: "Cap the dunning retry window",
+          head: "retry-window",
+          author: "alice",
+          reviews: [{ author: "bob", state: "CHANGES_REQUESTED", body: "one blocker" }],
+          statuses: [{ context: "ci/dunning", state: "failure", description: "2 of 41 failing" }],
+          comments: [{ body: "on the pull request", author: "alice" }],
+          review_comments: [{ body: "drop the sleep", path: "src/dunning.ts", line: 1, author: "bob" }],
+        },
+      ],
+    },
+  ],
+};
+
+function seeded(seed: unknown = WORLD): GitHubDomain {
+  const domain = new GitHubDomain(openGitHubCloneDatabase(":memory:"));
+  domain.seed(parseSeed(seed) as GitHubStateSeed);
+  return domain;
+}
+
+async function get(app: ReturnType<typeof createGitHubCloneApp>, path: string) {
+  const response = await app.request(`${base}${path}`, withAuth(token));
+  return { status: response.status, body: (await response.json()) as any };
+}
+
+describe("the number the seed asked for is the number the world has", () => {
+  it("exportState: issues [1], pulls [7]", () => {
+    const state = seeded().exportState() as unknown as {
+      repositories: Array<{
+        issues: Array<{ number: number }>;
+        pull_requests: Array<{ number: number }>;
+      }>;
+    };
+    const repo = state.repositories[0]!;
+    expect(repo.issues.map((issue) => issue.number)).toEqual([1]);
+    expect(repo.pull_requests.map((pull) => pull.number)).toEqual([7]);
+  });
+
+  it("GET /repos/:o/:r/pulls/7 serves it; #2 is not found", async () => {
+    const app = createGitHubCloneApp({ seed: parseSeed(WORLD) as GitHubStateSeed });
+    const found = await get(app, "/repos/vakoi/billing/pulls/7");
+    expect(found.status).toBe(200);
+    expect(found.body.title).toBe("Cap the dunning retry window");
+    expect((await get(app, "/repos/vakoi/billing/pulls/2")).status).toBe(404);
+  });
+});
+
+// "A missed table is a silent orphan" — every child keyed to the pull request's
+// number, asked for at the number the seed named.
+describe("every child rides the renumber", () => {
+  let app: ReturnType<typeof createGitHubCloneApp>;
+  beforeAll(() => {
+    app = createGitHubCloneApp({ seed: parseSeed(WORLD) as GitHubStateSeed });
+  });
+
+  it("pull_request_files — GET /pulls/7/files", async () => {
+    const { status, body } = await get(app, "/repos/vakoi/billing/pulls/7/files");
+    expect(status).toBe(200);
+    expect((body as Array<{ filename: string }>).map((file) => file.filename)).toContain(
+      "src/dunning.ts",
+    );
+  });
+
+  it("pull_request_reviews — GET /pulls/7/reviews", async () => {
+    const { status, body } = await get(app, "/repos/vakoi/billing/pulls/7/reviews");
+    expect(status).toBe(200);
+    expect((body as Array<{ body: string; state: string }>)[0]).toMatchObject({
+      body: "one blocker",
+      state: "CHANGES_REQUESTED",
+    });
+  });
+
+  it("pull_request_review_comments — GET /pulls/7/comments", async () => {
+    const { status, body } = await get(app, "/repos/vakoi/billing/pulls/7/comments");
+    expect(status).toBe(200);
+    expect((body as Array<{ body: string }>).map((row) => row.body)).toEqual(["drop the sleep"]);
+  });
+
+  it("issue_comments — GET /issues/7/comments, the PR's own timeline", async () => {
+    const { status, body } = await get(app, "/repos/vakoi/billing/issues/7/comments");
+    expect(status).toBe(200);
+    expect((body as Array<{ body: string }>).map((row) => row.body)).toEqual([
+      "on the pull request",
+    ]);
+  });
+
+  it("commit_statuses — GET /pulls/7/status", async () => {
+    const { status, body } = await get(app, "/repos/vakoi/billing/pulls/7/status");
+    expect(status).toBe(200);
+    expect(body.state).toBe("failure");
+  });
+
+  it("the issue's own comments did not move with it", async () => {
+    const { body } = await get(app, "/repos/vakoi/billing/issues/1/comments");
+    expect((body as Array<{ body: string }>).map((row) => row.body)).toEqual(["on the issue"]);
+  });
+});
+
+// Issues and pull requests share ONE per-repo counter, so a later insert must
+// not land on a number the seed already claimed.
+describe("the counter moves with the renumber", () => {
+  it("a pull request created after a seeded #7 gets #8, not #3", () => {
+    const domain = seeded();
+    domain.createBranch({ owner: "vakoi", repo: "billing", branch: "hotfix", from_branch: "main" });
+    domain.createOrUpdateFile({
+      owner: "vakoi",
+      repo: "billing",
+      path: "src/hotfix.ts",
+      message: "hotfix",
+      content: "export const x = 1;\n",
+      branch: "hotfix",
+    });
+    const created = domain.createPullRequest({
+      owner: "vakoi",
+      repo: "billing",
+      title: "after",
+      head: "hotfix",
+      base: "main",
+    }) as { number: number };
+    expect(created.number).toBe(8);
+  });
+
+  it("an issue created after a seeded #7 gets #8 too — one counter, both kinds", () => {
+    const domain = seeded();
+    const created = domain.createIssue({
+      owner: "vakoi",
+      repo: "billing",
+      title: "after",
+    }) as { number: number };
+    expect(created.number).toBe(8);
+  });
+});
+
+// There is no correct silent resolution: within a repo a number names an issue
+// or a pull request, never both. So it is refused where the author can still see
+// their own file — at parse.
+describe("a number claimed twice is refused at parse, naming both entities", () => {
+  it("a pull request colliding with an issue", () => {
+    expect(() =>
+      parseSeed({
+        repositories: [
+          {
+            owner: "vakoi",
+            name: "billing",
+            issues: [{ number: 3, title: "issue three" }],
+            pull_requests: [{ number: 3, title: "pull three", head: "feature" }],
+          },
+        ],
+      }),
+    ).toThrow(/issues\[0\][\s\S]*pull_requests\[0\]|pull_requests\[0\][\s\S]*issues\[0\]/);
+  });
+
+  it("names the number itself, so the author can search for it", () => {
+    expect(() =>
+      parseSeed({
+        repositories: [
+          {
+            owner: "vakoi",
+            name: "billing",
+            issues: [{ number: 3, title: "issue three" }],
+            pull_requests: [{ number: 3, title: "pull three", head: "feature" }],
+          },
+        ],
+      }),
+    ).toThrow(/\b3\b/);
+  });
+
+  it("two pull requests claiming one number", () => {
+    expect(() =>
+      parseSeed({
+        repositories: [
+          {
+            owner: "vakoi",
+            name: "billing",
+            pull_requests: [
+              { number: 5, title: "a", head: "a" },
+              { number: 5, title: "b", head: "b" },
+            ],
+          },
+        ],
+      }),
+    ).toThrow(/pull_requests\[0\][\s\S]*pull_requests\[1\]/);
+  });
+
+  it("two issues claiming one number", () => {
+    expect(() =>
+      parseSeed({
+        repositories: [
+          {
+            owner: "vakoi",
+            name: "billing",
+            issues: [
+              { number: 5, title: "a" },
+              { number: 5, title: "b" },
+            ],
+          },
+        ],
+      }),
+    ).toThrow(/issues\[0\][\s\S]*issues\[1\]/);
+  });
+
+  it("but the same number in two DIFFERENT repositories is fine", () => {
+    expect(() =>
+      parseSeed({
+        repositories: [
+          { owner: "vakoi", name: "billing", issues: [{ number: 3, title: "a" }] },
+          { owner: "vakoi", name: "dunning", pull_requests: [{ number: 3, title: "b", head: "f" }] },
+        ],
+      }),
+    ).not.toThrow();
+  });
+
+  it("and a seed that numbers nothing is still fine", () => {
+    expect(() =>
+      parseSeed({
+        repositories: [
+          {
+            owner: "vakoi",
+            name: "billing",
+            issues: [{ title: "a" }, { title: "b" }],
+            pull_requests: [{ title: "c", head: "f" }],
+          },
+        ],
+      }),
+    ).not.toThrow();
+  });
+});
+
+// The four `pr-summary-*` seeds pass today only by coincidence — ascending order
+// and `issues: []`. The renumber must not move a number that was already right.
+describe("a seed the accident already served correctly is unchanged", () => {
+  it("ascending pull requests with no issues still get 1, 2", () => {
+    const state = seeded({
+      repositories: [
+        {
+          owner: "vakoi",
+          name: "billing",
+          files: [
+            { path: "README.md", content: "# Billing\n" },
+            { path: "a.ts", content: "export const a = 1;\n", branch: "a" },
+            { path: "b.ts", content: "export const b = 1;\n", branch: "b" },
+          ],
+          issues: [],
+          pull_requests: [
+            { number: 1, title: "first", head: "a" },
+            { number: 2, title: "second", head: "b" },
+          ],
+        },
+      ],
+    }).exportState() as unknown as {
+      repositories: Array<{ pull_requests: Array<{ number: number; title: string }> }>;
+    };
+    expect(state.repositories[0]!.pull_requests.map((pull) => [pull.number, pull.title])).toEqual([
+      [1, "first"],
+      [2, "second"],
+    ]);
+  });
+
+  it("a pull request with no `number` still takes the next one", () => {
+    const state = seeded({
+      repositories: [
+        {
+          owner: "vakoi",
+          name: "billing",
+          files: [
+            { path: "README.md", content: "# Billing\n" },
+            { path: "a.ts", content: "export const a = 1;\n", branch: "a" },
+          ],
+          issues: [{ number: 4, title: "four" }],
+          pull_requests: [{ title: "unnumbered", head: "a" }],
+        },
+      ],
+    }).exportState() as unknown as {
+      repositories: Array<{ pull_requests: Array<{ number: number }> }>;
+    };
+    expect(state.repositories[0]!.pull_requests.map((pull) => pull.number)).toEqual([5]);
+  });
+});


### PR DESCRIPTION
> Top of a 4-PR stack: #508 (F-1689) → #509 (F-581) → #511 (F-584) → this. Base is `ao/f-584-stripe-slack-seed-schemas`.

`seedSchema` has accepted `number` on a pull request since the field existed. The applier called `createPullRequest` and kept whatever `nextNumber()` handed out. Measured 2026-08-29:

```
seed:  issue number: 1,  pull_request number: 7
world: issues [1],       pulls [2]
```

**This is not a missing check.** Criteria resolve a pull request *by number*, so a criterion naming #7 either fails at lookup with `pull request #7 not found` — which reads like an agent defect — or resolves to whatever #7 happens to be and grades **the wrong pull request, confidently**. Six `github.pr-comment-exists` criteria in `agent-examples/` ride on the coincidence today, per the [CONTEXT] note on the ticket.

`createIssue` right beside it already did this correctly. This is that path, for pull requests.

## Renumber immediately after create, not at the end

The ticket asks for four child tables to be renumbered (`pull_request_files`, `pull_request_reviews`, `pull_request_review_comments`, `issue_comments`) and warns that a missed one is a silent orphan. Putting the renumber where the **issue** renumber already sits removes the hazard instead of enumerating it: at that moment the only child that exists is `pull_request_files`, written by `createPullRequest` itself. Reviews, statuses, conversation comments and review comments are all seeded *afterwards*, against the returned number, so no table is ever written to a number that then moves.

The test still asks all five children for their rows at the number the seed named — `GET /pulls/7/files`, `/pulls/7/reviews`, `/pulls/7/comments`, `/issues/7/comments` (the PR's own timeline, same table and same number space as an issue's) and `/pulls/7/status` — plus that the issue's own comments did **not** move with it.

### ⚠️ `PRAGMA foreign_keys` is the wrong lever here, and silently so

SQLite makes `PRAGMA foreign_keys` a **no-op inside a transaction**, and `seed()` runs entirely inside one — so toggling it changes nothing and the FK still fails. (I wrote it that way first; the tests said `FOREIGN KEY constraint failed`.)

The PR-child FKs declare `ON DELETE CASCADE` and **not** `ON UPDATE CASCADE` — unlike `issue_labels` / `issue_assignees`, which is exactly why the issue path needs no such dance. With immediate enforcement there is no order that works: updating the parent first strands `pull_request_files` on a key that no longer exists, and updating the child first points it at a parent that does not exist yet. `defer_foreign_keys` *is* settable inside a transaction, holds enforcement to COMMIT, and resets itself when the transaction ends.

`bumpEntityCounter` moves with the renumber, so a pull request **or an issue** created after a seeded #7 gets #8 — one counter, both kinds.

## A number claimed twice is refused at parse

Issues and pull requests share one per-repo counter, so within a repo a number names one entity or the other, and there is no correct silent resolution: honour the first and the second entity is unreachable; honour the last and the first is. Refused in `parseSeed`, naming both claimants by path and naming the number.

The ticket asks for issue-vs-pull-request. The refinement covers pull-request-vs-pull-request and issue-vs-issue too — same shared counter, same absence of a right answer. The same number in two *different* repositories is still fine, and a seed that numbers nothing is untouched.

## Blast radius — measured

Every `<task>.seed.json` in the repo booted through the domain, exported pull-request numbers compared to the seeded ones:

```
22 seeded repo(s) with pull requests; 0 whose numbers moved.
```

The four `pr-summary-*` seeds and the six criteria riding on them are unaffected: they asked for the numbers the ascending-order accident already gave them, and now get them by construction. `cli/tasks/08-prompt-injection-issue-body.seed.json` is the sharpest one — it names PR **#2** beside issue #1, and got #2 by luck.

Green locally: full suite (359 files / 4010 tests), `lint`, `lint:test`, `typecheck`, `lint:dead-code`, `test:contract`, `gate:examples`, `smoke:examples`, `probe:examples`, `probe:twins`, `gate:golden`, `gate:route-inputs`, `gate:mcp-tools-list`, both tarball audits, all three manifest gates, `fidelity:parity` across five twins, `validate:mcp`, twin-github's coverage thresholds, and both showcases' `verify.sh`.

**The ticket's third check has no runner here.** "Re-run the corpus scan, expect still `143 of 143`" — this repo has no such script, and by the ticket's own [CONTEXT] note it could not have caught this either way: *"it resolves phrases and boots no twin, so it would report clean either way."* The scan above is the check that actually binds, because it boots the twin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
