### PR TITLE
add help conventions / rulesets

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,6 +9,21 @@ write a version number here or in `package.json`. Released entries are insertion
 only: a correction is the next entry, naming the one it corrects.
 
 
+## Unreleased (patch)
+
+**Machine-readable output being `--json` is a gate now** (F-1727). No option may
+be named `--format`, `--output-format` or `--fmt`, and `--json` may not take an
+argument, so the enum cannot come back under the surviving name. The
+index-line, doubled-default and declared-once tests gained a self-test that
+builds a broken command and proves the check goes red.
+
+**`pome docs linear` resolves**, where it was the only twin name that printed
+the topic list and exited non-zero; every twin the CLI ships is now asserted to
+have one. `pome twin status`'s summary says it reports whether the twin is
+running. Correcting 0.37.0: `--secrets-file` does not *always* print the
+connection summary — with `--json` it prints only the line naming the file.
+
+
 ## 0.42.0 — 2026-08-30
 
 **`pome twin seed` is now `pome twin new-seed`, and `--for-task` is gone**

--- a/cli/src/cli/docs-topics.ts
+++ b/cli/src/cli/docs-topics.ts
@@ -79,6 +79,12 @@ export const DOCS_TOPICS: DocsTopic[] = [
     keywords: ["messaging", "channels", "workspace", "slack", "exfiltration"],
   },
   {
+    id: "linear",
+    title: "Linear twin",
+    path: "/docs/twins/linear",
+    keywords: ["projects", "cycles", "linear"],
+  },
+  {
     id: "gmail",
     title: "Gmail twin",
     path: "/docs/twins/gmail",

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -1359,7 +1359,7 @@ export function createProgram() {
 
   twin
     .command("status")
-    .summary("Print the local twin's status")
+    .summary("Say whether the local twin is running")
     .description(
       "Say whether the twin `pome twin start` last booted here is still running, and print its paste-able env lines",
     )

--- a/cli/test/unit/docs-topic-pointers.test.ts
+++ b/cli/test/unit/docs-topic-pointers.test.ts
@@ -12,6 +12,8 @@ import { describe, expect, it } from "vitest";
 
 import { createProgram } from "../../src/cli/main.js";
 import { DOCS_TOPICS } from "../../src/cli/docs-topics.js";
+import { findTopic } from "../../src/cli/docs.js";
+import { TWIN_NAME_LIST } from "../../src/twin/registry.js";
 
 /** Every `pome docs <id>` reference in any command's help, at any depth. */
 function referencedTopics(cmd: Command, path: string[] = []): { where: string; id: string }[] {
@@ -42,5 +44,14 @@ describe("`pome docs <topic>` pointers in help text", () => {
       expect(ids.has(id), `\`${where}\` points at \`pome docs ${id}\`, which is not a topic`)
         .toBe(true);
     }
+  });
+});
+
+// `pome docs linear` printed the topic list and exited non-zero for four months
+// while /docs/twins/linear shipped, because the topic was simply never added.
+// Twin six would reintroduce that verbatim; the twin list is the registry's.
+describe("`pome docs <twin>`", () => {
+  it.each(TWIN_NAME_LIST)("resolves for %s", (twin) => {
+    expect(findTopic(twin, DOCS_TOPICS)?.id).toBe(twin);
   });
 });

--- a/cli/test/unit/global-flags.test.ts
+++ b/cli/test/unit/global-flags.test.ts
@@ -7,7 +7,7 @@
 // is added, and a hand-picked list of "control-plane talkers" is the same
 // hand-maintained list this deletes.
 
-import type { Command } from "commander";
+import { Command } from "commander";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { createProgram } from "../../src/cli/main.js";
@@ -25,6 +25,13 @@ function path(cmd: Command): string {
 
 const GLOBAL_FLAGS = ["--api-url", "--artifacts-dir"];
 
+/** Every command in the tree that declares `flag` itself. */
+function declaredBy(root: Command, flag: string): string[] {
+  return allCommands(root)
+    .filter((cmd) => cmd.options.some((opt) => opt.long === flag))
+    .map(path);
+}
+
 describe("program-level flags", () => {
   const saved = process.env.POME_API_URL;
 
@@ -34,10 +41,15 @@ describe("program-level flags", () => {
   });
 
   it.each(GLOBAL_FLAGS)("%s is declared exactly once, on the root", (flag) => {
-    const declaredBy = allCommands(createProgram())
-      .filter((cmd) => cmd.options.some((opt) => opt.long === flag))
-      .map(path);
-    expect(declaredBy).toEqual(["pome"]);
+    expect(declaredBy(createProgram(), flag)).toEqual(["pome"]);
+  });
+
+  // Green on today's tree proves nothing: the defect this gate exists for is a
+  // subcommand re-declaring the flag, so declare one and see it named.
+  it.each(GLOBAL_FLAGS)("%s: a subcommand re-declaring it is caught", (flag) => {
+    const program = new Command("pome").option(`${flag} <value>`, "Root copy");
+    program.command("run").option(`${flag} <value>`, "Second copy");
+    expect(declaredBy(program, flag)).toEqual(["pome", "pome run"]);
   });
 
   // `program.configureHelp({ showGlobalOptions: true })` is the only reason these

--- a/cli/test/unit/help-conventions.test.ts
+++ b/cli/test/unit/help-conventions.test.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// One help convention this milestone established, as a gate.
+//
+// Machine-readable output is `--json`, boolean. `pome sandbox create` and
+// `sandbox list` took `--format text|json`, and create had a third mode, `env`,
+// that printed nothing at all. Deleting `--format` cost a release; nothing
+// stopped it, or the next spelling of it, coming back.
+//
+// This asserts SHAPE, never truth: a gate cannot know whether a help string is
+// accurate. `--twin`'s help omitted `linear` while the code allowed it, and no
+// rule here would have caught that — it stays a human review.
+//
+// The arm is a pure function over a Command, so the self-test can build a
+// deliberately-violating program in memory and prove it goes RED. Green on
+// today's tree proves nothing.
+
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+
+import { createProgram } from "../../src/cli/main.js";
+
+/** Every command in the tree, including subcommands and hidden ones. */
+function allCommands(root: Command): Command[] {
+  return [root, ...root.commands.flatMap((cmd) => allCommands(cmd))];
+}
+
+function path(cmd: Command): string {
+  const names: string[] = [];
+  for (let node: Command | null = cmd; node; node = node.parent) names.unshift(node.name());
+  return names.join(" ");
+}
+
+/**
+ * No option asks for machine-readable output by any name but `--json`, and
+ * `--json` never takes an argument — a `--json <mode>` would smuggle the
+ * `--format` enum back in under the surviving name.
+ */
+function machineOutputSpellings(root: Command): string[] {
+  const violations: string[] = [];
+  for (const cmd of allCommands(root)) {
+    for (const opt of cmd.options) {
+      // Not `=== "--format"`: the defect class is an output mode spelled some
+      // other way, and `--output-format` is the obvious next spelling.
+      if (opt.long && (/format/.test(opt.long) || opt.long === "--fmt")) {
+        violations.push(`${path(cmd)} ${opt.flags}: machine-readable output is --json`);
+      }
+      if (opt.long === "--json" && (opt.required || opt.optional)) {
+        violations.push(`${path(cmd)} ${opt.flags}: --json takes no argument`);
+      }
+    }
+  }
+  return violations;
+}
+
+describe("machine-readable output is spelled one way", () => {
+  it("holds for every option in the command tree", () => {
+    expect(machineOutputSpellings(createProgram())).toEqual([]);
+  });
+
+  it("fails on every other spelling, and on a --json that takes an argument", () => {
+    const program = new Command("pome")
+      .option("--format <fmt>", "Output format")
+      .option("--output-format <fmt>", "Output format")
+      .option("--fmt <fmt>", "Output format")
+      .option("--json <mode>", "How much JSON");
+    expect(machineOutputSpellings(program)).toHaveLength(4);
+  });
+
+  it("finds a violation on a nested subcommand, not just the root", () => {
+    const program = new Command("pome");
+    program.command("twin").command("status").option("--format <fmt>", "Output format");
+    expect(machineOutputSpellings(program)).toEqual([
+      "pome twin status --format <fmt>: machine-readable output is --json",
+    ]);
+  });
+});

--- a/cli/test/unit/help-defaults.test.ts
+++ b/cli/test/unit/help-defaults.test.ts
@@ -11,7 +11,7 @@
 // typo. Prose like `twin start --port`'s "(default: $PORT, else …)" is fine,
 // since that option has no Commander default to duplicate.
 
-import type { Command } from "commander";
+import { Command } from "commander";
 import { describe, expect, it } from "vitest";
 
 import { createProgram } from "../../src/cli/main.js";
@@ -32,30 +32,42 @@ function path(cmd: Command): string {
  *  default" stays legal, and has to: `sandbox create --seed` needs it. */
 const PARENTHESIZED_DEFAULT = /\(default[: )]/i;
 
-describe("help text never renders a default twice", () => {
-  it("holds for every argument in the command tree", () => {
-    for (const cmd of allCommands(createProgram())) {
-      for (const arg of cmd.registeredArguments) {
-        const named = PARENTHESIZED_DEFAULT.test(arg.description);
-        const hasDefault = arg.defaultValue !== undefined;
-        expect(
-          named && hasDefault,
-          `${path(cmd)} <${arg.name()}> carries a default value and names one in its text: "${arg.description}"`,
-        ).toBe(false);
+/** Every declaration that carries a default AND names one in its own text. */
+function duplicatedDefaults(root: Command): string[] {
+  const violations: string[] = [];
+  for (const cmd of allCommands(root)) {
+    const declarations = [
+      ...cmd.registeredArguments.map((arg) => ({
+        term: `<${arg.name()}>`,
+        description: arg.description,
+        defaultValue: arg.defaultValue,
+      })),
+      ...cmd.options.map((opt) => ({
+        term: opt.flags,
+        description: opt.description,
+        defaultValue: opt.defaultValue,
+      })),
+    ];
+    for (const { term, description, defaultValue } of declarations) {
+      if (PARENTHESIZED_DEFAULT.test(description) && defaultValue !== undefined) {
+        violations.push(`${path(cmd)} ${term} carries a default and names one: "${description}"`);
       }
     }
+  }
+  return violations;
+}
+
+describe("help text never renders a default twice", () => {
+  it("holds for every argument and option in the command tree", () => {
+    expect(duplicatedDefaults(createProgram())).toEqual([]);
   });
 
-  it("holds for every option in the command tree", () => {
-    for (const cmd of allCommands(createProgram())) {
-      for (const opt of cmd.options) {
-        const named = PARENTHESIZED_DEFAULT.test(opt.description);
-        const hasDefault = opt.defaultValue !== undefined;
-        expect(
-          named && hasDefault,
-          `${path(cmd)} ${opt.flags} carries a default value and names one in its text: "${opt.description}"`,
-        ).toBe(false);
-      }
-    }
+  // Green on today's tree proves nothing, so break it here instead of in
+  // main.ts: one argument and one option, each doubling its own default.
+  it("fails on a declaration that names the default it already carries", () => {
+    const program = new Command("pome")
+      .argument("[name]", "Twin name (default: github)", "github")
+      .option("--limit <n>", "Max rows (default: 20)", "20");
+    expect(duplicatedDefaults(program)).toHaveLength(2);
   });
 });

--- a/cli/test/unit/root-help-index.test.ts
+++ b/cli/test/unit/root-help-index.test.ts
@@ -8,7 +8,7 @@
 // is that nothing in the list wraps: a command added later with a paragraph for
 // a summary regresses this silently, and nobody re-reads `--help` to notice.
 
-import type { Command } from "commander";
+import { Command } from "commander";
 import { describe, expect, it } from "vitest";
 
 import { createProgram } from "../../src/cli/main.js";
@@ -17,28 +17,43 @@ import { createProgram } from "../../src/cli/main.js";
  *  here so the assertion does not depend on the terminal running it. */
 const HELP_WIDTH = 80;
 
+/** `[entries, named]` from the root's Commands: block: every non-blank line,
+ *  and the subset that starts with a command name. A wrapped entry is a line
+ *  indented past the command column that names no command, so counting entries
+ *  against commands finds it without parsing the padding. */
+function indexBlock(program: Command): { entries: string[]; named: string[]; names: string[] } {
+  program.configureHelp({ helpWidth: HELP_WIDTH });
+  const help = program.createHelp();
+  // `visibleCommands` already includes Commander's own `help` entry.
+  const names = help.visibleCommands(program).map((cmd: Command) => cmd.name());
+
+  const lines = program.helpInformation().split("\n");
+  const start = lines.indexOf("Commands:");
+  expect(start, "root --help no longer prints a Commands: block").toBeGreaterThan(-1);
+  const entries = lines.slice(start + 1).filter((line) => line.trim().length > 0);
+  const named = entries.filter((line) => names.some((name) => line.trimStart().startsWith(name)));
+  return { entries, named, names };
+}
+
 describe("pome --help", () => {
   it("gives every command exactly one line", () => {
-    const program = createProgram();
-    program.configureHelp({ helpWidth: HELP_WIDTH });
-    const help = program.createHelp();
-    // `visibleCommands` already includes Commander's own `help` entry.
-    const names = help.visibleCommands(program).map((cmd: Command) => cmd.name());
-
-    const lines = program.helpInformation().split("\n");
-    const start = lines.indexOf("Commands:");
-    expect(start, "root --help no longer prints a Commands: block").toBeGreaterThan(-1);
-    const entries = lines.slice(start + 1).filter((line) => line.trim().length > 0);
-
-    // A wrapped entry is a line indented past the command column that names no
-    // command, so counting entries against commands finds it without parsing
-    // the padding.
-    const named = entries.filter((line) =>
-      names.some((name) => line.trimStart().startsWith(name)),
-    );
+    const { entries, named, names } = indexBlock(createProgram());
     const wrapped = entries.length - named.length;
 
     expect(wrapped, `${wrapped} index line(s) wrapped onto a second line`).toBe(0);
     expect(named).toHaveLength(names.length);
+  });
+
+  // Green on today's tree proves nothing: a 26th command with a paragraph for a
+  // summary has to fail, and this is the proof, without mutating main.ts.
+  it("fails on a command whose summary is a paragraph", () => {
+    const program = new Command("pome");
+    program
+      .command("verbose")
+      .summary(
+        "Does a thing, and then explains at length what the thing was, why it was done that way, and what to read next.",
+      );
+    const { entries, named } = indexBlock(program);
+    expect(entries.length - named.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
- `--format` cost a release to remove and nothing stopped it — or the next spelling of it — coming back. One check now rejects any option named `--format`, `--output-format` or `--fmt`, and a `--json` that takes an argument.
- The three help checks that already existed only asserted that today's code passes, which is the weaker half. Each now builds a deliberately broken command and proves it goes red.
- `pome docs linear` printed the topic list and exited non-zero while that page shipped — the only twin name that did not resolve. The twin list now comes from the registry, so a sixth twin cannot repeat it.
- `pome twin status`'s one-line summary still said it prints status; it has probed the twin since 0.39.1.
- Scope was cut deliberately: two proposed checks were dropped because neither held on today's code, so both would have shipped as frozen lists that red on unrelated renames.