### PR TITLE
Langsmith example's concurrency comment states 0.9.0's real mechanism (F-1776)

### DIFF
--- a/integration-examples/langsmith/src/index.ts
+++ b/integration-examples/langsmith/src/index.ts
@@ -209,14 +209,18 @@ export interface EvalOptions {
 /**
  * How many rows run at once.
  *
- * `maxConcurrency` is the field to set, and the near-miss is silent: `_evaluate`
- * builds its queue only `if (sharedConcurrency > 0)` where
- * `sharedConcurrency = maxConcurrency ?? 0`, and it uses SEPARATE queues only
- * when BOTH `targetConcurrency` and `evaluationConcurrency` are given. So
- * setting `targetConcurrency` alone leaves `maxConcurrency` undefined, no queue
- * is built at all, and every row runs at once — six sandboxes, one per row,
- * straight into `402 quota_exceeded`. Hence the floor below: a cap of 0 or
- * absent does not mean "no limit needed", it means no limit.
+ * `maxConcurrency` is the field to set, and one number is the point: `_evaluate`
+ * feeds it to both legs (`targetConcurrency ?? maxConcurrency ?? 0`, and the
+ * same for evaluation), so it bounds the target and the evaluators together.
+ * Nothing in langsmith@0.9.0 runs rows unbounded — the shared queue is built
+ * only `if (sharedConcurrency > 0)`, but when it is not, `_predict` and `_score`
+ * each fall back to their own
+ * `new PQueue({ concurrency: maxConcurrency === 0 ? 1 : maxConcurrency })`,
+ * "maxConcurrency: 0 means sequential execution (matching Python behavior)" per
+ * the SDK's own comment. So a cap of 0 or absent means one row at a time: the
+ * miss costs wall-clock time, never a stampede of sandboxes. Hence the floor
+ * below — an unset or bad `POME_EVAL_CONCURRENCY` should hold a couple of
+ * sandboxes open, not quietly serialize the run.
  */
 export function evalOptions(env: Env): EvalOptions {
   const requested = Number(env.POME_EVAL_CONCURRENCY);


### PR DESCRIPTION
Fixes the `evalOptions` doc comment in `integration-examples/langsmith/src/index.ts`, which claimed a concurrency mechanism that `langsmith@0.9.0` contradicts. Comment-only change; the advice (`maxConcurrency` + `POME_EVAL_CONCURRENCY` default 2) is unchanged. Linear: F-1776.

## What was wrong

The old comment said setting `targetConcurrency` alone builds no queue at all and "every row runs at once — six sandboxes, one per row, straight into `402 quota_exceeded`". Re-read from the installed `langsmith@0.9.0` `node_modules/langsmith/dist/evaluation/_runner.js` in this repo:

- The shared-queue guard is real (`sharedConcurrency > 0` at line 792), but when no shared queue is built, `_predict` (line 484) and `_score` (line 568) each fall back to their own `new PQueue({ concurrency: maxConcurrency === 0 ? 1 : maxConcurrency })`, with the SDK's own comment "maxConcurrency: 0 means sequential execution (matching Python behavior)". Nothing ever runs unbounded — the no-field case is sequential.
- `targetConcurrency` alone DOES bound predictions: `const targetConcurrency = standardFields.targetConcurrency ?? standardFields.maxConcurrency ?? 0` (line 772) is passed as `maxConcurrency: targetConcurrency` to `withPredictions` (line 798), which feeds the fallback queue.

## The comment and the docs page now tell the same story

`apps/docs/docs/examples/eval-stack.mdx` at pome-cloud `origin/main` (corrected in the F-1770 S4a sweep):

> **3. `maxConcurrency` is the field the cap rides on.** Nothing in 0.9.0 runs rows unbounded: leave every concurrency field unset and `evaluate()` falls back to a queue of one — sequential, "matching Python behavior" per the SDK's own comment — so the miss costs you time, not a stampede of sandboxes. One number on `maxConcurrency` bounds the target and the evaluators together, and `POME_EVAL_CONCURRENCY` (default 2) is what the example passes through. Read off `langsmith@0.9.0`'s `_runner.js`, 2026-08-30.

The rewritten comment:

> `maxConcurrency` is the field to set, and one number is the point: `_evaluate` feeds it to both legs (`targetConcurrency ?? maxConcurrency ?? 0`, and the same for evaluation), so it bounds the target and the evaluators together. Nothing in langsmith@0.9.0 runs rows unbounded — the shared queue is built only `if (sharedConcurrency > 0)`, but when it is not, `_predict` and `_score` each fall back to their own `new PQueue({ concurrency: maxConcurrency === 0 ? 1 : maxConcurrency })`, "maxConcurrency: 0 means sequential execution (matching Python behavior)" per the SDK's own comment. So a cap of 0 or absent means one row at a time: the miss costs wall-clock time, never a stampede of sandboxes. Hence the floor below — an unset or bad `POME_EVAL_CONCURRENCY` should hold a couple of sandboxes open, not quietly serialize the run.

Same mechanism (sequential PQueue fallback, `targetConcurrency` flows through, `maxConcurrency` as the single-number bound), same failure framing (time, not a sandbox stampede), same advice.

## Verification

- `npx vitest run test/langsmith-seam.test.ts` — 3 passed (the other two mechanical differences on the docs page, score `key` vs `name` and the `{results: [...]}` envelope, stay pinned there; no change needed).
- `npx tsc --noEmit` in the example — clean.
- `npm run lint` at repo root — 17 rule(s) passed.
- `node scripts/ci/check-release-note-required.mjs $(git merge-base origin/main HEAD)` — "Release inputs OK … 0 package(s) moved by this PR": the gate demands no changelog entry for this path, so none is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
