### PR TITLE
`pome checks <twin>` header names the real inlined twin version, or omits it honestly (F-1791)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,6 +9,20 @@ write a version number here or in `package.json`. Released entries are insertion
 only: a correction is the next entry, naming the one it corrects.
 
 
+## Unreleased (patch)
+
+**`pome checks <twin>` names the twin's real version instead of "unknown"**
+(F-1791). The header — the first grading-vocabulary output the docs send a
+newcomer to — printed `(@pome-sh/twin-github unknown)` on every install. The
+version lookup still read the CLI's own `dependencies`, but the twins stopped
+living there when tsup began inlining them: they are devDependency workspace
+links now, so that key could never name them again. The build bakes the
+inlined versions into the bundle (the same mechanism as `pome --version`), a
+source tree resolves the workspace link's own manifest, and when neither
+answers the parenthetical is omitted rather than filled with a placeholder.
+The digest-skew refusal and the offline `checks add` note named the same
+"unknown" pin and are fixed by the same resolution.
+
 ## 0.42.3 — 2026-08-30
 
 **`pome compile-seeds` compiles again.** Every file failed with the Anthropic

--- a/cli/src/cli/checks-add.ts
+++ b/cli/src/cli/checks-add.ts
@@ -33,7 +33,7 @@ import {
   displaySentence,
   findCheck,
   localDigest,
-  pinnedVersion,
+  pinLabel,
   twinOf,
   type DeclaredCheck,
 } from "./checks.js";
@@ -76,7 +76,6 @@ export async function handshake(
   twin: string,
   fetchRemote: (twin: string) => Promise<RemoteChecks>,
 ): Promise<HandshakeResult> {
-  const pin = pinnedVersion(`@pome-sh/twin-${twin}`);
   let remote: RemoteChecks;
   try {
     remote = await fetchRemote(twin);
@@ -85,7 +84,7 @@ export async function handshake(
       kind: "unverified",
       note:
         `Not verified against the cloud (${err instanceof Error ? err.message : "unreachable"}). ` +
-        `Writing from the local pin: @pome-sh/twin-${twin} ${pin}.`,
+        `Writing from the local pin: ${pinLabel(`@pome-sh/twin-${twin}`)}.`,
     };
   }
 

--- a/cli/src/cli/checks.ts
+++ b/cli/src/cli/checks.ts
@@ -9,7 +9,7 @@
  * to write a sentence when the two pins disagree.
  */
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { createRequire } from "node:module";
 
 import { checksDigest, templateSlots, type CheckDefinition } from "@pome-sh/sdk/checks";
 import { MOUNTED_TWINS } from "../contract/index.js";
@@ -18,8 +18,6 @@ import { GMAIL_CHECKS } from "@pome-sh/twin-gmail/checks";
 import { LINEAR_CHECKS } from "@pome-sh/twin-linear/checks";
 import { SLACK_CHECKS } from "@pome-sh/twin-slack/checks";
 import { STRIPE_CHECKS } from "@pome-sh/twin-stripe/checks";
-
-import { resolvePackageRoot } from "./resolve-package-root.js";
 
 // Args erased, exactly as pome-cloud's registry does it: the declarations are a
 // heterogeneous tuple that every consumer here handles uniformly.
@@ -107,20 +105,56 @@ export function localDigest(twin: string): string {
   return checksDigest(checksFor(twin));
 }
 
-/** Read the pin from OUR OWN manifest. The twin's exports map sends
- *  `./package.json` through its `"./*"` wildcard and fails to resolve — and the
- *  pin we control is the one that matters anyway. */
-export function pinnedVersion(pkg: string): string {
-  const root = resolvePackageRoot(import.meta.url);
-  if (!root) return "unknown";
+// Baked by tsup (`define: { POME_INLINED_PKG_VERSIONS }`): a JSON map from
+// package name to the version the bundle inlined. Undeclared under
+// `tsx src/cli/main.ts` and vitest, where the workspace fallback below applies
+// — the same split `main.ts` uses for PKG_VERSION.
+declare const POME_INLINED_PKG_VERSIONS: string | undefined;
+
+function bakedVersions(): Record<string, string> {
+  if (typeof POME_INLINED_PKG_VERSIONS !== "string") return {};
   try {
-    const manifest = JSON.parse(readFileSync(join(root, "package.json"), "utf8")) as {
-      dependencies?: Record<string, string>;
-    };
-    return manifest.dependencies?.[pkg] ?? "unknown";
+    return JSON.parse(POME_INLINED_PKG_VERSIONS) as Record<string, string>;
   } catch {
-    return "unknown";
+    return {};
   }
+}
+
+/**
+ * The version of an inlined `@pome-sh/*` package, or undefined when nothing
+ * can honestly answer.
+ *
+ * This used to read the CLI's own `dependencies`, which was right when the
+ * twins were real runtime dependencies. tsup's `noExternal` inlines them now,
+ * so they live in `devDependencies` as workspace `"*"` links, and the old
+ * lookup answered "unknown" on every install — including the header of
+ * `pome checks <twin>`, the first grading-vocabulary output the docs point a
+ * newcomer at (F-1791). The version of the code actually in this process is
+ * the one recorded at build time; in the source tree, the workspace link's
+ * own manifest says the same thing.
+ */
+export function pinnedVersion(pkg: string): string | undefined {
+  const baked = bakedVersions()[pkg];
+  if (baked) return baked;
+  try {
+    const require = createRequire(import.meta.url);
+    const manifest = JSON.parse(readFileSync(require.resolve(`${pkg}/package.json`), "utf8")) as {
+      name?: string;
+      version?: string;
+    };
+    if (manifest.name === pkg && typeof manifest.version === "string") return manifest.version;
+  } catch {
+    // Neither baked nor installed: callers omit the version rather than print
+    // a word that reads like a failure.
+  }
+  return undefined;
+}
+
+/** `@pome-sh/twin-github 0.12.0`, or the bare package name when the version
+ *  cannot be resolved. */
+export function pinLabel(pkg: string): string {
+  const version = pinnedVersion(pkg);
+  return version === undefined ? pkg : `${pkg} ${version}`;
 }
 
 export const SUBSTRATE_HELP: Record<string, string> = {
@@ -149,6 +183,14 @@ export function argFlagsFor(def: DeclaredCheck): string {
 
 export interface ChecksCommandOptions {
   json?: boolean;
+}
+
+/** The `pome checks <twin>` header. Version undefined means the parenthetical
+ *  is omitted, not filled with a placeholder (F-1791). Exported for the test
+ *  of that branch, which nothing in a source tree can reach naturally. */
+export function checksHeader(twin: string, count: number, version: string | undefined): string {
+  const label = bold(`${twin} — ${count} declared check${count === 1 ? "" : "s"}`);
+  return version === undefined ? label : `${label} ${dim(`(@pome-sh/twin-${twin} ${version})`)}`;
 }
 
 function jsonView(twin: string) {
@@ -212,10 +254,7 @@ export async function runChecksCommand(
     return;
   }
 
-  console.log(
-    `${bold(`${twin} — ${checks.length} declared check${checks.length === 1 ? "" : "s"}`)} ` +
-      dim(`(@pome-sh/twin-${twin} ${pinnedVersion(`@pome-sh/twin-${twin}`)})`),
-  );
+  console.log(checksHeader(twin, checks.length, pinnedVersion(`@pome-sh/twin-${twin}`)));
   console.log("");
   for (const def of checks) {
     console.log(`  ${bold(def.id)}`);

--- a/cli/src/cli/vocabulary-skew.ts
+++ b/cli/src/cli/vocabulary-skew.ts
@@ -27,7 +27,7 @@
  */
 import { checkPattern, templateSlots } from "@pome-sh/sdk/checks";
 
-import { checksFor, localDigest, pinnedVersion, type DeclaredCheck } from "./checks.js";
+import { checksFor, localDigest, pinLabel, type DeclaredCheck } from "./checks.js";
 
 /** One check as `GET /v1/checks` publishes it. */
 export interface RemoteCheck {
@@ -226,8 +226,8 @@ export function formatSkewRefusal(twin: string, findings: readonly SkewFinding[]
       `sentence written here might not be graded there.`,
     ...findings.flatMap(bullet),
     "",
-    `  local @pome-sh/twin-${twin} ${pinnedVersion(`@pome-sh/twin-${twin}`)}` +
-      (sdkImplicated ? `, @pome-sh/sdk ${pinnedVersion("@pome-sh/sdk")}` : ""),
+    `  local ${pinLabel(`@pome-sh/twin-${twin}`)}` +
+      (sdkImplicated ? `, ${pinLabel("@pome-sh/sdk")}` : ""),
     ...(sdkImplicated
       ? [`  The cloud publishes no sdk version here, so that is the only pin this CLI can name.`]
       : []),

--- a/cli/test/unit/checks-command.test.ts
+++ b/cli/test/unit/checks-command.test.ts
@@ -1,8 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0
+import { readFileSync } from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MOUNTED_TWINS } from "../../src/contract/index.js";
 import { createProgram } from "../../src/cli/main.js";
-import { checksFor, twinsWithoutChecks } from "../../src/cli/checks.js";
+import {
+  checksFor,
+  checksHeader,
+  pinLabel,
+  pinnedVersion,
+  twinsWithoutChecks,
+} from "../../src/cli/checks.js";
+
+// Read straight from the workspace tree, on purpose: the assertion must not
+// share a resolution mechanism with the code under test.
+function workspaceVersion(dir: string): string {
+  const manifest = JSON.parse(
+    readFileSync(new URL(`../../../packages/${dir}/package.json`, import.meta.url), "utf8"),
+  ) as { version: string };
+  return manifest.version;
+}
 
 interface CapturedConsole {
   log: string[];
@@ -64,6 +80,56 @@ describe("pome checks", () => {
     await createProgram().parseAsync(["node", "pome", "checks", "gitbub"]);
     expect(process.exitCode).toBe(2);
     expect(captured.error.join("\n")).toContain("github");
+  });
+
+  // F-1791: the header printed "(@pome-sh/twin-github unknown)" on every
+  // install. The old lookup read the CLI's own `dependencies`, but tsup INLINES
+  // the twins now — they are devDependency workspace links, so that manifest
+  // key can never name them again. The version that belongs here is the one of
+  // the twin code actually riding in this process.
+  it("names the inlined twin version in the header, never 'unknown'", async () => {
+    const captured = captureConsole();
+    await createProgram().parseAsync(["node", "pome", "checks", "github"]);
+    const header = captured.log[0]!;
+    expect(header).toContain(`(@pome-sh/twin-github ${workspaceVersion("twin-github")})`);
+    expect(header).not.toContain("unknown");
+  });
+
+  it("resolves an inlined package's version from the workspace link in dev", () => {
+    expect(pinnedVersion("@pome-sh/twin-github")).toBe(workspaceVersion("twin-github"));
+    expect(pinnedVersion("@pome-sh/sdk")).toBe(workspaceVersion("sdk"));
+  });
+
+  // The honest branch: when no version is resolvable the parenthetical is
+  // OMITTED — a word like "unknown" in the first line of the vocabulary
+  // listing reads as a defect, which is exactly how F-1791 was filed.
+  it("omits the version parenthetical entirely when it cannot be resolved", () => {
+    expect(pinnedVersion("@pome-sh/no-such-package")).toBeUndefined();
+    expect(checksHeader("github", 16, undefined)).toBe("github — 16 declared checks");
+    expect(pinLabel("@pome-sh/no-such-package")).toBe("@pome-sh/no-such-package");
+  });
+
+  // The published tarball has no workspace to fall back to, so the build must
+  // bake the versions in. Assert the map the tsup config defines, not the
+  // bundling itself: every inlined @pome-sh package, each with a real version.
+  it("bakes a version for every inlined @pome-sh package into the bundle", async () => {
+    const config = (await import("../../tsup.config.js")).default as {
+      define?: Record<string, string>;
+    };
+    const baked = JSON.parse(JSON.parse(config.define!.POME_INLINED_PKG_VERSIONS!)) as Record<
+      string,
+      string
+    >;
+    const manifest = JSON.parse(
+      readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+    ) as { devDependencies: Record<string, string> };
+    const inlined = Object.keys(manifest.devDependencies).filter((dep) =>
+      dep.startsWith("@pome-sh/"),
+    );
+    expect(inlined.length).toBeGreaterThan(0);
+    for (const dep of inlined) {
+      expect(baked[dep], `${dep} has no baked version`).toMatch(/^\d+\.\d+\.\d+/);
+    }
   });
 
   it("--json emits the declaration plus a digest, for skills and agents", async () => {

--- a/cli/tsup.config.ts
+++ b/cli/tsup.config.ts
@@ -31,13 +31,38 @@
 // asserts every specifier the inlined packages import is declared here.
 import { execSync } from "node:child_process";
 import { chmodSync, readFileSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { resolve } from "node:path";
 import { defineConfig } from "tsup";
 
 const CLI_ROOT = new URL(".", import.meta.url).pathname;
 const pkg = JSON.parse(readFileSync(resolve(CLI_ROOT, "package.json"), "utf8")) as {
   version: string;
+  devDependencies?: Record<string, string>;
 };
+
+/**
+ * Versions of the `@pome-sh/*` packages this bundle inlines. They are
+ * devDependencies resolved as workspace `"*"` links, so nothing in the
+ * published tarball records which twin vocabulary rode along — except this
+ * map, read by `src/cli/checks.ts`'s `pinnedVersion` for the
+ * `pome checks <twin>` header and the digest-skew refusals (F-1791). Baked at
+ * build time because build time is when the inlining happens.
+ */
+function inlinedPackageVersions(): Record<string, string> {
+  const require = createRequire(resolve(CLI_ROOT, "package.json"));
+  const inlined = Object.keys(pkg.devDependencies ?? {}).filter((dep) =>
+    dep.startsWith("@pome-sh/"),
+  );
+  return Object.fromEntries(
+    inlined.map((dep) => {
+      const manifest = JSON.parse(
+        readFileSync(require.resolve(`${dep}/package.json`), "utf8"),
+      ) as { version: string };
+      return [dep, manifest.version];
+    }),
+  );
+}
 
 const BIN_ENTRY = resolve(CLI_ROOT, "dist/src/cli/main.js");
 
@@ -109,6 +134,9 @@ export default defineConfig({
     // it now. Without the pin an old CLI quietly scaffolds an example written
     // against a newer one.
     PKG_GIT_SHA: JSON.stringify(resolveGitSha()),
+    // Read by src/cli/checks.ts. Double-stringified: define injects raw
+    // source text, and the runtime wants a string literal holding JSON.
+    POME_INLINED_PKG_VERSIONS: JSON.stringify(JSON.stringify(inlinedPackageVersions())),
   },
   async onSuccess() {
     ensureExecutableBin();

--- a/packages/sandbox-domains/CHANGELOG.md
+++ b/packages/sandbox-domains/CHANGELOG.md
@@ -1,5 +1,8 @@
 # @pome-sh/sandbox-domains
 
+## Unreleased (patch)
+
+The bundled `@pome-sh/sdk` exposes `./package.json` in its `exports`, so the CLI can resolve each inlined twin's version for the `pome checks <twin>` header (F-1791). No exported names, types or shapes change.
 
 ## 0.3.0 — 2026-08-29
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -38,7 +38,8 @@
     "./failure-injection-rules": {
       "types": "./dist/failure-injection-rules.d.ts",
       "default": "./dist/failure-injection-rules.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

On a plain npm install, `pome checks github` opened with:

```
github — 16 declared checks (@pome-sh/twin-github unknown)
```

— the first line of the first grading-vocabulary output the docs send a newcomer to, reading like something is broken (F-1791).

## Mechanism

`pinnedVersion()` read the CLI's own `package.json` `dependencies` for `@pome-sh/twin-github`. That was right when the twins were real runtime dependencies, but the tsup restructure inlines every `@pome-sh/*` package via `noExternal` and moved them to `devDependencies` as workspace `"*"` links — so the `dependencies` lookup answered "unknown" on every install: dev tree, built bundle, and published tarball alike. Reproduced in all three before the fix.

## Fix

Two resolution layers, then honest omission:

1. **Baked at build time** — `cli/tsup.config.ts` defines `POME_INLINED_PKG_VERSIONS`, a map from each inlined `@pome-sh/*` devDependency to the version its workspace manifest declared when the bundle inlined it (same mechanism as `PKG_VERSION` for `pome --version`). This is what a plain npm install prints.
2. **Workspace fallback** — a source-tree run (`tsx`, vitest) resolves the workspace link's own `package.json`. `packages/sdk` gains `"./package.json": "./package.json"` in its exports map so it resolves like the five twins already do (the stale comment claiming twins can't was from before they exported it).
3. **Unresolvable** — `pinnedVersion` returns `undefined` and the header omits the parenthetical entirely, per the ticket's "honestly omit" branch. No caller can print "unknown" again.

The digest-skew refusal (`vocabulary-skew.ts`) and the offline `checks add` note named the same "unknown" pin; both now go through a shared `pinLabel()` that names the bare package when no version resolves.

## Tests (failing first)

Four new tests in `cli/test/unit/checks-command.test.ts`, all red on the old code:

- header contains the real `packages/twin-github/package.json` version (read straight from the tree, not through the resolution under test) and never "unknown"
- `pinnedVersion` resolves twin + sdk from the workspace link
- unresolvable → `undefined`, header omits the parenthetical, `pinLabel` names the bare package
- the tsup define bakes a real semver for every inlined `@pome-sh/*` devDependency

## Verification

- Clean-room: `npm pack` → install tarball in fresh `/tmp` dir → `pome checks github` prints `github — 16 declared checks (@pome-sh/twin-github 0.12.0)`
- `npm test` (4031 tests), `npm run typecheck`, `npm run lint` (17 rules), `lint:dead-code`, `lint:test`, `gate:route-inputs`, `test:contract` (104 pass), `test:pack` — all green
- `## Unreleased (patch)` changelog entry included

🤖 Generated with [Claude Code](https://claude.com/claude-code)