### PR TITLE
update releasing workflow

### DIFF
--- a/.github/workflows/allocate-version.yml
+++ b/.github/workflows/allocate-version.yml
@@ -9,20 +9,22 @@ name: allocate version
 # (`scripts/ci/allocate-release-versions.mjs` decides), writes them into the
 # manifests and the CHANGELOG headings, and pushes ONE commit back to `main`.
 #
+# It runs when a human asks, never on a merge. One release covers every merge
+# since the last one: `pendingRelease` folds the accumulated `## Unreleased`
+# headings into one entry at the worst level any of them declared.
+#
 # ── WHAT THIS DELIBERATELY DOES NOT DO ───────────────────────────────────────
 #
 # It does not publish, and `release.yml` is untouched by it. `release.yml` still
 # triggers on push to `main`, still compares each package's local manifest
 # against its registry, still hard-fails on behind-npm and still baselines a
 # never-seen package at 0.0.0. The bump commit is a push to `main`, so the
-# publish is that commit's own `release.yml` run. Two consequences worth stating:
-# the run on the HUMAN merge commit sees no version diff and publishes nothing
-# (correct — the number does not exist yet at that sha), and `release.yml`'s
-# `concurrency: release-${{ github.ref }}` with `cancel-in-progress: false` is
-# what serialises the publish half.
+# publish is that commit's own `release.yml` run. `release.yml` keeps its push
+# arm: it is diff-gated, so an ordinary merge runs it and publishes nothing, and
+# its `concurrency: release-${{ github.ref }}` with `cancel-in-progress: false`
+# is what serialises the publish half.
 #
-# Nothing here waits for a release PR and nothing batches. What this moves is
-# WHO WRITES THE NUMBER, not when a release happens.
+# What this moves is WHO WRITES THE NUMBER. The trigger decides WHEN.
 #
 # ── WHY AN APP TOKEN AND NOT THE AMBIENT GITHUB_TOKEN ────────────────────────
 #
@@ -54,16 +56,14 @@ name: allocate version
 # nothing (reason 1) or publish nothing (reason 2), and both of those look like a
 # quiet green.
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
   # release.yml's `dispatch-allocate-version` job POSTs this event the
   # moment a publish lands, which is the ONLY moment `planExampleRepins` can see
-  # the just-published sibling on the registry: the run on the human merge commit
-  # plans before the version exists, and the run on the bump commit it produces
-  # is the one the `[release-bump]` guard below skips. A NAMED type, never a bare
-  # `repository_dispatch:` — that accepts every event type anyone ever POSTs at
-  # this repository as a licence to push to `main`.
+  # the just-published sibling on the registry: the run that ALLOCATES plans
+  # before the version exists on npm, so the repin it owes cannot be part of the
+  # same commit. This event is the second pass that sees it. A NAMED type,
+  # never a bare `repository_dispatch:` — that accepts every event type anyone
+  # ever POSTs at this repository as a licence to push to `main`.
   #
   # `repository_dispatch` and not `workflow_dispatch`, which is what this shipped
   # as first and could never have fired: `POST /repos/{owner}/{repo}/dispatches`
@@ -73,13 +73,14 @@ on:
   # an org owner re-approves the app with a wider grant. (Both requirements are
   # GitHub's documented fine-grained permission for the endpoint.)
   #
-  # Three properties of this event make it behave identically to the push arm
-  # below, so nothing downstream needs a special case: GitHub only starts it from
-  # the workflow file on the DEFAULT BRANCH, `github.sha` is the last commit on
-  # the default branch, and `github.ref` is the default branch — so the checkout
-  # ref expression resolves to `main` exactly as on a push, and the concurrency
-  # group is the same `allocate-version-refs/heads/main`, which is what makes a
-  # dispatch queue behind an allocation already in flight instead of racing it.
+  # Three properties of this event make it behave identically to a
+  # `workflow_dispatch`, so nothing downstream needs a special case: GitHub only
+  # starts it from the workflow file on the DEFAULT BRANCH, `github.sha` is the
+  # last commit on the default branch, and `github.ref` is the default branch —
+  # so the checkout ref expression resolves to `main` either way, and the
+  # concurrency group is the same `allocate-version-refs/heads/main`, which is
+  # what makes a dispatch queue behind an allocation already in flight instead of
+  # racing it.
   repository_dispatch:
     types: [repin-examples]
   # Changing the allocator or the table it reads must prove the job wiring still
@@ -119,35 +120,9 @@ permissions:
 
 jobs:
   allocate:
-    name: write the version numbers this push earned
+    name: write the version numbers main has earned
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # A cheap "don't even start" on the allocator's own commit — NOT the loop
-    # guard. The guard is structural and lives in the allocator: relevance is
-    # measured from the last commit that moved a package's version, and the bump
-    # commit is one, so its own diff is already inside the previous release. If
-    # this literal and BUMP_COMMIT_MARKER in the script ever drift apart, the job
-    # runs and finds nothing to do.
-    #
-    # SCOPED TO `push` EXPLICITLY, because `github.event.head_commit` exists on
-    # no other event. On `workflow_dispatch` and on `repository_dispatch` it is
-    # null, `contains` casts null to the empty string, and the guard therefore
-    # passes — the right answer (a dispatch is a deliberate request and must run
-    # even when main's tip IS a `[release-bump]` commit, which is precisely the
-    # tip release.yml dispatches from) arrived at by coercion. Naming the event
-    # makes it a decision, and stops the plausible "fix" for that null — widening
-    # the guard to cover every event — which would turn release.yml's dispatch
-    # into a silent no-op and reopen the deadlock it exists to close.
-    #
-    # Termination does NOT rest on this guard for the dispatch arm, and must not:
-    # release.yml dispatches only after a real publish, and the single commit this
-    # run pushes can only cause another publish by MOVING a package version,
-    # which requires a pending `## Unreleased` entry — which this same run
-    # consumes. A re-pin-only commit touches `agent-examples/*` and their lockfiles, no
-    # package version, so release.yml's `plan` finds no diff against the registry,
-    # publishes nothing, and dispatches nothing. The chain is bounded by the
-    # number of pending entries and CI writes none.
-    if: ${{ github.event_name != 'push' || !contains(github.event.head_commit.message, '[release-bump]') }}
     steps:
       # Named before the mint step rather than left to it: the action's own
       # failure on an empty input does not tell a reader which secret, on which
@@ -195,8 +170,8 @@ jobs:
       # release.
       #
       # THE REF IS PER ARM, and getting it wrong is how the first run of this
-      # workflow failed. On a push, `main` (not the event sha) because the number
-      # belongs to the TIP: if a second merge landed while this run queued, its
+      # workflow failed. On a dispatch, `main` (not the event sha) because the
+      # number belongs to the TIP: if a merge landed while this run queued, its
       # entry is already on main and belongs in the same release. On a
       # pull_request, `github.ref` — the merge ref — because that arm's whole job
       # is to prove THIS PR's allocator still runs, and a checkout of `main` does
@@ -226,7 +201,7 @@ jobs:
       - name: Regression-test the allocator
         run: node scripts/ci/allocate-release-versions.test.mjs
 
-      - name: What would this push allocate?
+      - name: What would a release allocate right now?
         if: github.event_name == 'pull_request'
         run: node scripts/ci/allocate-release-versions.mjs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,8 @@ jobs:
       - run: npm run gate:example-catalog
       - run: node scripts/emit-example-catalog.test.mjs
 
-      # Versions are written on main after the merge by allocate-version.yml, so
+      # Versions are written on main by allocate-version.yml when a human
+      # dispatches a release, never on the merge itself (F-1625), so
       # what this demands of a PR is the WORDS and not the number: an
       # `## Unreleased (patch|minor)` entry for every artifact the PR moves, no
       # hand-written version line, no rewrite of a released entry. The base is

--- a/.github/workflows/release-alarm.yml
+++ b/.github/workflows/release-alarm.yml
@@ -73,12 +73,6 @@ on:
       - ".github/workflows/release-alarm.yml"
       - ".github/workflows/release.yml"
       - "scripts/ci/decide-publish.sh"
-      # the alarm's UNALLOCATED leg reads these two: the CHANGELOG
-      # grammar it parses a pending entry with, and the table that says which
-      # CHANGELOG belongs to which published package. A change to either can
-      # blind that leg without touching a file above.
-      - "scripts/ci/changelog-entry.mjs"
-      - "scripts/ci/publish-relevance.mjs"
 
 concurrency:
   group: release-alarm-${{ github.ref }}
@@ -205,9 +199,7 @@ jobs:
 
           </details>
 
-          **UNALLOCATED** — `main` carries a pending `## Unreleased` entry and no version number was written for it, so nothing published and `main` and the registry agree on the old version. The number is allocated after the merge by `allocate-version.yml`: check that run, the `OPS_APP_ID` / `OPS_APP_PRIVATE_KEY` secrets, and that the `pome-ops-push` app (app_id 4582446) is still both installed on this repository and in ruleset 18797095's bypass list. Recovery is `gh workflow run allocate-version.yml --ref main` — do NOT hand-write the version to unstick it.
-
-          **UNPUBLISHED / BEHIND** — a version on `main` that its registry does not serve. Re-dispatch the release once the cause is fixed: `gh workflow run release.yml --ref main`. A 404 at the publish step is an AUTH failure (npm Trusted Publishing matches repo *and* workflow filename), not a missing package.
+          **UNPUBLISHED / BEHIND** — a version on `main` that its registry does not serve. Check the `allocate-version.yml` and `release.yml` runs, the `OPS_APP_ID` / `OPS_APP_PRIVATE_KEY` secrets, and that the `pome-ops-push` app (app_id 4582446) is still both installed on this repository and in ruleset 18797095's bypass list. Re-dispatch once the cause is fixed: `gh workflow run release.yml --ref main` — do NOT hand-write the version to unstick it. A 404 at the publish step is an AUTH failure (npm Trusted Publishing matches repo *and* workflow filename), not a missing package.
 
           **NEVER_RAN** — a push to `main` that triggered no release at all. Check Actions is enabled, and whether the push came from a bot using the ambient `GITHUB_TOKEN`, which GitHub refuses to let trigger workflows.
 

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ matrix-results/
 .gstack/
 .claude/
 .cursor/
+# Points at a launcher that clones the PRIVATE openapi-spec-mcp, so it can only
+# ever work for someone with access to it. Keep your own; the repo ships none.
+/.mcp.json
 
 # OS / editor
 .DS_Store

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "openapi-specs": {
-      "command": "bash",
-      "args": ["scripts/mcp/openapi-specs.sh"]
-    }
-  }
-}

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,11 +3,17 @@
 Entries are hand-written from 0.9.0 on. In a PR, add your entry under an
 `## Unreleased (patch)` (or `(minor)`) heading above the newest released one.
 `.github/workflows/allocate-version.yml` rewrites that heading to the version it
-allocates on `main` after the merge, in the same commit that moves
-`package.json`, and `.github/workflows/release.yml` publishes from there. Do not
-write a version number here or in `package.json`. Released entries are insertions
-only: a correction is the next entry, naming the one it corrects.
+allocates, in the same commit that moves `package.json`, and
+`.github/workflows/release.yml` publishes from there. Do not write a version
+number here or in `package.json`.
 
+Merging does not release; a human dispatches it, and one release covers every
+merge since the last one. Your entry may sit here a few days.
+
+**Keep it to a bold one-line summary and two or three sentences.** Say what a
+consumer must do differently. The reasoning belongs in the code it explains.
+Released entries are insertions only: a correction is the next entry, naming the
+one it corrects.
 
 ## 0.42.4 — 2026-08-30
 

--- a/scripts/ci/assert-allocate-token-path.test.mjs
+++ b/scripts/ci/assert-allocate-token-path.test.mjs
@@ -68,7 +68,7 @@ function insertInStep(text, name, line) {
 const PRECONDITION = "The pome-ops-push credentials must exist";
 const MINT = "Mint a pome-ops-push installation token";
 const PUSH = "Allocate, write, and push one commit to main";
-const PLAN = "What would this push allocate?";
+const PLAN = "What would a release allocate right now?";
 const names = (result) => result.errors.join("\n");
 
 console.log("assert-allocate-token-path.mjs — the real file");

--- a/scripts/ci/check-release-note-required.mjs
+++ b/scripts/ci/check-release-note-required.mjs
@@ -57,9 +57,9 @@ for (const pkg of PUBLISHED_PACKAGES) {
   if (baseVersion !== null && headVersion !== baseVersion) {
     failures.push(
       `${pkg.name}: this PR moves ${pkg.manifest}'s version from ${baseVersion} to ${headVersion}. ` +
-        `Version numbers are allocated on \`main\` after the merge, by ` +
+        `Version numbers are allocated on \`main\` when a release is dispatched, by ` +
         `.github/workflows/allocate-version.yml — a PR that carries one is invalidated by any ` +
-        `other merge that consumes it, silently and while still green. Revert the version line ` +
+        `other merge that lands before that release, silently and while still green. Revert the version line ` +
         `and describe the change under \`${PENDING_HEADING_EXAMPLE}\` in ${pkg.changelog} ` +
         `instead. The number is not yours to write; the words are.`,
     );

--- a/scripts/ci/decide-publish.test.mjs
+++ b/scripts/ci/decide-publish.test.mjs
@@ -249,14 +249,6 @@ console.log("\nrelease.yml wiring");
   );
 
   check(
-    "allocate-version.yml's [release-bump] guard is scoped to `push`, so the dispatched run is not skipped by a marker it cannot read",
-    /if:\s*\$\{\{\s*github\.event_name\s*!=\s*'push'\s*\|\|\s*!contains\(github\.event\.head_commit\.message,\s*'\[release-bump\]'\)\s*\}\}/.test(
-      allocate,
-    ),
-    "expected a job-level `if:` of the form `github.event_name != 'push' || !contains(github.event.head_commit.message, '[release-bump]')`",
-  );
-
-  check(
     "the publish job waits for the registry to serve what it published, with a staleness-forcing read",
     /npm view "\$\{PKG\}@\$\{version\}"[^\n]*--prefer-online/.test(publish),
     publish,

--- a/scripts/ci/release-alarm.mjs
+++ b/scripts/ci/release-alarm.mjs
@@ -13,12 +13,8 @@ import { appendFileSync, existsSync, readFileSync, realpathSync } from "node:fs"
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { pendingRelease } from "./changelog-entry.mjs";
-import { PUBLISHED_PACKAGES } from "./publish-relevance.mjs";
-
 const HERE = dirname(fileURLToPath(import.meta.url));
 const RELEASE_WORKFLOW = "release.yml";
-const ALLOCATE_WORKFLOW = "allocate-version.yml";
 
 export function parseTargets(root) {
   const targets = readTargets(root);
@@ -146,42 +142,6 @@ function inspectReleaseRuns({ repo, head, runs, now, graceMinutes, stuckMinutes 
   return { alarms, lines, headAge, forHead, inFlight };
 }
 
-function inspectPendingEntries({ root }) {
-  const alarms = [];
-  const lines = [];
-
-  for (const pkg of PUBLISHED_PACKAGES) {
-    const file = join(root, pkg.changelog);
-    if (!existsSync(file)) {
-      alarms.push(
-        `UNMEASURED — ${pkg.changelog} is missing, so nothing here can say whether ` +
-          `${pkg.name} is waiting for a version number.`,
-      );
-      continue;
-    }
-    let pending;
-    try {
-      pending = pendingRelease(readFileSync(file, "utf8"), pkg.changelog);
-    } catch (error) {
-      alarms.push(
-        `UNALLOCATED — ${pkg.changelog} cannot be read as a release request: ${error.message} ` +
-          `allocate-version.yml fails on the same parse, so nothing is being allocated.`,
-      );
-      continue;
-    }
-    if (!pending) continue;
-    lines.push(`${pkg.name} — pending ${pending.level} entry awaiting a number`);
-    alarms.push(
-      `UNALLOCATED — ${pkg.changelog} carries a pending \`## Unreleased (${pending.level})\` entry ` +
-        `that no allocation consumed. \`${ALLOCATE_WORKFLOW}\` writes the number on main after the ` +
-        `merge, so nothing has published this and the registry agrees with main about the OLD ` +
-        `version — the outcome check below cannot see it.`,
-    );
-  }
-
-  return { alarms, lines };
-}
-
 function inspectRegistries({ root, targets, readVersion }) {
   const alarms = [];
   const lines = [];
@@ -255,15 +215,12 @@ export function check({
   const alarms = [...path.alarms];
 
   if (path.headAge > graceMinutes) {
-    const allocation = inspectPendingEntries({ root });
-    lines.push(...allocation.lines);
-    alarms.push(...allocation.alarms);
     const registries = inspectRegistries({ root, targets, readVersion });
     lines.push(...registries.lines);
     alarms.push(...registries.alarms);
   } else {
     lines.push(
-      `registry drift and pending allocations not evaluated — HEAD is ` +
+      `registry drift not evaluated — HEAD is ` +
         `${path.headAge.toFixed(0)} min old (grace ${graceMinutes}); its number may still be ` +
         `being allocated and its release may still be building.`,
     );

--- a/scripts/ci/release-alarm.test.mjs
+++ b/scripts/ci/release-alarm.test.mjs
@@ -9,7 +9,6 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { PUBLISHED_PACKAGES } from "./publish-relevance.mjs";
 import { check, compareVersions, parseTargets, readTargets } from "./release-alarm.mjs";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
@@ -31,18 +30,7 @@ function check_(label, condition, detail = "") {
 
 const minutesAgo = (m) => new Date(NOW - m * 60_000).toISOString();
 
-function writeChangelogs(dir, pending = {}) {
-  for (const pkg of PUBLISHED_PACKAGES) {
-    mkdirSync(join(dir, dirname(pkg.changelog)), { recursive: true });
-    const section = pending[pkg.name] ? `${pending[pkg.name]}\n\n- words from a PR\n\n` : "";
-    writeFileSync(
-      join(dir, pkg.changelog),
-      `# ${pkg.name} — CHANGELOG\n\n${section}## 1.0.0 — 2026-08-01\n\nShipped.\n`,
-    );
-  }
-}
-
-function fixture(versions = {}, pending = {}) {
+function fixture(versions = {}) {
   const dir = mkdtempSync(join(tmpdir(), "release-alarm-"));
   mkdirSync(join(dir, ".github/workflows"), { recursive: true });
   cpSync(
@@ -56,7 +44,6 @@ function fixture(versions = {}, pending = {}) {
       JSON.stringify({ name: t.name, version: versions[t.name] ?? "1.0.0" }),
     );
   }
-  writeChangelogs(dir, pending);
   return dir;
 }
 
@@ -88,9 +75,9 @@ const registryStub = (map) => (name, registry) =>
   map[`${name}@${registry || "npm"}`] ?? map[name] ?? { version: "1.0.0" };
 
 function run(opts = {}) {
-  const { versions, head, runs, registry = {}, pending, ...rest } = opts;
+  const { versions, head, runs, registry = {}, ...rest } = opts;
   return check({
-    root: opts.root ?? fixture(versions, pending),
+    root: opts.root ?? fixture(versions),
     repo: REPO,
     now: NOW,
     gitHub: ghStub({ head, runs }),
@@ -256,44 +243,6 @@ console.log("FAILED — a broken release path with nothing owed");
   check_("a skipped run does not", !kinds(run({ runs: [{ ageMin: 200, conclusion: "skipped" }] })).includes("FAILED"));
 }
 
-console.log("UNALLOCATED — a number nobody wrote");
-{
-  const r = run({
-    runs: [{ ageMin: 300, conclusion: "success" }],
-    pending: { "@pome-sh/cli": "## Unreleased (patch)" },
-  });
-  check_("fires", kinds(r).includes("UNALLOCATED"), r.alarms.join("\n"));
-  check_(
-    "names the file and the level",
-    r.alarms.some((a) => a.includes("cli/CHANGELOG.md") && a.includes("(patch)")),
-    r.alarms.join("\n"),
-  );
-  check_(
-    "and nothing else fires — every version matches its registry",
-    r.alarms.length === 1,
-    r.alarms.join("\n"),
-  );
-  check_("the report names the waiting package", /@pome-sh\/cli — pending patch/.test(r.report), r.report);
-
-  const malformed = run({
-    runs: [{ ageMin: 300, conclusion: "success" }],
-    pending: { "@pome-sh/wire": "## Unreleased" },
-  });
-  check_(
-    "a malformed pending heading is UNALLOCATED, not silence",
-    kinds(malformed).includes("UNALLOCATED") &&
-      malformed.alarms.some((a) => a.includes("not a release request")),
-    malformed.alarms.join("\n"),
-  );
-
-  const fresh = run({
-    head: { sha: HEAD_SHA, ageMin: 4 },
-    runs: [{ ageMin: 4, status: "in_progress" }],
-    pending: { "@pome-sh/cli": "## Unreleased (minor)" },
-  });
-  check_("stays silent inside the grace window", fresh.alarms.length === 0, fresh.alarms.join("\n"));
-}
-
 console.log("UNMEASURED — an unreadable registry is never read as 'unpublished'");
 {
   const r = run({
@@ -332,7 +281,6 @@ console.log("four consecutive failed runs on one day, replayed");
       mkdirSync(join(dir, dirname(t.manifest)), { recursive: true });
       writeFileSync(join(dir, t.manifest), JSON.stringify({ name: t.name, version: "1.0.0" }));
     }
-    writeChangelogs(dir);
     return dir;
   }
 


### PR DESCRIPTION
- `allocate-version.yml` loses its `push: branches: [main]` arm. Every merge allocated a number and every number published: 26 of the last 60 commits on `main` were `[release-bump]`. A release is now dispatched by a human, and one release covers every merge since the last one.
- No change to the allocator was needed. Its unit was already `main`'s tip rather than a pushed range, and `pendingRelease` already folds accumulated `## Unreleased` headings into one entry at the worst level any of them declared.
- `release.yml` keeps its own push arm. It is diff-gated, so an ordinary merge runs it and publishes nothing.
- Deletes the job's `[release-bump]` skip guard, which read `github.event.head_commit` and can only be null without a push arm. Loop safety was always structural, in the allocator's `lastVersionChange()` walk. Also deletes the alarm's `UNALLOCATED` leg, which fired on any pending `## Unreleased` entry — now the steady state. Nothing nags anyone to cut a release.
- Separately, the repo stops shipping a `.mcp.json`. 

The `/pome-npm-release` skill in `pome-sh/agent-skills` is updated to match: "release now" previews with the allocator's dry run, dispatches, and watches.