### PR TITLE
compile-seeds carries the seed schema as prompt text, not a grammar the API refuses (F-1782)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,6 +9,19 @@ write a version number here or in `package.json`. Released entries are insertion
 only: a correction is the next entry, naming the one it corrects.
 
 
+## Unreleased (patch)
+
+**`pome compile-seeds` compiles again.** Every file failed with the Anthropic
+API's 400 "The compiled grammar is too large": the command registered the whole
+GitHub seed schema as a structured-output grammar (`output_config.format`), and
+that schema has outgrown the API's grammar-size limit — a trivial schema
+compiles, the largest single branch compiles, the full schema does not, on the
+pinned model and newer ones alike. The compiler now asks for plain JSON with
+the schema carried in the system prompt, and validates the reply locally
+against the same zod schema every compile already ended on. Sidecar format,
+caching, and the pinned model are unchanged; nothing was billed by the
+failures, since the 400 preceded inference.
+
 ## 0.42.2 — 2026-08-30
 
 **`pome init --example support-triage` no longer forks the capstone reader off

--- a/cli/src/task/seed-compiler.ts
+++ b/cli/src/task/seed-compiler.ts
@@ -1,8 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 /**
  * Compile a prose seed description into a JSON seed object matching
- * `seedStateSchema`. Uses the Anthropic Messages API with structured
- * output (`output_config` + `zodOutputFormat`).
+ * `seedStateSchema`. Uses the Anthropic Messages API with the schema
+ * carried in the system prompt and the reply validated locally.
+ *
+ * NOT structured output (`output_config.format`), deliberately: the seed
+ * schema compiled as a constrained-decoding grammar exceeds the API's
+ * undocumented grammar-size limit, and every request 400s with "The
+ * compiled grammar is too large" before inference. The limit is on the
+ * aggregate schema — a trivial schema compiles and the largest single
+ * branch (`pull_requests`) compiles, but the whole seed schema does not,
+ * on the pinned model and on newer ones alike — so any schema shrink
+ * would only last until the seed grows a field. Local validation is the
+ * path this module always ended on anyway (`parseGitHubSeedState`, and
+ * the twin boot check in `verifySeedWithTwin` after it).
  *
  * Why Messages API and not the Agent SDK: this is a pure prose-to-JSON
  * transform with no tools needed during generation, so the agent loop
@@ -10,12 +21,18 @@
  * also pushes per-call cost up ~3-10×.
  */
 import Anthropic from "@anthropic-ai/sdk";
-import { zodOutputFormat } from "@anthropic-ai/sdk/helpers/zod";
+import { z } from "zod";
 import { parseGitHubSeedState } from "./githubSeedCompat.js";
 // `/seed`, not the package root — see `parseTask.ts`'s note.
 import { seedSchema as seedStateSchema } from "@pome-sh/twin-github/seed";
 
 export const COMPILER_MODEL = "claude-opus-4-7";
+
+const MAX_TOKENS = 8192;
+
+// `io: "input"` — what `parseSeed` accepts, so fields with schema defaults are
+// optional. That is the shape rule 4 below already promises the model.
+const SEED_JSON_SCHEMA = JSON.stringify(z.toJSONSchema(seedStateSchema, { io: "input" }));
 
 const SYSTEM_PROMPT = `You convert natural-language descriptions of a GitHub twin's seed state into JSON matching the provided schema.
 
@@ -28,7 +45,13 @@ Rules:
 6. Issue \`number\` is required and must be set (use #N if the prose says so, otherwise start at 1).
 7. PR \`number\` is optional; set it when the prose says "#N".
 8. Issue \`assignees\` is an array of login strings; use [] when unassigned.
-9. Use fenced code blocks in the prose to indicate the exact content of \`files[].content\`. Preserve trailing newlines verbatim.`;
+9. Use fenced code blocks in the prose to indicate the exact content of \`files[].content\`. Preserve trailing newlines verbatim.
+
+Respond with a single JSON object that validates against this JSON Schema. Output only the JSON object — no prose, no markdown fences.
+
+<schema>
+${SEED_JSON_SCHEMA}
+</schema>`;
 
 export interface CompileResult {
   seed: unknown;
@@ -49,27 +72,35 @@ export async function compileSeed(prose: string, opts: { model?: string } = {}):
   const client = new Anthropic();
   const t0 = Date.now();
 
-  const response = await client.messages.parse({
+  const response = await client.messages.create({
     model,
-    max_tokens: 8192,
+    max_tokens: MAX_TOKENS,
     system: SYSTEM_PROMPT,
-    messages: [{ role: "user", content: prose }],
-    output_config: { format: zodOutputFormat(seedStateSchema) }
+    messages: [{ role: "user", content: prose }]
   });
 
   const durationMs = Date.now() - t0;
 
-  if (!response.parsed_output) {
+  if (response.stop_reason === "max_tokens") {
     throw new Error(
-      `Compiler returned no parsed_output (stop_reason=${response.stop_reason}). ` +
-        `This usually means the model produced output that failed schema validation.`
+      `Compiler output was truncated at max_tokens=${MAX_TOKENS}. ` +
+        `The seed prose may describe more state than one compile can emit.`
     );
   }
 
-  // Re-validate locally to be safe — `parse()` already ran the schema, but
-  // running it again here gives us a stable error site for tests + ensures
-  // downstream code holds a `ParsedSeedState`-shaped value, not `unknown`.
-  const seed = parseGitHubSeedState(response.parsed_output);
+  const text = response.content.map((block) => (block.type === "text" ? block.text : "")).join("");
+
+  let candidate: unknown;
+  try {
+    candidate = JSON.parse(extractJsonPayload(text));
+  } catch (err) {
+    throw new Error(`Compiler did not return valid JSON: ${(err as Error).message}`);
+  }
+
+  // The schema travels as prompt text, so this local parse IS the validation —
+  // it also ensures downstream code holds a `ParsedSeedState`-shaped value,
+  // not `unknown`.
+  const seed = parseGitHubSeedState(candidate);
 
   return {
     seed,
@@ -78,4 +109,11 @@ export async function compileSeed(prose: string, opts: { model?: string } = {}):
     model,
     durationMs
   };
+}
+
+/** The prompt forbids fences, but a fenced reply is still a valid compile. */
+function extractJsonPayload(text: string): string {
+  const trimmed = text.trim();
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/);
+  return fenced ? fenced[1]! : trimmed;
 }

--- a/cli/test/unit/seed-compiler.test.ts
+++ b/cli/test/unit/seed-compiler.test.ts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * `compileSeed` must not register the seed schema as a structured-output
+ * grammar.
+ *
+ * The GitHub seed schema has outgrown the Anthropic API's grammar-size limit:
+ * sent via `output_config.format`, every request fails with a 400 "The
+ * compiled grammar is too large" before any inference happens, which took
+ * `pome compile-seeds` down for every file. The schema still has to reach the
+ * model — as prose in the system prompt — and the reply is validated locally
+ * against the same zod schema, which is the validation path this command has
+ * always ended on anyway (`parseGitHubSeedState`, then the twin boot check).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createMock } = vi.hoisted(() => ({ createMock: vi.fn() }));
+
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: class AnthropicStandIn {
+    messages = { create: createMock };
+  },
+}));
+
+import { compileSeed, COMPILER_MODEL } from "../../src/task/seed-compiler.js";
+
+const VALID_SEED_JSON = JSON.stringify({
+  repositories: [{ owner: "acme", name: "api", issues: [{ number: 1, title: "tiny" }] }],
+});
+
+function textResponse(text: string, overrides: Record<string, unknown> = {}) {
+  return {
+    content: [{ type: "text", text }],
+    stop_reason: "end_turn",
+    usage: { input_tokens: 11, output_tokens: 22 },
+    ...overrides,
+  };
+}
+
+describe("compileSeed request shape", () => {
+  beforeEach(() => {
+    vi.stubEnv("ANTHROPIC_API_KEY", "test-key");
+    createMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("sends a plain message with no output_config grammar", async () => {
+    createMock.mockResolvedValue(textResponse(VALID_SEED_JSON));
+
+    const result = await compileSeed("One repo, acme/api, with a single open bug.");
+
+    expect(createMock).toHaveBeenCalledTimes(1);
+    const params = createMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(params.output_config).toBeUndefined();
+    expect(params.model).toBe(COMPILER_MODEL);
+    const seed = result.seed as { repositories: Array<{ owner: string }> };
+    expect(seed.repositories[0]!.owner).toBe("acme");
+    expect(result.inputTokens).toBe(11);
+    expect(result.outputTokens).toBe(22);
+  });
+
+  it("carries the seed JSON schema in the system prompt instead", async () => {
+    createMock.mockResolvedValue(textResponse(VALID_SEED_JSON));
+
+    await compileSeed("One repo, acme/api.");
+
+    const params = createMock.mock.calls[0]![0] as { system: string };
+    // Two fields that only the schema, not the prose rules, would name.
+    expect(params.system).toContain('"pull_requests"');
+    expect(params.system).toContain('"renamed_from"');
+  });
+});
+
+describe("compileSeed response handling", () => {
+  beforeEach(() => {
+    vi.stubEnv("ANTHROPIC_API_KEY", "test-key");
+    createMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("unwraps a fenced JSON reply", async () => {
+    createMock.mockResolvedValue(textResponse("```json\n" + VALID_SEED_JSON + "\n```"));
+
+    const result = await compileSeed("One repo, acme/api.");
+
+    const seed = result.seed as { repositories: Array<{ name: string }> };
+    expect(seed.repositories[0]!.name).toBe("api");
+  });
+
+  it("rejects a schema-invalid reply with the offending field named", async () => {
+    createMock.mockResolvedValue(textResponse(JSON.stringify({ repositories: [{ name: "api" }] })));
+
+    await expect(compileSeed("One repo.")).rejects.toThrow(/owner/);
+  });
+
+  it("rejects a non-JSON reply as a compile error, not a stack trace", async () => {
+    createMock.mockResolvedValue(textResponse("Sure! Here is the seed you asked for."));
+
+    await expect(compileSeed("One repo.")).rejects.toThrow(/valid JSON/);
+  });
+
+  it("rejects a reply truncated at the token ceiling before trying to parse it", async () => {
+    createMock.mockResolvedValue(textResponse('{"repositories": [', { stop_reason: "max_tokens" }));
+
+    await expect(compileSeed("One repo.")).rejects.toThrow(/truncated/);
+  });
+});


### PR DESCRIPTION
Fixes F-1782: `pome compile-seeds` failed 400 `"The compiled grammar is too large"` on every file (lane R live repro, CLI 0.42.2, reqs `req_011CeZaBT8mMNrYtektk7Rnx` / `req_011CeZaBVac3ScPGyRAAA5t7`).

## Root cause

`cli/src/task/seed-compiler.ts:52-58` sent the whole GitHub twin seed schema as a structured-output grammar — `client.messages.parse({..., output_config: { format: zodOutputFormat(seedStateSchema) }})` with the schema from `packages/twin-github/src/seed.ts:5-265`. The Anthropic API compiles that schema into a constrained-decoding grammar and rejects it as over its (undocumented) grammar-size limit, before any inference — so every file failed identically and nothing was billed.

Bisected live (a grammar 400 precedes inference and bills nothing, so failing probes are free):

- Reproduced byte-exactly: the JSON schema the SDK helper emits is stable at 7,354 bytes across `@anthropic-ai/sdk` 0.115.0 (lockfile) → 0.122.0 (what an end-user install of `^0.115.0` resolves) and zod 4.4.3 → 4.5.4, and the published 0.42.2 tarball bundles the identical zod schema. Sending it → 400 grammar-too-large (fresh req id).
- Trivial schema on `claude-opus-4-7` → passes (structured outputs per se is fine on the pinned model).
- Full schema on `claude-opus-4-8` → same 400 (not model-specific).
- Full schema with every `description` stripped → same 400 (annotations irrelevant).
- Repo object reduced to `{owner, name, pull_requests}` — the single largest branch — → passes.
- Repo object with `{owner, name, milestones, tags, releases, issues, pull_requests}` → same 400.

So the trigger is aggregate schema size, not any one construct: the seed schema outgrew the limit. The bundled sidecars were last compiled 2026-05-22; the schema has since gained milestones/tags/releases, seeded PR numbers, and `strictObject` everywhere. Any shrink-the-schema fix lasts only until the next seed field lands.

Not server-side: the 400 comes from the Anthropic Messages API (billed to `ANTHROPIC_API_KEY`), not pome-cloud. CLI-owned, lands here.

## Fix

Stop registering the schema as a grammar. `compileSeed` now sends a plain `messages.create` with the seed JSON Schema carried in the system prompt (`z.toJSONSchema(seedStateSchema, { io: "input" })` — input-io so fields with schema defaults are optional, which is what prompt rule 4 already promised the model), and validates the reply locally. Local validation is the path every compile already ended on: `parseGitHubSeedState` (same zod schema) and then `verifySeedWithTwin` (in-memory twin boot). Added handling for a truncated reply (`stop_reason === "max_tokens"`), a non-JSON reply, and a fenced reply. `COMPILER_MODEL`, the sidecar format, and the cache contract are unchanged, so no existing sidecar recompiles.

Cost change: the 7.4KB schema now travels as system-prompt text instead of a server-compiled grammar, so every compile pays roughly 2K more input tokens (the live confirmation's 2447-token input for a minimal task is mostly this schema).

## Failing test first

`cli/test/unit/seed-compiler.test.ts` (new) pins the request shape (no `output_config`, schema present in the system prompt) and the reply handling (fenced JSON, schema-invalid, non-JSON, truncated). Against the pre-fix implementation all 6 fail — the pre-fix code goes through the structured-output door (`client.messages.parse` + `output_config`), which the test's client stand-in does not provide:

```
Tests  6 failed (6)
  AssertionError: ... but got 'client.messages.parse is not a function'
```

After the fix: 6 passed; full suite 361 files / 4027 tests passed; `npm run lint` (17 rules) and `lint:dead-code` clean; cli typecheck clean.

## Live confirmation

One small compile with the locally-built CLI against prod Anthropic (lane-R authorized key from the provisioned throwaway account setup; nothing echoed anywhere): a minimal single-repo/single-issue github task — the same shape as the ticket's failing repro — now compiles: `OK tiny-seed-test.md (2447 in / 92 out, 1599ms)`, exact-text rules preserved (`# Acme API\n`, exact issue title), twin boot verification passed, sidecar provenance stamped `claude-opus-4-7`.

Release note: `cli/CHANGELOG.md` gains an `## Unreleased (patch)` entry (version allocated at merge).

