### PR TITLE
init --example points a docs-walked example at its documented walk

### DIFF
--- a/agent-examples/support-triage/package.json
+++ b/agent-examples/support-triage/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "description": "Pome hero example: the support-triage examinee as a local Claude Agent SDK subprocess, wired to the GitHub + Slack twins over MCP.",
+  "homepage": "https://docs.pome.sh/quickstart/coding-agent",
   "scripts": {
     "start": "tsx src/index.ts",
     "test": "vitest run",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,6 +9,16 @@ write a version number here or in `package.json`. Released entries are insertion
 only: a correction is the next entry, naming the one it corrects.
 
 
+## Unreleased (patch)
+
+**`pome init --example support-triage` no longer forks the capstone reader off
+the documented path.** Its next steps said `pome login` then `pome run` — the
+CLI route — to a reader who reached it from the docs walk (coach skills → MCP →
+paste-prompt). An example a docs page walks end to end now says so in its own
+package.json `homepage`, carried into the example catalog, and the next steps
+name that walk first with the CLI route kept as the second line. Examples with
+no walk are unchanged.
+
 ## 0.42.1 — 2026-08-30
 
 **Machine-readable output being `--json` is a gate now** (F-1727). No option may

--- a/cli/src/cli/example-catalog.ts
+++ b/cli/src/cli/example-catalog.ts
@@ -19,6 +19,9 @@ export interface CatalogExample {
   rel: string;
   /** The example's own package.json `description`. */
   description: string;
+  /** The example's own package.json `homepage`, set when a docs page walks it
+   *  end to end — `pome init --example` names it in the next steps. */
+  homepage?: string;
   /** Every file git tracks, relative to `rel`, sorted. */
   files: string[];
 }
@@ -181,6 +184,7 @@ export const CATALOG_EXAMPLES: CatalogExample[] = [
     rel: "agent-examples/support-triage",
     description:
       "Pome hero example: the support-triage examinee as a local Claude Agent SDK subprocess, wired to the GitHub + Slack twins over MCP.",
+    homepage: "https://docs.pome.sh/quickstart/coding-agent",
     files: [
       "README.md",
       "VERIFICATION.md",

--- a/cli/src/cli/init-example.ts
+++ b/cli/src/cli/init-example.ts
@@ -222,12 +222,31 @@ export function scaffoldSummary(result: ScaffoldResult): string {
   }
 
   const task = firstTaskFile(example);
+  const run = `pome run ${task ?? "<task>.md"}`;
+
+  // An example a docs page walks end to end (its package.json `homepage`,
+  // carried into the catalog) names that page first. The capstone reader
+  // arrives here MID-WALK — coach skills → MCP → paste-prompt — and a
+  // next-steps that says only `pome login` + `pome run` forks them onto the
+  // other route at the exact moment they are following the documented one.
+  // Both routes are real, so print both.
+  if (example.homepage) {
+    return (
+      `${header}\n` +
+      "Next steps:\n" +
+      `  1. cd ${dir}\n` +
+      "  2. npm install\n" +
+      `  3. Follow the documented walk: ${example.homepage}\n` +
+      `  4. Or from the CLI: pome login, then ${run}`
+    );
+  }
+
   return (
     `${header}\n` +
     "Next steps:\n" +
     `  1. cd ${dir}\n` +
     "  2. npm install\n" +
     "  3. pome login                    # one-time, opens the dashboard to sign in\n" +
-    `  4. pome run ${task ?? "<task>.md"}`
+    `  4. ${run}`
   );
 }

--- a/cli/test/unit/init-example.test.ts
+++ b/cli/test/unit/init-example.test.ts
@@ -215,6 +215,29 @@ describe("pome init --example <id>", () => {
     ).toMatch(/^\s*\d+\.\s*pome run tasks\//m);
   });
 
+  it("names the documented walk for an example a docs page drives — and keeps the CLI route", () => {
+    // support-triage is the capstone: the reader lands on `init --example`
+    // from the docs walk (coach skills → MCP → paste-prompt), so a next-steps
+    // that says only `pome login` + `pome run` forks them off it. Both routes
+    // print; the walk comes first.
+    const example = findExample("support-triage")!;
+    expect(example.homepage).toBe("https://docs.pome.sh/quickstart/coding-agent");
+
+    const summary = scaffoldSummary({ dir: example.id, example, ref: "main", fileCount: 12 });
+    const walkStep = summary.split("\n").findIndex((line) => line.includes(example.homepage!));
+    const cliStep = summary.split("\n").findIndex((line) => /pome login.*pome run tasks\//.test(line));
+    expect(walkStep).toBeGreaterThan(-1);
+    expect(cliStep).toBeGreaterThan(walkStep);
+
+    // An example no docs page walks keeps the plain CLI next-steps: no
+    // homepage, no walk line.
+    const plain = findExample("gmail-retry-notify")!;
+    expect(plain.homepage).toBeUndefined();
+    expect(
+      scaffoldSummary({ dir: plain.id, example: plain, ref: "main", fileCount: 10 }),
+    ).not.toContain("documented walk");
+  });
+
   it("refuses a target directory that already holds something", async () => {
     const dir = await tempProject();
     await mkdir(join(dir, "merge-agent"), { recursive: true });

--- a/scripts/emit-example-catalog.mjs
+++ b/scripts/emit-example-catalog.mjs
@@ -88,6 +88,18 @@ export function buildCatalog(repoRoot, listTrackedFiles = defaultListTrackedFile
       );
     }
 
+    // `homepage` is optional and means: a docs page walks THIS example end to
+    // end, and `pome init --example` should name it in the next steps. It must
+    // be an absolute https URL — a relative docs path printed in a terminal is
+    // a link nobody can follow.
+    const homepage = typeof pkg.homepage === "string" ? pkg.homepage.trim() : "";
+    if (homepage !== "" && !homepage.startsWith("https://")) {
+      throw new Error(
+        `${rel}/package.json has homepage "${homepage}", which is not an absolute https URL. ` +
+          "`pome init --example` prints it as a next step, so it has to be followable as printed.",
+      );
+    }
+
     const prefix = `${rel}/`;
     const files = listTrackedFiles(repoRoot, rel)
       .filter((path) => path.startsWith(prefix))
@@ -100,7 +112,7 @@ export function buildCatalog(repoRoot, listTrackedFiles = defaultListTrackedFile
       );
     }
 
-    entries.push({ id: name, root, rel, description, files });
+    entries.push({ id: name, root, rel, description, homepage: homepage || undefined, files });
   }
   return entries;
 }
@@ -117,6 +129,7 @@ export function renderCatalog(entries) {
         `    rel: ${JSON.stringify(entry.rel)},`,
         `    description:`,
         `      ${JSON.stringify(entry.description)},`,
+        ...(entry.homepage ? [`    homepage: ${JSON.stringify(entry.homepage)},`] : []),
         "    files: [",
         files,
         "    ],",
@@ -146,6 +159,9 @@ export interface CatalogExample {
   rel: string;
   /** The example's own package.json \`description\`. */
   description: string;
+  /** The example's own package.json \`homepage\`, set when a docs page walks it
+   *  end to end — \`pome init --example\` names it in the next steps. */
+  homepage?: string;
   /** Every file git tracks, relative to \`rel\`, sorted. */
   files: string[];
 }

--- a/scripts/emit-example-catalog.test.mjs
+++ b/scripts/emit-example-catalog.test.mjs
@@ -36,14 +36,15 @@ function threw(fn) {
   }
 }
 
-/** A repo root holding `{ "<root>/<name>": { description, files } }`. */
+/** A repo root holding `{ "<root>/<name>": { description, homepage, files } }`. */
 function fixture(spec) {
   const root = mkdtempSync(join(tmpdir(), "example-catalog-"));
   const tracked = new Map();
-  for (const [rel, { description, files }] of Object.entries(spec)) {
+  for (const [rel, { description, homepage, files }] of Object.entries(spec)) {
     mkdirSync(join(root, rel), { recursive: true });
     const manifest = { name: `@pome-sh/${rel.split("/").at(-1)}-example` };
     if (description !== undefined) manifest.description = description;
+    if (homepage !== undefined) manifest.homepage = homepage;
     writeFileSync(join(root, rel, "package.json"), JSON.stringify(manifest));
     tracked.set(rel, files.map((file) => `${rel}/${file}`));
   }
@@ -140,6 +141,42 @@ const OK_FILES = ["package.json", "src/index.ts"];
     "9. files render sorted, so a readdir order change is not a diff",
     rendered.indexOf('"README.md"') < rendered.indexOf('"package.json"'),
     rendered,
+  );
+}
+
+{
+  const { root, listTrackedFiles } = fixture({
+    "agent-examples/walked": {
+      description: "Walked in the docs.",
+      homepage: "https://docs.pome.sh/quickstart/coding-agent",
+      files: OK_FILES,
+    },
+    "integration-examples/plain": { description: "No docs walk.", files: OK_FILES },
+  });
+  const entries = buildCatalog(root, listTrackedFiles);
+  const rendered = renderCatalog(entries);
+  check(
+    "13. a package.json homepage reaches the catalog; its absence emits no field",
+    entries[0].homepage === "https://docs.pome.sh/quickstart/coding-agent" &&
+      entries[1].homepage === undefined &&
+      rendered.includes('homepage: "https://docs.pome.sh/quickstart/coding-agent",') &&
+      !rendered.includes("homepage: undefined"),
+    JSON.stringify(entries.map((e) => e.homepage)),
+  );
+}
+
+{
+  const { root, listTrackedFiles } = fixture({
+    "agent-examples/walked": {
+      description: "Walked in the docs.",
+      homepage: "/quickstart/coding-agent",
+      files: OK_FILES,
+    },
+  });
+  check(
+    "14. a homepage that is not an absolute https URL is RED — it prints as a next step",
+    /not an absolute https URL/.test(threw(() => buildCatalog(root, listTrackedFiles)) ?? ""),
+    "buildCatalog emitted a homepage nobody can follow from a terminal",
   );
 }
 


### PR DESCRIPTION
Lane W-D of the M4 docs full-check sweep (stranger-walk umbrella: F-1766, finding F14). Fixes the fork at the capstone's first command: `pome init --example support-triage` told the reader `pome login` → `pome run` — the CLI route — at the exact moment the documented walk (coach skills → MCP → paste-prompt, https://docs.pome.sh/quickstart/coding-agent) had them scaffolding the pack.

## What changed

The next-steps text lives in `scaffoldSummary()` (`cli/src/cli/init-example.ts`), branching only on the example's root; there was no per-example metadata. This PR adds the metadata rather than hard-coding an id:

- `agent-examples/support-triage/package.json` gains standard npm `homepage` = the docs page that walks it end to end.
- `scripts/emit-example-catalog.mjs` carries `homepage` into the generated catalog (optional field; RED on a value that is not an absolute https URL — it prints as a next step, so it must be followable as printed). Catalog regenerated via `npm run emit:example-catalog`.
- `scaffoldSummary()` prints both routes for a walked example, documented walk first, CLI route second. Examples with no walk are byte-identical; integration examples keep their own branch.
- `cli/CHANGELOG.md` carries the `## Unreleased (patch)` entry.

## Evidence

| Surface | Commands re-run | Claims checked | Fixes | Lines before → after |
| --- | --- | --- | --- | --- |
| `pome init --example support-triage` next-steps output | 2 (`npx @pome-sh/cli@latest --version` → **0.42.1**; `npx @pome-sh/cli@latest init --example support-triage`) | 4 (see below) | 1 (example-aware next steps) | 6 → 6 |

Claims checked, with pointers:

1. **The finding reproduces on what a stranger gets today.** `npx @pome-sh/cli@latest` resolved to 0.42.1 (= repo HEAD 221b095); capture below.
2. **The capstone's documented route is not the CLI route.** `apps/docs/quickstart/coding-agent.mdx` (pome-cloud) steps are install coach skills → connect MCP → paste prompt; the paste-prompt (`apps/docs/snippets/prompts/capstone.mdx:10`) runs `init --example support-triage` as its step 1 — so the old next-steps forked the walk at that moment.
3. **The CLI route is still real for this example**, so it stays as line 2: `agent-examples/support-triage/README.md:202` and `:480` document `pome run tasks/duplicate-issue.md`.
4. **F14 is support-triage-only.** The other docs-walked agent example, `minimal-viktor-langgraph`, is walked via `pome run` (`apps/docs/docs/examples/cross-twin-consistency.mdx:74`), so its unchanged next-steps do not fork; `braintrust`/`langsmith` are integration examples and keep their existing README-first branch. No other example gets a `homepage`.

### Capture — before (npx @pome-sh/cli@0.42.1, clean dir)

```
Scaffolded agent-examples/support-triage into ./support-triage (12 files, from 221b0951a0c236c1470e4d9602866726ed3592ad).
Next steps:
  1. cd support-triage
  2. npm install
  3. pome login                    # one-time, opens the dashboard to sign in
  4. pome run tasks/duplicate-issue.md
```

### Capture — after (this branch, source tree, clean dir)

```
Scaffolded agent-examples/support-triage into ./support-triage (12 files, from main).
Next steps:
  1. cd support-triage
  2. npm install
  3. Follow the documented walk: https://docs.pome.sh/quickstart/coding-agent
  4. Or from the CLI: pome login, then pome run tasks/duplicate-issue.md
```

Unchanged surfaces, re-run on this branch: `gmail-retry-notify` (no walk) and `braintrust` (integration) print byte-identical next-steps to 0.42.1.

## Gates run locally

- `npm run gate:example-catalog` — green (catalog regenerated, in sync)
- `node scripts/emit-example-catalog.test.mjs` — all cases pass, incl. new case 13 (homepage passthrough / absence emits no field) and 14 (non-https homepage is RED)
- `npx vitest run --project cli` — 124 files, 1325 tests pass (incl. new scaffoldSummary case)
- `cli` workspace `tsc --noEmit` — clean
- `node scripts/lint.mjs` — 17 rules pass; `knip --no-config-hints` — clean
- `node scripts/ci/check-release-note-required.mjs <merge-base>` — "1 package(s) moved by this PR: @pome-sh/cli", entry present

## Tickets filed

None — no product-decision finding; the fix is within the lane's mandate.

## Needs credentialed verification

- None. Neither route was executed past the scaffold: `pome login` / `pome run` need an account plus an Anthropic credential for the examinee, and the MCP walk is the paid/hosted path. Both routes are verified as *documented*, not as *run*, per the method card's hard rules.

## Residue

- `docs.pome.sh/docs/cli/init.mdx` (pome-cloud) does not quote the next-steps block verbatim, so no docs re-extract is owed by this change; the pin-bump lane picks up the new CLI output whenever `@pome-sh/cli` next publishes.
- If another example gains a docs walk later, setting `homepage` in its package.json is the whole change; the generator reds on a non-followable value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
