### PR TITLE
Machine-readable output is --json everywhere (F-1722)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,12 @@ it accepts, and `packages/twin-*/route-inputs.json` publishes that set.
 **Criterion markers are `[code]` and `[model]`.** The bracketed `D`/`P` forms
 are retired.
 
+**Machine-readable output is `--json`, boolean.** Never `--format <fmt>`: an
+enum grows a third member, and the third one is always a side effect wearing an
+output mode's clothes (`sandbox create --format env` only silenced the summary
+while `--secrets-file` did the writing). A command gains `--json` when something
+actually parses it, not on the chance that something might.
+
 **No bare `import.meta.main` in an entry guard.** It is `undefined` before Node
 24.2 and `engines` allows `>=24`, so the guard exits 0 having run nothing.
 Compare a realpath'd `process.argv[1]` against `import.meta.url` and throw on a

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,6 +9,17 @@ write a version number here or in `package.json`. Released entries are insertion
 only: a correction is the next entry, naming the one it corrects.
 
 
+## Unreleased (minor)
+
+**Machine-readable output is `--json` everywhere.** `pome sandbox create` and
+`pome sandbox list` take `--json` instead of `--format <fmt>`, matching `pome
+checks --json`. `--format env` is gone: it was never an output format, only a
+way to silence the summary while `--secrets-file` did the work. `--secrets-file`
+still writes the shell exports at mode 0600, and now always prints the
+connection summary on stderr — previously `--format env --secrets-file X` was
+silent.
+
+
 ## 0.36.1 — 2026-08-30
 
 **`pome init minimal-viktor` now copies a sixth test file.** The bundled

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -96,7 +96,6 @@ import { parseTaskFile } from "../task/parseTask.js";
 import type { RecorderEvent } from "../types/shared.js";
 
 const PACKAGE_VERSION = readPackageVersion();
-const SESSION_CREATE_FORMATS = new Set(["text", "json", "env"]);
 const DEFAULT_AGENT_FILE = "examples/agents/scripted-triage-agent.ts";
 // `node` (not `npx tsx`): Node ≥ 24 strips this file's type annotations
 // natively, so the scaffolded zero-install quickstart never has to resolve a
@@ -595,30 +594,20 @@ export function createProgram() {
       "--secrets-file <path>",
       "Write shell exports containing session secrets to a local file with mode 0600",
     )
-    .option(
-      "--format <fmt>",
-      "Output format: text, json, or env. env writes the exports to --secrets-file instead of printing them.",
-      "text",
-    )
+    .option("--json", "Print the sandbox as JSON instead of the human summary.", false)
     .action(
       async (opts: {
         twin?: string[];
         apiUrl: string;
         secretsFile?: string;
-        format: string;
+        json: boolean;
         seed?: string;
       }) => {
         try {
-          const format = opts.format.trim().toLowerCase();
-          if (!SESSION_CREATE_FORMATS.has(format)) {
-            console.error("Unknown session create format. Use one of: text, json, env.");
-            process.exitCode = 2;
-            return;
-          }
           await runSessionCreate({
             apiBaseUrl: opts.apiUrl,
             twins: opts.twin ?? [],
-            format: format as "text" | "json" | "env",
+            json: opts.json,
             secretsFile: opts.secretsFile,
             seedPath: opts.seed,
           });
@@ -643,9 +632,9 @@ export function createProgram() {
       "Filter by sandbox state: running, ready, done, expired, or all. `running` also matches the server-side `ready` state, the way the dashboard shows them in one column.",
       "running",
     )
-    .option("--format <fmt>", "Output format: text or json", "text")
+    .option("--json", "Print the sandboxes as JSON.", false)
     .action(
-      async (opts: { apiUrl: string; limit: string; state: string; format: string }) => {
+      async (opts: { apiUrl: string; limit: string; state: string; json: boolean }) => {
         const validStates: SessionListStateFilter[] = [
           "running",
           "ready",
@@ -665,7 +654,7 @@ export function createProgram() {
             apiBaseUrl: opts.apiUrl,
             limit: Number.parseInt(opts.limit, 10) || 20,
             state: opts.state as SessionListStateFilter,
-            format: opts.format as "text" | "json",
+            json: opts.json,
           });
         } catch (err) {
           console.error(friendlyHostedError(err));

--- a/cli/src/cli/session.ts
+++ b/cli/src/cli/session.ts
@@ -194,7 +194,7 @@ export async function runSessionCreate(opts: {
   /** One-or-more twins. Repeated `--twin` flags stand up a multi-twin session.
    *  May be empty when `seedPath` names exactly one twin. */
   twins: string[];
-  format: "text" | "json" | "env";
+  json: boolean;
   secretsFile?: string;
   /** `--seed <path>`: the sandbox starts from this seed instead of each twin's
    *  default. Same file `pome twin start --seed` takes. */
@@ -230,20 +230,9 @@ export async function runSessionCreate(opts: {
     console.error(`Wrote sandbox secrets to ${opts.secretsFile} (mode 0600).`);
   }
 
-  if (opts.format === "json") {
+  if (opts.json) {
     const payload = redactSession(session);
     console.log(JSON.stringify(payload, null, 2));
-    return;
-  }
-
-  if (opts.format === "env") {
-    if (opts.secretsFile) {
-      return;
-    }
-    console.error(
-      "Refusing to print environment exports. Use --secrets-file <path> to write them to a 0600 file.",
-    );
-    process.exitCode = 2;
     return;
   }
 
@@ -320,7 +309,7 @@ function matchesStateFilter(
 export async function runSessionList(opts: {
   apiBaseUrl: string;
   limit: number;
-  format: "text" | "json";
+  json: boolean;
   state: SessionListStateFilter;
 }): Promise<void> {
   const creds = await resolveCredentials({ apiBaseUrl: opts.apiBaseUrl });
@@ -335,7 +324,7 @@ export async function runSessionList(opts: {
   const all = await client.listSessions({ limit: fetchLimit });
   const filtered = all.filter((r) => matchesStateFilter(r.state, opts.state));
   const rows = filtered.slice(0, opts.limit);
-  if (opts.format === "json") {
+  if (opts.json) {
     console.log(JSON.stringify(rows, null, 2));
     return;
   }

--- a/cli/test/unit/sandbox-command.test.ts
+++ b/cli/test/unit/sandbox-command.test.ts
@@ -113,15 +113,14 @@ describe("`pome sandbox` is the only spelling", () => {
         "github",
         "--twin",
         "gmail",
-        "--format",
-        "json",
+        "--json",
         "--api-url",
         "https://api.example.test",
       ],
       expect: [
         expect.objectContaining({
           twins: ["github", "gmail"],
-          format: "json",
+          json: true,
           apiBaseUrl: "https://api.example.test",
         }),
       ],
@@ -129,8 +128,8 @@ describe("`pome sandbox` is the only spelling", () => {
     {
       name: "list",
       runner: "runSessionList",
-      argv: ["list", "--state", "all", "--limit", "5", "--format", "json"],
-      expect: [expect.objectContaining({ state: "all", limit: 5, format: "json" })],
+      argv: ["list", "--state", "all", "--limit", "5", "--json"],
+      expect: [expect.objectContaining({ state: "all", limit: 5, json: true })],
     },
     {
       name: "stop",

--- a/cli/test/unit/session-seed.test.ts
+++ b/cli/test/unit/session-seed.test.ts
@@ -91,7 +91,7 @@ describe("pome sandbox create --seed", () => {
     await runSessionCreate({
       apiBaseUrl: "https://api.example.com",
       twins: ["github"],
-      format: "text",
+      json: false,
     });
     expect(sentSeed()).toBeUndefined();
   });
@@ -100,7 +100,7 @@ describe("pome sandbox create --seed", () => {
     await runSessionCreate({
       apiBaseUrl: "https://api.example.com",
       twins: ["github"],
-      format: "text",
+      json: false,
       seedPath: await seedFile({ github: GITHUB_SEED }),
     });
     expect(sentTwins()).toEqual(["github"]);
@@ -114,7 +114,7 @@ describe("pome sandbox create --seed", () => {
     await runSessionCreate({
       apiBaseUrl: "https://api.example.com",
       twins: ["github"],
-      format: "text",
+      json: false,
       seedPath: await seedFile(GITHUB_SEED),
     });
     expect(sentSeed()).toMatchObject({ repositories: [expect.objectContaining({ name: "billing" })] });
@@ -124,7 +124,7 @@ describe("pome sandbox create --seed", () => {
     await runSessionCreate({
       apiBaseUrl: "https://api.example.com",
       twins: ["github", "slack"],
-      format: "text",
+      json: false,
       seedPath: await seedFile({ github: GITHUB_SEED, slack: SLACK_SEED }),
     });
     expect(sentTwins()).toEqual(["github", "slack"]);
@@ -137,7 +137,7 @@ describe("pome sandbox create --seed", () => {
     await runSessionCreate({
       apiBaseUrl: "https://api.example.com",
       twins: [],
-      format: "text",
+      json: false,
       seedPath: await seedFile({ linear: {} }),
     });
     expect(sentTwins()).toEqual(["linear"]);
@@ -148,7 +148,7 @@ describe("pome sandbox create --seed", () => {
       runSessionCreate({
         apiBaseUrl: "https://api.example.com",
         twins: ["github"],
-        format: "text",
+        json: false,
         seedPath: await seedFile({ github: GITHUB_SEED, slack: SLACK_SEED }),
       }),
     ).rejects.toThrow(/names slack, which this command was not asked for/);
@@ -160,7 +160,7 @@ describe("pome sandbox create --seed", () => {
       runSessionCreate({
         apiBaseUrl: "https://api.example.com",
         twins: ["github", "slack"],
-        format: "text",
+        json: false,
         seedPath: await seedFile(GITHUB_SEED),
       }),
     ).rejects.toThrow(/is a flat seed and this sandbox has 2 twins/);
@@ -172,7 +172,7 @@ describe("pome sandbox create --seed", () => {
       runSessionCreate({
         apiBaseUrl: "https://api.example.com",
         twins: [],
-        format: "text",
+        json: false,
         seedPath: await seedFile(GITHUB_SEED),
       }),
     ).rejects.toThrow(/No twin specified/);
@@ -186,7 +186,7 @@ describe("pome sandbox create --seed", () => {
       runSessionCreate({
         apiBaseUrl: "https://api.example.com",
         twins: ["github"],
-        format: "text",
+        json: false,
         seedPath: await seedFile({ github: { repositories: [{ owner: "acme" }] } }),
       }),
     ).rejects.toThrow(/is not a seed this twin can boot[\s\S]*name/);
@@ -197,7 +197,7 @@ describe("pome sandbox create --seed", () => {
     await runSessionCreate({
       apiBaseUrl: "https://api.example.com",
       twins: ["github"],
-      format: "text",
+      json: false,
       seedPath: await seedFile({ _meta: { source_hash: "sha256:abc" }, ...GITHUB_SEED }),
     });
     expect(sentSeed()).not.toHaveProperty("_meta");

--- a/cli/test/unit/session.test.ts
+++ b/cli/test/unit/session.test.ts
@@ -113,7 +113,7 @@ describe("runSessionCreate secret output", () => {
     await runSessionCreate({
       apiBaseUrl: "https://api.example.com",
       twins: ["github"],
-      format: "json",
+      json: true,
     });
 
     const output = stdout.join("\n");
@@ -131,7 +131,7 @@ describe("runSessionCreate secret output", () => {
       await runSessionCreate({
         apiBaseUrl: "https://api.example.com",
         twins: ["stripe"],
-        format: "env",
+        json: false,
         secretsFile,
       });
 
@@ -151,26 +151,12 @@ describe("runSessionCreate secret output", () => {
     }
   });
 
-  it("refuses env format without printing exports when no secrets file is provided", async () => {
-    await runSessionCreate({
-      apiBaseUrl: "https://api.example.com",
-      twins: ["github"],
-      format: "env",
-    });
-
-    const combinedOutput = [...stdout, ...stderr].join("\n");
-    expect(combinedOutput).toContain("Refusing to print environment exports");
-    expect(combinedOutput).not.toContain("agent_secret_token");
-    expect(combinedOutput).not.toContain("github_secret_token");
-    expect(process.exitCode).toBe(2);
-  });
-
   // ── Multi-twin (M3): slack allowed, repeated --twin, slack redaction, env ──
   it("allows the slack twin (MOUNTED_TWINS) and creates a session for it", async () => {
     await runSessionCreate({
       apiBaseUrl: "https://api.example.com",
       twins: ["slack"],
-      format: "json",
+      json: true,
     });
     expect(mocks.createSession).toHaveBeenCalledWith(
       expect.objectContaining({ twins: ["slack"] }),
@@ -181,7 +167,7 @@ describe("runSessionCreate secret output", () => {
     await runSessionCreate({
       apiBaseUrl: "https://api.example.com",
       twins: ["github", "slack"],
-      format: "json",
+      json: true,
     });
     expect(mocks.createSession).toHaveBeenCalledWith(
       expect.objectContaining({ twins: ["github", "slack"] }),
@@ -192,7 +178,7 @@ describe("runSessionCreate secret output", () => {
     await runSessionCreate({
       apiBaseUrl: "https://api.example.com",
       twins: ["github", "github"],
-      format: "json",
+      json: true,
     });
     expect(mocks.createSession).toHaveBeenCalledWith(
       expect.objectContaining({ twins: ["github"] }),
@@ -202,7 +188,7 @@ describe("runSessionCreate secret output", () => {
       runSessionCreate({
         apiBaseUrl: "https://api.example.com",
         twins: ["notion"],
-        format: "json",
+        json: true,
       }),
     ).rejects.toThrow(/Unknown twin "notion"/);
   });
@@ -211,7 +197,7 @@ describe("runSessionCreate secret output", () => {
     await runSessionCreate({
       apiBaseUrl: "https://api.example.com",
       twins: ["slack"],
-      format: "json",
+      json: true,
     });
     const output = stdout.join("\n");
     expect(output).toContain("***redacted***");
@@ -225,7 +211,7 @@ describe("runSessionCreate secret output", () => {
       await runSessionCreate({
         apiBaseUrl: "https://api.example.com",
         twins: ["github", "slack"],
-        format: "env",
+        json: false,
         secretsFile,
       });
       const contents = await readFile(secretsFile, "utf8");
@@ -255,7 +241,7 @@ describe("runSessionCreate secret output", () => {
       await runSessionCreate({
         apiBaseUrl: "https://api.example.com",
         twins: ["gmail"],
-        format: "env",
+        json: false,
         secretsFile,
       });
       const contents = await readFile(secretsFile, "utf8");


### PR DESCRIPTION
- Machine-readable output is now `--json` on every command that has it, and `--format` is gone.
- Deleted `--format env`, which was never an output format — it only silenced the summary while `--secrets-file` did the writing.
- `--secrets-file` still writes the shell exports at mode 0600, and now always prints the connection summary on stderr.
- No alias for `--format`: nothing depends on it, so there is no migration path to keep.
- Minor release — a documented flag is removed, so any script passing `--format` must switch.