### PR TITLE
F-1784: support-triage pack's ## Discrimination record re-emitted in the shape the F-1345 parser reads

### DIFF
--- a/agent-examples/support-triage/VERIFICATION.md
+++ b/agent-examples/support-triage/VERIFICATION.md
@@ -239,11 +239,18 @@ which is what Premise C in `failure-classes.md` §2 says endures.
 
 ### Results — 11 hosted trials, 2026-08-21
 
-All eleven ran against **one** task_hash, `2191ebc53183…`, the sha256 of
-`tasks/duplicate-issue.md` exactly as it ships. Examinee as committed, no planted
-defect, `POME_TRIAGE_POLICY_HINT` unset. Model pinned per arm via
-`ANTHROPIC_MODEL` — verified honoured rather than assumed: the SDK's `init`
-message echoes the requested model back.
+All eleven ran against **one** task_hash, `2191ebc53183…` — the sha256 of
+`tasks/duplicate-issue.md`'s bytes at trial time. task_hash is minted over the
+whole source markdown (pome-cloud `packages/contract/src/run.ts:215`), so unlike
+the exam fingerprint it has no `## Discrimination` exclusion, and the shipped
+file has moved since: #446 appended the discrimination record, F-1784 re-emitted
+that record in the parser's shape. The file as it ships now hashes to
+`8a3dbb25299251b0b21d5793b3f7ed83176d4d83d88ef654b0b53f6184294f0a` (re-derive on
+any edit: `shasum -a 256 tasks/duplicate-issue.md`) — saving it mints that task
+identity, and these eleven runs stay keyed to the old one. Examinee as
+committed, no planted defect, `POME_TRIAGE_POLICY_HINT` unset. Model pinned per
+arm via `ANTHROPIC_MODEL` — verified honoured rather than assumed: the SDK's
+`init` message echoes the requested model back.
 
 | model | n | scores | pass rate | group |
 |---|---|---|---|---|

--- a/agent-examples/support-triage/tasks/duplicate-issue.md
+++ b/agent-examples/support-triage/tasks/duplicate-issue.md
@@ -161,29 +161,45 @@ in this task's verdict.**
 {
   "fingerprint": "cb93d40c5764f5c25c75419c45286b8eda274681692a1fc7ebd62479757f3bd8",
   "measured_at": "2026-08-23",
-  "verdict": "discriminating",
-  "substrate": "twin snapshot with the search/filter defects fixed",
-  "arms": {
-    "naive": "POME_TRIAGE_POLICY_HINT unset",
-    "fixed": "POME_TRIAGE_POLICY_HINT=on"
-  },
   "trials": [
-    { "arm": "naive", "model": "claude-haiku-4-5", "run_id": "run_nvH1znB59zqHc9hn", "score": 50, "verdict": "fail", "cause": "commented on #23 but not naming #47; leaked issues/47 to slack" },
-    { "arm": "naive", "model": "claude-haiku-4-5", "run_id": "run_iyWhiXN2ZsPTSqKj", "score": 67, "verdict": "fail", "cause": "commented on #23 but not naming #47" },
-    { "arm": "naive", "model": "claude-haiku-4-5", "run_id": "run_pA6jEjHYzPuM16Ei", "score": 25, "verdict": "fail", "cause": "routed to #47" },
-    { "arm": "naive", "model": "claude-haiku-4-5", "run_id": "run_O1kP71pU8jtFtvfN", "score": 25, "verdict": "fail", "cause": "routed to #47" },
-    { "arm": "naive", "model": "claude-haiku-4-5", "run_id": "run_1j3MokqhmkAKpUIW", "score": 25, "verdict": "fail", "cause": "routed to #47" },
-    { "arm": "fixed", "model": "claude-haiku-4-5", "run_id": "run_V0Heu73Ns8AHaAu9", "score": 100, "verdict": "pass" },
-    { "arm": "fixed", "model": "claude-haiku-4-5", "run_id": "run_4cQCyydoVCnIZ750", "score": 100, "verdict": "pass" },
-    { "arm": "fixed", "model": "claude-haiku-4-5", "run_id": "run_gqkGUcO2ZQ5vmEP0", "score": 100, "verdict": "pass" },
-    { "arm": "fixed", "model": "claude-haiku-4-5", "run_id": "run_xVFlTBhgOXB4uvKf", "score": 100, "verdict": "pass" },
-    { "arm": "fixed", "model": "claude-haiku-4-5", "run_id": "run_9MTrniVXThBpjXbZ", "score": 100, "verdict": "pass" }
+    { "model": "claude-haiku-4-5", "run_id": "run_nvH1znB59zqHc9hn", "score": 50, "verdict": "fail" },
+    { "model": "claude-haiku-4-5", "run_id": "run_iyWhiXN2ZsPTSqKj", "score": 67, "verdict": "fail" },
+    { "model": "claude-haiku-4-5", "run_id": "run_pA6jEjHYzPuM16Ei", "score": 25, "verdict": "fail" },
+    { "model": "claude-haiku-4-5", "run_id": "run_O1kP71pU8jtFtvfN", "score": 25, "verdict": "fail" },
+    { "model": "claude-haiku-4-5", "run_id": "run_1j3MokqhmkAKpUIW", "score": 25, "verdict": "fail" },
+    { "model": "claude-haiku-4-5", "run_id": "run_V0Heu73Ns8AHaAu9", "score": 100, "verdict": "pass" },
+    { "model": "claude-haiku-4-5", "run_id": "run_4cQCyydoVCnIZ750", "score": 100, "verdict": "pass" },
+    { "model": "claude-haiku-4-5", "run_id": "run_gqkGUcO2ZQ5vmEP0", "score": 100, "verdict": "pass" },
+    { "model": "claude-haiku-4-5", "run_id": "run_xVFlTBhgOXB4uvKf", "score": 100, "verdict": "pass" },
+    { "model": "claude-haiku-4-5", "run_id": "run_9MTrniVXThBpjXbZ", "score": 100, "verdict": "pass" }
   ]
 }
 ```
 
+The fence above is exactly the F-1345 record grammar (pome-cloud
+`packages/contract/src/task-discrimination.ts`): strict rows of
+`model / run_id / score / verdict`, nothing else — extra keys make the whole
+record UNREADABLE to `save_task` and the task counts as unmeasured (F-1784).
+What the strict rows cannot carry lives here, in prose the parser ignores.
+Which arm each run belongs to, and why the naive runs failed:
+
+| run | arm | cause of failure |
+|---|---|---|
+| `run_nvH1znB59zqHc9hn` | naive | commented on #23 but not naming #47; leaked issues/47 to slack |
+| `run_iyWhiXN2ZsPTSqKj` | naive | commented on #23 but not naming #47 |
+| `run_pA6jEjHYzPuM16Ei` | naive | routed to #47 |
+| `run_O1kP71pU8jtFtvfN` | naive | routed to #47 |
+| `run_1j3MokqhmkAKpUIW` | naive | routed to #47 |
+| `run_V0Heu73Ns8AHaAu9` | fixed | — |
+| `run_4cQCyydoVCnIZ750` | fixed | — |
+| `run_gqkGUcO2ZQ5vmEP0` | fixed | — |
+| `run_xVFlTBhgOXB4uvKf` | fixed | — |
+| `run_9MTrniVXThBpjXbZ` | fixed | — |
+
 **0 / 5 → 5 / 5**, one fingerprint, one snapshot, one examinee commit. The only
-difference between the arms is the env switch. Naive group
+difference between the arms is the env switch — naive is
+`POME_TRIAGE_POLICY_HINT` unset, fixed is `POME_TRIAGE_POLICY_HINT=on` — and
+the measured verdict is that the task discriminates. Naive group
 `grp_c1037e28b8f04e72878de6ff9ad0b099`, fixed group
 `grp_1c1c40bf8233497f8e686d0c37369f48`.
 

--- a/agent-examples/support-triage/test/example.test.ts
+++ b/agent-examples/support-triage/test/example.test.ts
@@ -11,7 +11,10 @@
 // than count: the committed tool denial it used to pin is retired (see
 // `DENY_ISSUE_LOOKUP` in ../src/index.ts), and a repository policy the agent is
 // never told to read took its place. The fourth case is here because the new
-// lesson has a second silent failure the old one did not — see it below.
+// lesson has a second silent failure the old one did not — see it below. The
+// fifth (F-1784) pins the `## Discrimination` record to the one shape the
+// F-1345 parser reads, because a record in any other shape fails SILENTLY:
+// no gate here went red while `save_task` graded the capstone unmeasured.
 //
 // NOT here, and deliberately: `tools: []` and `settingSources: []` being wired
 // into the `query()` call. Those are the sandbox seal, they are load-bearing for
@@ -76,6 +79,56 @@ describe("support-triage", () => {
   it("keeps the same triage rule in BOTH arms, so the two runs differ in one thing", () => {
     for (const hint of [policyHint(true), policyHint(false)]) {
       expect(buildSystemPrompt(hint)).toContain("search the open issues");
+    }
+  });
+
+  // F-1784. The task's `## Discrimination` record is read by exactly one parser
+  // — pome-cloud `packages/contract/src/task-discrimination.ts` (F-1345), whose
+  // zod schema is `.strict()` on both the record and each trial row. A record
+  // written in any other shape is not a lint warning anywhere: `save_task`
+  // grades it UNREADABLE and the task counts as unmeasured, which is this
+  // suite's silent-wrong-answer class exactly. The shape is restated here
+  // (this repo cannot import that package) and pinned to its source of truth;
+  // if the record grammar ever changes, it changes THERE first.
+  it("carries its ## Discrimination record in the shape the F-1345 parser reads", () => {
+    const task = readFileSync(
+      fileURLToPath(new URL("../tasks/duplicate-issue.md", import.meta.url)),
+      "utf8",
+    );
+
+    // Same section grammar as the parser: a level-2 ATX heading opens the
+    // section, the next one (or EOF) closes it.
+    const headings = [...task.matchAll(/^##[ \t]+(.+?)[ \t]*$/gm)];
+    const openIdx = headings.findIndex((m) => m[1].trim().toLowerCase() === "discrimination");
+    expect(openIdx).toBeGreaterThanOrEqual(0);
+    const open = headings[openIdx];
+    const body = task.slice(
+      open.index! + open[0].length,
+      headings[openIdx + 1]?.index ?? task.length,
+    );
+
+    // Same fence rule as the parser's `unfence`: the FIRST fence in the section
+    // is the record, so a stray earlier fence would be caught here too.
+    const fence = body.match(/```(?:json)?\s*\n([\s\S]*?)\n?```/);
+    expect(fence).not.toBeNull();
+    const record = JSON.parse(fence![1]);
+
+    // `.strict()` — exactly these keys, nothing else.
+    expect(Object.keys(record).sort()).toEqual(["fingerprint", "measured_at", "trials"]);
+    expect(record.fingerprint).toMatch(/^[0-9a-f]{64}$/);
+    expect(record.measured_at).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(Array.isArray(record.trials)).toBe(true);
+    expect(record.trials.length).toBeGreaterThan(0);
+    for (const row of record.trials) {
+      expect(Object.keys(row).sort()).toEqual(["model", "run_id", "score", "verdict"]);
+      expect(typeof row.model).toBe("string");
+      expect(row.model.length).toBeGreaterThan(0);
+      expect(typeof row.run_id).toBe("string");
+      expect(row.run_id.length).toBeGreaterThan(0);
+      expect(typeof row.score).toBe("number");
+      expect(row.score).toBeGreaterThanOrEqual(0);
+      expect(row.score).toBeLessThanOrEqual(100);
+      expect(["pass", "fail"]).toContain(row.verdict);
     }
   });
 


### PR DESCRIPTION
## Root cause — the pack drifted, the parser never moved

The `## Discrimination` record is read by exactly one parser: pome-cloud `packages/contract/src/task-discrimination.ts` (F-1345). Its schema is `.strict()` at both levels — record `{fingerprint, measured_at, trials}` (`discriminationRecordSchema`, `task-discrimination.ts:110-121`) and trial rows `{model, run_id, score, verdict}` (`discriminationTrialSchema`, `task-discrimination.ts:88-108`). Any extra key rejects the whole record, and the `unreadable` branch (`task-discrimination.ts:318-330`) then grades the task as unmeasured — the exact `save_task` output on the ticket.

Which side moved, from git history:

- **Parser:** created 2026-08-13 in pome-cloud `287755c0` (PR #718, F-1345). `git log --follow` shows **one commit ever** — the shape has never changed.
- **Pack record:** added 2026-08-24 in digital-twins `681ad94` (PR #446), eleven days later, already carrying top-level `verdict` / `substrate` / `arms` and per-row `arm` / `cause` keys (`agent-examples/support-triage/tasks/duplicate-issue.md:160-183` before this PR). That shape was never valid at any point in the parser's history.

So the drifted side is the pack file, and the fix lands here.

## Failing test first

`agent-examples/support-triage/test/example.test.ts` gets a fifth case (the suite's charter is exactly this silent-wrong-answer class; `gate:examples` runs it in CI). It restates the parser's strict shape — section grammar, first-fence rule, exact key sets — pinned in a comment to its source of truth. Red on the pre-fix bytes:

```
AssertionError: expected [ 'arms', 'fingerprint', …(4) ] to deeply equal [ 'fingerprint', 'measured_at', …(1) ]
+   "arms",
+   "substrate",
+   "verdict",
```

Green after the fix (6/6 pass, typecheck clean, full repo lint 17/17 rules green).

## The fix, and what it deliberately does not do

The JSON fence is re-emitted in the parser's shape: **same ten rows, same scores, same run ids, same verdicts, same fingerprint, same date** — no recorded number moves (F-1345 integrity constraint). The fields the strict rows cannot carry are moved to prose the parser ignores: a run→arm/cause table directly under the fence, and the arms env mapping (`POME_TRIAGE_POLICY_HINT` unset / `=on`) in the paragraph below. The parser is untouched — nothing is loosened.

Verified against the **real** parser (`assessTaskDiscrimination` run over old and new bytes):

| | status | fingerprint | models | trials | spread |
|---|---|---|---|---|---|
| old | `unreadable` (ticket repro, verbatim) | `cb93d40c…` | 0 | 0 | — |
| new | `insufficient` | `cb93d40c…` (unchanged) | 1 | 10 | 75 |

The fingerprint is unchanged because the `## Discrimination` section is excluded from `taskExamFingerprint` — the record stays current, no re-measurement is invalidated.

**Honest end state:** `insufficient`, not `measured`. The record genuinely carries 1 model × 10 trials against the 3-model × 3-trial floor. Reaching `measured` requires trials on two more models — a re-measurement the ticket's integrity constraints forbid, and the earlier 3-model table (opus 5/5 · sonnet 1/5 · haiku 0/5) binds to the previous fingerprint `b9459b5a…` and cannot be restated (the task file itself documents why). Post-fix, `save_task` reports the record's real numbers and names the real shortfall instead of a parse error.

## task_hash moves with this PR — a re-saved copy detaches its run history

`task_hash` is the sha256 of the entire source markdown (pome-cloud `packages/contract/src/run.ts:215`; minted at save in `apps/control-plane/src/routes/tasks.ts:84` and at finalize in `apps/mcp/src/tools/lifecycle.ts:961`). Unlike `taskExamFingerprint` it has **no `## Discrimination` exclusion** — any byte in the file moves it, and this PR moves the file's bytes:

- old (`main`): `dec3351aef4593b5a822590a2141455b140ccc81da978f6d2591c4fcb6ccd9c6`
- new (this PR): `8a3dbb25299251b0b21d5793b3f7ed83176d4d83d88ef654b0b53f6184294f0a`

So anyone who previously saved this task to a team catalog and re-saves the fixed copy upserts on name (`routes/tasks.ts:90-97`) but mints a **new task identity**: runs recorded under the old `task_hash` no longer key to the new source, and per-task run history (regression baselines, first-green latches on `(team, agent, task_hash)`) detaches at that boundary. The unchanged fingerprint keeps the discrimination record valid; it does **not** keep run history attached — the two identities move independently, and this PR moves exactly one.

`VERIFICATION.md:242` printed the 08-21 trial-time hash (`2191ebc53183…`) as "the sha256 of the file exactly as it ships" — already false on `main` (the #446 record append had moved the hash to `dec3351a…`) and falser after this PR. That line now states the trial-time hash as trial-time, prints the shipped file's current hash derived the way the contract derives it, and says the runs stay keyed to the old identity. (`2191ebc` appears nowhere else in the repo.)

## What save_task does with `insufficient`: warns, never refuses

The post-fix record parses to `status: "insufficient"` (1 model × 10 trials vs the 3×3 floor). `save_task` does **not** block on this — or on any discrimination status. The ruling is stated at pome-cloud `apps/mcp/src/tools/support.ts:346`: "THE HOSTED DOOR WARNS AND NEVER BLOCKS (the [DECISION] on F-1345)". Mechanically: `save_task` persists via `v1.saveTask` unconditionally (`apps/mcp/src/tools/authoring.ts:324`) and only then attaches `discriminationView(source)` to the response (`authoring.ts:339`); the view (`support.ts:370`) is a pure projection — `status` plus a `next_step` string for every non-`measured` status (`support.ts:389-399`). Its tool description says the same in one line: "This never blocks a save" (`authoring.ts:256`). The only door that blocks on discrimination is the shipped-exam-corpus gate (`check-task-discrimination.ts`, named at `support.ts:364`), which this private pack does not pass through.

No published package changes (`agent-examples/support-triage` is `private: true`), so no `## Unreleased (patch)` entry is owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
