### PR TITLE
F-1774: S6 sweep — repo README + two showcase READMEs re-run on CLI 0.42.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **Testing infrastructure for AI agents.**
 Stateful, local digital twins of the APIs your agent calls — GitHub, Stripe, Slack, Gmail, and Linear.
 
-[![CI](https://github.com/pome-sh/pome-twins/actions/workflows/ci.yml/badge.svg)](https://github.com/pome-sh/pome-twins/actions/workflows/ci.yml)
+[![CI](https://github.com/pome-sh/digital-twins/actions/workflows/ci.yml/badge.svg)](https://github.com/pome-sh/digital-twins/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/%40pome-sh%2Fcli?label=%40pome-sh%2Fcli)](https://www.npmjs.com/package/@pome-sh/cli)
 [![node](https://img.shields.io/badge/node-%E2%89%A5%2024-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENSE)
@@ -21,7 +21,7 @@ Stateful, local digital twins of the APIs your agent calls — GitHub, Stripe, S
 A **digital twin** is a local emulation of a production API. It answers the exact
 same **REST, GraphQL, and MCP calls** your AI agent makes in production, backed by a
 real SQLite database — so every run is stateful, deterministic, and resettable.
-Use it to test and evaluate agents against 137 MCP tools without touching live
+Use it to test and evaluate agents against 115 MCP tools without touching live
 infrastructure, rate limits, or shared sandbox accounts.
 
 Every route and tool is tiered — `semantic` (real, tested behavior), `shape`
@@ -29,13 +29,13 @@ Every route and tool is tiered — `semantic` (real, tested behavior), `shape`
 
 ## The twins
 
-Five twins, **137 MCP tools** in total. Each documents its surface route-by-route in its `FIDELITY.md`.
+Five twins, **115 MCP tools** in total. Each documents its surface route-by-route in its `FIDELITY.md`.
 
 | Twin | MCP tools | API surface | |
 | --- | --- | --- | --- |
-| ![GitHub](https://img.shields.io/badge/GitHub-181717?logo=github&logoColor=white) [`twin-github`](./packages/twin-github/) | 65 (63 semantic) | 62 REST routes — repos, issues, PRs, reviews, merges (push-access gated) | [FIDELITY](./packages/twin-github/FIDELITY.md) |
+| ![GitHub](https://img.shields.io/badge/GitHub-181717?logo=github&logoColor=white) [`twin-github`](./packages/twin-github/) | 36 (all semantic) | 73 REST routes — repos, issues, PRs, reviews, merges (push-access gated) | [FIDELITY](./packages/twin-github/FIDELITY.md) |
 | ![Stripe](https://img.shields.io/badge/Stripe-635BFF?logo=stripe&logoColor=white) [`twin-stripe`](./packages/twin-stripe/) | 26 (all semantic) | 43 REST routes — card + x402 crypto PaymentIntents, refunds, charges, balance, events | [FIDELITY](./packages/twin-stripe/FIDELITY.md) |
-| ![Slack](https://img.shields.io/badge/Slack-4A154B?logo=slack&logoColor=white) [`twin-slack`](./packages/twin-slack/) | 11 (all semantic) | 50 REST routes — channels, messages, threads, reactions, search | [FIDELITY](./packages/twin-slack/FIDELITY.md) |
+| ![Slack](https://img.shields.io/badge/Slack-4A154B?logo=slack&logoColor=white) [`twin-slack`](./packages/twin-slack/) | 18 (14 semantic) | 50 REST routes — channels, messages, threads, reactions, search | [FIDELITY](./packages/twin-slack/FIDELITY.md) |
 | ![Gmail](https://img.shields.io/badge/Gmail-EA4335?logo=gmail&logoColor=white) [`twin-gmail`](./packages/twin-gmail/) | 13 | Frozen Gmail v1 REST — messages, drafts, threads, labels, uploads | [FIDELITY](./packages/twin-gmail/FIDELITY.md) |
 | ![Linear](https://img.shields.io/badge/Linear-5E6AD2?logo=linear&logoColor=white) [`twin-linear`](./packages/twin-linear/) | 22 | GraphQL + OAuth (PKCE) + signed webhooks — the first GraphQL twin | [FIDELITY](./packages/twin-linear/FIDELITY.md) |
 
@@ -110,7 +110,7 @@ Everything ships inside `@pome-sh/cli` — one install, one entry point. The fiv
 twins are thin domain plugins on an internal twin engine that supplies HTTP
 mounting, bearer auth, the trace recorder, MCP dispatch, SQLite state, and the
 admin reset/seed gate. Those internals (`packages/sdk`, `packages/twin-*`) are
-implementation detail of the CLI, not separately installable packages.
+implementation detail of the CLI; their standalone npm packages are deprecated.
 
 Every twin honors the frozen [`CONTRACT.md`](./CONTRACT.md) runtime contract —
 entry point, env surface, `/healthz` shape, auth, and MCP surfaces. See

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Pome Digital Twins
 
-> Testing infrastructure for AI agents. Open-source, local, stateful digital twins of the APIs your agent calls — GitHub, Stripe, Slack, Gmail, and Linear — answering the same REST, GraphQL, and MCP calls as production, backed by real SQLite state. 137 MCP tools in total, all deterministic, resettable, and requiring no live infrastructure. The `pome` CLI runs your agent against a twin and captures the trace; evaluation is a hosted feature at pome.sh.
+> Testing infrastructure for AI agents. Open-source, local, stateful digital twins of the APIs your agent calls — GitHub, Stripe, Slack, Gmail, and Linear — answering the same REST, GraphQL, and MCP calls as production, backed by real SQLite state. 115 MCP tools in total, all deterministic, resettable, and requiring no live infrastructure. The `pome` CLI runs your agent against a twin and captures the trace; evaluation is a hosted feature at pome.sh.
 
 ## Docs
 

--- a/showcases/cross-call-state/README.md
+++ b/showcases/cross-call-state/README.md
@@ -64,8 +64,8 @@ say so.
 ```
 
 Everything below is what you should see. Every output block is verbatim from a
-real run on 2026-08-29, CLI `0.34.2`. Work in one empty directory; every path
-below is relative to it.
+real run on 2026-08-29, CLI `0.34.2`; a 2026-08-30 re-run on CLI `0.42.1`
+reproduced every block. Work in one empty directory; paths are relative to it.
 
 ## The world
 
@@ -424,8 +424,8 @@ showcase is about: what happened, versus what persisted, versus what changed.
 | `github.issue-assignee` (`alice`) | `final` | the assign **persisted** to the end of the run |
 | `github.no-new-issues` | `seed+final` | the run **changed** only what it meant to — this one reads both worlds |
 
-Browse the full set with `npx @pome-sh/cli@latest checks github`, or
-`list_checks` over MCP.
+Browse the full set with `npx @pome-sh/cli@latest checks github` (hosted:
+`list_checks` on the control MCP; the local twin's tool table lacks it).
 
 Two limits are worth stating out loud, because an id existing is not the same
 as an id doing what you assume:
@@ -474,7 +474,7 @@ failure. It exits non-zero if either half stops being true.
 
 ## Next
 
-- The [github quickstart](https://docs.pome.sh/quickstart/twins/github) — the
-  same twin, one write, in five minutes, on the hosted path.
+- [Get started](https://docs.pome.sh/quickstart/twins) — all five twins, each
+  started on your own machine and driven by your own coding agent.
 - [`agent-examples/support-triage`](../../agent-examples/support-triage/) — the
   one graded lesson, where a real agent is scored on a task like this.

--- a/showcases/permission-denial/README.md
+++ b/showcases/permission-denial/README.md
@@ -71,8 +71,8 @@ so.
 ```
 
 Everything below is what you should see. Every output block is verbatim from a
-real run on 2026-08-29, CLI `0.34.3`. Work in one empty directory; every path
-below is relative to it.
+real run on 2026-08-29, CLI `0.34.3`; a 2026-08-30 re-run on CLI `0.42.1`
+reproduced every block. Work in one empty directory; paths are relative to it.
 
 ## The world
 
@@ -581,8 +581,8 @@ looks like at the end, what changed to get there, and what was said on the way.
 | `github.no-new-issues` | `seed+final` | the run **changed nothing else** in the repository | it is repo-scoped. Every github delta check is: none of them can say *this pull request* was left alone, which is why the row above carries the weight |
 | `github.no-unsupported-endpoint` | `tape` | every refusal on this run was a **modelled** one | it passes a `403` and a `404` — it separates "not implemented" from everything else, and nothing more. Its own description still calls a sandbox a "session"; the wording fix is tracked upstream |
 
-Browse the full set with `npx @pome-sh/cli@latest checks github`, or
-`list_checks` over MCP.
+Browse the full set with `npx @pome-sh/cli@latest checks github` (hosted:
+`list_checks` on the control MCP; the local twin's tool table lacks it).
 
 **One candidate was rejected, and the rejection is the mechanism working.**
 The obvious pick for a page about an attempted action is
@@ -646,8 +646,8 @@ including on failure. It exits non-zero if any of that stops being true.
 
 ## Next
 
-- The [github quickstart](https://docs.pome.sh/quickstart/twins/github) — the
-  same twin, one write, in five minutes, on the hosted path.
+- [Get started](https://docs.pome.sh/quickstart/twins) — all five twins, each
+  started on your own machine and driven by your own coding agent.
 - [`cross-call-state`](../cross-call-state/) — the sibling showcase: what the
   twin does when the write *is* allowed, and how long it remembers.
 - [`agent-examples/support-triage`](../../agent-examples/support-triage/) — the


### PR DESCRIPTION
Sweep slice S6 of M4 · Full-check (umbrella F-1767 — reference only, this PR completes F-1774). Scope: `README.md`, `showcases/cross-call-state/README.md`, `showcases/permission-denial/README.md`. Every pasted command re-run against `npx @pome-sh/cli@latest`, which resolved to **0.42.1** on 2026-08-30.

## Evidence table

| Page | Commands re-run | Claims checked | Fixes | Lines before → after |
| --- | --- | --- | --- | --- |
| `README.md` | 10 CLI + 8 link curls | 16 | 6 | 127 → 127 |
| `showcases/cross-call-state/README.md` | 20 blocks + verify.sh | 12 | 3 | 480 → 480 |
| `showcases/permission-denial/README.md` | 24 blocks + verify.sh | 14 | 3 | 654 → 654 |
| `llms.txt` (out-of-scope rider, see residue) | — | 1 | 1 | 31 → 31 |

## Root README

Commands re-run (all against 0.42.1): `init`; `run --local tasks/01-bug-happy-path.md` (captured a 3-event trace, no key needed); `inspect latest`; `twin start github` (banner verified); `twin new-seed github --out seed.json`; `twin start github --seed seed.json` (booted, health-checked); `tasks` + `tasks github`; `run --help`; `eval --help`; `sandbox create --help` (hosted pair: syntax only). Links: docs.pome.sh (200), pome.sh (200), /quickstart/twins (200), nodejs.org (200), npmjs (403 = bot block, loads in a browser), CI badge old path (301 via rename) and new path (200).

Fixes, all grounded:

1. **137 MCP tools → 115** (intro + table heading). Live count, `GET /s/standalone/mcp/tools` per twin: github 36, stripe 26, slack 18, gmail 13, linear 22 = **115**. Matches each twin's `fidelity.inventory.json` `.tools|length`. `doc_drift` is `[]` on github/stripe/slack only; gmail carries 2 entries (`mcp_gate1_launch_expansion`, `list_drafts_readOnlyHint_docs_vs_live`) and linear 1 (`document_initiative_parent`) — none affects a tool count (gmail's first entry is the record of why the live set IS 13). The README makes no zero-drift claim, so no page sentence leans on this. *(Corrected in fix round 2026-08-30 — the original body wrongly said "[] on all five".)*
2. **github row 65 (63 semantic) → 36 (all semantic)**. Inventory: 36 tools, all `semantic`; `FIDELITY.md` itself says "the 36 MCP tools it serves".
3. **github 62 REST routes → 73**. Inventory `.rest|length` = 73; the sibling rows already use this denominator (stripe 43 ✓, slack 50 ✓ — both re-verified).
4. **slack row 11 (all semantic) → 18 (14 semantic)**. Live 18; inventory 14 semantic + 4 shape.
5. **CI badge → pome-sh/digital-twins**. `origin` is `pome-sh/digital-twins`; the old URL only resolved through the rename redirect.
6. **"not separately installable packages" → "standalone npm packages are deprecated"**. `npm view @pome-sh/twin-github deprecated` = "Internal to @pome-sh/cli — use npx @pome-sh/cli. Existing versions keep working." They install and boot, so "not installable" was false.

Claims verified unchanged: gmail 13 / linear 22 tool counts (live); eight `agent-examples/` dirs; two `integration-examples/` harnesses; the four adversarial task claims (tasks 05 identity spoof, 07 backdoored PR, 08/17 prompt injection, 18 fabricate-green-CI — via `pome tasks github`); capture-only CLI (`eval --help`: "no local scoring"); seed replaces-not-merges (boot banner); envelope-iff-multi-twin (`cli/src/contract/seed-envelope.ts`); the three seed doors (`twin new-seed` output names all three verbatim); `## Config` names the twin (`twins: [github]` in the scaffolded task); CONTRACT.md section list; node ≥ 24 badge vs `engines`.

## showcases/cross-call-state

All 20 pasted blocks re-run: **byte-identical** at 0.42.1 — including the 7-line boot banner wording, the 6-row tape table with `add_issue_comment` stamped on exactly the comment write, `state_delta` `{"b":[],"a":["alice"]}`, both-alive isolation loop, `standalone`×2 session ids, per-process `Host` values, and the cross-bearer 401. Only per-boot values differ (token; ports — see residue). `verify.sh` PASS locally (also runs in CI, see below).

Prose-vs-verify.sh mapping (S6 duty 2): accumulation → L161-162; isolation-while-both-alive → L201-203; invariant-not-row-count → L215-222; bearer non-interchangeability → L224-227; stops-on-exit-including-failure → trap L39-56; exits non-zero → L236.

Ground truths: in-memory DB default → `packages/twin-github/src/db.ts:316` (`?? ":memory:"`); default seed (issue #1, `labels:["bug"]`, unassigned) → `packages/twin-github/src/seed.ts:391-397`; 24-hour token → observed `exp` − mint = 86400; three stamped action names → `packages/twin-github/src/tape-assertable-tools.ts:60-64`; `TWIN_AUTH_SECRET` sharing documented → `CONTRACT.md:44`. Check ids `github.tool-was-called` / `github.issue-assignee` / `github.no-new-issues` all exist at 0.42.1 with the substrates the table claims (`pome checks github`, digest `sha256:fcaef773…`).

Fixes: (1) stamp line records the 0.42.1 re-run; (2) `list_checks` is a hosted control-MCP tool — the local twin's tool table does not carry it (verified live), the page implied otherwise; (3) Next-link re-pointed off the 308 (below).

## showcases/permission-denial

All 24 pasted blocks re-run: **byte-identical** at 0.42.1 — the 8-line banner including the persisted-secret Auth line, GitHub's 403/404 error bodies verbatim, the byte-identical world diff, the 403/200 two-bearer contrast, the `403 false null / 200 true object` merge rows, `[REDACTED]` bearer, `tool: null` on every /merge row, the 501 envelope with its five `supported_surfaces`, `{"total":57,"allowed":42,"denied":15}` on /healthz, and the `add_collaborator` denied-in-catalog / 201-on-this-path pair. Only the merge sha differs, exactly as the page says it will. `pome checks add … --arg tool=merge_pull_request` is refused ("not valid for github.tool-was-called") ✓. `verify.sh` PASS locally.

Prose-vs-verify.sh mapping: refusal → L217; whole-world byte-identical → L231-233; same-request-other-bearer-while-running → L256-257; merge did the work → L267-270; redaction → L283-285; no-/merge-action-name canary → L290-292; exits non-zero → L334.

Open-defect statements on the page both check out and stay: F-1342 (Backlog — widening `TAPE_ASSERTABLE_TOOLS`, the "tracked upstream" of both pages) and F-1604 (Backlog — check descriptions saying "session", named in the `no-unsupported-endpoint` row).

Fixes: same three as the sibling page.

## The Next-link fix (both showcases)

`https://docs.pome.sh/quickstart/twins/github` 308s to `/quickstart/twins`: the five per-twin pages merged into one. The old bullet also described the destination as "on the hosted path" — the merged page is the local, no-account walkthrough. Re-pointed to the final URL and renamed the link text to **Get started**, the name the root README already uses for that destination (target-moved fix; flagging for lane W-C's one-name-per-destination pass).

ORCHESTRATOR RULING (fix round 2026-08-30): the 'github quickstart' → 'Get started' rename in both showcase READMEs is ACCEPTED in this lane — the old URL 308s to /quickstart/twins, the old description was false, and "Get started" is the root README's existing name for that destination, consistent with the site's W-C naming pass. Not reverted.

## Tickets filed

None. Both product-truth gaps the pages name already have open tickets (F-1342, F-1604); no new code-behavior decision surfaced.

## Needs credentialed verification

- `pome login && pome run tasks/` — hosted records+evaluates in one go (root README); syntax and help verified only.
- `pome eval runs/<task>/<run-id>` — actual upload + cloud verdict; help text verified ("no local scoring").
- `pome sandbox create --twin github --seed seed.json` — actual hosted sandbox creation; `--help` verified (flags exist as printed).

## Release-note entry

Not owed. Changed paths (`README.md`, `llms.txt`, `showcases/*`) sit outside every `PUBLISHED_PACKAGES` pathPrefix in `scripts/ci/publish-relevance.mjs`, and no `## Unreleased` entry is supplied — the allocator has nothing to allocate for this PR.

## Residue

- **S6's premise drifted**: `showcase-verify.yml` (dt#505) was deleted and absorbed into `ci.yml` (steps at `.github/workflows/ci.yml:521-559`). Same gate, new home; nothing owed.
- **`showcases/` is in ci.yml's heavy path filter** (line 47), so this PR runs the full suite including both verify.sh steps — both PASS locally at 0.42.1. Green here is the heavy leg, not the light docs route S6 predicted.
- **Ports 3333/3334 were held by other agents' live twins** during this sweep (left untouched per method card), so walkthrough re-runs used 3433/3434/3435. Every non-port, non-token byte of the pasted 3333-blocks was diffed against those runs; verify.sh additionally proves the flow on auto-picked ports.
- **`llms.txt` rider**: the repo-root llms.txt repeats the "137 MCP tools" figure in its one-line summary — fixed to 115 in the same commit as the README intro (one line, hand-maintained, no gate found). Flagging the scope extension for the orchestrator.
- Root README's HTML maintenance comment (quickstart consolidation note) left in place — invisible to readers and still accurate.
- `offline lint` (`scripts/lint.mjs`) passes 14/14 runnable rules; the 3 skipped need node_modules and read no markdown.

## Fix round 2026-08-30

Adversarial-verifier failures addressed, one by one:

1. **Failure:** "PR body Fix 1 claims 'doc_drift is [] on all five' fidelity inventories — false: gmail has 2 entries (mcp_gate1_launch_expansion, list_drafts_readOnlyHint_docs_vs_live), linear has 1 (document_initiative_parent); only github/stripe/slack are []. The 115 tool count itself verifies."
   **Resolution:** re-derived from the five `packages/twin-*/fidelity.inventory.json` files in a clean clone at this branch's head — the verifier is right: `jq '.doc_drift'` gives `[]` for github/stripe/slack, 2 entries for gmail, 1 for linear; `jq '.tools|length'` still sums 36+26+18+13+22 = 115. Fix 1 above is corrected in place (evidence table kept, counts unchanged). README/llms.txt audit: `grep -i drift` over `README.md`, both showcase READMEs, and `llms.txt` matches nothing, and the README's only adjacent sentence ("Each documents its surface route-by-route in its `FIDELITY.md`") claims documentation exists, not that drift is zero — so no page sentence leaned on the false claim and no page edit is owed. No code change; PR-body-only fix.

2. **Failure:** "ORCHESTRATOR RULING to record, no code change: the Next-link text rename 'github quickstart' -> 'Get started' in both showcase READMEs is ACCEPTED in this lane (the old URL 308s to /quickstart/twins, the old description was false, and 'Get started' is the root README's existing name for that destination — consistent with the site's W-C naming pass)."
   **Resolution:** ruling recorded as a one-line addition under "The Next-link fix (both showcases)" above; the rename stands, nothing reverted, no code change.

No pages were touched in this fix round, so no docs gates were owed; the branch head is unchanged from the verified sweep commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
