### PR TITLE
throw errors for pome twin start on a busy port & twin status now checks liveness

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -25,6 +25,25 @@ twin's own inventory tiers otherwise. For a twin's real surface, read its
 generated reference page, or `curl <base>/healthz` on a running twin.
 
 
+## Unreleased (patch)
+
+**`pome twin start` fails on a taken port instead of printing a working-looking
+twin** (F-1716). The bind is asynchronous and had no `error` listener, so
+EADDRINUSE wrote the status file and printed the URLs, token and `Ctrl-C to
+stop.` before dying on a stack trace. The bind is awaited now, and a taken port
+is a named error.
+
+**`pome twin status` says whether the twin is actually running.** It used to
+`cat` the status file, so after Ctrl-C or a crash it printed a dead twin's URL
+and token as if they worked. It now probes `/healthz` and requires the response
+to name this twin — 3333/3336/3337 are ordinary dev-server ports, and the next
+thing you start on one is not your twin. An unreadable status file is one named
+error. The file's format is unchanged.
+
+**`pome twin start --help` names linear's port override**, which the `--port`
+text omitted; it is built from the registry now.
+
+
 ## 0.38.0 — 2026-08-30
 
 **`pome compile-seeds --hosted` is gone, along with `--api-url`.** It POSTed a

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -80,7 +80,12 @@ import {
   readManifest,
   writeManifest,
 } from "./project-config.js";
-import { createGitHubSmokeApp, TWIN_NAME_LIST } from "../twin/registry.js";
+import {
+  createGitHubSmokeApp,
+  TWIN_NAME_LIST,
+  TWIN_REGISTRY,
+  type TwinName,
+} from "../twin/registry.js";
 import {
   buildFixPrompt,
   buildGroupFixPrompt,
@@ -1351,7 +1356,13 @@ export function createProgram() {
     )
     .option(
       "--port <port>",
-      "Port to bind (default: $PORT, else GMAIL_TWIN_PORT/3336 for gmail, else 3333)",
+      // Built from the registry rather than restated: the per-twin overrides
+      // are the registry's to add, and this text went stale when linear's did.
+      `Port to bind (default: $PORT, else ${TWIN_NAME_LIST.filter(
+        (twin) => TWIN_REGISTRY[twin].portEnvName,
+      )
+        .map((twin) => `${TWIN_REGISTRY[twin].portEnvName}/${TWIN_REGISTRY[twin].defaultPort} for ${twin}`)
+        .join(", ")}, otherwise 3333)`,
     )
     .option(
       "--seed <path>",
@@ -1383,13 +1394,52 @@ export function createProgram() {
 
   twin
     .command("status")
-    .description("Print standalone twin status")
+    .summary("Print the local twin's status")
+    .description(
+      "Say whether the twin `pome twin start` last booted here is still running, and print its paste-able env lines",
+    )
     .action(async () => {
-      if (!existsSync(".pome/twin-status.json")) {
+      const statusPath = ".pome/twin-status.json";
+      if (!existsSync(statusPath)) {
         console.log("No standalone twin status found.");
         return;
       }
-      console.log(await import("node:fs/promises").then((fs) => fs.readFile(".pome/twin-status.json", "utf8")));
+      // `twin start` writes this file non-atomically, so a Ctrl-C or a full disk
+      // mid-write leaves it truncated. Validate every field this command prints
+      // BEFORE printing any of it — one named message, not `Invalid URL` or an
+      // `undefined twin —` line above a TypeError.
+      let status: { name: string; rest_url: string; mcp_url: string; auth_token: string };
+      let origin: string;
+      try {
+        status = JSON.parse(await readFile(statusPath, "utf8"));
+        if (typeof status.name !== "string" || status.name === "") throw new Error("no name");
+        origin = new URL(status.rest_url).origin;
+      } catch {
+        throw new Error(
+          `pome twin status: ${statusPath} is unreadable — start a twin with \`pome twin start <${TWIN_NAME_LIST.join("|")}>\`.`,
+        );
+      }
+      // Nothing deletes the status file, so it outlives Ctrl-C, a SIGKILL and a
+      // failed bind. A 200 alone does not mean the twin is back: 3333/3336/3337
+      // are ordinary dev-server ports, and any other server on one would pass.
+      // `/healthz` names the twin serving it, so that is the discriminator.
+      const running = await fetch(`${origin}/healthz`, {
+        signal: AbortSignal.timeout(1000),
+      }).then(
+        async (res) =>
+          res.ok &&
+          ((await res.json().catch(() => ({}))) as { twin?: string }).twin === status.name,
+        () => false,
+      );
+      console.log(
+        running
+          ? `${status.name} twin — running`
+          : `${status.name} twin — not running (stale ${statusPath})`,
+      );
+      const envName = TWIN_REGISTRY[status.name as TwinName]?.envName ?? status.name.toUpperCase();
+      console.log(`POME_${envName}_REST_URL=${status.rest_url}`);
+      console.log(`POME_${envName}_MCP_URL=${status.mcp_url}`);
+      console.log(`POME_AUTH_TOKEN=${status.auth_token}`);
     });
 
   program

--- a/cli/src/twin/twinStart.ts
+++ b/cli/src/twin/twinStart.ts
@@ -189,8 +189,8 @@ export async function runTwinStartCommand(
       ? undefined
       : readSeedFileText(options.seed, "pome twin start --seed");
   const name = resolveStandaloneTwin(nameArg, options.seed, seedText);
-  // `PORT` wins when set (contract suite / packaged entries). Gmail defaults
-  // to 3336 via GMAIL_TWIN_PORT; other twins keep 3333.
+  // `PORT` wins when set (contract suite / packaged entries); gmail and linear
+  // then honor their own override (`defaultPortFor`), other twins keep 3333.
   const portRaw = options.port ?? defaultPortFor(name, process.env);
   const port = Number(portRaw);
   // Port 0 (ephemeral) is rejected: every printed URL and the status-file
@@ -235,6 +235,29 @@ export async function runTwinStartCommand(
   const server = serve({ fetch: harness.app.fetch, port, hostname: "127.0.0.1" });
 
   try {
+    // `serve()` calls listen() and attaches no `error` listener, and listen is
+    // async: without this await, an EADDRINUSE lands as an uncaught `error`
+    // event AFTER the status file and the whole banner have been written, so
+    // the reader gets a stack trace under a token that never worked.
+    await new Promise<void>((resolve, reject) => {
+      const onError = (err: NodeJS.ErrnoException) => {
+        reject(
+          err.code === "EADDRINUSE"
+            ? new Error(
+                `pome twin start: port ${port} is already in use — pass --port <port>, or stop the twin using it.`,
+              )
+            : err,
+        );
+      };
+      server.once("error", onError);
+      server.once("listening", () => {
+        server.off("error", onError);
+        // With no `error` listener at all, a post-bind server error is a fatal
+        // uncaught exception with a stack trace. Log it and keep serving.
+        server.on("error", (err) => console.error(`pome twin start: server error: ${err}`));
+        resolve();
+      });
+    });
     await mkdir(".pome", { recursive: true });
     await writeFile(
       ".pome/twin-status.json",

--- a/cli/test/e2e/twinStart.test.ts
+++ b/cli/test/e2e/twinStart.test.ts
@@ -9,6 +9,7 @@
 
 import { spawn, type ChildProcess } from "node:child_process";
 import { once } from "node:events";
+import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
@@ -234,6 +235,41 @@ describe("pome twin start (e2e)", () => {
     },
     90_000,
   );
+});
+
+describe("pome twin start — port already in use (e2e)", () => {
+  it("fails before writing the status file or printing a banner", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "pome-twin-start-inuse-e2e-"));
+    // Hold the port for the whole run: @hono/node-server binds without an
+    // `error` listener, so the ordering under test is "did anything get
+    // written before the bind was known to have failed?"
+    const holder = createServer();
+    holder.listen(0, "127.0.0.1");
+    await once(holder, "listening");
+    const port = (holder.address() as { port: number }).port;
+    try {
+      child = spawn(TSX_BIN, [MAIN_TS, "twin", "start", "github", "--port", String(port)], {
+        cwd,
+        env: { ...process.env },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      let stdout = "";
+      let stderr = "";
+      child.stdout?.on("data", (chunk) => { stdout += chunk; });
+      child.stderr?.on("data", (chunk) => { stderr += chunk; });
+      const code = await new Promise<number | null>((resolve, reject) => {
+        child?.once("error", reject);
+        child?.once("exit", (exitCode) => resolve(exitCode));
+      });
+
+      expect(code).not.toBe(0);
+      expect(stderr).toContain(`port ${port} is already in use`);
+      expect(stdout + stderr).not.toContain("listening at");
+      expect(existsSync(join(cwd, ".pome", "twin-status.json"))).toBe(false);
+    } finally {
+      await new Promise((resolve) => holder.close(resolve));
+    }
+  }, 90_000);
 });
 
 describe("pome twin start — unknown-twin error (e2e)", () => {

--- a/cli/test/unit/help-defaults.test.ts
+++ b/cli/test/unit/help-defaults.test.ts
@@ -8,7 +8,7 @@
 // Cosmetic, and the kind of thing a reader screenshots.
 //
 // The assertion is tree-wide because the defect is a class, not one command's
-// typo. Prose like `twin start --port`'s "(default: $PORT, else 3333)" is fine,
+// typo. Prose like `twin start --port`'s "(default: $PORT, else …)" is fine,
 // since that option has no Commander default to duplicate.
 
 import type { Command } from "commander";


### PR DESCRIPTION
- On a port collision `pome twin start` used to print the full success banner — URLs and auth token — write its status file, and *then* die on a raw stack trace. It now fails before printing anything, with a named error naming the port.
- `pome twin status` printed a saved file verbatim, so it happily handed you a dead twin's URL and token. It now probes the twin and says whether it is actually running.
- The probe confirms the twin identifies itself, so an unrelated server on the same port reads as "not running" rather than a false green.
- An unreadable status file gives one named message instead of a bare parser error or half-printed output.
- `--port` help now names all five twins' defaults; stacked on the deletion PR.