### PR TITLE
fix inconsistent CLI flags 

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,6 +9,16 @@ write a version number here or in `package.json`. Released entries are insertion
 only: a correction is the next entry, naming the one it corrects.
 
 
+## Unreleased (minor)
+
+**`--api-url` and `--artifacts-dir` are program-level flags** (F-1723). Declared
+13 times across 10 commands, now once on the root. They still work where you
+already write them, and `pome <cmd> --help` lists them under `Global Options`.
+
+**`POME_API_BASE` is gone.** An undocumented `pome demo`-only override that
+outranked `POME_API_URL`. Set `POME_API_URL` instead.
+
+
 ## 0.39.1 — 2026-08-30
 
 **`pome twin start` fails on a taken port instead of printing a working-looking

--- a/cli/src/capture-server/egress.ts
+++ b/cli/src/capture-server/egress.ts
@@ -101,7 +101,7 @@ export function parseAllowCsv(csv: string | undefined): string[] {
 // about to inject (loopback in self-host; hosted twin domains future-proof).
 //
 // `extraHosts` is the demo-mode valve: `pome demo` adds the
-// POME_API_BASE host so the bundled agent's anonymous-gateway calls
+// control-plane host so the bundled agent's anonymous-gateway calls
 // (POST /v1/demo/sessions/:id/llm) survive the deny-by-default floor. Same
 // pattern rules as everything else (exact host or `*.suffix`).
 export function buildEgressAllowlist(

--- a/cli/src/cli/agent-resolver.ts
+++ b/cli/src/cli/agent-resolver.ts
@@ -95,7 +95,7 @@ function mapHttpError(status: number, json: unknown): Error {
   if (status === 404) {
     return new HostedOrchError(
       err?.message ??
-        "POST /v1/agents is not available at this API URL. Upgrade pome-cloud or check that --api-url/POME_API_URL points at a version that supports agent registration.",
+        "POST /v1/agents returned 404 — check that --api-url/POME_API_URL points at a Pome control plane.",
     );
   }
   return new HostedOrchError(err?.message ?? `POST /v1/agents → HTTP ${status}`);

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// file-size: the whole CLI command surface — 29 `.command()` registrations plus their
+// file-size: the whole CLI command surface — 28 `.command()` registrations plus their
 // options, in one file so `pome --help` and this module list the same commands in the
 // same order. Splitting per command moves a registration away from its siblings, which
 // is how two commands end up disagreeing about a shared flag's name or default.

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -145,8 +145,26 @@ function readPackageVersion(): string {
   return "0.0.0";
 }
 
+/** `--api-url` and `--artifacts-dir` are declared once, on the root, so every
+ *  command inherits one default. A subcommand's own `opts()` is empty for an
+ *  inherited option, so every action that reads them goes through here. */
+function globals(cmd: Command): { apiUrl: string; artifactsDir: string } {
+  return cmd.optsWithGlobals() as { apiUrl: string; artifactsDir: string };
+}
+
 export function createProgram() {
   const program = new Command();
+
+  // Precedence, stated once: `--api-url` is flag > POME_API_URL > built-in
+  // default; `--artifacts-dir` is flag > "runs", with no env input.
+  program
+    .configureHelp({ showGlobalOptions: true })
+    .option(
+      "--api-url <url>",
+      "Control-plane base URL.",
+      process.env.POME_API_URL ?? DEFAULT_CONTROL_PLANE_URL,
+    )
+    .option("--artifacts-dir <dir>", "Directory for run artifacts", "runs");
 
   program
     .name("pome")
@@ -338,11 +356,6 @@ export function createProgram() {
     .summary("Sign in and save an API key")
     .description("Sign in with Clerk and store a hosted team API key (macOS Keychain or ~/.pome/credentials.json)")
     .option(
-      "--api-url <url>",
-      "Control-plane base URL.",
-      process.env.POME_API_URL ?? DEFAULT_CONTROL_PLANE_URL,
-    )
-    .option(
       "--dashboard-url <url>",
       "App URL for Clerk sign-in (must serve /cli/login).",
       process.env.POME_DASHBOARD_URL ?? DEFAULT_DASHBOARD_URL,
@@ -353,8 +366,11 @@ export function createProgram() {
       "pome login",
     )
     .action(
-      async (options: { apiUrl: string; dashboardUrl: string; keyName: string }) => {
-        await loginWithClerk(options);
+      async (
+        options: { dashboardUrl: string; keyName: string },
+        cmd: Command,
+      ) => {
+        await loginWithClerk({ ...options, apiUrl: globals(cmd).apiUrl });
       },
     );
 
@@ -453,19 +469,14 @@ export function createProgram() {
       (value: string, previous: string[] = []) => [...previous, value],
       [],
     )
-    .option(
-      "--api-url <url>",
-      "Control-plane URL",
-      process.env.POME_API_URL ?? DEFAULT_CONTROL_PLANE_URL,
-    )
     .description(
       "Add one [code] criterion by picking a declared check — pome writes the English",
     )
-    .action(async (file: string, opts: { check?: string; arg: string[]; apiUrl: string }) => {
+    .action(async (file: string, opts: { check?: string; arg: string[] }, cmd: Command) => {
       await runChecksAddCommand(file, {
         check: opts.check,
         arg: opts.arg,
-        apiBaseUrl: opts.apiUrl,
+        apiBaseUrl: globals(cmd).apiUrl,
       });
     });
 
@@ -505,11 +516,6 @@ export function createProgram() {
     .command("agent")
     .argument("<name>", "Human-readable agent name (e.g. \"triage-bot\")")
     .option(
-      "--api-url <url>",
-      "Control-plane URL",
-      process.env.POME_API_URL ?? DEFAULT_CONTROL_PLANE_URL,
-    )
-    .option(
       "--force",
       "Re-resolve the agent even when .pome/link.json already links one",
       false,
@@ -522,10 +528,14 @@ export function createProgram() {
       "Create a cloud agent under the current team and write agent.slug to pome.json",
     )
     .action(
-      async (name: string, opts: { apiUrl: string; force: boolean; twins?: string }) => {
+      async (
+        name: string,
+        opts: { force: boolean; twins?: string },
+        cmd: Command,
+      ) => {
         try {
           await runRegisterAgent({
-            apiBaseUrl: opts.apiUrl,
+            apiBaseUrl: globals(cmd).apiUrl,
             dashboardBaseUrl:
               process.env.POME_DASHBOARD_URL ?? DEFAULT_DASHBOARD_URL,
             name,
@@ -577,26 +587,23 @@ export function createProgram() {
       "Start the sandbox from a JSON or YAML seed file instead of each twin's default. A seed REPLACES the default; it does not merge. Same file `pome twin start --seed` takes; write one with `pome twin seed <name>`.",
     )
     .option(
-      "--api-url <url>",
-      "Control-plane URL",
-      process.env.POME_API_URL ?? DEFAULT_CONTROL_PLANE_URL,
-    )
-    .option(
       "--secrets-file <path>",
       "Write shell exports containing session secrets to a local file with mode 0600",
     )
     .option("--json", "Print the sandbox as JSON instead of the human summary.", false)
     .action(
-      async (opts: {
-        twin?: string[];
-        apiUrl: string;
-        secretsFile?: string;
-        json: boolean;
-        seed?: string;
-      }) => {
+      async (
+        opts: {
+          twin?: string[];
+          secretsFile?: string;
+          json: boolean;
+          seed?: string;
+        },
+        cmd: Command,
+      ) => {
         try {
           await runSessionCreate({
-            apiBaseUrl: opts.apiUrl,
+            apiBaseUrl: globals(cmd).apiUrl,
             twins: opts.twin ?? [],
             json: opts.json,
             secretsFile: opts.secretsFile,
@@ -612,11 +619,6 @@ export function createProgram() {
   session
     .command("list")
     .description("List hosted sandboxes (defaults to --state running, like the dashboard)")
-    .option(
-      "--api-url <url>",
-      "Control-plane URL",
-      process.env.POME_API_URL ?? DEFAULT_CONTROL_PLANE_URL,
-    )
     .option("--limit <n>", "Max rows", "20")
     .option(
       "--state <state>",
@@ -625,7 +627,10 @@ export function createProgram() {
     )
     .option("--json", "Print the sandboxes as JSON.", false)
     .action(
-      async (opts: { apiUrl: string; limit: string; state: string; json: boolean }) => {
+      async (
+        opts: { limit: string; state: string; json: boolean },
+        cmd: Command,
+      ) => {
         const validStates: SessionListStateFilter[] = [
           "running",
           "ready",
@@ -642,7 +647,7 @@ export function createProgram() {
         }
         try {
           await runSessionList({
-            apiBaseUrl: opts.apiUrl,
+            apiBaseUrl: globals(cmd).apiUrl,
             limit: Number.parseInt(opts.limit, 10) || 20,
             state: opts.state as SessionListStateFilter,
             json: opts.json,
@@ -659,11 +664,6 @@ export function createProgram() {
     .description("Stop a hosted sandbox")
     .argument("<session-id>", "Sandbox id (ses_…)")
     .option(
-      "--api-url <url>",
-      "Control-plane URL",
-      process.env.POME_API_URL ?? DEFAULT_CONTROL_PLANE_URL,
-    )
-    .option(
       "--discard",
       "Confirm destroying a session whose run has not been graded",
       false,
@@ -671,11 +671,12 @@ export function createProgram() {
     .action(
       async (
         sessionId: string,
-        opts: { apiUrl: string; discard?: boolean },
+        opts: { discard?: boolean },
+        cmd: Command,
       ) => {
         try {
           await runSessionStop({
-            apiBaseUrl: opts.apiUrl,
+            apiBaseUrl: globals(cmd).apiUrl,
             sessionId,
             discard: opts.discard === true,
           });
@@ -702,12 +703,6 @@ export function createProgram() {
       "-n, --trials <count>",
       "Number of trials to run as one group, 1 to 20. Hosted only; defaults to the task's `runs` field.",
     )
-    .option("--artifacts-dir <dir>", "Directory for run artifacts", "runs")
-    .option(
-      "--api-url <url>",
-      "Control-plane base URL.",
-      process.env.POME_API_URL ?? DEFAULT_CONTROL_PLANE_URL,
-    )
     .option("--agent-model <name>", "Informational; model name recorded on the run.", "unknown")
     .option(
       "--agent-version <version>",
@@ -730,14 +725,15 @@ export function createProgram() {
         options: {
           agent?: string;
           trials?: string;
-          artifactsDir: string;
           local?: boolean;
-          apiUrl: string;
           agentModel: string;
           agentVersion?: string;
           capture: boolean;
-        }
+        },
+        cmd: Command,
       ) => {
+        const { apiUrl, artifactsDir } = globals(cmd);
+
         // F0-5 — `pome run`'s pre-flight (resolving files, reading config,
         // resolving credentials) used to propagate plain `Error`s to
         // Commander's top-level catch, which always demoted to exit 2.
@@ -890,7 +886,7 @@ export function createProgram() {
         try {
           hostedCreds = useLocal
             ? null
-            : await resolveCredentials({ apiBaseUrl: options.apiUrl });
+            : await resolveCredentials({ apiBaseUrl: apiUrl });
         } catch (err) {
           const code = exitCodeFor(err);
           console.error(err instanceof Error ? err.message : String(err));
@@ -950,7 +946,7 @@ export function createProgram() {
                       ? "pome.json"
                       : "built-in default",
                   trials: k,
-                  artifactsDir: options.artifactsDir,
+                  artifactsDir,
                   hosted: {
                     baseUrl: hostedCreds.apiBaseUrl,
                     apiKey: hostedCreds.apiKey,
@@ -970,7 +966,7 @@ export function createProgram() {
               const result = await runTaskHosted({
                 taskPath: file,
                 agentCommand,
-                artifactsDir: options.artifactsDir,
+                artifactsDir,
                 hosted: { baseUrl: hostedCreds.apiBaseUrl, apiKey: hostedCreds.apiKey },
                 agentModel: options.agentModel,
                 agentVersion: options.agentVersion,
@@ -1007,7 +1003,7 @@ export function createProgram() {
             const result = await runTask({
               taskPath: file,
               agentCommand,
-              artifactsDir: options.artifactsDir,
+              artifactsDir,
               // Commander negates --no-* flags: `--no-capture` → `capture: false`.
               noCapture: options.capture === false,
             });
@@ -1045,20 +1041,12 @@ export function createProgram() {
       "Zero-auth first-run demo: boots a local GitHub twin, runs the bundled demo agent for 5 isolated trials (model calls via pome's anonymous demo gateway), and prints per-trial verdicts evaluated in Pome cloud. No signup, no API keys; ends with a no-login preview link.",
     )
     .option(
-      "--api-url <url>",
-      "Control-plane base URL.",
-      process.env.POME_API_BASE ??
-        process.env.POME_API_URL ??
-        DEFAULT_CONTROL_PLANE_URL,
-    )
-    .option(
       "--trials <n>",
       "Number of trials to run, 1 to 10",
       "5",
     )
-    .option("--artifacts-dir <dir>", "Directory for run artifacts", "runs")
     .action(
-      async (opts: { apiUrl: string; trials: string; artifactsDir: string }) => {
+      async (opts: { trials: string }, cmd: Command) => {
         const trials = Number.parseInt(opts.trials, 10);
         if (!Number.isInteger(trials) || trials < 1 || trials > 10) {
           console.error(`Invalid --trials "${opts.trials}" (expected 1-10).`);
@@ -1069,11 +1057,11 @@ export function createProgram() {
         // graph out of every other command's startup path.
         const { runDemo } = await import("../demo/runDemo.js");
         const result = await runDemo({
-          apiBase: opts.apiUrl.replace(/\/$/, ""),
+          apiBase: globals(cmd).apiUrl.replace(/\/$/, ""),
           dashboardBase:
             process.env.POME_DASHBOARD_URL ?? DEFAULT_DASHBOARD_URL,
           trials,
-          artifactsDir: opts.artifactsDir,
+          artifactsDir: globals(cmd).artifactsDir,
         });
         process.exitCode = result.exitCode;
       },
@@ -1113,11 +1101,6 @@ export function createProgram() {
       "Existing run directory (runs/<task>/<run-id>). Omit to use <artifacts-dir>/latest.json.",
     )
     .option(
-      "--artifacts-dir <dir>",
-      "Directory whose latest.json picks the run when no run dir is given.",
-      "runs",
-    )
-    .option(
       "--agent <slug>",
       "Agent identity for the eval session. Defaults to agent.slug from pome.json.",
     )
@@ -1125,30 +1108,26 @@ export function createProgram() {
       "--task <name>",
       "Task name recorded on the eval session. Defaults to meta.json's `scenario` slug (a legacy key name; then title).",
     )
-    .option(
-      "--api-url <url>",
-      "Control-plane base URL.",
-      process.env.POME_API_URL ?? DEFAULT_CONTROL_PLANE_URL,
-    )
     .description(
       "Upload an existing raw trace directory to Pome cloud for evaluation and print the authoritative score (capture/eval split — no local scoring; requires a control plane with POST /v1/eval-sessions)",
     )
     .action(
       async (
         runDir: string | undefined,
-        opts: { artifactsDir: string; agent?: string; task?: string; apiUrl: string },
+        opts: { agent?: string; task?: string },
+        cmd: Command,
       ) => {
-        await runEvalCommand(runDir, opts);
+        await runEvalCommand(runDir, { ...opts, ...globals(cmd) });
       },
     );
 
   program
     .command("inspect")
     .argument("<run>", "Run id, run directory, or latest")
-    .option("--artifacts-dir <dir>", "Directory for run artifacts", "runs")
     .description("Print a human-readable run report")
-    .action(async (run: string, options: { artifactsDir: string }) => {
-      const latest = run === "latest" ? await readLatestRun(options.artifactsDir) : undefined;
+    .action(async (run: string, _options: unknown, cmd: Command) => {
+      const latest =
+        run === "latest" ? await readLatestRun(globals(cmd).artifactsDir) : undefined;
       const runDir = latest?.run_dir ?? resolve(run);
 
       const eventsResult = await readEventsJsonl(runDir);

--- a/cli/src/demo/agent.ts
+++ b/cli/src/demo/agent.ts
@@ -10,7 +10,7 @@
 // LlmCallEvent rows.
 //
 // Env contract (beyond runTask's standard POME_* set):
-//   POME_DEMO_LLM_URL    — {POME_API_BASE}/v1/demo/sessions/{sid}/llm
+//   POME_DEMO_LLM_URL    — {api-base}/v1/demo/sessions/{sid}/llm
 //   POME_DEMO_TOKEN      — the trial session's demo_token (Bearer)
 //   POME_DEMO_TASK_NAME  — server-allowlisted task name ("first-run-demo")
 //   POME_DEMO_REPO       — "owner/name" the packaged seed created

--- a/cli/src/demo/gateway.ts
+++ b/cli/src/demo/gateway.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Client for the anonymous demo model-call gateway:
-// POST {POME_API_BASE}/v1/demo/sessions/:id/llm, Authorization: Bearer
+// POST {api-base}/v1/demo/sessions/:id/llm, Authorization: Bearer
 // <demo_token>.
 //
 // The wire shape is a STRICT ModelMessage subset (pome-cloud

--- a/cli/src/demo/mint.ts
+++ b/cli/src/demo/mint.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Anonymous demo session minting.
 //
-// POST {POME_API_BASE}/v1/demo/sessions with
+// POST {api-base}/v1/demo/sessions with
 //   { task_name: "first-run-demo", task_hash: "", group_id: "grp_…" }
 // → { session_id, demo_token, expires_at }. No auth: the response's
 // demo_token (a sid-scoped JWT) is the credential for everything that

--- a/cli/src/demo/runDemo.ts
+++ b/cli/src/demo/runDemo.ts
@@ -74,7 +74,7 @@ export type DemoTrialClient = Pick<
 >;
 
 export interface RunDemoOptions {
-  /** Control-plane base URL (POME_API_BASE, default https://api.pome.sh). */
+  /** Control-plane base URL (--api-url / POME_API_URL, default https://api.pome.sh). */
   apiBase: string;
   /** Dashboard base for the preview link (default https://app.pome.sh). */
   dashboardBase: string;

--- a/cli/src/runner/runTask.ts
+++ b/cli/src/runner/runTask.ts
@@ -53,7 +53,7 @@ export type RunTaskOptions = {
   // BEFORE the proxy vars — the capture path is not overridable.
   extraAgentEnv?: Record<string, string>;
   // Extra egress-floor allowlist patterns for this run (demo mode
-  // adds the POME_API_BASE host so gateway CONNECTs aren't refused).
+  // adds the control-plane host so gateway CONNECTs aren't refused).
   egressExtraHosts?: readonly string[];
 };
 

--- a/cli/test/unit/demo/egress-extra-hosts.test.ts
+++ b/cli/test/unit/demo/egress-extra-hosts.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Demo-mode egress valve: the POME_API_BASE host joins the deny-by-default floor's
+// Demo-mode egress valve: the control-plane host joins the deny-by-default floor's
 // allowlist so the bundled agent's gateway CONNECTs aren't refused, without.
 import { describe, expect, it } from "vitest";
 import {

--- a/cli/test/unit/global-flags.test.ts
+++ b/cli/test/unit/global-flags.test.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// `--api-url` and `--artifacts-dir` were declared 13 times across 10 commands,
+// which is how one of them ended up with an extra env var (POME_API_BASE) at
+// higher precedence than POME_API_URL. They are program-level now.
+//
+// Tree-walking on purpose: the next command to be added is covered the day it
+// is added, and a hand-picked list of "control-plane talkers" is the same
+// hand-maintained list this deletes.
+
+import type { Command } from "commander";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createProgram } from "../../src/cli/main.js";
+
+/** Every command in the tree, including subcommands and hidden ones. */
+function allCommands(root: Command): Command[] {
+  return [root, ...root.commands.flatMap((cmd) => allCommands(cmd))];
+}
+
+function path(cmd: Command): string {
+  const names: string[] = [];
+  for (let node: Command | null = cmd; node; node = node.parent) names.unshift(node.name());
+  return names.join(" ");
+}
+
+const GLOBAL_FLAGS = ["--api-url", "--artifacts-dir"];
+
+describe("program-level flags", () => {
+  const saved = process.env.POME_API_URL;
+
+  afterEach(() => {
+    if (saved === undefined) delete process.env.POME_API_URL;
+    else process.env.POME_API_URL = saved;
+  });
+
+  it.each(GLOBAL_FLAGS)("%s is declared exactly once, on the root", (flag) => {
+    const declaredBy = allCommands(createProgram())
+      .filter((cmd) => cmd.options.some((opt) => opt.long === flag))
+      .map(path);
+    expect(declaredBy).toEqual(["pome"]);
+  });
+
+  // `program.configureHelp({ showGlobalOptions: true })` is the only reason these
+  // stay discoverable once they are declared on the root alone. Commander's
+  // `configureHelp` REPLACES its configuration rather than merging, so a second
+  // call anywhere in `createProgram()` would silently drop both flags out of
+  // every subcommand's help with nothing else failing.
+  it.each(GLOBAL_FLAGS)("%s still renders on a subcommand's --help", (flag) => {
+    const program = createProgram();
+    const run = program.commands.find((cmd) => cmd.name() === "run");
+    expect(run, "pome run is no longer registered").toBeDefined();
+    expect(run!.helpInformation()).toContain(flag);
+  });
+
+  it("honours POME_API_URL on every command at every depth", () => {
+    process.env.POME_API_URL = "https://api.test.invalid";
+    for (const cmd of allCommands(createProgram())) {
+      const opts = cmd.optsWithGlobals();
+      expect(opts.apiUrl, `${path(cmd)} apiUrl`).toBe("https://api.test.invalid");
+      expect(opts.artifactsDir, `${path(cmd)} artifactsDir`).toBe("runs");
+    }
+  });
+});

--- a/cli/test/unit/register.test.ts
+++ b/cli/test/unit/register.test.ts
@@ -204,13 +204,13 @@ describe("runRegisterAgent", () => {
     ).rejects.toBeInstanceOf(HostedOrchError);
   });
 
-  it("explains /v1/agents 404 as route/version skew", async () => {
+  it("points a /v1/agents 404 at the --api-url the caller passed", async () => {
     await writeManifest({ agent: { slug: "triage-bot" } });
     vi.spyOn(globalThis, "fetch").mockResolvedValue(response({}, { status: 404 }));
 
     await expect(
       runRegisterAgent({ apiBaseUrl: "https://api.example.com", dashboardBaseUrl: "https://app.example.com", name: "Triage Bot", force: false }),
-    ).rejects.toThrow(/not available|version/);
+    ).rejects.toThrow(/--api-url\/POME_API_URL/);
   });
 
   it("POSTs {name, twins} and prints the cloud's enabled services", async () => {


### PR DESCRIPTION
- `--api-url` and `--artifacts-dir` were declared once per command across 13 commands, each with its own default and its own environment lookup. They are now declared once on `pome` and inherited by every subcommand.
- They still work exactly where you already write them — after the subcommand, after its arguments — and `pome <cmd> --help` still lists them, now under a `Global Options` heading.
- `POME_API_BASE` is deleted. It was an undocumented override that only `pome demo` read, at *higher* precedence than `POME_API_URL` — the exact drift that declaring a flag nine times invites.
- A `/v1/agents` 404 no longer suggests upgrading the server; that route has existed for the whole life of this CLI, so the message just points at the URL you passed.
- A new test walks the whole command tree, so a future command cannot re-declare either flag or quietly ignore `POME_API_URL`.